### PR TITLE
Alerting: Use URLs in image annotations

### DIFF
--- a/pkg/services/ngalert/notifier/images.go
+++ b/pkg/services/ngalert/notifier/images.go
@@ -23,11 +23,10 @@ func newImageStore(store store.ImageStore) images.ImageStore {
 func (i imageStore) GetImage(ctx context.Context, uri string) (*images.Image, error) {
 	var image *models.Image
 	var err error
-
 	// Check whether the uri is a token or a URL to know how to query the DB.
 	token := strings.TrimPrefix(uri, "token://")
 	if len(token) < len(uri) {
-		// If the final string is shorter, it means that it was prefixed.
+		// If the final string is shorter, that means it was prefixed.
 		if image, err = i.store.GetImage(ctx, token); err != nil {
 			return nil, err
 		}

--- a/pkg/services/ngalert/notifier/images_test.go
+++ b/pkg/services/ngalert/notifier/images_test.go
@@ -1,0 +1,47 @@
+package notifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetImage(t *testing.T) {
+	fakeImageStore := store.NewFakeImageStore(t)
+	store := newImageStore(fakeImageStore)
+
+	t.Run("queries by token when it gets a token", func(tt *testing.T) {
+		img := models.Image{
+			Token: "test",
+			URL:   "http://localhost:1234",
+			Path:  "test.png",
+		}
+		err := fakeImageStore.SaveImage(context.Background(), &img)
+		require.NoError(t, err)
+
+		savedImg, err := store.GetImage(context.Background(), "token://"+img.Token)
+		require.NoError(tt, err)
+		require.Equal(tt, savedImg.Token, img.Token)
+		require.Equal(tt, savedImg.URL, img.URL)
+		require.Equal(tt, savedImg.Path, img.Path)
+	})
+
+	t.Run("queries by URL when it gets a URL", func(tt *testing.T) {
+		img := models.Image{
+			Token: "test",
+			Path:  "test.png",
+			URL:   "https://test.com/test.png",
+		}
+		err := fakeImageStore.SaveImage(context.Background(), &img)
+		require.NoError(t, err)
+
+		savedImg, err := store.GetImage(context.Background(), img.URL)
+		require.NoError(tt, err)
+		require.Equal(tt, savedImg.Token, img.Token)
+		require.Equal(tt, savedImg.URL, img.URL)
+		require.Equal(tt, savedImg.Path, img.Path)
+	})
+}

--- a/pkg/services/ngalert/notifier/images_test.go
+++ b/pkg/services/ngalert/notifier/images_test.go
@@ -20,7 +20,7 @@ func TestGetImage(t *testing.T) {
 			Path:  "test.png",
 		}
 		err := fakeImageStore.SaveImage(context.Background(), &img)
-		require.NoError(t, err)
+		require.NoError(tt, err)
 
 		savedImg, err := store.GetImage(context.Background(), "token://"+img.Token)
 		require.NoError(tt, err)
@@ -36,7 +36,7 @@ func TestGetImage(t *testing.T) {
 			URL:   "https://test.com/test.png",
 		}
 		err := fakeImageStore.SaveImage(context.Background(), &img)
-		require.NoError(t, err)
+		require.NoError(tt, err)
 
 		savedImg, err := store.GetImage(context.Background(), img.URL)
 		require.NoError(tt, err)

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -31,6 +31,10 @@ func (f *fakeConfigStore) GetImage(ctx context.Context, token string) (*models.I
 	return nil, models.ErrImageNotFound
 }
 
+func (f *fakeConfigStore) GetImageByURL(ctx context.Context, url string) (*models.Image, error) {
+	return nil, models.ErrImageNotFound
+}
+
 func (f *fakeConfigStore) GetImages(ctx context.Context, tokens []string) ([]models.Image, []string, error) {
 	return nil, nil, models.ErrImageNotFound
 }

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -49,8 +49,8 @@ func stateToPostableAlert(alertState *state.State, appURL *url.URL) *models.Post
 		nA[alertingModels.ValueStringAnnotation] = alertState.LastEvaluationString
 	}
 
-	if alertState.Image != nil {
-		nA[alertingModels.ImageTokenAnnotation] = alertState.Image.Token
+	if alertState.ImageURI != "" {
+		nA[alertingModels.ImageTokenAnnotation] = alertState.ImageURI
 	}
 
 	if alertState.StateReason != "" {

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -49,8 +49,8 @@ func stateToPostableAlert(alertState *state.State, appURL *url.URL) *models.Post
 		nA[alertingModels.ValueStringAnnotation] = alertState.LastEvaluationString
 	}
 
-	if alertState.ImageURI != "" {
-		nA[alertingModels.ImageTokenAnnotation] = alertState.ImageURI
+	if alertState.Image != nil {
+		nA[alertingModels.ImageTokenAnnotation] = generateImageURI(alertState.Image)
 	}
 
 	if alertState.StateReason != "" {
@@ -166,4 +166,14 @@ func FromAlertsStateToStoppedAlert(firingStates []state.StateTransition, appURL 
 		alerts.PostableAlerts = append(alerts.PostableAlerts, *postableAlert)
 	}
 	return alerts
+}
+
+// generateImageURI returns a string that serves as an identifier for the image.
+// It first checks if there is an image URL available, and if not,
+// it prefixes the image token with `token://` and uses it as the URI.
+func generateImageURI(image *ngModels.Image) string {
+	if image.URL != "" {
+		return image.URL
+	}
+	return "token://" + image.Token
 }

--- a/pkg/services/ngalert/schedule/compat_test.go
+++ b/pkg/services/ngalert/schedule/compat_test.go
@@ -122,7 +122,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 				t.Run("add __alertImageToken__ if there is an image token", func(t *testing.T) {
 					alertState := randomState(tc.state)
 					alertState.Annotations = randomMapOfStrings()
-					alertState.Image = &ngModels.Image{Token: "test_token"}
+					alertState.ImageURI = "token://test_token"
 
 					result := stateToPostableAlert(alertState, appURL)
 
@@ -130,7 +130,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 					for k, v := range alertState.Annotations {
 						expected[k] = v
 					}
-					expected["__alertImageToken__"] = alertState.Image.Token
+					expected["__alertImageToken__"] = alertState.ImageURI
 
 					require.Equal(t, expected, result.Annotations)
 				})

--- a/pkg/services/ngalert/schedule/compat_test.go
+++ b/pkg/services/ngalert/schedule/compat_test.go
@@ -122,7 +122,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 				t.Run("add __alertImageToken__ if there is an image token", func(t *testing.T) {
 					alertState := randomState(tc.state)
 					alertState.Annotations = randomMapOfStrings()
-					alertState.ImageURI = "token://test_token"
+					alertState.Image = &ngModels.Image{Token: "test_token"}
 
 					result := stateToPostableAlert(alertState, appURL)
 
@@ -130,7 +130,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 					for k, v := range alertState.Annotations {
 						expected[k] = v
 					}
-					expected["__alertImageToken__"] = alertState.ImageURI
+					expected["__alertImageToken__"] = "token://" + alertState.Image.Token
 
 					require.Equal(t, expected, result.Annotations)
 				})

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -314,8 +314,9 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 				"dashboard", alertRule.GetDashboardUID(),
 				"panel", alertRule.GetPanelID(),
 				"error", err)
+		} else if image != nil {
+			currentState.ImageURI = generateImageURI(image)
 		}
-		currentState.ImageURI = generateImageURI(image)
 	}
 
 	st.cache.set(currentState)
@@ -444,7 +445,7 @@ func (st *Manager) deleteStaleStatesFromCache(ctx context.Context, logger log.Lo
 					"dashboard", alertRule.GetDashboardUID(),
 					"panel", alertRule.GetPanelID(),
 					"error", err)
-			} else {
+			} else if image != nil {
 				s.ImageURI = generateImageURI(image)
 			}
 		}

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -315,7 +315,6 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 				"panel", alertRule.GetPanelID(),
 				"error", err)
 		}
