### PR TITLE
AzureMonitor: Correct series name accounting for dimensions

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -371,6 +371,9 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 	averageLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
 		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
+	averageLink2 := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana-1%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22%22%2C` +
+		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana-1%22%7D%7D%5D%7D%5D%7D`)
 	totalLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
 		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A1%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
@@ -502,7 +505,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
 					data.NewField("Blob Count", data.Labels{"blobtype": "PageBlob"},
 						[]*float64{util.Pointer(3.0), util.Pointer(3.0), util.Pointer(3.0), util.Pointer(3.0), util.Pointer(3.0), nil}).
-						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}, DisplayName: "Blob Count grafana"})),
+						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}})),
 
 				data.NewFrame("",
 					data.NewField("Time", nil,
@@ -510,7 +513,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
 					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"},
 						[]*float64{util.Pointer(1.0), util.Pointer(1.0), util.Pointer(1.0), util.Pointer(1.0), util.Pointer(1.0), nil}).
-						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}, DisplayName: "Blob Count grafana"})),
+						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}})),
 
 				data.NewFrame("",
 					data.NewField("Time", nil,
@@ -518,7 +521,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
 					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"},
 						[]*float64{util.Pointer(0.0), util.Pointer(0.0), util.Pointer(0.0), util.Pointer(0.0), util.Pointer(0.0), nil}).
-						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}, DisplayName: "Blob Count grafana"})),
+						SetConfig(&data.FieldConfig{Unit: "short", Links: []data.DataLink{averageLink}})),
 			},
 		},
 		{
@@ -686,9 +689,53 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute),
 					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
-					data.NewField("Percentage CPU", data.Labels{"microsoft.resourceid": "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana"}, []*float64{
+					data.NewField("Percentage CPU", data.Labels{"resourceName": "grafana"}, []*float64{
 						util.Pointer(2.0875), util.Pointer(2.1525), util.Pointer(2.155), util.Pointer(3.6925), util.Pointer(2.44),
-					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink}, DisplayName: "Percentage CPU grafana"}),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink}}),
+				),
+			},
+		},
+		{
+			name:         "multiple time series response with multiple dimensions",
+			responseFile: "10-azure-monitor-response-multi-with-dimensions.json",
+			mockQuery: &types.AzureMonitorQuery{
+				URL: "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/providers/microsoft.insights/metrics",
+				Params: url.Values{
+					"aggregation": {"Average"},
+				},
+			},
+			expectedFrames: data.Frames{
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
+					data.NewField("Percentage CPU", data.Labels{"resourceName": "grafana", "Test Dimension": "value-1"}, []*float64{
+						util.Pointer(2.0875), util.Pointer(2.1525), util.Pointer(2.155), util.Pointer(3.6925), util.Pointer(2.44),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink}}),
+				),
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink}}),
+					data.NewField("Percentage CPU", data.Labels{"resourceName": "grafana", "Test Dimension": "value-2"}, []*float64{
+						util.Pointer(2.0875), util.Pointer(2.1525), util.Pointer(2.155), util.Pointer(3.6925), util.Pointer(2.44),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink}}),
+				),
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink2}}),
+					data.NewField("Percentage CPU", data.Labels{"resourceName": "grafana-1", "Test Dimension": "value-1"}, []*float64{
+						util.Pointer(2.0875), util.Pointer(2.1525), util.Pointer(2.155), util.Pointer(3.6925), util.Pointer(2.44),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink2}}),
+				),
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{averageLink2}}),
+					data.NewField("Percentage CPU", data.Labels{"resourceName": "grafana-1", "Test Dimension": "value-3"}, []*float64{
+						util.Pointer(2.0875), util.Pointer(2.1525), util.Pointer(2.155), util.Pointer(3.6925), util.Pointer(2.44),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", Links: []data.DataLink{averageLink2}}),
 				),
 			},
 		},

