### PR TITLE
AzureMonitor: Ensure dimension labels are consistent

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.test.tsx
@@ -140,7 +140,7 @@ describe(`Azure Monitor QueryEditor`, () => {
           {
             ...mockPanelData.series[0].fields[0],
             name: 'Test Dimension 1',
-            labels: { testdimension1: 'testlabel' },
+            labels: { Testdimension1: 'testlabel' },
           },
         ],
       },

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/DimensionFields.tsx
@@ -33,10 +33,11 @@ const useDimensionLabels = (data: PanelData | undefined, query: AzureMonitorQuer
       for (const label of labels) {
         // Labels only exist for series that have a dimension selected
         for (const [dimension, value] of Object.entries(label)) {
-          if (labelsObj[dimension]) {
-            labelsObj[dimension].add(value);
+          const dimensionLower = dimension.toLowerCase();
+          if (labelsObj[dimensionLower]) {
+            labelsObj[dimensionLower].add(value);
           } else {
-            labelsObj[dimension] = new Set([value]);
+            labelsObj[dimensionLower] = new Set([value]);
           }
         }
       }


### PR DESCRIPTION
This PR ensures that the labels used to identify dimensions are always lowercase, avoiding API inconsistency in label naming.

Fixes grafana/support-escalations#5492