### PR TITLE
NestedFolders: Don't require dev mode for feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -52,6 +52,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `disableAngular`                     | Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime. |
 | `grpcServer`                         | Run the GRPC server                                                                                                                                                                          |
 | `accessControlOnCall`                | Access control primitives for OnCall                                                                                                                                                         |
+| `nestedFolders`                      | Enable folder nesting                                                                                                                                                                        |
 | `alertingNoNormalState`              | Stop maintaining state of alerts that are not firing                                                                                                                                         |
 | `renderAuthJWT`                      | Uses JWT-based auth for rendering instead of relying on remote cache                                                                                                                         |
 | `enableElasticsearchBackendQuerying` | Enable the processing of queries and responses in the Elasticsearch data source through backend                                                                                              |
@@ -119,5 +120,4 @@ The following toggles require explicitly setting Grafana's [app mode]({{< relref
 | --------------------- | -------------------------------------------------------------- |
 | `k8s`                 | Explore native k8s integrations                                |
 | `entityStore`         | SQL-based entity store (requires storage flag also)            |
-| `nestedFolders`       | Enable folder nesting                                          |
 | `externalServiceAuth` | Starts an OAuth2 authentication provider for external services |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -279,11 +279,10 @@ var (
 			Owner:       grafanaAuthnzSquad,
 		},
 		{
-			Name:            "nestedFolders",
-			Description:     "Enable folder nesting",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true,
-			Owner:           grafanaBackendPlatformSquad,
+			Name:        "nestedFolders",
+			Description: "Enable folder nesting",
+			State:       FeatureStateBeta,
+			Owner:       grafanaBackendPlatformSquad,
 		},
 		{
 			Name:        "accessTokenExpirationCheck",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -40,7 +40,7 @@ newPanelChromeUI,stable,@grafana/dashboards-squad,false,false,false,true
 showDashboardValidationWarnings,alpha,@grafana/dashboards-squad,false,false,false,false
 mysqlAnsiQuotes,alpha,@grafana/backend-platform,false,false,false,false
 accessControlOnCall,beta,@grafana/grafana-authnz-team,false,false,false,false
-nestedFolders,alpha,@grafana/backend-platform,true,false,false,false
+nestedFolders,beta,@grafana/backend-platform,false,false,false,false
 accessTokenExpirationCheck,stable,@grafana/grafana-authnz-team,false,false,false,false
 showTraceId,alpha,@grafana/observability-logs,false,false,false,false
 datasourceOnboarding,alpha,@grafana/dashboards-squad,false,false,false,false


### PR DESCRIPTION
We no longer require dev mode for nestedFolders feature toggle, enabling the feature toggle to be used in Grafana Cloud.

Part of https://github.com/grafana/grafana/issues/65604