### PR TITLE
Plugins: Fix files with two dots in the name not being returned by LocalFS.Files()

### DIFF
--- a/pkg/plugins/localfiles.go
+++ b/pkg/plugins/localfiles.go
@@ -34,7 +34,7 @@ func NewLocalFS(basePath string) LocalFS {
 // file is allowed or not. Access to a file is allowed if the file is in the FS's Base() directory, and if it's a
 // symbolic link it should not end up outside the plugin's directory.
 func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.FileInfo) (bool, error) {
-	upperLevelSeparator := "../" + string(filepath.Separator)
+	upperLevelPrefix := "../" + string(filepath.Separator)
 	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 		symlinkPath, err := filepath.EvalSymlinks(absolutePath)
 		if err != nil {
@@ -51,7 +51,7 @@ func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.Fil
 		if err != nil {
 			return false, err
 		}
-		if p == ".." || strings.HasPrefix(p, upperLevelSeparator) {
+		if p == ".." || strings.HasPrefix(p, upperLevelPrefix) {
 			return false, fmt.Errorf("file '%s' not inside of plugin directory", p)
 		}
 
@@ -71,7 +71,7 @@ func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.Fil
 	if err != nil {
 		return false, err
 	}
-	if strings.HasPrefix(file, upperLevelSeparator) {
+	if strings.HasPrefix(file, upperLevelPrefix) {
 		return false, fmt.Errorf("file '%s' not inside of plugin directory", file)
 	}
 	return true, nil

--- a/pkg/plugins/localfiles.go
+++ b/pkg/plugins/localfiles.go
@@ -142,14 +142,13 @@ func (f LocalFS) Files() ([]string, error) {
 	// Convert the accumulator into a slice of relative path strings
 	relFiles := make([]string, 0, len(absFilePaths))
 	base := f.Base()
-	upperLevelPrefix := ".." + string(os.PathSeparator)
 	for fn := range absFilePaths {
 		relPath, err := filepath.Rel(base, fn)
 		if err != nil {
 			return nil, err
 		}
 		clenRelPath, err := util.CleanRelativePath(relPath)
-		if strings.HasPrefix(clenRelPath, upperLevelPrefix) || err != nil {
+		if err != nil {
 			continue
 		}
 		relFiles = append(relFiles, clenRelPath)

--- a/pkg/plugins/localfiles.go
+++ b/pkg/plugins/localfiles.go
@@ -34,7 +34,7 @@ func NewLocalFS(basePath string) LocalFS {
 // file is allowed or not. Access to a file is allowed if the file is in the FS's Base() directory, and if it's a
 // symbolic link it should not end up outside the plugin's directory.
 func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.FileInfo) (bool, error) {
-	upperLevelPrefix := "../" + string(filepath.Separator)
+	upperLevelPrefix := ".." + string(filepath.Separator)
 	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 		symlinkPath, err := filepath.EvalSymlinks(absolutePath)
 		if err != nil {

--- a/pkg/plugins/localfiles_test.go
+++ b/pkg/plugins/localfiles_test.go
@@ -277,3 +277,26 @@ func TestStaticFS(t *testing.T) {
 		})
 	})
 }
+
+// TestFSTwoDotsInFileName ensures that LocalFS and StaticFS allow two dots in file names.
+// This makes sure that FS' do not believe that two dots in a file name (anywhere in the path)
+// represent a path traversal attempt.
+func TestFSTwoDotsInFileName(t *testing.T) {
+	tmp := t.TempDir()
+	const fn = "test..png"
+	require.NoError(t, createDummyTempFile(tmp, fn))
+
+	localFS := NewLocalFS(tmp)
+	staticFS, err := NewStaticFS(localFS)
+	require.NoError(t, err)
+
+	// Test both with localFS and staticFS
+
+	files, err := localFS.Files()
+	require.NoError(t, err)
+	require.Equal(t, []string{"test..png"}, files)
+
+	files, err = staticFS.Files()
+	require.NoError(t, err)
+	require.Equal(t, []string{"test..png"}, files)
+}

--- a/pkg/plugins/localfiles_test.go
+++ b/pkg/plugins/localfiles_test.go
@@ -279,7 +279,7 @@ func TestStaticFS(t *testing.T) {
 }
 
 // TestFSTwoDotsInFileName ensures that LocalFS and StaticFS allow two dots in file names.
-// This makes sure that FS' do not believe that two dots in a file name (anywhere in the path)
+// This makes sure that FSes do not believe that two dots in a file name (anywhere in the path)
 // represent a path traversal attempt.
 func TestFSTwoDotsInFileName(t *testing.T) {
 	tmp := t.TempDir()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes `LocalFS.Files()` not returning files when there are two dots anywhere in the name.

When running in production with the newly introduced `StaticFS()`, this causes files with two dots in the name to fail signature validation and make the plugin fail to load.

**Why do we need this feature?**

Fixes a bug introduced with the work on `StaticFS`

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
