### PR TITLE
Plugins: display plugin id and url when it fails to install

### DIFF
--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -1,15 +1,12 @@
 package services
 
 import (
-	"bufio"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"runtime"
 
@@ -17,11 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
-type GrafanaComClient struct {
-	retryCount int
-}
-
-func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plugin, error) {
+func GetPluginInfoFromRepo(pluginId, repoUrl string) (models.Plugin, error) {
 	logger.Debugf("getting plugin metadata from: %v pluginId: %v \n", repoUrl, pluginId)
 	body, err := sendRequestGetBytes(HttpClient, repoUrl, "repo", pluginId)
 	if err != nil {
@@ -42,78 +35,7 @@ func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plug
 	return data, nil
 }
 
-func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error) {
-	// Try handling URL as a local file path first
-	if _, err := os.Stat(url); err == nil {
-		// We can ignore this gosec G304 warning since `url` stems from command line flag "pluginUrl". If the
-		// user shouldn't be able to read the file, it should be handled through filesystem permissions.
-		// nolint:gosec
-		f, err := os.Open(url)
-		if err != nil {
-			return fmt.Errorf("%v: %w", "Failed to read plugin archive", err)
-		}
-		_, err = io.Copy(tmpFile, f)
-		if err != nil {
-			return fmt.Errorf("%v: %w", "Failed to copy plugin archive", err)
-		}
-		return nil
-	}
-
-	client.retryCount = 0
-
-	defer func() {
-		if r := recover(); r != nil {
-			client.retryCount++
-			if client.retryCount < 3 {
-				logger.Info("Failed downloading. Will retry once.")
-				err = tmpFile.Truncate(0)
-				if err != nil {
-					return
-				}
-				_, err = tmpFile.Seek(0, 0)
-				if err != nil {
-					return
-				}
-				err = client.DownloadFile(pluginName, tmpFile, url, checksum)
-			} else {
-				client.retryCount = 0
-				failure := fmt.Sprintf("%v", r)
-				if failure == "runtime error: makeslice: len out of range" {
-					err = fmt.Errorf("corrupt HTTP response from source, please try again")
-				} else {
-					panic(r)
-				}
-			}
-		}
-	}()
-
-	// Using no timeout here as some plugins can be bigger and smaller timeout would prevent to download a plugin on
-	// slow network. As this is CLI operation hanging is not a big of an issue as user can just abort.
-	bodyReader, err := sendRequest(HttpClientNoTimeout, url)
-	if err != nil {
-		return fmt.Errorf("%v: %w", "Failed to send request", err)
-	}
-	defer func() {
-		if err := bodyReader.Close(); err != nil {
-			logger.Warn("Failed to close body", "err", err)
-		}
-	}()
-
-	w := bufio.NewWriter(tmpFile)
-	h := sha256.New()
-	if _, err = io.Copy(w, io.TeeReader(bodyReader, h)); err != nil {
-		return fmt.Errorf("%v: %w", "failed to compute SHA256 checksum", err)
-	}
-	if err := w.Flush(); err != nil {
-		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
-	}
-	if len(checksum) > 0 && checksum != fmt.Sprintf("%x", h.Sum(nil)) {
-		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive (%s: %s) - please contact security@grafana.com", pluginName, url)
-	}
-	return nil
-}
-
-func (client *GrafanaComClient) ListAllPlugins(repoUrl string) (models.PluginRepo, error) {
+func ListAllPlugins(repoUrl string) (models.PluginRepo, error) {
 	body, err := sendRequestGetBytes(HttpClient, repoUrl, "repo")
 
 	if err != nil {

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -108,7 +108,7 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
 	}
 	if len(checksum) > 0 && checksum != fmt.Sprintf("%x", h.Sum(nil)) {
-		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive - please contact security@grafana.com")
+		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive (%s: %s) - please contact security@grafana.com", pluginName, url)
 	}
 	return nil
 }

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -1,12 +1,15 @@
 package services
 
 import (
+	"bufio"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"runtime"
 
@@ -14,7 +17,11 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
-func GetPluginInfoFromRepo(pluginId, repoUrl string) (models.Plugin, error) {
+type GrafanaComClient struct {
+	retryCount int
+}
+
+func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plugin, error) {
 	logger.Debugf("getting plugin metadata from: %v pluginId: %v \n", repoUrl, pluginId)
 	body, err := sendRequestGetBytes(HttpClient, repoUrl, "repo", pluginId)
 	if err != nil {
@@ -35,7 +42,78 @@ func GetPluginInfoFromRepo(pluginId, repoUrl string) (models.Plugin, error) {
 	return data, nil
 }
 
-func ListAllPlugins(repoUrl string) (models.PluginRepo, error) {
+func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error) {
+	// Try handling URL as a local file path first
+	if _, err := os.Stat(url); err == nil {
+		// We can ignore this gosec G304 warning since `url` stems from command line flag "pluginUrl". If the
+		// user shouldn't be able to read the file, it should be handled through filesystem permissions.
+		// nolint:gosec
+		f, err := os.Open(url)
+		if err != nil {
+			return fmt.Errorf("%v: %w", "Failed to read plugin archive", err)
+		}
+		_, err = io.Copy(tmpFile, f)
+		if err != nil {
+			return fmt.Errorf("%v: %w", "Failed to copy plugin archive", err)
+		}
+		return nil
+	}
+
+	client.retryCount = 0
+
+	defer func() {
+		if r := recover(); r != nil {
+			client.retryCount++
+			if client.retryCount < 3 {
+				logger.Info("Failed downloading. Will retry once.")
+				err = tmpFile.Truncate(0)
+				if err != nil {
+					return
+				}
+				_, err = tmpFile.Seek(0, 0)
+				if err != nil {
+					return
+				}
+				err = client.DownloadFile(pluginName, tmpFile, url, checksum)
+			} else {
+				client.retryCount = 0
+				failure := fmt.Sprintf("%v", r)
+				if failure == "runtime error: makeslice: len out of range" {
+					err = fmt.Errorf("corrupt HTTP response from source, please try again")
+				} else {
+					panic(r)
+				}
+			}
+		}
+	}()
+
+	// Using no timeout here as some plugins can be bigger and smaller timeout would prevent to download a plugin on
+	// slow network. As this is CLI operation hanging is not a big of an issue as user can just abort.
+	bodyReader, err := sendRequest(HttpClientNoTimeout, url)
+	if err != nil {
+		return fmt.Errorf("%v: %w", "Failed to send request", err)
+	}
+	defer func() {
+		if err := bodyReader.Close(); err != nil {
+			logger.Warn("Failed to close body", "err", err)
+		}
+	}()
+
+	w := bufio.NewWriter(tmpFile)
+	h := sha256.New()
+	if _, err = io.Copy(w, io.TeeReader(bodyReader, h)); err != nil {
+		return fmt.Errorf("%v: %w", "failed to compute SHA256 checksum", err)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
+	}
+	if len(checksum) > 0 && checksum != fmt.Sprintf("%x", h.Sum(nil)) {
+		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive - please contact security@grafana.com")
+	}
+	return nil
+}
+
+func (client *GrafanaComClient) ListAllPlugins(repoUrl string) (models.PluginRepo, error) {
 	body, err := sendRequestGetBytes(HttpClient, repoUrl, "repo")
 
 	if err != nil {

--- a/pkg/plugins/repo/client.go
+++ b/pkg/plugins/repo/client.go
@@ -53,7 +53,7 @@ func (c *Client) download(_ context.Context, pluginZipURL, checksum string, comp
 		if err := tmpFile.Close(); err != nil {
 			c.log.Warn("Failed to close file", "err", err)
 		}
-		return nil, fmt.Errorf("%v: failed to download plugin archive (%s)", err, pluginZipURL)
+		return nil, fmt.Errorf("%w: failed to download plugin archive (%s)", err, pluginZipURL)
 	}
 
 	rc, err := zip.OpenReader(tmpFile.Name())

--- a/pkg/plugins/repo/client.go
+++ b/pkg/plugins/repo/client.go
@@ -53,7 +53,7 @@ func (c *Client) download(_ context.Context, pluginZipURL, checksum string, comp
 		if err := tmpFile.Close(); err != nil {
 			c.log.Warn("Failed to close file", "err", err)
 		}
-		return nil, fmt.Errorf("%v: %w", "failed to download plugin archive", err)
+		return nil, fmt.Errorf("%v: failed to download plugin archive (%s)", err, pluginZipURL)
 	}
 
 	rc, err := zip.OpenReader(tmpFile.Name())
@@ -143,7 +143,7 @@ func (c *Client) downloadFile(tmpFile *os.File, pluginURL, checksum string, comp
 		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
 	}
 	if len(checksum) > 0 && checksum != fmt.Sprintf("%x", h.Sum(nil)) {
-		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive - please contact security@grafana.com")
+		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive (%s) - please contact security@grafana.com", pluginURL)
 	}
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

When a plugin fails to install, the error message will include the plugin-id and when possible the URL to the zip file used.

**Why do we need this feature?**

This makes it easier to identify the plugin that is failing and remove it from a long list, or escalate to the team responsible.

**Who is this feature for?**

Administrators of Grafana

**Which issue(s) does this PR fix?**:

Fixes #67335

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
