### PR TITLE
Expressions/threshold: Fix incorrect thresholds args length

### DIFF
--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -30,6 +30,17 @@ var (
 )
 
 func NewThresholdCommand(refID, referenceVar, thresholdFunc string, conditions []float64) (*ThresholdCommand, error) {
+	switch thresholdFunc {
+	case ThresholdIsOutsideRange, ThresholdIsWithinRange:
+		if len(conditions) < 2 {
+			return nil, fmt.Errorf("incorrect number of arguments: got %d but need 2", len(conditions))
+		}
+	case ThresholdIsAbove, ThresholdIsBelow:
+		if len(conditions) < 1 {
+			return nil, fmt.Errorf("incorrect number of arguments: got %d but need 1", len(conditions))
+		}
+	}
+
 	return &ThresholdCommand{
 		RefID:         refID,
 		ReferenceVar:  referenceVar,
@@ -91,17 +102,6 @@ func (tc *ThresholdCommand) NeedsVars() []string {
 }
 
 func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error) {
-	switch tc.ThresholdFunc {
-	case ThresholdIsOutsideRange, ThresholdIsWithinRange:
-		if len(tc.Conditions) < 2 {
-			return mathexp.Results{}, fmt.Errorf("failed to evaluate threshold expression: incorrect number of arguments: got %d but need 2", len(tc.Conditions))
-		}
-	case ThresholdIsAbove, ThresholdIsBelow:
-		if len(tc.Conditions) < 1 {
-			return mathexp.Results{}, fmt.Errorf("failed to evaluate threshold expression: incorrect number of arguments: got %d but need 1", len(tc.Conditions))
-		}
-	}
-
 	mathExpression, err := createMathExpression(tc.ReferenceVar, tc.ThresholdFunc, tc.Conditions)
 	if err != nil {
 		return mathexp.Results{}, err

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -107,6 +107,17 @@ func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mat
 // createMathExpression converts all the info we have about a "threshold" expression in to a Math expression
 func createMathExpression(referenceVar string, thresholdFunc string, args []float64) (string, error) {
 	switch thresholdFunc {
+	case ThresholdIsOutsideRange, ThresholdIsWithinRange:
+		if len(args) < 2 {
+			return "", fmt.Errorf("failed to evaluate threshold expression: incorrect number of arguments: got %d but need 2", len(args))
+		}
+	case ThresholdIsAbove, ThresholdIsBelow:
+		if len(args) < 1 {
+			return "", fmt.Errorf("failed to evaluate threshold expression: incorrect number of arguments: got %d but need 1", len(args))
+		}
+	}
+
+	switch thresholdFunc {
 	case ThresholdIsAbove:
 		return fmt.Sprintf("${%s} > %f", referenceVar, args[0]), nil
 	case ThresholdIsBelow:

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -76,16 +76,6 @@ func TestNewThresholdCommand(t *testing.T) {
 	}
 }
 
-func TestNewThresholdCommandWithInsufficientConditions(t *testing.T) {
-	cmd, err := NewThresholdCommand("B", "A", "within_range", []float64{})
-	require.Error(t, err)
-	require.Nil(t, cmd)
-
-	cmd, err = NewThresholdCommand("B", "A", "lt", []float64{})
-	require.Error(t, err)
-	require.Nil(t, cmd)
-}
-
 func TestUnmarshalThresholdCommand(t *testing.T) {
 	type testCase struct {
 		description   string

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -8,9 +8,82 @@ import (
 )
 
 func TestNewThresholdCommand(t *testing.T) {
-	cmd, err := NewThresholdCommand("B", "A", "is_above", []float64{})
-	require.Nil(t, err)
-	require.NotNil(t, cmd)
+	type testCase struct {
+		fn            string
+		args          []float64
+		shouldError   bool
+		expectedError string
+	}
+
+	cases := []testCase{
+		{
+			fn:          "gt",
+			args:        []float64{0},
+			shouldError: false,
+		},
+		{
+			fn:          "lt",
+			args:        []float64{0},
+			shouldError: false,
+		},
+		{
+			fn:          "within_range",
+			args:        []float64{0, 1},
+			shouldError: false,
+		},
+		{
+			fn:          "outside_range",
+			args:        []float64{0, 1},
+			shouldError: false,
+		},
+		{
+			fn:            "gt",
+			args:          []float64{},
+			shouldError:   true,
+			expectedError: "incorrect number of arguments",
+		},
+		{
+			fn:            "lt",
+			args:          []float64{},
+			shouldError:   true,
+			expectedError: "incorrect number of arguments",
+		},
+		{
+			fn:            "within_range",
+			args:          []float64{0},
+			shouldError:   true,
+			expectedError: "incorrect number of arguments",
+		},
+		{
+			fn:            "outside_range",
+			args:          []float64{0},
+			shouldError:   true,
+			expectedError: "incorrect number of arguments",
+		},
+	}
+
+	for _, tc := range cases {
+		cmd, err := NewThresholdCommand("B", "A", tc.fn, tc.args)
+
+		if tc.shouldError {
+			require.Nil(t, cmd)
+			require.NotNil(t, err)
+			require.Contains(t, err.Error(), tc.expectedError)
+		} else {
+			require.Nil(t, err)
+			require.NotNil(t, cmd)
+		}
+	}
+}
+
+func TestNewThresholdCommandWithInsufficientConditions(t *testing.T) {
+	cmd, err := NewThresholdCommand("B", "A", "within_range", []float64{})
+	require.Error(t, err)
+	require.Nil(t, cmd)
+
+	cmd, err = NewThresholdCommand("B", "A", "lt", []float64{})
+	require.Error(t, err)
+	require.Nil(t, cmd)
 }
 
 func TestUnmarshalThresholdCommand(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

When using a threshold expression with fewer than the required number of args, it would panic because it accessed a non-existing index of the slice.

**Why do we need this feature?**

This fix returns a sensible error and does not dump a stack trace to the logs.

**Special notes for your reviewer:**

**Steps to reproduce**

1. Create a new alert (default settings are fine)
2. Change threshold to "is within range" and don't fill anything in 
3. Press "preview".


