### PR TITLE
Rendering: Fix panel rendered count on error

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -445,7 +445,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
   };
 
   shouldSignalRenderingCompleted(loadingState: LoadingState, pluginMeta: PanelPluginMeta) {
-    return loadingState === LoadingState.Done || pluginMeta.skipDataQuery;
+    return loadingState === LoadingState.Done || loadingState === LoadingState.Error || pluginMeta.skipDataQuery;
   }
 
   skipFirstRender(loadingState: LoadingState) {


### PR DESCRIPTION
**What is this feature?**
This increments the `panelsRendered` count even if there was an error (as it still means the rendering is done).

**Why do we need this feature?**
This is needed because currently when there is an error the counter is not incremented which causes the rendering service to wait for the timeout to be reached. 

**Who is this feature for?**
Users of the rendering / reporting features.

