### PR TITLE
Loki: Fix ad hoc filters when used with number and > and < operators

### DIFF
--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -52,6 +52,8 @@ describe('addLabelToQuery()', () => {
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser with an other escaped value'}                             | ${'bar'} | ${'='}   | ${'baz\\\\'}   | ${'{foo="bar"} | logfmt | bar=`baz\\`'}
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser with escaped value and regex operator'}                   | ${'bar'} | ${'~='}  | ${'\\"baz\\"'} | ${'{foo="bar"} | logfmt | bar~=`"baz"`'}
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser with escaped value and regex operator'}                   | ${'bar'} | ${'~='}  | ${'\\"baz\\"'} | ${'{foo="bar"} | logfmt | bar~=`"baz"`'}
+    ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser, > operator and number value'}                            | ${'bar'} | ${'>'}   | ${'5'}         | ${'{foo="bar"} | logfmt | bar>5'}
+    ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser, < operator and non-number value'}                        | ${'bar'} | ${'<'}   | ${'5KiB'}      | ${'{foo="bar"} | logfmt | bar<`5KiB`'}
   `(
     'should add label to query:  $query, description: $description',
     ({ query, description, label, operator, value, expectedResult }) => {

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -327,9 +327,16 @@ export function addFilterAsLabelFilter(
     const start = query.substring(prev, match.to);
     const end = isLast ? query.substring(match.to) : '';
 
-    // we now unescape all escaped values again, because we are using backticks which can handle those cases.
-    // we also don't care about the operator here, because we need to unescape for both, regex and equal.
-    const labelFilter = ` | ${filter.label}${filter.op}\`${unescapeLabelValue(filter.value)}\``;
+    let labelFilter = '';
+    // For < and >, if the value is number, we don't add quotes around it and use it as number
+    if (!Number.isNaN(Number(filter.value)) && (filter.op === '<' || filter.op === '>')) {
+      labelFilter = ` | ${filter.label}${filter.op}${Number(filter.value)}`;
+    } else {
+      // we now unescape all escaped values again, because we are using backticks which can handle those cases.
+      // we also don't care about the operator here, because we need to unescape for both, regex and equal.
+      labelFilter = ` | ${filter.label}${filter.op}\`${unescapeLabelValue(filter.value)}\``;
+    }
+
     newQuery += start + labelFilter + end;
     prev = match.to;
   }


### PR DESCRIPTION
When using ad hoc filters with `>` and `<` operators and `numbers`, we should add them as numbers and not as strings. 

Example of fixed query with `>` operator and number:

<img width="1900" alt="image" src="https://user-images.githubusercontent.com/30407135/232042552-a427900c-4f60-4387-8875-be7926b47329.png">

Example of fixed query with `>` operator and not number:

<img width="1910" alt="image" src="https://user-images.githubusercontent.com/30407135/232042740-37c4b073-1913-4bad-8825-ef7d069e1a10.png">

Fixes: https://github.com/grafana/grafana/issues/64172