### PR TITLE
Page: Add bottom border to page header

### DIFF
--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -121,6 +121,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageContent: css({
       label: 'page-content',
       flexGrow: 1,
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+      paddingTop: theme.spacing(3),
     }),
     pageInner: css({
       label: 'page-inner',

--- a/public/app/core/components/PageNew/PageTabs.tsx
+++ b/public/app/core/components/PageNew/PageTabs.tsx
@@ -13,7 +13,7 @@ export function PageTabs({ navItem }: Props) {
 
   return (
     <div className={styles.tabsWrapper}>
-      <TabsBar>
+      <TabsBar hideBorder>
         {navItem.children!.map((child, index) => {
           const icon = child.icon ? toIconName(child.icon) : undefined;
           return (
@@ -37,7 +37,7 @@ export function PageTabs({ navItem }: Props) {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     tabsWrapper: css({
-      paddingBottom: theme.spacing(3),
+      //paddingBottom: theme.spacing(3),
     }),
   };
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -65,12 +65,15 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
   }
 
   const subTitle = config.featureToggles.dataConnectionsConsole ? (
-    <p>
+    <div>
       Extend the Grafana experience with panel plugins and apps. To find more data sources go to{' '}
-      <a href={`${CONNECTIONS_ROUTES.ConnectData}?cat=data-source`}>Connections</a>.
-    </p>
+      <a href={`${CONNECTIONS_ROUTES.ConnectData}?cat=data-source`} className="external-link">
+        Connections
+      </a>
+      .
+    </div>
   ) : (
-    <p>Extend the Grafana experience with panel plugins and apps.</p>
+    <div>Extend the Grafana experience with panel plugins and apps.</div>
   );
 
   return (


### PR DESCRIPTION
This just an exploration / proposal (not sure this is better) 

Trying to solve 2 things
* More consistency in pages with tabs and those without tabs 
* For pages without tabs there is no dividing line between header and content. The line helps a bit connect the whole page and makes buttons on the right side (above or below the border) feel more connected to the page. 

Example with tabs (unchanged already has border that stretches the full page and separates the header from content):
![image](https://user-images.githubusercontent.com/10999/232744422-8b2f3e71-e34c-4ef4-9c20-e53e3bc6646a.png)

Example of the page without tabs (now has similar border and padding below, this is changed, in main this border is not there)
![Screenshot from 2023-04-18 12-06-38](https://user-images.githubusercontent.com/10999/232744786-8155c07f-51ff-453e-8f5a-4757d842fb5b.png)

![Screenshot from 2023-04-18 12-06-44](https://user-images.githubusercontent.com/10999/232744802-7517f0c6-5cf0-4251-a4a7-ce41cdac2b02.png)


