### PR TITLE
Prometheus: Add more robust healthcheck

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4795,7 +4795,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "19"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "20"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "21"],
-      [0, 0, 0, "Do not use any type assertions.", "22"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "23"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "24"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "25"],
@@ -4804,9 +4804,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "29"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "30"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "31"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "32"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "33"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "31"]
     ],
     "public/app/plugins/datasource/prometheus/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/pkg/tsdb/prometheus/healthcheck.go
+++ b/pkg/tsdb/prometheus/healthcheck.go
@@ -1,0 +1,117 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/tsdb/prometheus/kinds/dataquery"
+	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
+)
+
+const (
+	refID = "__healthcheck__"
+)
+
+var logger log.Logger = log.New("tsdb.prometheus")
+
+func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
+	error) {
+	logger := logger.FromContext(ctx)
+	i, err := s.getInstance(req.PluginContext)
+
+	// check that the datasource exists
+	if err != nil {
+		return getHealthCheckMessage(logger, "error getting datasource info", err)
+	}
+
+	if i == nil {
+		return getHealthCheckMessage(logger, "", errors.New("invalid datasource info received"))
+	}
+
+	// execute the Prometheus healthy api, e.g. http://localhost:9090/-/healthy
+	// https://prometheus.io/docs/prometheus/latest/management_api/
+	resp, err := i.resource.Execute(ctx, &backend.CallResourceRequest{
+		PluginContext: req.PluginContext,
+		Path:          "/-/healthy",
+		Method:        http.MethodGet,
+	})
+
+	if err != nil {
+		return getHealthCheckMessage(logger, "Prometheus healthcheck error.", err)
+	}
+
+	// if the prom instance does not have the healthy check
+	// fallback to making a simple query to check setup
+	if resp != nil {
+		if string(resp.Body) == "404 page not found\n" {
+			return healthcheckFallback(ctx, req, i)
+		}
+
+		return getHealthCheckMessage(logger, string(resp.Body), nil)
+	}
+
+	// for everything else
+	return getHealthCheckMessage(logger, "", errors.New("unknown prometheus issue"))
+}
+
+func getHealthCheckMessage(logger log.Logger, message string, err error) (*backend.CheckHealthResult, error) {
+	if err == nil {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusOk,
+			Message: fmt.Sprintf("Prometheus datasource is working. %s", message),
+		}, nil
+	}
+
+	logger.Warn("error performing prometheus healthcheck", "err", err.Error())
+	errorMessage := fmt.Sprintf("%s %s", err.Error(), message)
+
+	return &backend.CheckHealthResult{
+		Status:  backend.HealthStatusError,
+		Message: errorMessage,
+	}, nil
+}
+
+func healthcheckFallback(ctx context.Context, req *backend.CheckHealthRequest, i *instance) (*backend.CheckHealthResult, error) {
+	instant := true
+	qm := models.QueryModel{
+		LegendFormat: "",
+		UtcOffsetSec: 0,
+		PrometheusDataQuery: dataquery.PrometheusDataQuery{
+			Expr:    "1+1",
+			Instant: &instant,
+		},
+	}
+	b, _ := json.Marshal(&qm)
+
+	query := backend.DataQuery{
+		RefID: refID,
+		TimeRange: backend.TimeRange{
+			From: time.Unix(1, 0).UTC(),
+			To:   time.Unix(4, 0).UTC(),
+		},
+		JSON: b,
+	}
+	resp, err := i.queryData.Execute(ctx, &backend.QueryDataRequest{
+		PluginContext: req.PluginContext,
+		Queries:       []backend.DataQuery{query},
+	})
+
+	if err != nil {
+		return getHealthCheckMessage(logger, "Prometheus datasource error", err)
+	}
+
+	// This should be more descriptive but we don't return errors from execute.
+	//
+	if resp.Responses[refID].Error != nil {
+		return getHealthCheckMessage(logger, "Prometheus datasource configuration error", errors.New(resp.Responses[refID].Error.Error()))
+	}
+
+	return getHealthCheckMessage(logger, "A successful query has been made.", nil)
+}

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -2,6 +2,7 @@ package querydata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -173,6 +174,16 @@ func (s *QueryData) rangeQuery(ctx context.Context, c *client.Client, q *models.
 
 func (s *QueryData) instantQuery(ctx context.Context, c *client.Client, q *models.Query, headers map[string]string) backend.DataResponse {
 	res, err := c.QueryInstant(ctx, q)
+
+	// return errors speciically for healthcheck
+	if q.RefId == "__healthcheck__" {
+		if res.Status != "200 OK" {
+			return backend.DataResponse{
+				Error: errors.New(res.Status),
+			}
+		}
+	}
+
 	if err != nil {
 		return backend.DataResponse{
 			Error: err,

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -1050,45 +1050,6 @@ export class PrometheusDatasource
     );
   }
 
-  async testDatasource() {
-    const now = new Date().getTime();
-    const request: DataQueryRequest<PromQuery> = {
-      targets: [{ refId: 'test', expr: '1+1', instant: true }],
-      requestId: `${this.id}-health`,
-      scopedVars: {},
-      dashboardId: 0,
-      panelId: 0,
-      interval: '1m',
-      intervalMs: 60000,
-      maxDataPoints: 1,
-      range: {
-        from: dateTime(now - 1000),
-        to: dateTime(now),
-      },
-    } as DataQueryRequest<PromQuery>;
-
-    const buildInfo = await this.getBuildInfo();
-
-    return lastValueFrom(this.query(request))
-      .then((res: DataQueryResponse) => {
-        if (!res || !res.data || res.state !== LoadingState.Done) {
-          return { status: 'error', message: `Error reading Prometheus: ${res?.error?.message}` };
-        } else {
-          return {
-            status: 'success',
-            message: 'Data source is working',
-            details: buildInfo && {
-              verboseMessage: this.getBuildInfoMessage(buildInfo),
-            },
-          };
-        }
-      })
-      .catch((err: any) => {
-        console.error('Prometheus Error', err);
-        return { status: 'error', message: err.message };
-      });
-  }
-
   interpolateVariablesInQueries(queries: PromQuery[], scopedVars: ScopedVars): PromQuery[] {
     let expandedQueries = queries;
     if (queries && queries.length) {


### PR DESCRIPTION
**What is this feature?**
This is part of the Prometheus config overhaul which is part of the G10 Getting Started: Prometheus project. This adds a backend health check for the Prometheus datasource. When a user sets up a Prometheus configuration on the Prometheus config page meaningful errors are returned when they include a url that returns a 404 Not Found and when the auth is incorrect. 

This PR is a work in progress with https://github.com/grafana/grafana/pull/66198

Error examples

A user has access the `healthy` endpoint and the instance is healthy
![Screenshot 2023-04-16 at 6 58 17 PM](https://user-images.githubusercontent.com/25674746/232356981-82cdf3c2-c0c4-478a-a6a1-055de1848319.png)

A user enters an incorrect url and has access the `healthy` endpoint
![Screenshot 2023-04-16 at 6 57 58 PM](https://user-images.githubusercontent.com/25674746/232356978-5070fbcf-6f03-4550-9a3d-641aebf94849.png)

A user has an older version of prom without the `healthy` endpoint but the connection is successful.
![Screenshot 2023-04-16 at 6 59 21 PM](https://user-images.githubusercontent.com/25674746/232356983-9bd1f989-fe92-43c8-97a5-3d632052b414.png)

A user has an older version of prom without the `healthy` endpoint and the url is incorrect.
![Screenshot 2023-04-16 at 8 53 08 PM](https://user-images.githubusercontent.com/25674746/232356984-3212c7a9-a907-4176-b1cb-f0b1c0c13b30.png)

A user has an older version of prom without the `healthy` endpoint and the auth is incorrect.
![Screenshot 2023-04-16 at 9 02 34 PM](https://user-images.githubusercontent.com/25674746/232356985-4f1fcc69-d002-433e-bdbf-512c1f22fb70.png)

**Why do we need this feature?**
The previous health check  was a frontend health check that was flaky at best. Users received false positives, the url was correct etc. Certain versions of Prometheus have an api to check the health of the instance, [the `healthy` api ](https://prometheus.io/docs/prometheus/latest/management_api/). This feature implements the `healthy` api for the health check and falls back to a query check if the prom type or version does not implement this. 

**Who is this feature for?**
This is for users who are setting up a Prometheus datasource configuration.


**Special notes for your reviewer:**
Please test the following scenarios
1. Test with an incorrect URL
2. Test with incorrect auth
3. Test with a Prometheus type that does not support the `/-/healthy` api such as Cortex.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
