### PR TITLE
Docs: Fix help docs for SQL datasources

### DIFF
--- a/docs/sources/datasources/mssql/query-editor/index.md
+++ b/docs/sources/datasources/mssql/query-editor/index.md
@@ -236,12 +236,12 @@ To optionally customize the default series name formatting, refer to [Standard o
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time, '5m') as time,
+  $__timeGroupAlias(time_date_time, '5m'),
   min("value_double"),
   'min' as metric
 FROM test_data
 WHERE $__timeFilter(time_date_time)
-GROUP BY $__timeGroup(time_date_time, '5m')
+GROUP BY time
 ORDER BY 1
 ```
 
@@ -260,18 +260,18 @@ Data frame result:
 
 ### Time series query examples
 
-**Using the fill parameter in the $\_\_timeGroup macro to convert null values to be zero instead:**
+**Using the fill parameter in the $\_\_timeGroupAlias macro to convert null values to be zero instead:**
 
 ```sql
 SELECT
-  $__timeGroup(createdAt, '5m', 0) as time,
+  $__timeGroupAlias(createdAt, '5m', 0),
   sum(value) as value,
   hostname
 FROM test_data
 WHERE
   $__timeFilter(createdAt)
 GROUP BY
-  $__timeGroup(createdAt, '5m', 0),
+  time,
   hostname
 ORDER BY 1
 ```
@@ -295,12 +295,12 @@ Data frame result:
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time, '5m'),
+  $__timeGroupAlias(time_date_time, '5m'),
   min(value_double) as min_value,
   max(value_double) as max_value
 FROM test_data
 WHERE $__timeFilter(time_date_time)
-GROUP BY $__timeGroup(time_date_time, '5m')
+GROUP BY time
 ORDER BY 1
 ```
 

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -283,7 +283,7 @@ To optionally customize the default series name formatting, refer to [Standard o
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time,'5m'),
+  $__timeGroupAlias(time_date_time,'5m'),
   min(value_double),
   'min' as metric
 FROM test_data
@@ -305,11 +305,11 @@ Data frame result:
 +---------------------+-----------------+
 ```
 
-**Example using the fill parameter in the $\_\_timeGroup macro to convert null values to be zero instead:**
+**Example using the fill parameter in the $\_\_timeGroupAlias macro to convert null values to be zero instead:**
 
 ```sql
 SELECT
-  $__timeGroup(createdAt,'5m',0),
+  $__timeGroupAlias(createdAt,'5m',0),
   sum(value_double) as value,
   hostname
 FROM test_data
@@ -338,7 +338,7 @@ Data frame result:
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time,'5m'),
+  $__timeGroupAlias(time_date_time,'5m'),
   min(value_double) as min_value,
   max(value_double) as max_value
 FROM test_data

--- a/docs/sources/datasources/postgres/_index.md
+++ b/docs/sources/datasources/postgres/_index.md
@@ -235,7 +235,7 @@ To optionally customize the default series name formatting, refer to [Standard o
 
 ```sql
 SELECT
-  $__timeGroup("time_date_time",'5m'),
+  $__timeGroupAlias("time_date_time",'5m'),
   min("value_double"),
   'min' as metric
 FROM test_data
@@ -257,11 +257,11 @@ Data frame result:
 +---------------------+-----------------+
 ```
 
-**Example using the fill parameter in the $\_\_timeGroup macro to convert null values to be zero instead:**
+**Example using the fill parameter in the $\_\_timeGroupAlias macro to convert null values to be zero instead:**
 
 ```sql
 SELECT
-  $__timeGroup("createdAt",'5m',0),
+  $__timeGroupAlias("createdAt",'5m',0),
   sum(value) as value,
   hostname
 FROM test_data
@@ -290,7 +290,7 @@ Data frame result:
 
 ```sql
 SELECT
-  $__timeGroup("time_date_time",'5m'),
+  $__timeGroupAlias("time_date_time",'5m'),
   min("value_double") as "min_value",
   max("value_double") as "max_value"
 FROM test_data

--- a/public/app/plugins/datasource/mysql/CheatSheet.tsx
+++ b/public/app/plugins/datasource/mysql/CheatSheet.tsx
@@ -48,10 +48,10 @@ export function CheatSheet() {
         </li>
         <li>
           $__timeGroupAlias(column,&apos;5m&apos;) -&gt; cast(cast(UNIX_TIMESTAMP(column)/(300) as signed)*300 as
-          signed) AS &quote;time&quote;
+          signed) AS &quot;time&quot;
         </li>
         <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; column DIV 300 * 300</li>
-        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; column DIV 300 * 300 AS &quote;time&quote;</li>
+        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; column DIV 300 * 300 AS &quot;time&quot;</li>
       </ul>
       <p>Example of group by and order by with $__timeGroup:</p>
       <pre>

--- a/public/app/plugins/datasource/postgres/CheatSheet.tsx
+++ b/public/app/plugins/datasource/postgres/CheatSheet.tsx
@@ -32,8 +32,8 @@ export function CheatSheet() {
       </ul>
       Macros:
       <ul className={styles.ulPadding}>
-        <li>$__time(column) -&gt; column as &quote;time&quote;</li>
-        <li>$__timeEpoch -&gt; extract(epoch from column) as &quote;time&quote;</li>
+        <li>$__time(column) -&gt; column as &quot;time&quot;</li>
+        <li>$__timeEpoch -&gt; extract(epoch from column) as &quot;time&quot;</li>
         <li>
           $__timeFilter(column) -&gt; column BETWEEN &apos;2017-04-21T05:01:17Z&apos; AND
           &apos;2017-04-21T05:01:17Z&apos;
@@ -49,10 +49,10 @@ export function CheatSheet() {
         </li>
         <li>
           $__timeGroupAlias(column,&apos;5m&apos;) -&gt; (extract(epoch from column)/300)::bigint*300 AS
-          &quote;time&quote;
+          &quot;time&quot;
         </li>
         <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; floor(column/300)*300</li>
-        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; floor(column/300)*300 AS &quote;time&quote;</li>
+        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; floor(column/300)*300 AS &quot;time&quot;</li>
       </ul>
       <p>Example of group by and order by with $__timeGroup:</p>
       <pre>


### PR DESCRIPTION
This PR fixes some docs examples for the SQL datasources and a formatting issue for the code help.

| Before | After |
|:------:|:-----:|
|    ![before](https://camo.githubusercontent.com/fc153670125419bb538578c88c413ac132f0d720094f8a4beaeb823ec2222ee6/68747470733a2f2f67726166616e612e7a656e6465736b2e636f6d2f6174746163686d656e74732f746f6b656e2f6f717847763036506e4b31753936586145336b68584348306e2f3f6e616d653d696d6167652e706e67)    |   ![Screenshot 2023-04-18 at 11 35 42](https://user-images.githubusercontent.com/13729989/232759468-f63b1a17-b890-42e9-b2b2-2391a0591dd5.png)    |

The docs examples were wrong as if you copy and paste it it would throw an error that time is missing.  Because of that I changed the examples to use `$__timeGroupAlias` instead.