### PR TITLE
Nested folders: Provide count of all descendant dashboards and folders

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -462,7 +462,7 @@ func (hs *HTTPServer) registerRoutes() {
 				folderUidRoute.Put("/", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.UpdateFolder))
 				folderUidRoute.Post("/move", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.MoveFolder))
 				folderUidRoute.Delete("/", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersDelete, uidScope)), routing.Wrap(hs.DeleteFolder))
-				folderUidRoute.Get("/counts", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderChildrenCounts))
+				folderUidRoute.Get("/counts", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderDescendantCounts))
 
 				folderUidRoute.Group("/permissions", func(folderPermissionRoute routing.RouteRegister) {
 					folderPermissionRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionFoldersPermissionsRead, uidScope)), routing.Wrap(hs.GetFolderPermissionList))

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -299,19 +299,19 @@ func (hs *HTTPServer) DeleteFolder(c *contextmodel.ReqContext) response.Response
 	return response.JSON(http.StatusOK, "")
 }
 
-// swagger:route GET /folders/{folder_uid}/counts folders getFolderChildrenCounts
+// swagger:route GET /folders/{folder_uid}/counts folders getFolderDescendantCounts
 //
 // Gets the count of each descendant of a folder by kind. The folder is identified by UID.
 //
 // Responses:
-// 200: getFolderChildrenCountsResponse
+// 200: getFolderDescendantCountsResponse
 // 401: unauthorisedError
 // 403: forbiddenError
 // 404: notFoundError
 // 500: internalServerError
