### PR TITLE
NestedFolders: Backend nested-dashboards route

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,6 +152,12 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboards/*", reqSignedIn, hs.Index)
 	r.Get("/goto/:uid", reqSignedIn, hs.redirectFromShortURL, hs.Index)
 
+	// Temporary routes for the work-in-progress new Browse Dashboards views
+	if hs.Features.IsEnabled(featuremgmt.FlagNestedFolders) {
+		r.Get("/nested-dashboards/", reqSignedIn, hs.Index)
+		r.Get("/nested-dashboards/*", reqSignedIn, hs.Index)
+	}
+
 	if hs.Features.IsEnabled(featuremgmt.FlagPublicDashboards) {
 		// list public dashboards
 		r.Get("/public-dashboards/list", reqSignedIn, hs.Index)

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -47,7 +47,7 @@ export const DashboardListPage = memo(({ match, location }: Props) => {
       actions={
         config.featureToggles.nestedFolders && (
           <Link href="/nested-dashboards">
-            <Tooltip content="New Browse Dashboards for nested folders is still a work in progress and may be missing features">
+            <Tooltip content="New Browse Dashboards for nested folders is still under development and may be missing features">
               <span>
                 <Badge icon="folder" color="blue" text="Preview new Browse Dashboards" />
               </span>

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 
 import { locationUtil, NavModelItem } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
-import { Badge, Link } from '@grafana/ui';
+import { Badge, Link, Tooltip } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { FolderDTO } from 'app/types';
 
@@ -47,7 +47,11 @@ export const DashboardListPage = memo(({ match, location }: Props) => {
       actions={
         config.featureToggles.nestedFolders && (
           <Link href="/nested-dashboards">
-            <Badge icon="folder" color="blue" text="Try WIP nested folders UI" />
+            <Tooltip content="New Browse Dashboards for nested folders is still a work in progress and may be missing features">
+              <span>
+                <Badge icon="folder" color="blue" text="Preview new Browse Dashboards" />
+              </span>
+            </Tooltip>
           </Link>
         )
       }


### PR DESCRIPTION
 - Adds backend route for the temp new browse dashboards UI so the server doesn't send 404 status code
 - Adds a tooltip to the badge to push to new UI 
 - 
![image](https://user-images.githubusercontent.com/46142/233366585-1e151a53-30b9-44c2-8fbc-63cf2a79b37c.png)
