### PR TITLE
Elasticsearch: Update required database version to 7.16

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -30,7 +30,7 @@ Once you've added the Elasticsearch data source, you can [configure it]({{< relr
 
 This data source supports these versions of Elasticsearch:
 
-- v7.10+
+- v7.16+
 - v8.x
 
 ## Configure the data source

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -92,7 +92,7 @@ export const getScriptValue = (metric: MetricAggregationWithInlineScript) =>
   (typeof metric.settings?.script === 'object' ? metric.settings?.script?.inline : metric.settings?.script) || '';
 
 export const isSupportedVersion = (version: SemVer): boolean => {
-  if (gte(version, '7.10.0')) {
+  if (gte(version, '7.16.0')) {
     return true;
   }
 
@@ -100,4 +100,4 @@ export const isSupportedVersion = (version: SemVer): boolean => {
 };
 
 export const unsupportedVersionMessage =
-  'Support for Elasticsearch versions after their end-of-life (currently versions < 7.10) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results.';
+  'Support for Elasticsearch versions after their end-of-life (currently versions < 7.16) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results.';


### PR DESCRIPTION
Our supported-versions policy for Elasticsearch is: we support Elasticsearch versions that Elasticsearch-the-company supports.

the current info can be found at: https://www.elastic.co/support/eol

the support for `elastic 7.15.x` ended at `2023-03-22`, so we will only support versions `7.16.x or higher`.

(NOTE: the way this works is: you will still be able to use an older version of elasticsearch, but you will get warnings in the query-editor and in the datasource-config if you run an unsupported elasticsearch version)

(fixes https://github.com/grafana/grafana/issues/65908)

# Release notice breaking change

Grafana requires an Elasticsearch version of 7.16 or newer. If you use an older Elasticsearch version, you will get warnings in the query editor and on the datasource configuration page.