### PR TITLE
Alerting: Hide mute timing actions when dealing with vanilla prometheus

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -188,8 +188,12 @@ const AmRoutes = () => {
     );
   }
 
-  const readOnly = alertManagerSourceName
+  const readOnlyPolicies = alertManagerSourceName
     ? isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName) || isProvisioned
+    : true;
+
+  const readOnlyMuteTimings = alertManagerSourceName
+    ? isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName)
     : true;
 
   const numberOfMuteTimings = result?.alertmanager_config.mute_time_intervals?.length ?? 0;
@@ -254,7 +258,7 @@ const AmRoutes = () => {
                       currentRoute={rootRoute}
                       alertGroups={fetchAlertGroups.result}
                       contactPointsState={contactPointsState.receivers}
-                      readOnly={readOnly}
+                      readOnly={readOnlyPolicies}
                       alertManagerSourceName={alertManagerSourceName}
                       onAddPolicy={openAddModal}
                       onEditPolicy={openEditModal}
@@ -270,7 +274,9 @@ const AmRoutes = () => {
                 {alertInstancesModal}
               </>
             )}
-            {muteTimingsTabActive && <MuteTimingsTable alertManagerSourceName={alertManagerSourceName} />}
+            {muteTimingsTabActive && (
+              <MuteTimingsTable alertManagerSourceName={alertManagerSourceName} hideActions={readOnlyMuteTimings} />
+            )}
           </>
         )}
       </TabContent>

--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -188,13 +188,9 @@ const AmRoutes = () => {
     );
   }
 
-  const readOnlyPolicies = alertManagerSourceName
-    ? isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName) || isProvisioned
-    : true;
-
-  const readOnlyMuteTimings = alertManagerSourceName
-    ? isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName)
-    : true;
+  const vanillaPrometheusAlertManager = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
+  const readOnlyPolicies = alertManagerSourceName ? vanillaPrometheusAlertManager || isProvisioned : true;
+  const readOnlyMuteTimings = alertManagerSourceName ? vanillaPrometheusAlertManager : true;
 
   const numberOfMuteTimings = result?.alertmanager_config.mute_time_intervals?.length ?? 0;
   const haveData = result && !resultError && !resultLoading;

--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -189,8 +189,8 @@ const AmRoutes = () => {
   }
 
   const vanillaPrometheusAlertManager = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
-  const readOnlyPolicies = alertManagerSourceName ? vanillaPrometheusAlertManager || isProvisioned : true;
-  const readOnlyMuteTimings = alertManagerSourceName ? vanillaPrometheusAlertManager : true;
+  const readOnlyPolicies = vanillaPrometheusAlertManager || isProvisioned;
+  const readOnlyMuteTimings = vanillaPrometheusAlertManager;
 
   const numberOfMuteTimings = result?.alertmanager_config.mute_time_intervals?.length ?? 0;
   const haveData = result && !resultError && !resultLoading;


### PR DESCRIPTION
**What is this feature?**

Hides the Mute Timings actions when dealing with a vanilla Prometheus Alertmanager instance; those do not support editing of resources via the API.