### PR TITLE
Logs: Use millisecond precision for open context in split view

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -12,7 +12,8 @@ import {
   LogsDedupStrategy,
   LogsSortOrder,
   SelectableValue,
-  rangeUtil,
+  dateTime,
+  TimeRange,
 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
@@ -23,6 +24,7 @@ import { splitOpen } from 'app/features/explore/state/main';
 import { SETTINGS_KEYS } from 'app/features/explore/utils/logs';
 import { useDispatch } from 'app/types';
 
+import { sortLogRows } from '../../utils';
 import { LogRows } from '../LogRows';
 
 import { LoadMoreOptions, LogContextButtons } from './LogContextButtons';
@@ -154,16 +156,26 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
 
   const getFullTimeRange = useCallback(() => {
     const { before, after } = context;
-    const allRows = [...before, row, ...after].sort((a, b) => a.timeEpochMs - b.timeEpochMs);
-    const first = allRows[0];
-    const last = allRows[allRows.length - 1];
-    return rangeUtil.convertRawToRange(
-      {
-        from: first.timeUtc,
-        to: last.timeUtc,
+    const allRows = sortLogRows([...before, row, ...after], LogsSortOrder.Ascending);
+    const fromMs = allRows[0].timeEpochMs;
+    let toMs = allRows[allRows.length - 1].timeEpochMs;
+    // In case we have a lot of logs and from and to have same millisecond
+    // we add 1 millisecond to toMs to make sure we have a range
+    if (fromMs === toMs) {
+      toMs += 1;
+    }
+    const from = dateTime(fromMs);
+    const to = dateTime(toMs);
+
+    const range: TimeRange = {
+      from,
+      to,
+      raw: {
+        from,
+        to,
       },
-      'utc'
-    );
+    };
+    return range;
   }, [context, row]);
 
   const onChangeLimitOption = (option: SelectableValue<number>) => {


### PR DESCRIPTION
This PR fixes edge case issue of handling `open split view if all logs are within the same second`. We were doing `second` instead of `milliseconds` precision for log context queries opened in split view. Moreover, it also handles and edge case when `start` and `end` params are within the same millisecond. 

See bellow on how to reproduce and test (I added 2 lines option to context and used tns demo to reproduce).


Fixed:

https://user-images.githubusercontent.com/30407135/234849786-3ba7e105-2781-424d-9f10-4776c8266b68.mov


Broken:

https://user-images.githubusercontent.com/30407135/234849802-ad1543dc-6eaf-4567-b70b-5259be1b42b8.mov

