### PR TITLE
[WIP] FieldValues: use arrays for datasource 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4621,9 +4621,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
-    "public/app/plugins/datasource/loki/getDerivedFields.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/plugins/datasource/loki/queryUtils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -5049,11 +5046,10 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/testdata/QueryEditor.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/plugins/datasource/testdata/components/RandomWalkEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5079,11 +5075,16 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/testdata/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/plugins/datasource/testdata/module.tsx:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/testdata/nodeGraphUtils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/datasource/testdata/runStreams.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -234,7 +234,7 @@ export function frameToMetricFindValue(frame: DataFrame): MetricFindValue[] {
   }
   if (field) {
     for (let i = 0; i < field.values.length; i++) {
-      values.push({ text: '' + field.values.get(i) });
+      values.push({ text: '' + field.values[i] });
     }
   }
   return values;

--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -329,7 +329,7 @@ function getAllLabels(fields: LogFields): Labels[] {
   const { stringField, labelsField } = fields;
 
   if (labelsField !== undefined) {
-    return labelsField.values.toArray();
+    return labelsField.values;
   } else {
     return [stringField.labels ?? {}];
   }
@@ -342,7 +342,7 @@ function getLabelsForFrameRow(fields: LogFields, index: number): Labels {
   const { stringField, labelsField } = fields;
 
   if (labelsField !== undefined) {
-    return labelsField.values.get(index);
+    return labelsField.values[index];
   } else {
     return stringField.labels ?? {};
   }
@@ -407,13 +407,13 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
     const { timeField, timeNanosecondField, stringField, logLevelField, idField, series } = info;
 
     for (let j = 0; j < series.length; j++) {
-      const ts = timeField.values.get(j);
+      const ts = timeField.values[j];
       const time = toUtc(ts);
-      const tsNs = timeNanosecondField ? timeNanosecondField.values.get(j) : undefined;
+      const tsNs = timeNanosecondField ? timeNanosecondField.values[j] : undefined;
       const timeEpochNs = tsNs ? tsNs : time.valueOf() + '000000';
 
       // In edge cases, this can be undefined. If undefined, we want to replace it with empty string.
-      const messageValue: unknown = stringField.values.get(j) ?? '';
+      const messageValue: unknown = stringField.values[j] ?? '';
       // This should be string but sometimes isn't (eg elastic) because the dataFrame is not strongly typed.
       const message: string = typeof messageValue === 'string' ? messageValue : JSON.stringify(messageValue);
 
@@ -433,7 +433,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
       }
 
       let logLevel = LogLevel.unknown;
-      const logLevelKey = (logLevelField && logLevelField.values.get(j)) || (labels && labels['level']);
+      const logLevelKey = (logLevelField && logLevelField.values[j]) || (labels && labels['level']);
       if (logLevelKey) {
         logLevel = getLogLevelFromKey(logLevelKey);
       } else {
@@ -459,7 +459,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
         entry,
         raw: message,
         labels: labels || {},
-        uid: idField ? idField.values.get(j) : j.toString(),
+        uid: idField ? idField.values[j] : j.toString(),
         datasourceType,
       });
     }

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -117,7 +117,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
                       onClickHideField={onClickHideField}
                       onClickFilterOutLabel={onClickFilterOutLabel}
                       onClickFilterLabel={onClickFilterLabel}
-                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values.toArray())}
+                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values)}
                       displayedFields={displayedFields}
                       wrapLogMessage={wrapLogMessage}
                       row={row}
@@ -144,7 +144,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
                       links={links}
                       onClickShowField={onClickShowField}
                       onClickHideField={onClickHideField}
-                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values.toArray())}
+                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values)}
                       displayedFields={displayedFields}
                       wrapLogMessage={wrapLogMessage}
                       row={row}
@@ -163,7 +163,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
                       links={links}
                       onClickShowField={onClickShowField}
                       onClickHideField={onClickHideField}
-                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values.toArray())}
+                      getStats={() => calculateStats(row.dataFrame.fields[fieldIndex].values)}
                       displayedFields={displayedFields}
                       wrapLogMessage={wrapLogMessage}
                       row={row}

--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, FieldType, MutableDataFrame } from '@grafana/data';
+import { FieldType, MutableDataFrame } from '@grafana/data';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
 import { createLogRow } from './__mocks__/logRow';
@@ -17,7 +17,7 @@ describe('logParser', () => {
               name: 'labels',
               type: FieldType.other,
               config: {},
-              values: new ArrayVector([{ place: 'luna', source: 'data' }]),
+              values: [{ place: 'luna', source: 'data' }],
             },
           ],
         }),
@@ -39,7 +39,7 @@ describe('logParser', () => {
               name: 'labels',
               type: FieldType.string,
               config: {},
-              values: new ArrayVector([{ place: 'luna', source: 'data' }]),
+              values: [{ place: 'luna', source: 'data' }],
             },
           ],
         }),
@@ -60,7 +60,7 @@ describe('logParser', () => {
               name: 'id',
               type: FieldType.string,
               config: {},
-              values: new ArrayVector(['1659620138401000000_8b1f7688_']),
+              values: ['1659620138401000000_8b1f7688_'],
             },
           ],
         }),
