### PR TITLE
Cloudwatch Logs: Clarify Cloudwatch Logs Limits

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -74,9 +74,9 @@ export const ConfigEditor = (props: Props) => {
       <h3 className="page-heading">CloudWatch Logs</h3>
       <div className="gf-form-group">
         <InlineField
-          label="Timeout"
+          label="Retry Timeout"
           labelWidth={28}
-          tooltip='Custom timeout for CloudWatch Logs insights queries which have max concurrency limits. Default is 15 minutes. Must be a valid duration string, such as "15m" "30s" "2000ms" etc.'
+          tooltip='Cloudwatch Logs allows for a maximum of 30 concurrent queries. If Grafana hits a concurrent max query error from Cloudwatch Logs it will auto-retry requesting a query for up to 30min. This retry timeout strategy is configurable. Must be a valid duration string, such as "15m" "30s" "2000ms" etc.'
           invalid={Boolean(logsTimeoutError)}
         >
           <Input

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsSelector.tsx
@@ -139,11 +139,22 @@ export const LogGroupsSelector = ({
         <div>
           {!isLoading && selectableLogGroups.length >= 25 && (
             <>
-              <Label className={styles.limitLabel}>
+              <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
                 Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
                 search.
-              </Label>
+                <p>
+                  A{' '}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html"
+                  >
+                    maximum{' '}
+                  </a>{' '}
+                  of 50 Cloudwatch log groups can be queried at one time.
+                </p>
+              </div>
               <Space layout="block" v={1} />
             </>
           )}

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -26,6 +26,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     svg: {
       marginRight: theme.spacing(0.5),
     },
+    fontSize: 12,
   }),
 
   logGroupCountLabel: css({


### PR DESCRIPTION
**What is this feature?**
- notifies users that they can only query 50 log groups at a time
<img width="1081" alt="Screenshot 2023-04-21 at 4 29 59 PM" src="https://user-images.githubusercontent.com/6620164/233729160-9a5cee47-785a-4162-914b-6f7174aab8c9.png">

- clarifies what cloudwatch logs time out is about

<img width="493" alt="Screenshot 2023-04-21 at 4 29 44 PM" src="https://user-images.githubusercontent.com/6620164/233729191-d56a3a73-805e-4442-af11-6bcf9cecc2e4.png">
<img width="454" alt="Screenshot 2023-04-21 at 4 29 30 PM" src="https://user-images.githubusercontent.com/6620164/233729190-2552625c-066f-4c42-baec-3af017d9c932.png">

**Why do we need this feature?**
- It was unclear to users that they could only query 50 log groups at a time
- It was unclear to users what the cloudwatch log timeout does, as there is a [separate but unrelated cloudwatch logs timeout](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html) that is up to 60 minutes and not configurable:  In reality this timeout is referring to a retry limit that we do after hitting concurrency errors (https://github.com/grafana/grafana/pull/39290)

**Who is this feature for?**
Cloudwatch Logs users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64336
Fixes https://github.com/grafana/grafana/issues/65471

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
