### PR TITLE
Alerting: Split silences view expired/not-expired

### DIFF
--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -51,7 +51,8 @@ const dataSources = {
 
 const ui = {
   notExpiredTable: byTestId('not-expired-table'),
-  expiredTable: byTestId('not-expired-table'),
+  expiredTable: byTestId('expired-table'),
+  expiredCaret: byText(/expired/i),
   silenceRow: byTestId('row'),
   silencedAlertCell: byTestId('alerts'),
   addSilenceButton: byRole('button', { name: /add silence/i }),
@@ -131,13 +132,23 @@ describe('Silences', () => {
       renderSilences();
       await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
       await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
-      expect(ui.notExpiredTable.query()).not.toBeNull();
 
-      const silences = ui.silenceRow.queryAll();
+      await userEvent.click(ui.expiredCaret.get());
+      expect(ui.notExpiredTable.get()).not.toBeNull();
+      expect(ui.expiredTable.get()).not.toBeNull();
+      let silences = ui.silenceRow.queryAll();
       expect(silences).toHaveLength(3);
       expect(silences[0]).toHaveTextContent('foo=bar');
       expect(silences[1]).toHaveTextContent('foo!=bar');
       expect(silences[2]).toHaveTextContent('foo=bar');
+
+      await userEvent.click(ui.expiredCaret.getAll()[0]);
+      expect(ui.notExpiredTable.get()).not.toBeNull();
+      expect(ui.expiredTable.query()).toBeNull();
+      silences = ui.silenceRow.queryAll();
+      expect(silences).toHaveLength(2);
+      expect(silences[0]).toHaveTextContent('foo=bar');
+      expect(silences[1]).toHaveTextContent('foo!=bar');
     },
     TEST_TIMEOUT
   );

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -5,13 +5,15 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { byLabelText, byPlaceholderText, byRole, byTestId, byText } from 'testing-library-selector';
 
 import { dateTime } from '@grafana/data';
-import { locationService, setDataSourceSrv, config } from '@grafana/runtime';
+import { config, locationService, setDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertState, MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
 
+import { SilenceState } from '../../../plugins/datasource/alertmanager/types';
+
 import Silences from './Silences';
-import { fetchSilences, fetchAlerts, createOrUpdateSilence } from './api/alertmanager';
+import { createOrUpdateSilence, fetchAlerts, fetchSilences } from './api/alertmanager';
 import { mockAlertmanagerAlert, mockDataSource, MockDataSourceSrv, mockSilence } from './mocks';
 import { parseMatchers } from './utils/alertmanager';
 import { DataSourceType } from './utils/datasource';
@@ -48,7 +50,8 @@ const dataSources = {
 };
 
 const ui = {
-  silencesTable: byTestId('dynamic-table'),
+  notExpiredTable: byTestId('not-expired-table'),
+  expiredTable: byTestId('not-expired-table'),
   silenceRow: byTestId('row'),
   silencedAlertCell: byTestId('alerts'),
   addSilenceButton: byRole('button', { name: /add silence/i }),
@@ -75,6 +78,7 @@ const resetMocks = () => {
     return Promise.resolve([
       mockSilence({ id: '12345' }),
       mockSilence({ id: '67890', matchers: parseMatchers('foo!=bar'), comment: 'Catch all' }),
+      mockSilence({ id: '1111', status: { state: SilenceState.Expired } }),
     ]);
   });
 
@@ -127,13 +131,13 @@ describe('Silences', () => {
       renderSilences();
       await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
       await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
-
-      expect(ui.silencesTable.query()).not.toBeNull();
+      expect(ui.notExpiredTable.query()).not.toBeNull();
 
       const silences = ui.silenceRow.queryAll();
-      expect(silences).toHaveLength(2);
+      expect(silences).toHaveLength(3);
       expect(silences[0]).toHaveTextContent('foo=bar');
       expect(silences[1]).toHaveTextContent('foo!=bar');
+      expect(silences[2]).toHaveTextContent('foo=bar');
     },
     TEST_TIMEOUT
   );
@@ -158,7 +162,7 @@ describe('Silences', () => {
       await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
       await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
 
-      const silencedAlertRows = ui.silencedAlertCell.getAll(ui.silencesTable.get());
+      const silencedAlertRows = ui.silencedAlertCell.getAll(ui.notExpiredTable.get());
       expect(silencedAlertRows).toHaveLength(2);
       expect(silencedAlertRows[0]).toHaveTextContent('2');
       expect(silencedAlertRows[1]).toHaveTextContent('0');
@@ -177,7 +181,7 @@ describe('Silences', () => {
       await userEvent.click(queryBar);
       await userEvent.paste('foo=bar');
 
-      await waitFor(() => expect(ui.silenceRow.getAll()).toHaveLength(1));
+      await waitFor(() => expect(ui.silenceRow.getAll()).toHaveLength(2));
     },
     TEST_TIMEOUT
   );

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -55,7 +55,7 @@ const ui = {
   expiredCaret: byText(/expired/i),
   silenceRow: byTestId('row'),
   silencedAlertCell: byTestId('alerts'),
-  addSilenceButton: byRole('button', { name: /add silence/i }),
+  addSilenceButton: byRole('link', { name: /add silence/i }),
   queryBar: byPlaceholderText('Search'),
   editor: {
     timeRange: byLabelText('Timepicker', { exact: false }),

--- a/public/app/features/alerting/unified/components/DynamicTable.tsx
+++ b/public/app/features/alerting/unified/components/DynamicTable.tsx
@@ -28,6 +28,7 @@ export interface DynamicTableItemProps<T = unknown> {
 export interface DynamicTableProps<T = unknown> {
   cols: Array<DynamicTableColumnProps<T>>;
   items: Array<DynamicTableItemProps<T>>;
+  dataTestId?: string;
 
   isExpandable?: boolean;
   pagination?: DynamicTablePagination;
@@ -70,6 +71,7 @@ export const DynamicTable = <T extends object>({
   renderPrefixCell,
   renderPrefixHeader,
   footerRow,
+  dataTestId,
 }: DynamicTableProps<T>) => {
   const defaultPaginationStyles = useStyles2(getPaginationStyles);
 
@@ -98,7 +100,7 @@ export const DynamicTable = <T extends object>({
 
   return (
     <>
-      <div className={styles.container} data-testid="dynamic-table">
+      <div className={styles.container} data-testid={dataTestId ?? 'dynamic-table'}>
         <div className={styles.row} data-testid="header">
           {renderPrefixHeader && renderPrefixHeader()}
           {isExpandable && <div className={styles.cell} />}

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -2,36 +2,26 @@ import { css } from '@emotion/css';
 import { debounce, uniqueId } from 'lodash';
 import React, { FormEvent, useState } from 'react';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Label, Icon, Input, Tooltip, RadioButtonGroup, useStyles2, Button, Field } from '@grafana/ui';
+import { Button, Field, Icon, Input, Label, Tooltip, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
-import { SilenceState } from 'app/plugins/datasource/alertmanager/types';
 
 import { parseMatchers } from '../../utils/alertmanager';
 import { getSilenceFiltersFromUrlParams } from '../../utils/misc';
-
-const stateOptions: SelectableValue[] = Object.entries(SilenceState).map(([key, value]) => ({
-  label: key,
-  value,
-}));
 
 const getQueryStringKey = () => uniqueId('query-string-');
 
 export const SilencesFilter = () => {
   const [queryStringKey, setQueryStringKey] = useState(getQueryStringKey());
   const [queryParams, setQueryParams] = useQueryParams();
-  const { queryString, silenceState } = getSilenceFiltersFromUrlParams(queryParams);
+  const { queryString } = getSilenceFiltersFromUrlParams(queryParams);
   const styles = useStyles2(getStyles);
 
   const handleQueryStringChange = debounce((e: FormEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
     setQueryParams({ queryString: target.value || null });
   }, 400);
-
-  const handleSilenceStateChange = (state: string) => {
-    setQueryParams({ silenceState: state });
-  };
 
   const clearFilters = () => {
     setQueryParams({
@@ -77,10 +67,8 @@ export const SilencesFilter = () => {
           data-testid="search-query-input"
         />
       </Field>
-      <Field className={styles.rowChild} label="State">
-        <RadioButtonGroup options={stateOptions} value={silenceState} onChange={handleSilenceStateChange} />
-      </Field>
-      {(queryString || silenceState) && (
+
+      {queryString && (
         <div className={styles.rowChild}>
           <Button variant="secondary" icon="times" onClick={clearFilters}>
             Clear filters

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -87,8 +87,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: row;
     align-items: flex-end;
-    padding-bottom: ${theme.spacing(2)};
-    border-bottom: 1px solid ${theme.colors.border.strong};
+    padding-bottom: ${theme.spacing(3)};
+    border-bottom: 1px solid ${theme.colors.border.medium};
   `,
   rowChild: css`
     margin-right: ${theme.spacing(1)};

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 
 import { dateMath, GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, CollapsableSection, Icon, Link, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, Icon, Link, LinkButton, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertmanagerAlert, Silence, SilenceState } from 'app/plugins/datasource/alertmanager/types';
@@ -75,15 +75,13 @@ const SilencesTable = ({ silences, alertManagerAlerts, alertManagerSourceName }:
   return (
     <div data-testid="silences-table">
       {!!silences.length && (
-        <>
+        <Stack direction="column">
           <SilencesFilter />
           <Authorize actions={[permissions.create]} fallback={contextSrv.isEditor}>
             <div className={styles.topButtonContainer}>
-              <Link href={makeAMLink('/alerting/silence/new', alertManagerSourceName)}>
-                <Button className={styles.addNewSilence} icon="plus">
-                  Add Silence
-                </Button>
-              </Link>
+              <LinkButton href={makeAMLink('/alerting/silence/new', alertManagerSourceName)} icon="plus">
+                Add Silence
+              </LinkButton>
             </div>
           </Authorize>
           <SilenceList
@@ -91,18 +89,20 @@ const SilencesTable = ({ silences, alertManagerAlerts, alertManagerSourceName }:
             alertManagerSourceName={alertManagerSourceName}
             dataTestId="not-expired-table"
           />
-          <CollapsableSection label="Expired" isOpen={showExpiredFromUrl} className={styles.wrapper}>
-            <div className={styles.callout}>
-              <Icon className={styles.calloutIcon} name="info-circle" />
-              <span>Expired silences are automatically deleted after 5 days.</span>
-            </div>
-            <SilenceList
-              items={itemsExpired}
-              alertManagerSourceName={alertManagerSourceName}
-              dataTestId="expired-table"
-            />
-          </CollapsableSection>
-        </>
+          {itemsExpired.length > 0 && (
+            <CollapsableSection label={`Expired silences (${itemsExpired.length})`} isOpen={showExpiredFromUrl}>
+              <div className={styles.callout}>
+                <Icon className={styles.calloutIcon} name="info-circle" />
+                <span>Expired silences are automatically deleted after 5 days.</span>
+              </div>
+              <SilenceList
+                items={itemsExpired}
+                alertManagerSourceName={alertManagerSourceName}
+                dataTestId="expired-table"
+              />
+            </CollapsableSection>
+          )}
+        </Stack>
       )}
       {!silences.length && <NoSilencesSplash alertManagerSourceName={alertManagerSourceName} />}
     </div>
@@ -187,7 +187,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-top: ${theme.spacing(2)};
 
     & > * {
       margin-left: ${theme.spacing(1)};
@@ -198,9 +197,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   editButton: css`
     margin-left: ${theme.spacing(0.5)};
-  `,
-  wrapper: css`
-    width: fit-content;
   `,
 });
 


### PR DESCRIPTION
**What is this feature?**

This PR:
-  splits Silence list view with not expired / expired&pending.
-  Removes silence state radio button from the filter. And moves expired silences to an expandable section.
- To keep backwards-compatible, we expand expired silences in case we have the silencesState query param in the url.


Taking in account that expired silences are automatically deleted after 5 days, instead of implementing a DELETE button we'd prefer splitting the view between expired and active silences to preserve the history of previous silences.

**Why do we need this feature?**

User needs a way to see all the not expired silences in the same list. And we think that, by default, user wants to see the non-expired silences.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/36080

**Special notes for your reviewer:**

https://user-images.githubusercontent.com/33540275/232445188-b474d430-3f5d-4b7c-b1c2-8e42f06f6718.mp4


https://user-images.githubusercontent.com/33540275/232445239-e4be79f3-2add-43eb-950c-d0665ad308f8.mp4





Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
