### PR TITLE
NestedFolders: Add link to new work-in-progress UI

### DIFF
--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -3,7 +3,8 @@ import React, { memo } from 'react';
 import { useAsync } from 'react-use';
 
 import { locationUtil, NavModelItem } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
+import { Badge, Link } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { FolderDTO } from 'app/types';
 
@@ -40,7 +41,17 @@ export const DashboardListPage = memo(({ match, location }: Props) => {
   }, [match.params.uid]);
 
   return (
-    <Page navId="dashboards/browse" pageNav={value?.pageNav}>
+    <Page
+      navId="dashboards/browse"
+      pageNav={value?.pageNav}
+      actions={
+        config.featureToggles.nestedFolders && (
+          <Link href="/nested-dashboards">
+            <Badge icon="folder" color="blue" text="Try WIP nested folders UI" />
+          </Link>
+        )
+      }
+    >
       <Page.Contents
         isLoading={loading}
         className={css`


### PR DESCRIPTION
Behind nestedFolders feature flag, adds a link to the temporary work-in-progress nested folders page.

![image](https://user-images.githubusercontent.com/46142/232506102-a722c492-a880-4891-82a9-7273713ef7b0.png)


![image](https://user-images.githubusercontent.com/46142/232505958-8ee39902-dc94-440b-89d2-d292d177b229.png)
