### PR TITLE
Remove DS drawer feature toggle, to add a new one for the new DS picker

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -92,7 +92,6 @@ Alpha features might be changed or removed without prior notice.
 | `lokiQuerySplittingConfig`         | Give users the option to configure split durations for Loki queries                                                                                                                                 |
 | `individualCookiePreferences`      | Support overriding cookie preferences per user                                                                                                                                                      |
 | `onlyExternalOrgRoleSync`          | Prohibits a user from changing organization roles synced with external auth providers                                                                                                               |
-| `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                                                  |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                                           |
 | `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                                                |
 | `timeSeriesTable`                  | Enable time series table transformer & sparkline cell type                                                                                                                                          |
@@ -109,6 +108,7 @@ Alpha features might be changed or removed without prior notice.
 | `pyroscopeFlameGraph`              | Changes flame graph to pyroscope one                                                                                                                                                                |
 | `dataplaneFrontendFallback`        | Support dataplane contract field name change for transformations and field name matchers where the name is different                                                                                |
 | `authenticationConfigUI`           | Enables authentication configuration UI                                                                                                                                                             |
+| `advancedDataSourcePicker`         | Enable a new data source picker with contextual information, recently used order, CSV upload and advanced mode                                                                                      |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -76,7 +76,6 @@ export interface FeatureToggles {
   lokiQuerySplittingConfig?: boolean;
   individualCookiePreferences?: boolean;
   onlyExternalOrgRoleSync?: boolean;
-  drawerDataSourcePicker?: boolean;
   traceqlSearch?: boolean;
   prometheusMetricEncyclopedia?: boolean;
   timeSeriesTable?: boolean;
@@ -97,4 +96,5 @@ export interface FeatureToggles {
   useCachingService?: boolean;
   enableElasticsearchBackendQuerying?: boolean;
   authenticationConfigUI?: boolean;
+  advancedDataSourcePicker?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -392,13 +392,6 @@ var (
 			Owner:       grafanaAuthnzSquad,
 		},
 		{
-			Name:         "drawerDataSourcePicker",
-			Description:  "Changes the user experience for data source selection to a drawer.",
-			State:        FeatureStateAlpha,
-			FrontendOnly: true,
-			Owner:        grafanaBiSquad,
-		},
-		{
 			Name:         "traceqlSearch",
 			Description:  "Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries",
 			State:        FeatureStateAlpha,
@@ -525,6 +518,13 @@ var (
 			Description: "Enables authentication configuration UI",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAuthnzSquad,
+		},
+		{
+			Name:         "advancedDataSourcePicker",
+			Description:  "Enable a new data source picker with contextual information, recently used order, CSV upload and advanced mode",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -57,7 +57,6 @@ lokiQuerySplitting,alpha,@grafana/observability-logs,false,false,false,true
 lokiQuerySplittingConfig,alpha,@grafana/observability-logs,false,false,false,true
 individualCookiePreferences,alpha,@grafana/backend-platform,false,false,false,false
 onlyExternalOrgRoleSync,alpha,@grafana/grafana-authnz-team,false,false,false,false
-drawerDataSourcePicker,alpha,@grafana/grafana-bi-squad,false,false,false,true
 traceqlSearch,alpha,@grafana/observability-traces-and-profiling,false,false,false,true
 prometheusMetricEncyclopedia,alpha,@grafana/observability-metrics,false,false,false,true
 timeSeriesTable,alpha,@grafana/app-o11y,false,false,false,true
@@ -78,3 +77,4 @@ dataplaneFrontendFallback,alpha,@grafana/observability-metrics,false,false,false
 useCachingService,stable,@grafana/grafana-operator-experience-squad,false,false,true,false
 enableElasticsearchBackendQuerying,beta,@grafana/observability-logs,false,false,false,false
 authenticationConfigUI,alpha,@grafana/grafana-authnz-team,false,false,false,false
+advancedDataSourcePicker,alpha,@grafana/dashboards-squad,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -239,10 +239,6 @@ const (
 	// Prohibits a user from changing organization roles synced with external auth providers
 	FlagOnlyExternalOrgRoleSync = "onlyExternalOrgRoleSync"
 
-	// FlagDrawerDataSourcePicker
-	// Changes the user experience for data source selection to a drawer.
-	FlagDrawerDataSourcePicker = "drawerDataSourcePicker"
-
 	// FlagTraceqlSearch
 	// Enables the &#39;TraceQL Search&#39; tab for the Tempo datasource which provides a UI to generate TraceQL queries
 	FlagTraceqlSearch = "traceqlSearch"
@@ -322,4 +318,8 @@ const (
 	// FlagAuthenticationConfigUI
 	// Enables authentication configuration UI
 	FlagAuthenticationConfigUI = "authenticationConfigUI"
+
+	// FlagAdvancedDataSourcePicker
+	// Enable a new data source picker with contextual information, recently used order, CSV upload and advanced mode
+	FlagAdvancedDataSourcePicker = "advancedDataSourcePicker"
 )

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -214,7 +214,7 @@ export class QueryGroup extends PureComponent<Props, State> {
             Data source
           </InlineFormLabel>
           <div className={styles.dataSourceRowItem}>
-            {config.featureToggles.drawerDataSourcePicker ? (
+            {config.featureToggles.advancedDataSourcePicker ? (
               <DataSourcePickerWithHistory
                 onChange={this.onChangeDataSource}
                 current={options.dataSource}


### PR DESCRIPTION
The current drawer feature will be removed in favor of a new DS picker dropdown. This will go in v10 so this PR is removing the old feature toggle, in favor of the new one.

In the next PR, we will replace the drawer component with the new dropdown. The old feature toggle is only enabled internally in ops, and it is deactivated.