### PR TITLE
SQL Datasources: Fix saving of max idle connections and max connection lifetime

### DIFF
--- a/public/app/features/plugins/sql/components/configuration/ConnectionLimits.tsx
+++ b/public/app/features/plugins/sql/components/configuration/ConnectionLimits.tsx
@@ -35,7 +35,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
   // use a shared function to update respective properties
   const onJSONDataNumberChanged = (property: keyof SQLConnectionLimits) => {
     return (number?: number) => {
-      updateJsonData({ property: number });
+      updateJsonData({ [property]: number });
     };
   };
 


### PR DESCRIPTION
Fixes an issue with #65834 in which the max idle connections and max connection lifetime field are not saved correctly. The issue is that an object with the appropriate dynamic property was instead set with a static property. The ensures that the key used is dynamic so that the settings will be updated correctly.
