### PR TITLE
Chore: Try a different way to run integration tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -874,9 +874,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -892,9 +892,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1882,9 +1882,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1900,9 +1900,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5101,9 +5101,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5119,9 +5119,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5818,9 +5818,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5836,9 +5836,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6287,9 +6287,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6305,9 +6305,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6460,9 +6460,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6478,9 +6478,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
-    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
-    '+' | grep -o '\(.*\)/' | sort -u)
+  - go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6810,6 +6810,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: ee9529389a443da3fa7866e7b4c40ae1f938a75b3a909316142dff7bbca836eb
+hmac: d3567c954d0ac9f1f47d55bc85eb6594379c888fe591428f2dcd0146f2bd3ca2
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -877,6 +877,11 @@ steps:
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
     -timeout=5m {}'
   depends_on:
@@ -1885,6 +1890,11 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
@@ -5108,6 +5118,11 @@ steps:
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
     -timeout=5m {}'
   depends_on:
@@ -5827,6 +5842,11 @@ steps:
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
     -timeout=5m {}'
   depends_on:
@@ -6298,6 +6318,11 @@ steps:
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
     -timeout=5m {}'
   depends_on:
@@ -6471,6 +6496,11 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
+  - sleep 10
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
@@ -6822,6 +6852,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 223538b3edacddfff08ca901bfe20b25cc2a9e2f04646be8c6078e8fd18295ba
+hmac: 7a62a2220fa0bc854d3c48d9dfa13f5cb8f447e89bf9ca4791a9b3a44ceb7549
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -873,7 +873,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -890,7 +891,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -1879,7 +1881,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -1896,7 +1899,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -5096,7 +5100,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -5113,7 +5118,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -5811,7 +5817,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -5828,7 +5835,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -6278,7 +6286,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -6295,7 +6304,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -6449,7 +6459,8 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -6466,7 +6477,8 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+  - go clean -testcache
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
@@ -6798,6 +6810,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 42e93963321a6fdb6ff7ff2ab0ffb9556db2dfcce3cb66ce0a487ccf84b41231
+hmac: e53822750e0418df8683dd2bc90b1c71d7415d698df64d5c0e6c13dc3b15f5e6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -874,9 +874,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -1882,9 +1884,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5101,9 +5105,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5818,9 +5824,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -6287,9 +6295,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -6460,9 +6470,11 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
     ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
     | grep -o '\(.*\)/' | sort -u)
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -6810,6 +6822,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: e53822750e0418df8683dd2bc90b1c71d7415d698df64d5c0e6c13dc3b15f5e6
+hmac: 223538b3edacddfff08ca901bfe20b25cc2a9e2f04646be8c6078e8fd18295ba
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -336,7 +336,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -871,9 +873,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -888,9 +890,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1291,7 +1293,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -1875,9 +1879,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1892,9 +1896,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -2545,7 +2549,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -3107,7 +3113,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -4992,7 +5000,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -5086,9 +5096,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5103,9 +5113,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5678,7 +5688,9 @@ steps:
   image: grafana/build-container:1.7.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   image: grafana/build-container:1.7.3
@@ -5799,9 +5811,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5816,9 +5828,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6266,9 +6278,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6283,9 +6295,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6437,9 +6449,9 @@ steps:
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6454,9 +6466,9 @@ steps:
   - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
-  - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find
+    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
+    | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6786,6 +6798,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: da82099e984231d3b292921e031655723eae03f45efac84af1a5a2104601fbfe
+hmac: 42e93963321a6fdb6ff7ff2ab0ffb9556db2dfcce3cb66ce0a487ccf84b41231
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -874,16 +874,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -899,9 +892,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1889,16 +1882,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -1914,9 +1900,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5115,16 +5101,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5140,9 +5119,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5839,16 +5818,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -5864,9 +5836,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6315,16 +6287,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6340,9 +6305,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6495,16 +6460,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands
-  - sleep 10
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=5m {}'
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6520,9 +6478,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
-    ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+'
-    | grep -o '\(.*\)/' | sort -u)
+  - GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration'
+    $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}'
+    '+' | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
   environment:
@@ -6852,6 +6810,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 7a62a2220fa0bc854d3c48d9dfa13f5cb8f447e89bf9ca4791a9b3a44ceb7549
+hmac: ee9529389a443da3fa7866e7b4c40ae1f938a75b3a909316142dff7bbca836eb
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -138,25 +138,25 @@ test-go-integration-postgres: devenv-postgres ## Run integration tests for postg
 	@echo "test backend integration postgres tests"
 	$(GO) clean -testcache
 	GRAFANA_TEST_DB=postgres \
-	$(GO) test -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
+	$(GO) test -p=1 -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-mysql
 test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.
 	@echo "test backend integration mysql tests"
 	GRAFANA_TEST_DB=mysql \
-	$(GO) test -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
+	$(GO) test -p=1 -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-redis
 test-go-integration-redis: ## Run integration tests for redis cache.
 	@echo "test backend integration redis tests"
 	$(GO) clean -testcache
-	REDIS_URL=localhost:6379 $(GO) test -run IntegrationRedis -covermode=atomic -timeout=2m ./pkg/...
+	REDIS_URL=localhost:6379 $(GO) test -run IntegrationRedis -covermode=atomic -timeout=2m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-memcached
 test-go-integration-memcached: ## Run integration tests for memcached cache.
 	@echo "test backend integration memcached tests"
 	$(GO) clean -testcache
-	MEMCACHED_HOSTS=localhost:11211 $(GO) test -run IntegrationMemcached -covermode=atomic -timeout=2m ./pkg/...
+	MEMCACHED_HOSTS=localhost:11211 $(GO) test -run IntegrationMemcached -covermode=atomic -timeout=2m $(GO_INTEGRATION_TESTS)
 
 test-js: ## Run tests for frontend.
 	@echo "test frontend"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 
 targets := $(shell echo '$(sources)' | tr "," " ")
 
