### PR TITLE
PanelChrome: Remove "auto" cursor from title items

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
@@ -58,7 +58,6 @@ const getStyles = (theme: GrafanaTheme2) => {
   const item = css({
     color: `${theme.colors.text.secondary}`,
     label: 'panel-header-item',
-    cursor: 'auto',
     border: 'none',
     borderRadius: `${theme.shape.borderRadius()}`,
     padding: `${theme.spacing(0, 1)}`,


### PR DESCRIPTION
**What is this feature?**

Allow panel links ("a" tags) to use "pointer" cursor.
![image](https://user-images.githubusercontent.com/8481470/233397688-27eb5bbf-e67e-409e-a331-d61fb0a099a2.png)

**Why do we need this feature?**

The "auto" cursor CSS setting prevents links from showing the correct cursor. Instead the regular "default" cursor is shown (Chrome 112.0.5615.121)

**Who is this feature for?**

everyone

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