@@ -129,7 +129,7 @@ describe('logParser', () => {
           config: { links: [] },
           name: 'Line',
           type: FieldType.string,
-          values: new ArrayVector(['a', 'b']),
+          values: ['a', 'b'],
         },
         title: 'test',
         target: '_self',
@@ -163,7 +163,7 @@ describe('logParser', () => {
           config: { links: [] },
           name: 'Line',
           type: FieldType.string,
-          values: new ArrayVector(['a', 'b']),
+          values: ['a', 'b'],
         },
         title: 'test',
         target: '_self',
@@ -186,12 +186,12 @@ const testStringField = {
   name: 'test_field_string',
   type: FieldType.string,
   config: {},
-  values: new ArrayVector(['abc']),
+  values: ['abc'],
 };
 
 const testFieldWithNullValue = {
   name: 'test_field_null',
   type: FieldType.string,
   config: {},
-  values: new ArrayVector([null]),
+  values: [null],
 };

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -71,7 +71,7 @@ export const getDataframeFields = memoizeOne(
         const links = getFieldLinks ? getFieldLinks(field, row.rowIndex, row.dataFrame) : [];
         return {
           keys: [field.name],
-          values: [field.values.get(row.rowIndex).toString()],
+          values: [field.values[row.rowIndex].toString()],
           links: links,
           fieldIndex: field.index,
         };
@@ -93,7 +93,7 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   if (
     field.name === firstTimeField?.name &&
     field.type === FieldType.time &&
-    field.values.get(0) === firstTimeField.values.get(0)
+    field.values[0] === firstTimeField.values[0]
   ) {
     return true;
   }
@@ -102,7 +102,7 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
     return true;
   }
   // field that has empty value (we want to keep 0 or empty string)
-  if (field.values.get(row.rowIndex) == null) {
+  if (field.values[row.rowIndex] == null) {
     return true;
   }
   return false;

--- a/public/app/features/plugins/sql/ResponseParser.ts
+++ b/public/app/features/plugins/sql/ResponseParser.ts
@@ -11,11 +11,11 @@ export class ResponseParser implements ResponseParserType {
 
     if (textField && valueField) {
       for (let i = 0; i < textField.values.length; i++) {
-        values.push({ text: '' + textField.values.get(i), value: '' + valueField.values.get(i) });
+        values.push({ text: '' + textField.values[i], value: '' + valueField.values[i] });
       }
     } else {
       for (const field of frame.fields) {
-        for (const value of field.values.toArray()) {
+        for (const value of field.values) {
           values.push({ text: value });
         }
       }

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
@@ -4,7 +4,6 @@ import {
   DataFrame,
   dataFrameToJSON,
   MutableDataFrame,
-  ArrayVector,
   DataSourceInstanceSettings,
   DataSourceJsonData,
   DataSourceRef,
@@ -35,15 +34,15 @@ export function setupForLogs() {
     fields: [
       {
         name: '@message',
-        values: new ArrayVector(['something']),
+        values: ['something'],
       },
       {
         name: '@timestamp',
-        values: new ArrayVector([1]),
+        values: [1],
       },
       {
         name: '@xrayTraceId',
-        values: new ArrayVector(['1-613f0d6b-3e7cb34375b60662359611bd']),
+        values: ['1-613f0d6b-3e7cb34375b60662359611bd'],
       },
     ],
     meta: { custom: { Status: CloudWatchLogsQueryStatus.Complete } },

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -128,7 +128,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
         // This queries for the results
         this.logsQuery(
           frames.map((dataFrame) => ({
-            queryId: dataFrame.fields[0].values.get(0),
+            queryId: dataFrame.fields[0].values[0],
             region: dataFrame.meta?.custom?.['Region'] ?? 'default',
             refId: dataFrame.refId!,
             statsGroups: logQueries.find((target) => target.refId === dataFrame.refId)?.statsGroups,
@@ -350,8 +350,8 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       limit,
       startFromHead: direction !== LogRowContextQueryDirection.Backward,
       region: query?.region,
-      logGroupName: parseLogGroupName(logField!.values.get(row.rowIndex)),
-      logStreamName: logStreamField!.values.get(row.rowIndex),
+      logGroupName: parseLogGroupName(logField!.values[row.rowIndex]),
+      logStreamName: logStreamField!.values[row.rowIndex],
     };
 
     if (direction === LogRowContextQueryDirection.Backward) {

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
@@ -120,8 +120,8 @@ describe('runWithRetry', () => {
     // dataframe fields
     expect(values.length).toBe(1);
     expect(values[0].frames.length).toBe(2);
-    expect(values[0].frames[0].fields[0].values.get(0)).toBe('A');
-    expect(values[0].frames[1].fields[0].values.get(0)).toBe('B');
+    expect(values[0].frames[0].fields[0].values[0]).toBe('A');
+    expect(values[0].frames[1].fields[0].values[0]).toBe('B');
   });
 
   it('sends data and also error if only one query gets limit error', async () => {
@@ -145,7 +145,7 @@ describe('runWithRetry', () => {
     expect(queryFunc).nthCalledWith(1, targets);
     expect(values.length).toBe(1);
     expect(values[0].frames.length).toBe(1);
-    expect(values[0].frames[0].fields[0].values.get(0)).toBe('A');
+    expect(values[0].frames[0].fields[0].values[0]).toBe('A');
     expect(values[0].error).toEqual({ message: 'Some queries timed out: LimitExceededException' });
   });
 
@@ -190,8 +190,8 @@ describe('runWithRetry', () => {
     expect(queryFunc).nthCalledWith(3, [targetC]);
     expect(values.length).toBe(1);
     expect(values[0].frames.length).toBe(2);
-    expect(values[0].frames[0].fields[0].values.get(0)).toBe('A');
-    expect(values[0].frames[1].fields[0].values.get(0)).toBe('B');
+    expect(values[0].frames[0].fields[0].values[0]).toBe('A');
+    expect(values[0].frames[1].fields[0].values[0]).toBe('B');
     expect(values[0].error).toEqual({ message: 'Some queries timed out: LimitExceededException' });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
@@ -315,8 +315,8 @@ describe('ElasticResponse', () => {
       const frame = result.data[0];
       expect(frame.name).toBe('Count');
       expect(frame.length).toBe(2);
-      expect(getTimeField(frame).values.get(0)).toBe(1000);
-      expect(getValueField(frame).values.get(0)).toBe(10);
+      expect(getTimeField(frame).values[0]).toBe(1000);
+      expect(getValueField(frame).values[0]).toBe(10);
     });
   });
 
@@ -367,11 +367,11 @@ describe('ElasticResponse', () => {
       const frame1 = result.data[0];
       const frame2 = result.data[1];
       expect(frame1.length).toBe(2);
-      expect(getValueField(frame1).values.get(0)).toBe(10);
-      expect(getTimeField(frame1).values.get(0)).toBe(1000);
+      expect(getValueField(frame1).values[0]).toBe(10);
+      expect(getTimeField(frame1).values[0]).toBe(1000);
 
       expect(frame2.name).toBe('Average value');
-      expect(getValueField(frame2).values.toArray()).toEqual([88, 99]);
+      expect(getValueField(frame2).values).toEqual([88, 99]);
     });
   });
 
@@ -546,9 +546,9 @@ describe('ElasticResponse', () => {
       expect(result.data[0].length).toBe(2);
       expect(result.data[0].name).toBe('p75 @value');
       expect(result.data[1].name).toBe('p90 @value');
-      expect(getValueField(result.data[0]).values.get(0)).toBe(3.3);
-      expect(getTimeField(result.data[0]).values.get(0)).toBe(1000);
-      expect(getValueField(result.data[1]).values.get(1)).toBe(4.5);
+      expect(getValueField(result.data[0]).values[0]).toBe(3.3);
+      expect(getTimeField(result.data[0]).values[0]).toBe(1000);
+      expect(getValueField(result.data[1]).values[1]).toBe(4.5);
     });
   });
 
@@ -629,8 +629,8 @@ describe('ElasticResponse', () => {
       expect(result.data[0].name).toBe('server1 Max @value');
       expect(result.data[1].name).toBe('server1 Std Dev Upper @value');
 
-      expect(getValueField(result.data[0]).values.get(0)).toBe(10.2);
-      expect(getValueField(result.data[1]).values.get(0)).toBe(3);
+      expect(getValueField(result.data[0]).values[0]).toBe(10.2);
+      expect(getValueField(result.data[1]).values[0]).toBe(3);
     });
   });
 
@@ -688,20 +688,20 @@ describe('ElasticResponse', () => {
       const firstSeries = result.data[0];
       expect(firstSeries.name).toBe('Top Metrics @value');
       expect(firstSeries.length).toBe(2);
-      expect(getTimeField(firstSeries).values.toArray()).toEqual([
+      expect(getTimeField(firstSeries).values).toEqual([
         new Date('2021-01-01T00:00:00.000Z').valueOf(),
         new Date('2021-01-01T00:00:10.000Z').valueOf(),
       ]);
-      expect(getValueField(firstSeries).values.toArray()).toEqual([1, 1]);
+      expect(getValueField(firstSeries).values).toEqual([1, 1]);
 
       const secondSeries = result.data[1];
       expect(secondSeries.name).toBe('Top Metrics @anotherValue');
       expect(secondSeries.length).toBe(2);
-      expect(getTimeField(secondSeries).values.toArray()).toEqual([
+      expect(getTimeField(secondSeries).values).toEqual([
         new Date('2021-01-01T00:00:00.000Z').valueOf(),
         new Date('2021-01-01T00:00:10.000Z').valueOf(),
       ]);
-      expect(getValueField(secondSeries).values.toArray()).toEqual([2, 2]);
+      expect(getValueField(secondSeries).values).toEqual([2, 2]);
     });
   });
 
@@ -1044,9 +1044,9 @@ describe('ElasticResponse', () => {
       expect(field2.name).toBe('p75 value');
       expect(field3.name).toBe('p90 value');
 
-      expect(field1.values.toArray()).toEqual(['id1', 'id2']);
-      expect(field2.values.toArray()).toEqual([3.3, 2.3]);
-      expect(field3.values.toArray()).toEqual([5.5, 4.5]);
+      expect(field1.values).toEqual(['id1', 'id2']);
+      expect(field2.values).toEqual([3.3, 2.3]);
+      expect(field3.values).toEqual([5.5, 4.5]);
     });
   });
 
@@ -1088,9 +1088,9 @@ describe('ElasticResponse', () => {
     it('should include field in metric name', () => {
       expect(result.data[0].length).toBe(1);
       expect(result.data[0].fields.length).toBe(3);
-      expect(result.data[0].fields[0].values.toArray()).toEqual(['server-1']);
-      expect(result.data[0].fields[1].values.toArray()).toEqual([1000]);
-      expect(result.data[0].fields[2].values.toArray()).toEqual([3000]);
+      expect(result.data[0].fields[0].values).toEqual(['server-1']);
+      expect(result.data[0].fields[1].values).toEqual([1000]);
+      expect(result.data[0].fields[2].values).toEqual([3000]);
     });
   });
 
@@ -1139,7 +1139,7 @@ describe('ElasticResponse', () => {
       expect(fields.length).toBe(1);
       const field = fields[0];
       expect(field.type === FieldType.other);
-      const values = field.values.toArray();
+      const values = field.values;
       expect(values.length).toBe(2);
       expect(values[0].sourceProp).toBe('asd');
       expect(values[0].fieldProp).toBe('field');
@@ -1206,12 +1206,12 @@ describe('ElasticResponse', () => {
       expect(result.data[0].name).toBe('Sum @value');
       expect(result.data[1].name).toBe('Max @value');
       expect(result.data[2].name).toBe('Sum @value * Max @value');
-      expect(getValueField(result.data[0]).values.get(0)).toBe(2);
-      expect(getValueField(result.data[1]).values.get(0)).toBe(3);
-      expect(getValueField(result.data[2]).values.get(0)).toBe(6);
-      expect(getValueField(result.data[0]).values.get(1)).toBe(3);
-      expect(getValueField(result.data[1]).values.get(1)).toBe(4);
-      expect(getValueField(result.data[2]).values.get(1)).toBe(12);
+      expect(getValueField(result.data[0]).values[0]).toBe(2);
+      expect(getValueField(result.data[1]).values[0]).toBe(3);
+      expect(getValueField(result.data[2]).values[0]).toBe(6);
+      expect(getValueField(result.data[0]).values[1]).toBe(3);
+      expect(getValueField(result.data[1]).values[1]).toBe(4);
+      expect(getValueField(result.data[2]).values[1]).toBe(12);
     });
   });
 
@@ -1286,11 +1286,11 @@ describe('ElasticResponse', () => {
       expect(frame.length).toBe(2);
       const { fields } = frame;
       expect(fields.length).toBe(5);
-      expect(fields[0].values.toArray()).toEqual([1000, 2000]);
-      expect(fields[1].values.toArray()).toEqual([2, 3]);
-      expect(fields[2].values.toArray()).toEqual([3, 4]);
-      expect(fields[3].values.toArray()).toEqual([6, 12]);
-      expect(fields[4].values.toArray()).toEqual([24, 48]);
+      expect(fields[0].values).toEqual([1000, 2000]);
+      expect(fields[1].values).toEqual([2, 3]);
+      expect(fields[2].values).toEqual([3, 4]);
+      expect(fields[3].values).toEqual([6, 12]);
+      expect(fields[4].values).toEqual([24, 48]);
     });
   });
 
@@ -1338,7 +1338,7 @@ describe('ElasticResponse', () => {
     it('should have time field values in DateTime format', () => {
       const timeField = result.data[0].fields.find((field) => field.name === '@timestamp');
       expect(timeField).toBeDefined();
-      expect(timeField?.values.get(0)).toBe(1546300800000);
+      expect(timeField?.values[0]).toBe(1546300800000);
     });
   });
 
@@ -1467,14 +1467,14 @@ describe('ElasticResponse', () => {
       const result = new ElasticResponse(targets, response).getLogs(undefined, 'level');
       const fieldCache = new FieldCache(result.data[0]);
       const field = fieldCache.getFieldByName('level');
-      expect(field?.values.toArray()).toEqual(['debug', 'error']);
+      expect(field?.values).toEqual(['debug', 'error']);
     });
 
     it('should re map levels field to new field', () => {
       const result = new ElasticResponse(targets, response).getLogs(undefined, 'fields.lvl');
       const fieldCache = new FieldCache(result.data[0]);
       const field = fieldCache.getFieldByName('level');
-      expect(field?.values.toArray()).toEqual(['debug', 'info']);
+      expect(field?.values).toEqual(['debug', 'info']);
     });
 
     it('should correctly guess field types', () => {

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
@@ -604,7 +604,7 @@ export class ElasticResponse {
 
     for (let frame of dataFrame) {
       for (let field of frame.fields) {
-        if (field.type === FieldType.time && typeof field.values.get(0) !== 'number') {
+        if (field.type === FieldType.time && typeof field.values[0] !== 'number') {
           field.values = convertFieldType(field, { destinationType: FieldType.time }).values;
         }
       }

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -134,7 +134,7 @@ export class UnthemedQueryEditor extends PureComponent<Props, State> {
           next: (rsp) => {
             if (rsp.data.length) {
               const names = (rsp.data[0] as DataFrame).fields[0];
-              const folders = names.values.toArray().map((v) => ({
+              const folders = names.values.map((v) => ({
                 value: v,
                 label: v,
               }));

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -178,7 +178,7 @@ describe('graphiteDatasource', () => {
     it('should convert to millisecond resolution', async () => {
       await expect(response).toEmitValuesWith((values: any) => {
         const results = values[0];
-        expect(results.data[0].fields[1].values.get(0)).toBe(10);
+        expect(results.data[0].fields[1].values[0]).toBe(10);
       });
     });
   });

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -376,8 +376,8 @@ export class GraphiteDatasource
               const target = result.data[i];
 
               for (let y = 0; y < target.length; y++) {
-                const time = target.fields[0].values.get(y);
-                const value = target.fields[1].values.get(y);
+                const time = target.fields[0].values[y];
+                const value = target.fields[1].values[y];
 
                 if (!value) {
                   continue;

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -4,7 +4,6 @@ import { catchError, map } from 'rxjs/operators';
 
 import {
   AnnotationEvent,
-  ArrayVector,
   DataFrame,
   DataQueryError,
   DataQueryRequest,
@@ -89,7 +88,7 @@ function timeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
     name: TIME_SERIES_TIME_FIELD_NAME,
     type: FieldType.time,
     config: {},
-    values: new ArrayVector<number>(times),
+    values: times,
   };
 
   const valueField = {
@@ -98,7 +97,7 @@ function timeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
     config: {
       displayNameFromDS: timeSeries.title,
     },
-    values: new ArrayVector<unknown>(values),
+    values: values,
     labels: timeSeries.tags,
   };
 

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -234,12 +234,12 @@ function getTableCols(dfs: DataFrame[], table: TableModel, target: InfluxQuery):
 }
 
 function getTableRows(dfs: DataFrame[], table: TableModel, labels: string[]): TableModel {
-  const values = dfs[0].fields[0].values.toArray();
+  const values = dfs[0].fields[0].values;
 
   for (let i = 0; i < values.length; i++) {
     const time = values[i];
     const metrics = dfs.map((df: DataFrame) => {
-      return df.fields[1] ? df.fields[1].values.toArray()[i] : null;
+      return df.fields[1] ? df.fields[1].values[i] : null;
     });
     if (metrics.indexOf(null) < 0) {
       table.rows.push([time, ...labels, ...metrics]);

--- a/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import { ArrayVector, DataFrame, DataQueryResponse, Field, FieldType } from '@grafana/data';
+import { DataFrame, DataQueryResponse, Field, FieldType } from '@grafana/data';
 
 import { transformBackendResult } from './backendResultTransformer';
 
@@ -31,34 +31,34 @@ const inputFrame: DataFrame = {
       name: 'Time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1645030244810, 1645030247027]),
+      values: [1645030244810, 1645030247027],
     },
     {
       name: 'Line',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['line1', 'line2']),
+      values: ['line1', 'line2'],
     },
     {
       name: 'labels',
       type: FieldType.other,
       config: {},
-      values: new ArrayVector([
+      values: [
         { level: 'info', code: '41🌙' },
         { level: 'error', code: '41🌙' },
-      ]),
+      ],
     },
     {
       name: 'tsNs',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['1645030244810757120', '1645030247027735040']),
+      values: ['1645030244810757120', '1645030247027735040'],
     },
     {
       name: 'id',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['id1', 'id2']),
+      values: ['id1', 'id2'],
     },
   ],
   length: 5,
@@ -132,13 +132,13 @@ describe('loki backendResultTransformer', () => {
         {
           name: 'time',
           config: {},
-          values: new ArrayVector([1]),
+          values: [1],
           type: FieldType.time,
         },
         {
           name: 'line',
           config: {},
-          values: new ArrayVector(['line1']),
+          values: ['line1'],
           type: FieldType.string,
         },
       ],
@@ -167,10 +167,10 @@ describe('loki backendResultTransformer', () => {
       name: 'labels',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector([
+      values: [
         { level: 'info', code: '41🌙', __error__: 'LogfmtParserErr' },
         { level: 'error', code: '41🌙' },
-      ]),
+      ],
     };
     const response: DataQueryResponse = { data: [clonedFrame] };
 

--- a/public/app/plugins/datasource/loki/configuration/DebugSection.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DebugSection.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import cx from 'classnames';
 import React, { ReactNode, useState } from 'react';
 
-import { ArrayVector, Field, FieldType, LinkModel } from '@grafana/data';
+import { Field, FieldType, LinkModel } from '@grafana/data';
 import { LegacyForms } from '@grafana/ui';
 
 import { getFieldLinksForExplore } from '../../../../features/explore/utils/links';
@@ -102,7 +102,7 @@ function makeDebugFields(derivedFields: DerivedFieldConfig[], debugText: string)
             field: {
               name: '',
               type: FieldType.string,
-              values: new ArrayVector([value]),
+              values: [value],
               config: {
                 links: [{ title: '', url: field.url }],
               },

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -5,7 +5,6 @@ import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import {
   AbstractLabelOperator,
   AnnotationQueryRequest,
-  ArrayVector,
   CoreApp,
   DataFrame,
   dataFrameToJSON,
@@ -57,19 +56,19 @@ const testFrame: DataFrame = {
       name: 'Time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1, 2]),
+      values: [1, 2],
     },
     {
       name: 'Line',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['line1', 'line2']),
+      values: ['line1', 'line2'],
     },
     {
       name: 'labels',
       type: FieldType.other,
       config: {},
-      values: new ArrayVector([
+      values: [
         {
           label: 'value',
           label2: 'value ',
@@ -79,19 +78,19 @@ const testFrame: DataFrame = {
           label2: 'value2',
           label3: ' ',
         },
-      ]),
+      ],
     },
     {
       name: 'tsNs',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['1000000', '2000000']),
+      values: ['1000000', '2000000'],
     },
     {
       name: 'id',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['id1', 'id2']),
+      values: ['id1', 'id2'],
     },
   ],
   length: 2,
@@ -400,19 +399,19 @@ describe('LokiDatasource', () => {
             name: 'Time',
             type: FieldType.time,
             config: {},
-            values: new ArrayVector([1, 2]),
+            values: [1, 2],
           },
           {
             name: 'Line',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['hello', 'hello 2']),
+            values: ['hello', 'hello 2'],
           },
           {
             name: 'labels',
             type: FieldType.other,
             config: {},
-            values: new ArrayVector([
+            values: [
               {
                 label: 'value',
                 label2: 'value ',
@@ -422,19 +421,19 @@ describe('LokiDatasource', () => {
                 label2: 'value2',
                 label3: ' ',
               },
-            ]),
+            ],
           },
           {
             name: 'tsNs',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['1000000', '2000000']),
+            values: ['1000000', '2000000'],
           },
           {
             name: 'id',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['id1', 'id2']),
+            values: ['id1', 'id2'],
           },
         ],
         length: 2,
@@ -457,37 +456,37 @@ describe('LokiDatasource', () => {
             name: 'Time',
             type: FieldType.time,
             config: {},
-            values: new ArrayVector([1]),
+            values: [1],
           },
           {
             name: 'Line',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['hello']),
+            values: ['hello'],
           },
           {
             name: 'labels',
             type: FieldType.other,
             config: {},
-            values: new ArrayVector([
+            values: [
               {
                 label: 'value',
                 label2: 'value2',
                 label3: 'value3',
               },
-            ]),
+            ],
           },
           {
             name: 'tsNs',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['1000000']),
+            values: ['1000000'],
           },
           {
             name: 'id',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['id1']),
+            values: ['id1'],
           },
         ],
         length: 1,

--- a/public/app/plugins/datasource/loki/getDerivedFields.test.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.test.ts
@@ -39,14 +39,14 @@ describe('getDerivedFields', () => {
     ]);
     expect(newFields.length).toBe(2);
     const trace1 = newFields.find((f) => f.name === 'trace1');
-    expect(trace1!.values.toArray()).toEqual([null, '1234', null]);
+    expect(trace1!.values).toEqual([null, '1234', null]);
     expect(trace1!.config.links![0]).toEqual({
       url: 'http://localhost/${__value.raw}',
       title: '',
     });
 
     const trace2 = newFields.find((f) => f.name === 'trace2');
-    expect(trace2!.values.toArray()).toEqual([null, null, 'foo']);
+    expect(trace2!.values).toEqual([null, null, 'foo']);
     expect(trace2!.config.links!.length).toBe(2);
     expect(trace2!.config.links![0]).toEqual({
       title: '',

--- a/public/app/plugins/datasource/loki/getDerivedFields.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.ts
@@ -1,6 +1,6 @@
 import { groupBy } from 'lodash';
 
-import { FieldType, DataFrame, ArrayVector, DataLink, Field } from '@grafana/data';
+import { FieldType, DataFrame, DataLink, Field } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { DerivedFieldConfig } from './types';
@@ -22,7 +22,7 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
     throw new Error('invalid logs-dataframe, string-field missing');
   }
 
-  lineField.values.toArray().forEach((line) => {
+  lineField.values.forEach((line) => {
     for (const field of newFields) {
       const logMatch = line.match(derivedFieldsGrouped[field.name][0].matcherRegex);
       field.values.add(logMatch && logMatch[1]);
@@ -35,7 +35,7 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
 /**
  * Transform derivedField config into dataframe field with config that contains link.
  */
-function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]): Field<any, ArrayVector> {
+function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]): Field {
   const dataSourceSrv = getDataSourceSrv();
 
   const dataLinks = derivedFieldConfigs.reduce<DataLink[]>((acc, derivedFieldConfig) => {
@@ -72,6 +72,6 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
       links: dataLinks,
     },
     // We are adding values later on
-    values: new ArrayVector<string>([]),
+    values: [],
   };
 }

--- a/public/app/plugins/datasource/loki/makeTableFrames.test.ts
+++ b/public/app/plugins/datasource/loki/makeTableFrames.test.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
+import { DataFrame, FieldType } from '@grafana/data';
 
 import { makeTableFrames } from './makeTableFrames';
 
@@ -13,7 +13,7 @@ const frame1: DataFrame = {
       name: 'Time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1645029699311]),
+      values: [1645029699311],
     },
     {
       name: 'Value',
@@ -26,7 +26,7 @@ const frame1: DataFrame = {
       config: {
         displayNameFromDS: '{level="error", location="moon", protocol="http"}',
       },
-      values: new ArrayVector([23]),
+      values: [23],
     },
   ],
   length: 1,
@@ -43,7 +43,7 @@ const frame2: DataFrame = {
       name: 'Time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1645029699311]),
+      values: [1645029699311],
     },
     {
       name: 'Value',
@@ -56,7 +56,7 @@ const frame2: DataFrame = {
       config: {
         displayNameFromDS: '{level="info", location="moon", protocol="http"}',
       },
-      values: new ArrayVector([45]),
+      values: [45],
     },
   ],
   length: 1,
@@ -73,7 +73,7 @@ const frame3: DataFrame = {
       name: 'Time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1645029699311]),
+      values: [1645029699311],
     },
     {
       name: 'Value',
@@ -86,7 +86,7 @@ const frame3: DataFrame = {
       config: {
         displayNameFromDS: '{level="error", location="moon", protocol="http"}',
       },
-      values: new ArrayVector([72]),
+      values: [72],
     },
   ],
   length: 1,
@@ -95,11 +95,11 @@ const frame3: DataFrame = {
 const outputSingle = [
   {
     fields: [
-      { config: {}, name: 'Time', type: 'time', values: new ArrayVector([1645029699311]) },
-      { config: { filterable: true }, name: 'level', type: 'string', values: new ArrayVector(['error']) },
-      { config: { filterable: true }, name: 'location', type: 'string', values: new ArrayVector(['moon']) },
-      { config: { filterable: true }, name: 'protocol', type: 'string', values: new ArrayVector(['http']) },
-      { config: {}, name: 'Value #A', type: 'number', values: new ArrayVector([23]) },
+      { config: {}, name: 'Time', type: 'time', values: [1645029699311] },
+      { config: { filterable: true }, name: 'level', type: 'string', values: ['error'] },
+      { config: { filterable: true }, name: 'location', type: 'string', values: ['moon'] },
+      { config: { filterable: true }, name: 'protocol', type: 'string', values: ['http'] },
+      { config: {}, name: 'Value #A', type: 'number', values: [23] },
     ],
     length: 1,
     meta: { preferredVisualisationType: 'table' },
@@ -110,11 +110,11 @@ const outputSingle = [
 const outputMulti = [
   {
     fields: [
-      { config: {}, name: 'Time', type: 'time', values: new ArrayVector([1645029699311, 1645029699311]) },
-      { config: { filterable: true }, name: 'level', type: 'string', values: new ArrayVector(['error', 'info']) },
-      { config: { filterable: true }, name: 'location', type: 'string', values: new ArrayVector(['moon', 'moon']) },
-      { config: { filterable: true }, name: 'protocol', type: 'string', values: new ArrayVector(['http', 'http']) },
-      { config: {}, name: 'Value #A', type: 'number', values: new ArrayVector([23, 45]) },
+      { config: {}, name: 'Time', type: 'time', values: [1645029699311, 1645029699311] },
+      { config: { filterable: true }, name: 'level', type: 'string', values: ['error', 'info'] },
+      { config: { filterable: true }, name: 'location', type: 'string', values: ['moon', 'moon'] },
+      { config: { filterable: true }, name: 'protocol', type: 'string', values: ['http', 'http'] },
+      { config: {}, name: 'Value #A', type: 'number', values: [23, 45] },
     ],
     length: 2,
     meta: { preferredVisualisationType: 'table' },
@@ -122,11 +122,11 @@ const outputMulti = [
   },
   {
     fields: [
-      { config: {}, name: 'Time', type: 'time', values: new ArrayVector([1645029699311]) },
-      { config: { filterable: true }, name: 'level', type: 'string', values: new ArrayVector(['error']) },
-      { config: { filterable: true }, name: 'location', type: 'string', values: new ArrayVector(['moon']) },
-      { config: { filterable: true }, name: 'protocol', type: 'string', values: new ArrayVector(['http']) },
-      { config: {}, name: 'Value #B', type: 'number', values: new ArrayVector([72]) },
+      { config: {}, name: 'Time', type: 'time', values: [1645029699311] },
+      { config: { filterable: true }, name: 'level', type: 'string', values: ['error'] },
+      { config: { filterable: true }, name: 'location', type: 'string', values: ['moon'] },
+      { config: { filterable: true }, name: 'protocol', type: 'string', values: ['http'] },
+      { config: {}, name: 'Value #B', type: 'number', values: [72] },
     ],
     length: 1,
     meta: { preferredVisualisationType: 'table' },

--- a/public/app/plugins/datasource/loki/makeTableFrames.ts
+++ b/public/app/plugins/datasource/loki/makeTableFrames.ts
@@ -1,6 +1,6 @@
 import { groupBy } from 'lodash';
 
-import { DataFrame, Field, FieldType, ArrayVector } from '@grafana/data';
+import { DataFrame, Field, FieldType } from '@grafana/data';
 
 export function makeTableFrames(instantMetricFrames: DataFrame[]): DataFrame[] {
   // first we remove frames that have no refId
@@ -12,15 +12,15 @@ export function makeTableFrames(instantMetricFrames: DataFrame[]): DataFrame[] {
   return Object.entries(framesByRefId).map(([refId, frames]) => makeTableFrame(frames, refId));
 }
 
-type NumberField = Field<number, ArrayVector<number>>;
-type StringField = Field<string, ArrayVector<string>>;
+type NumberField = Field<number, number[]>;
+type StringField = Field<string, string[]>;
 
 function makeTableFrame(instantMetricFrames: DataFrame[], refId: string): DataFrame {
-  const tableTimeField: NumberField = { name: 'Time', config: {}, values: new ArrayVector(), type: FieldType.time };
+  const tableTimeField: NumberField = { name: 'Time', config: {}, values: [], type: FieldType.time };
   const tableValueField: NumberField = {
     name: `Value #${refId}`,
     config: {},
-    values: new ArrayVector(),
+    values: [],
     type: FieldType.number,
   };
 
@@ -34,7 +34,7 @@ function makeTableFrame(instantMetricFrames: DataFrame[], refId: string): DataFr
   const labelFields: StringField[] = sortedLabelNames.map((labelName) => ({
     name: labelName,
     config: { filterable: true },
-    values: new ArrayVector(),
+    values: [],
     type: FieldType.string,
   }));
 
@@ -45,15 +45,15 @@ function makeTableFrame(instantMetricFrames: DataFrame[], refId: string): DataFr
       return;
     }
 
-    const timeArray = timeField.values.toArray();
-    const valueArray = valueField.values.toArray();
+    const timeArray = timeField.values;
+    const valueArray = valueField.values;
 
     for (let x of timeArray) {
-      tableTimeField.values.add(x);
+      tableTimeField.values.push(x);
     }
 
     for (let x of valueArray) {
-      tableValueField.values.add(x);
+      tableValueField.values.push(x);
     }
 
     const labels = valueField.labels ?? {};
@@ -62,7 +62,7 @@ function makeTableFrame(instantMetricFrames: DataFrame[], refId: string): DataFr
       const text = labels[f.name] ?? '';
       // we insert the labels as many times as we have values
       for (let i = 0; i < valueArray.length; i++) {
-        f.values.add(text);
+        f.values.push(text);
       }
     }
   });

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -1,12 +1,4 @@
-import {
-  ArrayVector,
-  DataFrame,
-  DataSourceInstanceSettings,
-  DataSourceSettings,
-  FieldType,
-  PluginType,
-  toUtc,
-} from '@grafana/data';
+import { DataFrame, DataSourceInstanceSettings, DataSourceSettings, FieldType, PluginType, toUtc } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { getMockDataSource } from '../../../features/datasources/__mocks__';
@@ -116,38 +108,38 @@ export function getMockFrames() {
         name: 'Time',
         type: FieldType.time,
         config: {},
-        values: new ArrayVector([3, 4]),
+        values: [3, 4],
       },
       {
         name: 'Line',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['line1', 'line2']),
+        values: ['line1', 'line2'],
       },
       {
         name: 'labels',
         type: FieldType.other,
         config: {},
-        values: new ArrayVector([
+        values: [
           {
             label: 'value',
           },
           {
             otherLabel: 'other value',
           },
-        ]),
+        ],
       },
       {
         name: 'tsNs',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['3000000', '4000000']),
+        values: ['3000000', '4000000'],
       },
       {
         name: 'id',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['id1', 'id2']),
+        values: ['id1', 'id2'],
       },
     ],
     meta: {
@@ -166,35 +158,35 @@ export function getMockFrames() {
         name: 'Time',
         type: FieldType.time,
         config: {},
-        values: new ArrayVector([1, 2]),
+        values: [1, 2],
       },
       {
         name: 'Line',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['line3', 'line4']),
+        values: ['line3', 'line4'],
       },
       {
         name: 'labels',
         type: FieldType.other,
         config: {},
-        values: new ArrayVector([
+        values: [
           {
             otherLabel: 'other value',
           },
-        ]),
+        ],
       },
       {
         name: 'tsNs',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['1000000', '2000000']),
+        values: ['1000000', '2000000'],
       },
       {
         name: 'id',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector(['id3', 'id4']),
+        values: ['id3', 'id4'],
       },
     ],
     meta: {
@@ -213,13 +205,13 @@ export function getMockFrames() {
         name: 'Time',
         type: FieldType.time,
         config: {},
-        values: new ArrayVector([3000000, 4000000]),
+        values: [3000000, 4000000],
       },
       {
         name: 'Value',
         type: FieldType.number,
         config: {},
-        values: new ArrayVector([5, 4]),
+        values: [5, 4],
       },
     ],
     meta: {
@@ -238,13 +230,13 @@ export function getMockFrames() {
         name: 'Time',
         type: FieldType.time,
         config: {},
-        values: new ArrayVector([1000000, 2000000]),
+        values: [1000000, 2000000],
       },
       {
         name: 'Value',
         type: FieldType.number,
         config: {},
-        values: new ArrayVector([6, 7]),
+        values: [6, 7],
       },
     ],
     meta: {
@@ -264,13 +256,13 @@ export function getMockFrames() {
         name: 'Time',
         type: FieldType.time,
         config: {},
-        values: new ArrayVector([3000000, 4000000]),
+        values: [3000000, 4000000],
       },
       {
         name: 'Value',
         type: FieldType.number,
         config: {},
-        values: new ArrayVector([6, 7]),
+        values: [6, 7],
       },
     ],
     meta: {

--- a/public/app/plugins/datasource/loki/queryHints.test.ts
+++ b/public/app/plugins/datasource/loki/queryHints.test.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
+import { DataFrame, FieldType } from '@grafana/data';
 
 import { getQueryHints } from './queryHints';
 
@@ -12,7 +12,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['{"foo": "bar", "bar": "baz"}', '{"foo": "bar", "bar": "baz"}']),
+          values: ['{"foo": "bar", "bar": "baz"}', '{"foo": "bar", "bar": "baz"}'],
         },
       ],
     };
@@ -39,7 +39,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['foo="bar" bar="baz"', 'foo="bar" bar="baz"']),
+          values: ['foo="bar" bar="baz"', 'foo="bar" bar="baz"'],
         },
       ],
     };
@@ -66,7 +66,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"']),
+          values: ['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"'],
         },
       ],
     };
@@ -99,7 +99,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['{"_entry": "bar", "bar": "baz"}']),
+          values: ['{"_entry": "bar", "bar": "baz"}'],
         },
       ],
     };
@@ -139,13 +139,13 @@ describe('getQueryHints', () => {
             name: 'Line',
             type: FieldType.string,
             config: {},
-            values: new ArrayVector(['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"']),
+            values: ['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"'],
           },
           {
             name: 'labels',
             type: FieldType.other,
             config: {},
-            values: new ArrayVector([labelVariable, { job: 'baz', foo: 'bar' }]),
+            values: [labelVariable, { job: 'baz', foo: 'bar' }],
           },
         ],
       };
@@ -172,7 +172,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"']),
+          values: ['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"'],
         },
       ],
     };
