### PR TITLE
Azure Monitor: Fix bug that was not showing resources for certain locations

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -45,7 +45,7 @@ export function createMockResourcePickerData() {
   mockResourcePicker.getResourcesForResourceGroup = jest.fn().mockResolvedValue(mockResourcesByResourceGroup());
   mockResourcePicker.getResourceURIFromWorkspace = jest.fn().mockReturnValue('');
   mockResourcePicker.getResourceURIDisplayProperties = jest.fn().mockResolvedValue({});
-  mockResourcePicker.getLogsLocations = jest.fn().mockResolvedValue(mockGetValidLocations());
+  mockResourcePicker.getLocations = jest.fn().mockResolvedValue(mockGetValidLocations());
   return mockResourcePicker;
 }
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -34,8 +34,8 @@ const createResourcePickerData = (responses: AzureGraphResponse[]) => {
   resourcePickerData.postResource = postResource;
   const logLocationsMap = mockGetValidLocations();
   const getLogsLocations = jest.spyOn(resourcePickerData, 'getLogsLocations').mockResolvedValue(logLocationsMap);
-  resourcePickerData.logLocationsMap = logLocationsMap;
-  resourcePickerData.logLocations = Array.from(logLocationsMap.values()).map((location) => `"${location.name}"`);
+  resourcePickerData.locationsMap = logLocationsMap;
+  resourcePickerData.locations = Array.from(logLocationsMap.values()).map((location) => `"${location.name}"`);
   return { resourcePickerData, postResource, mockDatasource, getValidLocations: getLogsLocations };
 };
 
@@ -403,7 +403,6 @@ describe('AzureMonitor resourcePickerData', () => {
       expect(locations.has('northeurope')).toBe(true);
       expect(locations.get('northeurope')?.name).toBe('northeurope');
       expect(locations.get('northeurope')?.displayName).toBe('North Europe');
-      expect(locations.get('northeurope')?.supportsLogs).toBe(true);
     });
 
     it('returns the raw locations map if provider is undefined', async () => {
@@ -419,7 +418,6 @@ describe('AzureMonitor resourcePickerData', () => {
       expect(locations.has('northeurope')).toBe(true);
       expect(locations.get('northeurope')?.name).toBe('northeurope');
       expect(locations.get('northeurope')?.displayName).toBe('North Europe');
-      expect(locations.get('northeurope')?.supportsLogs).toBe(false);
     });
   });
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -32,11 +32,11 @@ const createResourcePickerData = (responses: AzureGraphResponse[]) => {
     postResource.mockResolvedValueOnce(res);
   });
   resourcePickerData.postResource = postResource;
-  const logLocationsMap = mockGetValidLocations();
-  const getLogsLocations = jest.spyOn(resourcePickerData, 'getLogsLocations').mockResolvedValue(logLocationsMap);
-  resourcePickerData.locationsMap = logLocationsMap;
-  resourcePickerData.locations = Array.from(logLocationsMap.values()).map((location) => `"${location.name}"`);
-  return { resourcePickerData, postResource, mockDatasource, getValidLocations: getLogsLocations };
+  const locationsMap = mockGetValidLocations();
+  const getLocations = jest.spyOn(resourcePickerData, 'getLocations').mockResolvedValue(locationsMap);
+  resourcePickerData.locationsMap = locationsMap;
+  resourcePickerData.locations = Array.from(locationsMap.values()).map((location) => `"${location.name}"`);
+  return { resourcePickerData, postResource, mockDatasource, getValidLocations: getLocations };
 };
 
 describe('AzureMonitor resourcePickerData', () => {
@@ -397,7 +397,7 @@ describe('AzureMonitor resourcePickerData', () => {
       const { resourcePickerData, getValidLocations } = createResourcePickerData([createMockARGSubscriptionResponse()]);
       getValidLocations.mockRestore();
       const subscriptions = await resourcePickerData.getSubscriptions();
-      const locations = await resourcePickerData.getLogsLocations(subscriptions);
+      const locations = await resourcePickerData.getLocations(subscriptions);
 
       expect(locations.size).toBe(1);
       expect(locations.has('northeurope')).toBe(true);
@@ -412,7 +412,7 @@ describe('AzureMonitor resourcePickerData', () => {
       getValidLocations.mockRestore();
       mockDatasource.azureMonitorDatasource.getProvider = jest.fn().mockResolvedValue(undefined);
       const subscriptions = await resourcePickerData.getSubscriptions();
-      const locations = await resourcePickerData.getLogsLocations(subscriptions);
+      const locations = await resourcePickerData.getLocations(subscriptions);
 
       expect(locations.size).toBe(1);
       expect(locations.has('northeurope')).toBe(true);

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -395,7 +395,6 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
   async getLocations(subscriptions: ResourceRowGroup): Promise<Map<string, AzureMonitorLocations>> {
     const subscriptionIds = subscriptions.map((sub) => sub.id);
     const locations = await this.azureMonitorDatasource.getLocations(subscriptionIds);
-
     return locations;
   }
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -58,7 +58,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     const subscriptions = await this.getSubscriptions();
 
     if (this.locationsMap.size === 0) {
-      this.locationsMap = await this.getLogsLocations(subscriptions);
+      this.locationsMap = await this.getLocations(subscriptions);
       this.locations = Array.from(this.locationsMap.values()).map((location) => `"${location.name}"`);
     }
 
@@ -392,12 +392,11 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     this.supportedMetricNamespaces = uniq(supportedMetricNamespaces).join(',');
   }
 
-  async getLogsLocations(subscriptions: ResourceRowGroup): Promise<Map<string, AzureMonitorLocations>> {
+  async getLocations(subscriptions: ResourceRowGroup): Promise<Map<string, AzureMonitorLocations>> {
     const subscriptionIds = subscriptions.map((sub) => sub.id);
     const locations = await this.azureMonitorDatasource.getLocations(subscriptionIds);
-    const locationsMap = new Map<string, AzureMonitorLocations>(locations);
 
-    return locationsMap;
+    return locations;
   }
 
   parseRows(resources: Array<string | AzureMonitorResource>): ResourceRow[] {


### PR DESCRIPTION
Azure Monitor currently automatically retrieves locations based on a users subscriptions. This PR fixes a bug where the locations were not all being retrieved by eliminating unnecessary filtering.

Fixes #63890