### PR TITLE
Fix issue-labeled.yml GH workflow

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -7,5 +7,4 @@ test:
 
 # Alerting team
 area/alerting:
-  github-board: 52
   channel-label: C02B9MXQE0J

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -14,18 +14,12 @@ jobs:
       - name: "Determine which team to notify"
         run: |
           # Default to null values.
-          BOARD="null"
           CHANNEL="null"
 
           echo "${{ github.event.label.name }} label added"
           export CURRENT_LABEL="${{ github.event.label.name }}" # Enable the use of the label in yq evaluations
           # yq is installed by default in ubuntu-latest
           if [[ $(yq e 'keys | .[] | select(. == env(CURRENT_LABEL))' teams.yml ) ]]; then
-            # Check if we have a board set to use.
-            if [[ $(yq '.[env(CURRENT_LABEL)] | has("github-board")' teams.yml ) == true ]]; then
-              BOARD=$(yq '.[env(CURRENT_LABEL)].github-board' teams.yml)
-              echo "Ready to add issue to Grafana board ${BOARD}"
-            fi
             # Check if we have a channel set to notify on comments.
             if [[ $(yq '.[env(CURRENT_LABEL)] | has("channel-label")' teams.yml ) == true ]]; then
               CHANNEL=$(yq '.[env(CURRENT_LABEL)].channel-label' teams.yml)
@@ -34,17 +28,7 @@ jobs:
           fi
 
           # set environment for next step
-          echo "BOARD=${BOARD}" >> $GITHUB_ENV
           echo "CHANNEL=${CHANNEL}" >> $GITHUB_ENV
-
-      - name: "Add to GitHub board"
-        if: ${{ env.BOARD != 'null' }}
-        uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        with:
-          project_id: ${{ env.BOARD }}
-          organization: grafana
-          resource_node_id: ${{ github.event.issue.node_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Prepare payload"
         uses: frabert/replace-string-action@v2.0


### PR DESCRIPTION
The workflow is currently failing when adding to the board, which can now be done directly with a board workflow anyway. This will only impact the alerting team which is the only team using this workflow.