### PR TITLE
grafana/e2e: Ensure data source picker is attached

### DIFF
--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -113,6 +113,13 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
     e2e().intercept(chartData.method, chartData.route).as('chartData');
 
     if (dataSourceName) {
+      e2e.components.DataSourcePicker.container().within(() => {
+        e2e()
+          .get('[class$="-input-suffix"]')
+          .then((element) => {
+            Cypress.dom.isAttached(element);
+          });
+      });
       selectOption({
         container: e2e.components.DataSourcePicker.container(),
         optionText: dataSourceName,

--- a/packages/grafana-e2e/src/flows/selectOption.ts
+++ b/packages/grafana-e2e/src/flows/selectOption.ts
@@ -19,6 +19,8 @@ export const selectOption = (config: SelectOptionConfig): any => {
 
   container.within(() => {
     if (clickToOpen) {
+      // Add this wait to ensure the data source picker component has rendered.
+      e2e().wait(500);
       e2e().get('[class$="-input-suffix"]').click();
     }
   });

--- a/packages/grafana-e2e/src/flows/selectOption.ts
+++ b/packages/grafana-e2e/src/flows/selectOption.ts
@@ -19,8 +19,6 @@ export const selectOption = (config: SelectOptionConfig): any => {
 
   container.within(() => {
     if (clickToOpen) {
-      // Add this wait to ensure the data source picker component has rendered.
-      e2e().wait(500);
       e2e().get('[class$="-input-suffix"]').click();
     }
   });


### PR DESCRIPTION
Add a check to ensure the data source picker has completed rendering due to changes in #66566.