### PR TITLE
NestedFolders: Basic search view

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -50,7 +50,7 @@ const BrowseDashboardsPage = memo(({ match, location }: Props) => {
           <AutoSizer>
             {({ width, height }) =>
               searchState.query ? (
-                <SearchView searchState={searchState} />
+                <SearchView width={width} height={height} folderUID={folderUID} />
               ) : (
                 <BrowseView width={width} height={height} folderUID={folderUID} />
               )

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -1,17 +1,61 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { parseRouteParams } from 'app/features/search/utils';
+import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
+import { SearchResultsProps, SearchResultsTable } from 'app/features/search/page/components/SearchResultsTable';
+import { newSearchSelection, updateSearchSelection } from 'app/features/search/page/selection';
+import { getSearchStateManager } from 'app/features/search/state/SearchStateManager';
 
 interface SearchViewProps {
-  searchState: ReturnType<typeof parseRouteParams>;
+  height: number;
+  width: number;
+  folderUID: string | undefined;
 }
 
-export function SearchView({ searchState }: SearchViewProps) {
-  return (
-    <div>
-      <p>SearchView</p>
+export function SearchView({ folderUID, width, height }: SearchViewProps) {
+  const showManage = true; // TODO: bring this in from parent?
 
-      <pre>{JSON.stringify(searchState, null, 2)}</pre>
-    </div>
+  const { keyboardEvents } = useKeyNavigationListener();
+
+  const stateManager = getSearchStateManager();
+  useEffect(() => stateManager.initStateFromUrl(folderUID), [folderUID, stateManager]);
+
+  const state = stateManager.useState();
+
+  const [searchSelection, setSearchSelection] = useState(() => newSearchSelection());
+
+  const value = state.result;
+
+  const selection = showManage ? searchSelection.isSelected : undefined;
+
+  const clearSelection = useCallback(() => {
+    searchSelection.items.clear();
+    setSearchSelection({ ...searchSelection });
+  }, [searchSelection]);
+
+  const toggleSelection = useCallback(
+    (kind: string, uid: string) => {
+      const current = searchSelection.isSelected(kind, uid);
+      setSearchSelection(updateSearchSelection(searchSelection, !current, kind, [uid]));
+    },
+    [searchSelection]
   );
+
+  if (!value) {
+    return <div>loading?</div>;
+  }
+
+  const props: SearchResultsProps = {
+    response: value,
+    selection,
+    selectionToggle: toggleSelection,
+    clearSelection,
+    width: width,
+    height: height,
+    onTagSelected: stateManager.onAddTag,
+    keyboardEvents,
+    onDatasourceChange: state.datasource ? stateManager.onDatasourceChange : undefined,
+    onClickItem: stateManager.onSearchItemClicked,
+  };
+
+  return <SearchResultsTable {...props} />;
 }

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
+import { Spinner } from '@grafana/ui';
 import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
 import { SearchResultsProps, SearchResultsTable } from 'app/features/search/page/components/SearchResultsTable';
-import { newSearchSelection, updateSearchSelection } from 'app/features/search/page/selection';
 import { getSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { DashboardViewItemKind } from 'app/features/search/types';
 import { useDispatch, useSelector } from 'app/types';
@@ -18,7 +18,6 @@ interface SearchViewProps {
 export function SearchView({ folderUID, width, height }: SearchViewProps) {
   const dispatch = useDispatch();
   const selectedItems = useSelector((wholeState) => wholeState.browseDashboards.selectedItems);
-  const showManage = true; // TODO: bring this in from parent?
 
   const { keyboardEvents } = useKeyNavigationListener();
 
@@ -26,9 +25,6 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
   useEffect(() => stateManager.initStateFromUrl(folderUID), [folderUID, stateManager]);
 
   const state = stateManager.useState();
-
-  const [searchSelection, setSearchSelection] = useState(() => newSearchSelection());
-
   const value = state.result;
 
   const selectionChecker = useCallback(
@@ -43,9 +39,8 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
   );
 
   const clearSelection = useCallback(() => {
-    searchSelection.items.clear();
-    setSearchSelection({ ...searchSelection });
-  }, [searchSelection]);
+    console.log('TODO: clearSelection');
+  }, []);
 
   const handleItemSelectionChange = useCallback(
     (kind: string, uid: string) => {
@@ -59,7 +54,11 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
   );
 
   if (!value) {
-    return <div>loading?</div>;
+    return (
+      <div>
+        <Spinner />
+      </div>
+    );
   }
 
   const props: SearchResultsProps = {

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -4,6 +4,10 @@ import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKey
 import { SearchResultsProps, SearchResultsTable } from 'app/features/search/page/components/SearchResultsTable';
 import { newSearchSelection, updateSearchSelection } from 'app/features/search/page/selection';
 import { getSearchStateManager } from 'app/features/search/state/SearchStateManager';
+import { DashboardViewItemKind } from 'app/features/search/types';
+import { useDispatch, useSelector } from 'app/types';
+
+import { setItemSelectionState } from '../state';
 
 interface SearchViewProps {
   height: number;
@@ -12,6 +16,8 @@ interface SearchViewProps {
 }
 
 export function SearchView({ folderUID, width, height }: SearchViewProps) {
+  const dispatch = useDispatch();
+  const selectedItems = useSelector((wholeState) => wholeState.browseDashboards.selectedItems);
   const showManage = true; // TODO: bring this in from parent?
 
   const { keyboardEvents } = useKeyNavigationListener();
@@ -25,19 +31,31 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
 
   const value = state.result;
 
-  const selection = showManage ? searchSelection.isSelected : undefined;
+  const selectionChecker = useCallback(
+    (kind: string | undefined, uid: string): boolean => {
+      if (!kind || kind === '*') {
+        return false;
+      }
+
+      return selectedItems[assertDashboardViewItemKind(kind)][uid] ?? false;
+    },
+    [selectedItems]
+  );
 
   const clearSelection = useCallback(() => {
     searchSelection.items.clear();
     setSearchSelection({ ...searchSelection });
   }, [searchSelection]);
 
-  const toggleSelection = useCallback(
+  const handleItemSelectionChange = useCallback(
     (kind: string, uid: string) => {
-      const current = searchSelection.isSelected(kind, uid);
-      setSearchSelection(updateSearchSelection(searchSelection, !current, kind, [uid]));
+      const newIsSelected = !selectionChecker(kind, uid);
+
+      dispatch(
+        setItemSelectionState({ item: { kind: assertDashboardViewItemKind(kind), uid }, isSelected: newIsSelected })
+      );
     },
-    [searchSelection]
+    [selectionChecker, dispatch]
   );
 
   if (!value) {
@@ -46,8 +64,8 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
 
   const props: SearchResultsProps = {
     response: value,
-    selection,
-    selectionToggle: toggleSelection,
+    selection: selectionChecker,
+    selectionToggle: handleItemSelectionChange,
     clearSelection,
     width: width,
     height: height,
@@ -58,4 +76,17 @@ export function SearchView({ folderUID, width, height }: SearchViewProps) {
   };
 
   return <SearchResultsTable {...props} />;
+}
+
+function assertDashboardViewItemKind(kind: string): DashboardViewItemKind {
+  switch (kind) {
+    case 'folder':
+      return 'folder';
+    case 'dashboard':
+      return 'dashboard';
+    case 'panel':
+      return 'panel';
+  }
+
+  throw new Error('Unsupported kind' + kind);
 }

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -38,7 +38,10 @@ export function setFolderOpenState(
 
 export function setItemSelectionState(
   state: BrowseDashboardsState,
-  action: PayloadAction<{ item: DashboardViewItem; isSelected: boolean }>
+
+  // SearchView doesn't use DashboardViewItemKind (yet), so we pick just the specific properties
+  // we're interested in
+  action: PayloadAction<{ item: Pick<DashboardViewItem, 'kind' | 'uid' | 'parentUID'>; isSelected: boolean }>
 ) {
   const { item, isSelected } = action.payload;
 

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -1,5 +1,7 @@
 import { DashboardViewItem as DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
+export type DashboardTreeSelection = Record<DashboardViewItemKind, Record<string, boolean | undefined>>;
+
 export interface BrowseDashboardsState {
   rootItems: DashboardViewItem[];
   childrenByParentUID: Record<string, DashboardViewItem[] | undefined>;
@@ -21,7 +23,5 @@ export interface DashboardsTreeItem<T extends DashboardViewItemWithUIItems = Das
   level: number;
   isOpen: boolean;
 }
-
-export type DashboardTreeSelection = Record<DashboardViewItemKind, Record<string, boolean | undefined>>;
 
 export const INDENT_AMOUNT_CSS_VAR = '--dashboards-tree-indentation';


### PR DESCRIPTION
Starts to restore Search in the new Browse Dashboards

 - Copies SearchView from existing search into new view
    - I would like to refactor this to make this whole component tree more in line with BrowseView, but that's something for another day :) 
 - Stores selection state in the same redux store in browse:
    - Note: ultimately I think we're going to need to seperate these selection states, but keeping them the same for now to see how that goes
    - I also think there's a bit of a perf issue when selecting items in SearchView that doesn't appear to be in BrowseView. I presume this is due to the `selectionChecker` function triggering more updates than it does in old/existing search
 - It _doesn't_ connect the Search input, filters, or sort options, so they're still not functional. At the moment the only way to do a search is via URL - `/nested-dashboards?sort=alpha-desc&query=Annotation`

Part of https://github.com/grafana/grafana/issues/65604   
Part of https://github.com/grafana/grafana/issues/66935