### PR TITLE
Chore: Remove test type app mode

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -47,7 +47,6 @@ const (
 	DefaultHTTPAddr  = "0.0.0.0"
 	Dev              = "development"
 	Prod             = "production"
-	Test             = "test"
 	ApplicationName  = "Grafana"
 )
 


### PR DESCRIPTION
There is a constant defined for test type, but it does not seem to be used anywhere.

If this has a real use/meaning, we should update docs+comments https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#app_mode.  But most likely we should remove it.

I discovered this while reviewing https://github.com/grafana/grafana/pull/64975 -- in that pr, @tskarhed is using test to indicate a test environment. 