### PR TITLE
Tracing: Update e2e test

### DIFF
--- a/e2e/various-suite/trace-view-scrolling.spec.ts
+++ b/e2e/various-suite/trace-view-scrolling.spec.ts
@@ -4,7 +4,7 @@ describe('Trace view', () => {
   it('Can lazy load big traces', () => {
     e2e.flows.login('admin', 'admin');
     e2e()
-      .intercept('GET', '**/api/traces/long-trace', {
+      .intercept('GET', '**/api/traces/trace', {
         fixture: 'long-trace-response.json',
       })
       .as('longTrace');
@@ -13,7 +13,9 @@ describe('Trace view', () => {
 
     e2e.components.DataSourcePicker.container().should('be.visible').type('gdev-jaeger{enter}');
 
-    e2e.components.QueryField.container().should('be.visible').type('long-trace');
+    e2e().wait(500);
+
+    e2e.components.QueryField.container().should('be.visible').type('trace', { delay: 100 });
 
     e2e().wait(500);
 


### PR DESCRIPTION
**What is this feature?**

Updates the trace-view-scrolling spec with measures to help with flakiness. From a previous failure the test failed because the text typed into the query field was not actually the text passed into the `.type()` function. The result was that the query could not be intercepted (where the trace json is returned). Adding a wait after selecting the ds and also a small delay in between key presses.