### PR TITLE
grafana/e2e: Put E2E select updates in selectOption

### DIFF
--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -113,13 +113,6 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
     e2e().intercept(chartData.method, chartData.route).as('chartData');
 
     if (dataSourceName) {
-      e2e.components.DataSourcePicker.container().within(() => {
-        e2e()
-          .get('[class$="-input-suffix"]')
-          .then((element) => {
-            Cypress.dom.isAttached(element);
-          });
-      });
       selectOption({
         container: e2e.components.DataSourcePicker.container(),
         optionText: dataSourceName,

--- a/packages/grafana-e2e/src/flows/selectOption.ts
+++ b/packages/grafana-e2e/src/flows/selectOption.ts
@@ -19,7 +19,12 @@ export const selectOption = (config: SelectOptionConfig): any => {
 
   container.within(() => {
     if (clickToOpen) {
-      e2e().get('[class$="-input-suffix"]').click();
+      e2e()
+        .get('[class$="-input-suffix"]', { timeout: 1000 })
+        .then((element) => {
+          expect(Cypress.dom.isAttached(element)).to.eq(true);
+          e2e().get('[class$="-input-suffix"]', { timeout: 1000 }).click({ force: true });
+        });
     }
   });
 


### PR DESCRIPTION
In my previous PR I put this logic in the `configurePanel` flow but it makes more sense to have this in the `selectOption` where the failure is happening. I've also added `force: true` as if the element is attached we should be fine to skip the warning.