### PR TITLE
QueryBuilder: Preserve query when switching from mixed

### DIFF
--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -215,6 +215,67 @@ describe('updateQueries', () => {
     expect(updated[0].datasource).toEqual({ type: 'old-type', uid: 'old-uid' });
     expect(updated[1].datasource).toEqual({ type: 'other-type', uid: 'other-uid' });
   });
+
+  it('should preserve query when switching from mixed to a datasource where a query has been saved', async () => {
+    const updated = await updateQueries(
+      newUidDS,
+      'new-uid',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'new-uid',
+            type: 'new-type',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid',
+            type: 'other-type',
+          },
+        },
+      ],
+      mixedDS
+    );
+
+    expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+    expect(updated.length).toEqual(1);
+  });
+
+  it('should return a default query if switching from mixed to a datasource where a query is not saved', async () => {
+    newUidDS.getDefaultQuery = jest.fn().mockReturnValue({ test: 'default-query' } as Partial<TestQuery>);
+    const updated = await updateQueries(
+      newUidDS,
+      'new-uid',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'other-uid-1',
+            type: 'other-type-1',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid-2',
+            type: 'other-type-2',
+          },
+        },
+      ],
+      mixedDS
+    );
+    expect(newUidDS.getDefaultQuery).toHaveBeenCalled();
+    expect(updated as TestQuery[]).toEqual([
+      {
+        datasource: { type: 'new-type', uid: 'new-uid' },
+        refId: 'A',
+        test: 'default-query',
+      },
+    ]);
+    expect(updated.length).toEqual(1);
+  });
 });
 
 describe('updateQueries with import', () => {

--- a/public/app/features/query/state/updateQueries.ts
+++ b/public/app/features/query/state/updateQueries.ts
@@ -26,9 +26,15 @@ export async function updateQueries(
     else if (currentDS && nextDS.importQueries) {
       nextQueries = await nextDS.importQueries(queries, currentDS);
     }
-    // Otherwise clear queries
+    // check to see if an existing query for that datasource exists in nextQueries and preserve it if it exists
     else {
-      return [DEFAULT_QUERY];
+      const savedQuery = nextQueries.find((query) => query.datasource?.type === nextDS.type);
+
+      if (savedQuery) {
+        return [{ ...savedQuery, refId: 'A' }];
+      } else {
+        return [DEFAULT_QUERY];
+      }
     }
   }
 


### PR DESCRIPTION
This PR preserves a query when switching from mixed to a datasource where a query is saved. If there is no saved query, then the default query will be set. 

NOTE: The original issue indicated that this was an issue with Azure Monitor but it actually applies to all datasources because of how the datasource picker worked.

https://user-images.githubusercontent.com/58453566/233394865-97cc9021-f175-4520-9434-332240bba3ad.mov

Fixed #50831 