### PR TITLE
Docs: Update references of `grafana-cli` to `grafana cli` and `grafana-server` to `grafana server`.

### DIFF
--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -1,11 +1,11 @@
 ---
 aliases:
   - administration/cli/
-description: Guide to using grafana-cli
+description: Guide to using grafana cli
 keywords:
   - grafana
   - cli
-  - grafana-cli
+  - grafana cli
   - command line interface
 title: Grafana CLI
 weight: 400
@@ -18,12 +18,12 @@ Grafana CLI is a small executable that is bundled with Grafana server. It can be
 To list all commands and options:
 
 ```
-grafana-cli -h
+grafana cli -h
 ```
 
 ## Invoking Grafana CLI
 
-To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` environment variable. Alternately, if your current directory is the `bin` directory, use `./grafana-cli`. Otherwise, you can specify full path to the CLI. For example, on Linux `/usr/share/grafana/bin/grafana-cli` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana-cli.exe`.
+To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` environment variable. Alternately, if your current directory is the `bin` directory, use `./grafana cli`. Otherwise, you can specify full path to the CLI. For example, on Linux `/usr/share/grafana/bin/grafana cli` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana cli.exe`.
 
 > **Note:** Some commands, such as installing or removing plugins, require `sudo` on Linux. If you are on Windows, run Windows PowerShell as Administrator.
 
@@ -32,7 +32,7 @@ To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` envir
 The general syntax for commands in Grafana CLI is:
 
 ```bash
-grafana-cli [global options] command [command options] [arguments...]
+grafana cli [global options] command [command options] [arguments...]
 ```
 
 ## Global options
@@ -48,7 +48,7 @@ Each global option applies only to the command in which it is used. For example,
 **Example:**
 
 ```bash
-grafana-cli -h
+grafana cli -h
 ```
 
 ### Display Grafana CLI version
@@ -58,7 +58,7 @@ grafana-cli -h
 **Example:**
 
 ```bash
-grafana-cli -v
+grafana cli -v
 ```
 
 ### Override default plugin directory
@@ -68,7 +68,7 @@ grafana-cli -v
 **Example:**
 
 ```bash
-grafana-cli --pluginsDir "/var/lib/grafana/devplugins" plugins install <plugin-id>
+grafana cli --pluginsDir "/var/lib/grafana/devplugins" plugins install <plugin-id>
 ```
 
 ### Override default plugin repo URL
@@ -78,7 +78,7 @@ grafana-cli --pluginsDir "/var/lib/grafana/devplugins" plugins install <plugin-i
 **Example:**
 
 ```bash
-grafana-cli --repo "https://example.com/plugins" plugins install <plugin-id>
+grafana cli --repo "https://example.com/plugins" plugins install <plugin-id>
 ```
 
 ### Override default plugin .zip URL
@@ -88,7 +88,7 @@ grafana-cli --repo "https://example.com/plugins" plugins install <plugin-id>
 **Example:**
 
 ```bash
-grafana-cli --pluginUrl https://company.com/grafana/plugins/<plugin-id>-<plugin-version>.zip plugins install <plugin-id>
+grafana cli --pluginUrl https://company.com/grafana/plugins/<plugin-id>-<plugin-version>.zip plugins install <plugin-id>
 ```
 
 ### Override Transport Layer Security
@@ -100,7 +100,7 @@ grafana-cli --pluginUrl https://company.com/grafana/plugins/<plugin-id>-<plugin-
 **Example:**
 
 ```bash
-grafana-cli --insecure --pluginUrl https://company.com/grafana/plugins/<plugin-id>-<plugin-version>.zip plugins install <plugin-id>
+grafana cli --insecure --pluginUrl https://company.com/grafana/plugins/<plugin-id>-<plugin-version>.zip plugins install <plugin-id>
 ```
 
 ### Enable debug logging
@@ -110,7 +110,7 @@ grafana-cli --insecure --pluginUrl https://company.com/grafana/plugins/<plugin-i
 **Example:**
 
 ```bash
