### PR TITLE
FieldValues: fix uPlot crash when using Vector

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -209,7 +209,7 @@ export function preparePlotData2(
       vals = Array(vals.length).fill(undefined);
       vals[firstValIdx] = firstVal;
     } else {
-      vals = vals.slice();
+      vals = Array.from(vals);
 
       if (custom.transform === GraphTransform.NegativeY) {
         for (let i = 0; i < vals.length; i++) {


### PR DESCRIPTION
:wave:  

https://github.com/grafana/grafana/pull/66706 broke our plugin which still uses `ArrayDataFrame` to provide field values for a sparkline. We can't switch to `Array` yet, need to support Grafana 9.5 for a short while. 

The root cause is that[ `preparePlotData2` calls `.slice()` to copy field values](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/utils.ts#L212), but [this method is not implemented on `FunctionalVector`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/vector/FunctionalVector.ts#L88).

Changing `vals.slice()` to equivalent `Array.from(vals)` fixes the issue. Could also implement `FunctionalVector.slice()`, not sure what is the intention there though?

Thanks!
