### PR TITLE
Docs: Clarify backport milestone

### DIFF
--- a/.github/bot.md
+++ b/.github/bot.md
@@ -23,7 +23,7 @@ Metrics are configured in [metrics-collector.json](https://github.com/grafana/gr
 ## Backport PR
 
 To automatically backport a PR to a release branch like v7.3.x add a label named `backport v7.3.x`. The label name should follow the pattern `backport <branch-name>`. Once merged grafanabot will automatically 
-try to cherry-pick the PR merge commit into that branch and open a PR. You must then add the milestone to your backport pr.
+try to cherry-pick the PR merge commit into that branch and open a PR. You must then add the milestone to your backport PR.
 
 If there are merge conflicts the bot will write a comment on the source PR saying the cherry-pick failed. In this case you have to do the cherry pick and backport PR manually. 
 

--- a/.github/bot.md
+++ b/.github/bot.md
@@ -23,7 +23,7 @@ Metrics are configured in [metrics-collector.json](https://github.com/grafana/gr
 ## Backport PR
 
 To automatically backport a PR to a release branch like v7.3.x add a label named `backport v7.3.x`. The label name should follow the pattern `backport <branch-name>`. Once merged grafanabot will automatically 
-try to cherry-pick the PR merge commit into that branch and open a PR. It will sync the milestone with the source PR so make sure the source PR also is assigned the milestone for the patch release. If the PR is already merged you can still add this label and trigger the backport automation. 
+try to cherry-pick the PR merge commit into that branch and open a PR. You must then add the milestone to your backport pr.
 
 If there are merge conflicts the bot will write a comment on the source PR saying the cherry-pick failed. In this case you have to do the cherry pick and backport PR manually. 
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -44,7 +44,7 @@ A milestone **should** be added to every pull request. Several things in the Gra
 
 This makes it easier to track what changes go into a certain release. Without this information, release managers have to go through git commits which is not an efficient process.
 
-Always assign the milestone for the version that a pr is merged into. Ex: if you create a pr that is going to be merged into the next minor (1.2.x) and you assign a backport label so that it is also released in the next patch (1.1.x), then put the milestone of the next minor in the original pr (1.2.x), and the milestone of the backport on the backport pr (1.1.x).
+Always assign the milestone for the version that a PR is merged into. PRs targetting `main` should use the next minor (or major) version and backport PRs should use the same value than the target branch.
 
 ### Include in changelog and release notes?
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -44,6 +44,8 @@ A milestone **should** be added to every pull request. Several things in the Gra
 
 This makes it easier to track what changes go into a certain release. Without this information, release managers have to go through git commits which is not an efficient process.
 
+Always assign the milestone for the version that a pr is merged into. Ex: if you create a pr that is going to be merged into the next minor (1.2.x) and you assign a backport label so that it is also released in the next patch (1.1.x), then put the milestone of the next minor in the original pr (1.2.x), and the milestone of the backport on the backport pr (1.1.x).
+
 ### Include in changelog and release notes?
 
 At Grafana we generate the [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md) and [release notes](https://grafana.com/docs/grafana/latest/release-notes/) based on merged pull requests. Including changes in the changelog/release notes is very important to provide a somewhat complete picture of what changes a Grafana release actually includes.


### PR DESCRIPTION
Clarifies how to handle milestones when creating a pr that will be backported

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
