### PR TITLE
Add a "matches only" toggle to trace view

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -31,6 +31,7 @@ function getTraceView(frames: DataFrame[]) {
         splitOpenFn={() => {}}
         traceProp={transformDataFrames(frames[0])!}
         search=""
+        showMatchesOnly={false}
         focusedSpanIdForSearch=""
         queryResponse={mockPanelData}
         datasource={undefined}

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -63,6 +63,7 @@ type Props = {
   scrollElement?: Element;
   traceProp: Trace;
   spanFindMatches?: Set<string>;
+  showMatchesOnly: boolean;
   search: string;
   focusedSpanIdForSearch: string;
   queryResponse: PanelData;
@@ -72,7 +73,7 @@ type Props = {
 };
 
 export function TraceView(props: Props) {
-  const { spanFindMatches, traceProp, datasource, topOfViewRef, topOfViewRefType } = props;
+  const { spanFindMatches, showMatchesOnly, traceProp, datasource, topOfViewRef, topOfViewRefType } = props;
 
   const {
     detailStates,
@@ -162,6 +163,7 @@ export function TraceView(props: Props) {
             registerAccessors={noop}
             scrollToFirstVisibleSpan={noop}
             findMatchesIDs={spanFindMatches}
+            showMatchesOnly={showMatchesOnly}
             trace={traceProp}
             datasourceType={datasourceType}
             spanBarOptions={spanBarOptions?.spanBar}

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -44,6 +44,7 @@ export function TraceViewContainer(props: Props) {
   const { dataFrames, splitOpenFn, exploreId, scrollElement, topOfViewRef, queryResponse } = props;
   const traceProp = useMemo(() => transformDataFrames(frame), [frame]);
   const { search, setSearch, spanFindMatches } = useSearch(traceProp?.spans);
+  const [showMatchesOnly, setMatchesOnly] = useState(false);
   const [focusedSpanIdForSearch, setFocusedSpanIdForSearch] = useState('');
   const [searchBarSuffix, setSearchBarSuffix] = useState('');
   const datasource = useSelector(
@@ -62,6 +63,8 @@ export function TraceViewContainer(props: Props) {
           navigable={true}
           searchValue={search}
           setSearch={setSearch}
+          showMatchesOnly={showMatchesOnly}
+          setMatchesOnly={setMatchesOnly}
           spanFindMatches={spanFindMatches}
           searchBarSuffix={searchBarSuffix}
           setSearchBarSuffix={setSearchBarSuffix}
@@ -77,6 +80,7 @@ export function TraceViewContainer(props: Props) {
         scrollElement={scrollElement}
         traceProp={traceProp}
         spanFindMatches={spanFindMatches}
+        showMatchesOnly={showMatchesOnly}
         search={search}
         focusedSpanIdForSearch={focusedSpanIdForSearch}
         queryResponse={queryResponse}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
@@ -14,11 +14,11 @@
 
 import { css } from '@emotion/css';
 import cx from 'classnames';
-import React, { memo, Dispatch, SetStateAction } from 'react';
+import React, { memo, Dispatch, SetStateAction, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, Field, useStyles2, Switch } from '@grafana/ui';
 
 import UiFindInput from '../common/UiFindInput';
 import { ubFlexAuto, ubJustifyEnd } from '../uberUtilityStyles';
@@ -66,6 +66,13 @@ export const getStyles = (theme: GrafanaTheme2) => {
       label: TracePageSearchBarLocateBtn;
       padding: 1px 8px 4px;
     `,
+    TracePageSearchBarMatchesOnlySwitch: css`
+      display: flex;
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-direction: row;
+      margin-left: 8px;
+    `,
   };
 };
 
@@ -73,6 +80,8 @@ export type TracePageSearchBarProps = {
   navigable: boolean;
   searchValue: string;
   setSearch: (value: string) => void;
+  showMatchesOnly: Boolean;
+  setMatchesOnly: (value: boolean) => void; // TODO(wperron): use the proper types for an event listener
   searchBarSuffix: string;
   spanFindMatches: Set<string> | undefined;
   focusedSpanIdForSearch: string;
@@ -86,6 +95,8 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
     navigable,
     setSearch,
     searchValue,
+    setMatchesOnly,
+    showMatchesOnly,
     searchBarSuffix,
     spanFindMatches,
     focusedSpanIdForSearch,
@@ -94,6 +105,8 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
     datasourceType,
   } = props;
   const styles = useStyles2(getStyles);
+
+  console.log(styles);
 
   const suffix = searchValue ? (
     <span className={styles.TracePageSearchBarSuffix} aria-label="Search bar suffix">
@@ -112,6 +125,9 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
     setFocusedSpanIdForSearch('');
     setSearchBarSuffix('');
     setSearch(value);
+    if (!value) {
+      setMatchesOnly(false);
+    }
   };
 
   const nextResult = () => {
@@ -171,7 +187,13 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
 
   return (
     <div className={styles.TracePageSearchBar}>
-      <span className={ubJustifyEnd} style={{ display: 'flex' }}>
+      <span
+        className={ubJustifyEnd}
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+        }}
+      >
         <UiFindInput
           onChange={setTraceSearch}
           value={searchValue}
@@ -179,6 +201,14 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
           allowClear={true}
         />
         <>
+          <Field label="matches only" className={styles.TracePageSearchBarMatchesOnlySwitch}>
+            <Switch
+              id="show-matches-only"
+              value={!!showMatchesOnly}
+              onChange={(value: React.ChangeEvent<HTMLInputElement>) => setMatchesOnly(value.currentTarget.checked)}
+              disabled={!searchValue}
+            />
+          </Field>
           {navigable && (
             <>
               <Button

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -296,6 +296,7 @@ export type SpanBarRowProps = {
   isChildrenExpanded: boolean;
   isDetailExpanded: boolean;
   isMatchingFilter: boolean;
+  showMatchesOnly: boolean;
   isFocused: boolean;
   onDetailToggled: (spanID: string) => void;
   onChildrenToggled: (spanID: string) => void;
@@ -360,6 +361,7 @@ export class UnthemedSpanBarRow extends React.PureComponent<SpanBarRowProps> {
       isChildrenExpanded,
       isDetailExpanded,
       isMatchingFilter,
+      showMatchesOnly,
       isFocused,
       numTicks,
       rpc,
@@ -411,6 +413,7 @@ export class UnthemedSpanBarRow extends React.PureComponent<SpanBarRowProps> {
 
     return (
       <TimelineRow
+        style={showMatchesOnly && !isMatchingFilter ? { display: 'none' } : {}}
         className={cx(
           styles.row,
           {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineRow.tsx
@@ -33,6 +33,7 @@ const getStyles = () => {
 type TTimelineRowProps = {
   children: React.ReactNode;
   className?: string;
+  style?: React.CSSProperties;
 };
 
 interface TimelineRowCellProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -87,6 +87,7 @@ type TVirtualizedTraceViewOwnProps = {
   currentViewRangeTime: [number, number];
   timeZone: TimeZone;
   findMatchesIDs: Set<string> | TNil;
+  showMatchesOnly: boolean;
   scrollToFirstVisibleSpan: () => void;
   registerAccessors: (accesors: Accessors) => void;
   trace: Trace;
@@ -387,6 +388,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
       detailStates,
       detailToggle,
       findMatchesIDs,
+      showMatchesOnly,
       spanNameColumnWidth,
       trace,
       spanBarOptions,
@@ -449,6 +451,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
           isChildrenExpanded={!isCollapsed}
           isDetailExpanded={isDetailExpanded}
           isMatchingFilter={isMatchingFilter}
+          showMatchesOnly={showMatchesOnly}
           isFocused={isFocused}
           numTicks={NUM_TICKS}
           onDetailToggled={detailToggle}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -74,6 +74,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
 export type TProps = TExtractUiFindFromStateReturn & {
   registerAccessors: (accessors: Accessors) => void;
   findMatchesIDs: Set<string> | TNil;
+  showMatchesOnly: boolean;
   scrollToFirstVisibleSpan: () => void;
   traceTimeline: TTraceTimeline;
   trace: Trace;

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -21,6 +21,7 @@ export const TracesPanel = ({ data }: PanelProps) => {
   const topOfViewRef = createRef<HTMLDivElement>();
   const traceProp = useMemo(() => transformDataFrames(data.series[0]), [data.series]);
   const { search, setSearch, spanFindMatches } = useSearch(traceProp?.spans);
+  const [showMatchesOnly, setMatchesOnly] = useState(false);
   const [focusedSpanIdForSearch, setFocusedSpanIdForSearch] = useState('');
   const [searchBarSuffix, setSearchBarSuffix] = useState('');
   const dataSource = useAsync(async () => {
@@ -45,6 +46,8 @@ export const TracesPanel = ({ data }: PanelProps) => {
           navigable={true}
           searchValue={search}
           setSearch={setSearch}
+          showMatchesOnly={showMatchesOnly}
+          setMatchesOnly={setMatchesOnly}
           spanFindMatches={spanFindMatches}
           searchBarSuffix={searchBarSuffix}
           setSearchBarSuffix={setSearchBarSuffix}
@@ -60,6 +63,7 @@ export const TracesPanel = ({ data }: PanelProps) => {
         traceProp={traceProp}
         spanFindMatches={spanFindMatches}
         search={search}
+        showMatchesOnly={showMatchesOnly}
         focusedSpanIdForSearch={focusedSpanIdForSearch}
         queryResponse={data}
         datasource={dataSource.value}


### PR DESCRIPTION
cc @adrapereira 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