-func (hs *HTTPServer) GetFolderChildrenCounts(c *contextmodel.ReqContext) response.Response {
+func (hs *HTTPServer) GetFolderDescendantCounts(c *contextmodel.ReqContext) response.Response {
 	uid := web.Params(c.Req)[":uid"]
-	counts, err := hs.folderService.GetChildrenCounts(c.Req.Context(), &folder.GetChildrenCountsQuery{OrgID: c.OrgID, UID: &uid, SignedInUser: c.SignedInUser})
+	counts, err := hs.folderService.GetDescendantCounts(c.Req.Context(), &folder.GetDescendantCountsQuery{OrgID: c.OrgID, UID: &uid, SignedInUser: c.SignedInUser})
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -546,16 +546,16 @@ type DeleteFolderResponse struct {
 	} `json:"body"`
 }
 
-// swagger:parameters getFolderChildrenCounts
-type GetFolderChildrenCountsParams struct {
+// swagger:parameters getFolderDescendantCounts
+type GetFolderDescendantCountsParams struct {
 	// in:path
 	// required:true
 	FolderUID string `json:"folder_uid"`
 }
 
-// swagger:response getFolderChildrenCountsResponse
-type GetFolderChildrenCountsResponse struct {
+// swagger:response getFolderDescendantCountsResponse
+type GetFolderDescendantCountsResponse struct {
 	// The response message
 	// in: body
-	Body folder.ChildrenCounts `json:"body"`
+	Body folder.DescendantCounts `json:"body"`
 }

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -625,6 +625,7 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 }
 
 func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
+	logger := s.log.FromContext(ctx)
 	if cmd.SignedInUser == nil {
 		return nil, folder.ErrBadRequest.Errorf("missing signed-in user")
 	}
@@ -640,6 +641,7 @@ func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescen
 	if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
 		subfolders, err := s.getNestedFolders(ctx, cmd.OrgID, *cmd.UID)
 		if err != nil {
+			logger.Error("failed to get subfolders", "error", err)
 			return nil, err
 		}
 		result = append(result, subfolders...)
@@ -650,6 +652,7 @@ func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescen
 		for _, folder := range result {
 			c, err := v.CountInFolder(ctx, cmd.OrgID, folder, cmd.SignedInUser)
 			if err != nil {
+				logger.Error("failed to count folder descendants", "error", err)
 				return nil, err
 			}
 			countsMap[v.Kind()] += c

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -624,7 +624,7 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 	return result, nil
 }
 
-func (s *Service) GetChildrenCounts(ctx context.Context, cmd *folder.GetChildrenCountsQuery) (folder.ChildrenCounts, error) {
+func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
 	if cmd.SignedInUser == nil {
 		return nil, folder.ErrBadRequest.Errorf("missing signed-in user")
 	}
@@ -636,7 +636,7 @@ func (s *Service) GetChildrenCounts(ctx context.Context, cmd *folder.GetChildren
 	}
 
 	result := []string{*cmd.UID}
-	countsMap := make(folder.ChildrenCounts, len(s.registry)+1)
+	countsMap := make(folder.DescendantCounts, len(s.registry)+1)
 	if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
 		subfolders, err := s.getNestedFolders(ctx, cmd.OrgID, *cmd.UID)
 		if err != nil {

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -645,6 +645,24 @@ func (s *Service) GetChildrenCounts(ctx context.Context, cmd *folder.GetChildren
 	return countsMap, nil
 }
 
+func (s *Service) getNestedFolders(ctx context.Context, orgID int64, uid string) ([]string, error) {
+	result := []string{}
+	folders, err := s.store.GetChildren(ctx, folder.GetChildrenQuery{UID: uid, OrgID: orgID})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range folders {
+		result = append(result, f.UID)
+		subfolders, err := s.getNestedFolders(ctx, f.OrgID, f.UID)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, subfolders...)
+	}
+	return result, nil
+}
+
 // MakeUserAdmin is copy of DashboardServiceImpl.MakeUserAdmin
 func (s *Service) MakeUserAdmin(ctx context.Context, orgID int64, userID, folderID int64, setViewAndEditPermissions bool) error {
 	rtEditor := org.RoleEditor

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -635,15 +636,16 @@ func (s *Service) GetChildrenCounts(ctx context.Context, cmd *folder.GetChildren
 	}
 
 	result := []string{*cmd.UID}
+	countsMap := make(folder.ChildrenCounts, len(s.registry)+1)
 	if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
 		subfolders, err := s.getNestedFolders(ctx, cmd.OrgID, *cmd.UID)
 		if err != nil {
 			return nil, err
 		}
 		result = append(result, subfolders...)
+		countsMap[entity.StandardKindFolder] = int64(len(subfolders))
 	}
 
-	countsMap := make(folder.ChildrenCounts, len(s.registry))
 	for _, v := range s.registry {
 		for _, folder := range result {
 			c, err := v.CountInFolder(ctx, cmd.OrgID, folder, cmd.SignedInUser)

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -322,7 +322,7 @@ func TestIntegrationFolderService(t *testing.T) {
 	})
 }
 
-func TestIntegrationDeleteNestedFolders(t *testing.T) {
+func TestIntegrationNestedFolderService(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -357,78 +357,99 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 		ParentUID:    "",
 		SignedInUser: &signedInUser,
 	}
-
-	t.Run("With nested folder feature flag on", func(t *testing.T) {
+	t.Run("Should get nested folders", func(t *testing.T) {
 		origNewGuardian := guardian.New
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
 
 		serviceWithFlagOn.store = nestedFolderStore
-		ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 3, "", createCmd)
+		ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 3, "getNestedFolders", createCmd)
 
-		deleteCmd := folder.DeleteFolderCommand{
-			UID:          ancestorUIDs[0],
-			OrgID:        orgID,
-			SignedInUser: &signedInUser,
-		}
-		err = serviceWithFlagOn.Delete(context.Background(), &deleteCmd)
+		folders, err := serviceWithFlagOn.getNestedFolders(context.Background(), orgID, ancestorUIDs[0])
 		require.NoError(t, err)
+		require.Equal(t, folders, ancestorUIDs[1:])
 
-		for i, uid := range ancestorUIDs {
-			// dashboard table
-			_, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
-			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
-			// folder table
-			_, err = serviceWithFlagOn.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
-			require.ErrorIs(t, err, folder.ErrFolderNotFound)
-		}
-		t.Cleanup(func() {
-			guardian.New = origNewGuardian
-		})
-	})
-	t.Run("With feature flag unset", func(t *testing.T) {
-		featuresFlagOff := featuremgmt.WithFeatures()
-		dashStore, err := database.ProvideDashboardStore(db, db.Cfg, featuresFlagOff, tagimpl.ProvideService(db, db.Cfg), quotaService)
-		require.NoError(t, err)
-		nestedFolderStore := ProvideStore(db, db.Cfg, featuresFlagOff)
-
-		serviceWithFlagOff := &Service{
-			cfg:                  cfg,
-			log:                  log.New("test-folder-service"),
-			dashboardStore:       dashStore,
-			dashboardFolderStore: folderStore,
-			store:                nestedFolderStore,
-			features:             featuresFlagOff,
-			bus:                  bus.ProvideBus(tracing.InitializeTracerForTest()),
-			db:                   db,
-		}
-
-		origNewGuardian := guardian.New
-		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
-
-		ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 1, "", createCmd)
-
-		deleteCmd := folder.DeleteFolderCommand{
-			UID:          ancestorUIDs[0],
-			OrgID:        orgID,
-			SignedInUser: &signedInUser,
-		}
-		err = serviceWithFlagOff.Delete(context.Background(), &deleteCmd)
-		require.NoError(t, err)
-
-		for i, uid := range ancestorUIDs {
-			// dashboard table
-			_, err := serviceWithFlagOff.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
-			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
-			// folder table
-			_, err = serviceWithFlagOff.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
-			require.NoError(t, err)
-		}
 		t.Cleanup(func() {
 			guardian.New = origNewGuardian
 			for _, uid := range ancestorUIDs {
-				err := serviceWithFlagOff.store.Delete(context.Background(), uid, orgID)
+				err := serviceWithFlagOn.store.Delete(context.Background(), uid, orgID)
+				assert.NoError(t, err)
+			}
+		})
+	})
+
+	t.Run("Should delete folders", func(t *testing.T) {
+		t.Run("With nested folder feature flag on", func(t *testing.T) {
+			origNewGuardian := guardian.New
+			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
+
+			serviceWithFlagOn.store = nestedFolderStore
+			ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 3, "", createCmd)
+
+			deleteCmd := folder.DeleteFolderCommand{
+				UID:          ancestorUIDs[0],
+				OrgID:        orgID,
+				SignedInUser: &signedInUser,
+			}
+			err = serviceWithFlagOn.Delete(context.Background(), &deleteCmd)
+			require.NoError(t, err)
+
+			for i, uid := range ancestorUIDs {
+				// dashboard table
+				_, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
+				require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
+				// folder table
+				_, err = serviceWithFlagOn.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
+				require.ErrorIs(t, err, folder.ErrFolderNotFound)
+			}
+			t.Cleanup(func() {
+				guardian.New = origNewGuardian
+			})
+		})
+		t.Run("With feature flag unset", func(t *testing.T) {
+			featuresFlagOff := featuremgmt.WithFeatures()
+			dashStore, err := database.ProvideDashboardStore(db, db.Cfg, featuresFlagOff, tagimpl.ProvideService(db, db.Cfg), quotaService)
+			require.NoError(t, err)
+			nestedFolderStore := ProvideStore(db, db.Cfg, featuresFlagOff)
+
+			serviceWithFlagOff := &Service{
+				cfg:                  cfg,
+				log:                  log.New("test-folder-service"),
+				dashboardStore:       dashStore,
+				dashboardFolderStore: folderStore,
+				store:                nestedFolderStore,
+				features:             featuresFlagOff,
+				bus:                  bus.ProvideBus(tracing.InitializeTracerForTest()),
+				db:                   db,
+			}
+
+			origNewGuardian := guardian.New
+			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
+
+			ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 1, "", createCmd)
+
+			deleteCmd := folder.DeleteFolderCommand{
+				UID:          ancestorUIDs[0],
+				OrgID:        orgID,
+				SignedInUser: &signedInUser,
+			}
+			err = serviceWithFlagOff.Delete(context.Background(), &deleteCmd)
+			require.NoError(t, err)
+
+			for i, uid := range ancestorUIDs {
+				// dashboard table
+				_, err := serviceWithFlagOff.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
+				require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
+				// folder table
+				_, err = serviceWithFlagOff.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
 				require.NoError(t, err)
 			}
+			t.Cleanup(func() {
+				guardian.New = origNewGuardian
+				for _, uid := range ancestorUIDs {
+					err := serviceWithFlagOff.store.Delete(context.Background(), uid, orgID)
+					require.NoError(t, err)
+				}
+			})
 		})
 	})
 }

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -951,7 +951,7 @@ func TestNestedFolderService(t *testing.T) {
 	})
 }
 
