### PR TITLE
Tempo: TraceQL query builder QoL improvements

### DIFF
--- a/public/app/plugins/datasource/loki/getDerivedFields.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.ts
@@ -49,7 +49,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
         url: '',
         // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
         internal: {
-          query: { query: derivedFieldConfig.url },
+          query: { query: derivedFieldConfig.url, queryType: dsSettings?.type === 'tempo' ? 'traceql' : undefined },
           datasourceUid: derivedFieldConfig.datasourceUid,
           datasourceName: dsSettings?.name ?? 'Data source not found',
         },

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/DurationInput.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/DurationInput.tsx
@@ -1,6 +1,7 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
-import { Select, HorizontalGroup, Input } from '@grafana/ui';
+import { Select, HorizontalGroup, Input, useStyles2 } from '@grafana/ui';
 
 import { TraceqlFilter } from '../dataquery.gen';
 
@@ -15,7 +16,18 @@ interface Props {
 
 const validationRegex = /^\d+(?:\.\d)?\d*(?:us|µs|ns|ms|s|m|h)$/;
 
+const getStyles = () => ({
+  noBoxShadow: css`
+    box-shadow: none;
+    *:focus {
+      box-shadow: none;
+    }
+  `,
+});
+
 const DurationInput = ({ filter, operators, updateFilter }: Props) => {
+  const styles = useStyles2(getStyles);
+
   let invalid = false;
   if (typeof filter.value === 'string') {
     invalid = filter.value ? !validationRegex.test(filter.value.concat('')) : false;
@@ -24,6 +36,7 @@ const DurationInput = ({ filter, operators, updateFilter }: Props) => {
   return (
     <HorizontalGroup spacing={'none'}>
       <Select
+        className={styles.noBoxShadow}
         inputId={`${filter.id}-operator`}
         options={operators.map(operatorSelectableValue)}
         value={filter.operator}
@@ -36,6 +49,7 @@ const DurationInput = ({ filter, operators, updateFilter }: Props) => {
         width={8}
       />
       <Input
+        className={styles.noBoxShadow}
         value={filter.value}
         onChange={(v) => {
           updateFilter({ ...filter, value: v.currentTarget.value });

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -170,6 +170,7 @@ const SearchField = ({
           aria-label={`select ${filter.id} value`}
           allowCustomValue={true}
           isMulti
+          allowCreateWhileLoading
         />
       )}
       {allowDelete && (

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
@@ -21,8 +21,11 @@ describe('generateQueryFromFilters generates the correct query for', () => {
 
   it('a field with tag, operator and tag', () => {
     expect(generateQueryFromFilters([{ id: 'foo', tag: 'footag', value: 'foovalue', operator: '=' }])).toBe(
-      '{.footag="foovalue"}'
+      '{.footag=foovalue}'
     );
+    expect(
+      generateQueryFromFilters([{ id: 'foo', tag: 'footag', value: 'foovalue', operator: '=', valueType: 'string' }])
+    ).toBe('{.footag="foovalue"}');
   });
 
   it('a field with valueType as integer', () => {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -16,7 +16,7 @@ const valueHelper = (f: TraceqlFilter) => {
   if (Array.isArray(f.value) && f.value.length > 1) {
     return `"${f.value.join('|')}"`;
   }
-  if (!f.valueType || f.valueType === 'string') {
+  if (f.valueType === 'string') {
     return `"${f.value}"`;
   }
   return f.value;


### PR DESCRIPTION
**What is this feature?**

This PR adds a few improvements to the TraceQL query builder:
 - Remove focus styling from duration inputs to be consistent with other inputs in the editor
 - Allow users to create options while they're loading
 - Options without type default to not have quotes in the generated query - users must add quotes themselves if needed
 - Set the query type to traceql when linking from logs to traces - Fix #66571

**Why do we need this feature?**

When the value options for a tag take a long time to load it's better to allow to users to add options when the value is already known.

**Who is this feature for?**

Users of the TraceQL query builder.

**Which issue(s) does this PR fix?**:

Fixes #66571 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
