### PR TITLE
Usagestats: Add interface for stats for user.Service and add Usagestats for `case_insensitive_login`

### DIFF
--- a/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
+++ b/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
@@ -3,13 +3,16 @@ package usagestatssvcs
 import (
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func ProvideUsageStatsProvidersRegistry(
 	accesscontrol accesscontrol.Service,
+	user user.Service,
 ) *UsageStatsProvidersRegistry {
 	return NewUsageStatsProvidersRegistry(
 		accesscontrol,
+		user,
 	)
 }
 

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -2,9 +2,12 @@ package user
 
 import (
 	"context"
+
+	"github.com/grafana/grafana/pkg/registry"
 )
 
 type Service interface {
+	registry.ProvidesUsageStats
 	Create(context.Context, *CreateUserCommand) (*User, error)
 	CreateServiceAccount(context.Context, *CreateUserCommand) (*User, error)
 	Delete(context.Context, *DeleteUserCommand) error

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -62,7 +62,6 @@ func ProvideService(
 	}); err != nil {
 		return s, err
 	}
-	s.GetUsageStats(context.Background())
 
 	bundleRegistry.RegisterSupportItemCollector(s.supportBundleCollector())
 	return s, nil

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -62,9 +62,21 @@ func ProvideService(
 	}); err != nil {
 		return s, err
 	}
+	s.GetUsageStats(context.Background())
 
 	bundleRegistry.RegisterSupportItemCollector(s.supportBundleCollector())
 	return s, nil
+}
+
+func (s *Service) GetUsageStats(ctx context.Context) map[string]interface{} {
+	stats := map[string]interface{}{}
+	caseInsensitiveLoginVal := 0
+	if s.cfg.CaseInsensitiveLogin {
+		caseInsensitiveLoginVal = 1
+	}
+
+	stats["stats.case_insensitive_login.count"] = caseInsensitiveLoginVal
+	return stats
 }
 
 func (s *Service) Usage(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error) {

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -14,6 +14,7 @@ type FakeUserService struct {
 	ExpectedSearchUsers      user.SearchUserQueryResult
 	ExpectedUserProfileDTO   *user.UserProfileDTO
 	ExpectedUserProfileDTOs  []*user.UserProfileDTO
+	ExpectedUsageStats       map[string]interface{}
 
 	GetSignedInUserFn func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error)
 	CreateFn          func(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error)
@@ -24,6 +25,10 @@ type FakeUserService struct {
 
 func NewUserServiceFake() *FakeUserService {
 	return &FakeUserService{}
+}
+
+func (f FakeUserService) GetUsageStats(ctx context.Context) map[string]interface{} {
+	return f.ExpectedUsageStats
 }
 
 func (f *FakeUserService) Create(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error) {


### PR DESCRIPTION
**What is this feature?**
Adds usagestats for configuration option `case_insensitive_login`

- Add registry.ProvidesUsageStats to user.Service interface
- Add GetUsageStats method to userService to satisfy the usagestats interface

```ini
# Enter a comma-separated list of users login to hide them in the Grafana UI. These users are shown to Grafana admins and themselves.
; hidden_users =
case_insensitive_login = true
```

Checked that stats are registered:  http://127.0.0.1:3000/api/admin/usage-report-preview
....
		"stats.bundles.count": 0,
		"stats.case_insensitive_login.count": 1,
		"stats.correlations.count": 3,
...

Fixes:
https://github.com/grafana/grafana/issues/66648