### PR TITLE
Prometheus: mark queries with instant results as invalid for incremental querying

### DIFF
--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -235,7 +235,7 @@ export class QueryCache {
     const newTo = request.range.to.valueOf();
 
     // only cache 'now'-relative queries (that can benefit from a backfill cache)
-    const shouldCache = request.rangeRaw?.to?.toString() === 'now';
+    const shouldCache = request.rangeRaw?.to?.toString() === 'now' && !request.targets.some((targ) => targ.instant);
 
     // all targets are queried together, so we check for any that causes group cache invalidation & full re-query
     let doPartialQuery = shouldCache;


### PR DESCRIPTION

**What is this feature?**

Fixing bug in incremental/delta querying that @LudoVio  found this morning. 

**Why do we need this feature?**

Current implementation is breaking instant query results

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
