### PR TITLE
loki: query splitting: labels-based frame matching

### DIFF
--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -1,6 +1,7 @@
 import {
   ArrayVector,
   DataFrame,
+  DataFrameType,
   DataSourceInstanceSettings,
   DataSourceSettings,
   FieldType,
@@ -151,6 +152,9 @@ export function getMockFrames() {
       },
     ],
     meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
       stats: [
         { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
         { displayName: 'Ingester: total reached', value: 1 },
@@ -198,6 +202,9 @@ export function getMockFrames() {
       },
     ],
     meta: {
+      custom: {
+        frameType: 'LabeledTimeValues',
+      },
       stats: [
         { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
         { displayName: 'Ingester: total reached', value: 2 },
@@ -220,9 +227,13 @@ export function getMockFrames() {
         type: FieldType.number,
         config: {},
         values: new ArrayVector([5, 4]),
+        labels: {
+          level: 'debug',
+        },
       },
     ],
     meta: {
+      type: DataFrameType.TimeSeriesMulti,
       stats: [
         { displayName: 'Ingester: total reached', value: 1 },
         { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
@@ -245,9 +256,13 @@ export function getMockFrames() {
         type: FieldType.number,
         config: {},
         values: new ArrayVector([6, 7]),
+        labels: {
+          level: 'debug',
+        },
       },
     ],
     meta: {
+      type: DataFrameType.TimeSeriesMulti,
       stats: [
         { displayName: 'Ingester: total reached', value: 2 },
         { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
@@ -271,9 +286,13 @@ export function getMockFrames() {
         type: FieldType.number,
         config: {},
         values: new ArrayVector([6, 7]),
+        labels: {
+          level: 'error',
+        },
       },
     ],
     meta: {
+      type: DataFrameType.TimeSeriesMulti,
       stats: [
         { displayName: 'Ingester: total reached', value: 2 },
         { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -191,6 +191,9 @@ describe('combineResponses', () => {
           ],
           length: 4,
           meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -228,10 +231,14 @@ describe('combineResponses', () => {
               name: 'Value',
               type: 'number',
               values: new ArrayVector([6, 7, 5, 4]),
+              labels: {
+                level: 'debug',
+              },
             },
           ],
           length: 4,
           meta: {
+            type: 'timeseries-multi',
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -269,10 +276,14 @@ describe('combineResponses', () => {
               name: 'Value',
               type: 'number',
               values: new ArrayVector([6, 7, 5, 4]),
+              labels: {
+                level: 'debug',
+              },
             },
           ],
           length: 4,
           meta: {
+            type: 'timeseries-multi',
             stats: [
               {
                 displayName: 'Summary: total bytes processed',

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -1,6 +1,7 @@
 import {
   ArrayVector,
   DataFrame,
+  DataFrameType,
   DataQueryResponse,
   DataQueryResponseData,
   Field,
@@ -8,6 +9,7 @@ import {
   isValidGoDuration,
   Labels,
   QueryResultMetaStat,
+  shallowCompare,
 } from '@grafana/data';
 
 import { isBytesString } from './languageUtils';
@@ -123,7 +125,38 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
     return false;
   }
 
-  return frame1.name === frame2.name;
+  const frameType1 = frame1.meta?.type;
+  const frameType2 = frame2.meta?.type;
+
+  if (frameType1 !== frameType2) {
+    // we do not join things that have a different type
+    return false;
+  }
+
+  // metric range query data
+  if (frameType1 === DataFrameType.TimeSeriesMulti) {
+    const field1 = frame1.fields.find((f) => f.type === FieldType.number);
+    const field2 = frame2.fields.find((f) => f.type === FieldType.number);
+    if (field1 === undefined || field2 === undefined) {
+      // should never happen
+      return false;
+    }
+
+    return shallowCompare(field1.labels ?? {}, field2.labels ?? {});
+  }
+
+  // logs query data
+  // logs use a special attribute in the dataframe's "custom" section
+  // because we do not have a good "frametype" value for them yet.
+  const customType1 = frame1.meta?.custom?.frameType;
+  const customType2 = frame2.meta?.custom?.frameType;
+
+  if (customType1 === 'LabeledTimeValues' && customType2 === 'LabeledTimeValues') {
+    return true;
+  }
+
+  // should never reach here
+  return false;
 }
 
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/66661)

in the loki query splitting code, we need to join the "correct" dataframes. right now it is done by looking at their `frame.name` field.

but, as we are trying to make Loki's metric output compatible with grafana's timeseries-data-specification ( https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#properties-shared-by-all-time-series-based-formats ), we will stop setting the `frame.name` attribute.

so we cannot use it to decide if two frames are "joinable".

this PR changes the logic so that it looks at the dataframe's number-field's labels. if they have the same labels they are joinable.

for this to work, we need handle separately the metric-data coming from Loki and logs-data coming from Loki

(btw. logs-dataframes can always be joined)


how to test:
1. run split-query metric and logs queries, make sure it works
    - make sure you run a metric query that produces multiple series, for example something like:
       - `sum(count_over_time({place="luna"}|logfmt[1d])) by(level)` . you should see multiple lines in the graph.
3. enable the `lokiMetricDataplane`, and repeat the test from [1]. again, make sure you see multiple lines in the graph.