### PR TITLE
Loki: Update docs for show context

### DIFF
--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -101,9 +101,9 @@ For more information about log queries and LogQL, refer to the [Loki log queries
 
 ### Show log context
 
-When using a search expression as detailed above, you can retrieve the context surrounding your filtered results.
-By clicking the `Show Context` link on the filtered rows, you'll be able to investigate the log messages that came before and after the
-log message you're interested in.
+In Explore, you can can retrieve the context surrounding your log results by clicking on the `Show Context` button. You'll be able to investigate the logs from the same log stream that came before and after the log message you're interested in.
+
+The initial log context query is created from all labels defining the stream for the selected log line. You can use log context query editor to widen the search by removing one or more of the label filters from log stream. Additionally, if you use parser in your original query, you can refine your search by using extracted label filters.
 
 ### Tail live logs
 

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -101,7 +101,7 @@ For more information about log queries and LogQL, refer to the [Loki log queries
 
 ### Show log context
 
-In Explore, you can can retrieve the context surrounding your log results by clicking on the `Show Context` button. You'll be able to investigate the logs from the same log stream that came before and after the log message you're interested in.
+In Explore, you can can retrieve the context surrounding your log results by clicking the `Show Context` button. You'll be able to investigate the logs from the same log stream that came before and after the log message you're interested in.
 
 The initial log context query is created from all labels defining the stream for the selected log line. You can use the log context query editor to widen the search by removing one or more of the label filters from log stream. Additionally, if you used a parser in your original query, you can refine your search by using extracted labels filters.
 

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -103,7 +103,7 @@ For more information about log queries and LogQL, refer to the [Loki log queries
 
 In Explore, you can can retrieve the context surrounding your log results by clicking on the `Show Context` button. You'll be able to investigate the logs from the same log stream that came before and after the log message you're interested in.
 
-The initial log context query is created from all labels defining the stream for the selected log line. You can use log context query editor to widen the search by removing one or more of the label filters from log stream. Additionally, if you use parser in your original query, you can refine your search by using extracted label filters.
+The initial log context query is created from all labels defining the stream for the selected log line. You can use the log context query editor to widen the search by removing one or more of the label filters from log stream. Additionally, if you used a parser in your original query, you can refine your search by using extracted labels filters.
 
 ### Tail live logs
 


### PR DESCRIPTION
This PR updates documentation for log context in Loki data source. Related to newly enabled Loki log context editor in https://github.com/grafana/grafana/pull/67131. Moreover in https://github.com/grafana/grafana/pull/66379 we have introduced always showing on context toggle as log context is created from all labels defining the stream for the selected log line. And it has basically nothing to do with filter being present/not being present. 

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/30407135/234274708-7c3263b7-506c-4ce8-8063-cdd47e2e0d51.png">
