### PR TITLE
Chore: Remove accidental console.log statements

### DIFF
--- a/public/app/features/plugins/admin/components/SearchField.tsx
+++ b/public/app/features/plugins/admin/components/SearchField.tsx
@@ -20,7 +20,6 @@ const useDebounceWithoutFirstRender = (callBack: () => any, delay = 0, deps: Rea
         isFirstRender.current = false;
         return;
       }
-      console.log('--------- DEBUOUNCE');
       return callBack();
     },
     delay,
@@ -43,7 +42,6 @@ export const SearchField = ({ value, onSearch }: Props) => {
       }}
       placeholder="Search Grafana plugins"
       onChange={(value) => {
-        console.log('--------- ONCHANGE', value);
         setQuery(value);
       }}
       width={46}


### PR DESCRIPTION
### What changed?

Removed `console.log()` statements accidentally introduced in https://github.com/grafana/grafana/pull/66663/files/00c023387cdc6250c285a5954bc18025bc69cd30#diff-6fc89b906d16c2ad4a3695c5bcd4c777ad73b9cefe971be11b84664237a0b6b8R46.