### PR TITLE
Nested folders: Fix API response ordering when fetching subfolders

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -28,7 +28,9 @@ import (
 //
 // Returns all folders that the authenticated user has permission to view.
 // If nested folders are enabled, it expects an additional query parameter with the parent folder UID
-// and returns the immediate subfolders.
+// and returns the immediate subfolders that the authenticated user has permission to view.
+// If the parameter is not supplied then it returns immediate subfolders under the root
+// that the authenticated user has permission to view.
 //
 // Responses:
 // 200: getFoldersResponse

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -239,10 +239,10 @@ func (ss *sqlStore) GetChildren(ctx context.Context, q folder.GetChildrenQuery) 
 		sql := strings.Builder{}
 		args := make([]interface{}, 0, 2)
 		if q.UID == "" {
-			sql.Write([]byte("SELECT * FROM folder WHERE parent_uid IS NULL AND org_id=?"))
+			sql.Write([]byte("SELECT * FROM folder WHERE parent_uid IS NULL AND org_id=? ORDER BY title ASC"))
 			args = append(args, q.OrgID)
 		} else {
-			sql.Write([]byte("SELECT * FROM folder WHERE parent_uid=? AND org_id=?"))
+			sql.Write([]byte("SELECT * FROM folder WHERE parent_uid=? AND org_id=? ORDER BY title ASC"))
 			args = append(args, q.UID, q.OrgID)
 		}
 

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -3,6 +3,7 @@ package folderimpl
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -544,6 +545,7 @@ func TestIntegrationGetChildren(t *testing.T) {
 	require.NoError(t, err)
 
 	treeLeaves := CreateLeaves(t, folderStore, parent, 8)
+	sort.Strings(treeLeaves)
 
 	t.Cleanup(func() {
 		for _, uid := range treeLeaves {
@@ -768,9 +770,10 @@ func CreateLeaves(t *testing.T, store *sqlStore, parent *folder.Folder, num int)
 
 	leaves := make([]string, 0)
 	for i := 0; i < num; i++ {
+		uid := util.GenerateShortUID()
 		f, err := store.Create(context.Background(), folder.CreateFolderCommand{
-			Title:     fmt.Sprintf("folder-%d", i),
-			UID:       util.GenerateShortUID(),
+			Title:     fmt.Sprintf("folder-%s", uid),
+			UID:       uid,
 			OrgID:     parent.OrgID,
 			ParentUID: parent.UID,
 		})

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -5404,7 +5404,7 @@
     },
     "/folders": {
       "get": {
-        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders.",
+        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders that the authenticated user has permission to view.\nIf the parameter is not supplied then it returns immediate subfolders under the root\nthat the authenticated user has permission to view.",
         "tags": [
           "folders"
         ],
@@ -11885,6 +11885,13 @@
         }
       }
     },
+    "ChildrenCounts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "int64"
+      }
+    },
     "ConfFloat64": {
       "description": "ConfFloat64 is a float64. It Marshals float64 values of NaN of Inf\nto null.",
       "type": "number",
@@ -13592,13 +13599,6 @@
           "type": "integer",
           "format": "int64"
         }
-      }
-    },
-    "FolderChildrenCounts": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "integer",
-        "format": "int64"
       }
     },
     "FolderSearchHit": {
@@ -20344,7 +20344,7 @@
     "getFolderChildrenCountsResponse": {
       "description": "(empty)",
       "schema": {
-        "$ref": "#/definitions/FolderChildrenCounts"
+        "$ref": "#/definitions/ChildrenCounts"
       }
     },
     "getFolderPermissionListResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -796,7 +796,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/FolderChildrenCounts"
+              "$ref": "#/components/schemas/ChildrenCounts"
             }
           }
         },
@@ -2952,6 +2952,13 @@
         },
         "type": "object"
       },
+      "ChildrenCounts": {
+        "additionalProperties": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "type": "object"
+      },
       "ConfFloat64": {
         "description": "ConfFloat64 is a float64. It Marshals float64 values of NaN of Inf\nto null.",
         "format": "double",
@@ -4658,13 +4665,6 @@
             "format": "int64",
             "type": "integer"
           }
-        },
-        "type": "object"
-      },
-      "FolderChildrenCounts": {
-        "additionalProperties": {
-          "format": "int64",
-          "type": "integer"
         },
         "type": "object"
       },
@@ -16759,7 +16759,7 @@
     },
     "/folders": {
       "get": {
-        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders.",
+        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders that the authenticated user has permission to view.\nIf the parameter is not supplied then it returns immediate subfolders under the root\nthat the authenticated user has permission to view.",
         "operationId": "getFolders",
         "parameters": [
           {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It fixes the ordering of `GET /api/folders` response when nested folders are enabled.
Ordering used to be by sequential Id and it changes to be by title (ascending).

<details>
<summary>Example response when nested folders are enabled (before the fix)</summary>

```
```
~:  curl http://admin:admin@localhost:3000/api/folders | jq
[
  {
    "id": 1,
    "uid": "SjagdfBVk",
    "title": "folder_2"
  },
  {
    "id": 2,
    "uid": "bb3cc0b8-9748-4839-ac95-b4538982535a",
    "title": "gdev dashboards"
  },
  {
    "id": 499,
    "uid": "b3dd42aa-d513-49c3-bb0d-abbdd0aef044",
    "title": "f0"
  }
]
```
```
</details>

<details>
<summary>Example response when nested folders are enabled (after the fix)</summary>

```
~:  curl http://admin:admin@localhost:3000/api/folders | jq
[
  {
    "id": 499,
    "uid": "b3dd42aa-d513-49c3-bb0d-abbdd0aef044",
    "title": "f0"
  },
  {
    "id": 1,
    "uid": "SjagdfBVk",
    "title": "folder_2"
  },
  {
    "id": 2,
    "uid": "bb3cc0b8-9748-4839-ac95-b4538982535a",
    "title": "gdev dashboards"
  }
]
```

</details>

<details>
<summary>Example response when nested folders are disabled (flat hierarchy)</summary>

```
~:  curl http://admin:admin@localhost:3000/api/folders | jq
[
  {
    "id": 499,
    "uid": "b3dd42aa-d513-49c3-bb0d-abbdd0aef044",
    "title": "f0"
  },
  {
    "id": 501,
    "uid": "fb453428-3e7b-4991-8b58-1f399779e93d",
    "title": "f1"
  },
  {
    "id": 502,
    "uid": "f2e72b7e-412c-4beb-bdd9-57f093335b8d",
    "title": "f2"
  },
  {
    "id": 503,
    "uid": "bc028eed-a6ad-4fe8-97d2-11bb7571658e",
    "title": "f3"
  },
  {
    "id": 504,
    "uid": "d302b761-8c45-4e86-bebf-80c0737370cc",
    "title": "f4"
  },
  {
    "id": 505,
    "uid": "d229a1ce-9dfb-4795-9420-f5565aacb0bd",
    "title": "f5"
  },
  {
    "id": 506,
    "uid": "b104712f-fd73-474b-a4cb-6d0312549752",
    "title": "f6"
  },
  {
    "id": 507,
    "uid": "f5e764d1-276f-4fe5-81b0-0c6ce6c8d6c8",
    "title": "f7"
  },
  {
    "id": 508,
    "uid": "dedb1563-2271-4677-a72c-8357cf4d9516",
    "title": "f8"
  },
  {
    "id": 1,
    "uid": "SjagdfBVk",
    "title": "folder_2"
  },
  {
    "id": 2,
    "uid": "bb3cc0b8-9748-4839-ac95-b4538982535a",
    "title": "gdev dashboards"
  }
]
```
</details>

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
