### PR TITLE
PublicDashboards: Remove flaky test

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -144,14 +144,6 @@ describe('SharePublic', () => {
     await renderSharePublicDashboard();
     expect(screen.getByText('Last 6 hours')).toBeInTheDocument();
   });
-  it('renders default absolute time in input 2', async () => {
-    mockDashboard.time = { from: '2022-08-30T03:00:00.000Z', to: '2022-09-04T02:59:59.000Z' };
-    //@ts-ignore
-    mockDashboard.originalTime = { from: '2022-08-30T06:00:00.000Z', to: '2022-09-04T06:59:59.000Z' };
-
-    await renderSharePublicDashboard();
-    expect(screen.getByText('2022-08-30 00:00:00 to 2022-09-04 00:59:59')).toBeInTheDocument();
-  });
   it('when modal is opened, then checkboxes are enabled but create button is disabled', async () => {
     server.use(getNonExistentPublicDashboardResponse());
     await renderSharePublicDashboard();


### PR DESCRIPTION
**What is this feature?**

Removing unit test that only works with Node 18 or above. The test itself it's not critical and it was causing issues and time effort when developers tried to run locally with a node version older than 18.
