### PR TITLE
Proxy: Improve header handling for reverse proxy

### DIFF
--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -1,11 +1,13 @@
 package proxyutil
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // UserHeaderName name of the header used when forwarding the Grafana user login.
@@ -73,6 +75,16 @@ func ClearCookieHeader(req *http.Request, keepCookiesNames []string, skipCookies
 // Sets Content-Security-Policy: sandbox
 func SetProxyResponseHeaders(header http.Header) {
 	header.Set("Content-Security-Policy", "sandbox")
+}
+
+// SetViaHeader adds Grafana's reverse proxy to the proxy chain.
+// Defined in RFC 9110 7.6.3 https://datatracker.ietf.org/doc/html/rfc9110#name-via
+func SetViaHeader(header http.Header, major, minor int) {
+	via := fmt.Sprintf("%d.%d %s grafana", major, minor, setting.InstanceName)
+	if old := header.Get("Via"); old != "" {
+		via = fmt.Sprintf("%s, %s", via, old)
+	}
+	header.Set("Via", via)
 }
 
 // ApplyUserHeader Set the X-Grafana-User header if needed (and remove if not).

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // UserHeaderName name of the header used when forwarding the Grafana user login.
@@ -80,7 +79,7 @@ func SetProxyResponseHeaders(header http.Header) {
 // SetViaHeader adds Grafana's reverse proxy to the proxy chain.
 // Defined in RFC 9110 7.6.3 https://datatracker.ietf.org/doc/html/rfc9110#name-via
 func SetViaHeader(header http.Header, major, minor int) {
-	via := fmt.Sprintf("%d.%d %s grafana", major, minor, setting.InstanceName)
+	via := fmt.Sprintf("%d.%d grafana", major, minor)
 	if old := header.Get("Via"); old != "" {
 		via = fmt.Sprintf("%s, %s", via, old)
 	}

--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -89,16 +89,9 @@ func wrapDirector(d func(*http.Request)) func(req *http.Request) {
 var deletedHeaders = []string{
 	"Alt-Svc",
 	"Close",
-	"Connection",
-	"Keep-Alive",
-	"Proxy-Authenticate",
-	"Proxy-Connection",
 	"Server",
 	"Set-Cookie",
 	"Strict-Transport-Security",
-	"TE",
-	"Transfer-Encoding",
-	"Upgrade",
 }
 
 // modifyResponse enforces certain constraints on http.Response.

--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -79,11 +79,37 @@ func wrapDirector(d func(*http.Request)) func(req *http.Request) {
 	}
 }
 
+// deletedHeaders lists a number of headers that we don't want to
+// pass-through from the upstream when using a reverse proxy.
+//
+// These are related to the connection between Grafana and the proxy
+// or instructions that would alter how a browser will interact with
+// future requests to Grafana (such as enabling Strict Transport
+// Security)
+var deletedHeaders = []string{
+	"Alt-Svc",
+	"Close",
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Connection",
+	"Server",
+	"Set-Cookie",
+	"Strict-Transport-Security",
+	"TE",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
 // modifyResponse enforces certain constraints on http.Response.
 func modifyResponse(logger glog.Logger) func(resp *http.Response) error {
 	return func(resp *http.Response) error {
-		resp.Header.Del("Set-Cookie")
+		for _, header := range deletedHeaders {
+			resp.Header.Del(header)
+		}
+
 		SetProxyResponseHeaders(resp.Header)
+		SetViaHeader(resp.Header, resp.ProtoMajor, resp.ProtoMinor)
 		return nil
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Remove more headers from the reverse proxy that risks confusing a client.

**Who is this feature for?**

Users of Grafana as a proxy (most users).

**Which issue(s) does this PR fix?**:

Fixes #64486

**Special notes for your reviewer:**

I'm unsure about backporting this to v9.5 or holding it off until v10.0. Let me know what you think.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
