### PR TITLE
Chore: Don't fail tests on console logs at all during local dev

### DIFF
--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -5,9 +5,13 @@ import { initReactI18next } from 'react-i18next';
 
 import { matchers } from './matchers';
 
-failOnConsole({
-  shouldFailOnLog: process.env.CI ? true : false,
-});
+if (process.env.CI) {
+  failOnConsole({
+    shouldFailOnLog: true,
+    shouldFailOnDebug: true,
+    shouldFailOnInfo: true,
+  });
+}
 
 expect.extend(matchers);
 


### PR DESCRIPTION
Tests that log to `console.error` still fail tests when running locally. This makes errors/warnings significantly more verbose than desired.

This PR makes sure we only setup `failOnConsole` during CI.