### PR TITLE
Nested folders: Fix error response codes

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -558,7 +558,7 @@ func (s *Service) Move(ctx context.Context, cmd *folder.MoveFolderCommand) (*fol
 
 	// current folder height + current folder + parent folder + parent folder depth should be less than or equal 8
 	if folderHeight+len(parents)+2 > folder.MaxNestedFolderDepth {
-		return nil, folder.ErrMaximumDepthReached
+		return nil, folder.ErrMaximumDepthReached.Errorf("failed to move folder")
 	}
 
 	// if the current folder is already a parent of newparent, we should return error
@@ -775,7 +775,7 @@ func (s *Service) validateParent(ctx context.Context, orgID int64, parentUID str
 	}
 
 	if len(ancestors) == folder.MaxNestedFolderDepth {
-		return folder.ErrMaximumDepthReached
+		return folder.ErrMaximumDepthReached.Errorf("failed to validate parent folder")
 	}
 
 	// Create folder under itself is not allowed

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -284,7 +284,7 @@ func (ss *sqlStore) getParentsMySQL(ctx context.Context, cmd folder.GetParentsQu
 			folders = append(folders, f)
 			uid = f.ParentUID
 			if len(folders) > folder.MaxNestedFolderDepth {
-				return folder.ErrFolderTooDeep
+				return folder.ErrMaximumDepthReached.Errorf("failed to get parent folders iteratively")
 			}
 		}
 		return nil

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -11,7 +11,6 @@ var ErrMaximumDepthReached = errutil.NewBase(errutil.StatusBadRequest, "folder.m
 var ErrBadRequest = errutil.NewBase(errutil.StatusBadRequest, "folder.bad-request")
 var ErrDatabaseError = errutil.NewBase(errutil.StatusInternal, "folder.database-error")
 var ErrInternal = errutil.NewBase(errutil.StatusInternal, "folder.internal")
-var ErrFolderTooDeep = errutil.NewBase(errutil.StatusInternal, "folder.too-deep")
 var ErrCircularReference = errutil.NewBase(errutil.StatusBadRequest, "folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.NewBase(errutil.StatusInternal, "folder.target-registry-srv-conflict")
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In certain cases we used to return [errutil.Base](https://github.com/grafana/grafana/blob/4089514432b221b558b44b1d6792fc452c126144/pkg/util/errutil/errors.go#L10) instead of [errutil.Error](https://github.com/grafana/grafana/blob/4089514432b221b558b44b1d6792fc452c126144/pkg/util/errutil/errors.go#L149)
As a result, [this condition](https://github.com/grafana/grafana/blob/4089514432b221b558b44b1d6792fc452c126144/pkg/api/response/response.go#L285) used to fail and we fell back to default error response (500 InternalServerError)
Following [the guidelines](https://github.com/grafana/grafana/blob/main/contribute/backend/errors.md#declaring-errors):
errors should be constructed using the `Base.Errorf()` method

**Why do we need this feature?**

With this fix the Error API responses return the expected status codes.

<details>
<summary>Example response before the fix</summary>

```
# curl 'http://localhost:3000/api/folders' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/111.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate, br' -H 'Referer: http://localhost:3000/dashboards/folder/new/?folderUid=d15cc243-d5a8-4e1e-9fcd-21ff6141b04d' -H 'content-type: application/json' -H 'x-grafana-org-id: 1' -H 'Origin: http://localhost:3000' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Cookie: grafana_session=bf0b778fdb760df6026b6c246e412268; grafana_session_expiry=1681985502' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-origin' --data-raw '{"title":"f2","parentUid":"d15cc243-d5a8-4e1e-9fcd-21ff6141b04d"}' |jq
{
  "error": "[folder.maximum-depth-reached] ",
  "message": "Folder API error",
  "traceID": ""
}
```
</details>

<details>
<summary>Example response after the fix</summary>

```
# curl 'http://localhost:3000/api/folders' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/111.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate, br' -H 'Referer: http://localhost:3000/dashboards/folder/new/?folderUid=d15cc243-d5a8-4e1e-9fcd-21ff6141b04d' -H 'content-type: application/json' -H 'x-grafana-org-id: 1' -H 'Origin: http://localhost:3000' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Cookie: grafana_session=bf0b778fdb760df6026b6c246e412268; grafana_session_expiry=1681985502' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-origin' --data-raw '{"title":"f2","parentUid":"d15cc243-d5a8-4e1e-9fcd-21ff6141b04d"}' |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--   100   187  100   122  100    65  10375   5528 --:--:-- --:--:-- --:--:-- 26714
{
  "message": "Maximum nested folder depth reached",
  "messageId": "folder.maximum-depth-reached",
  "statusCode": 400,
  "traceID": ""
```
</details>

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
