### PR TITLE
Elasticsearch: Use array of strings as index in backend queries

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -207,7 +207,7 @@ func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchReque
 			header: map[string]interface{}{
 				"search_type":        "query_then_fetch",
 				"ignore_unavailable": true,
-				"index":              strings.Join(c.indices, ","),
+				"index":              c.indices,
 			},
 			body:     searchReq,
 			interval: searchReq.Interval,

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -96,7 +96,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		jBody, err := simplejson.NewJson(bodyBytes)
 		require.NoError(t, err)
 
-		assert.Equal(t, "metrics-2018.05.15", jHeader.Get("index").MustString())
+		assert.Equal(t, []string{"metrics-2018.05.15"}, jHeader.Get("index").MustStringArray())
 		assert.True(t, jHeader.Get("ignore_unavailable").MustBool(false))
 		assert.Equal(t, "query_then_fetch", jHeader.Get("search_type").MustString())
 		assert.Empty(t, jHeader.Get("max_concurrent_shard_requests"))

--- a/pkg/tsdb/elasticsearch/snapshot_test.go
+++ b/pkg/tsdb/elasticsearch/snapshot_test.go
@@ -82,7 +82,7 @@ func TestRequestSnapshots(t *testing.T) {
 	queryHeader := []byte(`
 	{
 		"ignore_unavailable": true,
-		"index": "testdb-2022.11.14",
+		"index": ["testdb-2022.11.14"],
 		"search_type": "query_then_fetch"
 	}
 	`)


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011

Based on https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html#search-multi-search-api-request-body we are changing index in backend request's header to be array of strings, rather then comma separated list. 

The test have been updated.

To test, run queries and ensure that they are working. 
