### PR TITLE
Loki: Use maxLines settings for logs sample

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -970,7 +970,7 @@ describe('LokiDatasource', () => {
           expr: '{label=value}',
           queryType: 'range',
           refId: 'log-sample-A',
-          maxLines: 100,
+          maxLines: 20,
         });
       });
 
@@ -985,7 +985,7 @@ describe('LokiDatasource', () => {
           expr: '{label=value}',
           queryType: 'instant',
           refId: 'log-sample-A',
-          maxLines: 100,
+          maxLines: 20,
         });
       });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -208,7 +208,7 @@ export class LokiDatasource
           ...normalizedQuery,
           refId: `${REF_ID_STARTER_LOG_SAMPLE}${normalizedQuery.refId}`,
           expr: getLogQueryFromMetricsQuery(expr),
-          maxLines: 100,
+          maxLines: this.maxLines,
         };
 
       default:


### PR DESCRIPTION
**What is this feature?**

Initially, when working on logs sample, we were expecting this feature to remember if it was open/closed which could have resulted in running quite a lot of logs queries. That's why we have decided to use lower (100) line limit. However, this was then re-thinked and we have changed the feature, so you need to always open it to see logs. 

So this became user-triggered action and therefore we arbitrary set line limit has currently no reason to be there.

This was creating confusion, when `see logs in split view`, cause it used originally run query, with 100 line limit. I was thinking about how to fix this and change limit to `this.maxLines` for split open action, but now I am not convinced about hardcoded 100 lines limit, and I think we should keep it as `this.maxLines`, rather than adding new options/overrides to `getSupplementaryQuery`. 

Also, we have tracking for these queries trough special header, so in a case where we learn these are causing issues, we can re-evaluate. 

But as I mentioned, Logs sample in Explore need to be opened at the beginning of each querying session by users for queries to run (compared to for example logs volume, that is always run, if user previously opened it).

We can always re-evaluate this and change the limit in the feature.

Fixes https://github.com/grafana/grafana/issues/64038

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.