-func TestGetChildrenCounts(t *testing.T) {
+func TestGetDescendantCounts(t *testing.T) {
 	g := guardian.New
 	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanViewValue: true})
 	t.Cleanup(func() {
@@ -1001,7 +1001,7 @@ func TestGetChildrenCounts(t *testing.T) {
 
 	signedInUser := user.SignedInUser{UserID: 1, OrgID: orgID}
 	ctx := appcontext.WithUser(context.Background(), &signedInUser)
-	res, err := folderService.GetChildrenCounts(ctx, &folder.GetChildrenCountsQuery{
+	res, err := folderService.GetDescendantCounts(ctx, &folder.GetDescendantCountsQuery{
 		SignedInUser: usr,
 		UID:          &folderUID,
 		OrgID:        orgID,

--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -7,10 +7,10 @@ import (
 )
 
 type FakeService struct {
-	ExpectedFolders        []*folder.Folder
-	ExpectedFolder         *folder.Folder
-	ExpectedError          error
-	ExpectedChildrenCounts map[string]int64
+	ExpectedFolders          []*folder.Folder
+	ExpectedFolder           *folder.Folder
+	ExpectedError            error
+	ExpectedDescendantCounts map[string]int64
 }
 
 func NewFakeService() *FakeService {
@@ -51,6 +51,6 @@ func (s *FakeService) RegisterService(service folder.RegistryService) error {
 	return s.ExpectedError
 }
 
-func (s *FakeService) GetChildrenCounts(ctx context.Context, cmd *folder.GetChildrenCountsQuery) (folder.ChildrenCounts, error) {
-	return s.ExpectedChildrenCounts, s.ExpectedError
+func (s *FakeService) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
+	return s.ExpectedDescendantCounts, s.ExpectedError
 }

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -156,7 +156,7 @@ type HasAdminPermissionInDashboardsOrFoldersQuery struct {
 }
 
 // GetDescendantCountsQuery captures the information required by the folder service
-// to return the count of children in a folder.
+// to return the count of descendants (direct and indirect) in a folder.
 type GetDescendantCountsQuery struct {
 	UID   *string
 	OrgID int64

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -155,13 +155,13 @@ type HasAdminPermissionInDashboardsOrFoldersQuery struct {
 	SignedInUser *user.SignedInUser
 }
 
-// GetChildrenCountsQuery captures the information required by the folder service
+// GetDescendantCountsQuery captures the information required by the folder service
 // to return the count of children in a folder.
-type GetChildrenCountsQuery struct {
+type GetDescendantCountsQuery struct {
 	UID   *string
 	OrgID int64
 
 	SignedInUser *user.SignedInUser `json:"-"`
 }
 
-type ChildrenCounts map[string]int64
+type DescendantCounts map[string]int64

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -26,7 +26,7 @@ type Service interface {
 	// Move changes a folder's parent folder to the requested new parent.
 	Move(ctx context.Context, cmd *MoveFolderCommand) (*Folder, error)
 	RegisterService(service RegistryService) error
-	GetChildrenCounts(ctx context.Context, cmd *GetChildrenCountsQuery) (ChildrenCounts, error)
+	GetDescendantCounts(ctx context.Context, cmd *GetDescendantCountsQuery) (DescendantCounts, error)
 }
 
 // FolderStore is a folder store.

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11885,13 +11885,6 @@
         }
       }
     },
-    "ChildrenCounts": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "integer",
-        "format": "int64"
-      }
-    },
     "ConfFloat64": {
       "description": "ConfFloat64 is a float64. It Marshals float64 values of NaN of Inf\nto null.",
       "type": "number",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -5655,7 +5655,7 @@
           "folders"
         ],
         "summary": "Gets the count of each descendant of a folder by kind. The folder is identified by UID.",
-        "operationId": "getFolderChildrenCounts",
+        "operationId": "getFolderDescendantCounts",
         "parameters": [
           {
             "type": "string",
@@ -5666,7 +5666,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/getFolderChildrenCountsResponse"
+            "$ref": "#/responses/getFolderDescendantCountsResponse"
           },
           "401": {
             "$ref": "#/responses/unauthorisedError"
@@ -13098,6 +13098,13 @@
         }
       }
     },
+    "DescendantCounts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "int64"
+      }
+    },
     "DiscordConfig": {
       "type": "object",
       "title": "DiscordConfig configures notifications via Discord.",
@@ -20341,10 +20348,10 @@
         "$ref": "#/definitions/DataSourceList"
       }
     },
-    "getFolderChildrenCountsResponse": {
+    "getFolderDescendantCountsResponse": {
       "description": "(empty)",
       "schema": {
-        "$ref": "#/definitions/ChildrenCounts"
+        "$ref": "#/definitions/DescendantCounts"
       }
     },
     "getFolderPermissionListResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2952,13 +2952,6 @@
         },
         "type": "object"
       },
