### PR TITLE
Build: Force same version of @emotion/react via webpack config

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -22,6 +22,9 @@ module.exports = {
       // some of data source plugins use global Prism object to add the language definition
       // we want to have same Prism object in core and in grafana/ui
       prismjs: require.resolve('prismjs'),
+      // some sub-dependencies use a different version of @emotion/react and generate warnings
+      // in the browser about @emotion/react loaded twice. We want to only load it once
+      '@emotion/react': require.resolve('@emotion/react'),
     },
     modules: ['node_modules', path.resolve('public')],
     fallback: {


### PR DESCRIPTION
**What is this feature?**

Fixes browser warning about `@emotion/react` loading twice in the page.

**Why do we need this feature?**
To reduce noise in the console and possible conflicts of versions
![image](https://user-images.githubusercontent.com/227916/233030044-0bc8d83c-819c-4a3a-9ca3-967a1d8da1f5.png)

**Who is this feature for?**

All grafana users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
