### PR TITLE
DataGrid: Avoid MutableDataFrame where possible

### DIFF
--- a/public/app/plugins/panel/datagrid/utils.test.ts
+++ b/public/app/plugins/panel/datagrid/utils.test.ts
@@ -70,6 +70,20 @@ describe('when deleting rows', () => {
     expect(newDf.fields[2].values.toArray()).toEqual([]);
     expect(newDf.length).toEqual(0);
   });
+
+  it('should do nothing if there are no fields', () => {
+    const newDf = deleteRows(
+      {
+        name: 'emptyDataframe',
+        fields: [],
+        length: 0,
+      },
+      [0, 1, 2, 3, 4],
+      true
+    );
+
+    expect(newDf.length).toEqual(0);
+  });
 });
 
 describe('when clearing cells from range selection', () => {
@@ -118,5 +132,18 @@ describe('when clearing cells from range selection', () => {
     expect(newDf.fields[1].values.toArray()).toEqual([1, null, 3, 4, 5]);
     expect(newDf.fields[2].values.toArray()).toEqual(['a', 'b', 'c', 'd', 'e']);
     expect(newDf.length).toEqual(5);
+  });
+
+  it('should do nothing if there are no fields', () => {
+    const newDf = clearCellsFromRangeSelection(
+      {
+        name: 'emptyDataframe',
+        fields: [],
+        length: 0,
+      },
+      { x: 0, y: 0, width: 0, height: 0 }
+    );
+
+    expect(newDf.length).toEqual(0);
   });
 });

--- a/public/app/plugins/panel/datagrid/utils.ts
+++ b/public/app/plugins/panel/datagrid/utils.ts
@@ -1,16 +1,7 @@
 import { css } from '@emotion/css';
 import { CompactSelection, GridCell, GridCellKind, GridSelection, Theme } from '@glideapps/glide-data-grid';
 
-import {
-  ArrayVector,
-  DataFrame,
-  DataFrameJSON,
-  dataFrameToJSON,
-  MutableDataFrame,
-  Field,
-  GrafanaTheme2,
-  FieldType,
-} from '@grafana/data';
+import { ArrayVector, DataFrame, DataFrameJSON, dataFrameToJSON, Field, GrafanaTheme2, FieldType } from '@grafana/data';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
 
@@ -131,7 +122,10 @@ export const deleteRows = (gridData: DataFrame, rows: number[], hardDelete = fal
     field.values = new ArrayVector(valuesArray);
   }
 
-  return new MutableDataFrame(gridData);
+  return {
+    ...gridData,
+    fields: [...gridData.fields],
+  };
 };
 
 export const clearCellsFromRangeSelection = (gridData: DataFrame, range: CellRange): DataFrame => {
@@ -147,7 +141,10 @@ export const clearCellsFromRangeSelection = (gridData: DataFrame, range: CellRan
     field.values = new ArrayVector(valuesArray);
   }
 
-  return new MutableDataFrame(gridData);
+  return {
+    ...gridData,
+    fields: [...gridData.fields],
+  };
 };
 
 export const publishSnapshot = (data: DataFrame, panelID: number): void => {

--- a/public/app/plugins/panel/datagrid/utils.ts
+++ b/public/app/plugins/panel/datagrid/utils.ts
@@ -125,6 +125,7 @@ export const deleteRows = (gridData: DataFrame, rows: number[], hardDelete = fal
   return {
     ...gridData,
     fields: [...gridData.fields],
+    length: gridData.fields[0]?.values.length ?? 0,
   };
 };
 
@@ -144,6 +145,7 @@ export const clearCellsFromRangeSelection = (gridData: DataFrame, range: CellRan
   return {
     ...gridData,
     fields: [...gridData.fields],
+    length: gridData.fields[0]?.values.length ?? 0,
   };
 };
 


### PR DESCRIPTION
MutableDataFrame is a very expensive wrapper that supports many features... the datagrid should avoid using these because they are unnecessary and just add a few additional layers of abstraction.


