### PR TITLE
Alerting: Fix panic when reparenting receivers to groups following an attempted rename via Provisioning

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -453,7 +453,7 @@ groupLoop:
 
 				// Otherwise, we only want to rename the receiver we are touching... NOT all of them.
 				// Check to see whether a different group with the name we want already exists.
-				for i, candidateExistingGroup := range cfg.AlertmanagerConfig.Receivers {
+				for _, candidateExistingGroup := range cfg.AlertmanagerConfig.Receivers {
 					// If so, put our modified receiver into that group. Done!
 					if candidateExistingGroup.Name == target.Name {
 						// Drop it from the old group...

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -619,67 +619,6 @@ func TestStitchReceivers(t *testing.T) {
 			},
 		},
 		{
-			name: "rename to another existing group, moves receiver",
-			new: &definitions.PostableGrafanaReceiver{
-				UID:  "def",
-				Name: "receiver-1",
-				Type: "slack",
-			},
-			expModified: true,
-			expCfg: definitions.PostableApiAlertingConfig{
-				Config: definitions.Config{
-					Route: &definitions.Route{
-						Receiver: "receiver-1",
-						Routes: []*definitions.Route{
-							{
-								Receiver: "receiver-1",
-							},
-						},
-					},
-				},
-				Receivers: []*definitions.PostableApiReceiver{
-					{
-						Receiver: config.Receiver{
-							Name: "receiver-1",
-						},
-						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
-							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
-								{
-									UID:  "abc",
-									Name: "receiver-1",
-									Type: "slack",
-								},
-								{
-									UID:  "def",
-									Name: "receiver-1",
-									Type: "slack",
-								},
-							},
-						},
-					},
-					{
-						Receiver: config.Receiver{
-							Name: "receiver-2",
-						},
-						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
-							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
-								{
-									UID:  "ghi",
-									Name: "receiver-2",
-									Type: "email",
-								},
-								{
-									UID:  "jkl",
-									Name: "receiver-2",
-									Type: "discord",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "rename when there are many groups",
 			initial: &definitions.PostableUserConfig{
 				AlertmanagerConfig: definitions.PostableApiAlertingConfig{

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -494,6 +494,353 @@ func TestStitchReceivers(t *testing.T) {
 			},
 		},
 		{
+			name: "rename to another, larger group",
+			initial: &definitions.PostableUserConfig{
+				AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+					Config: definitions.Config{
+						Route: &definitions.Route{
+							Receiver: "receiver-1",
+							Routes: []*definitions.Route{
+								{
+									Receiver: "receiver-1",
+								},
+							},
+						},
+					},
+					Receivers: []*definitions.PostableApiReceiver{
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-1",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "1",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+									{
+										UID:  "2",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+								},
+							},
+						},
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-2",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "3",
+										Name: "receiver-2",
+										Type: "slack",
+									},
+									{
+										UID:  "4",
+										Name: "receiver-2",
+										Type: "slack",
+									},
+									{
+										UID:  "5",
+										Name: "receiver-2",
+										Type: "slack",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &definitions.PostableGrafanaReceiver{
+				UID:  "2",
+				Name: "receiver-2",
+				Type: "slack",
+			},
+			expModified: true,
+			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-1",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "1",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+							},
+						},
+					},
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-2",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "3",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+								{
+									UID:  "4",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+								{
+									UID:  "5",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+								{
+									UID:  "2",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rename to another existing group, moves receiver",
+			new: &definitions.PostableGrafanaReceiver{
+				UID:  "def",
+				Name: "receiver-1",
+				Type: "slack",
+			},
+			expModified: true,
+			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-1",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "abc",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+								{
+									UID:  "def",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+							},
+						},
+					},
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-2",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "ghi",
+									Name: "receiver-2",
+									Type: "email",
+								},
+								{
+									UID:  "jkl",
+									Name: "receiver-2",
+									Type: "discord",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rename when there are many groups",
+			initial: &definitions.PostableUserConfig{
+				AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+					Config: definitions.Config{
+						Route: &definitions.Route{
+							Receiver: "receiver-1",
+							Routes: []*definitions.Route{
+								{
+									Receiver: "receiver-1",
+								},
+							},
+						},
+					},
+					Receivers: []*definitions.PostableApiReceiver{
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-1",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "1",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+									{
+										UID:  "2",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+								},
+							},
+						},
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-2",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "3",
+										Name: "receiver-2",
+										Type: "slack",
+									},
+								},
+							},
+						},
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-3",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "4",
+										Name: "receiver-4",
+										Type: "slack",
+									},
+								},
+							},
+						},
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-4",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "5",
+										Name: "receiver-4",
+										Type: "slack",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &definitions.PostableGrafanaReceiver{
+				UID:  "2",
+				Name: "receiver-4",
+				Type: "slack",
+			},
+			expModified: true,
+			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-1",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "1",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+							},
+						},
+					},
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-2",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "3",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+							},
+						},
+					},
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-3",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "4",
+									Name: "receiver-4",
+									Type: "slack",
+								},
+							},
+						},
+					},
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-4",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "5",
+									Name: "receiver-4",
+									Type: "slack",
+								},
+								{
+									UID:  "2",
+									Name: "receiver-4",
+									Type: "slack",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "rename to a name that doesn't exist, creates new group and moves",
 			new: &definitions.PostableGrafanaReceiver{
 				UID:  "jkl",


### PR DESCRIPTION
**What is this feature?**

Fixes a panic caused by renaming contact groups in certain cases. The logic to re-group the points by name contained a bug where an index was incorrectly shadowed.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
