### PR TITLE
Prometheus: Adding VictoriaMetrics development enviroment

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -62,6 +62,18 @@ datasources:
       prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
       prometheusVersion: 2.40.0
 
+  - name: gdev-victoriametrics
+    uid: gdev-victoriametrics
+    type: prometheus
+    access: proxy
+    url: http://localhost:8428
+    jsonData:
+      manageAlerts: false # @todo add support for vmalerts
+      alertmanagerUid: gdev-alertmanager
+      prometheusType: VictoriaMetrics #Cortex | Mimir | Prometheus | Thanos | VictoriaMetrics
+      prometheusVersion: 1.90.0
+      incrementalQuerying: true
+
   - name: gdev-slow-prometheus
     type: prometheus
     access: proxy

--- a/devenv/docker/blocks/victoriametrics/Dockerfile
+++ b/devenv/docker/blocks/victoriametrics/Dockerfile
@@ -1,0 +1,4 @@
+FROM victoriametrics/victoria-metrics:latest
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/victoriametrics/alert.yml
+++ b/devenv/docker/blocks/victoriametrics/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/victoriametrics/docker-compose.yaml
+++ b/devenv/docker/blocks/victoriametrics/docker-compose.yaml
@@ -1,0 +1,30 @@
+  victoriametrics:
+    build: docker/blocks/victoriametrics
+    ports:
+      - "8428:8428"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --promscrape.config=/etc/prometheus/prometheus.yml
+
+  node_exporter:
+    image: prom/node-exporter
+    ports:
+      - "9100:9100"
+
+  fake-prometheus-data:
+    image: grafana/fake-data-gen
+    ports:
+      - "9091:9091"
+    environment:
+      FD_DATASOURCE: prom
+#
+#  alertmanager:
+#    image: quay.io/prometheus/alertmanager
+#    ports:
+#      - "9093:9093"
+
+  prometheus-random-data:
+    build: docker/blocks/prometheus_random_data
+    ports:
+      - "8081:8080"

--- a/devenv/docker/blocks/victoriametrics/prometheus.yml
+++ b/devenv/docker/blocks/victoriametrics/prometheus.yml
@@ -1,0 +1,47 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+#  evaluation_interval: 10s # By default, scrape targets every 15 seconds. not supported in VM config, needs to be set in vmalert
+  # scrape_timeout is set to the global default (10s).
+#
+## Load and evaluate rules in this file every 'evaluation_interval' seconds.
+#rule_files: not supported in VM config, needs to be set in vmalert
+#  - "alert.yml"
+#  - "recording.yml"
+## - "second.rules"
+
+#alerting: not supported in VM config, needs to be set in vmalert
+#  alertmanagers:
+#  - scheme: http
+#    static_configs:
+#    - targets:
+#      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'victoriametrics'
+    static_configs:
+      - targets: ['localhost:8428']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+#
+#  - job_name: 'mysql'
+#    static_configs:
+#      - targets: ['mysql-exporter:9104']
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/victoriametrics/recording.yml
+++ b/devenv/docker/blocks/victoriametrics/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}


### PR DESCRIPTION
This is a quick and dirty setup that basically copies our prometheus config and removes anything that broke in VM. VM has it's own alerting setup with [vmalert](https://docs.victoriametrics.com/vmalert.html), so alerting won't work in VM on this PR.

**What is this feature?**
Adding more devenvs for o11y-metrics hack day

**Why do we need this feature?**
Make it easier for developers to work with other prometheus types.

**Who is this feature for?**
Grafana developers, primarily o11y-metrics
