### PR TITLE
Google Cloud Monitoring: Fix project variable

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -645,7 +645,7 @@ func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, e
 
 	instance, ok := i.(*datasourceInfo)
 	if !ok {
-		return nil, fmt.Errorf("failed to cast datsource info")
+		return nil, fmt.Errorf("failed to cast datasource info")
 	}
 
 	return instance, nil

--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
@@ -62,7 +62,7 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
 
   async componentDidMount() {
     await this.props.datasource.ensureGCEDefaultProject();
-    const projectName = this.props.datasource.getDefaultProject();
+    const projectName = this.props.query.projectName || this.props.datasource.getDefaultProject();
     const projects = (await this.props.datasource.getProjects()) as MetricDescriptor[];
     const metricDescriptors = await this.props.datasource.getMetricTypes(
       this.props.query.projectName || this.props.datasource.getDefaultProject()


### PR DESCRIPTION
**What is this feature?**

Checks if there is a project variable defined before returning the default project in the variable query editor.

Fixes #66523

