### PR TITLE
Dashboard: Clear current dashboard when moving away from dashboard

### DIFF
--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -49,14 +49,11 @@ export class DashboardSrv {
     return new DashboardModel(dashboard, meta);
   }
 
-  setCurrent(dashboard: DashboardModel) {
+  setCurrent(dashboard: DashboardModel | undefined) {
     this.dashboard = dashboard;
   }
 
   getCurrent(): DashboardModel | undefined {
-    if (!this.dashboard) {
-      console.warn('Calling getDashboardSrv().getCurrent() without calling getDashboardSrv().setCurrent() first.');
-    }
     return this.dashboard;
   }
 

--- a/public/app/features/dashboard/state/actions.ts
+++ b/public/app/features/dashboard/state/actions.ts
@@ -9,6 +9,7 @@ import { DashboardAcl, DashboardAclUpdateDTO, NewDashboardAclItem, PermissionLev
 
 import { loadPluginDashboards } from '../../plugins/admin/state/actions';
 import { cancelVariables } from '../../variables/state/actions';
+import { getDashboardSrv } from '../services/DashboardSrv';
 import { getTimeSrv } from '../services/TimeSrv';
 
 import { cleanUpDashboard, loadDashboardPermissions } from './reducers';
@@ -124,10 +125,12 @@ export const cleanUpDashboardAndVariables = (): ThunkResult<void> => (dispatch, 
   }
 
   getTimeSrv().stopAutoRefresh();
-
   dispatch(cleanUpDashboard());
   dispatch(removeAllPanels());
+
   dashboardWatcher.leave();
+
+  getDashboardSrv().setCurrent(undefined);
 };
 
 export const updateTimeZoneDashboard =


### PR DESCRIPTION

* [x] Clear current dashboard state when moving away from a dashboard
* [x] Remove warning when calling getCurrent when there is no dashboard set (seeing this in scenes app from the query analytics event) 