### PR TITLE
Data source config page: add generic description

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -477,6 +477,10 @@
     "tracing": {
       "type": "boolean",
       "description": "For data source plugins, if the plugin supports tracing. Used for example to link logs (e.g. Loki logs) with tracing plugins."
+    },
+    "hasRequiredConfigFields": {
+      "type": "boolean",
+      "description": "For data source plugins, if the plugin has required fields marked with * in the config. Used to render info about required fields on top of the config page."
     }
   }
 }

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -139,6 +139,7 @@ export interface DataSourcePluginMeta<T extends KeyValue = {}> extends PluginMet
   unlicensed?: boolean;
   backend?: boolean;
   isBackend?: boolean;
+  hasRequiredConfigFields?: boolean;
 }
 
 interface PluginMetaQueryOptions {

--- a/public/app/features/datasources/components/DataSourceDescription.test.tsx
+++ b/public/app/features/datasources/components/DataSourceDescription.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { DataSourceDescription } from './DataSourceDescription';
+
+describe('<DataSourceDescription />', () => {
+  it('should render data source name', () => {
+    const dataSourceName = 'Test data source name';
+    const { getByText } = render(<DataSourceDescription dataSourceName={dataSourceName} />);
+
+    expect(getByText(dataSourceName, { exact: false })).toBeInTheDocument();
+  });
+
+  it('should not render docs link when `docsLink` prop is not passed', () => {
+    const { getByText } = render(<DataSourceDescription dataSourceName={'Test data source name'} />);
+
+    expect(() => getByText('view the documentation')).toThrow();
+  });
+
+  it('should render docs link when `docsLink` prop is passed', () => {
+    const docsLink = 'https://grafana.com/test-datasource-docs';
+    const { getByText } = render(
+      <DataSourceDescription dataSourceName={'Test data source name'} docsLink={docsLink} />
+    );
+
+    const docsLinkEl = getByText('view the documentation');
+
+    expect(docsLinkEl.getAttribute('href')).toBe(docsLink);
+  });
+
+  it('should not render text about required fields when `hasRequiredFields` prop is not passed', () => {
+    const { getByText } = render(
+      <DataSourceDescription
+        dataSourceName={'Test data source name'}
+        docsLink={'https://grafana.com/test-datasource-docs'}
+      />
+    );
+
+    expect(() => getByText('Fields marked in', { exact: false })).toThrow();
+  });
+
+  it('should render text about required fields when `hasRequiredFields` prop is `true`', () => {
+    const { getByText } = render(
+      <DataSourceDescription
+        dataSourceName={'Test data source name'}
+        docsLink={'https://grafana.com/test-datasource-docs'}
+        hasRequiredFields={true}
+      />
+    );
+
+    expect(getByText('Fields marked in', { exact: false })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/datasources/components/DataSourceDescription.tsx
+++ b/public/app/features/datasources/components/DataSourceDescription.tsx
@@ -14,7 +14,7 @@ export const DataSourceDescription: React.FC<Props> = ({ dataSourceName, docsLin
 
   const styles = {
     container: css({
-      marginBottom: theme.spacing(4),
+      margin: theme.spacing(4, 0),
     }),
     text: css({
       ...theme.typography.body,

--- a/public/app/features/datasources/components/DataSourceDescription.tsx
+++ b/public/app/features/datasources/components/DataSourceDescription.tsx
@@ -1,0 +1,59 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { useTheme2 } from '@grafana/ui';
+
+type Props = {
+  dataSourceName: string;
+  docsLink?: string;
+  hasRequiredFields?: boolean;
+};
+
+export const DataSourceDescription: React.FC<Props> = ({ dataSourceName, docsLink, hasRequiredFields = false }) => {
+  const theme = useTheme2();
+
+  const styles = {
+    container: css({
+      marginBottom: theme.spacing(4),
+    }),
+    text: css({
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+      a: css({
+        color: theme.colors.text.link,
+        textDecoration: 'underline',
+        '&:hover': {
+          textDecoration: 'none',
+        },
+      }),
+    }),
+    asterisk: css`
+      color: ${theme.colors.error.main};
+    `,
+  };
+
+  return (
+    <div className={styles.container}>
+      <p className={styles.text}>
+        Before you can use the {dataSourceName} data source, you must configure it below or in the config file.
+        {docsLink && (
+          <>
+            <br />
+            For detailed instructions,{' '}
+            <a href={docsLink} target="_blank" rel="noreferrer">
+              view the documentation
+            </a>
+            .
+          </>
+        )}
+      </p>
+      {hasRequiredFields && (
+        <p className={styles.text}>
+          <i>
+            Fields marked in <span className={styles.asterisk}>*</span> are required
+          </i>
+        </p>
+      )}
+    </div>
+  );
+};

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -260,5 +260,16 @@ describe('<EditDataSource>', () => {
       expect(screen.queryByText(detailsMessage)).not.toBeInTheDocument();
       expect(screen.queryByText(detailsVerboseMessage)).toBeInTheDocument();
     });
+
+    it('should render generic description', () => {
+      const dataSourceMeta = getMockDataSourceMeta();
+      setup({ dataSourceMeta });
+
+      expect(
+        screen.queryByText(
+          `Before you can use the ${dataSourceMeta.name} data source, you must configure it below or in the config file.`
+        )
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -165,7 +165,7 @@ export function EditDataSourceView({
 
       <DataSourceDescription
         dataSourceName={dataSourceMeta.name}
-        docsLink={dataSourceMeta.info.links.find((l) => l.name === 'Docs' || l.name === 'Documentation')?.url}
+        docsLink={dataSourceMeta.info?.links?.find((l) => l.name === 'Docs' || l.name === 'Documentation')?.url}
         hasRequiredFields={dataSourceMeta.hasRequiredConfigFields}
       />
 

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -29,6 +29,7 @@ import { DataSourceRights } from '../types';
 import { BasicSettings } from './BasicSettings';
 import { ButtonRow } from './ButtonRow';
 import { CloudInfoBox } from './CloudInfoBox';
+import { DataSourceDescription } from './DataSourceDescription';
 import { DataSourceLoadError } from './DataSourceLoadError';
 import { DataSourceMissingRightsMessage } from './DataSourceMissingRightsMessage';
 import { DataSourcePluginConfigPage } from './DataSourcePluginConfigPage';
@@ -160,6 +161,12 @@ export function EditDataSourceView({
         onNameChange={onNameChange}
         alertingSupported={alertingSupported}
         disabled={readOnly || !hasWriteRights}
+      />
+
+      <DataSourceDescription
+        dataSourceName={dataSourceMeta.name}
+        docsLink={dataSourceMeta.info.links.find((l) => l.name === 'Docs' || l.name === 'Documentation')?.url}
+        hasRequiredFields={dataSourceMeta.hasRequiredConfigFields}
       />
 
       {plugin && (

--- a/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
@@ -54,7 +54,7 @@ describe('<EditDataSourcePage>', () => {
   const uid = 'foo';
   const name = 'My DataSource';
   const dataSource = getMockDataSource<{}>({ uid, name });
-  const dataSourceMeta = getMockDataSourceMeta();
+  const dataSourceMeta = getMockDataSourceMeta({ id: dataSource.type });
   const dataSourceSettings = getMockDataSourceSettingsState();
   let store: Store;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding a generic description for the data source config page which includes links to the docs and information about required fields. This is a part of a config redesign project.

As not every data source has a link to the docs, we render it only when we are able to find it in the links inside `plugin.json`.
We also want to render information about required fields. But as data source might not have required fields or required fields are not yet marked with asterisk, we are rendering this information only when `hasRequiredConfigFields` is present in the `plugin.json`. So developers can add it when the datasource is ready and this information will start appearing.

Screenshots:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234283920-777b8658-0a83-4257-947e-9e5c78d949f4.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234284222-49484373-9834-4d95-aa7b-aaee3e25c5ed.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234284471-c6460c47-bc01-4c19-8f6d-430e4b0ca3c8.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234284642-86d6d13d-0a16-4295-ab8e-423dca44e452.png">


**Why do we need this feature?**

To simplify the datasource configuration experience.

**Who is this feature for?**

Users who configure data sources.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/enterprise-datasources/issues/218

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