-grafana-cli --debug plugins install <plugin-id>
+grafana cli --debug plugins install <plugin-id>
 ```
 
 ### Override a configuration setting
@@ -122,7 +122,7 @@ For example, you can use it to redirect logging to another file (maybe to log pl
 **Example:**
 
 ```bash
-grafana-cli --configOverrides cfg:default.paths.log=/dev/null plugins install <plugin-id>
+grafana cli --configOverrides cfg:default.paths.log=/dev/null plugins install <plugin-id>
 ```
 
 ### Override homepath value
@@ -132,7 +132,7 @@ Sets the path for the Grafana install/home path, defaults to working directory. 
 **Example:**
 
 ```bash
-grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password <new password>
+grafana cli --homepath "/usr/share/grafana" admin reset-admin-password <new password>
 ```
 
 ### Override config file
@@ -142,7 +142,7 @@ grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password <new pass
 **Example:**
 
 ```bash
-grafana-cli --config "/etc/configuration/" admin reset-admin-password mynewpassword
+grafana cli --config "/etc/configuration/" admin reset-admin-password mynewpassword
 ```
 
 ## Plugins commands
@@ -154,43 +154,43 @@ All listed commands apply to the Grafana default repositories and directories. Y
 ### List available plugins
 
 ```bash
-grafana-cli plugins list-remote
+grafana cli plugins list-remote
 ```
 
 ### Install the latest version of a plugin
 
 ```bash
-grafana-cli plugins install <plugin-id>
+grafana cli plugins install <plugin-id>
 ```
 
 ### Install a specific version of a plugin
 
 ```bash
-grafana-cli plugins install <plugin-id> <version>
+grafana cli plugins install <plugin-id> <version>
 ```
 
 ### List installed plugins
 
 ```bash
-grafana-cli plugins ls
+grafana cli plugins ls
 ```
 
 ### Update all installed plugins
 
 ```bash
-grafana-cli plugins update-all
+grafana cli plugins update-all
 ```
 
 ### Update one plugin
 
 ```bash
-grafana-cli plugins update <plugin-id>
+grafana cli plugins update <plugin-id>
 ```
 
 ### Remove one plugin
 
 ```bash
-grafana-cli plugins remove <plugin-id>
+grafana cli plugins remove <plugin-id>
 ```
 
 ## Admin commands
@@ -200,12 +200,12 @@ Admin commands are only available in Grafana 4.1 and later.
 ### Show all admin commands
 
 ```bash
-grafana-cli admin
+grafana cli admin
 ```
 
 ### Reset admin password
 
-`grafana-cli admin reset-admin-password <new password>` resets the password for the admin user using the CLI. You might need to do this if you lose the admin password.
+`grafana cli admin reset-admin-password <new password>` resets the password for the admin user using the CLI. You might need to do this if you lose the admin password.
 
 If there are two flags being used to set the homepath and the config file path, then running the command returns this error:
 
@@ -214,7 +214,7 @@ If there are two flags being used to set the homepath and the config file path, 
 To correct this, use the `--homepath` global option to specify the Grafana default homepath for this command:
 
 ```bash
-grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password <new password>
+grafana cli --homepath "/usr/share/grafana" admin reset-admin-password <new password>
 ```
 
 If you have not lost the admin password, we recommend that you change the user password either in the User Preferences or in the Server Admin > User tab.
@@ -230,5 +230,5 @@ If you need to set the password in a script, then you can use the [Grafana User 
 **Example:**
 
 ```bash
