### PR TITLE
Loki Derived Fields: Validate duplicated field names

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -47,7 +47,7 @@ export const ConfigEditor = (props: Props) => {
       />
 
       <DerivedFields
-        value={options.jsonData.derivedFields}
+        fields={options.jsonData.derivedFields}
         onChange={(value) => onOptionsChange(setDerivedFields(options, value))}
       />
     </>

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
@@ -8,6 +9,10 @@ import { setDataSourceSrv } from '@grafana/runtime';
 import { DerivedField } from './DerivedField';
 
 const mockList = jest.fn();
+const validateMock = {
+  rule: jest.fn(),
+  errorMessage: '',
+};
 
 describe('DerivedField', () => {
   beforeEach(() => {
@@ -54,7 +59,15 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.getByLabelText(selectors.components.DataSourcePicker.inputV2)).toBeInTheDocument();
@@ -68,7 +81,15 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.queryByLabelText(selectors.components.DataSourcePicker.inputV2)).not.toBeInTheDocument();
@@ -82,12 +103,38 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
     expect(mockList).toHaveBeenCalledWith(
       expect.objectContaining({
         tracing: true,
       })
     );
+  });
+
+  it('validates the field name', async () => {
+    const value = {
+      matcherRegex: '',
+      name: 'field-name',
+      datasourceUid: 'test',
+    };
+    const validate = {
+      rule: jest.fn().mockReturnValue(false),
+      errorMessage: 'Error message',
+    };
+    render(
+      <DerivedField validateName={validate} value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />
+    );
+    userEvent.click(await screen.findByDisplayValue(value.name));
+
+    expect(await screen.findByText(validate.errorMessage)).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,15 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import {
-  Button,
-  DataLinkInput,
-  EventsWithValidation,
-  LegacyForms,
-  regexValidation,
-  useStyles2,
-  ValidationRule,
-} from '@grafana/ui';
+import { Button, DataLinkInput, EventsWithValidation, LegacyForms, useStyles2, ValidationRule } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
@@ -79,6 +71,7 @@ export const DerivedField = (props: Props) => {
             <Input
               value={value.name}
               onChange={handleChange('name')}
+              placeholder="Field name"
               validationEvents={{
                 [EventsWithValidation.onBlur]: [validateName],
                 [EventsWithValidation.onFocus]: [validateName],
@@ -86,7 +79,6 @@ export const DerivedField = (props: Props) => {
             />
           }
           label="Name"
-          type="text"
         />
         <FormField
           labelWidth={10}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -158,7 +158,6 @@ export const DerivedField = (props: Props) => {
                 datasourceUid: ds.uid,
               })
             }
-            noDefault
             current={value.datasourceUid}
           />
         )}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -158,6 +158,7 @@ export const DerivedField = (props: Props) => {
                 datasourceUid: ds.uid,
               })
             }
+            noDefault
             current={value.datasourceUid}
           />
         )}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,11 +4,19 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, LegacyForms, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  DataLinkInput,
