### PR TITLE
Packaging: Added deprecation warnings when running `grafana-cli` or `grafana-server`; the `grafana` command should be used instead.

### DIFF
--- a/pkg/util/cmd/cmd.go
+++ b/pkg/util/cmd/cmd.go
@@ -21,9 +21,9 @@ func RunGrafanaCmd(subCmd string) int {
 
 	switch filepath.Base(curr) {
 	case "grafana-server":
-		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning:"), "The standalone 'grafana-server' program is deprecated and will be removed in the future. Please update all uses of 'grafana-server' to 'grafana server'")
+		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning"), "The standalone 'grafana-server' program is deprecated and will be removed in the future. Please update all uses of 'grafana-server' to 'grafana server'")
 	case "grafana-cli":
-		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning:"), "The standalone 'grafana-cli' program is deprecated and will be removed in the future. Please update all uses of 'grafana-cli' to 'grafana cli'")
+		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning"), "The standalone 'grafana-cli' program is deprecated and will be removed in the future. Please update all uses of 'grafana-cli' to 'grafana cli'")
 	}
 
 	executable := "grafana"

--- a/pkg/util/cmd/cmd.go
+++ b/pkg/util/cmd/cmd.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"syscall"
+
+	"github.com/fatih/color"
 )
 
 func RunGrafanaCmd(subCmd string) int {
@@ -15,6 +17,13 @@ func RunGrafanaCmd(subCmd string) int {
 	if err != nil {
 		fmt.Println("Error locating executable:", err)
 		return 1
+	}
+
+	switch filepath.Base(curr) {
+	case "grafana-server":
+		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning:"), "The standalone 'grafana-server' program is deprecated and will be removed in the future. Please update all uses of 'grafana-server' to 'grafana server'")
+	case "grafana-cli":
+		fmt.Printf("%s: %s\n", color.RedString("Deprecation warning:"), "The standalone 'grafana-cli' program is deprecated and will be removed in the future. Please update all uses of 'grafana-cli' to 'grafana cli'")
 	}
 
 	executable := "grafana"


### PR DESCRIPTION
This change adds a deprecation warning when running `grafana-server` and `grafana-cli`.

When running either of these, the warning is printed in red:

grafana-server:
```
» ./bin/linux-amd64/grafana-server
Deprecation warning:: The standalone 'grafana-server' program is deprecated and will be removed in the future. Please update all uses of 'grafana-server' to 'grafana server'
INFO [04-20|09:41:25] Starting Grafana                         logger=settings version=10.0.0-pre commit=5dbaa82ce1 branch=km/66967/add-deprecation-warning-grafana-cli-and-server compiled=2023-04-18T02:18:37-05:00
WARN [04-20|09:41:25] "sentry" frontend logging provider is deprecated and will be removed in the next major version. Use "grafana" provider instead. logger=settings
INFO [04-20|09:41:25] Config loaded from                       logger=settings file=/home/kminehart/Work/Grafana/grafana/conf/defaults.ini
```

grafana-cli:
```
» ./bin/linux-amd64/grafana-cli
Deprecation warning:: The standalone 'grafana-cli' program is deprecated and will be removed in the future. Please update all uses of 'grafana-cli' to 'grafana cli'
NAME:
   grafana cli - run the grafana cli

USAGE:
   grafana cli command [command options] [arguments...]
```

And using just the `grafana` command does not print a deprecation warning:

```
» ./bin/linux-amd64/grafana cli
NAME:
   grafana cli - run the grafana cli

USAGE:
   grafana cli command [command options] [arguments...]

COMMANDS:
   plugins  Manage plugins for grafana
```

# Deprecation notice

Scripts, systemd unit files and etc should stop using the `grafana-cli` and `grafana-server` programs, and instead use the `grafana` program. Uses of `grafana-server` should become `grafana server`, and uses of `grafana-cli` should become `grafana cli`.