### PR TITLE
Datagrid: Fix add column btn styling

### DIFF
--- a/public/app/plugins/panel/datagrid/utils.ts
+++ b/public/app/plugins/panel/datagrid/utils.ts
@@ -266,7 +266,7 @@ export const getStyles = (theme: GrafanaTheme2, isResizeInProgress: boolean) => 
         transition: background-color 200ms;
         cursor: pointer;
         :hover {
-          background-color: ${theme.colors.secondary.shade};
+          background-color: ${theme.colors.background.secondary};
         }
       }
       input {


### PR DESCRIPTION
Changes the add column btn on hover style to match the hover style of other column headers

Fixes #67365