### PR TITLE
Trace View: Update the queryType to traceql for checking if same trace when clicking span link

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -256,7 +256,8 @@ function useFocusSpanLink(options: {
     // Check if the link is to a different trace or not.
     // If it's the same trace, only update panel state with setFocusedSpanId (no navigation).
     // If it's a different trace, use splitOpenFn to open a new explore panel
-    const sameTrace = (query?.queryType === 'traceql' || query?.queryType === 'traceId') && (query as TempoQuery).query === traceId;
+    const sameTrace =
+      (query?.queryType === 'traceql' || query?.queryType === 'traceId') && (query as TempoQuery).query === traceId;
 
     return mapInternalLinkToExplore({
       link,

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -256,8 +256,7 @@ function useFocusSpanLink(options: {
     // Check if the link is to a different trace or not.
     // If it's the same trace, only update panel state with setFocusedSpanId (no navigation).
     // If it's a different trace, use splitOpenFn to open a new explore panel
-    const sameTrace =
-      (query?.queryType === 'traceql' || query?.queryType === 'traceId') && (query as TempoQuery).query === traceId;
+    const sameTrace = query?.queryType === 'traceql' && (query as TempoQuery).query === traceId;
 
     return mapInternalLinkToExplore({
       link,

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -256,7 +256,7 @@ function useFocusSpanLink(options: {
     // Check if the link is to a different trace or not.
     // If it's the same trace, only update panel state with setFocusedSpanId (no navigation).
     // If it's a different trace, use splitOpenFn to open a new explore panel
-    const sameTrace = query?.queryType === 'traceId' && (query as TempoQuery).query === traceId;
+    const sameTrace = (query?.queryType === 'traceql' || query?.queryType === 'traceId') && (query as TempoQuery).query === traceId;
 
     return mapInternalLinkToExplore({
       link,


### PR DESCRIPTION
**What is this feature?**

This PR is a bug fix for the TraceView component. When clicking a trace span's  ["links"](https://opentelemetry.io/docs/reference/specification/trace/api/#specifying-links), a split pane was always opening even if the span belonged to the same trace. The intended behavior is to only open a new pane if it's a different trace.

As far as i can tell from git history, this is a regression is part of the migration to the `traceql` tab from the `traceid` tab (see: https://github.com/grafana/grafana/pull/60180). This work enabled the `traceql` tab to also be used for individual trace lookup/viewing individual traces + the PR hid the `traceid` tab. Looks like a line was just missed for updating queryType from `traceid` to `traceql` as part of that work. Reviewing the tests it seems like this should just be `traceql`, but I've tried to introduce this gracefully (support both comparing a check for queryType `traceql` and `traceid` when deciding whether a new pane should be opened for a span link) in case any folks have already built custom monkeypatches assuming `traceid`.

We just picked this up on the upgrade to 9.4 and are already running this patch in production without issue, for context.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

folks using opentelemetry span links or other similar styles of relationship between traces.

**Which issue(s) does this PR fix?**:

n/a, i can open an issue demonstrating the problem but this is pretty straightforward imo.



**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
