### PR TITLE
Testdata: Update testdata annotations editor

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5052,10 +5052,11 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/testdata/QueryEditor.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/plugins/datasource/testdata/components/RandomWalkEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5081,11 +5082,7 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/testdata/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
-    "public/app/plugins/datasource/testdata/module.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/testdata/nodeGraphUtils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/features/annotations/components/AnnotationResultMapper.tsx
+++ b/public/app/features/annotations/components/AnnotationResultMapper.tsx
@@ -42,7 +42,8 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
   }
 
   updateFields = () => {
-    const frame = this.props.response?.panelData?.series[0];
+    const panelData = this.props.response?.panelData;
+    const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
     if (frame && frame.fields) {
       const fieldNames = frame.fields.map((f) => {
         const name = getFieldDisplayName(f, frame);

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -132,7 +132,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
         icon = 'exclamation-triangle';
         text = 'No events found';
       } else {
-        const frame = panelData?.series[0];
+        const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
 
         text = `${events.length} events (from ${frame?.fields.length} fields)`;
       }

--- a/public/app/features/annotations/executeAnnotationQuery.ts
+++ b/public/app/features/annotations/executeAnnotationQuery.ts
@@ -71,11 +71,12 @@ export function executeAnnotationQuery(
 
   return runRequest(datasource, queryRequest).pipe(
     mergeMap((panelData) => {
-      if (!panelData.series) {
+      // Some annotations set the topic already
+      const data = panelData?.series.length ? panelData.series : panelData.annotations;
+      if (!data?.length) {
         return of({ panelData, events: [] });
       }
-
-      return processor.processEvents!(annotation, panelData.series).pipe(map((events) => ({ panelData, events })));
+      return processor.processEvents!(annotation, data).pipe(map((events) => ({ panelData, events })));
     })
   );
 }

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -57,10 +57,10 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
     }
 
     const vals = await datasource.getScenarios();
-    const hideAlias = ['simulation'];
+    const hideAlias = [TestDataQueryType.Simulation, TestDataQueryType.Annotations];
     return vals.map((v) => ({
       ...v,
-      hideAliasField: hideAlias.includes(v.id),
+      hideAliasField: hideAlias.includes(v.id as TestDataQueryType),
     }));
   }, []);
 
@@ -113,6 +113,9 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
         break;
       case TestDataQueryType.PredictableCSVWave:
         update.csvWave = defaultCSVWaveQuery;
+        break;
+      case TestDataQueryType.Annotations:
+        update.lines = 10;
         break;
       case TestDataQueryType.USA:
         update.usa = {
@@ -277,7 +280,20 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
           </InlineField>
         </InlineFieldRow>
       )}
-
+      {scenarioId === TestDataQueryType.Annotations && (
+        <InlineFieldRow>
+          <InlineField label="Count" labelWidth={14}>
+            <Input
+              type="number"
+              name="lines"
+              value={query.lines}
+              width={32}
+              onChange={onInputChange}
+              placeholder="10"
+            />
+          </InlineField>
+        </InlineFieldRow>
+      )}
       {scenarioId === TestDataQueryType.USA && <USAQueryEditor onChange={onUSAStatsChange} query={query.usa ?? {}} />}
       {scenarioId === TestDataQueryType.GrafanaAPI && (
         <InlineField labelWidth={14} label="Endpoint">

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -15,6 +15,7 @@ import {
   ScopedVars,
   toDataFrame,
   MutableDataFrame,
+  AnnotationQuery,
 } from '@grafana/data';
 import { DataSourceWithBackend, getBackendSrv, getGrafanaLiveSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { getSearchFilterScopedVar } from 'app/features/variables/utils';
@@ -35,6 +36,24 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
   ) {
     super(instanceSettings);
     this.variables = new TestDataVariableSupport();
+    this.annotations = {
+      getDefaultQuery: () => ({ scenarioId: TestDataQueryType.Annotations, lines: 10 }),
+
+      // Make sure annotations have scenarioId set
+      prepareAnnotation: (old: AnnotationQuery<TestData>) => {
+        if (old.target?.scenarioId?.length) {
+          return old;
+        }
+        return {
+          ...old,
+          target: {
+            refId: 'Anno',
+            scenarioId: TestDataQueryType.Annotations,
+            lines: 10,
+          },
+        };
+      },
+    };
   }
 
   getDefaultQuery(): Partial<TestData> {
@@ -66,7 +85,7 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
         case 'grafana_api':
           streams.push(runGrafanaAPI(target, options));
           break;
-        case 'annotations':
+        case TestDataQueryType.Annotations:
           streams.push(this.annotationDataTopicTest(target, options));
           break;
         case 'variables-query':
@@ -144,10 +163,9 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
   }
 
   annotationDataTopicTest(target: TestData, req: DataQueryRequest<TestData>): Observable<DataQueryResponse> {
-    const events = this.buildFakeAnnotationEvents(req.range, 50);
+    const events = this.buildFakeAnnotationEvents(req.range, target.lines ?? 10);
     const dataFrame = new ArrayDataFrame(events);
     dataFrame.meta = { dataTopic: DataTopic.Annotations };
-
     return of({ key: target.refId, data: [dataFrame] }).pipe(delay(100));
   }
 
@@ -167,10 +185,6 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
     }
 
     return events;
-  }
-
-  annotationQuery(options: any) {
-    return Promise.resolve(this.buildFakeAnnotationEvents(options.range, 10));
   }
 
   getQueryDisplayText(query: TestData) {

--- a/public/app/plugins/datasource/testdata/module.tsx
+++ b/public/app/plugins/datasource/testdata/module.tsx
@@ -5,16 +5,9 @@ import { QueryEditor } from './QueryEditor';
 import { TestInfoTab } from './TestInfoTab';
 import { TestDataDataSource } from './datasource';
 
-class TestDataAnnotationsQueryCtrl {
-  annotation: any;
-  constructor() {}
-  static template = '<h2>Annotation scenario</h2>';
-}
-
 export const plugin = new DataSourcePlugin(TestDataDataSource)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor)
-  .setAnnotationQueryCtrl(TestDataAnnotationsQueryCtrl)
   .addConfigPage({
     title: 'Setup',
     icon: 'list-ul',


### PR DESCRIPTION
See also #66325 

This PR updates the testdata datasource so we have more control of the test annotations.  It can now:
* give control over the number of annotations set
* allow mapping any query into annotations

<img width="861" alt="image" src="https://user-images.githubusercontent.com/705951/232600875-5c36b995-4ebb-4773-a7ce-f81e2666a605.png">


<img width="1236" alt="image" src="https://user-images.githubusercontent.com/705951/232601087-903f5034-e937-44e0-9413-515528dd775d.png">

