### PR TITLE
Docs: Fix broken links to section on Variable syntax page

### DIFF
--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -22,7 +22,7 @@ Panel titles and metric queries can refer to variables using two different synta
   This syntax is easy to read, but it does not allow you to use a variable in the middle of a word.
   **Example:** apps.frontend.$server.requests.count
 - `${var_name}` Use this syntax when you want to interpolate a variable in the middle of an expression.
-- `${var_name:<format>}` This format gives you more control over how Grafana interpolates values. Refer to [Advanced variable format options]({{< relref "#advanced-variable-format-options/" >}}) for more detail on all the formatting types.
+- `${var_name:<format>}` This format gives you more control over how Grafana interpolates values. Refer to [Advanced variable format options]({{< relref "#advanced-variable-format-options" >}}) for more detail on all the formatting types.
 - `[[varname]]` Do not use. Deprecated old syntax, will be removed in a future release.
 
 Before queries are sent to your data source the query is _interpolated_, meaning the variable is replaced with its current value. During
@@ -30,7 +30,7 @@ interpolation, the variable value might be _escaped_ in order to conform to the 
 For example, a variable used in a regex expression in an InfluxDB or Prometheus query will be regex escaped. Read the data source specific
 documentation topic for details on value escaping during interpolation.
 
-For advanced syntax to override data source default formatting, refer to [Advanced variable format options]({{< relref "#advanced-variable-format-options/" >}}).
+For advanced syntax to override data source default formatting, refer to [Advanced variable format options]({{< relref "#advanced-variable-format-options" >}}).
 
 ## Advanced variable format options
 


### PR DESCRIPTION
These links have a trailing slash which don't work when linking to a specific element.