### PR TITLE
docs: fix create dashboard steps

### DIFF
--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -33,7 +33,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
 1. Click the Refresh dashboard icon to query the data source.
 
-   ![Refresh dashboard icon](img here)
+   ![Refresh dashboard icon](/media/docs/grafana/dashboards/screenshot-refresh-dashboard-9.5.png)
 
 1. In the visualization list, select a visualization type.
 

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -31,6 +31,10 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    For more information about data sources, refer to [Data sources]({{< relref "../../../datasources/" >}}) for specific guidelines.
 
+1. Click the Refresh dashboard icon to query the data source.
+
+   ![Refresh dashboard icon](img here)
+
 1. In the visualization list, select a visualization type.
 
    ![Visualization selector](/media/docs/grafana/dashboards/screenshot-select-visualization-9-5.png)
@@ -49,7 +53,10 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
    - [Configure thresholds]({{< relref "../../../panels-visualizations/configure-thresholds/" >}})
    - [Configure standard options]({{< relref "../../../panels-visualizations/configure-standard-options/" >}})
 
-1. When you've finished editing your panel, click **Save** in the top right corner.
+1. When you've finished editing your panel, click **Save** to save the dashboard.
+
+   Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
+
 1. Enter a name for your dashboard and select a folder, if applicable.
 1. Click **Save**.
 

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -10,7 +10,7 @@ weight: 200
 
 # Build your first dashboard
 
-This topic helps you get started with Grafana and build your first dashboard. To learn more about Grafana, refer to [What is Grafana?]({{< relref "_index.md" >}}).
+This topic helps you get started with Grafana and build your first dashboard using the built-in `Grafana` data source. To learn more about Grafana, refer to [What is Grafana?]({{< relref "_index.md" >}}). If you've already set up a data source that you know how to query, refer to [Create a dashboard]({{< relref "../../../dashboards/build-dashboards/create-dashboard/" >}}) instead.
 
 > **Note:** Grafana also offers a [free account with Grafana Cloud](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) to help getting started even easier and faster. You can install Grafana to self-host or get a free Grafana Cloud account.
 
@@ -47,7 +47,14 @@ To create your first dashboard:
 
    This generates the Random Walk dashboard.
 
-1. Click **Save** in the top right corner of your screen to save the dashboard.
+1. Click the Refresh dashboard icon to query the data source.
+
+   ![Refresh dashboard icon](img here)
+
+1. When you've finished editing your panel, click **Save** to save the dashboard.
+
+   Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
+
 1. Add a descriptive name for the dashboard, and then click **Save**.
 
 Congratulations, you have created your first dashboard and it is displaying results.

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -10,7 +10,7 @@ weight: 200
 
 # Build your first dashboard
 
-This topic helps you get started with Grafana and build your first dashboard using the built-in `Grafana` data source. To learn more about Grafana, refer to [What is Grafana?]({{< relref "_index.md" >}}). If you've already set up a data source that you know how to query, refer to [Create a dashboard]({{< relref "../../../dashboards/build-dashboards/create-dashboard/" >}}) instead.
+This topic helps you get started with Grafana and build your first dashboard using the built-in `Grafana` data source. To learn more about Grafana, refer to [Introduction to Grafana]({{< relref "../introduction/" >}}).
 
 > **Note:** Grafana also offers a [free account with Grafana Cloud](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) to help getting started even easier and faster. You can install Grafana to self-host or get a free Grafana Cloud account.
 
@@ -37,7 +37,9 @@ To sign in to Grafana for the first time:
 
 #### Create a dashboard
 
-To create your first dashboard:
+If you've already set up a data source that you know how to query, refer to [Create a dashboard]({{< relref "../dashboards/build-dashboards/create-dashboard/" >}}) instead.
+
+To create your first dashboard using the built-in `Grafana` data source:
 
 1. Click **Dashboards** in the left-side menu.
 1. On the Dashboards page, click **New** and select **New Dashboard** from the dropdown menu.
@@ -49,7 +51,7 @@ To create your first dashboard:
 
 1. Click the Refresh dashboard icon to query the data source.
 
-   ![Refresh dashboard icon](img here)
+   ![Refresh dashboard icon](/media/docs/grafana/dashboards/screenshot-refresh-dashboard-9.5.png)
 
 1. When you've finished editing your panel, click **Save** to save the dashboard.
 


### PR DESCRIPTION
- Updates steps in both _Create a dashboard_ and _Build your first dashboard_ to indicate you must refresh the dashboard to see your query visualized.
- Adds reference to the **Apply** option.
- Adds intro text about the built-in data source in the _Build your first dashboard_ topic and points you to _Create a dashboard_ if you already have a data source.

TO DO
- [x] Check how far back these changes should be backported 