### PR TITLE
RBAC: Update dashboardIntegrationFolder tests to use RBAC

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -162,10 +162,8 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	guard, err := getGuardianForSavePermissionCheck(ctx, dash, dto.User)
 	if err != nil {
-		fmt.Printf("getGuardianForSavePermissionCheck error: %v", err)
 		return nil, err
 	}
-	fmt.Printf("getGuardianForSavePermissionCheck: %v", guard)
 
 	if dash.ID == 0 {
 		if canCreate, err := guard.CanCreate(dash.FolderID, dash.IsFolder); err != nil || !canCreate {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -355,7 +355,6 @@ func (dr *DashboardServiceImpl) SaveDashboard(ctx context.Context, dto *dashboar
 
 	cmd, err := dr.BuildSaveDashboardCommand(ctx, dto, setting.IsLegacyAlertingEnabled(), !allowUiUpdate)
 	if err != nil {
-		fmt.Printf("BuildSaveDashboardCommand failed: %v", err)
 		return nil, err
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -162,8 +162,10 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	guard, err := getGuardianForSavePermissionCheck(ctx, dash, dto.User)
 	if err != nil {
+		fmt.Printf("getGuardianForSavePermissionCheck error: %v", err)
 		return nil, err
 	}
+	fmt.Printf("getGuardianForSavePermissionCheck: %v", guard)
 
 	if dash.ID == 0 {
 		if canCreate, err := guard.CanCreate(dash.FolderID, dash.IsFolder); err != nil || !canCreate {
@@ -355,6 +357,7 @@ func (dr *DashboardServiceImpl) SaveDashboard(ctx context.Context, dto *dashboar
 
 	cmd, err := dr.BuildSaveDashboardCommand(ctx, dto, setting.IsLegacyAlertingEnabled(), !allowUiUpdate)
 	if err != nil {
+		fmt.Printf("BuildSaveDashboardCommand failed: %v", err)
 		return nil, err
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -826,8 +826,6 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 		cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 		sqlStore := db.InitTestDB(t)
 		quotaService := quotatest.New(false, nil)
-		// TODO: is this needed for the testing of RBAC?
-		// ac := acimpl.ProvideAccessControl(sqlStore.Cfg)
 		ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
 		require.NoError(t, err)
@@ -906,7 +904,7 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 		featuremgmt.WithFeatures(),
 		folderPermissions,
 		dashboardPermissions,
-		actest.FakeAccessControl{ExpectedEvaluate: true},
+		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
@@ -929,7 +927,7 @@ func callSaveWithError(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSto
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
 		accesscontrolmock.NewMockedPermissionsService(),
-		actest.FakeAccessControl{ExpectedEvaluate: true},
+		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
@@ -1020,7 +1018,7 @@ func saveTestFolder(t *testing.T, title string, orgID int64, sqlStore db.DB) *da
 		featuremgmt.WithFeatures(),
 		folderPermissions,
 		accesscontrolmock.NewMockedPermissionsService(),
-		actest.FakeAccessControl{ExpectedEvaluate: true},
+		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -826,6 +826,7 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 		cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 		sqlStore := db.InitTestDB(t)
 		quotaService := quotatest.New(false, nil)
+		// TODO: is this needed for the testing of RBAC?
 		// ac := acimpl.ProvideAccessControl(sqlStore.Cfg)
 		ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
@@ -905,7 +906,6 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 		featuremgmt.WithFeatures(),
 		folderPermissions,
 		dashboardPermissions,
-		// FIXME: do we need to add the same folder permissions as the test scenario above?
 		actest.FakeAccessControl{ExpectedEvaluate: true},
 		foldertest.NewFakeService(),
 	)
@@ -928,7 +928,6 @@ func callSaveWithError(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSto
 		cfg, dashboardStore, folderStore, &dummyDashAlertExtractor{},
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
-		// FIXME: do we need to add the same folder permissions as the test scenario above?
 		accesscontrolmock.NewMockedPermissionsService(),
 		actest.FakeAccessControl{ExpectedEvaluate: true},
 		foldertest.NewFakeService(),
@@ -972,7 +971,6 @@ func saveTestDashboard(t *testing.T, title string, orgID, folderID int64, sqlSto
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
 		dashboardPermissions,
-		// FIXME: do we need to add the same folder permissions as the test scenario above?
 		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
@@ -1022,14 +1020,11 @@ func saveTestFolder(t *testing.T, title string, orgID int64, sqlStore db.DB) *da
 		featuremgmt.WithFeatures(),
 		folderPermissions,
 		accesscontrolmock.NewMockedPermissionsService(),
-		// FIXME: do we need to add the same folder permissions as the test scenario above?
 		actest.FakeAccessControl{ExpectedEvaluate: true},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
 	res, err := service.SaveDashboard(context.Background(), &dto, false)
-	t.Logf("res: %v", res)
-	t.Logf("err: %v", err)
 	require.NoError(t, err)
 
 	return res

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -5,10 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/alerting/models"
@@ -21,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
-	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -815,29 +818,32 @@ type permissionScenarioFunc func(t *testing.T, sc *permissionScenarioContext)
 func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionScenarioFunc) {
 	t.Helper()
 
-	mock := &guardian.FakeDashboardGuardian{
+	guardianMock := &guardian.FakeDashboardGuardian{
 		CanSaveValue: canSave,
 	}
 
 	t.Run(desc, func(t *testing.T) {
 		cfg := setting.NewCfg()
-		cfg.RBACEnabled = false
 		cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 		sqlStore := db.InitTestDB(t)
 		quotaService := quotatest.New(false, nil)
+		ac := acimpl.ProvideAccessControl(sqlStore.Cfg)
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
 		require.NoError(t, err)
 		folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
-		service, err := ProvideDashboardServiceImpl(
+		folderPermissions := accesscontrolmock.NewMockedPermissionsService()
+		folderPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
+		dashboardPermissions := accesscontrolmock.NewMockedPermissionsService()
+		dashboardService, err := ProvideDashboardServiceImpl(
 			cfg, dashboardStore, folderStore, &dummyDashAlertExtractor{},
 			featuremgmt.WithFeatures(),
-			accesscontrolmock.NewMockedPermissionsService(),
-			accesscontrolmock.NewMockedPermissionsService(),
-			accesscontrolmock.New(),
+			folderPermissions,
+			dashboardPermissions,
+			ac,
 			foldertest.NewFakeService(),
 		)
 		require.NoError(t, err)
-		guardian.InitLegacyGuardian(cfg, sqlStore, service, &teamtest.FakeService{})
+		guardian.InitAccessControlGuardian(cfg, sqlStore, ac, folderPermissions, dashboardPermissions, dashboardService)
 
 		savedFolder := saveTestFolder(t, "Saved folder", testOrgID, sqlStore)
 		savedDashInFolder := saveTestDashboard(t, "Saved dash in folder", testOrgID, savedFolder.ID, sqlStore)
@@ -863,10 +869,10 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 		t.Cleanup(func() {
 			guardian.New = origNewDashboardGuardian
 		})
-		guardian.MockDashboardGuardian(mock)
+		guardian.MockDashboardGuardian(guardianMock)
 
 		sc := &permissionScenarioContext{
-			dashboardGuardianMock:    mock,
+			dashboardGuardianMock:    guardianMock,
 			sqlStore:                 sqlStore,
 			savedDashInFolder:        savedDashInFolder,
 			otherSavedFolder:         otherSavedFolder,
@@ -884,7 +890,6 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 
 	dto := toSaveDashboardDto(cmd)
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
@@ -895,7 +900,8 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
 		accesscontrolmock.NewMockedPermissionsService(),
-		accesscontrolmock.New(),
+		// FIXME: do we need to add the same folder permissions as the test scenario above?
+		actest.FakeAccessControl{ExpectedEvaluate: true},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
@@ -908,7 +914,6 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 func callSaveWithError(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlStore db.DB) error {
 	dto := toSaveDashboardDto(cmd)
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
@@ -918,8 +923,9 @@ func callSaveWithError(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSto
 		cfg, dashboardStore, folderStore, &dummyDashAlertExtractor{},
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
+		// FIXME: do we need to add the same folder permissions as the test scenario above?
 		accesscontrolmock.NewMockedPermissionsService(),
-		accesscontrolmock.New(),
+		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
@@ -948,9 +954,7 @@ func saveTestDashboard(t *testing.T, title string, orgID, folderID int64, sqlSto
 			OrgRole: org.RoleAdmin,
 		},
 	}
-
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
@@ -961,11 +965,13 @@ func saveTestDashboard(t *testing.T, title string, orgID, folderID int64, sqlSto
 		featuremgmt.WithFeatures(),
 		accesscontrolmock.NewMockedPermissionsService(),
 		accesscontrolmock.NewMockedPermissionsService(),
-		accesscontrolmock.New(),
+		// FIXME: do we need to add the same folder permissions as the test scenario above?
+		actest.FakeAccessControl{},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
 	res, err := service.SaveDashboard(context.Background(), &dto, false)
+
 	require.NoError(t, err)
 
 	return res
@@ -989,26 +995,33 @@ func saveTestFolder(t *testing.T, title string, orgID int64, sqlStore db.DB) *da
 		User: &user.SignedInUser{
 			UserID:  1,
 			OrgRole: org.RoleAdmin,
+			Permissions: map[int64]map[string][]string{
+				1: {dashboards.ScopeDashboardsAll: {}},
+			},
 		},
 	}
 
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg), quotaService)
 	require.NoError(t, err)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
+	folderPermissions := accesscontrolmock.NewMockedPermissionsService()
+	folderPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 	service, err := ProvideDashboardServiceImpl(
 		cfg, dashboardStore, folderStore, &dummyDashAlertExtractor{},
 		featuremgmt.WithFeatures(),
+		folderPermissions,
 		accesscontrolmock.NewMockedPermissionsService(),
-		accesscontrolmock.NewMockedPermissionsService(),
-		accesscontrolmock.New(),
+		// FIXME: do we need to add the same folder permissions as the test scenario above?
+		actest.FakeAccessControl{ExpectedEvaluate: true},
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, err)
 	res, err := service.SaveDashboard(context.Background(), &dto, false)
+	t.Logf("res: %v", res)
+	t.Logf("err: %v", err)
 	require.NoError(t, err)
 
 	return res


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
implements `folderPermissions and dashboardPermissions` for specific tests
Changes the legacyAC to new AC

**Why do we need this feature?**

RBAC is the default access control now, and will be the only access control starting from Grafana 10, so all the tests should be using RBAC.

Which issue(s) does this PR fix?:
https://github.com/grafana/grafana-enterprise/issues/4929
