### PR TITLE
fix(background svcs): reinstate load-bearing guardian initialization

### DIFF
--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
+	"github.com/grafana/grafana/pkg/services/guardian"
 	ldapapi "github.com/grafana/grafana/pkg/services/ldap/api"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
@@ -50,6 +51,8 @@ func ProvideBackgroundServiceRegistry(
 	_ dashboardsnapshots.Service, _ *alerting.AlertNotificationService,
 	_ *plugindashboardsservice.DashboardUpdater, _ *sanitizer.Provider,
 	_ *grpcserver.HealthService, _ entity.EntityStoreServer, _ *grpcserver.ReflectionService, _ *ldapapi.Service,
+	_ *guardian.Provider,
+
 ) *BackgroundServiceRegistry {
 	return NewBackgroundServiceRegistry(
 		ng,


### PR DESCRIPTION
[This change](https://github.com/grafana/grafana/commit/3370eca4b3ac8cc17495fd3ceb67ae4f1a85d56a#diff-cee3378f62a27dd53c0d3be445f4f64a482a8be79fa83938b87cfda290b8fd96L54) was causing a panic in a "fresh" startup of grafana from this branch (Grafana starts fine as long as it had started successfully before, for example from main. Something must get written to the db?)  