### PR TITLE
Variables: Add support for `$__timezone` template variable

### DIFF
--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -317,9 +317,9 @@ This is used in several places, including:
 
 ### $\_\_timezone
 
-The `$__timezone` variable returns the currently selected time zone, either `utc` or an entry of the IANA time zone database (e.g. `America/New_York`).
+The `$__timezone` variable returns the currently selected time zone, either `utc` or an entry of the IANA time zone database (for example, `America/New_York`).
 
-If the currently selected time zone is _Browser Time_, your browser time zone will be guessed.
+If the currently selected time zone is _Browser Time_, Grafana will try to determine your browser time zone.
 
 ## Chained variables
 

--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -315,6 +315,12 @@ This is used in several places, including:
 - SQL queries in MySQL, Postgres, and MSSQL.
 - The `$__timeFilter` variable is used in the MySQL data source.
 
+### $\_\_timezone
+
+The `$__timezone` variable returns the currently selected time zone, either `utc` or an entry of the IANA time zone database (e.g. `America/New_York`).
+
+If the currently selected time zone is _Browser Time_, your browser time zone will be guessed.
+
 ## Chained variables
 
 _Chained variables_, also called _linked variables_ or _nested variables_, are query variables with one or more other variables in their variable query. This section explains how chained variables work and provides links to example dashboards that use chained variables.

--- a/public/app/features/templating/macroRegistry.test.ts
+++ b/public/app/features/templating/macroRegistry.test.ts
@@ -3,7 +3,8 @@ import { initTemplateSrv } from 'test/helpers/initTemplateSrv';
 import { DataLinkBuiltInVars } from '@grafana/data';
 import { getTemplateSrv, setTemplateSrv } from '@grafana/runtime';
 
-import { setTimeSrv } from '../dashboard/services/TimeSrv';
+import { setTimeSrv, TimeSrv } from '../dashboard/services/TimeSrv';
+import { TimeModel } from '../dashboard/state/TimeModel';
 import { variableAdapters } from '../variables/adapters';
 import { createQueryVariableAdapter } from '../variables/query/adapter';
 
@@ -50,5 +51,20 @@ describe('__url_time_range', () => {
   it('should interpolate to url params', () => {
     const out = getTemplateSrv().replace(`/d/1?$${DataLinkBuiltInVars.keepTime}`);
     expect(out).toBe('/d/1?from=1607687293000&to=1607687293100');
+  });
+});
+
+describe('__timezone', () => {
+  beforeAll(() => {
+    setTimeSrv({
+      timeModel: {
+        getTimezone: () => 'Pacific/Noumea',
+      } as TimeModel,
+    } as TimeSrv);
+  });
+
+  it('should interpolate to time zone', () => {
+    const out = getTemplateSrv().replace(`TIMEZONE('$__timezone', '2023-04-19 00:00:00')`);
+    expect(out).toBe(`TIMEZONE('Pacific/Noumea', '2023-04-19 00:00:00')`);
   });
 });

--- a/public/app/features/templating/macroRegistry.ts
+++ b/public/app/features/templating/macroRegistry.ts
@@ -1,4 +1,6 @@
-import { DataLinkBuiltInVars, ScopedVars, urlUtil } from '@grafana/data';
+import moment from 'moment-timezone';
+
+import { DataLinkBuiltInVars, getTimeZone, ScopedVars, urlUtil } from '@grafana/data';
 
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { getVariablesUrlParams } from '../variables/getAllVariableValuesForUrl';
@@ -13,6 +15,7 @@ export const macroRegistry: Record<string, MacroHandler> = {
   ['__field']: fieldMacro,
   [DataLinkBuiltInVars.includeVars]: includeVarsMacro,
   [DataLinkBuiltInVars.keepTime]: urlTimeRangeMacro,
+  ['__timezone']: timeZoneMacro,
 };
 
 function includeVarsMacro(match: string, fieldPath?: string, scopedVars?: ScopedVars) {
@@ -22,4 +25,9 @@ function includeVarsMacro(match: string, fieldPath?: string, scopedVars?: Scoped
 
 function urlTimeRangeMacro() {
   return urlUtil.toUrlParams(getTimeSrv().timeRangeForUrl());
+}
+
+function timeZoneMacro() {
+  const timeZone = getTimeZone({ timeZone: getTimeSrv().timeModel?.getTimezone() });
+  return timeZone === 'browser' ? moment.tz.guess() : timeZone;
 }


### PR DESCRIPTION
### What is this feature?

This PR adds a new `$__timezone` variables, replaced by the currently selected time zone by the template server (in queries, labels, etc.)

### Why do we need this feature?

 Use case: Using the Postgres datasource, it allows using functions such as `DATE_TRUNC` to manipulate datetimes in the correct timezone server-side. Example: `DATE_TRUNC('month', TIMEZONE('$__timezone', my_datetime_column))`. See #38159.

Bonus use case: Synchronizing time zones between Grafana and the [clock-panel plugin](https://github.com/grafana/clock-panel).

### Who is this feature for?

All Grafana OSS & Enterprise users.

### Which issue(s) does this PR fix?

Not an issue, but:

Fixes #38159

### Special notes for your reviewer:

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
