### PR TITLE
Docs: adds legacy wording to api docs

### DIFF
--- a/docs/sources/developers/http_api/alerting.md
+++ b/docs/sources/developers/http_api/alerting.md
@@ -13,9 +13,9 @@ keywords:
 title: 'Alerting HTTP API '
 ---
 
-# Alerting API
+# Legacy Alerting API
 
-> **Note:** Starting with v9.0, the Alerting HTTP API is deprecated. It will be removed in a future release.
+> **Note:** Starting with v9.0, the Legacy Alerting HTTP API is deprecated. It will be removed in a future release.
 
 This topic is relevant for the [legacy dashboard alerts](https://grafana.com/docs/grafana/v8.5/alerting/old-alerting/) only.
 

--- a/docs/sources/developers/http_api/alerting_notification_channels.md
+++ b/docs/sources/developers/http_api/alerting_notification_channels.md
@@ -14,7 +14,9 @@ keywords:
 title: 'Alerting Notification Channels HTTP API '
 ---
 
-# Alerting Notification Channels API
+# Legacy Alerting Notification Channels API
+
+> **Note:** Starting with v9.0, the Legacy Alerting HTTP API is deprecated. It will be removed in a future release.
 
 This page documents the Alerting Notification Channels API.
 

--- a/docs/sources/developers/http_api/alerting_notification_channels.md
+++ b/docs/sources/developers/http_api/alerting_notification_channels.md
@@ -16,7 +16,7 @@ title: 'Alerting Notification Channels HTTP API '
 
 # Legacy Alerting Notification Channels API
 
-> **Note:** Starting with v9.0, the Legacy Alerting HTTP API is deprecated. It will be removed in a future release.
+> **Note:** Starting with v9.0, the Legacy Alerting Notification Channels API is deprecated. It will be removed in a future release.
 
 This page documents the Alerting Notification Channels API.
 


### PR DESCRIPTION
Adds legacy to alerting apis to make it clearer that these apis are no longer current.