-grafana-cli admin data-migration encrypt-datasource-passwords
+grafana cli admin data-migration encrypt-datasource-passwords
 ```

--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -23,7 +23,7 @@ grafana cli -h
 
 ## Invoking Grafana CLI
 
-To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` environment variable. Alternately, if your current directory is the `bin` directory, use `./grafana cli`. Otherwise, you can specify full path to the CLI. For example, on Linux `/usr/share/grafana/bin/grafana cli` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana cli.exe`.
+To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` environment variable. Alternately, if your current directory is the `bin` directory, use `./grafana cli`. Otherwise, you can specify full path to the CLI. For example, on Linux `/usr/share/grafana/bin/grafana` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana.exe`, and invoke it with `grafana cli`.
 
 > **Note:** Some commands, such as installing or removing plugins, require `sudo` on Linux. If you are on Windows, run Windows PowerShell as Administrator.
 

--- a/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
@@ -9,7 +9,7 @@ weight: 200
 
 # Configure tracing to troubleshoot Grafana
 
-You can set up the `grafana-server` process to enable certain diagnostics when it starts. This can be helpful
+You can set up the `grafana` server process to enable certain diagnostics when it starts. This can be helpful
 when investigating certain performance problems. It's _not_ recommended to have these enabled by default.
 
 ## Turn on profiling
@@ -18,7 +18,7 @@ The `grafana-server` can be started with the arguments `-profile` to enable prof
 `-profile-port` to override the default HTTP port (`6060`) where the `pprof` debugging endpoints are available. For example:
 
 ```bash
-./grafana-server -profile -profile-addr=0.0.0.0 -profile-port=8080
+./grafana server -profile -profile-addr=0.0.0.0 -profile-port=8080
 ```
 
 Note that `pprof` debugging endpoints are served on a different port than the Grafana HTTP server.
@@ -38,7 +38,7 @@ Refer to [Go command pprof](https://golang.org/cmd/pprof/) for more information 
 The `grafana-server` can be started with the arguments `-tracing` to enable tracing and `-tracing-file` to override the default trace file (`trace.out`) where trace result is written to. For example:
 
 ```bash
-./grafana-server -tracing -tracing-file=/tmp/trace.out
+./grafana server -tracing -tracing-file=/tmp/trace.out
 ```
 
 You can configure or override profiling settings using environment variables:

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
@@ -49,19 +49,19 @@ You can re-encrypt secrets in order to:
 - Move already existing secrets' encryption forward from legacy to envelope encryption.
 - Re-encrypt secrets after a [data keys rotation](#rotate-data-keys).
 
-To re-encrypt secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration re-encrypt` command or the `/encryption/reencrypt-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#roll-back-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To re-encrypt secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana cli admin secrets-migration re-encrypt` command or the `/encryption/reencrypt-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#roll-back-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Roll back secrets
 
 You can roll back secrets encrypted with envelope encryption to legacy encryption. This might be necessary to downgrade to Grafana versions prior to v9.0 after an unsuccessful upgrade.
 
-To roll back secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration rollback` command or the `/encryption/rollback-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To roll back secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana cli admin secrets-migration rollback` command or the `/encryption/rollback-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Re-encrypt data keys
 
 You can re-encrypt data keys encrypted with a specific key encryption key (KEK). This allows you to either re-encrypt existing data keys with a new KEK version (see [KMS integration](#kms-integration) rotation) or to re-encrypt them with a completely different KEK.
 
-To re-encrypt data keys, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration re-encrypt-data-keys` command or the `/encryption/reencrypt-data-keys` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-data-encryption-keys" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To re-encrypt data keys, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana cli admin secrets-migration re-encrypt-data-keys` command or the `/encryption/reencrypt-data-keys` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-data-encryption-keys" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Rotate data keys
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-aws-kms/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-aws-kms/index.md
@@ -75,7 +75,7 @@ You can use an encryption key from AWS Key Management Service to encrypt secrets
 
 8. (Optional) From the command line and the root directory of Grafana, re-encrypt all of the secrets within the Grafana database with the new key using the following command:
 
-   `grafana-cli admin secrets-migration re-encrypt`
+   `grafana cli admin secrets-migration re-encrypt`
 
    If you do not re-encrypt existing secrets, then they will remain encrypted by the previous encryption key. Users will still be able to access them.
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-azure-key-vault/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-azure-key-vault/index.md
@@ -73,7 +73,7 @@ You can use an encryption key from Azure Key Vault to encrypt secrets in the Gra
 
 10. (Optional) From the command line and the root directory of Grafana Enterprise, re-encrypt all of the secrets within the Grafana database with the new key using the following command:
 
