### PR TITLE
[v8.4.x] Alerting: Update migration to put alerts to the default folder if dashboard folder is missing

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -262,7 +262,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 
 	// cache for folders created for dashboards that have custom permissions
 	folderCache := make(map[string]*dashboard)
-	
+
 	gf := func(dash dashboard, da dashAlert) (*dashboard, error) {
 		f, ok := folderCache[GENERAL_FOLDER]
 		if !ok {


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/7b2f44762e87ab0b1eee87ee36e7293a8a26885e from https://github.com/grafana/grafana/pull/65577

diff with the original PR
- no test 
- map generalFolderCache does not yet exist. Instead, map folderCache is used.
- folderHelper does not exist yet.