### PR TITLE
Require access to all settings for the nav item

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -100,7 +100,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		})
 	}
 
-	if hasAccess(ac.ReqGrafanaAdmin, ac.EvalPermission(ac.ActionSettingsRead)) {
+	if hasAccess(ac.ReqGrafanaAdmin, ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)) {
 		configNodes = append(configNodes, &navtree.NavLink{
 			Text: "Settings", SubTitle: "View the settings defined in your Grafana config", Id: "server-settings", Url: s.cfg.AppSubURL + "/admin/settings", Icon: "sliders-v-alt",
 		})


### PR DESCRIPTION

**What is this feature?**

The change ensures that users can access Settings page only in scenarios where they have access to all settings, which is controlled by the assigned scope.

**Why do we need this feature?**

This will ensure that we have flexibility to show settings in certain pages (e.g. Authentication), but not open up entire settings whenever a user has access to those specific pages.


