### PR TITLE
APIkeys: Add metrics for apikey endpoints

### DIFF
--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/components/apikeygen"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/web"
@@ -64,6 +65,7 @@ func (hs *HTTPServer) GetAPIKeys(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
+	metrics.MApiAPIkeysGet.Inc()
 	return response.JSON(http.StatusOK, result)
 }
 
@@ -99,6 +101,7 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 		return response.Error(status, "Failed to delete API key", err)
 	}
 
+	metrics.MApiAPIkeysDelete.Inc()
 	return response.Success("API key deleted")
 }
 
@@ -166,6 +169,7 @@ func (hs *HTTPServer) AddAPIKey(c *contextmodel.ReqContext) response.Response {
 		Key:  newKeyInfo.ClientSecret,
 	}
 
+	metrics.MApiAPIkeysCreate.Inc()
 	return response.JSON(http.StatusOK, result)
 }
 

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -109,6 +109,12 @@ var (
 
 	// MPublicDashboardDatasourceQuerySuccess is a metric counter for successful queries labelled by datasource
 	MPublicDashboardDatasourceQuerySuccess *prometheus.CounterVec
+
+	MApiAPIkeysGet prometheus.Counter
+
+	MApiAPIkeysCreate prometheus.Counter
+
+	MApiAPIkeysDelete prometheus.Counter
 )
 
 // Timers
@@ -446,6 +452,24 @@ func init() {
 		Namespace: ExporterName,
 	}, []string{"datasource", "status"}, map[string][]string{"status": pubdash.QueryResultStatuses})
 
+	MApiAPIkeysGet = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
+		Name:      "api_api_keys_get_total",
+		Help:      "counter for getting api keys",
+		Namespace: ExporterName,
+	})
+
+	MApiAPIkeysCreate = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
+		Name:      "api_api_keys_create_total",
+		Help:      "counter for creating api keys",
+		Namespace: ExporterName,
+	})
+
+	MApiAPIkeysDelete = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
+		Name:      "api_api_keys_delete_total",
+		Help:      "counter for deleting api keys",
+		Namespace: ExporterName,
+	})
+
 	MStatTotalDashboards = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_dashboard",
 		Help:      "total amount of dashboards",
@@ -715,5 +739,8 @@ func initMetricVars() {
 		MPublicDashboardRequestCount,
 		MPublicDashboardDatasourceQuerySuccess,
 		MStatTotalCorrelations,
+		MApiAPIkeysGet,
+		MApiAPIkeysCreate,
+		MApiAPIkeysDelete,
 	)
 }


### PR DESCRIPTION
**What is this feature?**

added metrics:
```
grafana_api_api_keys_create_total 3
grafana_api_api_keys_delete_total 1
grafana_api_api_keys_get_total 7
```

**Why do we need this feature?**
This is needed for monitoring of the use of API keys for users as part of the deprecation strategy

OG issue: https://github.com/grafana/grafana/issues/53567