### PR TITLE
Datagrid: Remove multi-paste

### DIFF
--- a/public/app/plugins/panel/datagrid/DataGridPanel.tsx
+++ b/public/app/plugins/panel/datagrid/DataGridPanel.tsx
@@ -76,7 +76,7 @@ export function DataGridPanel({ options, data, id, fieldConfig, width, height }:
     return getGridCellKind(field, row, hasGridSelection(gridSelection));
   };
 
-  const onCellEdited = async (cell: Item, newValue: EditableGridCell) => {
+  const onCellEdited = (cell: Item, newValue: EditableGridCell) => {
     // if there are rows selected, return early, we don't want to edit any cell
     if (hasGridSelection(gridSelection)) {
       return;
@@ -263,7 +263,6 @@ export function DataGridPanel({ options, data, id, fieldConfig, width, height }:
         getCellsForSelection={isDatagridEnabled() ? true : undefined}
         showSearch={isDatagridEnabled() ? toggleSearch : false}
         onSearchClose={onSearchClose}
-        onPaste={isDatagridEnabled() ? true : undefined}
         gridSelection={gridSelection}
         onGridSelectionChange={isDatagridEnabled() ? onGridSelectionChange : undefined}
         onRowAppended={isDatagridEnabled() ? addNewRow : undefined}


### PR DESCRIPTION
Remove the ability to paste multiple rows/columns for the moment as it doesn't work properly. Will return to this and enhance it (by adding the possibility to also create new rows/columns if the pasted data is larger than the datagrid size) after G10 release