### PR TITLE
Loki: Enable dataplane-compliant metric data by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -36,6 +36,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `logsSampleInExplore`               | Enables access to the logs sample feature in Explore                                                                                                                                                | Yes                |
 | `logsContextDatasourceUi`           | Allow datasource to provide custom UI for context view                                                                                                                                              | Yes                |
 | `prometheusDataplane`               | Changes responses to from Prometheus to be compliant with the dataplane specification. In particular it sets the numeric Field.Name from 'Value' to the value of the `__name__` label when present. | Yes                |
+| `lokiMetricDataplane`               | Changes metric responses from Loki to be compliant with the dataplane specification.                                                                                                                | Yes                |
 | `dataplaneFrontendFallback`         | Support dataplane contract field name change for transformations and field name matchers where the name is different                                                                                | Yes                |
 | `useCachingService`                 | When turned on, the new query and resource caching implementation using a wire service inject will be used in place of the previous middleware implementation                                       |                    |
 
@@ -101,7 +102,6 @@ Alpha features might be changed or removed without prior notice.
 | `prometheusResourceBrowserCache`   | Displays browser caching options in Prometheus data source configuration                                       |
 | `influxdbBackendMigration`         | Query InfluxDB InfluxQL without the proxy                                                                      |
 | `clientTokenRotation`              | Replaces the current in-request token rotation so that the client initiates the rotation                       |
-| `lokiMetricDataplane`              | Changes responses from Loki to be compliant with the dataplane specification.                                  |
 | `disableSSEDataplane`              | Disables dataplane specific processing in server side expressions.                                             |
 | `alertStateHistoryLokiSecondary`   | Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.   |
 | `alertStateHistoryLokiPrimary`     | Enable a remote Loki instance as the primary source for state history reads.                                   |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -435,8 +435,9 @@ var (
 		},
 		{
 			Name:        "lokiMetricDataplane",
-			Description: "Changes responses from Loki to be compliant with the dataplane specification.",
-			State:       FeatureStateAlpha,
+			Description: "Changes metric responses from Loki to be compliant with the dataplane specification.",
+			State:       FeatureStateStable,
+			Expression:  "true",
 			Owner:       grafanaObservabilityLogsSquad,
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -63,7 +63,7 @@ prometheusResourceBrowserCache,alpha,@grafana/observability-metrics,false,false,
 influxdbBackendMigration,alpha,@grafana/observability-metrics,false,false,false,true
 clientTokenRotation,alpha,@grafana/grafana-authnz-team,false,false,false,false
 prometheusDataplane,stable,@grafana/observability-metrics,false,false,false,false
-lokiMetricDataplane,alpha,@grafana/observability-logs,false,false,false,false
+lokiMetricDataplane,stable,@grafana/observability-logs,false,false,false,false
 dataplaneFrontendFallback,stable,@grafana/observability-metrics,false,false,false,true
 disableSSEDataplane,alpha,@grafana/observability-metrics,false,false,false,false
 alertStateHistoryLokiSecondary,alpha,@grafana/alerting-squad,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -264,7 +264,7 @@ const (
 	FlagPrometheusDataplane = "prometheusDataplane"
 
 	// FlagLokiMetricDataplane
-	// Changes responses from Loki to be compliant with the dataplane specification.
+	// Changes metric responses from Loki to be compliant with the dataplane specification.
 	FlagLokiMetricDataplane = "lokiMetricDataplane"
 
 	// FlagDataplaneFrontendFallback


### PR DESCRIPTION
With the feature-flag enabled by default, the dataframes emitted by the loki datasource plugin will be compliant with the [TimeSeriesMulti](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-multi-format-timeseriesmulti) dataplane format.

the change this causes is fairly minimal, we do not expect many problems, but it is an observable change in the format, so it is a breaking change. affected users can disable the feature-flag to return to the previous behavior. at a certain point in the future, the feature-flag will be removed and it will not be possible to switch back to the "old" format.

# Release notice breaking change

The data-format used by the Loki data source  for metric (graph producing) queries was changed to be compliant with the recommended Grafana format. The change is very small, we do not expect it to cause problems: for instant-queries the dataframe-type changed from `timeseries-multi` to `numeric-multi`, the dataframe-name attribute is not used anymore. If you are affected by this, you can revert back to the old format by setting the feature flag `lokiMetricDataplane` to `false`. We recommend migrating to the new format, because the feature-flag will be removed at some point in the future.