### PR TITLE
InteractiveTable: Updated design and minor tweak to Correlactions page

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -17,7 +17,6 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     table: css`
       border-radius: ${theme.shape.borderRadius()};
-      // border: solid 1px ${theme.colors.border.weak};
       width: 100%;
 
       td {

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -71,11 +71,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     expandedContentRow: css`
       label: expanded-row-content;
-      border-bottom: 1px solid ${theme.colors.border.weak};
-      position: relative;
-      padding: ${theme.spacing(2, 2, 2, 5)};
 
       td {
+        border-bottom: 1px solid ${theme.colors.border.weak};
+        position: relative;
+        padding: ${theme.spacing(2, 2, 2, 5)};
+
         &:before {
           content: '';
           position: absolute;

--- a/public/app/features/correlations/CorrelationsPage.test.tsx
+++ b/public/app/features/correlations/CorrelationsPage.test.tsx
@@ -173,12 +173,23 @@ const mocks = {
   reportInteraction: jest.fn(),
 };
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  reportInteraction: (...args: Parameters<typeof reportInteraction>) => {
-    mocks.reportInteraction(...args);
-  },
-}));
+jest.mock('@grafana/runtime', () => {
+  const runtime = jest.requireActual('@grafana/runtime');
+
+  return {
+    ...runtime,
+    config: {
+      ...runtime.config,
+      featureToggles: {
+        ...runtime.config.featureToggles,
+        topnav: true,
+      },
+    },
+    reportInteraction: (...args: Parameters<typeof reportInteraction>) => {
+      mocks.reportInteraction(...args);
+    },
+  };
+});
 
 beforeAll(() => {
   mocks.contextSrv.hasPermission.mockImplementation(() => true);

--- a/public/app/features/correlations/CorrelationsPage.tsx
+++ b/public/app/features/correlations/CorrelationsPage.tsx
@@ -136,22 +136,26 @@ export default function CorrelationsPage() {
   );
 
   const data = useMemo(() => get.value, [get.value]);
-
   const showEmptyListCTA = data?.length === 0 && !isAdding && !get.error;
+  const addButton = canWriteCorrelations && data?.length !== 0 && data !== undefined && !isAdding && (
+    <Button icon="plus" onClick={() => setIsAdding(true)}>
+      Add new
+    </Button>
+  );
 
   return (
-    <Page navModel={navModel}>
+    <Page
+      navModel={navModel}
+      subTitle="Define how data living in different data sources relates to each other."
+      actions={addButton}
+    >
       <Page.Contents>
         <div>
           <HorizontalGroup justify="space-between">
-            <div>
+            <Page.OldNavOnly>
               <p>Define how data living in different data sources relates to each other.</p>
-            </div>
-            {canWriteCorrelations && data?.length !== 0 && data !== undefined && !isAdding && (
-              <Button icon="plus" onClick={() => setIsAdding(true)}>
-                Add new
-              </Button>
-            )}
+            </Page.OldNavOnly>
+            <Page.OldNavOnly>{addButton}</Page.OldNavOnly>
           </HorizontalGroup>
         </div>
 


### PR DESCRIPTION
In an effort to align table designs I propose we make this change to the InterativeTable to make it look better and more inline with other tables. 

* Remove table header background (standard Table component does not have this) 
* Remove the surrounding border (Feels unnecessary, placing the table inside a box with border feels like should be up to each use case and not part of the component itself). 
* Add row hover highlight (Same as we have with standard Table component) 
* Remove striped rows and just use border separator for all rows (it's the same in standard Table) 
* For expanded rows we don't show the bottom border, and we add a left border to make the expanded content more connected to the expanded row. 
* Improve indentation of the expanded row content 

Fixes 
* Issue with bad background for even rows where forms where placed on a background they were not designed for (Correlations edit form). 
* Better add button placement on the correlations page 


Before: 
![Screenshot from 2023-04-13 11-40-05](https://user-images.githubusercontent.com/10999/231720012-8f2e1140-4cb5-4235-b7c6-a24fb088dae9.png)

After:
![Screenshot from 2023-04-13 11-31-20](https://user-images.githubusercontent.com/10999/231719570-5cddedc2-a6e0-4281-a74d-438256a3b12c.png)


Also tweaks some things on the correlations page
* Use Page subtitle for the paragraph below instead of the two page descriptions 
* Place add button in the top right corner (Page actions slot) 

Correlations table question
* Think it would make sense to move the "Read only" label to be the last column instead of first 