### PR TITLE
Timeseries: Update auto-migration e2e test

### DIFF
--- a/e2e/various-suite/graph-auto-migrate.spec.ts
+++ b/e2e/various-suite/graph-auto-migrate.spec.ts
@@ -35,7 +35,7 @@ e2e.scenario({
         e2e.pages.Dashboard.Annotations.marker().should('exist');
       });
 
-    e2e.pages.Dashboard.wrapper().children().children('.scrollbar-view').scrollTo('bottom');
+    cy.get('body').children().find('.scrollbar-view').first().scrollTo('bottom');
 
     e2e.components.Panels.Panel.title('05:00')
       .should('exist')

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -49,7 +49,6 @@ export const Pages = {
   },
   Dashboard: {
     url: (uid: string) => `/d/${uid}`,
-    wrapper: 'data-testid dashboard-page-wrapper',
     DashNav: {
       /**
        * @deprecated use navV2 from Grafana 8.3 instead

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -3,7 +3,6 @@ import { css, cx } from '@emotion/css';
 import React, { useLayoutEffect } from 'react';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 import { CustomScrollbar, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
@@ -51,7 +50,7 @@ export const Page: PageType = ({
   }, [navModel, pageNav, chrome, layout]);
 
   return (
-    <div className={cx(styles.wrapper, className)} {...otherProps} data-testid={selectors.pages.Dashboard.wrapper}>
+    <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
           <div className={styles.pageInner}>


### PR DESCRIPTION
Removes unnecessary test id added to Page.tsx.
Updates the e2e test.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
