### PR TITLE
Documentation: add 2 SAML troubleshooting steps

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -529,3 +529,27 @@ cookie_secure = true
 ```
 
 Ensure cookie_secure is set to true to ensure that cookies are only sent over HTTPS.
+
+
+### Error: "Corresponding relay state was not found"
+
+This can happen in case of IdP initiated authentication, when it is isn’t enabled in Grafana, or the relay_state configurations don’t match between Grafana and the IdP.
+
+The configuration for IdP initiated login is here: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/#idp-initiated-single-sign-on-sso 
+
+If this error happens when logging in from the Grafana login page, it means that there is an issue with the saml_state cookie created at the beginning of the authentication process (in the login/saml request). Either the cookie expired (this can happen if there’s MFA set up on the IdP side, and the authentication process takes a while). In this case raising the max_issue_delay should help.
+
+In any case, you need to check what happens to this cookie to figure out what the issue is. It can be caused by HTTP/HTTPS issues in some cases.
+
+
+### Error: "Failed to save the SAML received information"
+
+This means the assertion configuration in Grafana doesn’t match what’s in the IdP. You need to turn on debug logs for SAML:
+
+```ini
+[log]
+filters = saml.auth:debug
+```
+
+This will add in the logs the information received from the IdP, and these need to be mapped exactly in Grafana.  
+

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -535,7 +535,7 @@ Ensure cookie_secure is set to true to ensure that cookies are only sent over HT
 
 This can happen in case of IdP initiated authentication, when it is isn’t enabled in Grafana, or the relay_state configurations don’t match between Grafana and the IdP.
 
-The configuration for IdP initiated login is here: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/#idp-initiated-single-sign-on-sso 
+For more information about IdP-initiated login, refer to [IdP-initiated Single Sign-On (SSO)](#idp-initiated-single-sign-on-sso).
 
 If this error happens when logging in from the Grafana login page, it means that there is an issue with the saml_state cookie created at the beginning of the authentication process (in the login/saml request). Either the cookie expired (this can happen if there’s MFA set up on the IdP side, and the authentication process takes a while). In this case raising the max_issue_delay should help.
 


### PR DESCRIPTION
These are based on notes taken during a recent customer SAML setup session.

**What is this feature?**

2 additional Troubleshooting steps, as recommended by a Grafana Labs Support Engineer I worked with during a customer session on SAML setup.

**Why do we need this feature?**

To provide more self-help material for customers working with SAML.

**Who is this feature for?**

Any Grafana user/prospect/customer working on setting up SAML for SSO.

**Which issue(s) does this PR fix?**:
None - this is just a standalone submission.