### PR TITLE
Tracing: Span filters reset filters and button

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.test.tsx
@@ -27,22 +27,25 @@ const defaultProps = {
 describe('<NewTracePageSearchBar>', () => {
   it('renders buttons', () => {
     render(<NewTracePageSearchBar {...(defaultProps as unknown as TracePageSearchBarProps)} />);
-    const nextResButton = screen.queryByRole('button', { name: 'Next result button' });
-    const prevResButton = screen.queryByRole('button', { name: 'Prev result button' });
+    const nextResButton = screen.getByRole('button', { name: 'Next result button' });
+    const prevResButton = screen.getByRole('button', { name: 'Prev result button' });
+    const resetFiltersButton = screen.getByRole('button', { name: 'Reset filters button' });
     expect(nextResButton).toBeInTheDocument();
     expect(prevResButton).toBeInTheDocument();
+    expect(resetFiltersButton).toBeInTheDocument();
     expect((nextResButton as HTMLButtonElement)['disabled']).toBe(true);
     expect((prevResButton as HTMLButtonElement)['disabled']).toBe(true);
+    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
   });
 
-  it('renders buttons that can be used to search if filters added', () => {
+  it('renders buttons that can be used to search if results found', () => {
     const props = {
       ...defaultProps,
       spanFilterMatches: new Set(['2ed38015486087ca']),
     };
     render(<NewTracePageSearchBar {...(props as unknown as TracePageSearchBarProps)} />);
-    const nextResButton = screen.queryByRole('button', { name: 'Next result button' });
-    const prevResButton = screen.queryByRole('button', { name: 'Prev result button' });
+    const nextResButton = screen.getByRole('button', { name: 'Next result button' });
+    const prevResButton = screen.getByRole('button', { name: 'Prev result button' });
     expect(nextResButton).toBeInTheDocument();
     expect(prevResButton).toBeInTheDocument();
     expect((nextResButton as HTMLButtonElement)['disabled']).toBe(false);

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
@@ -162,6 +162,29 @@ describe('SpanFilters', () => {
     jest.advanceTimersByTime(1000);
     expect(screen.getAllByLabelText('Select tag key').length).toBe(1);
   });
+
+  it('should allow resetting filters', async () => {
+    render(<SpanFiltersWithProps />);
+    const resetFiltersButton = screen.getByRole('button', { name: 'Reset filters button' });
+    expect(resetFiltersButton).toBeInTheDocument();
+    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
+
+    const serviceValue = screen.getByLabelText('Select service name');
+    const spanValue = screen.getByLabelText('Select span name');
+    const tagKey = screen.getByLabelText('Select tag key');
+    const tagValue = screen.getByLabelText('Select tag value');
+    await selectAndCheckValue(user, serviceValue, 'Service0');
+    await selectAndCheckValue(user, spanValue, 'Span0');
+    await selectAndCheckValue(user, tagKey, 'TagKey0');
+    await selectAndCheckValue(user, tagValue, 'TagValue0');
+
+    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(false);
+    await user.click(resetFiltersButton);
+    expect(screen.queryByText('Service0')).not.toBeInTheDocument();
+    expect(screen.queryByText('Span0')).not.toBeInTheDocument();
+    expect(screen.queryByText('TagKey0')).not.toBeInTheDocument();
+    expect(screen.queryByText('TagValue0')).not.toBeInTheDocument();
+  });
 });
 
 const selectAndCheckValue = async (user: ReturnType<typeof userEvent.setup>, elem: HTMLElement, text: string) => {

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -14,7 +14,7 @@
 
 import { css } from '@emotion/css';
 import { uniq } from 'lodash';
-import React, { useState, memo } from 'react';
+import React, { useState, useEffect, memo, useCallback } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
@@ -30,7 +30,7 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
-import { randomId, SearchProps, Tag } from '../../../useSearch';
+import { defaultFilters, randomId, SearchProps, Tag } from '../../../useSearch';
 import { Trace } from '../../types';
 import NewTracePageSearchBar from '../NewTracePageSearchBar';
 
@@ -63,6 +63,18 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
   const [spanNames, setSpanNames] = useState<Array<SelectableValue<string>>>();
   const [tagKeys, setTagKeys] = useState<Array<SelectableValue<string>>>();
   const [tagValues, setTagValues] = useState<{ [key: string]: Array<SelectableValue<string>> }>({});
+
+  const reset = useCallback(() => {
+    setServiceNames(undefined);
+    setSpanNames(undefined);
+    setTagKeys(undefined);
+    setTagValues({});
+    setSearch(defaultFilters);
+  }, [setSearch]);
+
+  useEffect(() => {
+    reset();
+  }, [reset, trace]);
 
   if (!trace) {
     return null;
@@ -237,7 +249,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                 onOpenMenu={getServiceNames}
                 options={serviceNames}
                 placeholder="All service names"
-                value={search.serviceName}
+                value={search.serviceName || null}
               />
             </HorizontalGroup>
           </InlineField>
@@ -258,7 +270,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                 onOpenMenu={getSpanNames}
                 options={spanNames}
                 placeholder="All span names"
-                value={search.spanName}
+                value={search.spanName || null}
               />
             </HorizontalGroup>
           </InlineField>
@@ -309,7 +321,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                       onOpenMenu={getTagKeys}
                       options={tagKeys}
                       placeholder="Select tag"
-                      value={tag.key}
+                      value={tag.key || null}
                     />
                     <Select
                       aria-label={`Select tag operator`}
@@ -374,6 +386,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
           focusedSpanIdForSearch={focusedSpanIdForSearch}
           setFocusedSpanIdForSearch={setFocusedSpanIdForSearch}
           datasourceType={datasourceType}
+          reset={reset}
         />
       </Collapse>
     </div>


### PR DESCRIPTION
**What is this feature?**

Resets the filters selected on new trace and also adds reset button.

**Why do we need this feature?**

So filters are accurate to current trace and users can quickly remove all filters if necessary.

**Who is this feature for?**

Users of span filters in the trace view.

**Special notes for your reviewer:**

![Screenshot 2023-04-18 at 16 30 29](https://user-images.githubusercontent.com/90795735/232827176-eb8a7c38-c715-4736-afe9-b061e716afda.png)


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
