### PR TITLE
Prometheus: Fix regression for $__rate_interval comparison

### DIFF
--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -156,6 +156,10 @@ func calculatePrometheusInterval(
 	query backend.DataQuery,
 	intervalCalculator intervalv2.Calculator,
 ) (time.Duration, error) {
+	// we need to compare the original query model after it is overwritten below to variables so that we can
+	// calculate the rateInterval if it is equal to $__rate_interval or ${__rate_interval}
+	originalQueryInterval := queryInterval
+
 	// If we are using variable for interval/step, we will replace it with calculated interval
 	if isVariableInterval(queryInterval) {
 		queryInterval = ""
@@ -173,7 +177,8 @@ func calculatePrometheusInterval(
 		adjustedInterval = calculatedInterval.Value
 	}
 
-	if queryInterval == varRateInterval || queryInterval == varRateIntervalAlt {
+	// here is where we compare for $__rate_interval or ${__rate_interval}
+	if originalQueryInterval == varRateInterval || originalQueryInterval == varRateIntervalAlt {
 		// Rate interval is final and is not affected by resolution
 		return calculateRateInterval(adjustedInterval, timeInterval, intervalCalculator), nil
 	} else {

--- a/pkg/tsdb/prometheus/models/query_test.go
+++ b/pkg/tsdb/prometheus/models/query_test.go
@@ -376,7 +376,6 @@ func TestParse(t *testing.T) {
 			"format": "time_series",
 			"intervalFactor": 1,
 			"interval": "$__rate_interval",
-			"intervalMs": 60000,
 			"refId": "A"
 		}`, timeRange)
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5738

This fixes a regression when passing `$__rate_interval` into the prometheus minstep option. 

There was a regression where the queryInterval being passed to the backend `calculatePrometheusInterval`, where if it was `$__rate_interval` or `${__rate_interval} was being overwritten, as it was supposed to be, but was never checked again for those variables to `calculateRateInterval()` if those variables were present. See below for the difference.

When we compare this (before regression)

https://github.com/grafana/grafana/blob/a81a665f43104a86c4db87483d4664bf002096a6/pkg/tsdb/prometheus/models/query.go#L142-L172

to this 

https://github.com/grafana/grafana/blob/21f6414f132c463cea63a8d752ee862385ed1f03/pkg/tsdb/prometheus/models/query.go#L153-L186

we see that `model.Interval` is the original query and that is assigned to queryInterval, then compared to variables equal to `$__rate_interval` or `${__rate_interval}`

Also, the test that include 60000 ms as intervalMs, that value was not present before the regression and this value changes the adjusted interval calculating giving a false positive in favor of the regression. Therefore, I removed it and the `$__rate_interval` is calculated correctly.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
