### PR TITLE
CloudMonitor: Correctly re-render `VisualMetricQueryEditor` on `TimeRange` updates

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -48,7 +48,11 @@ export function Editor({
   const [timeRange, setTimeRange] = useState<TimeRange>({ ...datasource.timeSrv.timeRange() });
 
   const useTime = (time: TimeRange) => {
-    if (timeRange !== null && (timeRange.raw.from !== time.raw.from || timeRange.raw.to !== time.raw.to)) {
+    if (
+      timeRange !== null &&
+      (timeRange.raw.from.toString() !== time.raw.from.toString() ||
+        timeRange.raw.to.toString() !== time.raw.to.toString())
+    ) {
       setTimeRange({ ...time });
     }
   };


### PR DESCRIPTION
#61410 introduced functionality to refresh labels when the `timeRange` updated. Unfortunately this also introduced a bug that led to an infinite re-render loop as the condition to validate if the previous and current `timeRanges` are equal was comparing object references rather than actual values.

Fixes grafana/support-escalations#5154
Fixes grafana/support-escalations#5443