### PR TITLE
Devenv: Add prometheus_oauth2_proxy_azure devenv

### DIFF
--- a/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/README.md
+++ b/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/README.md
@@ -1,0 +1,25 @@
+# Prometheus behind an OAuth2-proxy
+
+## How to setup OAuth2-proxy
+
+1. Make a copy of `oauth2-proxy.example.cfg` and rename it to `oauth2-proxy.cfg`
+1. Fill in the required information (`azure client id`, `azure client secret`, `azure tenant id`)
+1. Start the containers by executing `make devenv sources="prometheus,auth/prometheus_oauth2_proxy_azure"`
+> If you would like to test the login flow from the browser then you need to setup TLS or start a tunnel. I usually use a tunnel (`cloudflared tunnel --url http://localhost:4180`). Do not forget to set the Redirect URIs on Azure's App Registration page
+
+## How to add a new Prometheus datasource with Azure Authentication enabled
+
+1. Navigate to Grafana and login
+1. Add a new Prometheus datasource
+1. On the new Prometheus datasource page
+   1. Set the URL
+   1. Enable Azure Authentication
+   1. Fill in the required fields of the `Azure Authentication` section
+   1. Click `Save & test` 
+   1. You should get a "Data source is working" message
+
+If you check the logs of OAuth2-proxy, you should see similar lines to this:
+```
+2023-04-19 11:29:40 172.31.0.1:55602 - d96b832a-170a-41eb-a974-6558c5ce4454 - - [2023/04/19 09:29:40] some-random-tunnel-address.trycloudflare.com GET / "/api/v1/status/buildinfo" HTTP/1.1 "Grafana/10.0.0-pre" 200 187 0.016
+2023-04-19 11:29:41 172.31.0.1:55602 - db27c56a-ccd6-4cdb-a040-318113781abf - 65ac87f4-931f-4e46-9761-f8bf1ad36b48 [2023/04/19 09:29:41] some-random-tunnel-address.trycloudflare.com POST / "/api/v1/query" HTTP/1.1 "Grafana/10.0.0-pre" 200 103 0.003
+```

--- a/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/docker-compose.yaml
@@ -1,0 +1,27 @@
+  oauth2proxy:
+    container_name: oauth2-proxy
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
+    command: --config /oauth2-proxy.cfg
+    # command: [
+    #   "--provider=azure",
+    #   "--cookie-secret=SECRETSECRET1234",
+    #   "--client-id=<azure client id>",
+    #   "--client-secret=<azure client secret>",
+    #   "--azure-tenant=<azure tenant id>",
+    #   "--oidc-issuer-url=https://login.microsoftonline.com/<azure tenant id>/v2.0",
+    #   "--email-domain=*",
+    #   "--http-address=0.0.0.0:4180",
+    #   "--ssl-upstream-insecure-skip-verify=true",
+    #   "--upstream=http://local-prometheus:9090/",
+    #   "--skip-jwt-bearer-tokens=true",
+    #   "--extra-jwt-issuers=https://sts.windows.net/<azure tenant id>/=https://prometheus.monitor.azure.com",
+    #   "--skip-auth-route=/api/v1/status/buildinfo",
+    # ]
+    ports:
+      - 4180:4180
+    hostname: oauth2-proxy
+    volumes:
+      - "./docker/blocks/auth/prometheus_oauth2_proxy_azure/oauth2-proxy.cfg:/oauth2-proxy.cfg"
+    extra_hosts:
+      - "local-prometheus:host-gateway"
+    restart: unless-stopped

--- a/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/oauth2-proxy.example.cfg
+++ b/devenv/docker/blocks/auth/prometheus_oauth2_proxy_azure/oauth2-proxy.example.cfg
@@ -1,0 +1,13 @@
+provider="azure"
+cookie_secret="SECRETSECRET1234"
+client_id="<azure client id>"
+client_secret="<azure client secret>"
+azure_tenant="<azure tenant id>"
+oidc_issuer_url="https://login.microsoftonline.com/<azure tenant id>/v2.0"
+email_domains=["*"]
+http_address="0.0.0.0:4180"
+ssl_upstream_insecure_skip_verify="true"
+upstreams=[ "http://local-prometheus:9090/" ]
+skip_jwt_bearer_tokens="true"
+extra_jwt_issuers="https://sts.windows.net/<azure tenant id>/=https://prometheus.monitor.azure.com"
+skip_auth_routes=[ "/api/v1/status/buildinfo" ]


### PR DESCRIPTION
**What is this feature?**
This PR adds a new devenv to test the Azure Authentication of the Prometheus datasource with an OAuth2-proxy in front of Prometheus.

**Why do we need this feature?**
To have both an example setup and a devenv in case we need to debug something.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