-
 		currentState.ImageURI = generateImageURI(image)
 	}
 
@@ -464,9 +463,9 @@ func stateIsStale(evaluatedAt time.Time, lastEval time.Time, intervalSeconds int
 	return !lastEval.Add(2 * time.Duration(intervalSeconds) * time.Second).After(evaluatedAt)
 }
 
-// generateImageURI returns a string used to identify the image.
-// The first option is to use the image URL, but if there's none,
-// the token will be prefixed with `token://` and used as the URI.
+// generateImageURI returns a string that serves as an identifier for the image.
+// It first checks if there is an image URL available, and if not,
+// it prefixes the image token with `token://` and uses it as the URI.
 func generateImageURI(image *ngModels.Image) string {
 	if image.URL != "" {
 		return image.URL

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -307,7 +307,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 	// to Alertmanager.
 	currentState.Resolved = oldState == eval.Alerting && currentState.State == eval.Normal
 
-	if shouldTakeImage(currentState.State, oldState, currentState.ImageURI, currentState.Resolved) {
+	if shouldTakeImage(currentState.State, oldState, currentState.Image, currentState.Resolved) {
 		image, err := takeImage(ctx, st.images, alertRule)
 		if err != nil {
 			logger.Warn("Failed to take an image",
@@ -315,7 +315,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 				"panel", alertRule.GetPanelID(),
 				"error", err)
 		} else if image != nil {
-			currentState.ImageURI = generateImageURI(image)
+			currentState.Image = image
 		}
 	}
 
@@ -446,7 +446,7 @@ func (st *Manager) deleteStaleStatesFromCache(ctx context.Context, logger log.Lo
 					"panel", alertRule.GetPanelID(),
 					"error", err)
 			} else if image != nil {
-				s.ImageURI = generateImageURI(image)
+				s.Image = image
 			}
 		}
 
@@ -462,14 +462,4 @@ func (st *Manager) deleteStaleStatesFromCache(ctx context.Context, logger log.Lo
 
 func stateIsStale(evaluatedAt time.Time, lastEval time.Time, intervalSeconds int64) bool {
 	return !lastEval.Add(2 * time.Duration(intervalSeconds) * time.Second).After(evaluatedAt)
-}
-
-// generateImageURI returns a string that serves as an identifier for the image.
-// It first checks if there is an image URL available, and if not,
-// it prefixes the image token with `token://` and uses it as the URI.
-func generateImageURI(image *ngModels.Image) string {
-	if image.URL != "" {
-		return image.URL
-	}
-	return "token://" + image.Token
 }

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -42,15 +42,9 @@ type State struct {
 	// All subsequent states will be false until the next transition from Firing to Normal.
 	Resolved bool
 
-	// ImageURI contains a URI that represents an optional image for the state.
-	// This image is usually included in notifications to explain why the alert fired.
-	// The identifier can take one of two forms:
-	// 1. A URL that points to the image.
-	//		- Can be used directly in notifications (if supported).
-	//		- Can be used to query the database for image metadata.
-	// 2. A token, prefixed by `token://`.
-	//		- Can be used to query the database for image metadata.
-	ImageURI string
+	// Image contains an optional image for the state. It tends to be included in notifications
+	// as a visualization to show why the alert fired.
+	Image *models.Image
 
 	// Annotations contains the annotations from the alert rule. If an annotation is templated
 	// then the template is first evaluated to derive the final annotation.
@@ -375,10 +369,10 @@ func (a *State) GetLastEvaluationValuesForCondition() map[string]float64 {
 // shouldTakeImage returns true if the state just has transitioned to alerting from another state,
 // transitioned to alerting in a previous evaluation but does not have a screenshot, or has just
 // been resolved.
-func shouldTakeImage(state, previousState eval.State, previousImageURI string, resolved bool) bool {
+func shouldTakeImage(state, previousState eval.State, previousImage *models.Image, resolved bool) bool {
 	return resolved ||
 		state == eval.Alerting && previousState != eval.Alerting ||
-		state == eval.Alerting && previousImageURI == ""
+		state == eval.Alerting && previousImage == nil
 }
 
 // takeImage takes an image for the alert rule. It returns nil if screenshots are disabled or

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -389,7 +389,7 @@ func takeImage(ctx context.Context, s ImageCapturer, r *models.AlertRule) (*mode
 		if errors.Is(err, screenshot.ErrScreenshotsUnavailable) ||
 			errors.Is(err, models.ErrNoDashboard) ||
 			errors.Is(err, models.ErrNoPanel) {
-			return &models.Image{}, nil
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -42,14 +42,14 @@ type State struct {
 	// All subsequent states will be false until the next transition from Firing to Normal.
 	Resolved bool
 
-	// ImageURI contains a URI for an optional image for the state.
-	// This image tends to be included in notifications as a visualization to show why the alert fired.
-	// The identifier could be either:
-	//	1. A URL pointing to the image.
-	//		- Used directly in notifications (if supported).
+	// ImageURI contains a URI that represents an optional image for the state.
+	// This image is usually included in notifications to explain why the alert fired.
+	// The identifier can take one of two forms:
+	// 1. A URL that points to the image.
+	//		- Can be used directly in notifications (if supported).
 	//		- Can be used to query the database for image metadata.
-	//	2. A token, prefixed by `token://`.
-	//		- Used to query the database for image metadata.
+	// 2. A token, prefixed by `token://`.
+	//		- Can be used to query the database for image metadata.
 	ImageURI string
 
 	// Annotations contains the annotations from the alert rule. If an annotation is templated

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -550,12 +550,12 @@ func TestResolve(t *testing.T) {
 
 func TestShouldTakeImage(t *testing.T) {
 	tests := []struct {
-		name          string
-		state         eval.State
-		previousState eval.State
-		previousImage *ngmodels.Image
-		resolved      bool
-		expected      bool
+		name             string
+		state            eval.State
+		previousState    eval.State
+		previousImageURI string
+		resolved         bool
+		expected         bool
 	}{{
 		name:          "should take image for state that just transitioned to alerting",
 		state:         eval.Alerting,
@@ -581,15 +581,15 @@ func TestShouldTakeImage(t *testing.T) {
 		state:         eval.Pending,
 		previousState: eval.Normal,
 	}, {
-		name:          "should not take image for alerting state with image",
-		state:         eval.Alerting,
-		previousState: eval.Alerting,
-		previousImage: &ngmodels.Image{Path: "foo.png", URL: "https://example.com/foo.png"},
+		name:             "should not take image for alerting state with image",
+		state:            eval.Alerting,
+		previousState:    eval.Alerting,
+		previousImageURI: "https://example.com/foo.png",
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, shouldTakeImage(test.state, test.previousState, test.previousImage, test.resolved))
+			assert.Equal(t, test.expected, shouldTakeImage(test.state, test.previousState, test.previousImageURI, test.resolved))
 		})
 	}
 }

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -550,12 +550,12 @@ func TestResolve(t *testing.T) {
 
 func TestShouldTakeImage(t *testing.T) {
 	tests := []struct {
-		name             string
-		state            eval.State
-		previousState    eval.State
-		previousImageURI string
-		resolved         bool
-		expected         bool
+		name          string
+		state         eval.State
+		previousState eval.State
+		previousImage *ngmodels.Image
+		resolved      bool
+		expected      bool
 	}{{
 		name:          "should take image for state that just transitioned to alerting",
 		state:         eval.Alerting,
@@ -581,15 +581,15 @@ func TestShouldTakeImage(t *testing.T) {
 		state:         eval.Pending,
 		previousState: eval.Normal,
 	}, {
-		name:             "should not take image for alerting state with image",
-		state:            eval.Alerting,
-		previousState:    eval.Alerting,
-		previousImageURI: "https://example.com/foo.png",
+		name:          "should not take image for alerting state with image",
+		state:         eval.Alerting,
+		previousState: eval.Alerting,
+		previousImage: &ngmodels.Image{URL: "https://example.com/foo.png"},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, shouldTakeImage(test.state, test.previousState, test.previousImageURI, test.resolved))
+			assert.Equal(t, test.expected, shouldTakeImage(test.state, test.previousState, test.previousImage, test.resolved))
 		})
 	}
 }

--- a/pkg/services/ngalert/store/image.go
+++ b/pkg/services/ngalert/store/image.go
@@ -21,7 +21,7 @@ type ImageStore interface {
 	GetImage(ctx context.Context, token string) (*models.Image, error)
 
 	// GetImageByURL looks for a image by its URL. It returns ErrImageNotFound
-	// if the image has expired or if an image with the token does not exist.
+	// if the image has expired or if there is no image associated with the URL.
 	GetImageByURL(ctx context.Context, url string) (*models.Image, error)
 
 	// GetImages returns all images that match the tokens. If one or more images

--- a/pkg/services/ngalert/store/image_test.go
+++ b/pkg/services/ngalert/store/image_test.go
@@ -60,12 +60,24 @@ func TestIntegrationSaveAndGetImage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, image2, *result2)
 
+	// Querying by URL should yield the same result.
+	result2, err = dbstore.GetImageByURL(ctx, image2.URL)
+	require.NoError(t, err)
+	assert.Equal(t, image2, *result2)
+
 	// expired image should not be returned
 	image1.ExpiresAt = time.Now().Add(-time.Second)
 	require.NoError(t, dbstore.SaveImage(ctx, &image1))
 	result1, err = dbstore.GetImage(ctx, image1.Token)
 	assert.EqualError(t, err, "image not found")
 	assert.Nil(t, result1)
+
+	// Querying by URL should yield the same result.
+	image2.ExpiresAt = time.Now().Add(-time.Second)
+	require.NoError(t, dbstore.SaveImage(ctx, &image1))
+	result2, err = dbstore.GetImage(ctx, image2.URL)
+	assert.EqualError(t, err, "image not found")
+	assert.Nil(t, result2)
 }
 
 func TestIntegrationGetImages(t *testing.T) {

--- a/pkg/services/ngalert/store/image_test.go
+++ b/pkg/services/ngalert/store/image_test.go
@@ -30,7 +30,7 @@ func TestIntegrationSaveAndGetImage(t *testing.T) {
 	// create an image with a path on disk
 	image1 := models.Image{Path: "example.png"}
 	require.NoError(t, dbstore.SaveImage(ctx, &image1))
-	require.NotEqual(t, "", image1.Token)
+	require.NotEqual(t, image1.Token, "")
 
 	// image should not have expired
 	assert.False(t, image1.HasExpired())
@@ -49,7 +49,12 @@ func TestIntegrationSaveAndGetImage(t *testing.T) {
 	// create an image with a URL
 	image2 := models.Image{URL: "https://example.com/example.png"}
 	require.NoError(t, dbstore.SaveImage(ctx, &image2))
-	require.NotEqual(t, "", image2.Token)
+	require.NotEqual(t, image2.Token, "")
+
+	// create another image with the same URL
+	image3 := models.Image{URL: "https://example.com/example.png"}
+	require.NoError(t, dbstore.SaveImage(ctx, &image3))
+	require.NotEqual(t, image3.Token, "")
 
 	// image should not have expired
 	assert.False(t, image2.HasExpired())
@@ -60,7 +65,7 @@ func TestIntegrationSaveAndGetImage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, image2, *result2)
 
-	// Querying by URL should yield the same result.
+	// querying by URL should yield the same result even though we have two images with the same URL
 	result2, err = dbstore.GetImageByURL(ctx, image2.URL)
 	require.NoError(t, err)
 	assert.Equal(t, image2, *result2)

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -49,6 +49,18 @@ func (s *FakeImageStore) GetImage(_ context.Context, token string) (*models.Imag
 	return nil, models.ErrImageNotFound
 }
 
+func (s *FakeImageStore) GetImageByURL(_ context.Context, url string) (*models.Image, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for _, image := range s.images {
+		if image.URL == url {
+			return image, nil
+		}
+	}
+
+	return nil, models.ErrImageNotFound
+}
+
 func (s *FakeImageStore) GetImages(_ context.Context, tokens []string) ([]models.Image, []string, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()


### PR DESCRIPTION
### Description

This PR prioritizes URLs over tokens in `ImageTokenAnnotation`, which will allow us to add support for images in the Grafana Cloud Alertmanager.

There are two possibilities for `ImageTokenAnnotation`:
- The first option is to use the image URL.
- If there's none, the token will be prefixed by `token://` and used in the annotation.

### Changes

- The `ImageTokenAnnotation` is a URI that can be either the image URL or the image token with a prefix.
- URLs can be used to look for images, so integrations can still query the DB using the value extracted from `ImageTokenAnnotation`.
- Instead of adding a `*models.Image` in state changes, the state manager just adds a URI (string).

### Advantages over the previous PR

This PR is meant to replace https://github.com/grafana/grafana/pull/66327, and it has a series of advantages over the latter:
- No modifications to our database schemas.
- The `Token` field is still relevant and used to identify images.
- No duplicate fields (in case of no image URL, we prefixed the `Path` value and added it to the `url` column).


_Related issue: https://github.com/grafana/alerting-squad/issues/458_