### PR TITLE
[v9.5.x] Loki: Fix log samples using `instant` queries (#67271)

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -982,8 +982,7 @@ describe('LokiDatasource', () => {
           })
         ).toEqual({
           expr: 'sum by (level) (count_over_time({label=value}[$__interval]))',
-          instant: false,
-          queryType: 'range',
+          queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
         });
@@ -1035,7 +1034,7 @@ describe('LokiDatasource', () => {
           })
         ).toEqual({
           expr: '{label=value}',
-          queryType: 'instant',
+          queryType: LokiQueryType.Range,
           refId: 'log-sample-A',
           maxLines: 100,
         });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -195,7 +195,7 @@ export class LokiDatasource
         return {
           ...normalizedQuery,
           refId: `${REF_ID_STARTER_LOG_VOLUME}${normalizedQuery.refId}`,
-          instant: false,
+          queryType: LokiQueryType.Range,
           supportingQueryType: SupportingQueryType.LogsVolume,
           expr: `sum by (level) (count_over_time(${expr}[$__interval]))`,
         };
@@ -208,6 +208,7 @@ export class LokiDatasource
         }
         return {
           ...normalizedQuery,
+          queryType: LokiQueryType.Range,
           refId: `${REF_ID_STARTER_LOG_SAMPLE}${normalizedQuery.refId}`,
           expr: getLogQueryFromMetricsQuery(expr),
           maxLines: 100,


### PR DESCRIPTION
backport of #67271