### PR TITLE
[Chore] Dashboard: Update analytic events for new panel/row/import/pasted panel

### DIFF
--- a/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
+++ b/public/app/features/dashboard/components/AddPanelButton/AddPanelMenu.tsx
@@ -27,7 +27,7 @@ export const AddPanelMenu = ({ dashboard }: Props) => {
         label={t('dashboard.add-menu.visualization', 'Visualization')}
         testId={selectors.components.PageToolbar.itemButton('Add new visualization menu item')}
         onClick={() => {
-          reportInteraction('Create new panel');
+          reportInteraction('dashboards_toolbar_add_clicked', { item: 'add_visualization' });
           const id = onCreateNewPanel(dashboard);
           locationService.partial({ editPanel: id });
         }}
@@ -37,7 +37,7 @@ export const AddPanelMenu = ({ dashboard }: Props) => {
         label={t('dashboard.add-menu.row', 'Row')}
         testId={selectors.components.PageToolbar.itemButton('Add new row menu item')}
         onClick={() => {
-          reportInteraction('Create new row');
+          reportInteraction('dashboards_toolbar_add_clicked', { item: 'add_row' });
           onCreateNewRow(dashboard);
         }}
       />
@@ -46,7 +46,7 @@ export const AddPanelMenu = ({ dashboard }: Props) => {
         label={t('dashboard.add-menu.import', 'Import from library')}
         testId={selectors.components.PageToolbar.itemButton('Add new panel from panel library menu item')}
         onClick={() => {
-          reportInteraction('Add a panel from the panel library');
+          reportInteraction('dashboards_toolbar_add_clicked', { item: 'import_from_library' });
           onAddLibraryPanel(dashboard);
         }}
       />
@@ -55,7 +55,7 @@ export const AddPanelMenu = ({ dashboard }: Props) => {
         label={t('dashboard.add-menu.paste-panel', 'Paste panel')}
         testId={selectors.components.PageToolbar.itemButton('Add new panel from clipboard menu item')}
         onClick={() => {
-          reportInteraction('Paste panel from clipboard');
+          reportInteraction('dashboards_toolbar_add_clicked', { item: 'paste_panel' });
           onPasteCopiedPanel(dashboard, copiedPanelPlugin);
         }}
         disabled={!copiedPanelPlugin}

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -36,7 +36,7 @@ export const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
             icon="plus"
             aria-label="Add new panel"
             onClick={() => {
-              reportInteraction('Create new panel');
+              reportInteraction('dashboards_emptydashboard_clicked', { item: 'add_visualization' });
               const id = onCreateNewPanel(dashboard);
               locationService.partial({ editPanel: id });
             }}
@@ -58,7 +58,7 @@ export const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
               fill="outline"
               aria-label="Add new row"
               onClick={() => {
-                reportInteraction('Create new row');
+                reportInteraction('dashboards_emptydashboard_clicked', { item: 'add_row' });
                 onCreateNewRow(dashboard);
               }}
               disabled={!canCreate}
@@ -80,7 +80,7 @@ export const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
               fill="outline"
               aria-label="Add new panel from panel library"
               onClick={() => {
-                reportInteraction('Add a panel from the panel library');
+                reportInteraction('dashboards_emptydashboard_clicked', { item: 'import_from_library' });
                 onAddLibraryPanel(dashboard);
               }}
               disabled={!canCreate}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changes events sent to rudderstack for creating content in a dashboard. Separate for empty dashboard and from the Add button in toolbar. 

Fixes https://github.com/grafana/grafana/issues/66285

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
