### PR TITLE
Chore: Restore shouldFailOnLog being enabled only during CI

### DIFF
--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -6,7 +6,7 @@ import { initReactI18next } from 'react-i18next';
 import { matchers } from './matchers';
 
 failOnConsole({
-  shouldFailOnLog: true,
+  shouldFailOnLog: process.env.CI ? true : false,
 });
 
 expect.extend(matchers);


### PR DESCRIPTION
We disabled this during local test running a while back https://github.com/grafana/grafana/pull/59901 but it got inadvertently undone in https://github.com/grafana/grafana/pull/59553