### PR TITLE
AppChrome: Fix scrollbar issue for small (mobile)  breakpoint

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -109,6 +109,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageContainer: css({
       label: 'page-container',
       flexGrow: 1,
+      minHeight: 0,
     }),
   };
 };


### PR DESCRIPTION
Noticed that when I reduce the width so the section nav moves to be above the page a scrollbar appears (and not the correct page scrollbar) 


![Screenshot from 2023-04-21 17-14-28](https://user-images.githubusercontent.com/10999/233673162-bbded14f-6fd7-4167-8b04-95eee6012e61.png)

![Screenshot from 2023-04-21 17-14-14](https://user-images.githubusercontent.com/10999/233673152-0c76839c-1af3-4435-a0c3-b44b0ab2c6a8.png)
