### PR TITLE
Explore: fix table sizing with few rows

### DIFF
--- a/public/app/features/explore/TableContainer.tsx
+++ b/public/app/features/explore/TableContainer.tsx
@@ -46,7 +46,7 @@ export class TableContainer extends PureComponent<Props> {
     }
 
     // tries to estimate table height
-    return Math.max(Math.min(600, mainFrame.length * 35) + 35);
+    return Math.max(Math.min(600, mainFrame.length * 36) + 40 + 46);
   }
 
   render() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

https://github.com/grafana/grafana/pull/66370 made explore starting using the new panel chrome, which caused the "magic" calculation in Explore to be outdated, resulting in tables with few rows to be unreadable. 

BEFORE:
![Screenshot 2023-04-14 at 09 33 33](https://user-images.githubusercontent.com/1170767/231990321-15bf06b0-5399-4952-962a-4516c018ed67.png)


this PR introduces a new "magic" calculation. it's not either more scalable or more future-proof. just updated magic.

AFTER:
![Screenshot 2023-04-14 at 09 32 32](https://user-images.githubusercontent.com/1170767/231990066-957f89e6-9a3e-40a7-b919-3139338b5f71.png)


**Why do we need this feature?**

Ie. instant queries in loki are very common and are likely to produce something similar

**Who is this feature for?**

Explore users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
