### PR TITLE
NestedFolders: Make TagsCell return null when showing nothing

### DIFF
--- a/public/app/features/browse-dashboards/components/TagsCell.tsx
+++ b/public/app/features/browse-dashboards/components/TagsCell.tsx
@@ -10,11 +10,11 @@ import { DashboardsTreeItem } from '../types';
 export function TagsCell({ row: { original: data } }: CellProps<DashboardsTreeItem, unknown>) {
   const styles = useStyles2(getStyles);
   const item = data.item;
-  if (item.kind === 'ui-empty-folder') {
-    return <></>;
+  if (item.kind === 'ui-empty-folder' || !item.tags) {
+    return null;
   }
 
-  return <TagList className={styles.tagList} tags={item.tags ?? []} />;
+  return <TagList className={styles.tagList} tags={item.tags} />;
 }
 
 function getStyles(theme: GrafanaTheme2) {


### PR DESCRIPTION
Tidy up suggested by @ashharrison90.

I swear i tried this before, but it works now.

Perhaps return type is inferred better now that i made TagsCell a seperate components, rather than defined inline in DashboardsTree?