### PR TITLE
Logs: Fix LogContext scrolling behavior

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -120,6 +120,10 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
 }) => {
   const scrollElement = React.createRef<HTMLDivElement>();
   const entryElement = React.createRef<HTMLTableRowElement>();
+  // We can not use `entryElement` to scroll to the right element because it's
+  // sticky. That's why we add another row and use this ref to scroll to that
+  // first.
+  const preEntryElement = React.createRef<HTMLTableRowElement>();
 
   const theme = useTheme2();
   const styles = getStyles(theme);
@@ -198,10 +202,11 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   };
 
   useLayoutEffect(() => {
-    if (entryElement.current) {
+    if (!loading && entryElement.current && preEntryElement.current) {
+      preEntryElement.current.scrollIntoView({ block: 'center' });
       entryElement.current.scrollIntoView({ block: 'center' });
     }
-  }, [entryElement, context]);
+  }, [entryElement, preEntryElement, context, loading]);
 
   useLayoutEffect(() => {
     const width = scrollElement?.current?.parentElement?.clientWidth;
@@ -252,6 +257,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                 />
               </td>
             </tr>
+            <tr ref={preEntryElement}></tr>
             <tr ref={entryElement} className={styles.entry}>
               <td className={styles.noMarginBottom}>
                 <LogRows


### PR DESCRIPTION
**What is this feature?**

Fixes the scrolling behavior where the LogContex was not centered to a certain log line.

**Which issue(s) does this PR fix?**:

Fixes #66557

**Special notes for your reviewer:**

How to reproduce it (as minimally and precisely as possible):

1. Query a Loki including a line filter
2. Disable "wrap loglines"
3. Make sure you have long enough log lines
4. Scroll down to a match "deep" in the logs
5. Open LogContext