### PR TITLE
Elasticsearch: Handle multiple annotation structures

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/AnnotationQueryEditor.tsx
@@ -23,9 +23,15 @@ export function ElasticsearchAnnotationsQueryEditor(props: Props) {
         <ElasticSearchQueryField
           value={annotation.target?.query}
           onChange={(query) => {
+            const currentTarget = annotation.target ?? { refId: 'annotation_query' };
+            const newTarget = {
+              ...currentTarget,
+              query,
+            };
+
             onAnnotationChange({
               ...annotation,
-              query,
+              target: newTarget,
             });
           }}
         />

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -256,7 +256,17 @@ export class ElasticDatasource
     const annotation = options.annotation;
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
-    const queryString = annotation.query;
+
+    // the `target.query` is the "new" location for the query.
+    // normally we would write this code as
+    // try-the-new-place-then-try-the-old-place,
+    // but we had the bug at
+    // https://github.com/grafana/grafana/issues/61107
+    // that may have stored annotations where
+    // both the old and the new place are set,
+    // and in that scenario the old place needs
+    // to have priority.
+    const queryString = annotation.query ?? annotation.target?.query;
     const tagsField = annotation.tagsField || 'tags';
     const textField = annotation.textField || null;
 


### PR DESCRIPTION
since the elastic annotation handling was migrated from Angular to react in https://github.com/grafana/grafana/pull/49529 , we have a bug in how they are handled. this PR fixes the problem.

in Grafana versions up to `9.0.9` the annotation editor for elastic was angular based, and this is how it worked:
you entered a lucene query, and it stored in the annotation-structure like this (there are other fields there too, but they are not important here, i'm ignoring them):
```json
{
    "query":"level:error"
}
```

this is stored in the dashboard-json, and then the datasource's `annotationQuery` method reads it at: https://github.com/grafana/grafana/blob/720fe9d1d147e9c61a29751f8768fad0d2f28d5b/public/app/plugins/datasource/elasticsearch/datasource.ts#L246

NOTE: an unrelated thing that will be important here is: we are doing custom annotation-handling here. Grafana is able to do a generic annotation-handling-thing (for other datasources), and in such a case it creates the JSON like this:
```json
{
    "target": {
        "query": "level:error"
    }
}
```
(it basically stores a whole Query-object at `annotation.target`.

with Grafana `9.1.0`, we switched for elastic-annotations to React, and wrote custom code to handle this.  we tried to keep the JSON shape the same, so we still write to the top-level `"query"` field:
https://github.com/grafana/grafana/blob/b33ce06af99e1d62f3f0491f44bf6fd5dd554b29/public/app/plugins/datasource/elasticsearch/components/QueryEditor/AnnotationQueryEditor.tsx#L26-L29

this worked well, but there's a complication. with this being in React, some other generic Grafana code gets activated, that tries to "migrat" from the OLD toplevel-query-format to the NEW inside-target-format:
https://github.com/grafana/grafana/blob/b33ce06af99e1d62f3f0491f44bf6fd5dd554b29/public/app/features/annotations/standardAnnotationSupport.ts#L24-L37

this always happens whenever an annotation-query is opened for editing. and when this happens, the shape of our JSON changes, `query` becomes `target.query`. and when this happens, the `datasource.annotationQuery` function is not able to do it's work, because it expect the value at `query`, not at `target.query`.

also, note that the elastic AnnotationQueryEditor, when editing an existing annotation, READS from `target.query`, but WRITES to `query`:
https://github.com/grafana/grafana/blob/b33ce06af99e1d62f3f0491f44bf6fd5dd554b29/public/app/plugins/datasource/elasticsearch/components/QueryEditor/AnnotationQueryEditor.tsx#L24-L30

(this works because when an annotation is opened for editing, that generic grafana migration code happens, and the annotation received by the react component is already in the NEW format)

but this causes problems too. imagine that we have this JSON in dashboard-json, that we open for editing:
```json
{
    "query": "level:error"
}
```

now, in the react annotation-editor we will see `level:error` in the text-field. we change it to `level:info`, and save the JSON.
but, the JSON stored to dashboard-json will be this:
```json
{
    "query": "level:info",
   "target": {
        "query":"level:error"
   }
}
```

(the automatic grafana migration thing happens when the form is opened for editing, not when the content is saved at the end)

so, to handle all this, this pull request does two changes:

1. we change `datasource.annotationQuery` to look for both places (`query` for old annotations, and `target.query` for new annotations).. when both exist, we take the old-format one, because of the bug i described just above.. i think it's better to prefer the old value in this scenario.
2. we change the elastic AnnotationQueryEditor to write to `target.query`

this should cover all the possible cases.

how to test:
(technically we should start with a locally built grafana 9.0.9, but i was not able to build it locally anymore, it complained about some yarn-thing, so i used grafana-in-docker instead)
1. use grafana 9.0.9 with something like `make devenv=grafana grafana_version=9.0.9`
2. create an annotation. if you are using devenv-elastic, an easy-to-use one is:
     - query: `counter:42`. 
     - set the "text" field to "counter"
3. verify that you see a single line in the dashboard panel, and when you mouseover to the value of the annotation, it says `42`.
4. verify that the structure of the json is top-level-query, not in-target-query
5. copy the whole dashboard-json out into a file on your computer.
6. now switch to this PR on your computer
7. we need to import the dashboard into your computer, but the UID of the elastic-datasource might be different, so do this:
    - find out the UID of your elastic datasource on your computer. for example, go to edit-datasource-config, and the UID is the last part of the URL.
    - choose import dashboard JSON, and afterwards modify the JSON by correcting the datasource-UID
    - at this point the dashboard should work correctly.
9. refresh the dashboard. verify that you see a single line in the dashboard panel. (so that new code works well with old-format)
10. switch to grafana main-branch
11. edit the dashboard-annotation, set the lucene query to `counter:43`
12. save the dashboard
13. check the dashboard-json, verify that it has a top-level `counter:43` and an inside-target `counter:42`.
14. switch to this PR
15. refresh the dashboard
16. verify that you see a single line in the dashboard panel, and when you mouseover to the value of the annotation, it says `43`. (so that the new code shows `.query`when both `.query` and `.target.query` exists.
17. edit the annotation, set the lucene query to `counter:44`
18. save the dashboard
19. verify in the dashboard-json that `.target.query` exists with `counter:44`, and no `.query` exists.
20. refresh the dashboard
21. verify that you see a single line in the dashboard panel, and when you mouseover to the value of the annotation, it says `44`. (so that the new code is able to read `.target.query` too)
22. delete the existing annotation, save dashboard, add a new annotation, for example set the query to `counter:45`. save dashboard, and verify in the JSON that `.target.query` is set to `counter:45`, and `.query` does not exist. refresh dashboard, verify the annotation says `45` (so a newly created annotation works too)
23. done 😄 


(fixes https://github.com/grafana/grafana/issues/61107)