### PR TITLE
Chore: use native async fs.readFile in json-file-to-job-output script

### DIFF
--- a/.github/workflows/scripts/json-file-to-job-output.js
+++ b/.github/workflows/scripts/json-file-to-job-output.js
@@ -1,7 +1,7 @@
 module.exports = async ({ core, filePath }) => {
     try {
-        const fs = require('fs');
-        const content = await readFile(fs, filePath);
+        const fs = require('fs').promises;
+        const content = await fs.readFile(filepath)
         const result = JSON.parse(content);
     
         core.startGroup('Parsing json file...');
@@ -15,13 +15,4 @@ module.exports = async ({ core, filePath }) => {
     } catch (error) {
         core.restFailed(error.message);
     }
-}
-
-async function readFile(fs, path) {
-    return new Promise((resolve, reject) => {
-        fs.readFile(path, (error, data) => {
-            if (error) return reject(error);
-            return resolve(data);
-        });
-    });
 }


### PR DESCRIPTION
Node has a [filesystem promises api](https://nodejs.org/api/fs.html#promises-api), so there's no need to wrap `fs.readFile` in a promise.