### PR TITLE
CI: Add Windows backend tests in more places

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -29,6 +29,10 @@ load(
     "publish_image_pipelines_public",
     "publish_image_pipelines_security",
 )
+load(
+    "scripts/drone/pipelines/ci_images.star",
+    "publish_ci_windows_test_image_pipeline",
+)
 load("scripts/drone/pipelines/github.star", "publish_github_pipeline")
 load("scripts/drone/pipelines/aws_marketplace.star", "publish_aws_marketplace_pipeline")
 load("scripts/drone/version.star", "version_branch_pipelines")
@@ -59,6 +63,7 @@ def main(_ctx):
         artifacts_page_pipeline() +
         version_branch_pipelines() +
         integration_test_pipelines() +
+        publish_ci_windows_test_image_pipeline() +
         cronjobs() +
         secrets()
     )

--- a/.drone.yml
+++ b/.drone.yml
@@ -373,6 +373,55 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
+name: pr-oss-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands: []
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags oss ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  event:
+  - pull_request
+  paths:
+    exclude:
+    - docs/**
+    - '*.md'
+    - pkg/**
+    - packaging/**
+    - go.sum
+    - go.mod
+    include: []
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
 name: pr-lint-backend
 node:
   type: no-parallel
@@ -2094,6 +2143,124 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: main-oss-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands: []
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags oss ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  branch: main
+  event:
+  - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: main-enterprise-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands:
+  - $$ProgressPreference = "SilentlyContinue"
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/windows/grabpl.exe
+    -OutFile grabpl.exe
+  image: grafana/ci-wix:0.1.1
+  name: grabpl
+- commands:
+  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout main
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: clone
+- commands:
+  - cp -r grafana-enterprise C:\App\grafana-enterprise
+  - rm -r -force grafana-enterprise
+  - cp grabpl.exe C:\App\grabpl.exe
+  - rm -force grabpl.exe
+  - C:\App\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\App\grafana-enterprise
+  - cp C:\App\grabpl.exe grabpl.exe
+  depends_on:
+  - clone
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags enterprise ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  branch: main
+  event:
+  - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
 kind: pipeline
 name: notify-drone-changes
 platform:
@@ -2648,10 +2815,128 @@ volumes:
 ---
 clone:
   retries: 3
+depends_on: []
+environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-oss-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands: []
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags oss ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-enterprise-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands:
+  - $$ProgressPreference = "SilentlyContinue"
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/windows/grabpl.exe
+    -OutFile grabpl.exe
+  image: grafana/ci-wix:0.1.1
+  name: grabpl
+- commands:
+  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout ${DRONE_TAG}
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: clone
+- commands:
+  - cp -r grafana-enterprise C:\App\grafana-enterprise
+  - rm -r -force grafana-enterprise
+  - cp grabpl.exe C:\App\grabpl.exe
+  - rm -force grabpl.exe
+  - C:\App\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\App\grafana-enterprise
+  - cp C:\App\grabpl.exe grabpl.exe
+  depends_on:
+  - clone
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags enterprise ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
 depends_on:
 - release-oss-build-e2e-publish
 - release-oss-test-frontend
-- release-oss-test-backend
+- release-oss-test-backend-windows
 environment:
   EDITION: oss
 image_pull_secrets:
@@ -5210,6 +5495,112 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
+name: release-branch-oss-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands: []
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags oss ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  ref:
+  - refs/heads/v[0-9]*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-branch-enterprise-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands:
+  - $$ProgressPreference = "SilentlyContinue"
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/windows/grabpl.exe
+    -OutFile grabpl.exe
+  image: grafana/ci-wix:0.1.1
+  name: grabpl
+- commands:
+  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout $$env:DRONE_BRANCH
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: clone
+- commands:
+  - cp -r grafana-enterprise C:\App\grafana-enterprise
+  - rm -r -force grafana-enterprise
+  - cp grabpl.exe C:\App\grabpl.exe
+  - rm -force grabpl.exe
+  - C:\App\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\App\grafana-enterprise
+  - cp C:\App\grabpl.exe grabpl.exe
+  depends_on:
+  - clone
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags enterprise ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  ref:
+  - refs/heads/v[0-9]*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
 name: release-branch-oss-integration-tests
 node:
   type: no-parallel
@@ -5383,7 +5774,7 @@ clone:
 depends_on:
 - release-branch-oss-build-e2e-publish
 - release-branch-oss-test-frontend
-- release-branch-oss-test-backend
+- release-branch-oss-test-backend-windows
 environment:
   EDITION: oss
 image_pull_secrets:
@@ -7148,6 +7539,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 1a5358f92b6ca848288fb7917e62b994430c89eaa43ac2e5c1de49df359886d5
+hmac: f9f8134852054c32442e7194605bbb979234d3cffd398fa5a997af3adccea10b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -411,7 +411,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2137,7 +2137,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2183,7 +2183,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2255,7 +2255,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2856,7 +2856,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2928,7 +2928,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -2994,7 +2994,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -3578,7 +3578,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -5524,7 +5524,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -5590,7 +5590,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -5822,7 +5822,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -6596,7 +6596,7 @@ trigger:
 type: docker
 volumes:
 - host:
-    path: /var/run/docker.sock
+    path: //./pipe/docker_engine/
   name: docker
 ---
 clone:
@@ -7236,6 +7236,54 @@ volumes:
     medium: memory
 ---
 clone:
+  disable: true
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-ci-windows-test-image
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands:
+  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-ci-sandbox.git"
+    .
+  - git checkout -f $$env:DRONE_COMMIT
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: clone
+- commands:
+  - cd scripts\build\ci-windows-test
+  - docker login -u $$env:DOCKER_USERNAME -p $$env:DOCKER_PASSWORD
+  - docker build -t grafana/grafana-ci-windows-test:$$env:TAG .
+  - docker push grafana/grafana-ci-windows-test:$$env:TAG
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  image: docker:windowsservercore-1809
+  name: build-and-publish
+  volumes:
+  - name: docker
+    path: //./pipe/docker_engine/
+trigger:
+  event:
+  - promote
+  target:
+  - ci-windows-test-image
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+clone:
   retries: 3
 kind: pipeline
 name: scan-grafana/grafana:latest-image
@@ -7539,6 +7587,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: f9f8134852054c32442e7194605bbb979234d3cffd398fa5a997af3adccea10b
+hmac: 996bdb4771e7c483f7c912d8026e29b6fb088e1e529cd9811e3561a68d632e01
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -394,6 +394,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -2169,6 +2170,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -2241,6 +2243,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -2842,6 +2845,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -2914,6 +2918,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -5516,6 +5521,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -5582,6 +5588,7 @@ steps:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
+  failure: ignore
   image: grafana/grafana-ci-windows-test:0.1.0
   name: test-backend
 trigger:
@@ -7587,6 +7594,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 996bdb4771e7c483f7c912d8026e29b6fb088e1e529cd9811e3561a68d632e01
+hmac: de8e1e63e1e22d145970d335bb1140c68c77e3833d54748f0a34720ab72d7be2
 
 ...

--- a/scripts/build/ci-windows-test/Dockerfile
+++ b/scripts/build/ci-windows-test/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.20.3-windowsservercore-1809
+
+SHELL ["powershell", "-command"]
+
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+RUN choco install mingw -y --version 12.2.0.03042023

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -32,6 +32,7 @@ load(
 load(
     "scripts/drone/pipelines/windows.star",
     "windows",
+    "windows_test_backend",
 )
 load(
     "scripts/drone/pipelines/trigger_downstream.star",
@@ -89,6 +90,8 @@ def main_pipelines():
         build_e2e(trigger, ver_mode),
         integration_tests(trigger, prefix = ver_mode, ver_mode = ver_mode),
         windows(trigger, edition = "oss", ver_mode = ver_mode),
+        windows_test_backend(trigger, "oss", ver_mode),
+        windows_test_backend(trigger, "enterprise", ver_mode),
         notify_pipeline(
             name = "notify-drone-changes",
             slack_channel = "slack-webhooks-test",

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -16,6 +16,10 @@ load(
     "integration_tests",
 )
 load(
+    "scripts/drone/pipelines/windows.star",
+    "windows_test_backend",
+)
+load(
     "scripts/drone/pipelines/build.star",
     "build_e2e",
 )
@@ -98,6 +102,13 @@ def pr_pipelines():
                     "devenv/**",
                 ],
             ),
+            ver_mode,
+        ),
+        windows_test_backend(
+            get_pr_trigger(
+                exclude_paths = ["pkg/**", "packaging/**", "go.sum", "go.mod"],
+            ),
+            "oss",
             ver_mode,
         ),
         lint_backend_pipeline(

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -61,6 +61,10 @@ load(
     "test_backend",
     "test_backend_enterprise",
 )
+load(
+    "scripts/drone/pipelines/windows.star",
+    "windows_test_backend",
+)
 load("scripts/drone/vault.star", "from_secret", "prerelease_bucket")
 
 ver_mode = "release"
@@ -223,7 +227,7 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
         depends_on = [
             "{}-oss-build-e2e-publish".format(ver_mode),
             "{}-oss-test-frontend".format(ver_mode),
-            "{}-oss-test-backend".format(ver_mode),
+            "{}-oss-test-backend-windows".format(ver_mode),
         ],
         environment = environment,
     )
@@ -240,6 +244,8 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
         ),
         test_frontend(trigger, ver_mode),
         test_backend(trigger, ver_mode),
+        windows_test_backend(trigger, "oss", ver_mode),
+        windows_test_backend(trigger, "enterprise", ver_mode),
     ]
 
     if ver_mode not in ("release"):

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -1,0 +1,63 @@
+load(
+    "scripts/drone/steps/lib.star",
+    "wix_image",
+)
+load(
+    "scripts/drone/utils/utils.star",
+    "pipeline",
+)
+load(
+    "scripts/drone/vault.star",
+    "from_secret",
+)
+
+def publish_ci_windows_test_image_pipeline():
+    trigger = {
+        "event": ["promote"],
+        "target": ["ci-windows-test-image"],
+    }
+    pl = pipeline(
+        name = "publish-ci-windows-test-image",
+        trigger = trigger,
+        edition = "",
+        platform = "windows",
+        steps = [
+            {
+                "name": "clone",
+                "image": wix_image,
+                "environment": {
+                    "GITHUB_TOKEN": from_secret("github_token"),
+                },
+                "commands": [
+                    'git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-ci-sandbox.git" .',
+                    "git checkout -f $$env:DRONE_COMMIT",
+                ],
+            },
+            {
+                "name": "build-and-publish",
+                "image": "docker:windowsservercore-1809",
+                "environment": {
+                    "DOCKER_USERNAME": from_secret("docker_username"),
+                    "DOCKER_PASSWORD": from_secret("docker_password"),
+                },
+                "commands": [
+                    "cd scripts\\build\\ci-windows-test",
+                    "docker login -u $$env:DOCKER_USERNAME -p $$env:DOCKER_PASSWORD",
+                    "docker build -t grafana/grafana-ci-windows-test:$$env:TAG .",
+                    "docker push grafana/grafana-ci-windows-test:$$env:TAG",
+                ],
+                "volumes": [
+                    {
+                        "name": "docker",
+                        "path": "//./pipe/docker_engine/",
+                    },
+                ],
+            }
+        ],
+    )
+
+    pl["clone"] = {
+        "disable": True,
+    }
+
+    return [pl]

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -1,3 +1,7 @@
+"""
+This module contains steps and pipelines relating to creating CI Docker images.
+"""
+
 load(
     "scripts/drone/steps/lib.star",
     "wix_image",
@@ -52,7 +56,7 @@ def publish_ci_windows_test_image_pipeline():
                         "path": "//./pipe/docker_engine/",
                     },
                 ],
-            }
+            },
         ],
     )
 

--- a/scripts/drone/pipelines/windows.star
+++ b/scripts/drone/pipelines/windows.star
@@ -9,7 +9,47 @@ load(
 load(
     "scripts/drone/steps/lib.star",
     "get_windows_steps",
+    "windows_go_image",
+    "windows_init_enterprise_steps",
+    "windows_test_backend_step",
+    "windows_wire_install_step",
 )
+
+def windows_test_backend(trigger, edition, ver_mode):
+    """ Generates a pipeline that runs backend tests on Windows
+
+    Args:
+      trigger: a Drone trigger for the pipeline
+      edition: controls whether enterprise code is included or not
+      ver_mode: controls whether a pre-release or actual release pipeline is generated.
+    Returns:
+        A single pipeline running backend tests for Windows
+    """
+    environment = {"EDITION": edition}
+    steps = []
+
+    if edition == "enterprise":
+        steps.extend(windows_init_enterprise_steps(ver_mode))
+    else:
+        steps.extend([{
+            "name": "windows-init",
+            "image": windows_go_image,
+            "commands": [],
+        }])
+
+    steps.extend([
+        windows_wire_install_step(edition),
+        windows_test_backend_step(),
+    ])
+    return pipeline(
+        name = "{}-{}-test-backend-windows".format(ver_mode, edition),
+        edition = edition,
+        trigger = trigger,
+        steps = steps,
+        depends_on = [],
+        platform = "windows",
+        environment = environment,
+    )
 
 def windows(trigger, edition, ver_mode):
     """Generates the pipeline used for building Grafana on Windows.

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -687,7 +687,9 @@ def test_backend_step(image = build_image):
     }
 
 def windows_test_backend_step():
-    return test_backend_step(image = windows_go_image)
+    step = test_backend_step(image = windows_go_image)
+    step["failure"] = "ignore"
+    return step
 
 def test_backend_integration_step():
     return {

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -17,6 +17,7 @@ curl_image = "byrnedo/alpine-curl:0.1.8"
 windows_image = "mcr.microsoft.com/windows:1809"
 wix_image = "grafana/ci-wix:0.1.1"
 go_image = "golang:1.20.4"
+windows_go_image = "grafana/grafana-ci-windows-test:0.1.0"
 
 trigger_oss = {
     "repo": [
@@ -54,6 +55,19 @@ def wire_install_step():
         ],
         "depends_on": [
             "verify-gen-cue",
+        ],
+    }
+
+def windows_wire_install_step(edition):
+    return {
+        "name": "wire-install",
+        "image": windows_go_image,
+        "commands": [
+            "go install github.com/google/wire/cmd/wire@v0.5.0",
+            "wire gen -tags {} ./pkg/server".format(edition),
+        ],
+        "depends_on": [
+            "windows-init",
         ],
     }
 
@@ -187,6 +201,61 @@ def init_enterprise_step(ver_mode):
             "mv /tmp/grabpl bin/",
         ],
     }
+
+def windows_init_enterprise_steps(ver_mode):
+    """Performs init-enterprise steps in a Windows environment
+
+    Args:
+        ver_mode: in what mode should this be run
+
+    Returns:
+        A list of steps setting up an enterprise folder
+    """
+    if ver_mode == "release":
+        source = "${DRONE_TAG}"
+    elif ver_mode == "release-branch":
+        source = "$$env:DRONE_BRANCH"
+    else:
+        source = "main"
+
+    clone_cmds = [
+        'git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"',
+        "cd grafana-enterprise",
+        "git checkout {}".format(source),
+    ]
+
+    init_cmds = [
+        # Need to move grafana-enterprise out of the way, so directory is empty and can be cloned into
+        "cp -r grafana-enterprise C:\\App\\grafana-enterprise",
+        "rm -r -force grafana-enterprise",
+        "cp grabpl.exe C:\\App\\grabpl.exe",
+        "rm -force grabpl.exe",
+        "C:\\App\\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\\App\\grafana-enterprise",
+        "cp C:\\App\\grabpl.exe grabpl.exe",
+    ]
+
+    steps = []
+    steps.extend(
+        [
+            download_grabpl_step(platform = "windows"),
+            {
+                "name": "clone",
+                "image": wix_image,
+                "environment": {
+                    "GITHUB_TOKEN": from_secret("github_token"),
+                },
+                "commands": clone_cmds,
+            },
+            {
+                "name": "windows-init",
+                "image": wix_image,
+                "commands": init_cmds,
+                "depends_on": ["clone"],
+                "environment": {"GITHUB_TOKEN": from_secret("github_token")},
+            },
+        ],
+    )
+    return steps
 
 def download_grabpl_step(platform = "linux"):
     if platform == "windows":
@@ -605,10 +674,10 @@ def build_plugins_step(edition, ver_mode):
         ],
     }
 
-def test_backend_step():
+def test_backend_step(image = build_image):
     return {
         "name": "test-backend",
-        "image": build_image,
+        "image": image,
         "depends_on": [
             "wire-install",
         ],
@@ -616,6 +685,9 @@ def test_backend_step():
             "go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...",
         ],
     }
+
+def windows_test_backend_step():
+    return test_backend_step(image = windows_go_image)
 
 def test_backend_integration_step():
     return {
@@ -1379,6 +1451,8 @@ def get_windows_steps(edition, ver_mode):
                 },
             ],
         )
+
+    # TODO: Run windows backend tests
 
     if (
         ver_mode == "main" and (edition not in ("enterprise", "enterprise2"))

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -63,6 +63,10 @@ def pipeline(
             },
         }
 
+    docker_mount_path = "/var/run/docker.sock"
+    if platform == "windows":
+        docker_mount_path = "//./pipe/docker_engine/"
+
     pipeline = {
         "kind": "pipeline",
         "type": "docker",
@@ -77,7 +81,7 @@ def pipeline(
             {
                 "name": "docker",
                 "host": {
-                    "path": "/var/run/docker.sock",
+                    "path": docker_mount_path,
                 },
             },
         ],


### PR DESCRIPTION
**What is this feature?**

This runs backend tests on Windows VMs in various places.

**Why do we need this feature?**

There are some edge cases that are only discoverable when we also run the unittests in native Windows environments.

**Who is this feature for?**

Backend & delivery


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-delivery/issues/103

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
