### PR TITLE
Set a help text when a readonly prometheus has no examplars configuration

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/ExemplarsSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ExemplarsSettings.tsx
@@ -57,6 +57,8 @@ export function ExemplarsSettings({ options, onChange, disabled }: Props) {
           Add
         </Button>
       )}
+
+      {disabled && !options && <i>No exemplars configurations</i>}
     </>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Set a help text when a readonly prometheus has no examplars configuration

**Why do we need this feature?**

Currently there is an `Exemplars` title, but the body is empty, which looks like a UI glitch

**Who is this feature for?**

All users looking at a readonly prometheus datasoure setting


before:
![Screenshot 2023-04-18 122556](https://user-images.githubusercontent.com/9373203/232663260-abd89c47-a17a-4d8d-a5b7-10f261121e07.png)

after:
![Screenshot 2023-04-18 122519](https://user-images.githubusercontent.com/9373203/232663277-d941124e-5be2-4f24-9035-b7aabc947a4a.png)
