### PR TITLE
Dashboard: Fix library panels in collapsed rows not getting updated

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -195,6 +195,27 @@ describe('PanelModel', () => {
       expect(saveModel.events).toBe(undefined);
     });
 
+    it('getSaveModel should clean libraryPanels from a collapsed row', () => {
+      const newmodelJson = {
+        type: 'row',
+        panels: [
+          {
+            ...modelJson,
+            libraryPanel: {
+              uid: 'BVIBScisnl',
+              model: modelJson,
+              name: 'Library panel title',
+            },
+          },
+          modelJson,
+        ],
+      };
+      const newmodel = new PanelModel(newmodelJson);
+      const saveModel = newmodel.getSaveModel();
+      expect(saveModel.panels[0].tagrets).toBe(undefined);
+      expect(saveModel.panels[1].targets).toBeTruthy();
+    });
+
     describe('variables interpolation', () => {
       beforeEach(() => {
         model.scopedVars = {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -308,6 +308,26 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       model[property] = cloneDeep(this[property]);
     }
 
+    // clean libraryPanel from collapsed rows
+    if (this.type === 'row' && this.panels && this.panels.length > 0) {
+      model.panels = this.panels.map((panel) => {
+        if (panel.libraryPanel) {
+          const { id, title, libraryPanel, gridPos } = panel;
+          return {
+            id,
+            title,
+            gridPos,
+            libraryPanel: {
+              uid: libraryPanel.uid,
+              name: libraryPanel.name,
+            },
+          };
+        }
+
+        return panel;
+      });
+    }
+
     return model;
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR unifies the way that library panels are saved in a dashboard JSON, whether the library panel is in a collapsed row or not.

In practice, this PR modifies the way that a library panel inside a collapsed row gets saved.

```json
{
    "gridPod": {...},
    "id": 123,
    "libraryPanel": {
        "uid": "z9imSuIVz",
        "name": "LIBRARY_PANEL_NAME"
    },
    "title": "PANEL_TITLE"
}
```

**Why do we need this feature?**

Library panels in collapsed rows are currently not being cleaned into the format just above and are therefore being saved with their model hardcoded. This means that they are not updated when the library panel has a new version (see attached issue below).

**Who is this feature for?**

Everyone!

**Which issue(s) does this PR fix?**:

Fixes #66640

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
