### PR TITLE
Revert "APIkeys: Add metrics for apikey endpoints (#66732)"

### DIFF
--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/components/apikeygen"
-	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/web"
@@ -65,7 +64,6 @@ func (hs *HTTPServer) GetAPIKeys(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
-	metrics.MApiAPIkeysGet.Inc()
 	return response.JSON(http.StatusOK, result)
 }
 
@@ -101,7 +99,6 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 		return response.Error(status, "Failed to delete API key", err)
 	}
 
-	metrics.MApiAPIkeysDelete.Inc()
 	return response.Success("API key deleted")
 }
 
@@ -169,7 +166,6 @@ func (hs *HTTPServer) AddAPIKey(c *contextmodel.ReqContext) response.Response {
 		Key:  newKeyInfo.ClientSecret,
 	}
 
-	metrics.MApiAPIkeysCreate.Inc()
 	return response.JSON(http.StatusOK, result)
 }
 

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -109,12 +109,6 @@ var (
 
 	// MPublicDashboardDatasourceQuerySuccess is a metric counter for successful queries labelled by datasource
 	MPublicDashboardDatasourceQuerySuccess *prometheus.CounterVec
-
-	MApiAPIkeysGet prometheus.Counter
-
-	MApiAPIkeysCreate prometheus.Counter
-
-	MApiAPIkeysDelete prometheus.Counter
 )
 
 // Timers
@@ -452,24 +446,6 @@ func init() {
 		Namespace: ExporterName,
 	}, []string{"datasource", "status"}, map[string][]string{"status": pubdash.QueryResultStatuses})
 
-	MApiAPIkeysGet = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
-		Name:      "api_api_keys_get_total",
-		Help:      "counter for getting api keys",
-		Namespace: ExporterName,
-	})
-
-	MApiAPIkeysCreate = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
-		Name:      "api_api_keys_create_total",
-		Help:      "counter for creating api keys",
-		Namespace: ExporterName,
-	})
-
-	MApiAPIkeysDelete = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
-		Name:      "api_api_keys_delete_total",
-		Help:      "counter for deleting api keys",
-		Namespace: ExporterName,
-	})
-
 	MStatTotalDashboards = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_dashboard",
 		Help:      "total amount of dashboards",
@@ -739,8 +715,5 @@ func initMetricVars() {
 		MPublicDashboardRequestCount,
 		MPublicDashboardDatasourceQuerySuccess,
 		MStatTotalCorrelations,
-		MApiAPIkeysGet,
-		MApiAPIkeysCreate,
-		MApiAPIkeysDelete,
 	)
 }


### PR DESCRIPTION
This reverts commit c505d26430e85baa20429675c8958d42ea67adf4 from https://github.com/grafana/grafana/pull/66732