-    `grafana-cli admin secrets-migration re-encrypt`
+    `grafana cli admin secrets-migration re-encrypt`
 
     If you do not re-encrypt existing secrets, then they will remain encrypted by the previous encryption key. Users will still be able to access them.
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-google-cloud-kms/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-google-cloud-kms/index.md
@@ -62,7 +62,7 @@ You can use an encryption key from Google Cloud Key Management Service to encryp
 
 9. (Optional) From the command line and the root directory of Grafana Enterprise, re-encrypt all of the secrets within the Grafana database with the new key using the following command:
 
-   `grafana-cli admin secrets-migration re-encrypt`
+   `grafana cli admin secrets-migration re-encrypt`
 
    If you do not re-encrypt existing secrets, then they will remain encrypted by the previous encryption key. Users will still be able to access them.
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault/index.md
@@ -69,7 +69,7 @@ You can use an encryption key from Hashicorp Vault to encrypt secrets in the Gra
 
 8. (Optional) From the command line and the root directory of Grafana Enterprise, re-encrypt all of the secrets within the Grafana database with the new key using the following command:
 
-   `grafana-cli admin secrets-migration re-encrypt`
+   `grafana cli admin secrets-migration re-encrypt`
 
    If you do not re-encrypt existing secrets, then they will remain encrypted by the previous encryption key. Users will still be able to access them.
 

--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -80,7 +80,7 @@ You can install official and community plugins listed on the Grafana [plugins pa
 
 ### Install official and community Grafana plugins
 
-Pass the plugins you want installed to Docker with the `GF_INSTALL_PLUGINS` environment variable as a comma-separated list. This sends each plugin name to `grafana-cli plugins install ${plugin}` and installs them when Grafana starts.
+Pass the plugins you want installed to Docker with the `GF_INSTALL_PLUGINS` environment variable as a comma-separated list. This sends each plugin name to `grafana cli plugins install ${plugin}` and installs them when Grafana starts.
 
 ```bash
 docker run -d \

--- a/docs/sources/setup-grafana/installation/mac/index.md
+++ b/docs/sources/setup-grafana/installation/mac/index.md
@@ -54,7 +54,7 @@ To install Grafana on macOS using the standalone binaries, complete the followin
 1. To start Grafana service, go to the directory and run the command:
 
    ```bash
-   ./bin/grafana-server
+   ./bin/grafana server
    ```
 
 ## Next steps

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -95,12 +95,12 @@ sudo service grafana-server restart
 
 ### Start the server using the binary
 
-The `grafana-server` binary .tar.gz needs the working directory to be the root install directory where the binary and the `public` folder are located.
+The `grafana` binary .tar.gz needs the working directory to be the root install directory where the binary and the `public` folder are located.
 
 To start the Grafana server, run the following command:
 
 ```bash
-./bin/grafana-server
+./bin/grafana server
 ```
 
 ## Docker
@@ -139,9 +139,9 @@ To restart the running container, use this command:
 
 Complete the following steps to start the Grafana server on Windows:
 
-1. Execute `grafana-server.exe`, which is located in the `bin` directory.
+1. Execute `grafana.exe server`; the `grafana` binary is located in the `bin` directory.
 
-   We recommend that you run `grafana-server.exe` from the command line.
+   We recommend that you run `grafana.exe server` from the command line.
 
    If you want to run Grafana as a Windows service, you can download [NSSM](https://nssm.cc/).
 
@@ -183,7 +183,7 @@ To restart Grafana:
 1. Run the command:
 
 ```bash
-./bin/grafana-server
+./bin/grafana server
 ```
 
 ## Next steps

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -183,5 +183,5 @@ can make older plugins stop working properly.
 Run the following command to update plugins:
 
 ```bash
-grafana-cli plugins update-all
+grafana cli plugins update-all
 ```


### PR DESCRIPTION
According to https://github.com/grafana/grafana/pull/66976, these two commands are deprecated as of Grafana 10, so we should update the documentation to reflect how we would prefer users invoke the Grafana CLI and server.

There are still references to `grafana-server` in the context of the systemd service; this is not changing so the systemd service name 'grafana-server' should remain.