### PR TITLE
Cloudwatch: Change type of `ts` field in log responses to `time`

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -164,7 +165,7 @@ func (e *cloudWatchExecutor) handleGetLogEvents(ctx context.Context, logsClient 
 	}
 
 	messages := make([]*string, 0)
-	timestamps := make([]*int64, 0)
+	timestamps := make([]time.Time, 0)
 
 	sort.Slice(logEvents.Events, func(i, j int) bool {
 		return *(logEvents.Events[i].Timestamp) > *(logEvents.Events[j].Timestamp)
@@ -172,7 +173,7 @@ func (e *cloudWatchExecutor) handleGetLogEvents(ctx context.Context, logsClient 
 
 	for _, event := range logEvents.Events {
 		messages = append(messages, event.Message)
-		timestamps = append(timestamps, event.Timestamp)
+		timestamps = append(timestamps, time.UnixMilli(*event.Timestamp).UTC())
 	}
 
 	timestampField := data.NewField("ts", nil, timestamps)

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -1,7 +1,10 @@
 package mocks
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,4 +49,16 @@ func (f *MockFeatures) IsEnabled(feature string) bool {
 	args := f.Called(feature)
 
 	return args.Bool(0)
+}
+
+type MockLogEvents struct {
+	cloudwatchlogsiface.CloudWatchLogsAPI
+
+	mock.Mock
+}
+
+func (m *MockLogEvents) GetLogEventsWithContext(ctx aws.Context, input *cloudwatchlogs.GetLogEventsInput, option ...request.Option) (*cloudwatchlogs.GetLogEventsOutput, error) {
+	args := m.Called(ctx, input, option)
+
+	return args.Get(0).(*cloudwatchlogs.GetLogEventsOutput), args.Error(1)
 }


### PR DESCRIPTION
**What is this feature?**

The `ts` field of DataFrames returned from the Cloudwatch Logs datasource is currently `string`, but should be a `time` field. This parses the previously used int64 to Time.

