### PR TITLE
AppRootPage: Reduce flickering while loading plugin

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -32,7 +32,7 @@ export class AppChromeService {
     sectionNav: { node: { text: t('nav.home.title', 'Home') }, main: { text: '' } },
     searchBarHidden: store.getBool(this.searchBarStorageKey, false),
     kioskMode: null,
-    layout: PageLayoutType.Standard,
+    layout: PageLayoutType.Canvas,
   });
 
   setMatchedRoute(route: RouteDescriptor) {
@@ -77,6 +77,7 @@ export class AppChromeService {
     if (newState.sectionNav !== current.sectionNav || newState.pageNav !== current.pageNav) {
       if (
         newState.actions === current.actions &&
+        newState.layout === current.layout &&
         navItemsAreTheSame(newState.sectionNav.node, current.sectionNav.node) &&
         navItemsAreTheSame(newState.pageNav, current.pageNav)
       ) {

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -7,6 +7,7 @@ import { AppEvents, AppPlugin, AppPluginMeta, NavModel, NavModelItem, PluginType
 import { config, locationSearchToObject } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
+import { useGrafana } from 'app/core/context/GrafanaContext';
 import { appEvents } from 'app/core/core';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
 
@@ -41,6 +42,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const navModel = buildPluginSectionNav(pluginNavSection, pluginNav, currentUrl);
   const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel), [navModel]);
+  const grafanaContext = useGrafana();
 
   useEffect(() => {
     loadAppPlugin(pluginId, dispatch);
@@ -52,8 +54,10 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   );
 
   if (!plugin || pluginId !== plugin.meta.id) {
+    // Use current layout while loading to reduce flickering
+    const currentLayout = grafanaContext.chrome.state.getValue().layout;
     return (
-      <Page navModel={navModel} pageNav={{ text: '' }}>
+      <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
       </Page>
     );

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -52,7 +52,11 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   );
 
   if (!plugin || pluginId !== plugin.meta.id) {
-    return <Page navModel={navModel}>{loading && <PageLoader />}</Page>;
+    return (
+      <Page navModel={navModel} pageNav={{ text: '' }}>
+        {loading && <PageLoader />}
+      </Page>
+    );
   }
 
   if (!plugin.root) {


### PR DESCRIPTION
A big problem for app plugins (especially the cloud home) is how it temporarily shows a section nav and standard page named "Home" while loading. 

It looks like React 18 or some other changes in main has made this problem slightly less noticeable but think this is a good change anyway 

* Fixes bug if you load an App with a PluginPage layout set to canvas as the first page it would still show left side section nav 
* Default to Canvas layout to reduce flickering when loading an app plugin that uses canvas layout (for example the hg home app) 
* While the plugin load use an empty page title to reduce flickering of plugin name in page header while plugin loads 
