### PR TITLE
CI: Use new update-changelog action in grafana-github-actions-go

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -5,21 +5,23 @@ on:
       version:
         required: true
         description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
+      skip_pr:
+        required: false
+        default: "0"
+      skip_community_post:
+        required: false
+        default: "0"
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
-          ref: main
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
-      - name: Run update changelog (manually invoked)        
-        uses: ./actions/update-changelog
+      - name: Run update changelog (manually invoked)
+        uses: grafana/grafana-github-actions-go/update-changelog@main
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-          metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
-          grafanabotForumKey: ${{ secrets.GRAFANABOT_FORUM_KEY }}
+          version: ${{ inputs.version }}
+          metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
+          community_api_key: ${{ secrets.GRAFANABOT_FORUM_KEY }}
+          community_api_username: grafanabot
+          skip_pr: ${{ inputs.skip_pr }}
+          skip_community_post: ${{ inputs.skip_community_post }}


### PR DESCRIPTION
**What is this feature?**

Replaces the GHA used for generating the changelog with one that will be maintained by @grafana/grafana-delivery 


**Why do we need this feature?**

The old GHA is hard to test and based on a very old code-base which makes it hard to maintain.

**Who is this feature for?**

@grafana/grafana-delivery 

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


## TODOs:

- [x] Clarify how we should proceed with the  forum integration in the original action, if it should be integrated, moved behind a feature flag, moved into a separate action altogether... //cc @zuchka 