### PR TITLE
Variables are available in the new DS picker and modal

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -146,11 +146,10 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
       <div className={styles.dataSourceList}>
         <CustomScrollbar>
           <DataSourceList
-            mixed
-            dashboard
+            {...props}
             current={current}
             onChange={changeCallback}
-            filter={(ds) => !ds.meta.builtIn && ds.name.includes(filterTerm ?? '')}
+            filter={(ds) => ds.name.includes(filterTerm ?? '')}
           ></DataSourceList>
         </CustomScrollbar>
       </div>

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -60,6 +60,7 @@ export function DataSourceModal({
             <DataSourceList
               dashboard={false}
               mixed={false}
+              variables
               // FIXME: Filter out the grafana data source in a hacky way
               filter={(ds) => ds.name.includes(search) && ds.name !== '-- Grafana --'}
               onChange={onChange}

--- a/public/app/features/datasources/components/picker/DataSourcePickerNG.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePickerNG.tsx
@@ -81,6 +81,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
     return (
       <div>
         <DataSourceDropdown
+          {...this.props}
           datasources={this.getDatasources()}
           onChange={this.onChange}
           recentlyUsed={recentlyUsed}


### PR DESCRIPTION
|Picker offers DS variables| Modal offers DS variables|
|-|-|
|![Captura de pantalla 2023-04-20 a las 11 28 14](https://user-images.githubusercontent.com/5699976/233323257-4dda18b0-6622-4a9f-a613-4034e3875182.png)|![Captura de pantalla 2023-04-20 a las 11 28 22](https://user-images.githubusercontent.com/5699976/233323263-7a06450b-7fdd-42a1-b337-c206e53739a9.png)

**Fixes**
#66922 

**Solution**
* Forward filter options into the dropdown
* Add filters to the modal list

**Note for reviewers**
This happens because we're delegating the responsibility to the list to fetch the DS, so it creates inconsistencies between both lists. This will be solved with this refactor, where we will use a single hook everywhere to retrieve the data sources.