### PR TITLE
adding backup ubuntu mirrors into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN if grep -i -q alpine /etc/issue; then \
       apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
       apk info -vv | sort; \
     elif grep -i -q ubuntu /etc/issue; then \
+      sed -i "s|deb http://.*/ \(.*\)|\0\ndeb http://mirrors.mit.edu/ubuntu/ \1\ndeb http://mirrors.ocf.berkeley.edu/ubuntu/ \1|g" /etc/apt/sources.list && \
       DEBIAN_FRONTEND=noninteractive && \
       apt-get update && \
       apt-get install -y ca-certificates curl tzdata && \


### PR DESCRIPTION

**What is this feature?**

Add 2 ubuntu mirrors to /etc/apt/sources.list so that we have backups in case archive.ubuntu.com is down. Using a sed command to inject the 2 extra mirrors was necessary because we cannot conditionally copy files in a dockerfile, and we don't want or need this in the alpine build. I also tried to make the regex as generic as possible so that this will work for multiple URLs (ex: archives.ubuntu.com and ports.ubuntu.com).

**Why do we need this feature?**

To ensure successful builds in case the default ubuntu mirror is down.

**Who is this feature for?**

The grafana delivery team. 

**Which issue(s) does this PR fix?**:

Closes grafana-delivery issue [112.](https://github.com/grafana/grafana-delivery/issues/112) 

** Testing **

To test this, I mocked the mirrors being offline by overriding my /etc/hosts file to point those to localhost. 
Ex: 127.0.0.1   archive.ubuntu.com

I verified that the apt-get commands were successful in each case of a mirror (or several mirrors) being offline. I also verified that there was not a significant increase in build time because of the extra mirrors.