### PR TITLE
Graphite: Variable editor add definition to onChange

### DIFF
--- a/public/app/plugins/datasource/graphite/components/GraphiteVariableEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteVariableEditor.tsx
@@ -8,7 +8,7 @@ import { convertToGraphiteQueryObject } from './helpers';
 
 interface Props {
   query: GraphiteQuery | string;
-  onChange: (query: GraphiteQuery) => void;
+  onChange: (query: GraphiteQuery, definition: string) => void;
 }
 
 const GRAPHITE_QUERY_VARIABLE_TYPE_OPTIONS = [
@@ -36,10 +36,13 @@ export const GraphiteVariableEditor = (props: Props) => {
             });
 
             if (value.target) {
-              onChange({
-                ...value,
-                queryType: selectableValue.value,
-              });
+              onChange(
+                {
+                  ...value,
+                  queryType: selectableValue.value,
+                },
+                value.target ?? ''
+              );
             }
           }}
         />
@@ -48,7 +51,7 @@ export const GraphiteVariableEditor = (props: Props) => {
         <Input
           aria-label="Variable editor query input"
           value={value.target}
-          onBlur={() => onChange(value)}
+          onBlur={() => onChange(value, value.target ?? '')}
           onChange={(e) => {
             setValue({
               ...value,


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5607

**What is this feature?**
Show and update variable definitions in variable list.

**Why do we need this feature?**
Variable definitions were not shown after update to Graphite variable editor.

**Who is this feature for?**
Users who create or update variables in Graphite.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
