### PR TITLE
Setup whatwg-fetch as polyfill for Jest

### DIFF
--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -18,8 +18,6 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction, ContactPointsState } from 'app/types';
 
-import 'whatwg-fetch';
-
 import Receivers from './Receivers';
 import { fetchAlertManagerConfig, fetchStatus, testReceivers, updateAlertManagerConfig } from './api/alertmanager';
 import { AlertmanagersChoiceResponse } from './api/alertmanagerApi';

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -19,8 +19,6 @@ import { RuleFormValues } from '../../types/rule-form';
 import { Annotation } from '../../utils/constants';
 import { getDefaultFormValues } from '../../utils/rule-form';
 
-import 'whatwg-fetch';
-
 import AnnotationsField from './AnnotationsField';
 
 // To get anything displayed inside the Autosize component we need to mock it

--- a/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
@@ -3,8 +3,6 @@ import { setupServer } from 'msw/node';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import 'whatwg-fetch';
-
 import { DataSourceJsonData, DataSourceSettings } from '@grafana/data';
 import { config, setBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
-import 'whatwg-fetch';
 import { BootData, DataQuery } from '@grafana/data/src';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { reportInteraction, setEchoSrv } from '@grafana/runtime';

--- a/public/app/features/datasources/components/EmptyStateNoDatasource.test.tsx
+++ b/public/app/features/datasources/components/EmptyStateNoDatasource.test.tsx
@@ -8,7 +8,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { DataSourcePluginMeta } from '@grafana/data';
 import * as runtime from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import 'whatwg-fetch';
 
 import { EmptyStateNoDatasource } from './EmptyStateNoDatasource';
 

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.test.tsx
@@ -3,7 +3,6 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import React from 'react';
 import { Provider } from 'react-redux';
-import 'whatwg-fetch';
 import { BrowserRouter } from 'react-router-dom';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import 'whatwg-fetch';
 import i18next from 'i18next';
 import failOnConsole from 'jest-fail-on-console';
 import { initReactI18next } from 'react-i18next';


### PR DESCRIPTION
**Problem**
[When running Jest](https://drone.grafana.net/grafana/grafana/110671/2/6), logs plenty of `console.warn` because there is no `fetch` existing for the test environment.

Some files use `import whatwg-fetch` but when adding new tests that use fetch behind the scenes, we're adding more `console.warn` without noticing it, because the test passes.

**Solution**
Setup `whatwg-fetch` as a polyfill for tests.