--- a/pkg/tsdb/azuremonitor/testdata/azuremonitor/10-azure-monitor-response-multi-with-dimensions.json
+++ b/pkg/tsdb/azuremonitor/testdata/azuremonitor/10-azure-monitor-response-multi-with-dimensions.json
@@ -1,0 +1,180 @@
+{
+	"cost": 1439,
+	"timespan": "2022-09-28T15:33:05Z/2022-09-29T15:33:05Z",
+	"interval": "PT5M",
+	"value": [
+		{
+			"id": "subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/providers/Microsoft.Insights/metrics/Percentage CPU",
+			"type": "Microsoft.Insights/metrics",
+			"name": {
+				"value": "Percentage CPU",
+				"localizedValue": "Percentage CPU"
+			},
+			"unit": "Percent",
+			"timeseries": [
+				{
+					"metadatavalues": [
+						{
+							"name": {
+								"value": "microsoft.resourceid",
+								"localizedValue": "microsoft.resourceid"
+							},
+							"value": "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana"
+						},
+						{
+							"name": {
+								"value": "test-dimension",
+								"localizedValue": "Test Dimension"
+							},
+							"value": "value-1"
+						}
+					],
+					"data": [
+                        {
+                            "timeStamp": "2019-02-08T10:13:00Z",
+                            "average": 2.0875
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:14:00Z",
+                            "average": 2.1525
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:15:00Z",
+                            "average": 2.155
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:16:00Z",
+                            "average": 3.6925
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:17:00Z",
+                            "average": 2.44
+                          }
+                    ]
+				},
+				{
+					"metadatavalues": [
+						{
+							"name": {
+								"value": "microsoft.resourceid",
+								"localizedValue": "microsoft.resourceid"
+							},
+							"value": "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana"
+						},
+						{
+							"name": {
+								"value": "test-dimension",
+								"localizedValue": "Test Dimension"
+							},
+							"value": "value-2"
+						}
+					],
+					"data": [
+                        {
+                            "timeStamp": "2019-02-08T10:13:00Z",
+                            "average": 2.0875
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:14:00Z",
+                            "average": 2.1525
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:15:00Z",
+                            "average": 2.155
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:16:00Z",
+                            "average": 3.6925
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:17:00Z",
+                            "average": 2.44
+                          }
+                    ]
+				},
+				{
+					"metadatavalues": [
+						{
+							"name": {
+								"value": "microsoft.resourceid",
+								"localizedValue": "microsoft.resourceid"
+							},
+							"value": "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana-1"
+						},
+						{
+							"name": {
+								"value": "test-dimension",
+								"localizedValue": "Test Dimension"
+							},
+							"value": "value-1"
+						}
+					],
+					"data": [
+                        {
+                            "timeStamp": "2019-02-08T10:13:00Z",
+                            "average": 2.0875
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:14:00Z",
+                            "average": 2.1525
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:15:00Z",
+                            "average": 2.155
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:16:00Z",
+                            "average": 3.6925
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:17:00Z",
+                            "average": 2.44
+                          }
+                    ]
+				},
+				{
+					"metadatavalues": [
+						{
+							"name": {
+								"value": "microsoft.resourceid",
+								"localizedValue": "microsoft.resourceid"
+							},
+							"value": "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana-1"
+						},
+						{
+							"name": {
+								"value": "test-dimension",
+								"localizedValue": "Test Dimension"
+							},
+							"value": "value-3"
+						}
+					],
+					"data": [
+                        {
+                            "timeStamp": "2019-02-08T10:13:00Z",
+                            "average": 2.0875
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:14:00Z",
+                            "average": 2.1525
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:15:00Z",
+                            "average": 2.155
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:16:00Z",
+                            "average": 3.6925
+                          },
+                          {
+                            "timeStamp": "2019-02-08T10:17:00Z",
+                            "average": 2.44
+                          }
+                    ]
+				}
+			]
+		}
+	],
+	"namespace": "Microsoft.Compute/virtualMachines",
+	"resourceregion": "northeurope"
+}


### PR DESCRIPTION
A bug was introduced in #61750 that led to the series names being incorrect if the resultant data also included dimensions. The resource name was also always appended to the series name if the query in question was not a multi-resource query. 

This PR fixes that by allowing the built-in Grafana methods to determine the series name if the `alias` property is not set. In the case of multi-resource queries we append an additional `resourceName` label to ensure that each resource is distinguishable from the other.

Fixes #66858 
Fixes #63633 