### PR TITLE
Trace View: Export trace button 

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -3,6 +3,7 @@ import React, { RefObject, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 
 import {
+  CoreApp,
   DataFrame,
   DataLink,
   DataSourceApi,
@@ -76,7 +77,7 @@ type Props = {
 };
 
 export function TraceView(props: Props) {
-  const { spanFindMatches, traceProp, datasource, topOfViewRef, topOfViewRefType } = props;
+  const { spanFindMatches, traceProp, datasource, topOfViewRef, topOfViewRefType, exploreId } = props;
 
   const {
     detailStates,
@@ -158,6 +159,7 @@ export function TraceView(props: Props) {
             <>
               <NewTracePageHeader
                 trace={traceProp}
+                data={props.dataFrames[0]}
                 timeZone={timeZone}
                 search={newTraceViewHeaderSearch}
                 setSearch={setNewTraceViewHeaderSearch}
@@ -168,6 +170,7 @@ export function TraceView(props: Props) {
                 spanFilterMatches={spanFilterMatches}
                 datasourceType={datasourceType}
                 setHeaderHeight={setHeaderHeight}
+                app={exploreId ? CoreApp.Explore : CoreApp.Unknown}
               />
               <SpanGraph
                 trace={traceProp}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -1,13 +1,12 @@
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
-import { CoreApp, DataFrame, MutableDataFrame } from '@grafana/data';
+import { CoreApp, DataFrame } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import { config } from '../../../../../../core/config';
-import { transformToOTLP } from '../../../../../../plugins/datasource/tempo/resultTransformer';
-import { downloadAsJson } from '../../../../../inspector/utils/download';
+import { downloadTraceAsJson } from '../../../../../inspector/utils/download';
 
 import ActionButton from './ActionButton';
 
@@ -41,14 +40,13 @@ export default function TracePageActions(props: TracePageActionsProps) {
   };
 
   const exportTrace = () => {
+    const traceFormat = downloadTraceAsJson(data, 'Trace-' + traceId.substring(traceId.length - 6));
     reportInteraction('grafana_traces_download_traces_clicked', {
       app,
       grafana_version: config.buildInfo.version,
-      trace_format: 'otlp',
+      trace_format: traceFormat,
       location: 'trace-view',
     });
-    let res = transformToOTLP(new MutableDataFrame(data));
-    downloadAsJson(res, 'Trace-' + traceId.substring(traceId.length - 6));
   };
 
   return (

--- a/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageHeader.test.tsx
@@ -15,6 +15,7 @@
 import { getByText, render } from '@testing-library/react';
 import React from 'react';
 
+import { MutableDataFrame } from '@grafana/data';
 import config from 'app/core/config';
 
 import { defaultFilters } from '../../useSearch';
@@ -35,6 +36,7 @@ const setup = () => {
     setFocusedSpanIdForSearch: jest.fn(),
     datasourceType: 'tempo',
     setHeaderHeight: jest.fn(),
+    data: new MutableDataFrame(),
   };
 
   return render(<NewTracePageHeader {...defaultProps} />);

--- a/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageHeader.tsx
@@ -16,7 +16,7 @@ import { css } from '@emotion/css';
 import cx from 'classnames';
 import React, { memo, useEffect, useMemo } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { CoreApp, DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 import { Badge, BadgeColor, Tooltip, useStyles2 } from '@grafana/ui';
 
@@ -34,6 +34,8 @@ import { timestamp, getStyles } from './TracePageHeader';
 
 export type TracePageHeaderProps = {
   trace: Trace | null;
+  data: DataFrame;
+  app?: CoreApp;
   timeZone: TimeZone;
   search: SearchProps;
   setSearch: React.Dispatch<React.SetStateAction<SearchProps>>;
@@ -49,6 +51,8 @@ export type TracePageHeaderProps = {
 export const NewTracePageHeader = memo((props: TracePageHeaderProps) => {
   const {
     trace,
+    data,
+    app,
     timeZone,
     search,
     setSearch,
@@ -99,7 +103,7 @@ export const NewTracePageHeader = memo((props: TracePageHeaderProps) => {
       <div className={styles.titleRow}>
         {links && links.length > 0 && <ExternalLinks links={links} className={styles.TracePageHeaderBack} />}
         {title}
-        <TracePageActions traceId={trace.traceID} />
+        <TracePageActions traceId={trace.traceID} data={data} app={app} />
       </div>
 
       <div className={styles.subtitle}>

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -9,7 +9,6 @@ import {
   CSVConfig,
   DataFrame,
   DataTransformerID,
-  MutableDataFrame,
   SelectableValue,
   TimeZone,
   transformDataFrame,
@@ -22,13 +21,10 @@ import { t, Trans } from 'app/core/internationalization';
 import { dataFrameToLogsModel } from 'app/core/logsModel';
 import { PanelModel } from 'app/features/dashboard/state';
 import { GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
-import { transformToJaeger } from 'app/plugins/datasource/jaeger/responseTransform';
-import { transformToOTLP } from 'app/plugins/datasource/tempo/resultTransformer';
-import { transformToZipkin } from 'app/plugins/datasource/zipkin/utils/transforms';
 
 import { InspectDataOptions } from './InspectDataOptions';
 import { getPanelInspectorStyles } from './styles';
-import { downloadAsJson, downloadDataFrameAsCsv, downloadLogsModelAsTxt } from './utils/download';
+import { downloadAsJson, downloadDataFrameAsCsv, downloadLogsModelAsTxt, downloadTraceAsJson } from './utils/download';
 
 interface Props {
   isLoading: boolean;
@@ -124,28 +120,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
       if (df.meta?.preferredVisualisationType !== 'trace') {
         continue;
       }
-      let traceFormat = 'otlp';
-
-      switch (df.meta?.custom?.traceFormat) {
-        case 'jaeger': {
-          let res = transformToJaeger(new MutableDataFrame(df));
-          downloadAsJson(res, (panel ? panel.getDisplayTitle() : 'Explore') + '-traces');
-          traceFormat = 'jaeger';
-          break;
-        }
-        case 'zipkin': {
-          let res = transformToZipkin(new MutableDataFrame(df));
-          downloadAsJson(res, (panel ? panel.getDisplayTitle() : 'Explore') + '-traces');
-          traceFormat = 'zipkin';
-          break;
-        }
-        case 'otlp':
-        default: {
-          let res = transformToOTLP(new MutableDataFrame(df));
-          downloadAsJson(res, (panel ? panel.getDisplayTitle() : 'Explore') + '-traces');
-          break;
-        }
-      }
+      const traceFormat = downloadTraceAsJson(df, (panel ? panel.getDisplayTitle() : 'Explore') + '-traces');
 
       reportInteraction('grafana_traces_download_traces_clicked', {
         app,


### PR DESCRIPTION
**What is this feature?**

This PR adds a new button to the trace view that allows for quick access to export the current trace. 

⚠️ This feature is currently behind the `newTraceViewHeader` feature toggle.

**Why do we need this feature?**

To allow quick access to export/download traces so they can easily be shared or annexed to incidents, for example.

**Who is this feature for?**

Users of the trace view. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
