### PR TITLE
NestedFolders: Fix warning from tests, restore page default export

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -21,7 +21,7 @@ interface Props extends GrafanaRouteComponentProps<BrowseDashboardsPageRoutePara
 
 // New Browse/Manage/Search Dashboards views for nested folders
 
-export const BrowseDashboardsPage = memo(({ match, location }: Props) => {
+const BrowseDashboardsPage = memo(({ match, location }: Props) => {
   const { uid: folderUID } = match.params;
 
   const searchState = useMemo(() => {
@@ -45,3 +45,4 @@ export const BrowseDashboardsPage = memo(({ match, location }: Props) => {
 });
 
 BrowseDashboardsPage.displayName = 'BrowseDashboardsPage';
+export default BrowseDashboardsPage;

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -1,37 +1,39 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { BaseQueryFn, createApi } from '@reduxjs/toolkit/query/react';
+import { lastValueFrom } from 'rxjs';
 
+import { BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
 import { FolderDTO } from 'app/types';
 
-// interface RequestOptions extends BackendSrvRequest {
-//   manageError?: (err: unknown) => { error: unknown };
-//   showErrorAlert?: boolean;
-// }
+interface RequestOptions extends BackendSrvRequest {
+  manageError?: (err: unknown) => { error: unknown };
+  showErrorAlert?: boolean;
+}
 
-// function createBackendSrvBaseQuery({ baseURL }: { baseURL: string }): BaseQueryFn<RequestOptions> {
-//   async function backendSrvBaseQuery(requestOptions: RequestOptions) {
-//     try {
-//       const { data: responseData, ...meta } = await lastValueFrom(
-//         getBackendSrv().fetch({
-//           ...requestOptions,
-//           url: baseURL + requestOptions.url,
-//           showErrorAlert: requestOptions.showErrorAlert,
-//         })
-//       );
-//       return { data: responseData, meta };
-//     } catch (error) {
-//       return requestOptions.manageError ? requestOptions.manageError(error) : { error };
-//     }
-//   }
+function createBackendSrvBaseQuery({ baseURL }: { baseURL: string }): BaseQueryFn<RequestOptions> {
+  async function backendSrvBaseQuery(requestOptions: RequestOptions) {
+    try {
+      const { data: responseData, ...meta } = await lastValueFrom(
+        getBackendSrv().fetch({
+          ...requestOptions,
+          url: baseURL + requestOptions.url,
+          showErrorAlert: requestOptions.showErrorAlert,
+        })
+      );
+      return { data: responseData, meta };
+    } catch (error) {
+      return requestOptions.manageError ? requestOptions.manageError(error) : { error };
+    }
+  }
 
-//   return backendSrvBaseQuery;
-// }
+  return backendSrvBaseQuery;
+}
 
 export const browseDashboardsAPI = createApi({
   reducerPath: 'browse-dashboards',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  baseQuery: createBackendSrvBaseQuery({ baseURL: '/api' }),
   endpoints: (builder) => ({
     getFolder: builder.query<FolderDTO, string>({
-      query: (folderUID) => `/folders/${folderUID}`,
+      query: (folderUID) => ({ url: `/folders/${folderUID}` }),
     }),
   }),
 });


### PR DESCRIPTION
 - Fixes new `/nested-dashboards` Browse Dashboards route not loading because the routerrequires a default export
 - Fixes warning in tests from fetch not being available in tests