### PR TITLE
Suggestions: Prioritize preferred visualizations for suggestion list

### DIFF
--- a/public/app/features/panel/state/getAllSuggestions.test.ts
+++ b/public/app/features/panel/state/getAllSuggestions.test.ts
@@ -338,6 +338,29 @@ scenario('Given default loki logs data', (ctx) => {
   });
 });
 
+scenario('Given a preferredVisualisationType', (ctx) => {
+  ctx.setData([
+    toDataFrame({
+      meta: {
+        preferredVisualisationType: 'table',
+      },
+      fields: [
+        {
+          name: 'Trace Id',
+          type: FieldType.number,
+          values: [1, 2, 3],
+          config: {},
+        },
+        { name: 'Trace Group', type: FieldType.string, values: ['traceGroup1', 'traceGroup2', 'traceGroup3'] },
+      ],
+    }),
+  ]);
+
+  it('should return the preferred visualization first', () => {
+    expect(ctx.names()[0]).toEqual(SuggestionName.Table);
+  });
+});
+
 function repeatFrame(count: number, frame: DataFrame): DataFrame[] {
   const frames: DataFrame[] = [];
   for (let i = 0; i < count; i++) {

--- a/public/app/features/panel/state/getAllSuggestions.ts
+++ b/public/app/features/panel/state/getAllSuggestions.ts
@@ -54,6 +54,14 @@ export async function getAllSuggestions(data?: PanelData, panel?: PanelModel): P
   }
 
   return list.sort((a, b) => {
+    if (builder.dataSummary.preferredVisualisationType) {
+      if (a.pluginId === builder.dataSummary.preferredVisualisationType) {
+        return -1;
+      }
+      if (b.pluginId === builder.dataSummary.preferredVisualisationType) {
+        return 1;
+      }
+    }
     return (b.score ?? VisualizationSuggestionScore.OK) - (a.score ?? VisualizationSuggestionScore.OK);
   });
 }


### PR DESCRIPTION
**What is this feature?**

Right now if a datasource plugin specifies a preferred visualization type it is not prioritized as a suggestion in the list. This moves the suggestion to the top of the suggestion list:

<img width="363" alt="Screenshot 2023-04-26 at 3 49 27 PM" src="https://user-images.githubusercontent.com/6620164/234687086-fe7aa652-562a-49b7-b3a9-fafa14d43aee.png">

**Why do we need this feature?**
We were working on adding Traces to our Opensearch Datasource Plugin which looks best when rendered as a table. When you use Explore, the table shows by default, but when you view it on the query editor it defaults to a timeseries and when you click on suggestions, the table visualization is at the bottom of the list, even though it is the preferred visualization type.

**Who is this feature for?**
Plugin Developers and Users of Plugins

**Which issue(s) does this PR fix?**:

(didn't make one sorry was just kind of poking around trying to figure out what was happening and ended up making a pr)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
