### PR TITLE
Prometheus: remove part of flaky e2e test

### DIFF
--- a/e2e/various-suite/query-editor.spec.ts
+++ b/e2e/various-suite/query-editor.spec.ts
@@ -30,11 +30,6 @@ e2e.scenario({
 
     cy.contains(queryText).should('be.visible');
 
-    cy.get('body').click();
     e2e.components.Alert.alertV2('error').should('not.be.visible');
-
-    cy.contains('label', 'Builder').click();
-
-    cy.get('[data-testid="operations.0.wrapper"]').should('be.visible');
   },
 });


### PR DESCRIPTION
This test only checks 'undo' in the code editor and then checks if the query builder is present. The test is timing out when looking for the query builder. There should be a second test to check if undo works in the query builder so I'm removing the query builder check. I will add an issue to create a test for 'undo' in the query builder.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