@@ -199,7 +199,7 @@ describe('getQueryHints', () => {
           name: 'Line',
           type: FieldType.string,
           config: {},
-          values: new ArrayVector(['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"']),
+          values: ['{"foo": "bar", "bar": "baz"}', 'foo="bar" bar="baz"'],
         },
       ],
     };
@@ -226,7 +226,7 @@ describe('getQueryHints', () => {
           name: 'labels',
           type: FieldType.other,
           config: {},
-          values: new ArrayVector([{ __error__: 'some error', job: 'a' }]),
+          values: [{ __error__: 'some error', job: 'a' }],
         },
       ],
     };

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import { ArrayVector, DataQueryResponse, QueryResultMetaStat, DataFrame, FieldType } from '@grafana/data';
+import { DataQueryResponse, QueryResultMetaStat, DataFrame, FieldType } from '@grafana/data';
 
 import { getMockFrames } from './mocks';
 import {
@@ -21,19 +21,19 @@ const frame: DataFrame = {
       name: 'Time',
       config: {},
       type: FieldType.time,
-      values: new ArrayVector([1]),
+      values: [1],
     },
     {
       name: 'labels',
       config: {},
       type: FieldType.other,
-      values: new ArrayVector([{ level: 'info' }]),
+      values: [{ level: 'info' }],
     },
     {
       name: 'Line',
       config: {},
       type: FieldType.string,
-      values: new ArrayVector(['line1']),
+      values: ['line1'],
     },
   ],
 };
