### PR TITLE
Alerting: fix condition to distinguish multiple datasources type in dropdown

### DIFF
--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
@@ -12,6 +12,8 @@ import { getDataSourceSrv, DataSourcePickerState, DataSourcePickerProps } from '
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { ActionMeta, HorizontalGroup, PluginSignatureBadge, MultiSelect } from '@grafana/ui';
 
+import { isDataSourceManagingAlerts } from '../../utils/datasource';
+
 export interface MultipleDataSourcePickerProps extends Omit<DataSourcePickerProps, 'onChange' | 'current'> {
   onChange: (ds: DataSourceInstanceSettings, action: 'add' | 'remove') => void;
   current: string[] | undefined;
@@ -102,17 +104,15 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
       type,
     });
 
-    const alertManagingDs = dataSources
-      .filter((ds) => ds.jsonData.manageAlerts)
-      .map((ds) => ({
-        value: ds.name,
-        label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
-        imgUrl: ds.meta.info.logos.small,
-        meta: ds.meta,
-      }));
+    const alertManagingDs = dataSources.filter(isDataSourceManagingAlerts).map((ds) => ({
+      value: ds.name,
+      label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
+      imgUrl: ds.meta.info.logos.small,
+      meta: ds.meta,
+    }));
 
     const nonAlertManagingDs = dataSources
-      .filter((ds) => !ds.jsonData.manageAlerts)
+      .filter((ds) => !isDataSourceManagingAlerts(ds))
       .map((ds) => ({
         value: ds.name,
         label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,

--- a/public/app/features/alerting/unified/utils/datasource.test.ts
+++ b/public/app/features/alerting/unified/utils/datasource.test.ts
@@ -1,0 +1,39 @@
+import { mockDataSource } from '../mocks';
+
+import { isDataSourceManagingAlerts } from './datasource';
+
+describe('isDataSourceManagingAlerts', () => {
+  it('should return true when the prop is set as true', () => {
+    expect(
+      isDataSourceManagingAlerts(
+        mockDataSource({
+          jsonData: {
+            manageAlerts: true,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('should return true when the prop is undefined', () => {
+    expect(
+      isDataSourceManagingAlerts(
+        mockDataSource({
+          jsonData: {},
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+it('should return false when the prop is set as false', () => {
+  expect(
+    isDataSourceManagingAlerts(
+      mockDataSource({
+        jsonData: {
+          manageAlerts: false,
+        },
+      })
+    )
+  ).toBe(false);
+});

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -191,3 +191,7 @@ export function getDefaultOrFirstCompatibleDataSource(): DataSourceInstanceSetti
 
   return defaultIsCompatible ? defaultDataSource : getFirstCompatibleDataSource();
 }
+
+export function isDataSourceManagingAlerts(ds: DataSourceInstanceSettings<DataSourceJsonData>) {
+  return ds.jsonData.manageAlerts !== false; //if this prop is undefined it defaults to true
+}


### PR DESCRIPTION
**What is this feature?**

In the alert list view when searching by datasources, we distinguish between the ones that manage alert rules and the ones that don't. The condition for this differentiation was wrong making some alert-managing datasources be displayed under the "Other" category.
![image](https://user-images.githubusercontent.com/6271380/233689510-73c6d4e4-a047-4412-af24-1d6130fb8002.png)


**Why do we need this feature?**

To properly differentiate datasource types in the dropdown.

**Who is this feature for?**

All users.
