### PR TITLE
Authentication UI: Fix permissions required to show config page

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -163,9 +163,7 @@ func enableServiceAccount(s *ServiceImpl, c *contextmodel.ReqContext) bool {
 
 func evalAuthenticationSettings() ac.Evaluator {
 	return ac.EvalAll(
-		ac.EvalPermission(ac.ActionSettingsWrite, ac.ScopeSettingsAuth),
 		ac.EvalPermission(ac.ActionSettingsWrite, ac.ScopeSettingsSAML),
-		ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAuth),
 		ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsSAML),
 	)
 }


### PR DESCRIPTION
**What is this feature?**
Fix permissions required to show authentication config page. Otherwise non Grafana Admins cannot access SAML UI.

**Why do we need this feature?**

To fix SAML UI on cloud instances.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
