### PR TITLE
Replace eslint plugin import with forked eslint-plugin-i

### DIFF
--- a/package.json
+++ b/package.json
@@ -415,6 +415,7 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.1/xlsx-0.19.1.tgz"
   },
   "resolutions": {
+    "eslint-plugin-import": "npm:eslint-plugin-i@^2.25.3",
     "underscore": "1.13.6",
     "@types/slate": "0.47.11",
     "@rushstack/rig-package": "0.3.18",

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -3,6 +3,7 @@ import { program } from 'commander';
 
 import { nodeVersionCheckerTask } from './tasks/nodeVersionChecker';
 import { buildPackageTask } from './tasks/package.build';
+import { bundleManagedTask } from './tasks/plugin/bundle.managed';
 import { pluginBuildTask } from './tasks/plugin.build';
 import { ciBuildPluginTask, ciPackagePluginTask, ciPluginReportTask } from './tasks/plugin.ci';
 import { pluginDevTask } from './tasks/plugin.dev';
@@ -10,7 +11,6 @@ import { pluginSignTask } from './tasks/plugin.sign';
 import { pluginTestTask } from './tasks/plugin.tests';
 import { pluginUpdateTask } from './tasks/plugin.update';
 import { getToolkitVersion, githubPublishTask } from './tasks/plugin.utils';
-import { bundleManagedTask } from './tasks/plugin/bundle.managed';
 import { searchTestDataSetupTask } from './tasks/searchTestDataSetup';
 import { templateTask } from './tasks/template';
 import { toolkitBuildTask } from './tasks/toolkit.build';

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.dev.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.dev.ts
@@ -1,7 +1,7 @@
 import { useSpinner } from '../utils/useSpinner';
 
-import { lintPlugin } from './plugin.build';
 import { bundlePlugin as bundleFn, PluginBundleOptions } from './plugin/bundle';
+import { lintPlugin } from './plugin.build';
 import { Task, TaskRunner } from './task';
 
 const bundlePlugin = (options: PluginBundleOptions) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12132,7 +12132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.2.1, array.prototype.flat@npm:^1.2.5":
+"array.prototype.flat@npm:^1.2.1":
   version: 1.3.0
   resolution: "array.prototype.flat@npm:1.3.0"
   dependencies:
@@ -12141,6 +12141,18 @@ __metadata:
     es-abstract: ^1.19.2
     es-shim-unscopables: ^1.0.0
   checksum: 2a652b3e8dc0bebb6117e42a5ab5738af0203a14c27341d7bb2431467bdb4b348e2c5dc555dfcda8af0a5e4075c400b85311ded73861c87290a71a17c3e0a257
+  languageName: node
+  linkType: hard
+
+"array.prototype.flat@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "array.prototype.flat@npm:1.3.1"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+    es-shim-unscopables: ^1.0.0
+  checksum: 5a8415949df79bf6e01afd7e8839bbde5a3581300e8ad5d8449dea52639e9e59b26a467665622783697917b43bf39940a6e621877c7dd9b3d1c1f97484b9b88b
   languageName: node
   linkType: hard
 
@@ -16004,7 +16016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.0, debug@npm:^2.6.9":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.0":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -17716,46 +17728,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "eslint-import-resolver-node@npm:0.3.6"
+"eslint-import-resolver-node@npm:^0.3.7":
+  version: 0.3.7
+  resolution: "eslint-import-resolver-node@npm:0.3.7"
   dependencies:
     debug: ^3.2.7
-    resolve: ^1.20.0
-  checksum: 6266733af1e112970e855a5bcc2d2058fb5ae16ad2a6d400705a86b29552b36131ffc5581b744c23d550de844206fb55e9193691619ee4dbf225c4bde526b1c8
+    is-core-module: ^2.11.0
+    resolve: ^1.22.1
+  checksum: 3379aacf1d2c6952c1b9666c6fa5982c3023df695430b0d391c0029f6403a7775414873d90f397e98ba6245372b6c8960e16e74d9e4a3b0c0a4582f3bdbe3d6e
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.7.3":
-  version: 2.7.3
-  resolution: "eslint-module-utils@npm:2.7.3"
+"eslint-module-utils@npm:^2.7.4":
+  version: 2.8.0
+  resolution: "eslint-module-utils@npm:2.8.0"
   dependencies:
     debug: ^3.2.7
-    find-up: ^2.1.0
-  checksum: 77048263f309167a1e6a1e1b896bfb5ddd1d3859b2e2abbd9c32c432aee13d610d46e6820b1ca81b37fba437cf423a404bc6649be64ace9148a3062d1886a678
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 74c6dfea7641ebcfe174be61168541a11a14aa8d72e515f5f09af55cd0d0862686104b0524aa4b8e0ce66418a44aa38a94d2588743db5fd07a6b49ffd16921d2
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.26.0":
-  version: 2.26.0
-  resolution: "eslint-plugin-import@npm:2.26.0"
+"eslint-plugin-import@npm:eslint-plugin-i@^2.25.3":
+  version: 2.27.5
+  resolution: "eslint-plugin-i@npm:2.27.5"
   dependencies:
-    array-includes: ^3.1.4
-    array.prototype.flat: ^1.2.5
-    debug: ^2.6.9
+    array-includes: ^3.1.6
+    array.prototype.flat: ^1.3.1
+    array.prototype.flatmap: ^1.3.1
+    debug: ^3.2.7
     doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.6
-    eslint-module-utils: ^2.7.3
+    eslint-import-resolver-node: ^0.3.7
+    eslint-module-utils: ^2.7.4
+    get-tsconfig: ^4.2.0
     has: ^1.0.3
-    is-core-module: ^2.8.1
+    is-core-module: ^2.11.0
     is-glob: ^4.0.3
     minimatch: ^3.1.2
-    object.values: ^1.1.5
-    resolve: ^1.22.0
-    tsconfig-paths: ^3.14.1
+    object.values: ^1.1.6
+    resolve: ^1.22.1
+    semver: ^6.3.0
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-  checksum: 0bf77ad80339554481eafa2b1967449e1f816b94c7a6f9614ce33fb4083c4e6c050f10d241dd50b4975d47922880a34de1e42ea9d8e6fd663ebb768baa67e655
+  checksum: 64b0c6400be15709ed87eab2af7f67569adead44420c994634efe3e2f31794d9fd81ddfcbce5dc7174621d789234f57583025a9852e377c62002053cc0ee4066
   languageName: node
   linkType: hard
 
@@ -19698,6 +19715,13 @@ __metadata:
     call-bind: ^1.0.2
     get-intrinsic: ^1.1.1
   checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.2.0":
+  version: 4.5.0
+  resolution: "get-tsconfig@npm:4.5.0"
+  checksum: 687ee2bd69a5a07db2e2edeb4d6c41c3debb38f6281a66beb643e3f5b520252e27fcbbb5702bdd9a5f05dcf8c1d2e0150a4d8a960ad75cbdea74e06a51e91b02
   languageName: node
   linkType: hard
 
@@ -21942,6 +21966,15 @@ __metadata:
   bin:
     is-ci: bin.js
   checksum: 192c66dc7826d58f803ecae624860dccf1899fc1f3ac5505284c0a5cf5f889046ffeb958fa651e5725d5705c5bcb14f055b79150ea5fcad7456a9569de60260e
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.11.0":
+  version: 2.12.0
+  resolution: "is-core-module@npm:2.12.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: f7f7eb2ab71fd769ee9fb2385c095d503aa4b5ce0028c04557de03f1e67a87c85e5bac1f215945fc3c955867a139a415a3ec4c4234a0bffdf715232660f440a6
   languageName: node
   linkType: hard
 
@@ -32210,19 +32243,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.0":
-  version: 1.22.0
-  resolution: "resolve@npm:1.22.0"
-  dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: a2d14cc437b3a23996f8c7367eee5c7cf8149c586b07ca2ae00e96581ce59455555a1190be9aa92154785cf9f2042646c200d0e00e0bbd2b8a995a93a0ed3e4e
-  languageName: node
-  linkType: hard
-
 "resolve@npm:^1.22.1, resolve@npm:^1.3.2":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
@@ -32266,19 +32286,6 @@ __metadata:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
   checksum: a0dd7d16a8e47af23afa9386df2dff10e3e0debb2c7299a42e581d9d9b04d7ad5d2c53f24f1e043f7b3c250cbdc71150063e53d0b6559683d37f790b7c8c3cd5
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
-  version: 1.22.0
-  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=c3c19d"
-  dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
   languageName: node
   linkType: hard
 
@@ -35624,7 +35631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.14.1, tsconfig-paths@npm:^3.9.0":
+"tsconfig-paths@npm:^3.9.0":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
   dependencies:


### PR DESCRIPTION
**What is this feature?**

Replaces the eslint plugin import with the fork [eslint-plugin-i](https://github.com/un-es/eslint-plugin-i) that is much optimized for speed.

The eslint-plugin import doesn't look actively maintained and we rely on its configuration to keep the code base up to standard.

### How faster is it?

Twice as fast as the original plugin. 

Original

```
❯ TIMING=1 yarn lint:ts
Rule                                 | Time (ms) | Relative
:------------------------------------|----------:|--------:
import/order                         | 23567.876 |    67.0%
@typescript-eslint/naming-convention |  2259.145 |     6.4%
react/display-name                   |  1524.432 |     4.3%
react/no-direct-mutation-state       |  1466.310 |     4.2%
jsdoc/check-alignment                |  1293.511 |     3.7%
react/require-render-return          |   609.075 |     1.7%
jest/no-focused-tests                |   500.388 |     1.4%
@typescript-eslint/no-redeclare      |   392.313 |     1.1%
react/no-deprecated                  |   343.911 |     1.0%
react/no-string-refs                 |   229.577 |     0.7%

```

Fork

```
Rule                                 | Time (ms) | Relative
:------------------------------------|----------:|--------:
import/order                         | 11557.527 |    52.2%
@typescript-eslint/naming-convention |  2032.964 |     9.2%
react/no-direct-mutation-state       |  1405.007 |     6.3%
react/display-name                   |  1335.425 |     6.0%
jsdoc/check-alignment                |  1181.331 |     5.3%
react/require-render-return          |   568.163 |     2.6%
jest/no-focused-tests                |   446.722 |     2.0%
@typescript-eslint/no-redeclare      |   339.637 |     1.5%
react/no-deprecated                  |   314.284 |     1.4%
react/no-string-refs                 |   243.381 |     1.1%

```

It makes eslint run 15% faster 
Base:
```❯ hyperfine "yarn eslint . --ext .js,.tsx,.ts" --prepare "rm .eslintcache||true" --runs 3
Benchmark 1: yarn eslint . --ext .js,.tsx,.ts
  Time (mean ± σ):     71.782 s ±  0.372 s    [User: 94.503 s, System: 2.087 s]
  Range (min … max):   71.456 s … 72.188 s    3 runs

```
modified:
```
❯ hyperfine "yarn eslint . --ext .js,.tsx,.ts" --prepare "rm .eslintcache||true" --runs 3
Benchmark 1: yarn eslint . --ext .js,.tsx,.ts
  Time (mean ± σ):     60.910 s ±  3.390 s    [User: 84.338 s, System: 2.042 s]
  Range (min … max):   57.300 s … 64.026 s    3 runs

```

**Why do we need this feature?**

Our current eslint setup is slow, specially in CI. This will improve pre-commit hooks speed and CI speed

**Who is this feature for?**

Grafana developers and CI pipeline

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
