### PR TITLE
EmptyDashboard: Fix wrong font weight

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -130,7 +130,7 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     headerSection: css({
       label: 'header-section',
-      fontWeight: 600,
+      fontWeight: theme.typography.fontWeightMedium,
       textAlign: 'center',
     }),
     headerBig: css({


### PR DESCRIPTION
Notice that the font weight looked off on the empty dashboard page, and indeed the headings where using a non theme font weight (that we don't have an inter font version for). 

We should really change the h1-h5 so they by default use font weight medium, will look into changing that for G10

Before:
![Screenshot from 2023-04-14 12-09-41](https://user-images.githubusercontent.com/10999/232016374-cc17c6f7-2ed4-4f63-b861-07d46ddaa473.png)

After:  
![Screenshot from 2023-04-14 12-09-23](https://user-images.githubusercontent.com/10999/232016401-c4d38b3c-bcc4-4288-9bb1-eafeb6f93ca7.png)

