### PR TITLE
Log Context: Add `wrap lines` button to easier wrap lines

### DIFF
--- a/public/app/features/explore/utils/logs.ts
+++ b/public/app/features/explore/utils/logs.ts
@@ -4,4 +4,5 @@ export const SETTINGS_KEYS = {
   wrapLogMessage: 'grafana.explore.logs.wrapLogMessage',
   prettifyLogMessage: 'grafana.explore.logs.prettifyLogMessage',
   logsSortOrder: 'grafana.explore.logs.sortOrder',
+  logContextWrapLogMessage: 'grafana.explore.logs.logContext.wrapLogMessage',
 };

--- a/public/app/features/logs/components/log-context/LogContextButtons.tsx
+++ b/public/app/features/logs/components/log-context/LogContextButtons.tsx
@@ -7,11 +7,8 @@ import { ButtonGroup, ButtonSelect, InlineField, InlineFieldRow, InlineSwitch, u
 
 const getStyles = () => {
   return {
-    inlineButtons: css`
+    buttonGroup: css`
       display: inline-flex;
-    `,
-    center: css`
-      align-self: center;
     `,
   };
 };
@@ -50,7 +47,7 @@ export const LogContextButtons = (props: Props) => {
   const styles = useStyles2(getStyles);
 
   return (
-    <ButtonGroup className={styles.inlineButtons}>
+    <ButtonGroup className={styles.buttonGroup}>
       {position === 'top' && onChangeWrapLines && (
         <InlineFieldRow>
           <InlineField label="Wrap lines">

--- a/public/app/features/logs/components/log-context/LogContextButtons.tsx
+++ b/public/app/features/logs/components/log-context/LogContextButtons.tsx
@@ -1,13 +1,17 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { ButtonGroup, ButtonSelect, useStyles2 } from '@grafana/ui';
+import { reportInteraction } from '@grafana/runtime';
+import { ButtonGroup, ButtonSelect, InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
 
 const getStyles = () => {
   return {
-    logSamplesButton: css`
+    inlineButtons: css`
       display: inline-flex;
+    `,
+    center: css`
+      align-self: center;
     `,
   };
 };
@@ -24,14 +28,36 @@ export type Props = {
   option: SelectableValue<number>;
   onChangeOption: (item: SelectableValue<number>) => void;
   position?: 'top' | 'bottom';
+
+  wrapLines?: boolean;
+  onChangeWrapLines?: (wrapLines: boolean) => void;
 };
 
 export const LogContextButtons = (props: Props) => {
-  const { option, onChangeOption } = props;
+  const { option, onChangeOption, wrapLines, onChangeWrapLines, position } = props;
+  const internalOnChangeWrapLines = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      if (onChangeWrapLines) {
+        const state = event.currentTarget.checked;
+        reportInteraction('grafana_explore_logs_log_context_toggle_lines_clicked', {
+          state,
+        });
+        onChangeWrapLines(state);
+      }
+    },
+    [onChangeWrapLines]
+  );
   const styles = useStyles2(getStyles);
 
   return (
-    <ButtonGroup className={styles.logSamplesButton}>
+    <ButtonGroup className={styles.inlineButtons}>
+      {position === 'top' && onChangeWrapLines && (
+        <InlineFieldRow>
+          <InlineField label="Wrap lines">
+            <InlineSwitch value={wrapLines} onChange={internalOnChangeWrapLines} />
+          </InlineField>
+        </InlineFieldRow>
+      )}
       <ButtonSelect variant="canvas" value={option} options={LoadMoreOptions} onChange={onChangeOption} />
     </ButtonGroup>
   );

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -114,7 +114,7 @@ describe('LogRowContextModal', () => {
     await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
 
     const tenLinesButton = screen.getByRole('button', {
-      name: /10 lines/i,
+      name: /50 lines/i,
     });
     await userEvent.click(tenLinesButton);
     const twentyLinesButton = screen.getByRole('menuitemradio', {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -146,6 +146,9 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   const [loadingWidth, setLoadingWidth] = useState(0);
   const [loadMoreOption, setLoadMoreOption] = useState<SelectableValue<number>>(LoadMoreOptions[0]);
   const [contextQuery, setContextQuery] = useState<DataQuery | null>(null);
+  const [wrapLines, setWrapLines] = useState(
+    store.getBool(SETTINGS_KEYS.logContextWrapLogMessage, store.getBool(SETTINGS_KEYS.wrapLogMessage, true))
+  );
 
   const getFullTimeRange = useCallback(() => {
     const { before, after } = context;
@@ -265,7 +268,13 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
           Showing {context.after.length} lines {logsSortOrder === LogsSortOrder.Ascending ? 'after' : 'before'} match.
         </div>
         <div>
-          <LogContextButtons onChangeOption={onChangeLimitOption} option={loadMoreOption} />
+          <LogContextButtons
+            position="top"
+            wrapLines={wrapLines}
+            onChangeWrapLines={setWrapLines}
+            onChangeOption={onChangeLimitOption}
+            option={loadMoreOption}
+          />
         </div>
       </div>
       <div className={loading ? '' : styles.hidden}>
@@ -281,7 +290,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                   dedupStrategy={LogsDedupStrategy.none}
                   showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
                   showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
-                  wrapLogMessage={store.getBool(SETTINGS_KEYS.wrapLogMessage, true)}
+                  wrapLogMessage={wrapLines}
                   prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
                   enableLogDetails={true}
                   timeZone={timeZone}
@@ -299,7 +308,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                   dedupStrategy={LogsDedupStrategy.none}
                   showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
                   showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
-                  wrapLogMessage={store.getBool(SETTINGS_KEYS.wrapLogMessage, true)}
+                  wrapLogMessage={wrapLines}
                   prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
                   enableLogDetails={true}
                   timeZone={timeZone}
@@ -316,7 +325,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                   dedupStrategy={LogsDedupStrategy.none}
                   showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
                   showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
-                  wrapLogMessage={store.getBool(SETTINGS_KEYS.wrapLogMessage, true)}
+                  wrapLogMessage={wrapLines}
                   prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
                   enableLogDetails={true}
                   timeZone={timeZone}

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -142,9 +142,11 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   const theme = useTheme2();
   const styles = getStyles(theme);
   const [context, setContext] = useState<{ after: LogRowModel[]; before: LogRowModel[] }>({ after: [], before: [] });
-  const [limit, setLimit] = useState<number>(LoadMoreOptions[0].value!);
+  // LoadMoreOptions[2] refers to 50 lines
+  const defaultLimit = LoadMoreOptions[2];
+  const [limit, setLimit] = useState<number>(defaultLimit.value!);
   const [loadingWidth, setLoadingWidth] = useState(0);
-  const [loadMoreOption, setLoadMoreOption] = useState<SelectableValue<number>>(LoadMoreOptions[0]);
+  const [loadMoreOption, setLoadMoreOption] = useState<SelectableValue<number>>(defaultLimit);
   const [contextQuery, setContextQuery] = useState<DataQuery | null>(null);
   const [wrapLines, setWrapLines] = useState(
     store.getBool(SETTINGS_KEYS.logContextWrapLogMessage, store.getBool(SETTINGS_KEYS.wrapLogMessage, true))


### PR DESCRIPTION
**What is this feature?**

Log Context on small screen sizes with large log lines is not nice to navigate. This PR adds a toggle to wrap lines directly to LogContext.

NB: also changing the default lines to 50 in this PR since it's a very small change.