### PR TITLE
NestedFolders: Rename 'General' to 'Dashboards' in FolderPicker

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -5,6 +5,7 @@ import { useAsync } from 'react-use';
 
 import { AppEvents, SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { useStyles2, ActionMeta, Input, InputActionMeta, AsyncVirtualizedSelect } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
@@ -70,13 +71,15 @@ export function FolderPicker(props: Props) {
     initialFolderUid,
     initialTitle = '',
     permissionLevel = PermissionLevelString.Edit,
-    rootName = 'General',
+    rootName: rootNameProp,
     showRoot = true,
     skipInitialLoad,
     searchQueryType,
     customAdd,
     folderWarning,
   } = props;
+
+  const rootName = rootNameProp ?? config.featureToggles.nestedFolders ? 'Dashboards' : 'General';
 
   const [folder, setFolder] = useState<SelectedFolder | null>(null);
   const [isCreatingNew, setIsCreatingNew] = useState(false);


### PR DESCRIPTION
When nestedFolders is enabled, we don't have a General folder. Dashboards are just shown at the root view.

This PR renames the "General" folder item to "Dashboards" when nestedFolders feature flag is enabled.

![image](https://user-images.githubusercontent.com/46142/234018187-1948bfa5-38f1-4daf-b2e3-6e87c0d1f4f1.png)

Part of https://github.com/grafana/grafana/issues/65604