### PR TITLE
CI: Add `sync-grafana-mirror` step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2141,7 +2141,19 @@ platform:
   os: linux
 services: []
 steps:
-- image: grafana/drone-downstream
+- commands:
+  - git fetch origin main-synced
+  - git checkout main-synced
+  - git remote add grafana-mirror $${DOWNSTREAM_REPO}
+  - git push -f grafana-mirror main
+  environment:
+    DOWNSTREAM_REPO:
+      from_secret: grafana_downstream_repo
+  image: grafana/build-container:1.7.4
+  name: sync-grafana-mirror
+- depends_on:
+  - sync-grafana-mirror
+  image: grafana/drone-downstream
   name: trigger-enterprise-downstream
   settings:
     params:
@@ -7148,6 +7160,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 1a5358f92b6ca848288fb7917e62b994430c89eaa43ac2e5c1de49df359886d5
+hmac: 3b7fe8f3ee70f3fdb96c8f5e41e2fd9c84992a93e1ddae5518065580f4e11ea7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2142,8 +2142,8 @@ platform:
 services: []
 steps:
 - commands:
-  - git fetch origin main-synced
-  - git checkout main-synced
+  - git fetch origin main
+  - git checkout main
   - git remote add grafana-mirror $${DOWNSTREAM_REPO}
   - git push -f grafana-mirror main
   environment:
@@ -7160,6 +7160,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 3b7fe8f3ee70f3fdb96c8f5e41e2fd9c84992a93e1ddae5518065580f4e11ea7
+hmac: 973109dcb66504d619152d83d6d591ea30f809012f6abd28ad00ebdff40dc1ec
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7142,6 +7142,12 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 get:
+  name: downstream-repo
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: grafana_downstream_repo
+---
+get:
   name: gcp_service_account_base64
   path: infra/data/ci/grafana-release-eng/rgm
 kind: secret
@@ -7160,6 +7166,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 973109dcb66504d619152d83d6d591ea30f809012f6abd28ad00ebdff40dc1ec
+hmac: 6bf44e00d6f9d7f0be53a9efa466c2e4bf5d685ec08452f145c84756db880813
 
 ...

--- a/scripts/drone/pipelines/trigger_downstream.star
+++ b/scripts/drone/pipelines/trigger_downstream.star
@@ -7,7 +7,6 @@ load(
     "enterprise_downstream_step",
     "sync_grafana_mirror_step",
 )
-
 load(
     "scripts/drone/utils/utils.star",
     "pipeline",

--- a/scripts/drone/pipelines/trigger_downstream.star
+++ b/scripts/drone/pipelines/trigger_downstream.star
@@ -5,7 +5,9 @@ This module returns the pipeline used for triggering a downstream pipeline for G
 load(
     "scripts/drone/steps/lib.star",
     "enterprise_downstream_step",
+    "sync_grafana_mirror_step",
 )
+
 load(
     "scripts/drone/utils/utils.star",
     "pipeline",
@@ -28,6 +30,7 @@ trigger = {
 def enterprise_downstream_pipeline():
     environment = {"EDITION": "oss"}
     steps = [
+        sync_grafana_mirror_step(),
         enterprise_downstream_step(ver_mode = "main"),
     ]
     deps = [

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -273,7 +273,9 @@ def enterprise_downstream_step(ver_mode):
         step.update({"failure": "ignore"})
         step["settings"]["params"].append("OSS_PULL_REQUEST=${DRONE_PULL_REQUEST}")
     if ver_mode == "main":
-        step.update({"depends_on": ["sync-grafana-mirror",]})
+        step.update({"depends_on": [
+            "sync-grafana-mirror",
+        ]})
 
     return step
 
@@ -1586,15 +1588,15 @@ def get_trigger_storybook(ver_mode):
 
 def sync_grafana_mirror_step():
     return {
-        'name': 'sync-grafana-mirror',
-        'image': build_image,
+        "name": "sync-grafana-mirror",
+        "image": build_image,
         "environment": {
-            "DOWNSTREAM_REPO": from_secret('grafana_downstream_repo'),
+            "DOWNSTREAM_REPO": from_secret("grafana_downstream_repo"),
         },
-        'commands': [
-            'git fetch origin main',
-            'git checkout main',
-            'git remote add grafana-mirror $${DOWNSTREAM_REPO}',
-            'git push -f grafana-mirror main',
-        ]
+        "commands": [
+            "git fetch origin main",
+            "git checkout main",
+            "git remote add grafana-mirror $${DOWNSTREAM_REPO}",
+            "git push -f grafana-mirror main",
+        ],
     }

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1592,8 +1592,8 @@ def sync_grafana_mirror_step():
             "DOWNSTREAM_REPO": from_secret('grafana_downstream_repo'),
         },
         'commands': [
-            'git fetch origin main-synced',
-            'git checkout main-synced',
+            'git fetch origin main',
+            'git checkout main',
             'git remote add grafana-mirror $${DOWNSTREAM_REPO}',
             'git push -f grafana-mirror main',
         ]

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -272,6 +272,8 @@ def enterprise_downstream_step(ver_mode):
     if ver_mode == "pr":
         step.update({"failure": "ignore"})
         step["settings"]["params"].append("OSS_PULL_REQUEST=${DRONE_PULL_REQUEST}")
+    if ver_mode == "main":
+        step.update({"depends_on": ["sync-grafana-mirror",]})
 
     return step
 
@@ -1581,3 +1583,18 @@ def get_trigger_storybook(ver_mode):
             },
         }
     return trigger_storybook
+
+def sync_grafana_mirror_step():
+    return {
+        'name': 'sync-grafana-mirror',
+        'image': build_image,
+        "environment": {
+            "DOWNSTREAM_REPO": from_secret('grafana_downstream_repo'),
+        },
+        'commands': [
+            'git fetch origin main-synced',
+            'git checkout main-synced',
+            'git remote add grafana-mirror $${DOWNSTREAM_REPO}',
+            'git push -f grafana-mirror main',
+        ]
+    }

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -8,6 +8,7 @@ gcp_upload_artifacts_key = "gcp_upload_artifacts_key"
 azure_sp_app_id = "azure_sp_app_id"
 azure_sp_app_pw = "azure_sp_app_pw"
 azure_tenant = "azure_tenant"
+grafana_downstream_repo = "grafana_downstream_repo"
 
 rgm_gcp_key_base64 = "gcp_key_base64"
 rgm_destination = "destination"
@@ -122,6 +123,11 @@ def secrets():
             "enterprise2_security_prefix",
             "infra/data/ci/grafana-release-eng/enterprise2",
             "security_prefix",
+        ),
+        vault_secret(
+            "grafana_downstream_repo",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "downstream-repo",
         ),
         vault_secret(
             rgm_gcp_key_base64,


### PR DESCRIPTION
**What is this feature?**

Step to sync `grafana/grafana` repository main, with `grafana-mirror` main.

The way it works is that after every push to main, assuming that all the build/test pipelines have run, the `main-trigger-downstream` pipeline will include this step, which will first sync `origin main` with `grafana-mirror main` main and **then** start the downstream built normally, as happened in the past. 

Fixes https://github.com/grafana/grafana-delivery/issues/117