### PR TITLE
Explore: Remove click tracking for external links

### DIFF
--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -57,15 +57,7 @@ describe('explore links utils', () => {
 
       expect(links[0].href).toBe('http://regionalhost');
       expect(links[0].title).toBe('external');
-      expect(links[0].onClick).toBeDefined();
-
-      links[0].onClick!({});
-
-      expect(reportInteraction).toBeCalledWith('grafana_data_link_clicked', {
-        app: CoreApp.Explore,
-        internal: false,
-        origin: DataLinkConfigOrigin.Datasource,
-      });
+      expect(links[0].onClick).not.toBeDefined();
     });
 
     it('returns generates title for external link', () => {

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -122,30 +122,6 @@ export const getFieldLinksForExplore = (options: {
         if (!linkModel.title) {
           linkModel.title = getTitleFromHref(linkModel.href);
         }
-
-        // Take over the onClick to report the click, then either call the original onClick or navigate to the URL
-        // Note: it is likely that an external link that opens in the same tab will not be reported, as the browser redirect might cancel reporting the interaction
-        const origOnClick = linkModel.onClick;
-
-        linkModel.onClick = (...args) => {
-          reportInteraction(DATA_LINK_USAGE_KEY, {
-            origin: link.origin || DataLinkConfigOrigin.Datasource,
-            app: CoreApp.Explore,
-            internal: false,
-          });
-
-          if (origOnClick) {
-            origOnClick?.apply(...args);
-          } else {
-            // for external links without an onClick, we want to duplicate default href behavior since onClick stops it
-            if (linkModel.target === '_blank') {
-              window.open(linkModel.href);
-            } else {
-              window.location.href = linkModel.href;
-            }
-          }
-        };
-
         return linkModel;
       } else {
         let internalLinkSpecificVars: ScopedVars = {};


### PR DESCRIPTION
**What is this feature?**

In #65221 we added click tracking for data links. Although this was done specifically to track correlations, we broadened the scope to track all data links. For external data links, we needed to change the native `href` behavior to be an `onClick` instead, so we could add a javascript function call before the navigation was completed. This broke other `href` native features such as right clicking to open in a new tab. Since this tracking wasn't necessary for our new feature, we can remove it and revisit it later if click tracking on all data links is necessary.

**Why do we need this feature?**

We shouldn't impact user experience for the sake of usage tracking.

**Special notes for your reviewer:**
Correlation data links are always internal and will not be affected by this change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
