### PR TITLE
GRPC: Document GRPC flags to allow overriding env vars

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -90,6 +90,14 @@ read_timeout = 0
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2
 
+#################################### GRPC Server #########################
+[grpc_server]
+network = "tcp"
+address = "127.0.0.1:10000"
+use_tls = false
+cert_file =
+key_file =
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -91,6 +91,14 @@
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2
 
+#################################### GRPC Server #########################
+;[grpc_server]
+;network = "tcp"
+;address = "127.0.0.1:10000"
+;use_tls = false
+;cert_file =
+;key_file =
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password


### PR DESCRIPTION
Turns out, Grafana won't allow you to use the `GF_` environment variables for a given configuration unless it's already defined as part of the default configuration.