@@ -41,7 +41,7 @@ const frame: DataFrame = {
 describe('dataFrameHasParsingError', () => {
   it('handles frame with parsing error', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ level: 'info', __error__: 'error' }]);
+    input.fields[1].values = [{ level: 'info', __error__: 'error' }];
     expect(dataFrameHasLokiError(input)).toBe(true);
   });
   it('handles frame without parsing error', () => {
@@ -53,12 +53,12 @@ describe('dataFrameHasParsingError', () => {
 describe('dataFrameHasLevelLabel', () => {
   it('returns true if level label is present', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ level: 'info' }]);
+    input.fields[1].values = [{ level: 'info' }];
     expect(dataFrameHasLevelLabel(input)).toBe(true);
   });
   it('returns false if level label is present', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ foo: 'bar' }]);
+    input.fields[1].values = [{ foo: 'bar' }];
     expect(dataFrameHasLevelLabel(input)).toBe(false);
   });
 });
@@ -66,17 +66,17 @@ describe('dataFrameHasLevelLabel', () => {
 describe('extractLevelLikeLabelFromDataFrame', () => {
   it('returns label if lvl label is present', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ lvl: 'info' }]);
+    input.fields[1].values = [{ lvl: 'info' }];
     expect(extractLevelLikeLabelFromDataFrame(input)).toBe('lvl');
   });
   it('returns label if level-like label is present', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ error_level: 'info' }]);
+    input.fields[1].values = [{ error_level: 'info' }];
     expect(extractLevelLikeLabelFromDataFrame(input)).toBe('error_level');
   });
   it('returns undefined if no level-like label is present', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ foo: 'info' }]);
+    input.fields[1].values = [{ foo: 'info' }];
     expect(extractLevelLikeLabelFromDataFrame(input)).toBe(null);
   });
 });
@@ -88,12 +88,12 @@ describe('extractLogParserFromDataFrame', () => {
   });
   it('identifies JSON', () => {
     const input = cloneDeep(frame);
-    input.fields[2].values = new ArrayVector(['{"a":"b"}']);
+    input.fields[2].values = ['{"a":"b"}'];
     expect(extractLogParserFromDataFrame(input)).toEqual({ hasJSON: true, hasLogfmt: false, hasPack: false });
   });
   it('identifies logfmt', () => {
     const input = cloneDeep(frame);
-    input.fields[2].values = new ArrayVector(['a=b']);
+    input.fields[2].values = ['a=b'];
     expect(extractLogParserFromDataFrame(input)).toEqual({ hasJSON: false, hasLogfmt: true, hasPack: false });
   });
 });
