### PR TITLE
CI: Remove COPY kinds kinds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN go mod download && \
 
 COPY embed.go Makefile build.go package.json ./
 COPY cue.mod cue.mod
-COPY kinds kinds
 COPY local local
 COPY packages/grafana-schema packages/grafana-schema
 COPY public/app/plugins public/app/plugins


### PR DESCRIPTION
**What is this feature?**

Removes the copying of the `kinds` folder in the Dockerfile since it doesn't exist for v9.2.x.

Bug introduced here: https://github.com/grafana/grafana/pull/66445
