### PR TITLE
Elasticsearch Data Links: Validate duplicated fields 

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -63,7 +63,7 @@ export const ConfigEditor = (props: Props) => {
       />
 
       <DataLinks
-        value={options.jsonData.dataLinks}
+        links={options.jsonData.dataLinks}
         onChange={(newValue) => {
           onOptionsChange({
             ...options,

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
@@ -4,11 +4,11 @@ import { usePrevious } from 'react-use';
 
 import { VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, LegacyForms, DataLinkInput, stylesFactory } from '@grafana/ui';
+import { Button, LegacyForms, DataLinkInput, stylesFactory, EventsWithValidation, ValidationRule } from '@grafana/ui';
 
 import { DataLinkConfig } from '../types';
 
-const { FormField, Switch } = LegacyForms;
+const { FormField, Switch, Input } = LegacyForms;
 
 const getStyles = stylesFactory(() => ({
   firstRow: css`
@@ -38,9 +38,10 @@ type Props = {
   onDelete: () => void;
   suggestions: VariableSuggestion[];
   className?: string;
+  validateField: ValidationRule;
 };
 export const DataLink = (props: Props) => {
-  const { value, onChange, onDelete, suggestions, className } = props;
+  const { value, onChange, onDelete, suggestions, className, validateField } = props;
   const styles = getStyles();
   const [showInternalLink, setShowInternalLink] = useInternalLink(value.datasourceUid);
 
@@ -57,13 +58,19 @@ export const DataLink = (props: Props) => {
         <FormField
           className={styles.nameField}
           labelWidth={6}
-          // A bit of a hack to prevent using default value for the width from FormField
-          inputWidth={null}
+          inputEl={
+            <Input
+              value={value.field}
+              onChange={handleChange('field')}
+              placeholder="Field name or regex pattern"
+              validationEvents={{
+                [EventsWithValidation.onBlur]: [validateField],
+                [EventsWithValidation.onFocus]: [validateField],
+              }}
+            />
+          }
           label="Field"
-          type="text"
-          value={value.field}
           tooltip={'Can be exact field name or a regex pattern that will match on the field name.'}
-          onChange={handleChange('field')}
         />
         <Button
           variant={'destructive'}
@@ -97,6 +104,7 @@ export const DataLink = (props: Props) => {
         <FormField
           className={styles.urlDisplayLabelField}
           inputWidth={null}
+          labelWidth={7}
           label="URL Label"
           type="text"
           value={value.urlDisplayLabel}

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
@@ -53,6 +53,44 @@ describe('DataLinks tests', () => {
 
     expect(onChangeMock).toHaveBeenCalled();
   });
+
+  it('should validate duplicated data links', async () => {
+    const duplicatedLinks = [
+      {
+        field: 'regex1',
+        url: '',
+      },
+      {
+        field: 'regex1',
+        url: '',
+      },
+    ];
+
+    setup({ links: duplicatedLinks });
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name or regex pattern')[0]);
+
+    expect(await screen.findByText('Field already in use')).toBeInTheDocument();
+  });
+
+  it('should not validate empty data links as duplicated', () => {
+    const duplicatedLinks = [
+      {
+        field: '',
+        url: '',
+      },
+      {
+        field: '',
+        url: '',
+      },
+    ];
+
+    setup({ links: duplicatedLinks });
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name or regex pattern')[0]);
+
+    expect(screen.queryByText('Field already in use')).not.toBeInTheDocument();
+  });
 });
 
 const testLinks: DataLinkConfig[] = [

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
@@ -8,7 +8,7 @@ import { DataLinks, Props } from './DataLinks';
 
 const setup = (propOverrides?: Partial<Props>) => {
   const props: Props = {
-    value: [],
+    links: [],
     onChange: jest.fn(),
     ...propOverrides,
   };
@@ -26,7 +26,7 @@ describe('DataLinks tests', () => {
   });
 
   it('should render correctly when passed fields', async () => {
-    setup({ value: testValue });
+    setup({ links: testLinks });
 
     expect(await screen.findAllByRole('button', { name: 'Remove field' })).toHaveLength(2);
     expect(await screen.findAllByRole('checkbox', { name: 'Internal link' })).toHaveLength(2);
@@ -45,7 +45,7 @@ describe('DataLinks tests', () => {
 
   it('should call onChange to remove a field when the remove button is clicked', async () => {
     const onChangeMock = jest.fn();
-    setup({ value: testValue, onChange: onChangeMock });
+    setup({ links: testLinks, onChange: onChangeMock });
 
     expect(onChangeMock).not.toHaveBeenCalled();
     const removeButton = await screen.findAllByRole('button', { name: 'Remove field' });
@@ -55,7 +55,7 @@ describe('DataLinks tests', () => {
   });
 });
 
-const testValue: DataLinkConfig[] = [
+const testLinks: DataLinkConfig[] = [
   {
     field: 'regex1',
     url: 'localhost1',

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
@@ -21,21 +21,21 @@ const getStyles = (theme: GrafanaTheme2) => {
 };
 
 export type Props = {
-  value?: DataLinkConfig[];
+  links?: DataLinkConfig[];
   onChange: (value: DataLinkConfig[]) => void;
 };
 export const DataLinks = (props: Props) => {
-  const { value, onChange } = props;
+  const { links, onChange } = props;
   const styles = useStyles2(getStyles);
 
   const validateFieldRule = useMemo(() => {
     return {
       rule: (field: string) => {
-        return value ? value.filter((value) => value.field && value.field === field).length <= 1 : true;
+        return links ? links.filter((link) => link.field && link.field === field).length <= 1 : true;
       },
-      errorMessage: 'Name already in use',
+      errorMessage: 'Field already in use',
     };
-  }, [value]);
+  }, [links]);
 
   return (
     <>
@@ -45,21 +45,21 @@ export const DataLinks = (props: Props) => {
         Add links to existing fields. Links will be shown in log row details next to the field value.
       </div>
 
-      {value && value.length > 0 && (
+      {links && links.length > 0 && (
         <div className="gf-form-group">
-          {value.map((field, index) => {
+          {links.map((link, index) => {
             return (
               <DataLink
                 className={styles.dataLink}
                 key={index}
-                value={field}
+                value={link}
                 onChange={(newField) => {
-                  const newDataLinks = [...value];
+                  const newDataLinks = [...links];
                   newDataLinks.splice(index, 1, newField);
                   onChange(newDataLinks);
                 }}
                 onDelete={() => {
-                  const newDataLinks = [...value];
+                  const newDataLinks = [...links];
                   newDataLinks.splice(index, 1);
                   onChange(newDataLinks);
                 }}
@@ -87,7 +87,7 @@ export const DataLinks = (props: Props) => {
         icon="plus"
         onClick={(event) => {
           event.preventDefault();
-          const newDataLinks = [...(value || []), { field: '', url: '' }];
+          const newDataLinks = [...(links || []), { field: '', url: '' }];
           onChange(newDataLinks);
         }}
       >

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { GrafanaTheme2, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
 import { Button, useStyles2 } from '@grafana/ui';
@@ -27,6 +27,15 @@ export type Props = {
 export const DataLinks = (props: Props) => {
   const { value, onChange } = props;
   const styles = useStyles2(getStyles);
+
+  const validateFieldRule = useMemo(() => {
+    return {
+      rule: (field: string) => {
+        return value ? value.filter((value) => value.field && value.field === field).length <= 1 : true;
+      },
+      errorMessage: 'Name already in use',
+    };
+  }, [value]);
 
   return (
     <>
@@ -62,6 +71,7 @@ export const DataLinks = (props: Props) => {
                     origin: VariableOrigin.Value,
                   },
                 ]}
+                validateField={validateFieldRule}
               />
             );
           })}


### PR DESCRIPTION
This PR adds name validation to data link fields, to tell the user when they have a duplicated data link name, which is not supported.

![imagen](https://user-images.githubusercontent.com/1069378/234338313-863dd88c-1f69-45ea-8438-14dfb996b494.png)

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/52598

**Special notes for your reviewer:**

Go to an Elasticsearch data source settings, and configure data link fields. The underlying function should be unchanged, we're just adding validation.