### PR TITLE
Alerting: Change tooltip error text in collapsed contact point table

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -3,10 +3,10 @@ import React, { useMemo, useState } from 'react';
 
 import { dateTime, dateTimeFormat } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, ConfirmModal, Modal, useStyles2, Badge, Icon } from '@grafana/ui';
+import { Badge, Button, ConfirmModal, Icon, Modal, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
-import { useDispatch, AccessControlAction, ContactPointsState, NotifiersState, ReceiversState } from 'app/types';
+import { AccessControlAction, ContactPointsState, NotifiersState, ReceiversState, useDispatch } from 'app/types';
 
 import { useGetContactPointsState } from '../../api/receiversApi';
 import { Authorize } from '../../components/Authorize';
@@ -84,11 +84,13 @@ interface ReceiverErrorProps {
   errorCount: number;
   errorDetail?: string;
   showErrorCount: boolean;
+  tooltip?: string;
 }
 
-function ReceiverError({ errorCount, errorDetail, showErrorCount }: ReceiverErrorProps) {
+function ReceiverError({ errorCount, errorDetail, showErrorCount, tooltip }: ReceiverErrorProps) {
   const text = showErrorCount ? `${errorCount} ${pluralize('error', errorCount)}` : 'Error';
-  return <Badge color="orange" icon="exclamation-triangle" text={text} tooltip={errorDetail ?? 'Error'} />;
+  const tooltipToRender = tooltip ?? errorDetail ?? 'Error';
+  return <Badge color="orange" icon="exclamation-triangle" text={text} tooltip={tooltipToRender} />;
 }
 interface NotifierHealthProps {
   errorsByNotifier: number;
@@ -115,7 +117,11 @@ function ReceiverHealth({ errorsByReceiver, someWithNoAttempt }: ReceiverHealthP
   const noErrorsColor = someWithNoAttempt ? 'orange' : 'green';
   const noErrorsText = someWithNoAttempt ? 'No attempts' : 'OK';
   return errorsByReceiver > 0 ? (
-    <ReceiverError errorCount={errorsByReceiver} showErrorCount={true} />
+    <ReceiverError
+      errorCount={errorsByReceiver}
+      showErrorCount={true}
+      tooltip="Expand the contact point to see error details."
+    />
   ) : (
     <Badge color={noErrorsColor} text={noErrorsText} tooltip="" />
   );


### PR DESCRIPTION
**What is this feature?**

This PR changes the tooltip text for errors in the contact points table collapsed => 

- before change, tooltip text was `Error`
- after change: `Expand the contact point to see error details.`

**Why do we need this feature?**

We were rendering 'Error' string message and users were confused about how to see the details.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**
<img width="2183" alt="Screenshot 2023-04-21 at 08 54 02" src="https://user-images.githubusercontent.com/33540275/233564200-070c907e-070a-46c5-bdf0-bb22a2a200cc.png">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
