### PR TITLE
ThemeDemo: Add transparent to ThemeDemo

### DIFF
--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -121,6 +121,7 @@ export const ThemeDemo = () => {
                   <td>name</td>
                   <td>main</td>
                   <td>shade (used for hover)</td>
+                  <td>transparent</td>
                   <td>border & text</td>
                 </tr>
               </thead>
@@ -243,6 +244,17 @@ export function RichColorDemo({ theme, color }: RichColorDemoProps) {
           className={css`
             background: ${color.shade};
             color: ${color.contrastText};
+            border-radius: 4px;
+            padding: 8px;
+          `}
+        >
+          {color.shade}
+        </div>
+      </td>
+      <td>
+        <div
+          className={css`
+            background: ${color.transparent};
             border-radius: 4px;
             padding: 8px;
           `}


### PR DESCRIPTION
Noticed that the ThemeDemo was missing the transparent color in the table for rich colors 

![Screenshot from 2023-04-20 19-45-16](https://user-images.githubusercontent.com/10999/233447492-f9df3c18-9329-42f1-a639-5623f287c107.png)
