### PR TITLE
Alerting: Fix DatasourceUID and RefID missing for DatasourceNoData alerts

### DIFF
--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -575,6 +575,26 @@ func TestEvaluate(t *testing.T) {
 				"ref_id":         "A",
 			},
 		}},
+	}, {
+		name: "is no data for one frame with no fields",
+		cond: models.Condition{
+			Data: []models.AlertQuery{{
+				RefID:         "A",
+				DatasourceUID: "test",
+			}},
+		},
+		resp: backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": {Frames: []*data.Frame{{Fields: nil}}},
+			},
+		},
+		expected: Results{{
+			State: NoData,
+			Instance: data.Labels{
+				"datasource_uid": "test",
+				"ref_id":         "A",
+			},
+		}},
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This commit fixes a bug where DatasourceUID and RefID annotations are missing for DatasourceNoData alerts in Grafana 9.5. This bug affects datasource plugins that have moved to using the data plane contract.

This bug appears to have been introduced in https://github.com/grafana/grafana/pull/62254 which updates the Prometheus plugin to send back no data data frames as documented in the data plane contract.

Fixes #66629

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
