### PR TITLE
Stats Inspector: Prevent long stats from being hidden

### DIFF
--- a/public/app/features/inspector/InspectStatsTab.tsx
+++ b/public/app/features/inspector/InspectStatsTab.tsx
@@ -18,7 +18,6 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
   if (!data.request) {
     return null;
   }
-  const styles = getStyles();
   let stats: QueryResultMetaStat[] = [];
 
   const requestTime = data.request.endTime ? data.request.endTime - data.request.startTime : -1;
@@ -65,7 +64,7 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
   const traceIdsStatsTableName = t('dashboard.inspect-stats.data-traceids', 'Trace IDs');
 
   return (
-    <div aria-label={selectors.components.PanelInspector.Stats.content} className={styles.container}>
+    <div aria-label={selectors.components.PanelInspector.Stats.content} className={containerStyles}>
       <InspectStatsTable timeZone={timeZone} name={statsTableName} stats={stats} />
       <InspectStatsTable timeZone={timeZone} name={dataStatsTableName} stats={dataStats} />
       {config.featureToggles.showTraceId && (
@@ -75,11 +74,7 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
   );
 };
 
-const getStyles = () => {
-  return {
-    container: css`
-      height: 100%;
-      overflow-y: scroll;
-    `,
-  };
-};
+const containerStyles = css`
+  height: 100%;
+  overflow-y: scroll;
+`;

--- a/public/app/features/inspector/InspectStatsTab.tsx
+++ b/public/app/features/inspector/InspectStatsTab.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
 import { PanelData, QueryResultMetaStat, TimeZone } from '@grafana/data';
@@ -17,7 +18,7 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
   if (!data.request) {
     return null;
   }
-
+  const styles = getStyles();
   let stats: QueryResultMetaStat[] = [];
 
   const requestTime = data.request.endTime ? data.request.endTime - data.request.startTime : -1;
@@ -64,7 +65,7 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
   const traceIdsStatsTableName = t('dashboard.inspect-stats.data-traceids', 'Trace IDs');
 
   return (
-    <div aria-label={selectors.components.PanelInspector.Stats.content}>
+    <div aria-label={selectors.components.PanelInspector.Stats.content} className={styles.container}>
       <InspectStatsTable timeZone={timeZone} name={statsTableName} stats={stats} />
       <InspectStatsTable timeZone={timeZone} name={dataStatsTableName} stats={dataStats} />
       {config.featureToggles.showTraceId && (
@@ -72,4 +73,13 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
       )}
     </div>
   );
+};
+
+const getStyles = () => {
+  return {
+    container: css`
+      height: 100%;
+      overflow-y: scroll;
+    `,
+  };
 };


### PR DESCRIPTION
This PR adds some simple styles to prevent stats from being hidden when there is a long list of them. In general, if there was overflow, the last item would be hidden.

This is particularly important because now, for Loki, the last stat will be the Trace ID, used by customers to report and trace bugs and errors.

Fixes https://github.com/grafana/grafana/issues/66694

**Special notes for your reviewer:**

Before (see hidden last row):

![imagen](https://user-images.githubusercontent.com/1069378/233118483-237a3e72-6f17-4c8d-8759-4e859a64e3ec.png)

After:

![imagen](https://user-images.githubusercontent.com/1069378/233118123-4137b2f6-b13f-4cea-aa20-adb034d63722.png)

To reproduce:
In explore, run a Loki query, wait for it to return data, click on `Query Inspector, and go to `Stats`. 
