### PR TITLE
Advanced DS Picker points to Connections page when toggle is enabled

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -13,7 +13,10 @@ import {
   Input,
   Icon,
 } from '@grafana/ui';
+import { config } from 'app/core/config';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import * as DFImport from 'app/features/dataframe-import';
+import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 
 import { DataSourceList } from './DataSourceList';
 
@@ -35,6 +38,9 @@ export function DataSourceModal({
 }: DataSourceModalProps) {
   const styles = useStyles2(getDataSourceModalStyles);
   const [search, setSearch] = useState('');
+  const newDataSourceURL = config.featureToggles.dataConnectionsConsole
+    ? CONNECTIONS_ROUTES.DataSourcesNew
+    : DATASOURCES_ROUTES.New;
 
   return (
     <Modal
@@ -96,7 +102,7 @@ export function DataSourceModal({
           )}
         </div>
         <div className={styles.dsCTAs}>
-          <LinkButton variant="secondary" href={`datasources/new`}>
+          <LinkButton variant="secondary" href={newDataSourceURL}>
             Configure a new data source
           </LinkButton>
         </div>


### PR DESCRIPTION
|Before|After|
|-|-|
|![2023-04-24 17 32 38](https://user-images.githubusercontent.com/5699976/234045798-f06f7a46-8732-471a-aecb-a1dcefc77f17.gif)|![2023-04-24 17 35 41](https://user-images.githubusercontent.com/5699976/234045824-c5e76545-e8fd-4d1a-aa6d-24a154b20390.gif)|

**Problem**
The new DS picker uses `datasources/new` to create a new DS. But the new page to manage DS is `your-connections/datasources/new`.

**Solution**
We check if the feature toggle for the connection page. If it is enabled, we use the new one.