### PR TITLE
TraceView: Supporting JSON strings for arrays in trace data

### DIFF
--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TraceResponse } from '../types';
+import { TraceKeyValuePair, TraceResponse } from '../types';
 
 import transformTraceData, { orderTags, deduplicateTags } from './transform-trace-data';
 
@@ -161,5 +161,36 @@ describe('transformTraceData()', () => {
     } as unknown as TraceResponse;
 
     expect(transformTraceData(traceData)!.traceName).toEqual(`${serviceName}: ${rootOperationName}`);
+  });
+
+  it('should return tags when defined as JSON strings', () => {
+    const expectedTags: TraceKeyValuePair[] = [
+      {
+        key: 'tag1',
+        value: 'value1',
+      },
+      {
+        key: 'tag2',
+        value: 'value2',
+      },
+    ];
+
+    const traceData = {
+      traceID,
+      processes,
+      spans: [
+        {
+          traceID,
+          spanID: '41f71485ed2593e4',
+          operationName: 'someOperationName',
+          startTime,
+          duration,
+          tags: JSON.stringify(expectedTags),
+          processID: 'p1',
+        },
+      ],
+    } as unknown as TraceResponse;
+
+    expect(transformTraceData(traceData)?.spans[0]?.tags).toEqual(expectedTags);
   });
 });


### PR DESCRIPTION
**What is this feature?**

Allows TraceView to consume from data sources which return array data in JSONified strings.

**Why do we need this feature?**

Data sources like ADX cannot be used with TraceView.

**Who is this feature for?**

End user

**Which issue(s) does this PR fix?**:

Fixes #67454

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
