### PR TITLE
Elasticsearch: Deprecate the usage of the database field in provisioning

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -126,9 +126,9 @@ datasources:
     type: elasticsearch
     uid: gdev-elasticsearch
     access: proxy
-    database: "[logs-]YYYY.MM.DD"
     url: http://localhost:9200
     jsonData:
+      index: "[logs-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
       logLevelField: level
@@ -137,9 +137,9 @@ datasources:
   - name: gdev-elasticsearch-filebeat
     type: elasticsearch
     access: proxy
-    database: "[filebeat-]YYYY.MM.DD"
     url: http://localhost:9200
     jsonData:
+      index: "[filebeat-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
       timeInterval: "10s"
@@ -149,9 +149,9 @@ datasources:
   - name: gdev-elasticsearch-metricbeat
     type: elasticsearch
     access: proxy
-    database: "[metricbeat-]YYYY.MM.DD"
     url: http://localhost:9200
     jsonData:
+      index: "[metricbeat-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
       timeInterval: "10s"

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -71,18 +71,18 @@ datasources:
   - name: gdev-elasticsearch
     type: elasticsearch
     access: proxy
-    database: "[logs-]YYYY.MM.DD"
     url: http://elasticsearch:9200
     jsonData:
+      index: "[logs-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
 
   - name: gdev-elasticsearch-filebeat
     type: elasticsearch
     access: proxy
-    database: "[filebeat-]YYYY.MM.DD"
     url: http://elasticsearch:9200
     jsonData:
+      index: "[filebeat-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
       timeInterval: "10s"
@@ -92,9 +92,9 @@ datasources:
   - name: gdev-elasticsearch-metricbeat
     type: elasticsearch
     access: proxy
-    database: "[metricbeat-]YYYY.MM.DD"
     url: http://elasticsearch:9200
     jsonData:
+      index: "[metricbeat-]YYYY.MM.DD"
       interval: Daily
       timeField: "@timestamp"
       timeInterval: "10s"

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -140,8 +140,9 @@ For more information about AWS authentication options, refer to [AWS authenticat
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
 
-> **Note:** `database` [field is deprecated](https://github.com/grafana/grafana/pull/58647).
-> We suggest to use `index` field in `jsonData`. Please see the examples below.
+> **Note:** The previously used `database` field has now been [deprecated](https://github.com/grafana/grafana/pull/58647).
+> You should now use the `index` field in `jsonData` to store the index name.
+> Please see the examples below.
 
 #### Provisioning examples
 

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -140,6 +140,9 @@ For more information about AWS authentication options, refer to [AWS authenticat
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
 
+> **Note:** `database` [field is deprecated](https://github.com/grafana/grafana/pull/58647).
+> We suggest to use `index` field in `jsonData`. Please see the examples below.
+
 #### Provisioning examples
 
 **Basic provisioning:**
@@ -151,9 +154,9 @@ datasources:
   - name: Elastic
     type: elasticsearch
     access: proxy
-    database: '[metrics-]YYYY.MM.DD'
     url: http://localhost:9200
     jsonData:
+      index: '[metrics-]YYYY.MM.DD'
       interval: Daily
       timeField: '@timestamp'
 ```
@@ -167,9 +170,9 @@ datasources:
   - name: elasticsearch-v7-filebeat
     type: elasticsearch
     access: proxy
-    database: '[filebeat-]YYYY.MM.DD'
     url: http://localhost:9200
     jsonData:
+      index: '[filebeat-]YYYY.MM.DD'
       interval: Daily
       timeField: '@timestamp'
       logMessageField: message


### PR DESCRIPTION
**What is this feature?**
updates the documentation for elasticsearch datasource provisioning.
updates the provisioning files for the elastic gdev datasources

**Which issue(s) does this PR fix?**:
Related #59098

**Special notes for your reviewer:**
elastic datasources **after** after new provisioning
```
gdev-elasticsearch            || { "index":"[logs-]YYYY.MM.DD", "interval":"Daily", ... }
gdev-elasticsearch-filebeat   || { "index":"[filebeat-]YYYY.MM.DD", "interval":"Daily", ...}
gdev-elasticsearch-metricbeat || { "index":"[metricbeat-]YYYY.MM.DD", "interval":"Daily", ... }
```

# Deprecation notice

The `database` field has been deprecated in the Elasticsearch datasource provisioning files, please use the `index` field in `jsonData` instead.