### PR TITLE
Chore: Make grot own generated feature flag files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -477,8 +477,8 @@ lerna.json @grafana/frontend-ops
 /scripts/generate-a11y-report.sh @grafana/grafana-frontend-platform
 .pa11yci.conf.js @grafana/grafana-frontend-platform
 .pa11yci-pr.conf.js @grafana/grafana-frontend-platform
-.betterer.results @joshhunt
-.betterer.ts @joshhunt
+.betterer.results @grafanabot
+.betterer.ts @grafana/grafana-frontend-platform
 
 # @grafana/ui component documentation
 *.mdx @grafana/plugins-platform-frontend
@@ -601,6 +601,10 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/update-changelog.yml @grafana/grafana-delivery
 /.github/workflows/snyk.yml @grafana/security-team
 
+# Generated files not requiring owner approval
+/packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot
+/pkg/services/featuremgmt/toggles_gen.csv @grafanabot
+/pkg/services/featuremgmt/toggles_gen.go @grafanabot
 
 # Conf
 /conf/defaults.ini @torkelo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -603,6 +603,7 @@ embed.go @grafana/grafana-as-code
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot
+/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md @grafanabot
 /pkg/services/featuremgmt/toggles_gen.csv @grafanabot
 /pkg/services/featuremgmt/toggles_gen.go @grafanabot
 


### PR DESCRIPTION
Having generated feature flag files owned by teams is rough because it results in lots of GitHub notification/review requests for changes that we otherwise don't have much to do with.

This changes the generated Go and Typescript files to instead be owned by @grafanabot so Grot can get all the notification spam. Thanks robot 😄 

Two outstanding questions:

 - @grafana/docs-squad - Would you like to retain codeownership of the generated feature flag documentation so you're pinged for reviews.
 - @grafana/backend-platform - Would you like to retain codeownership of the non-generated [featuremgmt/registry.go](https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go) file?