### PR TITLE
Prometheus: Default cache value in UI doesn't match functional default

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -357,7 +357,10 @@ export const PromSettings = (props: Props) => {
                     className={`width-25`}
                     onChange={onChangeHandler('cacheLevel', options, onOptionsChange)}
                     options={cacheValueOptions}
-                    value={cacheValueOptions.find((o) => o.value === options.jsonData.cacheLevel)}
+                    disabled={options.readOnly}
+                    value={
+                      cacheValueOptions.find((o) => o.value === options.jsonData.cacheLevel) ?? PrometheusCacheLevel.Low
+                    }
                   />
                 }
               />

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -139,7 +139,7 @@ export class QueryCache {
             let fetchUrl = entryTypeCast.name;
 
             if (fetchUrl.includes('/api/ds/query')) {
-              let match = fetchUrl.match(/requestId=([a-z\d]+)/i);
+              let match = fetchUrl.match(/requestid=([a-z\d]+)/i);
 
               if (match) {
                 let requestId = match[1];

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -139,7 +139,7 @@ export class QueryCache {
             let fetchUrl = entryTypeCast.name;
 
             if (fetchUrl.includes('/api/ds/query')) {
-              let match = fetchUrl.match(/requestid=([a-z\d]+)/i);
+              let match = fetchUrl.match(/requestId=([a-z\d]+)/i);
 
               if (match) {
                 let requestId = match[1];


### PR DESCRIPTION
**What is this feature?**
When viewing the prometheus config, and this value isn't already set, currently we display "Choose" instead of the functional default when no value is selected, which is "Low".

**Why do we need this feature?**
Fix UI bugs, set better expectations, don't confuse users.

**Who is this feature for?**
Users of prometheus data source configuration UI.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/67158

**Special notes for your reviewer:**
Looks like I forgot to check this the first time around, the code will functionally default to the Low cache value, this just brings the UI inline with that behavior.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