+  EventsWithValidation,
+  LegacyForms,
+  regexValidation,
+  useStyles2,
+  ValidationRule,
+} from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
-const { Switch, FormField } = LegacyForms;
+const { Switch, FormField, Input } = LegacyForms;
 
 const getStyles = (theme: GrafanaTheme2) => ({
   row: css`
@@ -36,9 +44,10 @@ type Props = {
   onDelete: () => void;
   suggestions: VariableSuggestion[];
   className?: string;
+  validateName: ValidationRule;
 };
 export const DerivedField = (props: Props) => {
-  const { value, onChange, onDelete, suggestions, className } = props;
+  const { value, onChange, onDelete, suggestions, className, validateName } = props;
   const styles = useStyles2(getStyles);
   const [showInternalLink, setShowInternalLink] = useState(!!value.datasourceUid);
   const previousUid = usePrevious(value.datasourceUid);
@@ -66,12 +75,18 @@ export const DerivedField = (props: Props) => {
         <FormField
           labelWidth={10}
           className={styles.nameField}
-          // A bit of a hack to prevent using default value for the width from FormField
-          inputWidth={null}
+          inputEl={
+            <Input
+              value={value.name}
+              onChange={handleChange('name')}
+              validationEvents={{
+                [EventsWithValidation.onBlur]: [validateName],
+                [EventsWithValidation.onFocus]: [validateName],
+              }}
+            />
+          }
           label="Name"
           type="text"
-          value={value.name}
-          onChange={handleChange('name')}
         />
         <FormField
           labelWidth={10}

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -66,6 +66,24 @@ describe('DerivedFields', () => {
 
     expect(await screen.findByText('Name already in use')).toBeInTheDocument();
   });
+
+  it('does not validate empty names as repeated', () => {
+    const repeatedFields = [
+      {
+        matcherRegex: '',
+        name: '',
+      },
+      {
+        matcherRegex: '',
+        name: '',
+      },
+    ];
+    render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+
+    expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
+  });
 });
 
 const testFields = [

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DerivedFields } from './DerivedFields';
@@ -23,7 +24,7 @@ describe('DerivedFields', () => {
   });
 
   it('renders correctly when there are fields', async () => {
-    render(<DerivedFields value={testValue} onChange={() => {}} />);
+    render(<DerivedFields fields={testFields} onChange={() => {}} />);
 
     await waitFor(() => expect(screen.getAllByTestId('derived-field')).toHaveLength(2));
     expect(screen.getByText('Add')).toBeInTheDocument();
@@ -34,22 +35,40 @@ describe('DerivedFields', () => {
     const onChange = jest.fn();
     render(<DerivedFields onChange={onChange} />);
 
-    fireEvent.click(screen.getByText('Add'));
+    userEvent.click(screen.getByText('Add'));
 
     await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
   });
 
   it('removes a field', async () => {
     const onChange = jest.fn();
-    render(<DerivedFields value={testValue} onChange={onChange} />);
+    render(<DerivedFields fields={testFields} onChange={onChange} />);
 
-    fireEvent.click((await screen.findAllByTitle('Remove field'))[0]);
+    userEvent.click((await screen.findAllByTitle('Remove field'))[0]);
 
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith([testValue[1]]));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([testFields[1]]));
+  });
+
+  it('validates duplicated field names', async () => {
+    const repeatedFields = [
+      {
+        matcherRegex: '',
+        name: 'repeated',
+      },
+      {
+        matcherRegex: '',
+        name: 'repeated',
+      },
+    ];
+    render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+
+    expect(await screen.findByText('Name already in use')).toBeInTheDocument();
   });
 });
 
-const testValue = [
+const testFields = [
   {
     matcherRegex: 'regex1',
     name: 'test1',

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -33,7 +33,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
   const validateNameRule = useMemo(() => {
     return {
       rule: (name: string) => {
-        return fields.filter((field) => field.name === name).length <= 1;
+        return fields.filter((field) => field.name && field.name === name).length <= 1;
       },
       errorMessage: 'Name already in use',
     };

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -20,11 +20,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 type Props = {
-  value?: DerivedFieldConfig[];
+  fields?: DerivedFieldConfig[];
   onChange: (value: DerivedFieldConfig[]) => void;
 };
 
-export const DerivedFields = ({ value = [], onChange }: Props) => {
+export const DerivedFields = ({ fields = [], onChange }: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
@@ -33,11 +33,11 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
   const validateNameRule = useMemo(() => {
     return {
       rule: (name: string) => {
-        return value.filter((field) => field.name === name).length <= 1;
+        return fields.filter((field) => field.name === name).length <= 1;
       },
       errorMessage: 'Name already in use',
     };
-  }, [value]);
+  }, [fields]);
 
   return (
     <>
@@ -48,19 +48,19 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
       </div>
 
       <div className="gf-form-group">
-        {value.map((field, index) => {
+        {fields.map((field, index) => {
           return (
             <DerivedField
               className={styles.derivedField}
               key={index}
               value={field}
               onChange={(newField) => {
-                const newDerivedFields = [...value];
+                const newDerivedFields = [...fields];
                 newDerivedFields.splice(index, 1, newField);
                 onChange(newDerivedFields);
               }}
               onDelete={() => {
-                const newDerivedFields = [...value];
+                const newDerivedFields = [...fields];
                 newDerivedFields.splice(index, 1);
                 onChange(newDerivedFields);
               }}
@@ -85,14 +85,14 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
             icon="plus"
             onClick={(event) => {
               event.preventDefault();
-              const newDerivedFields = [...value, { name: '', matcherRegex: '' }];
+              const newDerivedFields = [...fields, { name: '', matcherRegex: '' }];
               onChange(newDerivedFields);
             }}
           >
             Add
           </Button>
 
-          {value.length > 0 && (
+          {fields.length > 0 && (
             <Button variant="secondary" type="button" onClick={() => setShowDebug(!showDebug)}>
               {showDebug ? 'Hide example log message' : 'Show example log message'}
             </Button>
@@ -106,7 +106,7 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
             className={css`
               margin-bottom: 10px;
             `}
-            derivedFields={value}
+            derivedFields={fields}
           />
         </div>
       )}

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { GrafanaTheme2, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
 import { Button, useTheme2 } from '@grafana/ui';
@@ -30,6 +30,15 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
 
   const [showDebug, setShowDebug] = useState(false);
 
+  const validateNameRule = useMemo(() => {
+    return {
+      rule: (name: string) => {
+        return value.filter((field) => field.name === name).length <= 1;
+      },
+      errorMessage: 'Name already in use',
+    };
+  }, [value]);
+
   return (
     <>
       <h3 className="page-heading">Derived fields</h3>
@@ -55,6 +64,7 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
                 newDerivedFields.splice(index, 1);
                 onChange(newDerivedFields);
               }}
+              validateName={validateNameRule}
               suggestions={[
                 {
                   value: DataLinkBuiltInVars.valueRaw,


### PR DESCRIPTION
This PR adds name validation to derived fields, to tell the user when they have a duplicated derived field name, which is not supported.

![imagen](https://user-images.githubusercontent.com/1069378/234328113-eb813b36-eee9-4c12-a212-6ee3d027fa30.png)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/52598

**Special notes for your reviewer:**

Go to a Loki data source settings, and configure derived fields. The underlying function should be unchanged, we're just adding validation.

Note that this form is a legacy form, so it has been done with legacy form components. When we migrate the configuration page we need to migrate this form and its validation as well.