### PR TITLE
[docs] remove auth/saml alias from team sync page

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-team-sync.md
+++ b/docs/sources/setup-grafana/configure-security/configure-team-sync.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - ../../auth/saml/
   - ../../auth/team-sync/
   - ../../enterprise/team-sync/
 description: Learn how to use Team Sync to synchronize between your authentication


### PR DESCRIPTION
Bad redirect behaviour already fixed on PRs #66728, #66792, #66800 and website PR [12684](https://github.com/grafana/website/pull/12684). This is just cleanup.