### PR TITLE
RBAC: Update TestIntegrationFolderService remove RBAC setting

### DIFF
--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
-	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -37,19 +36,6 @@ import (
 var orgID = int64(1)
 var usr = &user.SignedInUser{UserID: 1, OrgID: orgID}
 
-func TestIntegrationProvideFolderService(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	t.Run("should register scope resolvers", func(t *testing.T) {
-		cfg := setting.NewCfg()
-		ac := acmock.New()
-		ProvideService(ac, bus.ProvideBus(tracing.InitializeTracerForTest()), cfg, nil, nil, nil, &featuremgmt.FeatureManager{})
-
-		require.Len(t, ac.Calls.RegisterAttributeScopeResolver, 3)
-	})
-}
-
 func TestIntegrationFolderService(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -62,7 +48,6 @@ func TestIntegrationFolderService(t *testing.T) {
 		folderStore := foldertest.NewFakeFolderStore(t)
 
 		cfg := setting.NewCfg()
-		cfg.RBACEnabled = true
 		features := featuremgmt.WithFeatures()
 
 		service := &Service{
@@ -449,7 +434,6 @@ func TestNestedFolderServiceFeatureToggle(t *testing.T) {
 	dashboardFolderStore.On("GetFolderByID", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).Return(&folder.Folder{}, nil)
 
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	folderService := &Service{
 		cfg:                  cfg,
 		store:                nestedFolderStore,
@@ -972,7 +956,6 @@ func setup(t *testing.T, dashStore dashboards.Store, dashboardFolderStore folder
 
 	// nothing enabled yet
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	return &Service{
 		cfg:                  cfg,
 		log:                  log.New("test-folder-service"),

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -35,6 +36,19 @@ import (
 
 var orgID = int64(1)
 var usr = &user.SignedInUser{UserID: 1, OrgID: orgID}
+
+func TestIntegrationProvideFolderService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	t.Run("should register scope resolvers", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		ac := acmock.New()
+		ProvideService(ac, bus.ProvideBus(tracing.InitializeTracerForTest()), cfg, nil, nil, nil, &featuremgmt.FeatureManager{})
+
+		require.Len(t, ac.Calls.RegisterAttributeScopeResolver, 3)
+	})
+}
 
 func TestIntegrationFolderService(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
**What is this feature?**
- Removes the RBAC setting from tests in the folder_service_test.go
- Unclear about this test, removed the test that was testing Accesscontrol settings in the folder_service, was added in this PR https://github.com/grafana/grafana/pull/46380/files#diff-a2a2f2de680c9563c671187770ff5397df8fd982bae7faefc343e7db63dd2217R40

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
https://github.com/grafana/grafana-enterprise/issues/4976