### PR TITLE
NestedFolders: Indicate when folders have mixed-selection children

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -75,9 +75,10 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
 
   it('displays the filters and hides the actions initially', async () => {
     render(<BrowseDashboardsPage {...props} />);
+    await screen.findByPlaceholderText('Search for dashboards and folders');
 
-    expect(await screen.findByText('Sort')).toBeInTheDocument();
-    expect(await screen.findByText('Filter by tag')).toBeInTheDocument();
+    expect(screen.queryByText('Sort')).toBeInTheDocument();
+    expect(screen.queryByText('Filter by tag')).toBeInTheDocument();
 
     expect(screen.queryByRole('button', { name: 'Move' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -118,7 +118,7 @@ describe('browse-dashboards BrowseView', () => {
   });
 
   it('shows indeterminate checkboxes when a descendant is selected', async () => {
-    render(<BrowseView folderUID={undefined} width={WIDTH} height={HEIGHT} />);
+    render(<BrowseView canSelect={true} folderUID={undefined} width={WIDTH} height={HEIGHT} />);
     await screen.findByText(folderA.item.title);
 
     await expandFolder(folderA.item.uid);

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -116,6 +116,26 @@ describe('browse-dashboards BrowseView', () => {
     const grandparentCheckbox = screen.queryByTestId(selectors.pages.BrowseDashbards.table.checkbox(folderA.item.uid));
     expect(grandparentCheckbox).not.toBeChecked();
   });
+
+  it('shows indeterminate checkboxes when an ancestor is selected', async () => {
+    render(<BrowseView folderUID={undefined} width={WIDTH} height={HEIGHT} />);
+    await screen.findByText(folderA.item.title);
+
+    await expandFolder(folderA.item.uid);
+    await expandFolder(folderA_folderB.item.uid);
+
+    await clickCheckbox(folderA_folderB_dashbdB.item.uid);
+
+    const parentCheckbox = screen.queryByTestId(
+      selectors.pages.BrowseDashbards.table.checkbox(folderA_folderB.item.uid)
+    );
+    expect(parentCheckbox).not.toBeChecked();
+    expect(parentCheckbox).toBePartiallyChecked();
+
+    const grandparentCheckbox = screen.queryByTestId(selectors.pages.BrowseDashbards.table.checkbox(folderA.item.uid));
+    expect(grandparentCheckbox).not.toBeChecked();
+    expect(grandparentCheckbox).toBePartiallyChecked();
+  });
 });
 
 async function expandFolder(uid: string) {

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -117,7 +117,7 @@ describe('browse-dashboards BrowseView', () => {
     expect(grandparentCheckbox).not.toBeChecked();
   });
 
-  it('shows indeterminate checkboxes when an ancestor is selected', async () => {
+  it('shows indeterminate checkboxes when a descendant is selected', async () => {
     render(<BrowseView folderUID={undefined} width={WIDTH} height={HEIGHT} />);
     await screen.findByText(folderA.item.title);
 

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -42,11 +42,6 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
 
   useEffect(() => {
     dispatch(fetchChildren(folderUID));
-
-    handleFolderClick('c056cc75-9162-426f-80af-fd7722172e60', true);
-    handleFolderClick('fd51d699-bd35-4e6b-83de-235aa1946fe7', true);
-    handleFolderClick('dfe4a6d2-b608-48a3-aa49-3ecd0de7553b', true);
-    handleFolderClick('c6a3b0e9-7bad-4c5c-9026-e079cbb79888', true);
   }, [handleFolderClick, dispatch, folderUID]);
 
   const handleItemSelectionChange = useCallback(

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 
-import { DashboardViewItem } from 'app/features/search/types';
+import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 import { useDispatch } from 'app/types';
 
 import {
@@ -9,8 +9,10 @@ import {
   fetchChildren,
   setFolderOpenState,
   setItemSelectionState,
+  useChildrenByParentUIDState,
   setAllSelection,
 } from '../state';
+import { SelectionState } from '../types';
 
 import { DashboardsTree } from './DashboardsTree';
 
@@ -25,6 +27,7 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
   const dispatch = useDispatch();
   const flatTree = useFlatTreeState(folderUID);
   const selectedItems = useCheckboxSelectionState();
+  const childrenByParentUID = useChildrenByParentUIDState();
 
   useEffect(() => {
     dispatch(fetchChildren(folderUID));
@@ -48,13 +51,36 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
     [dispatch]
   );
 
+  const isSelected = useCallback(
+    (kind: DashboardViewItemKind | '$all', uid: string): SelectionState => {
+      if (kind === '$all') {
+        return selectedItems.$all ? SelectionState.Selected : SelectionState.Unselected;
+      }
+
+      const isSelected = selectedItems[kind][uid];
+      if (isSelected) {
+        return SelectionState.Selected;
+      }
+
+      // Because if _all_ children, then the parent is selected (and bailed in the previous check),
+      // this .some check will only return true if the children are partially selected
+      const isMixed = (childrenByParentUID[uid] ?? []).some((v) => selectedItems[v.kind][v.uid]);
+      if (isMixed) {
+        return SelectionState.Mixed;
+      }
+
+      return SelectionState.Unselected;
+    },
+    [selectedItems, childrenByParentUID]
+  );
+
   return (
     <DashboardsTree
       canSelect={canSelect}
       items={flatTree}
       width={width}
       height={height}
-      selectedItems={selectedItems}
+      isSelected={isSelected}
       onFolderClick={handleFolderClick}
       onAllSelectionChange={(newState) => dispatch(setAllSelection({ isSelected: newState }))}
       onItemSelectionChange={handleItemSelectionChange}

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { Checkbox } from '@grafana/ui';
+
+import { DashboardsTreeCellProps, SelectionState } from '../types';
+
+export default function CheckboxCell({
+  row: { original: row },
+  isSelected,
+  onItemSelectionChange,
+}: DashboardsTreeCellProps) {
+  const item = row.item;
+
+  if (item.kind === 'ui-empty-folder' || !isSelected) {
+    return null;
+  }
+
+  const state = isSelected(item.kind, item.uid);
+
+  if (state === SelectionState.Mixed) {
+    return (
+      <div
+        style={{ width: 16, height: 16, marginRight: 8, background: 'blue' }}
+        onClick={() => onItemSelectionChange?.(item, false)}
+      />
+    );
+  }
+
+  return (
+    <Checkbox
+      data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
+      value={state === SelectionState.Selected}
+      onChange={(ev) => onItemSelectionChange?.(item, ev.currentTarget.checked)}
+    />
+  );
+}

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -18,21 +18,11 @@ export default function CheckboxCell({
 
   const state = isSelected(item);
 
-  if (state === SelectionState.Mixed) {
-    // PR TODO: replace this with indeterminate checkbox once its merged in
-    return (
-      <div
-        data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
-        style={{ width: 16, height: 16, marginRight: 8, background: '#3D71D9', borderRadius: 2 }}
-        onClick={() => onItemSelectionChange?.(item, true)}
-      />
-    );
-  }
-
   return (
     <Checkbox
       data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
       value={state === SelectionState.Selected}
+      indeterminate={state === SelectionState.Mixed}
       onChange={(ev) => onItemSelectionChange?.(item, ev.currentTarget.checked)}
     />
   );

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -19,9 +19,11 @@ export default function CheckboxCell({
   const state = isSelected(item.kind, item.uid);
 
   if (state === SelectionState.Mixed) {
+    // PR TODO: replace this with indeterminate checkbox once its merged in
     return (
       <div
-        style={{ width: 16, height: 16, marginRight: 8, background: 'blue' }}
+        data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
+        style={{ width: 16, height: 16, marginRight: 8, background: '#3D71D9', borderRadius: 2 }}
         onClick={() => onItemSelectionChange?.(item, false)}
       />
     );

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -16,7 +16,7 @@ export default function CheckboxCell({
     return null;
   }
 
-  const state = isSelected(item.kind, item.uid);
+  const state = isSelected(item);
 
   if (state === SelectionState.Mixed) {
     // PR TODO: replace this with indeterminate checkbox once its merged in
@@ -24,7 +24,7 @@ export default function CheckboxCell({
       <div
         data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
         style={{ width: 16, height: 16, marginRight: 8, background: '#3D71D9', borderRadius: 2 }}
-        onClick={() => onItemSelectionChange?.(item, false)}
+        onClick={() => onItemSelectionChange?.(item, true)}
       />
     );
   }

--- a/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
@@ -10,6 +10,7 @@ export default function CheckboxHeaderCell({ isSelected, onAllSelectionChange }:
   return (
     <Checkbox
       value={state === SelectionState.Selected}
+      indeterminate={state === SelectionState.Mixed}
       onChange={(ev) => onAllSelectionChange?.(ev.currentTarget.checked)}
     />
   );

--- a/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from '@grafana/ui';
 import { DashboardTreeHeaderProps, SelectionState } from '../types';
 
 export default function CheckboxHeaderCell({ isSelected, onAllSelectionChange }: DashboardTreeHeaderProps) {
-  const state = isSelected?.('$all', '$all') ?? SelectionState.Unselected;
+  const state = isSelected?.('$all') ?? SelectionState.Unselected;
 
   return (
     <Checkbox

--- a/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxHeaderCell.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Checkbox } from '@grafana/ui';
+
+import { DashboardTreeHeaderProps, SelectionState } from '../types';
+
+export default function CheckboxHeaderCell({ isSelected, onAllSelectionChange }: DashboardTreeHeaderProps) {
+  const state = isSelected?.('$all', '$all') ?? SelectionState.Unselected;
+
+  return (
+    <Checkbox
+      value={state === SelectionState.Selected}
+      onChange={(ev) => onAllSelectionChange?.(ev.currentTarget.checked)}
+    />
+  );
+}

--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -49,7 +49,7 @@ describe('browse-dashboards DashboardsTree', () => {
       <DashboardsTree
         canSelect={false}
         items={[dashboard]}
-        selectedItems={selectedItems}
+        isSelected={isSelected}
         width={WIDTH}
         height={HEIGHT}
         onFolderClick={noop}

--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -7,6 +7,7 @@ import { assertIsDefined } from 'test/helpers/asserts';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { wellFormedDashboard, wellFormedEmptyFolder, wellFormedFolder } from '../fixtures/dashboardsTreeItem.fixture';
+import { SelectionState } from '../types';
 
 import { DashboardsTree } from './DashboardsTree';
 
@@ -22,19 +23,14 @@ describe('browse-dashboards DashboardsTree', () => {
   const emptyFolderIndicator = wellFormedEmptyFolder();
   const dashboard = wellFormedDashboard(2);
   const noop = () => {};
-  const selectedItems = {
-    $all: false,
-    folder: {},
-    dashboard: {},
-    panel: {},
-  };
+  const isSelected = () => SelectionState.Unselected;
 
   it('renders a dashboard item', () => {
     render(
       <DashboardsTree
         canSelect
         items={[dashboard]}
-        selectedItems={selectedItems}
+        isSelected={isSelected}
         width={WIDTH}
         height={HEIGHT}
         onFolderClick={noop}
@@ -71,7 +67,7 @@ describe('browse-dashboards DashboardsTree', () => {
       <DashboardsTree
         canSelect
         items={[folder]}
-        selectedItems={selectedItems}
+        isSelected={isSelected}
         width={WIDTH}
         height={HEIGHT}
         onFolderClick={noop}
@@ -89,7 +85,7 @@ describe('browse-dashboards DashboardsTree', () => {
       <DashboardsTree
         canSelect
         items={[folder]}
-        selectedItems={selectedItems}
+        isSelected={isSelected}
         width={WIDTH}
         height={HEIGHT}
         onFolderClick={handler}
@@ -108,7 +104,7 @@ describe('browse-dashboards DashboardsTree', () => {
       <DashboardsTree
         canSelect
         items={[emptyFolderIndicator]}
-        selectedItems={selectedItems}
+        isSelected={isSelected}
         width={WIDTH}
         height={HEIGHT}
         onFolderClick={noop}

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -5,14 +5,13 @@ import { FixedSizeList as List } from 'react-window';
 
 import { GrafanaTheme2, isTruthy } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Checkbox, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
 import {
   DashboardsTreeCellProps,
   DashboardsTreeColumn,
   DashboardsTreeItem,
-  DashboardTreeHeaderProps,
   INDENT_AMOUNT_CSS_VAR,
   SelectionState,
 } from '../types';

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -6,7 +6,7 @@ import { FixedSizeList as List } from 'react-window';
 import { GrafanaTheme2, isTruthy } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '@grafana/ui';
-import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
+import { DashboardViewItem } from 'app/features/search/types';
 
 import {
   DashboardsTreeCellProps,
@@ -27,7 +27,7 @@ interface DashboardsTreeProps {
   items: DashboardsTreeItem[];
   width: number;
   height: number;
-  isSelected: (kind: DashboardViewItemKind | '$all', uid: string) => SelectionState;
+  isSelected: (kind: DashboardViewItem | '$all') => SelectionState;
   onFolderClick: (uid: string, newOpenState: boolean) => void;
   onAllSelectionChange: (newState: boolean) => void;
   onItemSelectionChange: (item: DashboardViewItem, newState: boolean) => void;

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { useMemo } from 'react';
-import { CellProps, Column, HeaderProps, TableInstance, useTable } from 'react-table';
+import { TableInstance, useTable } from 'react-table';
 import { FixedSizeList as List } from 'react-window';
 
 import { GrafanaTheme2, isTruthy } from '@grafana/data';
@@ -8,8 +8,17 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Checkbox, useStyles2 } from '@grafana/ui';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
-import { DashboardsTreeItem, DashboardTreeSelection, INDENT_AMOUNT_CSS_VAR } from '../types';
+import {
+  DashboardsTreeCellProps,
+  DashboardsTreeColumn,
+  DashboardsTreeItem,
+  DashboardTreeHeaderProps,
+  INDENT_AMOUNT_CSS_VAR,
+  SelectionState,
+} from '../types';
 
+import CheckboxCell from './CheckboxCell';
+import CheckboxHeaderCell from './CheckboxHeaderCell';
 import { NameCell } from './NameCell';
 import { TagsCell } from './TagsCell';
 import { TypeCell } from './TypeCell';
@@ -19,22 +28,12 @@ interface DashboardsTreeProps {
   items: DashboardsTreeItem[];
   width: number;
   height: number;
-  selectedItems: DashboardTreeSelection;
+  isSelected: (kind: DashboardViewItemKind | '$all', uid: string) => SelectionState;
   onFolderClick: (uid: string, newOpenState: boolean) => void;
   onAllSelectionChange: (newState: boolean) => void;
   onItemSelectionChange: (item: DashboardViewItem, newState: boolean) => void;
   canSelect: boolean;
 }
-
-type DashboardsTreeColumn = Column<DashboardsTreeItem>;
-type DashboardTreeHeaderProps = HeaderProps<DashboardsTreeItem> & {
-  // Note: userProps for cell renderers (e.g. second argument in `cell.render('Cell', foo)` )
-  // aren't typed, so we must be careful when accessing this
-  selectedItems?: DashboardsTreeProps['selectedItems'];
-};
-type DashboardsTreeCellProps = CellProps<DashboardsTreeItem, unknown> & {
-  selectedItems?: DashboardsTreeProps['selectedItems'];
-};
 
 const HEADER_HEIGHT = 35;
 const ROW_HEIGHT = 35;
@@ -43,7 +42,7 @@ export function DashboardsTree({
   items,
   width,
   height,
-  selectedItems,
+  isSelected,
   onFolderClick,
   onAllSelectionChange,
   onItemSelectionChange,
@@ -52,32 +51,12 @@ export function DashboardsTree({
   const styles = useStyles2(getStyles);
 
   const tableColumns = useMemo(() => {
-    const checkboxColumn: DashboardsTreeColumn | null = canSelect
-      ? {
-          id: 'checkbox',
-          width: 0,
-          Header: ({ selectedItems }: DashboardTreeHeaderProps) => {
-            const isAllSelected = selectedItems?.$all ?? false;
-            return <Checkbox value={isAllSelected} onChange={(ev) => onAllSelectionChange(ev.currentTarget.checked)} />;
-          },
-          Cell: ({ row: { original: row }, selectedItems }: DashboardsTreeCellProps) => {
-            const item = row.item;
-            if (item.kind === 'ui-empty-folder' || !selectedItems) {
-              return <></>;
-            }
-
-            const isSelected = selectedItems?.[item.kind][item.uid] ?? false;
-
-            return (
-              <Checkbox
-                data-testid={selectors.pages.BrowseDashbards.table.checkbox(item.uid)}
-                value={isSelected}
-                onChange={(ev) => onItemSelectionChange(item, ev.currentTarget.checked)}
-              />
-            );
-          },
-        }
-      : null;
+    const checkboxColumn: DashboardsTreeColumn = {
+      id: 'checkbox',
+      width: 0,
+      Header: CheckboxHeaderCell,
+      Cell: CheckboxCell,
+    };
 
     const nameColumn: DashboardsTreeColumn = {
       id: 'name',
@@ -102,17 +81,20 @@ export function DashboardsTree({
     const columns = [canSelect && checkboxColumn, nameColumn, typeColumn, tagsColumns].filter(isTruthy);
 
     return columns;
-  }, [onItemSelectionChange, onAllSelectionChange, onFolderClick, canSelect]);
+  }, [onFolderClick, canSelect]);
 
   const table = useTable({ columns: tableColumns, data: items }, useCustomFlexLayout);
   const { getTableProps, getTableBodyProps, headerGroups } = table;
 
-  const virtualData = useMemo(() => {
-    return {
+  const virtualData = useMemo(
+    () => ({
       table,
-      selectedItems,
-    };
-  }, [table, selectedItems]);
+      isSelected,
+      onAllSelectionChange,
+      onItemSelectionChange,
+    }),
+    [table, isSelected, onAllSelectionChange, onItemSelectionChange]
+  );
 
   return (
     <div {...getTableProps()} className={styles.tableRoot} role="table">
@@ -128,7 +110,7 @@ export function DashboardsTree({
 
               return (
                 <div key={key} {...headerProps} role="columnheader" className={styles.cell}>
-                  {column.render('Header', { selectedItems })}
+                  {column.render('Header', { isSelected, onAllSelectionChange })}
                 </div>
               );
             })}
@@ -156,13 +138,15 @@ interface VirtualListRowProps {
   style: React.CSSProperties;
   data: {
     table: TableInstance<DashboardsTreeItem>;
-    selectedItems: Record<DashboardViewItemKind, Record<string, boolean | undefined>>;
+    isSelected: DashboardsTreeCellProps['isSelected'];
+    onAllSelectionChange: DashboardsTreeCellProps['onAllSelectionChange'];
+    onItemSelectionChange: DashboardsTreeCellProps['onItemSelectionChange'];
   };
 }
 
 function VirtualListRow({ index, style, data }: VirtualListRowProps) {
   const styles = useStyles2(getStyles);
-  const { table, selectedItems } = data;
+  const { table, isSelected, onItemSelectionChange } = data;
   const { rows, prepareRow } = table;
 
   const row = rows[index];
@@ -179,7 +163,7 @@ function VirtualListRow({ index, style, data }: VirtualListRowProps) {
 
         return (
           <div key={key} {...cellProps} className={styles.cell}>
-            {cell.render('Cell', { selectedItems })}
+            {cell.render('Cell', { isSelected, onItemSelectionChange })}
           </div>
         );
       })}

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -44,6 +44,10 @@ export function useCheckboxSelectionState() {
   return useSelector((wholeState: StoreState) => wholeState.browseDashboards.selectedItems);
 }
 
+export function useChildrenByParentUIDState() {
+  return useSelector((wholeState: StoreState) => wholeState.browseDashboards.childrenByParentUID);
+}
+
 export function useActionSelectionState() {
   return useSelector((state) => selectedItemsForActionsSelector(state));
 }

--- a/public/app/features/browse-dashboards/state/reducers.test.ts
+++ b/public/app/features/browse-dashboards/state/reducers.test.ts
@@ -196,6 +196,53 @@ describe('browse-dashboards reducers', () => {
         panel: {},
       });
     });
+
+    it('selects ancestors when all their children are now selected', () => {
+      const state = createInitialState();
+
+      const parentFolder = wellFormedFolder(1).item;
+      const childDashboard = wellFormedDashboard(2, {}, { parentUID: parentFolder.uid }).item;
+      const childFolder = wellFormedFolder(3, {}, { parentUID: parentFolder.uid }).item;
+      const grandchildDashboard = wellFormedDashboard(4, {}, { parentUID: childFolder.uid }).item;
+
+      state.rootItems = [parentFolder];
+      state.childrenByParentUID[parentFolder.uid] = [childDashboard, childFolder];
+      state.childrenByParentUID[childFolder.uid] = [grandchildDashboard];
+
+      // Selected the deepest grandchild dashboard
+      setItemSelectionState(state, {
+        type: 'setItemSelectionState',
+        payload: { item: grandchildDashboard, isSelected: true },
+      });
+
+      expect(state.selectedItems).toEqual({
+        dashboard: {
+          [grandchildDashboard.uid]: true,
+        },
+        folder: {
+          [parentFolder.uid]: false,
+          [childFolder.uid]: true, // is selected because all it's children (grandchildDashboard) is selected
+        },
+        panel: {},
+      });
+
+      setItemSelectionState(state, {
+        type: 'setItemSelectionState',
+        payload: { item: childDashboard, isSelected: true },
+      });
+
+      expect(state.selectedItems).toEqual({
+        dashboard: {
+          [childDashboard.uid]: true,
+          [grandchildDashboard.uid]: true,
+        },
+        folder: {
+          [parentFolder.uid]: true, // is now selected because we also selected its other child
+          [childFolder.uid]: true,
+        },
+        panel: {},
+      });
+    });
   });
 
   describe('setAllSelection', () => {

--- a/public/app/features/browse-dashboards/state/reducers.test.ts
+++ b/public/app/features/browse-dashboards/state/reducers.test.ts
@@ -250,6 +250,55 @@ describe('browse-dashboards reducers', () => {
         panel: {},
       });
     });
+
+    it('selects the $all header checkbox when all descendants are now selected', () => {
+      const state = createInitialState();
+
+      const rootDashboard = wellFormedDashboard(1).item;
+      const rootFolder = wellFormedFolder(2).item;
+      const childDashboardA = wellFormedDashboard(3, {}, { parentUID: rootFolder.uid }).item;
+      const childDashboardB = wellFormedDashboard(4, {}, { parentUID: rootFolder.uid }).item;
+
+      state.rootItems = [rootFolder, rootDashboard];
+      state.childrenByParentUID[rootFolder.uid] = [childDashboardA, childDashboardB];
+
+      state.selectedItems.dashboard = { [rootDashboard.uid]: true, [childDashboardA.uid]: true };
+
+      // Selected the deepest grandchild dashboard
+      setItemSelectionState(state, {
+        type: 'setItemSelectionState',
+        payload: { item: childDashboardB, isSelected: true },
+      });
+
+      expect(state.selectedItems.$all).toBeTruthy();
+    });
+
+    it('unselects the $all header checkbox a descendant is unselected', () => {
+      const state = createInitialState();
+
+      const rootDashboard = wellFormedDashboard(1).item;
+      const rootFolder = wellFormedFolder(2).item;
+      const childDashboardA = wellFormedDashboard(3, {}, { parentUID: rootFolder.uid }).item;
+      const childDashboardB = wellFormedDashboard(4, {}, { parentUID: rootFolder.uid }).item;
+
+      state.rootItems = [rootFolder, rootDashboard];
+      state.childrenByParentUID[rootFolder.uid] = [childDashboardA, childDashboardB];
+
+      state.selectedItems.dashboard = {
+        [rootDashboard.uid]: true,
+        [childDashboardA.uid]: true,
+        [childDashboardB.uid]: true,
+      };
+      state.selectedItems.folder = { [rootFolder.uid]: true };
+
+      // Selected the deepest grandchild dashboard
+      setItemSelectionState(state, {
+        type: 'setItemSelectionState',
+        payload: { item: childDashboardB, isSelected: false },
+      });
+
+      expect(state.selectedItems.$all).toBeFalsy();
+    });
   });
 
   describe('setAllSelection', () => {

--- a/public/app/features/browse-dashboards/state/reducers.test.ts
+++ b/public/app/features/browse-dashboards/state/reducers.test.ts
@@ -115,8 +115,10 @@ describe('browse-dashboards reducers', () => {
 
   describe('setItemSelectionState', () => {
     it('marks items as selected', () => {
+      const folder = wellFormedFolder(1).item;
+      const dashboard = wellFormedDashboard(2).item;
       const state = createInitialState();
-      const dashboard = wellFormedDashboard().item;
+      state.rootItems = [folder, dashboard];
 
       setItemSelectionState(state, { type: 'setItemSelectionState', payload: { item: dashboard, isSelected: true } });
 
@@ -133,11 +135,13 @@ describe('browse-dashboards reducers', () => {
     it('marks descendants as selected when the parent folder is selected', () => {
       const state = createInitialState();
 
-      const parentFolder = wellFormedFolder(1).item;
-      const childDashboard = wellFormedDashboard(2, {}, { parentUID: parentFolder.uid }).item;
-      const childFolder = wellFormedFolder(3, {}, { parentUID: parentFolder.uid }).item;
-      const grandchildDashboard = wellFormedDashboard(4, {}, { parentUID: childFolder.uid }).item;
+      const rootDashboard = wellFormedDashboard(1).item;
+      const parentFolder = wellFormedFolder(2).item;
+      const childDashboard = wellFormedDashboard(3, {}, { parentUID: parentFolder.uid }).item;
+      const childFolder = wellFormedFolder(4, {}, { parentUID: parentFolder.uid }).item;
+      const grandchildDashboard = wellFormedDashboard(5, {}, { parentUID: childFolder.uid }).item;
 
+      state.rootItems = [parentFolder, rootDashboard];
       state.childrenByParentUID[parentFolder.uid] = [childDashboard, childFolder];
       state.childrenByParentUID[childFolder.uid] = [grandchildDashboard];
 
@@ -200,12 +204,13 @@ describe('browse-dashboards reducers', () => {
     it('selects ancestors when all their children are now selected', () => {
       const state = createInitialState();
 
-      const parentFolder = wellFormedFolder(1).item;
-      const childDashboard = wellFormedDashboard(2, {}, { parentUID: parentFolder.uid }).item;
-      const childFolder = wellFormedFolder(3, {}, { parentUID: parentFolder.uid }).item;
-      const grandchildDashboard = wellFormedDashboard(4, {}, { parentUID: childFolder.uid }).item;
+      const rootDashboard = wellFormedDashboard(1).item;
+      const parentFolder = wellFormedFolder(2).item;
+      const childDashboard = wellFormedDashboard(3, {}, { parentUID: parentFolder.uid }).item;
+      const childFolder = wellFormedFolder(4, {}, { parentUID: parentFolder.uid }).item;
+      const grandchildDashboard = wellFormedDashboard(5, {}, { parentUID: childFolder.uid }).item;
 
-      state.rootItems = [parentFolder];
+      state.rootItems = [parentFolder, rootDashboard];
       state.childrenByParentUID[parentFolder.uid] = [childDashboard, childFolder];
       state.childrenByParentUID[childFolder.uid] = [grandchildDashboard];
 

--- a/public/app/features/browse-dashboards/state/reducers.test.ts
+++ b/public/app/features/browse-dashboards/state/reducers.test.ts
@@ -216,6 +216,7 @@ describe('browse-dashboards reducers', () => {
       });
 
       expect(state.selectedItems).toEqual({
+        $all: false,
         dashboard: {
           [grandchildDashboard.uid]: true,
         },
@@ -232,6 +233,7 @@ describe('browse-dashboards reducers', () => {
       });
 
       expect(state.selectedItems).toEqual({
+        $all: false,
         dashboard: {
           [childDashboard.uid]: true,
           [grandchildDashboard.uid]: true,

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -84,8 +84,7 @@ export function setItemSelectionState(
       const allChildrenSelected = children?.every((v) => state.selectedItems[v.kind][v.uid]) ?? false;
       state.selectedItems[parent.kind][parent.uid] = allChildrenSelected;
     } else {
-      // If we're unselecting an item, unselect all ancestors (parent, grandparent, etc) also
-      // so we can show a UI-only 'mixed' checkbox
+      // A folder cannot be selected if any of it's children are unselected
       state.selectedItems[parent.kind][parent.uid] = false;
     }
 

--- a/public/app/features/browse-dashboards/state/slice.ts
+++ b/public/app/features/browse-dashboards/state/slice.ts
@@ -12,12 +12,8 @@ const initialState: BrowseDashboardsState = {
   childrenByParentUID: {},
   openFolders: {},
   selectedItems: {
-    dashboard: {
-      'ad5eb449-330a-414b-ab23-8508811aaa53': true,
-    },
-    folder: {
-      'c6a3b0e9-7bad-4c5c-9026-e079cbb79888': true,
-    },
+    dashboard: {},
+    folder: {},
     panel: {},
     $all: false,
   },

--- a/public/app/features/browse-dashboards/state/slice.ts
+++ b/public/app/features/browse-dashboards/state/slice.ts
@@ -12,8 +12,12 @@ const initialState: BrowseDashboardsState = {
   childrenByParentUID: {},
   openFolders: {},
   selectedItems: {
-    dashboard: {},
-    folder: {},
+    dashboard: {
+      'ad5eb449-330a-414b-ab23-8508811aaa53': true,
+    },
+    folder: {
+      'c6a3b0e9-7bad-4c5c-9026-e079cbb79888': true,
+    },
     panel: {},
     $all: false,
   },

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -33,7 +33,7 @@ export const INDENT_AMOUNT_CSS_VAR = '--dashboards-tree-indentation';
 interface RendererUserProps {
   // Note: userProps for cell renderers (e.g. second argument in `cell.render('Cell', foo)` )
   // aren't typed, so we must be careful when accessing this
-  isSelected?: (kind: DashboardViewItemKind | '$all', uid: string) => SelectionState;
+  isSelected?: (kind: DashboardViewItem | '$all') => SelectionState;
   onAllSelectionChange?: (newState: boolean) => void;
   onItemSelectionChange?: (item: DashboardViewItem, newState: boolean) => void;
 }

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -1,3 +1,5 @@
+import { CellProps, Column, HeaderProps } from 'react-table';
+
 import { DashboardViewItem as DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
 export type DashboardTreeSelection = Record<DashboardViewItemKind, Record<string, boolean | undefined>> & {
@@ -27,3 +29,21 @@ export interface DashboardsTreeItem<T extends DashboardViewItemWithUIItems = Das
 }
 
 export const INDENT_AMOUNT_CSS_VAR = '--dashboards-tree-indentation';
+
+interface RendererUserProps {
+  // Note: userProps for cell renderers (e.g. second argument in `cell.render('Cell', foo)` )
+  // aren't typed, so we must be careful when accessing this
+  isSelected?: (kind: DashboardViewItemKind | '$all', uid: string) => SelectionState;
+  onAllSelectionChange?: (newState: boolean) => void;
+  onItemSelectionChange?: (item: DashboardViewItem, newState: boolean) => void;
+}
+
+export type DashboardsTreeColumn = Column<DashboardsTreeItem>;
+export type DashboardsTreeCellProps = CellProps<DashboardsTreeItem, unknown> & RendererUserProps;
+export type DashboardTreeHeaderProps = HeaderProps<DashboardsTreeItem> & RendererUserProps;
+
+export enum SelectionState {
+  Unselected,
+  Selected,
+  Mixed,
+}


### PR DESCRIPTION
 - Uses indeterminate checkbox when a folder has both selected and unselected children
 - Because a checkbox's visual state now depends on other items (it's children), DashboardTree is now passed a function that performs isSelected logic.
 - When selecting an item, check ancestors to see if all their children are selected. If they are, select the ancestor also :) 

Requires https://github.com/grafana/grafana/pull/67312

Part of https://github.com/grafana/grafana/issues/65604 