### PR TITLE
Fix: Hide invite when disabled login form is set

### DIFF
--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { mockToolkitActionCreator } from 'test/core/redux/mocks';
 
+import { config } from 'app/core/config';
+
 import { Props, UsersActionBarUnconnected } from './UsersActionBar';
 import { searchQueryChanged } from './state/reducers';
 
@@ -61,5 +63,18 @@ describe('Render', () => {
     });
 
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute('href', 'some/url');
+  });
+
+  it('should not show invite button when disableLoginForm is set', () => {
+    const originalDisableLoginForm = config.disableLoginForm;
+    config.disableLoginForm = true;
+
+    setup({
+      canInvite: true,
+    });
+
+    expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
+    // Reset the disableLoginForm mock to its original value
+    config.disableLoginForm = originalDisableLoginForm;
   });
 });

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -63,7 +63,7 @@ export const UsersActionBarUnconnected = ({
           <RadioButtonGroup value={showInvites ? 'invites' : 'users'} options={options} onChange={onShowInvites} />
         </div>
       )}
-      {canAddToOrg && <LinkButton href="org/users/invite">Invite</LinkButton>}
+      {!externalUserMngLinkUrl && canAddToOrg && <LinkButton href="org/users/invite">Invite</LinkButton>}
       {externalUserMngLinkUrl && (
         <LinkButton href={externalUserMngLinkUrl} target="_blank" rel="noopener">
           {externalUserMngLinkName}

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -49,7 +49,8 @@ export const UsersActionBarUnconnected = ({
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
   const canAddToOrg: boolean = contextSrv.hasAccess(AccessControlAction.OrgUsersAdd, canInvite);
-  const showInviteButton: boolean = canAddToOrg && !externalUserMngLinkUrl && !config.disableLoginForm;
+  // backend rejects invitations if the login form is disabled
+  const showInviteButton: boolean = canAddToOrg && !config.disableLoginForm;
 
   return (
     <div className="page-action-bar" data-testid="users-action-bar">

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { RadioButtonGroup, LinkButton, FilterInput } from '@grafana/ui';
+import config from 'app/core/config';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction, StoreState } from 'app/types';
 
@@ -48,6 +49,7 @@ export const UsersActionBarUnconnected = ({
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
   const canAddToOrg: boolean = contextSrv.hasAccess(AccessControlAction.OrgUsersAdd, canInvite);
+  const showInviteButton: boolean = canAddToOrg && !externalUserMngLinkUrl && !config.disableLoginForm;
 
   return (
     <div className="page-action-bar" data-testid="users-action-bar">
@@ -63,7 +65,7 @@ export const UsersActionBarUnconnected = ({
           <RadioButtonGroup value={showInvites ? 'invites' : 'users'} options={options} onChange={onShowInvites} />
         </div>
       )}
-      {!externalUserMngLinkUrl && canAddToOrg && <LinkButton href="org/users/invite">Invite</LinkButton>}
+      {showInviteButton && <LinkButton href="org/users/invite">Invite</LinkButton>}
       {externalUserMngLinkUrl && (
         <LinkButton href={externalUserMngLinkUrl} target="_blank" rel="noopener">
           {externalUserMngLinkName}


### PR DESCRIPTION
**What is this feature?**
- Add test for config set and remove the button
- Removes the invite button if the config disabledLoginForm is set

**Why do we need this feature?**
See the issue description, the gist is:
We need to remove the invite button from the frontend when disabled_login_form is set, because the backend rejects calls if this setting is true. So there is no need for the invite button

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana-authnz-team/issues/200
