### PR TITLE
Prometheus: Update healthcheck text message

### DIFF
--- a/e2e/various-suite/exemplars.spec.ts
+++ b/e2e/various-suite/exemplars.spec.ts
@@ -4,7 +4,7 @@ const dataSourceName = 'PromExemplar';
 const addDataSource = () => {
   e2e.flows.addDataSource({
     type: 'Prometheus',
-    expectedAlertMessage: 'saved',
+    expectedAlertMessage: 'Prometheus',
     name: dataSourceName,
     form: () => {
       e2e.components.DataSource.Prometheus.configPage.exemplarsAddButton().click();

--- a/pkg/tsdb/prometheus/healthcheck.go
+++ b/pkg/tsdb/prometheus/healthcheck.go
@@ -64,15 +64,15 @@ func healthcheck(ctx context.Context, req *backend.CheckHealthRequest, i *instan
 	})
 
 	if err != nil {
-		return getHealthCheckMessage(logger, "Your configuration has been saved but there is an error.", err)
+		return getHealthCheckMessage(logger, "There was an error returned querying the Prometheus API.", err)
 	}
 
 	if resp.Responses[refID].Error != nil {
-		return getHealthCheckMessage(logger, "Your configuration has been saved but there is an error.",
+		return getHealthCheckMessage(logger, "There was an error returned querying the Prometheus API.",
 			errors.New(resp.Responses[refID].Error.Error()))
 	}
 
-	return getHealthCheckMessage(logger, "Successfully saved the configuration and queried the Prometheus API.", nil)
+	return getHealthCheckMessage(logger, "Successfully queried the Prometheus API.", nil)
 }
 
 func getHealthCheckMessage(logger log.Logger, message string, err error) (*backend.CheckHealthResult, error) {


### PR DESCRIPTION
The healthcheck can be used outside the config save & test so change text message to something more generic that does not include a save message.

The health check messages will also be updated in stage 2 of the Prometheus Config Overhaul
https://github.com/grafana/grafana/issues/65877

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