-      "ChildrenCounts": {
-        "additionalProperties": {
-          "format": "int64",
-          "type": "integer"
-        },
-        "type": "object"
-      },
       "ConfFloat64": {
         "description": "ConfFloat64 is a float64. It Marshals float64 values of NaN of Inf\nto null.",
         "format": "double",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -792,11 +792,11 @@
         },
         "description": "(empty)"
       },
-      "getFolderChildrenCountsResponse": {
+      "getFolderDescendantCountsResponse": {
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ChildrenCounts"
+              "$ref": "#/components/schemas/DescendantCounts"
             }
           }
         },
@@ -4162,6 +4162,13 @@
           "instance": {
             "type": "string"
           }
+        },
+        "type": "object"
+      },
+      "DescendantCounts": {
+        "additionalProperties": {
+          "format": "int64",
+          "type": "integer"
         },
         "type": "object"
       },
@@ -17026,7 +17033,7 @@
     },
     "/folders/{folder_uid}/counts": {
       "get": {
-        "operationId": "getFolderChildrenCounts",
+        "operationId": "getFolderDescendantCounts",
         "parameters": [
           {
             "in": "path",
@@ -17039,7 +17046,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/getFolderChildrenCountsResponse"
+            "$ref": "#/components/responses/getFolderDescendantCountsResponse"
           },
           "401": {
             "$ref": "#/components/responses/unauthorisedError"


### PR DESCRIPTION
**What is this feature?**
It builds on https://github.com/grafana/grafana/pull/66550. The API endpoint introduced in that PR now provides the count of all descendant dashboards as well as folders instead of just the direct ones.

**Why do we need this feature?**
Counts will provide a better idea of the contents of a folder and will allow users to make informed decisions when managing folders, for instance when deleting nested folders.

**Who is this feature for?**
It supports the nested folders feature which is for the users referenced in the [Product DNA doc](https://docs.google.com/document/d/1xGkmfP5iemurkyAoHXx6BxeewurZumFkc9TTcUIYN34/edit#).

**Which issue(s) does this PR fix?**:
- Partial #63872
- Expanding this to address (partially) #66038 as well. Currently only returning the count of dashboard and folder descendants and not counts for other types of children.

**Special notes for your reviewer:**
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
