### PR TITLE
DataSourcePicker: Fix datasource picker input not clearing on close

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -46,6 +46,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
   });
 
   const onClose = useCallback(() => {
+    setFilterTerm('');
     setOpen(false);
     markerElement?.blur();
   }, [setOpen, markerElement]);
@@ -82,6 +83,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
           placeholder={dataSourceLabel(currentDataSourceInstanceSettings)}
           onFocus={openDropdown}
           onClick={openDropdown}
+          value={filterTerm}
           onChange={(e) => {
             setFilterTerm(e.currentTarget.value);
           }}


### PR DESCRIPTION
**What is this feature?**
When using the search box for the datasource picker the search would not clear on close, and as such fail to display the select datasource.

***:red_circle: Before:***

![dspickerbefore](https://user-images.githubusercontent.com/468940/234503243-a454afb6-b362-4f61-a6d6-3b7bf3aa12aa.gif)

***:green_circle: After:***

![dspickerafter](https://user-images.githubusercontent.com/468940/234503295-58f4b6e7-a2d2-41bc-980d-1852e6005ea3.gif)