+GO_INTEGRATION_TESTS := $(shell find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
+
 all: deps build
 
 ##@ Dependencies
@@ -129,19 +131,20 @@ test-go-unit: ## Run unit tests for backend with flags.
 .PHONY: test-go-integration
 test-go-integration: ## Run integration tests for backend with flags.
 	@echo "test backend integration tests"
-	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+	$(GO) test -count=1 -run "^TestIntegration" -covermode=atomic -timeout=5m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-postgres
 test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.
 	@echo "test backend integration postgres tests"
 	$(GO) clean -testcache
-	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=postgres go test -run Integration -covermode=atomic -timeout=2m {}'
+	GRAFANA_TEST_DB=postgres \
+	$(GO) test -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-mysql
 test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.
 	@echo "test backend integration mysql tests"
-	$(GO) clean -testcache
-	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=mysql go test -run Integration -covermode=atomic -timeout=2m {}'
+	GRAFANA_TEST_DB=mysql \
+	$(GO) test -count=1 -run "^TestIntegration" -covermode=atomic -timeout=10m $(GO_INTEGRATION_TESTS)
 
 .PHONY: test-go-integration-redis
 test-go-integration-redis: ## Run integration tests for redis cache.

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1097,7 +1097,7 @@ def postgres_integration_tests_step():
         "psql -p 5432 -h postgres -U grafanatest -d grafanatest -f " +
         "devenv/docker/blocks/postgres_tests/setup.sql",
         "go clean -testcache",
-        "GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "postgres-integration-tests",
@@ -1118,7 +1118,7 @@ def mysql_integration_tests_step():
         "dockerize -wait tcp://mysql:3306 -timeout 120s",
         "cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass",
         "go clean -testcache",
-        "GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go test -p=1 -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "mysql-integration-tests",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -623,7 +623,7 @@ def test_backend_integration_step():
             "wire-install",
         ],
         "commands": [
-            "go test -run Integration -covermode=atomic -timeout=5m ./pkg/...",
+					  "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
         ],
     }
 
@@ -1096,9 +1096,7 @@ def postgres_integration_tests_step():
         "dockerize -wait tcp://postgres:5432 -timeout 120s",
         "psql -p 5432 -h postgres -U grafanatest -d grafanatest -f " +
         "devenv/docker/blocks/postgres_tests/setup.sql",
-        # Make sure that we don't use cached results for another database
-        "go clean -testcache",
-        "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
+        "go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "postgres-integration-tests",
@@ -1118,9 +1116,7 @@ def mysql_integration_tests_step():
         "apt-get install -yq default-mysql-client",
         "dockerize -wait tcp://mysql:3306 -timeout 120s",
         "cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass",
-        # Make sure that we don't use cached results for another database
-        "go clean -testcache",
-        "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
+        "go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "mysql-integration-tests",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1096,7 +1096,8 @@ def postgres_integration_tests_step():
         "dockerize -wait tcp://postgres:5432 -timeout 120s",
         "psql -p 5432 -h postgres -U grafanatest -d grafanatest -f " +
         "devenv/docker/blocks/postgres_tests/setup.sql",
-        "go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go clean -testcache",
+        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "postgres-integration-tests",
@@ -1116,7 +1117,8 @@ def mysql_integration_tests_step():
         "apt-get install -yq default-mysql-client",
         "dockerize -wait tcp://mysql:3306 -timeout 120s",
         "cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass",
-        "go test -count=1 -covermode=atomic -timeout=10m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go clean -testcache",
+        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "mysql-integration-tests",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1097,7 +1097,8 @@ def postgres_integration_tests_step():
         "psql -p 5432 -h postgres -U grafanatest -d grafanatest -f " +
         "devenv/docker/blocks/postgres_tests/setup.sql",
         "go clean -testcache",
-        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
     ]
     return {
         "name": "postgres-integration-tests",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1098,6 +1098,9 @@ def postgres_integration_tests_step():
         "devenv/docker/blocks/postgres_tests/setup.sql",
         "go clean -testcache",
         "echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands",
+        "sleep 10",
+        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
         "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
     ]
     return {

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -623,7 +623,7 @@ def test_backend_integration_step():
             "wire-install",
         ],
         "commands": [
-					  "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+            "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
         ],
     }
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1097,11 +1097,7 @@ def postgres_integration_tests_step():
         "psql -p 5432 -h postgres -U grafanatest -d grafanatest -f " +
         "devenv/docker/blocks/postgres_tests/setup.sql",
         "go clean -testcache",
-        "echo go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
-        "go test -run Integration -covermode=atomic -timeout=5m ./pkg/cmd/grafana-cli/commands",
-        "sleep 10",
-        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
-        "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
+        "GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "postgres-integration-tests",
@@ -1122,7 +1118,7 @@ def mysql_integration_tests_step():
         "dockerize -wait tcp://mysql:3306 -timeout 120s",
         "cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass",
         "go clean -testcache",
-        "go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
+        "GOMAXPROCS=1 go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\\(.*\\)/' | sort -u)",
     ]
     return {
         "name": "mysql-integration-tests",


### PR DESCRIPTION
This PR changes the way we launch integration tests.

Previously, we've been using `go list` to find a list of packages, then compiled every of them, and launched the resulting binary with `-run` filter to execute only integration tests.

But only ~30% of our packages contain integration tests, so it was quite wasteful. Also compilation happened sequentially and was rather slow.

This PR finds a list of packages at start and runs a single `go test` for that list. Tests don't run in parallel, but compilation happens concurrently.

Seems like it speeds up mysql and postgres from ~15 min down to ~5 min.