### PR TITLE
Authentication UI: Hide empty settings section

### DIFF
--- a/public/app/features/auth-config/AuthConfigPage.tsx
+++ b/public/app/features/auth-config/AuthConfigPage.tsx
@@ -100,9 +100,9 @@ export const AuthConfigPageUnconnected = ({
             ))}
           </div>
         )}
-        <div className={styles.settingsSection}>
-          <h3>Settings</h3>
-          {authSettings && (
+        {!isEmpty(authSettings) && (
+          <div className={styles.settingsSection}>
+            <h3>Settings</h3>
             <table className="filter-table">
               <tbody>
                 {Object.entries(authSettings).map(([sectionName, sectionSettings], i) => (
@@ -121,8 +121,8 @@ export const AuthConfigPageUnconnected = ({
                 ))}
               </tbody>
             </table>
-          )}
-        </div>
+          </div>
+        )}
       </Page.Contents>
     </Page>
   );


### PR DESCRIPTION
**What is this feature?**

This PR fixes displaying empty settings section (hides it completely).

**Why do we need this feature?**

Since we decided to hide settings for non Grafana Admins, we need to hide the whole section if settings are empty.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
