### PR TITLE
Auth: Make GitHub auth's allowed_organizations be case insensitive

### DIFF
--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -67,7 +68,7 @@ func (s *SocialGithub) IsOrganizationMember(client *http.Client, organizationsUr
 
 	for _, allowedOrganization := range s.allowedOrganizations {
 		for _, organization := range organizations {
-			if organization == allowedOrganization {
+			if strings.ToLower(organization) == strings.ToLower(allowedOrganization) {
 				return true
 			}
 		}

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -68,7 +68,7 @@ func (s *SocialGithub) IsOrganizationMember(client *http.Client, organizationsUr
 
 	for _, allowedOrganization := range s.allowedOrganizations {
 		for _, organization := range organizations {
-			if strings.ToLower(organization) == strings.ToLower(allowedOrganization) {
+			if strings.EqualFold(organization, allowedOrganization) {
 				return true
 			}
 		}


### PR DESCRIPTION
**What is this feature?**

Its a bugfix for the github authentication for the `allowed_organizations` configuration that incorrectly was case sensitive. Some github organizations have a capitcal case, for example https://github.com/smithsonian, which can be seen using the GitHub CLI to work against GitHub's API:

```
gh api /orgs/smithsonian | jq .login
"Smithsonian"
```

**Which issue(s) does this PR fix?**:

Fixes #66876

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
