### PR TITLE
[WIP] Timeseries: Allow custom log distribution option

### DIFF
--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -176,6 +176,7 @@ export const ScaleDistributionEditor = ({ value, onChange }: StandardEditorProps
                 log: v.value!,
               });
             }}
+            allowCustomValue={true}
           />
         </Field>
       )}


### PR DESCRIPTION
What this PR does / why we need it:
Currently log scale distributions are limited to 2 or 10. This allows selection of a custom value.

- [ ] Further investigate potential constraints in uplot logic for log scale options other than 2 or 10.