### PR TITLE
Docs: Add labels for support bundles troubleshooting page

### DIFF
--- a/docs/sources/troubleshooting/support-bundles/index.md
+++ b/docs/sources/troubleshooting/support-bundles/index.md
@@ -1,5 +1,10 @@
 ---
 description: Learn how to send a support bundle to Grafana Labs support for troubleshooting
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
 keywords:
   - grafana
   - troubleshooting


### PR DESCRIPTION
**What is this feature?**

Adding Cloud label to the support bundles documentation.

**Why do we need this feature?**

[Support bundles](https://grafana.com/docs/grafana/next/troubleshooting/support-bundles/) are available in OSS, Enterprise and Cloud, however the page had only labels for Open Source and Enterprise. 

<img width="846" alt="Screenshot 2023-04-24 at 09 36 01" src="https://user-images.githubusercontent.com/1861190/233929616-e43d4c3d-d0f8-4ef3-be4a-e4c37710b911.png">

**Special notes for your reviewer:**

I assumed [cascading](https://github.com/grafana/grafana/blob/main/docs/sources/troubleshooting/_index.md?plain=1#L4) should work as the support bundles docs are in the main troubleshooting directory, however they seem to be not working in this case. Is it perhaps because [cascading](https://grafana.com/docs/writers-toolkit/writing-guide/front-matter/#labels) applies only to the files under current directory and not to subfolders.