@@ -101,7 +101,7 @@ describe('extractLogParserFromDataFrame', () => {
 describe('extractLabelKeysFromDataFrame', () => {
   it('returns empty by default', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([]);
+    input.fields[1].values = [];
     expect(extractLabelKeysFromDataFrame(input)).toEqual([]);
   });
   it('extracts label keys', () => {
@@ -113,12 +113,12 @@ describe('extractLabelKeysFromDataFrame', () => {
 describe('extractUnwrapLabelKeysFromDataFrame', () => {
   it('returns empty by default', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([]);
+    input.fields[1].values = [];
     expect(extractUnwrapLabelKeysFromDataFrame(input)).toEqual([]);
   });
   it('extracts possible unwrap label keys', () => {
     const input = cloneDeep(frame);
-    input.fields[1].values = new ArrayVector([{ number: 13 }]);
+    input.fields[1].values = [{ number: 13 }];
     expect(extractUnwrapLabelKeysFromDataFrame(input)).toEqual(['number']);
   });
 });
@@ -152,19 +152,19 @@ describe('combineResponses', () => {
               config: {},
               name: 'Time',
               type: 'time',
-              values: new ArrayVector([1, 2, 3, 4]),
+              values: [1, 2, 3, 4],
             },
             {
               config: {},
               name: 'Line',
               type: 'string',
-              values: new ArrayVector(['line3', 'line4', 'line1', 'line2']),
+              values: ['line3', 'line4', 'line1', 'line2'],
             },
             {
               config: {},
               name: 'labels',
               type: 'other',
-              values: new ArrayVector([
+              values: [
                 {
                   otherLabel: 'other value',
                 },
@@ -174,19 +174,19 @@ describe('combineResponses', () => {
                 {
                   otherLabel: 'other value',
                 },
-              ]),
+              ],
             },
             {
               config: {},
               name: 'tsNs',
               type: 'string',
-              values: new ArrayVector(['1000000', '2000000', '3000000', '4000000']),
+              values: ['1000000', '2000000', '3000000', '4000000'],
             },
             {
               config: {},
               name: 'id',
               type: 'string',
-              values: new ArrayVector(['id3', 'id4', 'id1', 'id2']),
+              values: ['id3', 'id4', 'id1', 'id2'],
             },
           ],
           length: 4,
@@ -221,13 +221,13 @@ describe('combineResponses', () => {
               config: {},
               name: 'Time',
               type: 'time',
-              values: new ArrayVector([1000000, 2000000, 3000000, 4000000]),
+              values: [1000000, 2000000, 3000000, 4000000],
             },
             {
               config: {},
               name: 'Value',
               type: 'number',
-              values: new ArrayVector([6, 7, 5, 4]),
+              values: [6, 7, 5, 4],
             },
           ],
           length: 4,
@@ -262,13 +262,13 @@ describe('combineResponses', () => {
               config: {},
               name: 'Time',
               type: 'time',
-              values: new ArrayVector([1000000, 2000000, 3000000, 4000000]),
+              values: [1000000, 2000000, 3000000, 4000000],
             },
             {
               config: {},
               name: 'Value',
               type: 'number',
-              values: new ArrayVector([6, 7, 5, 4]),
+              values: [6, 7, 5, 4],
             },
           ],
           length: 4,

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -1,5 +1,4 @@
 import {
-  ArrayVector,
   DataFrame,
   DataQueryResponse,
   DataQueryResponseData,
@@ -14,12 +13,12 @@ import { isBytesString } from './languageUtils';
 import { isLogLineJSON, isLogLineLogfmt, isLogLinePacked } from './lineParser';
 
 export function dataFrameHasLokiError(frame: DataFrame): boolean {
-  const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values.toArray() ?? [];
+  const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values ?? [];
   return labelSets.some((labels) => labels.__error__ !== undefined);
 }
 
 export function dataFrameHasLevelLabel(frame: DataFrame): boolean {
-  const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values.toArray() ?? [];
+  const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values ?? [];
   return labelSets.some((labels) => labels.level !== undefined);
 }
 
@@ -33,7 +32,7 @@ export function extractLogParserFromDataFrame(frame: DataFrame): {
     return { hasJSON: false, hasLogfmt: false, hasPack: false };
   }
 
-  const logLines: string[] = lineField.values.toArray();
+  const logLines: string[] = lineField.values;
 
   let hasJSON = false;
   let hasLogfmt = false;
@@ -55,7 +54,7 @@ export function extractLogParserFromDataFrame(frame: DataFrame): {
 
 export function extractLabelKeysFromDataFrame(frame: DataFrame): string[] {
   const labelsArray: Array<{ [key: string]: string }> | undefined =
-    frame?.fields?.find((field) => field.name === 'labels')?.values.toArray() ?? [];
+    frame?.fields?.find((field) => field.name === 'labels')?.values ?? [];
 
   if (!labelsArray?.length) {
     return [];
@@ -66,7 +65,7 @@ export function extractLabelKeysFromDataFrame(frame: DataFrame): string[] {
 
 export function extractUnwrapLabelKeysFromDataFrame(frame: DataFrame): string[] {
   const labelsArray: Array<{ [key: string]: string }> | undefined =
-    frame?.fields?.find((field) => field.name === 'labels')?.values.toArray() ?? [];
+    frame?.fields?.find((field) => field.name === 'labels')?.values ?? [];
 
   if (!labelsArray?.length) {
     return [];
@@ -92,7 +91,7 @@ export function extractHasErrorLabelFromDataFrame(frame: DataFrame): boolean {
     return false;
   }
 
-  const labels: Array<{ [key: string]: string }> = labelField.values.toArray();
+  const labels: Array<{ [key: string]: string }> = labelField.values;
   return labels.some((label) => label['__error__']);
 }
 
@@ -104,7 +103,7 @@ export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | n
 
   // Depending on number of labels, this can be pretty heavy operation.
   // Let's just look at first 2 lines If needed, we can introduce more later.
-  const labelsArray: Array<{ [key: string]: string }> = labelField.values.toArray().slice(0, 2);
+  const labelsArray: Array<{ [key: string]: string }> = labelField.values.slice(0, 2);
   let levelLikeLabel: string | null = null;
 
   // Find first level-like label
@@ -170,9 +169,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
 function combineFrames(dest: DataFrame, source: DataFrame) {
   const totalFields = dest.fields.length;
   for (let i = 0; i < totalFields; i++) {
-    dest.fields[i].values = new ArrayVector(
-      [].concat.apply(source.fields[i].values.toArray(), dest.fields[i].values.toArray())
-    );
+    dest.fields[i].values = [].concat.apply(source.fields[i].values, dest.fields[i].values);
   }
   dest.length += source.length;
   dest.meta = {
@@ -218,9 +215,9 @@ export function cloneQueryResponse(response: DataQueryResponse): DataQueryRespon
 function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
   return {
     ...frame,
-    fields: frame.fields.map((field: Field<unknown, ArrayVector>) => ({
+    fields: frame.fields.map((field: Field) => ({
       ...field,
-      values: new ArrayVector(field.values.toArray()),
+      values: field.values,
     })),
   };
 }

--- a/public/app/plugins/datasource/loki/sortDataFrame.test.ts
+++ b/public/app/plugins/datasource/loki/sortDataFrame.test.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
+import { DataFrame, FieldType } from '@grafana/data';
 
 import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
 
@@ -9,19 +9,19 @@ const inputFrame: DataFrame = {
       name: 'time',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([1005, 1001, 1004, 1002, 1003]),
+      values: [1005, 1001, 1004, 1002, 1003],
     },
     {
       name: 'value',
       type: FieldType.string,
       config: {},
-      values: new ArrayVector(['line5', 'line1', 'line4', 'line2', 'line3']),
+      values: ['line5', 'line1', 'line4', 'line2', 'line3'],
     },
     {
       name: 'tsNs',
       type: FieldType.time,
       config: {},
-      values: new ArrayVector([`1005000000`, `1001000000`, `1004000000`, `1002000000`, `1003000000`]),
+      values: [`1005000000`, `1001000000`, `1004000000`, `1002000000`, `1003000000`],
     },
   ],
   length: 5,
@@ -31,23 +31,23 @@ describe('loki sortDataFrame', () => {
   it('sorts a dataframe ascending', () => {
     const sortedFrame = sortDataFrameByTime(inputFrame, SortDirection.Ascending);
     expect(sortedFrame.length).toBe(5);
-    const timeValues = sortedFrame.fields[0].values.toArray();
-    const lineValues = sortedFrame.fields[1].values.toArray();
-    const tsNsValues = sortedFrame.fields[2].values.toArray();
+    const timeValues = sortedFrame.fields[0].values;
+    const lineValues = sortedFrame.fields[1].values;
+    const tsNsValues = sortedFrame.fields[2].values;
 
-    expect(timeValues).toStrictEqual([1001, 1002, 1003, 1004, 1005]);
-    expect(lineValues).toStrictEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
-    expect(tsNsValues).toStrictEqual([`1001000000`, `1002000000`, `1003000000`, `1004000000`, `1005000000`]);
+    expect(timeValues).toEqual([1001, 1002, 1003, 1004, 1005]);
+    expect(lineValues).toEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
+    expect(tsNsValues).toEqual([`1001000000`, `1002000000`, `1003000000`, `1004000000`, `1005000000`]);
   });
   it('sorts a dataframe descending', () => {
     const sortedFrame = sortDataFrameByTime(inputFrame, SortDirection.Descending);
     expect(sortedFrame.length).toBe(5);
-    const timeValues = sortedFrame.fields[0].values.toArray();
-    const lineValues = sortedFrame.fields[1].values.toArray();
-    const tsNsValues = sortedFrame.fields[2].values.toArray();
+    const timeValues = sortedFrame.fields[0].values;
+    const lineValues = sortedFrame.fields[1].values;
+    const tsNsValues = sortedFrame.fields[2].values;
 
-    expect(timeValues).toStrictEqual([1005, 1004, 1003, 1002, 1001]);
-    expect(lineValues).toStrictEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
-    expect(tsNsValues).toStrictEqual([`1005000000`, `1004000000`, `1003000000`, `1002000000`, `1001000000`]);
+    expect(timeValues).toEqual([1005, 1004, 1003, 1002, 1001]);
+    expect(lineValues).toEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
+    expect(tsNsValues).toEqual([`1005000000`, `1004000000`, `1003000000`, `1002000000`, `1001000000`]);
   });
 });

--- a/public/app/plugins/datasource/loki/sortDataFrame.ts
+++ b/public/app/plugins/datasource/loki/sortDataFrame.ts
@@ -16,7 +16,7 @@ export enum SortDirection {
 // - the first row will become the second
 // - the second row will become the third
 function makeIndex(field: Field<string>, dir: SortDirection): number[] {
-  const fieldValues: string[] = field.values.toArray();
+  const fieldValues: string[] = field.values;
 
   // we first build an array which is [0,1,2,3....]
   const index = Array(fieldValues.length);
@@ -65,7 +65,7 @@ export function sortDataFrameByTime(frame: DataFrame, dir: SortDirection): DataF
     ...rest,
     fields: fields.map((field) => ({
       ...field,
-      values: new SortedVector(field.values, index),
+      values: new SortedVector(field.values, index).toArray(),
     })),
   };
 

--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -23,13 +23,13 @@ export class MssqlDatasource extends SqlDatasource {
 
   async fetchDatasets(): Promise<string[]> {
     const datasets = await this.runSql<{ name: string[] }>(showDatabases(), { refId: 'datasets' });
-    return datasets.fields.name?.values.toArray().flat() ?? [];
+    return datasets.fields.name?.values.flat() ?? [];
   }
 
   async fetchTables(dataset?: string): Promise<string[]> {
     // We get back the table name with the schema as well. like dbo.table
     const tables = await this.runSql<{ schemaAndName: string[] }>(getSchemaAndName(dataset), { refId: 'tables' });
-    return tables.fields.schemaAndName?.values.toArray().flat() ?? [];
+    return tables.fields.schemaAndName?.values.flat() ?? [];
   }
 
   async fetchFields(query: SQLQuery): Promise<SQLSelectableValue[]> {
@@ -42,8 +42,8 @@ export class MssqlDatasource extends SqlDatasource {
     });
     const result: SQLSelectableValue[] = [];
     for (let i = 0; i < schema.length; i++) {
-      const column = schema.fields.column.values.get(i);
-      const type = schema.fields.type.values.get(i);
+      const column = schema.fields.column.values[i];
+      const type = schema.fields.type.values[i];
       result.push({ label: column, value: column, type, icon: getIcon(type), raqbFieldType: getRAQBType(type) });
     }
     return result;

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -24,7 +24,7 @@ export class PostgresDatasource extends SqlDatasource {
 
   async getVersion(): Promise<string> {
     const value = await this.runSql<{ version: number }>(getVersion());
-    const results = value.fields.version?.values.toArray();
+    const results = value.fields.version?.values;
 
     if (!results) {
       return '';
@@ -35,7 +35,7 @@ export class PostgresDatasource extends SqlDatasource {
 
   async getTimescaleDBVersion(): Promise<string | undefined> {
     const value = await this.runSql<{ extversion: string }>(getTimescaleDBVersion());
-    const results = value.fields.extversion?.values.toArray();
+    const results = value.fields.extversion?.values;
 
     if (!results) {
       return undefined;
@@ -46,7 +46,7 @@ export class PostgresDatasource extends SqlDatasource {
 
   async fetchTables(): Promise<string[]> {
     const tables = await this.runSql<{ table: string[] }>(showTables(), { refId: 'tables' });
-    return tables.fields.table?.values.toArray().flat() ?? [];
+    return tables.fields.table?.values.flat() ?? [];
   }
 
   getSqlLanguageDefinition(db: DB): LanguageDefinition {
@@ -70,8 +70,8 @@ export class PostgresDatasource extends SqlDatasource {
     const schema = await this.runSql<{ column: string; type: string }>(getSchema(query.table), { refId: 'columns' });
     const result: SQLSelectableValue[] = [];
     for (let i = 0; i < schema.length; i++) {
-      const column = schema.fields.column.values.get(i);
-      const type = schema.fields.type.values.get(i);
+      const column = schema.fields.column.values[i];
+      const type = schema.fields.type.values[i];
       result.push({ label: column, value: column, type, ...getFieldConfig(type) });
     }
     return result;

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -396,9 +396,9 @@ describe('PrometheusDatasource', () => {
       ds.performTimeSeriesQuery = jest.fn().mockReturnValue(of(responseMock));
       await expect(ds.query(query)).toEmitValuesWith((result) => {
         const results = result[0].data;
-        expect(results[0].fields[1].values.toArray()).toEqual([10, 10]);
-        expect(results[0].fields[2].values.toArray()).toEqual([10, 0]);
-        expect(results[0].fields[3].values.toArray()).toEqual([5, 0]);
+        expect(results[0].fields[1].values).toEqual([10, 10]);
+        expect(results[0].fields[2].values).toEqual([10, 0]);
+        expect(results[0].fields[3].values).toEqual([5, 0]);
       });
     });
 
@@ -1018,27 +1018,27 @@ describe('PrometheusDatasource2', () => {
     });
 
     it('should fill null until first datapoint in response', () => {
-      expect(results.data[0].fields[0].values.get(0)).toBe(start * 1000);
-      expect(results.data[0].fields[1].values.get(0)).toBe(null);
-      expect(results.data[0].fields[0].values.get(1)).toBe((start + step * 1) * 1000);
-      expect(results.data[0].fields[1].values.get(1)).toBe(3846);
+      expect(results.data[0].fields[0].values[0]).toBe(start * 1000);
+      expect(results.data[0].fields[1].values[0]).toBe(null);
+      expect(results.data[0].fields[0].values[1]).toBe((start + step * 1) * 1000);
+      expect(results.data[0].fields[1].values[1]).toBe(3846);
     });
 
     it('should fill null after last datapoint in response', () => {
       const length = (end - start) / step + 1;
-      expect(results.data[0].fields[0].values.get(length - 2)).toBe((end - step * 1) * 1000);
-      expect(results.data[0].fields[1].values.get(length - 2)).toBe(3848);
-      expect(results.data[0].fields[0].values.get(length - 1)).toBe(end * 1000);
-      expect(results.data[0].fields[1].values.get(length - 1)).toBe(null);
+      expect(results.data[0].fields[0].values[length - 2]).toBe((end - step * 1) * 1000);
+      expect(results.data[0].fields[1].values[length - 2]).toBe(3848);
+      expect(results.data[0].fields[0].values[length - 1]).toBe(end * 1000);
+      expect(results.data[0].fields[1].values[length - 1]).toBe(null);
     });
 
     it('should fill null at gap between series', () => {
-      expect(results.data[0].fields[0].values.get(2)).toBe((start + step * 2) * 1000);
-      expect(results.data[0].fields[1].values.get(2)).toBe(null);
-      expect(results.data[1].fields[0].values.get(1)).toBe((start + step * 1) * 1000);
-      expect(results.data[1].fields[1].values.get(1)).toBe(null);
-      expect(results.data[1].fields[0].values.get(3)).toBe((start + step * 3) * 1000);
-      expect(results.data[1].fields[1].values.get(3)).toBe(null);
+      expect(results.data[0].fields[0].values[2]).toBe((start + step * 2) * 1000);
+      expect(results.data[0].fields[1].values[2]).toBe(null);
+      expect(results.data[1].fields[0].values[1]).toBe((start + step * 1) * 1000);
+      expect(results.data[1].fields[1].values[1]).toBe(null);
+      expect(results.data[1].fields[0].values[3]).toBe((start + step * 3) * 1000);
+      expect(results.data[1].fields[1].values[3]).toBe(null);
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -866,10 +866,10 @@ export class PrometheusDatasource
       const timeValueTuple: Array<[number, number]> = [];
 
       let idx = 0;
-      valueField.values.toArray().forEach((value: string) => {
+      valueField.values.forEach((value: string) => {
         let timeStampValue: number;
         let valueValue: number;
-        const time = timeField.values.get(idx);
+        const time = timeField.values[idx];
 
         // If we want to use value as a time, we use value as timeStampValue and valueValue will be 1
         if (options.annotation.useValueForTime) {

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.test.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.test.ts
@@ -268,7 +268,7 @@ describe('QueryCache', function () {
       // All of the new values should be the ones that were stored, this is overkill
       secondFrames.forEach((frame, frameIdx) => {
         frame.fields.forEach((field, fieldIdx) => {
-          secondFrames[frameIdx].fields[fieldIdx].values.toArray().forEach((value) => {
+          secondFrames[frameIdx].fields[fieldIdx].values.forEach((value) => {
             expect(secondStoredFrames[frameIdx].fields[fieldIdx].values).toContain(value);
           });
         });
@@ -394,12 +394,8 @@ describe('QueryCache', function () {
 
     // Since the step is 15s, and the request was 30 seconds later, we should have 2 extra frames, but we should evict the first two, so we should get the same length
     expect(firstMergedLength).toEqual(secondMergedLength);
-    expect(firstQueryResult[0].fields[0].values.toArray()[2]).toEqual(
-      secondQueryResult[0].fields[0].values.toArray()[0]
-    );
-    expect(firstQueryResult[0].fields[0].values.toArray()[0] + 30000).toEqual(
-      secondQueryResult[0].fields[0].values.toArray()[0]
-    );
+    expect(firstQueryResult[0].fields[0].values[2]).toEqual(secondQueryResult[0].fields[0].values[0]);
+    expect(firstQueryResult[0].fields[0].values[0] + 30000).toEqual(secondQueryResult[0].fields[0].values[0]);
 
     cache.set(targetIdentity, `'1=1'|${interval}|${JSON.stringify(thirdRange.raw)}`);
 
@@ -418,7 +414,7 @@ describe('QueryCache', function () {
     );
 
     const cachedAfterThird = storage.cache.get(targetIdentity);
-    const storageLengthAfterThirdQuery = cachedAfterThird?.frames[0].fields[0].values.toArray().length;
+    const storageLengthAfterThirdQuery = cachedAfterThird?.frames[0].fields[0].values.length;
     expect(storageLengthAfterThirdQuery).toEqual(20);
   });
 

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -1,5 +1,4 @@
 import {
-  ArrayVector,
   DataFrame,
   DataQueryRequest,
   dateTime,
@@ -200,14 +199,14 @@ export class QueryCache {
 
             // amend & re-cache
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            let prevTable: Table = cachedFrame.fields.map((field) => field.values.toArray()) as Table;
+            let prevTable: Table = cachedFrame.fields.map((field) => field.values) as Table;
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            let nextTable: Table = respFrame.fields.map((field) => field.values.toArray()) as Table;
+            let nextTable: Table = respFrame.fields.map((field) => field.values) as Table;
 
             let amendedTable = amendTable(prevTable, nextTable);
 
             for (let i = 0; i < amendedTable.length; i++) {
-              cachedFrame.fields[i].values = new ArrayVector(amendedTable[i]);
+              cachedFrame.fields[i].values = amendedTable[i];
             }
 
             cachedFrame.length = cachedFrame.fields[0].values.length;
@@ -219,13 +218,13 @@ export class QueryCache {
 
         cachedFrames.forEach((frame) => {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          let table: Table = frame.fields.map((field) => field.values.toArray()) as Table;
+          let table: Table = frame.fields.map((field) => field.values) as Table;
 
           let trimmed = trimTable(table, newFrom, newTo);
 
           if (trimmed[0].length > 0) {
             for (let i = 0; i < trimmed.length; i++) {
-              frame.fields[i].values = new ArrayVector(trimmed[i]);
+              frame.fields[i].values = trimmed[i];
             }
             nonEmptyCachedFrames.push(frame);
           }
@@ -248,7 +247,7 @@ export class QueryCache {
           config: {
             ...field.config, // prevents mutatative exemplars links (re)enrichment
           },
-          values: new ArrayVector(field.values.toArray().slice()),
+          values: field.values.slice(),
         })),
       }));
     }

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCacheTestData.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCacheTestData.ts
@@ -1,20 +1,18 @@
 import { clone } from 'lodash';
 
-import { ArrayVector } from '@grafana/data/src';
-
 /**
  *
  * @param length - Number of values to add
  * @param start - First timestamp (ms)
  * @param step - step duration (ms)
  */
-export const getMockTimeFrameArray = (length: number, start: number, step: number): ArrayVector => {
-  let timeValues = [];
+export const getMockTimeFrameArray = (length: number, start: number, step: number) => {
+  let timeValues: number[] = [];
   for (let i = 0; i < length; i++) {
     timeValues.push(start + i * step);
   }
 
-  return new ArrayVector(timeValues);
+  return timeValues;
 };
 
 /**
@@ -22,8 +20,8 @@ export const getMockTimeFrameArray = (length: number, start: number, step: numbe
  * @param values
  * @param high
  */
-export const getMockValueFrameArray = (length: number, values = 0): ArrayVector => {
-  return new ArrayVector(Array(length).fill(values));
+export const getMockValueFrameArray = (length: number, values = 0): number[] => {
+  return Array(length).fill(values);
 };
 
 const timeFrameWithMissingValuesInMiddle = getMockTimeFrameArray(721, 1675262550000, 30000);
@@ -31,9 +29,9 @@ const timeFrameWithMissingValuesAtStart = getMockTimeFrameArray(721, 16752625500
 const timeFrameWithMissingValuesAtEnd = getMockTimeFrameArray(721, 1675262550000, 30000);
 
 // Deleting some out the middle
-timeFrameWithMissingValuesInMiddle.toArray().splice(360, 721 - 684);
-timeFrameWithMissingValuesAtStart.toArray().splice(0, 721 - 684);
-timeFrameWithMissingValuesAtEnd.toArray().splice(721 - 684, 721 - 684);
+timeFrameWithMissingValuesInMiddle.splice(360, 721 - 684);
+timeFrameWithMissingValuesAtStart.splice(0, 721 - 684);
+timeFrameWithMissingValuesAtEnd.splice(721 - 684, 721 - 684);
 
 const mockLabels = {
   __name__: 'cortex_request_duration_seconds_bucket',

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -366,9 +366,9 @@ describe('Prometheus Result Transformer', () => {
 
       const series = transformV2(response, options, {});
       expect(series.data[0].fields.length).toEqual(4);
-      expect(series.data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-      expect(series.data[0].fields[2].values.toArray()).toEqual([10, 0, 30]);
-      expect(series.data[0].fields[3].values.toArray()).toEqual([10, 0, 10]);
+      expect(series.data[0].fields[1].values).toEqual([10, 10, 0]);
+      expect(series.data[0].fields[2].values).toEqual([10, 0, 30]);
+      expect(series.data[0].fields[3].values).toEqual([10, 0, 10]);
       expect(series.data[0].fields[1].name).toEqual('1');
       expect(series.data[0].fields[2].name).toEqual('2');
       expect(series.data[0].fields[3].name).toEqual('+Inf');
@@ -467,9 +467,9 @@ describe('Prometheus Result Transformer', () => {
 
       const series = transformV2(response, options, {});
       expect(series.data[0].fields.length).toEqual(4);
-      expect(series.data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-      expect(series.data[0].fields[2].values.toArray()).toEqual([10, 0, 30]);
-      expect(series.data[0].fields[3].values.toArray()).toEqual([10, 0, 10]);
+      expect(series.data[0].fields[1].values).toEqual([10, 10, 0]);
+      expect(series.data[0].fields[2].values).toEqual([10, 0, 30]);
+      expect(series.data[0].fields[3].values).toEqual([10, 0, 10]);
     });
 
     it('results with heatmap format and multiple histograms should be grouped and de-accumulated by non-le labels', () => {
@@ -600,17 +600,17 @@ describe('Prometheus Result Transformer', () => {
 
       const series = transformV2(response, options, {});
       expect(series.data[0].fields.length).toEqual(4);
-      expect(series.data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-      expect(series.data[0].fields[2].values.toArray()).toEqual([10, 0, 30]);
-      expect(series.data[0].fields[3].values.toArray()).toEqual([10, 0, 10]);
+      expect(series.data[0].fields[1].values).toEqual([10, 10, 0]);
+      expect(series.data[0].fields[2].values).toEqual([10, 0, 30]);
+      expect(series.data[0].fields[3].values).toEqual([10, 0, 10]);
 
-      expect(series.data[1].fields[1].values.toArray()).toEqual([0, 10, 10]);
-      expect(series.data[1].fields[2].values.toArray()).toEqual([20, 0, 30]);
-      expect(series.data[1].fields[3].values.toArray()).toEqual([10, 0, 20]);
+      expect(series.data[1].fields[1].values).toEqual([0, 10, 10]);
+      expect(series.data[1].fields[2].values).toEqual([20, 0, 30]);
+      expect(series.data[1].fields[3].values).toEqual([10, 0, 20]);
 
-      expect(series.data[2].fields[1].values.toArray()).toEqual([30, 30, 60]);
-      expect(series.data[2].fields[2].values.toArray()).toEqual([0, 10, 0]);
-      expect(series.data[2].fields[3].values.toArray()).toEqual([10, 0, 0]);
+      expect(series.data[2].fields[1].values).toEqual([30, 30, 60]);
+      expect(series.data[2].fields[2].values).toEqual([0, 10, 0]);
+      expect(series.data[2].fields[3].values).toEqual([10, 0, 0]);
     });
 
     it('Retains exemplar frames when data returned is a heatmap', () => {
@@ -667,14 +667,7 @@ describe('Prometheus Result Transformer', () => {
       const series = transformV2(response, options, {});
       expect(series.data[0].fields.length).toEqual(2);
       expect(series.data.length).toEqual(2);
-      expect(series.data[1].fields[2].values.toArray()).toEqual([
-        'hello',
-        'doctor',
-        'name',
-        'continue',
-        'yesterday',
-        'tomorrow',
-      ]);
+      expect(series.data[1].fields[2].values).toEqual(['hello', 'doctor', 'name', 'continue', 'yesterday', 'tomorrow']);
       expect(series.data[1].fields.length).toEqual(3);
     });
 
@@ -765,9 +758,9 @@ describe('Prometheus Result Transformer', () => {
       expect(tableDf.fields.length).toBe(4);
       expect(tableDf.fields[0].name).toBe('Time');
       expect(tableDf.fields[1].name).toBe('label1');
-      expect(tableDf.fields[1].values.get(0)).toBe('value1');
+      expect(tableDf.fields[1].values[0]).toBe('value1');
       expect(tableDf.fields[2].name).toBe('label2');
-      expect(tableDf.fields[2].values.get(0)).toBe('value2');
+      expect(tableDf.fields[2].values[0]).toBe('value2');
       expect(tableDf.fields[3].name).toBe('Value');
     });
 
@@ -789,9 +782,9 @@ describe('Prometheus Result Transformer', () => {
       expect(tableDf.fields.length).toBe(4);
       expect(tableDf.fields[0].name).toBe('Time');
       expect(tableDf.fields[1].name).toBe('label1');
-      expect(tableDf.fields[1].values.get(0)).toBe('value1');
+      expect(tableDf.fields[1].values[0]).toBe('value1');
       expect(tableDf.fields[2].name).toBe('label2');
-      expect(tableDf.fields[2].values.get(0)).toBe('value2');
+      expect(tableDf.fields[2].values[0]).toBe('value2');
       expect(tableDf.fields[3].name).toBe('Value');
     });
 
@@ -824,16 +817,16 @@ describe('Prometheus Result Transformer', () => {
       expect(transformedTableDataFrames[0].fields.length).toBe(4);
       expect(transformedTableDataFrames[0].fields[0].name).toBe('Time');
       expect(transformedTableDataFrames[0].fields[1].name).toBe('label1');
-      expect(transformedTableDataFrames[0].fields[1].values.get(0)).toBe(value1);
+      expect(transformedTableDataFrames[0].fields[1].values[0]).toBe(value1);
       expect(transformedTableDataFrames[0].fields[2].name).toBe('label2');
-      expect(transformedTableDataFrames[0].fields[2].values.get(0)).toBe(value2);
+      expect(transformedTableDataFrames[0].fields[2].values[0]).toBe(value2);
       expect(transformedTableDataFrames[0].fields[3].name).toBe('Value #A');
 
       // Expect the invalid/empty results not to throw an error and to return empty arrays
       expect(transformedTableDataFrames[1].fields[1].labels).toBe(undefined);
       expect(transformedTableDataFrames[1].fields[1].name).toBe('Value #B');
-      expect(transformedTableDataFrames[1].fields[1].values.toArray()).toEqual([]);
-      expect(transformedTableDataFrames[1].fields[0].values.toArray()).toEqual([]);
+      expect(transformedTableDataFrames[1].fields[1].values).toEqual([]);
+      expect(transformedTableDataFrames[1].fields[0].values).toEqual([]);
     });
   });
 
@@ -901,22 +894,20 @@ describe('Prometheus Result Transformer', () => {
             format: 'table',
           },
         });
-        expect(result[0].fields[0].values.toArray()).toEqual([
-          1443454528000, 1443454530000, 1443454529000, 1443454531000,
-        ]);
+        expect(result[0].fields[0].values).toEqual([1443454528000, 1443454530000, 1443454529000, 1443454531000]);
         expect(result[0].fields[0].name).toBe('Time');
         expect(result[0].fields[0].type).toBe(FieldType.time);
-        expect(result[0].fields[1].values.toArray()).toEqual(['test', 'test', 'test2', 'test2']);
+        expect(result[0].fields[1].values).toEqual(['test', 'test', 'test2', 'test2']);
         expect(result[0].fields[1].name).toBe('__name__');
         expect(result[0].fields[1].config.filterable).toBe(true);
         expect(result[0].fields[1].type).toBe(FieldType.string);
-        expect(result[0].fields[2].values.toArray()).toEqual(['', '', 'localhost:8080', 'localhost:8080']);
+        expect(result[0].fields[2].values).toEqual(['', '', 'localhost:8080', 'localhost:8080']);
         expect(result[0].fields[2].name).toBe('instance');
         expect(result[0].fields[2].type).toBe(FieldType.string);
-        expect(result[0].fields[3].values.toArray()).toEqual(['testjob', 'testjob', 'otherjob', 'otherjob']);
+        expect(result[0].fields[3].values).toEqual(['testjob', 'testjob', 'otherjob', 'otherjob']);
         expect(result[0].fields[3].name).toBe('job');
         expect(result[0].fields[3].type).toBe(FieldType.string);
-        expect(result[0].fields[4].values.toArray()).toEqual([3846, 3848, 3847, 3849]);
+        expect(result[0].fields[4].values).toEqual([3846, 3848, 3847, 3849]);
         expect(result[0].fields[4].name).toEqual('Value');
         expect(result[0].fields[4].type).toBe(FieldType.number);
         expect(result[0].refId).toBe('A');
@@ -952,13 +943,13 @@ describe('Prometheus Result Transformer', () => {
 
       it('should return data frame', () => {
         const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
-        expect(result[0].fields[0].values.toArray()).toEqual([1443454528000]);
+        expect(result[0].fields[0].values).toEqual([1443454528000]);
         expect(result[0].fields[0].name).toBe('Time');
-        expect(result[0].fields[1].values.toArray()).toEqual(['test']);
+        expect(result[0].fields[1].values).toEqual(['test']);
         expect(result[0].fields[1].name).toBe('__name__');
-        expect(result[0].fields[2].values.toArray()).toEqual(['testjob']);
+        expect(result[0].fields[2].values).toEqual(['testjob']);
         expect(result[0].fields[2].name).toBe('job');
-        expect(result[0].fields[3].values.toArray()).toEqual([3846]);
+        expect(result[0].fields[3].values).toEqual([3846]);
         expect(result[0].fields[3].name).toEqual('Value');
       });
 
@@ -976,7 +967,7 @@ describe('Prometheus Result Transformer', () => {
           },
         };
         const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
-        expect(result[0].fields[1].values.toArray()).toEqual([102]);
+        expect(result[0].fields[1].values).toEqual([102]);
         expect(result[0].fields[1].type).toEqual(FieldType.number);
       });
     });
@@ -1046,10 +1037,10 @@ describe('Prometheus Result Transformer', () => {
         ]);
 
         const result = transform({ data: response } as any, { query: options, target: options } as any);
-        expect(result[0].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-        expect(result[0].fields[2].values.toArray()).toEqual([10, 0, 30]);
-        expect(result[0].fields[3].values.toArray()).toEqual([10, 0, 10]);
+        expect(result[0].fields[0].values).toEqual([1445000010000, 1445000020000, 1445000030000]);
+        expect(result[0].fields[1].values).toEqual([10, 10, 0]);
+        expect(result[0].fields[2].values).toEqual([10, 0, 30]);
+        expect(result[0].fields[3].values).toEqual([10, 0, 10]);
       });
 
       it('should handle missing datapoints', () => {
@@ -1078,9 +1069,9 @@ describe('Prometheus Result Transformer', () => {
           },
         ]);
         const result = transform({ data: response } as any, { query: options, target: options } as any);
-        expect(result[0].fields[1].values.toArray()).toEqual([1, 2]);
-        expect(result[0].fields[2].values.toArray()).toEqual([1, 3, 1]);
-        expect(result[0].fields[3].values.toArray()).toEqual([1, 2]);
+        expect(result[0].fields[1].values).toEqual([1, 2]);
+        expect(result[0].fields[2].values).toEqual([1, 3, 1]);
+        expect(result[0].fields[3].values).toEqual([1, 2]);
       });
     });
 
@@ -1137,8 +1128,8 @@ describe('Prometheus Result Transformer', () => {
             end: 2,
           },
         });
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
+        expect(result[0].fields[0].values).toEqual([0, 1000, 2000]);
+        expect(result[0].fields[1].values).toEqual([10, 10, 0]);
         expect(result[0].name).toBe('test{job="testjob"}');
       });
 
@@ -1148,8 +1139,8 @@ describe('Prometheus Result Transformer', () => {
           query: { step: 1, start: 0, end: 2 },
         });
 
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([null, 10, 0]);
+        expect(result[0].fields[0].values).toEqual([0, 1000, 2000]);
+        expect(result[0].fields[1].values).toEqual([null, 10, 0]);
       });
 
       it('should use __name__ label as series name', () => {
@@ -1242,8 +1233,8 @@ describe('Prometheus Result Transformer', () => {
         };
 
         const result = transform({ data: response } as any, { ...options, query: { step: 2, start: 0, end: 8 } });
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 2000, 4000, 6000, 8000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([null, null, 10, null, 10]);
+        expect(result[0].fields[0].values).toEqual([0, 2000, 4000, 6000, 8000]);
+        expect(result[0].fields[1].values).toEqual([null, null, 10, null, 10]);
       });
     });
 
@@ -1262,7 +1253,7 @@ describe('Prometheus Result Transformer', () => {
             ...options,
             target: { format: 'table' },
           });
-          expect(result[0].fields[1].values.toArray()).toEqual([Number.POSITIVE_INFINITY]);
+          expect(result[0].fields[1].values).toEqual([Number.POSITIVE_INFINITY]);
         });
       });
 
@@ -1290,7 +1281,7 @@ describe('Prometheus Result Transformer', () => {
               ...options,
               target: { format: 'table' },
             });
-            expect(result[0].fields[3].values.toArray()).toEqual([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]);
+            expect(result[0].fields[3].values).toEqual([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]);
           });
         });
       });

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -3,7 +3,6 @@ import { flatten, forOwn, groupBy, partition } from 'lodash';
 
 import {
   ArrayDataFrame,
-  ArrayVector,
   CoreApp,
   DataFrame,
   DataFrameType,
@@ -226,7 +225,7 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
               name: label,
               config: { filterable: true },
               type: numberField ? FieldType.number : FieldType.string,
-              values: new ArrayVector(),
+              values: [],
             });
           }
         });
@@ -234,10 +233,10 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
 
     // Fill valueField, timeField and labelFields with values
     dataFramesByRefId[refId].forEach((df) => {
-      const timeFields = df.fields[0]?.values ?? new ArrayVector();
-      const dataFields = df.fields[1]?.values ?? new ArrayVector();
-      timeFields.toArray().forEach((value) => timeField.values.add(value));
-      dataFields.toArray().forEach((value) => {
+      const timeFields = df.fields[0]?.values ?? [];
+      const dataFields = df.fields[1]?.values ?? [];
+      timeFields.forEach((value) => timeField.values.add(value));
+      dataFields.forEach((value) => {
         valueField.values.add(parseSampleValue(value));
         const labelsForField = df.fields[1].labels ?? {};
         labelFields.forEach((field) => field.values.add(getLabelValue(labelsForField, field.name)));
@@ -515,12 +514,13 @@ function transformMetricDataToTable(md: MatrixOrVectorResult[], options: Transfo
       // Labels have string field type, otherwise table tries to figure out the type which can result in unexpected results
       // Only "le" label has a number field type
       const numberField = label === HISTOGRAM_QUANTILE_LABEL_NAME;
-      return {
+      const field: Field = {
         name: label,
         config: { filterable: true },
         type: numberField ? FieldType.number : FieldType.string,
-        values: new ArrayVector(),
+        values: [],
       };
+      return field;
     });
   const valueField = getValueField({ data: [], valueName: valueText });
 
@@ -528,12 +528,12 @@ function transformMetricDataToTable(md: MatrixOrVectorResult[], options: Transfo
     if (isMatrixData(d)) {
       d.values.forEach((val) => {
         timeField.values.add(val[0] * 1000);
-        metricFields.forEach((metricField) => metricField.values.add(getLabelValue(d.metric, metricField.name)));
+        metricFields.forEach((metricField) => metricField.values.push(getLabelValue(d.metric, metricField.name)));
         valueField.values.add(parseSampleValue(val[1]));
       });
     } else {
       timeField.values.add(d.value[0] * 1000);
-      metricFields.forEach((metricField) => metricField.values.add(getLabelValue(d.metric, metricField.name)));
+      metricFields.forEach((metricField) => metricField.values.push(getLabelValue(d.metric, metricField.name)));
       valueField.values.add(parseSampleValue(d.value[1]));
     }
   });
@@ -561,7 +561,7 @@ function getTimeField(data: PromValue[], isMs = false): MutableField {
     name: TIME_SERIES_TIME_FIELD_NAME,
     type: FieldType.time,
     config: {},
-    values: new ArrayVector<number>(data.map((val) => (isMs ? val[0] : val[0] * 1000))),
+    values: data.map((val) => (isMs ? val[0] : val[0] * 1000)),
   };
 }
 
@@ -588,7 +588,7 @@ function getValueField({
       displayNameFromDS,
     },
     labels,
-    values: new ArrayVector<number | null>(data.map((val) => (parseValue ? parseSampleValue(val[1]) : val[1]))),
+    values: data.map((val) => (parseValue ? parseSampleValue(val[1]) : val[1])),
   };
 }
 
@@ -660,8 +660,8 @@ function transformToHistogramOverTime(seriesList: DataFrame[]) {
     }
 
     for (let j = 0; j < topSeries.values.length; j++) {
-      const bottomPoint = bottomSeries.values.get(j) || [0];
-      topSeries.values.toArray()[j] -= bottomPoint;
+      const bottomPoint = bottomSeries.values[j] || [0];
+      topSeries.values[j] -= bottomPoint;
     }
   }
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -2,7 +2,6 @@ import { lastValueFrom, Observable, of } from 'rxjs';
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
 
 import {
-  ArrayVector,
   DataFrame,
   dataFrameToJSON,
   DataSourceInstanceSettings,
@@ -144,7 +143,7 @@ describe('Tempo data source', () => {
     expect(
       (response.data[0] as DataFrame).fields.map((f) => ({
         name: f.name,
-        values: f.values.toArray(),
+        values: f.values,
       }))
     ).toMatchObject([
       { name: 'traceID', values: ['04450900759028499335'] },
@@ -162,7 +161,7 @@ describe('Tempo data source', () => {
     expect(
       (response.data[1] as DataFrame).fields.map((f) => ({
         name: f.name,
-        values: f.values.toArray(),
+        values: f.values,
       }))
     ).toMatchObject([
       { name: 'id', values: ['4322526419282105830'] },
@@ -176,7 +175,7 @@ describe('Tempo data source', () => {
     expect(
       (response.data[2] as DataFrame).fields.map((f) => ({
         name: f.name,
-        values: f.values.toArray(),
+        values: f.values,
       }))
     ).toMatchObject([
       { name: 'id', values: [] },
@@ -196,7 +195,7 @@ describe('Tempo data source', () => {
     const field = response.data[0].fields[0];
     expect(field.name).toBe('traceID');
     expect(field.type).toBe(FieldType.string);
-    expect(field.values.get(0)).toBe('60ba2abb44f13eae');
+    expect(field.values[0]).toBe('60ba2abb44f13eae');
     expect(field.values.length).toBe(6);
   });
 
@@ -457,14 +456,14 @@ describe('Tempo service graph view', () => {
 
     // Service Graph view
     expect(response.data[0].fields[0].name).toBe('Name');
-    expect(response.data[0].fields[0].values.toArray().length).toBe(2);
-    expect(response.data[0].fields[0].values.toArray()[0]).toBe('HTTP Client');
-    expect(response.data[0].fields[0].values.toArray()[1]).toBe('HTTP GET - root');
+    expect(response.data[0].fields[0].values.length).toBe(2);
+    expect(response.data[0].fields[0].values[0]).toBe('HTTP Client');
+    expect(response.data[0].fields[0].values[1]).toBe('HTTP GET - root');
 
     expect(response.data[0].fields[1].name).toBe('Rate');
-    expect(response.data[0].fields[1].values.toArray().length).toBe(2);
-    expect(response.data[0].fields[1].values.toArray()[0]).toBe(12.75164671814457);
-    expect(response.data[0].fields[1].values.toArray()[1]).toBe(12.121331111401608);
+    expect(response.data[0].fields[1].values.length).toBe(2);
+    expect(response.data[0].fields[1].values[0]).toBe(12.75164671814457);
+    expect(response.data[0].fields[1].values[1]).toBe(12.121331111401608);
     expect(response.data[0].fields[1].config.decimals).toBe(2);
     expect(response.data[0].fields[1].config.links[0].title).toBe('Rate');
     expect(response.data[0].fields[1].config.links[0].internal.query.expr).toBe(
@@ -474,9 +473,9 @@ describe('Tempo service graph view', () => {
     expect(response.data[0].fields[1].config.links[0].internal.query.exemplar).toBe(true);
     expect(response.data[0].fields[1].config.links[0].internal.query.instant).toBe(false);
 
-    expect(response.data[0].fields[2].values.toArray().length).toBe(2);
-    expect(response.data[0].fields[2].values.toArray()[0]).toBe(12.75164671814457);
-    expect(response.data[0].fields[2].values.toArray()[1]).toBe(12.121331111401608);
+    expect(response.data[0].fields[2].values.length).toBe(2);
+    expect(response.data[0].fields[2].values[0]).toBe(12.75164671814457);
+    expect(response.data[0].fields[2].values[1]).toBe(12.121331111401608);
     expect(response.data[0].fields[2].config.color.mode).toBe('continuous-BlPu');
     expect(response.data[0].fields[2].config.custom.cellOptions.mode).toBe(BarGaugeDisplayMode.Lcd);
     expect(response.data[0].fields[2].config.custom.cellOptions.type).toBe(TableCellDisplayMode.Gauge);
@@ -678,7 +677,7 @@ describe('Tempo service graph view', () => {
               filterable: true,
             },
             type: 'string',
-            values: new ArrayVector(['HTTP Client', 'HTTP GET', 'HTTP GET - root', 'HTTP POST', 'HTTP POST - post']),
+            values: ['HTTP Client', 'HTTP GET', 'HTTP GET - root', 'HTTP POST', 'HTTP POST - post'],
           },
         ],
       },

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -597,7 +597,7 @@ function errorAndDurationQuery(
   let serviceGraphViewMetrics = [];
   let errorRateBySpanName = '';
   let durationsBySpanName: string[] = [];
-  const spanNames = rateResponse.data[0][0]?.fields[1]?.values.toArray() ?? [];
+  const spanNames = rateResponse.data[0][0]?.fields[1]?.values ?? [];
 
   if (spanNames.length > 0) {
     errorRateBySpanName = buildExpr(errorRateMetric, 'span_name=~"' + spanNames.join('|') + '"', request);
@@ -797,8 +797,8 @@ function getServiceGraphView(
   }
 
   if (errorRate.length > 0 && errorRate[0].fields?.length > 2) {
-    const errorRateNames = errorRate[0].fields[1]?.values.toArray() ?? [];
-    const errorRateValues = errorRate[0].fields[2]?.values.toArray() ?? [];
+    const errorRateNames = errorRate[0].fields[1]?.values ?? [];
+    const errorRateValues = errorRate[0].fields[2]?.values ?? [];
     let errorRateObj: any = {};
     errorRateNames.map((name: string, index: number) => {
       errorRateObj[name] = { value: errorRateValues[index] };
@@ -848,7 +848,7 @@ function getServiceGraphView(
     duration.map((d) => {
       const delimiter = d.refId?.includes('span_name=~"') ? 'span_name=~"' : 'span_name="';
       const name = d.refId?.split(delimiter)[1].split('"}')[0];
-      durationObj[name] = { value: d.fields[1].values.toArray()[0] };
+      durationObj[name] = { value: d.fields[1].values[0] };
     });
 
     df.fields.push({
@@ -918,7 +918,7 @@ export function getRateAlignedValues(
   rateResp: DataQueryResponseData[],
   objToAlign: { [x: string]: { value: string } }
 ) {
-  const rateNames = rateResp[0]?.fields[1]?.values.toArray() ?? [];
+  const rateNames = rateResp[0]?.fields[1]?.values ?? [];
   let values: string[] = [];
 
   for (let i = 0; i < rateNames.length; i++) {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -85,7 +85,7 @@ export function createTableFrame(
             const match = (line as string).match(traceRegex);
             if (match) {
               const traceId = match[1];
-              const time = timeField ? timeField.values.get(i) : null;
+              const time = timeField ? timeField.values[i] : null;
               tableFrame.fields[0].values.add(time);
               tableFrame.fields[1].values.add(traceId);
               tableFrame.fields[2].values.add(line);

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -57,10 +57,10 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
     }
 
     const vals = await datasource.getScenarios();
-    const hideAlias = [TestDataQueryType.Simulation, TestDataQueryType.Annotations];
+    const hideAlias = ['simulation'];
     return vals.map((v) => ({
       ...v,
-      hideAliasField: hideAlias.includes(v.id as TestDataQueryType),
+      hideAliasField: hideAlias.includes(v.id),
     }));
   }, []);
 
@@ -113,9 +113,6 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
         break;
       case TestDataQueryType.PredictableCSVWave:
         update.csvWave = defaultCSVWaveQuery;
-        break;
-      case TestDataQueryType.Annotations:
-        update.lines = 10;
         break;
       case TestDataQueryType.USA:
         update.usa = {
@@ -280,20 +277,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
           </InlineField>
         </InlineFieldRow>
       )}
-      {scenarioId === TestDataQueryType.Annotations && (
-        <InlineFieldRow>
-          <InlineField label="Count" labelWidth={14}>
-            <Input
-              type="number"
-              name="lines"
-              value={query.lines}
-              width={32}
-              onChange={onInputChange}
-              placeholder="10"
-            />
-          </InlineField>
-        </InlineFieldRow>
-      )}
+
       {scenarioId === TestDataQueryType.USA && <USAQueryEditor onChange={onUSAStatsChange} query={query.usa ?? {}} />}
       {scenarioId === TestDataQueryType.GrafanaAPI && (
         <InlineField labelWidth={14} label="Endpoint">

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -15,7 +15,6 @@ import {
   ScopedVars,
   toDataFrame,
   MutableDataFrame,
-  AnnotationQuery,
 } from '@grafana/data';
 import { DataSourceWithBackend, getBackendSrv, getGrafanaLiveSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { getSearchFilterScopedVar } from 'app/features/variables/utils';
@@ -36,24 +35,6 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
   ) {
     super(instanceSettings);
     this.variables = new TestDataVariableSupport();
-    this.annotations = {
-      getDefaultQuery: () => ({ scenarioId: TestDataQueryType.Annotations, lines: 10 }),
-
-      // Make sure annotations have scenarioId set
-      prepareAnnotation: (old: AnnotationQuery<TestData>) => {
-        if (old.target?.scenarioId?.length) {
-          return old;
-        }
-        return {
-          ...old,
-          target: {
-            refId: 'Anno',
-            scenarioId: TestDataQueryType.Annotations,
-            lines: 10,
-          },
-        };
-      },
-    };
   }
 
   getDefaultQuery(): Partial<TestData> {
@@ -85,7 +66,7 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
         case 'grafana_api':
           streams.push(runGrafanaAPI(target, options));
           break;
-        case TestDataQueryType.Annotations:
+        case 'annotations':
           streams.push(this.annotationDataTopicTest(target, options));
           break;
         case 'variables-query':
@@ -163,9 +144,10 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
   }
 
   annotationDataTopicTest(target: TestData, req: DataQueryRequest<TestData>): Observable<DataQueryResponse> {
-    const events = this.buildFakeAnnotationEvents(req.range, target.lines ?? 10);
+    const events = this.buildFakeAnnotationEvents(req.range, 50);
     const dataFrame = new ArrayDataFrame(events);
     dataFrame.meta = { dataTopic: DataTopic.Annotations };
+
     return of({ key: target.refId, data: [dataFrame] }).pipe(delay(100));
   }
 
@@ -185,6 +167,10 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
     }
 
     return events;
+  }
+
+  annotationQuery(options: any) {
+    return Promise.resolve(this.buildFakeAnnotationEvents(options.range, 10));
   }
 
   getQueryDisplayText(query: TestData) {

--- a/public/app/plugins/datasource/testdata/module.tsx
+++ b/public/app/plugins/datasource/testdata/module.tsx
@@ -5,9 +5,16 @@ import { QueryEditor } from './QueryEditor';
 import { TestInfoTab } from './TestInfoTab';
 import { TestDataDataSource } from './datasource';
 
+class TestDataAnnotationsQueryCtrl {
+  annotation: any;
+  constructor() {}
+  static template = '<h2>Annotation scenario</h2>';
+}
+
 export const plugin = new DataSourcePlugin(TestDataDataSource)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor)
+  .setAnnotationQueryCtrl(TestDataAnnotationsQueryCtrl)
   .addConfigPage({
     title: 'Setup',
     icon: 'list-ul',

--- a/public/app/plugins/datasource/testdata/nodeGraphUtils.ts
+++ b/public/app/plugins/datasource/testdata/nodeGraphUtils.ts
@@ -1,11 +1,4 @@
-import {
-  ArrayVector,
-  FieldColorModeId,
-  FieldDTO,
-  FieldType,
-  MutableDataFrame,
-  NodeGraphDataFrameFieldNames,
-} from '@grafana/data';
+import { FieldColorModeId, FieldDTO, FieldType, MutableDataFrame, NodeGraphDataFrameFieldNames } from '@grafana/data';
 
 import { nodes, edges } from './testData/serviceMapResponse';
 
@@ -51,9 +44,9 @@ export function generateRandomNodes(count = 10) {
     nodes[sourceIndex].edges.push(nodes[targetIndex].id);
   }
 
-  const nodeFields: Record<string, Omit<FieldDTO, 'name'> & { values: ArrayVector }> = {
+  const nodeFields: Record<string, Omit<FieldDTO, 'name'> & { values: any[] }> = {
     [NodeGraphDataFrameFieldNames.id]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.string,
       config: {
         links: [
@@ -70,35 +63,35 @@ export function generateRandomNodes(count = 10) {
       },
     },
     [NodeGraphDataFrameFieldNames.title]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.string,
     },
     [NodeGraphDataFrameFieldNames.subTitle]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.string,
     },
     [NodeGraphDataFrameFieldNames.mainStat]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.number,
       config: { displayName: 'Transactions per second' },
     },
     [NodeGraphDataFrameFieldNames.secondaryStat]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.number,
       config: { displayName: 'Average duration' },
     },
     [NodeGraphDataFrameFieldNames.arc + 'success']: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.number,
       config: { color: { fixedColor: 'green', mode: FieldColorModeId.Fixed }, displayName: 'Success' },
     },
     [NodeGraphDataFrameFieldNames.arc + 'errors']: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.number,
       config: { color: { fixedColor: 'red', mode: FieldColorModeId.Fixed }, displayName: 'Errors' },
     },
     [NodeGraphDataFrameFieldNames.icon]: {
-      values: new ArrayVector(),
+      values: [],
       type: FieldType.string,
     },
   };
@@ -115,10 +108,10 @@ export function generateRandomNodes(count = 10) {
   const edgesFrame = new MutableDataFrame({
     name: 'edges',
     fields: [
-      { name: NodeGraphDataFrameFieldNames.id, values: new ArrayVector(), type: FieldType.string },
-      { name: NodeGraphDataFrameFieldNames.source, values: new ArrayVector(), type: FieldType.string },
-      { name: NodeGraphDataFrameFieldNames.target, values: new ArrayVector(), type: FieldType.string },
-      { name: NodeGraphDataFrameFieldNames.mainStat, values: new ArrayVector(), type: FieldType.number },
+      { name: NodeGraphDataFrameFieldNames.id, values: [], type: FieldType.string },
+      { name: NodeGraphDataFrameFieldNames.source, values: [], type: FieldType.string },
+      { name: NodeGraphDataFrameFieldNames.target, values: [], type: FieldType.string },
+      { name: NodeGraphDataFrameFieldNames.mainStat, values: [], type: FieldType.number },
     ],
     meta: { preferredVisualisationType: 'nodeGraph' },
   });


### PR DESCRIPTION
See https://github.com/grafana/grafana/issues/66480

This PR splits up the mostly mechanical changes in https://github.com/grafana/grafana/pull/66612 so we focus on visualizations

This is mostly mechanical changes:

removing toArray() usage -- the values are already an array, so it is unnecessary
replace .get(idx) with array indexing