### PR TITLE
Loki: Fix log samples using `instant` queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -932,8 +932,7 @@ describe('LokiDatasource', () => {
           )
         ).toEqual({
           expr: 'sum by (level) (count_over_time({label=value}[$__interval]))',
-          instant: false,
-          queryType: 'range',
+          queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
         });
@@ -997,7 +996,7 @@ describe('LokiDatasource', () => {
           )
         ).toEqual({
           expr: '{label=value}',
-          queryType: 'instant',
+          queryType: LokiQueryType.Range,
           refId: 'log-sample-A',
           maxLines: 20,
         });
@@ -1015,7 +1014,7 @@ describe('LokiDatasource', () => {
           )
         ).toEqual({
           expr: '{label=value}',
-          queryType: 'instant',
+          queryType: LokiQueryType.Range,
           refId: 'log-sample-A',
           maxLines: 5,
         });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -193,7 +193,7 @@ export class LokiDatasource
         return {
           ...normalizedQuery,
           refId: `${REF_ID_STARTER_LOG_VOLUME}${normalizedQuery.refId}`,
-          instant: false,
+          queryType: LokiQueryType.Range,
           supportingQueryType: SupportingQueryType.LogsVolume,
           expr: `sum by (level) (count_over_time(${expr}[$__interval]))`,
         };
@@ -206,6 +206,7 @@ export class LokiDatasource
         }
         return {
           ...normalizedQuery,
+          queryType: LokiQueryType.Range,
           refId: `${REF_ID_STARTER_LOG_SAMPLE}${normalizedQuery.refId}`,
           expr: getLogQueryFromMetricsQuery(expr),
           maxLines: Number.isNaN(Number(options.limit)) ? this.maxLines : Number(options.limit),


### PR DESCRIPTION
**What is this feature?**

LogSamples should always use `range` queries for Loki.

**Special notes for your reviewer:**

1. Make a metric and instant query.
2. Try to see LogSamples without this PR -> no results.
3. With this PR -> results.