### PR TITLE
Caching: Fix concurrent HTTP Header read/write in caching middleware

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
@@ -56,16 +56,16 @@ func (m *CachingMiddleware) QueryData(ctx context.Context, req *backend.QueryDat
 	// First look in the query cache if enabled
 	hit, cr := m.caching.HandleQueryRequest(ctx, req)
 
-	defer func() {
-		// record request duration if caching was used
-		if ch := reqCtx.Resp.Header().Get(caching.XCacheHeader); ch != "" {
+	// record request duration if caching was used
+	if ch := reqCtx.Resp.Header().Get(caching.XCacheHeader); ch != "" {
+		defer func() {
 			QueryCachingRequestHistogram.With(prometheus.Labels{
 				"datasource_type": req.PluginContext.DataSourceInstanceSettings.Type,
 				"cache":           ch,
 				"query_type":      getQueryType(reqCtx),
 			}).Observe(time.Since(start).Seconds())
-		}
-	}()
+		}()
+	}
 
 	// Cache hit; return the response
 	if hit {
@@ -102,15 +102,15 @@ func (m *CachingMiddleware) CallResource(ctx context.Context, req *backend.CallR
 	// First look in the resource cache if enabled
 	hit, cr := m.caching.HandleResourceRequest(ctx, req)
 
-	defer func() {
-		// record request duration if caching was used
-		if ch := reqCtx.Resp.Header().Get(caching.XCacheHeader); ch != "" {
+	// record request duration if caching was used
+	if ch := reqCtx.Resp.Header().Get(caching.XCacheHeader); ch != "" {
+		defer func() {
 			ResourceCachingRequestHistogram.With(prometheus.Labels{
 				"plugin_id": req.PluginContext.PluginID,
 				"cache":     ch,
 			}).Observe(time.Since(start).Seconds())
-		}
-	}()
+		}()
+	}
 
 	// Cache hit; send the response and return
 	if hit {


### PR DESCRIPTION
**What is this feature?**

This fixes a panic that can occur in the caching plugin middleware `CallResource` func. 

Because the entire code block was deferred, it was reading the response header at the same time as `plugin_resource.go`'s `flushStream()` func was executing in a separate goroutine, leading to concurrency issues. By reading the response header in the middleware _before_ `sender.Send()` is ever called, it should ensure safety from this race condition.

Same change applied to both the query and resource calls just for consistency.

**Why do we need this feature?**

Prevent crashes