### PR TITLE
Check add ds permissions in advanced ds picker

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -14,9 +14,11 @@ import {
   Icon,
 } from '@grafana/ui';
 import { config } from 'app/core/config';
+import { contextSrv } from 'app/core/core';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import * as DFImport from 'app/features/dataframe-import';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
+import { AccessControlAction } from 'app/types';
 
 import { DataSourceList } from './DataSourceList';
 
@@ -38,6 +40,7 @@ export function DataSourceModal({
 }: DataSourceModalProps) {
   const styles = useStyles2(getDataSourceModalStyles);
   const [search, setSearch] = useState('');
+  const hasCreateRights = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
   const newDataSourceURL = config.featureToggles.dataConnectionsConsole
     ? CONNECTIONS_ROUTES.DataSourcesNew
     : DATASOURCES_ROUTES.New;
@@ -101,11 +104,14 @@ export function DataSourceModal({
             </FileDropzone>
           )}
         </div>
-        <div className={styles.dsCTAs}>
-          <LinkButton variant="secondary" href={newDataSourceURL}>
-            Configure a new data source
-          </LinkButton>
-        </div>
+
+        {hasCreateRights && (
+          <div className={styles.dsCTAs}>
+            <LinkButton variant="secondary" href={newDataSourceURL}>
+              Configure a new data source
+            </LinkButton>
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -105,13 +105,18 @@ export function DataSourceModal({
           )}
         </div>
 
-        {hasCreateRights && (
+        {
           <div className={styles.dsCTAs}>
-            <LinkButton variant="secondary" href={newDataSourceURL}>
+            <LinkButton
+              variant="secondary"
+              disabled={!hasCreateRights}
+              href={newDataSourceURL}
+              tooltip={!hasCreateRights ? 'You do not have permission to configure new data sources' : undefined}
+            >
               Configure a new data source
             </LinkButton>
           </div>
-        )}
+        }
       </div>
     </Modal>
   );


### PR DESCRIPTION
**Bug**
Only users with "Add DS" permissions can add a new DS. So, the CTA should only be displayed when the user is granted to complete the action.

| ✅ User with permissions to add a DS | ❌ User without permissions to add a DS|
|-|-|
|![Captura de pantalla 2023-04-25 a las 20 47 27](https://user-images.githubusercontent.com/5699976/234375203-38b5bf5b-3f7f-4fbc-9c3b-683aef784bb1.png)|![Captura de pantalla 2023-04-25 a las 21 06 54](https://user-images.githubusercontent.com/5699976/234377941-e53320e5-d579-4c4d-a245-feb588ccb8ee.png)

Fixes https://github.com/grafana/grafana/issues/67239