### PR TITLE
Prometheus: Fix ad-hoc filters

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -72,7 +72,7 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
       return;
     }
 
-    datasource.getLabelNames().then((labelNames: Array<{ text: string }>) => {
+    datasource.getTagKeys().then((labelNames: Array<{ text: string }>) => {
       setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
     });
   }, [datasource, qryType]);

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -167,7 +167,7 @@ describe('PrometheusDatasource', () => {
       ).rejects.toMatchObject({
         message: expect.stringMatching('Browser access'),
       });
-      await expect(directDs.getLabelNames()).rejects.toMatchObject({
+      await expect(directDs.getTagKeys()).rejects.toMatchObject({
         message: expect.stringMatching('Browser access'),
       });
       await expect(directDs.getTagValues()).rejects.toMatchObject({

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -94,6 +94,16 @@ describe('PrometheusDatasource', () => {
     ds = new PrometheusDatasource(instanceSettings, templateSrvStub, timeSrvStub);
   });
 
+  // Some functions are required by the parent datasource class to provide functionality such as ad-hoc filters, which requires the definition of the getTagKeys, and getTagValues functions
+  describe('Datasource contract', () => {
+    it('has function called getTagKeys', () => {
+      expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ds))).toContain('getTagKeys');
+    });
+    it('has function called getTagValues', () => {
+      expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ds))).toContain('getTagValues');
+    });
+  });
+
   describe('Query', () => {
     it('returns empty array when no queries', async () => {
       await expect(ds.query(createDataRequest([]))).toEmitValuesWith((response) => {

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -934,10 +934,11 @@ export class PrometheusDatasource
     );
   }
 
+  // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   // this is used to get label keys, a.k.a label names
   // it is used in metric_find_query.ts
   // and in Tempo here grafana/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
-  async getLabelNames(options?: any) {
+  async getTagKeys(options?: any) {
     if (options?.series) {
       // Get tags for the provided series only
       const seriesLabels: Array<Record<string, string[]>> = await Promise.all(
@@ -956,6 +957,7 @@ export class PrometheusDatasource
     }
   }
 
+  // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   async getTagValues(options: { key?: string } = {}) {
     const params = this.getTimeRangeParams();
     const result = await this.metadataRequest(`/api/v1/label/${options.key}/values`, params);

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -25,7 +25,7 @@ export default class PrometheusMetricFindQuery {
     const queryResultRegex = /^query_result\((.+)\)\s*$/;
     const labelNamesQuery = this.query.match(labelNamesRegex);
     if (labelNamesQuery) {
-      return this.datasource.getLabelNames();
+      return this.datasource.getTagKeys();
     }
 
     const labelValuesQuery = this.query.match(labelValuesRegex);

--- a/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
@@ -29,7 +29,7 @@ export function ServiceGraphSection({
   const [hasKeys, setHasKeys] = useState<boolean | undefined>(undefined);
   useEffect(() => {
     async function fn(ds: PrometheusDatasource) {
-      const keys = await ds.getLabelNames({
+      const keys = await ds.getTagKeys({
         series: [
           'traces_service_graph_request_server_seconds_sum',
           'traces_service_graph_request_total',


### PR DESCRIPTION
Refactor label names function back to getTagKeys to fulfill contract with parent class required for ad-hoc functionality

**What is this feature?**
Fix ad-hoc filter functionality with prometheus datasources in 9.5

Fixes https://github.com/grafana/grafana/issues/66520

**Special notes for your reviewer:**


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
