### PR TITLE
Transforms: Add Alpha Group by Time Transform

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -283,6 +283,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "packages/grafana-data/src/transformations/transformers/groupByTime.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
     "packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -3393,6 +3397,9 @@ exports[`better eslint`] = {
     "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
+    "public/app/features/transformers/editors/GroupByTimeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/packages/grafana-data/src/transformations/transformers.ts
+++ b/packages/grafana-data/src/transformations/transformers.ts
@@ -7,6 +7,7 @@ import { filterFieldsByNameTransformer } from './transformers/filterByName';
 import { filterFramesByRefIdTransformer } from './transformers/filterByRefId';
 import { filterByValueTransformer } from './transformers/filterByValue';
 import { groupByTransformer } from './transformers/groupBy';
+import { groupByTimeTransformer } from './transformers/groupByTime';
 import { groupingToMatrixTransformer } from './transformers/groupingToMatrix';
 import { histogramTransformer } from './transformers/histogram';
 import { joinByFieldTransformer } from './transformers/joinByField';
@@ -42,6 +43,7 @@ export const standardTransformers = {
   labelsToFieldsTransformer,
   ensureColumnsTransformer,
   groupByTransformer,
+  groupByTimeTransformer,
   sortByTransformer,
   mergeTransformer,
   renameByRegexTransformer,

--- a/packages/grafana-data/src/transformations/transformers/groupByTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupByTime.ts
@@ -1,0 +1,210 @@
+import moment from 'moment';
+import { map } from 'rxjs/operators';
+
+import { MutableField } from '../../dataframe/MutableDataFrame';
+import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
+import { getFieldDisplayName } from '../../field/fieldState';
+import { DataFrame, Field, FieldType } from '../../types/dataFrame';
+import { DataTransformerInfo } from '../../types/transformations';
+import { reduceField, ReducerID } from '../fieldReducer';
+
+import { DataTransformerID } from './ids';
+
+export enum GroupByOperationID {
+  aggregate = 'aggregate',
+  groupBy = 'groupby',
+}
+
+export enum GroupByTimeBucket {
+    day = 'YYYY-MM-DD',
+    month = 'YYYY-MM',
+    year = 'YYYY',
+}
+
+export interface GroupByTimeFieldOptions {
+    timeBucket?: GroupByTimeBucket | null,
+    aggregations: ReducerID[];
+    operation: GroupByOperationID | null;
+}
+
+export interface GroupByTimeTransformerOptions {
+  fields: Record<string, GroupByTimeFieldOptions>;
+}
+
+export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerOptions> = {
+  id: DataTransformerID.groupByTime,
+  name: 'Group by time',
+  description: 'Group the data by time then process calculations for each group',
+  defaultOptions: {
+    fields: {},
+  },
+
+  /**
+   * Return a modified copy of the series.  If the transform is not or should not
+   * be applied, just return the input series
+   */
+  operator: (options) => (source) =>
+    source.pipe(
+      map((data) => {
+        const hasValidConfig = Object.keys(options.fields).find(
+          (name) => options.fields[name].operation === GroupByOperationID.groupBy
+        );
+
+        if (!hasValidConfig) {
+          return data;
+        }
+
+        const processed: DataFrame[] = [];
+
+        for (const frame of data) {
+        // Create an array of fields to group by
+        // and then add configured fields to this array
+          const groupByFields: Field[] = [];
+          for (const field of frame.fields) {
+            if (shouldGroupOnField(field, options)) {
+              groupByFields.push(field);
+            }
+          }
+
+          // If there are no fields to group by we do nothing
+          if (groupByFields.length === 0) {
+            continue; 
+          }
+
+          // Group the values by fields and groups so we can get all values for a
+          // group for a given field.
+          const valuesByGroupKey = new Map<string, Record<string, MutableField>>();
+          for (let rowIndex = 0; rowIndex < frame.length; rowIndex++) {
+            // Get the key for the grouping bucket for each format
+            // we format using the appropriate date string to get
+            // the correct grouping key
+          
+            const groupKey = String(groupByFields.map((field) => {
+                const fieldName = getFieldDisplayName(field);
+                const format = options.fields[fieldName].timeBucket;
+                const date = moment(field.values[rowIndex]);
+
+                return date.isValid() ? date.format(format as string) : null;
+            }));
+
+            const valuesByField = valuesByGroupKey.get(groupKey) ?? {};
+
+            if (!valuesByGroupKey.has(groupKey)) {
+              valuesByGroupKey.set(groupKey, valuesByField);
+            }
+
+            for (let field of frame.fields) {
+              const fieldName = getFieldDisplayName(field);
+
+              if (!valuesByField[fieldName]) {
+                valuesByField[fieldName] = {
+                  name: fieldName,
+                  type: field.type,
+                  config: { ...field.config },
+                  values: [],
+                };
+              }
+
+              valuesByField[fieldName].values.push(field.values[rowIndex]);
+            }
+          }
+
+          const fields: Field[] = [];
+
+          for (const field of groupByFields) {
+            const values: any[] = [];
+            const fieldName = getFieldDisplayName(field);
+
+            valuesByGroupKey.forEach((value) => {
+              values.push(value[fieldName].values[0]);
+            });
+
+            fields.push({
+              name: field.name,
+              type: field.type,
+              config: {
+                ...field.config,
+              },
+              values: values,
+            });
+          }
+
+          // Then for each calculations configured, compute and add a new field (column)
+          for (const field of frame.fields) {
+            if (!shouldCalculateField(field, options)) {
+              continue;
+            }
+
+            const fieldName = getFieldDisplayName(field);
+            const aggregations = options.fields[fieldName].aggregations;
+            const valuesByAggregation: Record<string, any[]> = {};
+
+            valuesByGroupKey.forEach((value) => {
+              const fieldWithValuesForGroup = value[fieldName];
+              const results = reduceField({
+                field: fieldWithValuesForGroup,
+                reducers: aggregations,
+              });
+
+              for (const aggregation of aggregations) {
+                if (!Array.isArray(valuesByAggregation[aggregation])) {
+                  valuesByAggregation[aggregation] = [];
+                }
+                valuesByAggregation[aggregation].push(results[aggregation]);
+              }
+            });
+
+            for (const aggregation of aggregations) {
+              const aggregationField: Field = {
+                name: `${fieldName} (${aggregation})`,
+                values: valuesByAggregation[aggregation],
+                type: FieldType.other,
+                config: {},
+              };
+
+              aggregationField.type = detectFieldType(aggregation, field, aggregationField);
+              fields.push(aggregationField);
+            }
+          }
+
+          processed.push({
+            fields,
+            length: valuesByGroupKey.size,
+          });
+        }
+
+        return processed;
+      })
+    ),
+};
+
+const shouldGroupOnField = (field: Field, options: GroupByTimeTransformerOptions): boolean => {
+  const fieldName = getFieldDisplayName(field);
+  return (
+    options?.fields[fieldName]?.operation === GroupByOperationID.groupBy && 
+    options?.fields[fieldName]?.timeBucket !== null
+  );
+};
+
+const shouldCalculateField = (field: Field, options: GroupByTimeTransformerOptions): boolean => {
+  const fieldName = getFieldDisplayName(field);
+  return (
+    options?.fields[fieldName]?.operation === GroupByOperationID.aggregate &&
+    Array.isArray(options?.fields[fieldName].aggregations) &&
+    options?.fields[fieldName].aggregations.length > 0
+  );
+};
+
+const detectFieldType = (aggregation: string, sourceField: Field, targetField: Field): FieldType => {
+  switch (aggregation) {
+    case ReducerID.allIsNull:
+      return FieldType.boolean;
+    case ReducerID.last:
+    case ReducerID.lastNotNull:
+    case ReducerID.first:
+    case ReducerID.firstNotNull:
+      return sourceField.type;
+    default:
+      return guessFieldTypeForField(targetField) ?? FieldType.string;
+  }
+};

--- a/packages/grafana-data/src/transformations/transformers/groupByTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupByTime.ts
@@ -70,7 +70,7 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
           if (groupByFields.length === 0) {
             continue; 
           }
-
+ 
           // Group the values by fields and groups so we can get all values for a
           // group for a given field.
           const valuesByGroupKey = new Map<string, Record<string, MutableField>>();
@@ -81,10 +81,10 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
           
             const groupKey = String(groupByFields.map((field) => {
                 const fieldName = getFieldDisplayName(field);
-                const format = options.fields[fieldName].timeBucket;
+                const format = options.fields[fieldName].timeBucket?.toString();
                 const date = moment(field.values[rowIndex]);
 
-                return date.isValid() ? date.format(format as string) : null;
+                return date.isValid() ? date.format(format) : null;
             }));
 
             const valuesByField = valuesByGroupKey.get(groupKey) ?? {};

--- a/packages/grafana-data/src/transformations/transformers/groupByTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupByTime.ts
@@ -16,15 +16,15 @@ export enum GroupByOperationID {
 }
 
 export enum GroupByTimeBucket {
-    day = 'YYYY-MM-DD',
-    month = 'YYYY-MM',
-    year = 'YYYY',
+  day = 'YYYY-MM-DD',
+  month = 'YYYY-MM',
+  year = 'YYYY',
 }
 
 export interface GroupByTimeFieldOptions {
-    timeBucket?: GroupByTimeBucket | null,
-    aggregations: ReducerID[];
-    operation: GroupByOperationID | null;
+  timeBucket?: GroupByTimeBucket | null;
+  aggregations: ReducerID[];
+  operation: GroupByOperationID | null;
 }
 
 export interface GroupByTimeTransformerOptions {
@@ -57,8 +57,8 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
         const processed: DataFrame[] = [];
 
         for (const frame of data) {
-        // Create an array of fields to group by
-        // and then add configured fields to this array
+          // Create an array of fields to group by
+          // and then add configured fields to this array
           const groupByFields: Field[] = [];
           for (const field of frame.fields) {
             if (shouldGroupOnField(field, options)) {
@@ -68,9 +68,9 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
 
           // If there are no fields to group by we do nothing
           if (groupByFields.length === 0) {
-            continue; 
+            continue;
           }
- 
+
           // Group the values by fields and groups so we can get all values for a
           // group for a given field.
           const valuesByGroupKey = new Map<string, Record<string, MutableField>>();
@@ -78,14 +78,16 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
             // Get the key for the grouping bucket for each format
             // we format using the appropriate date string to get
             // the correct grouping key
-          
-            const groupKey = String(groupByFields.map((field) => {
+
+            const groupKey = String(
+              groupByFields.map((field) => {
                 const fieldName = getFieldDisplayName(field);
                 const format = options.fields[fieldName].timeBucket?.toString();
                 const date = moment(field.values[rowIndex]);
 
                 return date.isValid() ? date.format(format) : null;
-            }));
+              })
+            );
 
             const valuesByField = valuesByGroupKey.get(groupKey) ?? {};
 
@@ -181,7 +183,7 @@ export const groupByTimeTransformer: DataTransformerInfo<GroupByTimeTransformerO
 const shouldGroupOnField = (field: Field, options: GroupByTimeTransformerOptions): boolean => {
   const fieldName = getFieldDisplayName(field);
   return (
-    options?.fields[fieldName]?.operation === GroupByOperationID.groupBy && 
+    options?.fields[fieldName]?.operation === GroupByOperationID.groupBy &&
     options?.fields[fieldName]?.timeBucket !== null
   );
 };

--- a/packages/grafana-data/src/transformations/transformers/ids.ts
+++ b/packages/grafana-data/src/transformations/transformers/ids.ts
@@ -21,6 +21,7 @@ export enum DataTransformerID {
   noop = 'noop',
   ensureColumns = 'ensureColumns',
   groupBy = 'groupBy',
+  groupByTime = 'groupByTime',
   sortBy = 'sortBy',
   histogram = 'histogram',
   configFromData = 'configFromData',

--- a/public/app/features/transformers/editors/GroupByTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTimeTransformerEditor.tsx
@@ -68,9 +68,9 @@ const options = [
 ];
 
 const timeFrameOptions = [
-  { label: 'Day', value:  GroupByTimeBucket.day },
-  { label: 'Month', value:  GroupByTimeBucket.month  },
-  { label: 'Year', value:  GroupByTimeBucket.year  },
+  { label: 'Day', value: GroupByTimeBucket.day },
+  { label: 'Month', value: GroupByTimeBucket.month },
+  { label: 'Year', value: GroupByTimeBucket.year },
 ];
 
 export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }: FieldProps) => {
@@ -87,13 +87,16 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
     [config, onConfigChange]
   );
 
-  const onTimeBucketChange = useCallback((value: SelectableValue<GroupByTimeBucket | null>) => {
-    onConfigChange({
-      aggregations: config?.aggregations ?? [],
-      operation: config?.operation ?? null,
-      timeBucket: value?.value ?? null,
-    })
-  }, [config, onConfigChange])
+  const onTimeBucketChange = useCallback(
+    (value: SelectableValue<GroupByTimeBucket | null>) => {
+      onConfigChange({
+        aggregations: config?.aggregations ?? [],
+        operation: config?.operation ?? null,
+        timeBucket: value?.value ?? null,
+      });
+    },
+    [config, onConfigChange]
+  );
 
   return (
     <div className={cx('gf-form-inline', styles.row)}>
@@ -121,6 +124,7 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
             placeholder="Select Timeframe"
             options={timeFrameOptions}
             onChange={onTimeBucketChange}
+            value={config?.timeBucket}
             isClearable
           />
         </div>
@@ -144,29 +148,29 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
 };
 
 const getStyling = stylesFactory(() => {
-    const cell = css`
-      display: table-cell;
-    `;
-  
-    return {
-      row: css`
-        display: table-row;
-      `,
-      cell: cell,
-      rowSpacing: css`
-        margin-bottom: 4px;
-      `,
-      fieldName: css`
-        ${cell}
-        min-width: 250px;
-        white-space: nowrap;
-      `,
-      calculations: css`
-        ${cell}
-        width: 99%;
-      `,
-    };
-  });
+  const cell = css`
+    display: table-cell;
+  `;
+
+  return {
+    row: css`
+      display: table-row;
+    `,
+    cell: cell,
+    rowSpacing: css`
+      margin-bottom: 4px;
+    `,
+    fieldName: css`
+      ${cell}
+      min-width: 250px;
+      white-space: nowrap;
+    `,
+    calculations: css`
+      ${cell}
+      width: 99%;
+    `,
+  };
+});
 
 export const groupByTimeTransformRegistryItem: TransformerRegistryItem<GroupByTimeTransformerOptions> = {
   id: DataTransformerID.groupByTime,
@@ -174,5 +178,5 @@ export const groupByTimeTransformRegistryItem: TransformerRegistryItem<GroupByTi
   transformation: standardTransformers.groupByTimeTransformer,
   name: standardTransformers.groupByTimeTransformer.name,
   description: standardTransformers.groupByTimeTransformer.description,
-  state: PluginState.alpha
+  state: PluginState.alpha,
 };

--- a/public/app/features/transformers/editors/GroupByTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTimeTransformerEditor.tsx
@@ -1,0 +1,178 @@
+import { css, cx } from '@emotion/css';
+import React, { useCallback } from 'react';
+
+import {
+  DataTransformerID,
+  PluginState,
+  ReducerID,
+  SelectableValue,
+  standardTransformers,
+  TransformerRegistryItem,
+  TransformerUIProps,
+} from '@grafana/data';
+import {
+  GroupByTimeBucket,
+  GroupByTimeFieldOptions,
+  GroupByOperationID,
+  GroupByTimeTransformerOptions,
+} from '@grafana/data/src/transformations/transformers/groupByTime';
+import { Select, StatsPicker, stylesFactory } from '@grafana/ui';
+
+import { useAllFieldNamesFromDataFrames } from '../utils';
+
+interface FieldProps {
+  fieldName: string;
+  config?: GroupByTimeFieldOptions;
+  onConfigChange: (config: GroupByTimeFieldOptions) => void;
+}
+
+export const GroupByTimeTransformerEditor = ({
+  input,
+  options,
+  onChange,
+}: TransformerUIProps<GroupByTimeTransformerOptions>) => {
+  const fieldNames = useAllFieldNamesFromDataFrames(input);
+
+  const onConfigChange = useCallback(
+    (fieldName: string) => (config: GroupByTimeFieldOptions) => {
+      onChange({
+        ...options,
+        fields: {
+          ...options.fields,
+          [fieldName]: config,
+        },
+      });
+    },
+    // Adding options to the dependency array causes infinite loop here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [onChange]
+  );
+
+  return (
+    <div>
+      {fieldNames.map((key) => (
+        <GroupByFieldConfiguration
+          onConfigChange={onConfigChange(key)}
+          fieldName={key}
+          config={options.fields[key]}
+          key={key}
+        />
+      ))}
+    </div>
+  );
+};
+
+const options = [
+  { label: 'Group by', value: GroupByOperationID.groupBy },
+  { label: 'Calculate', value: GroupByOperationID.aggregate },
+];
+
+const timeFrameOptions = [
+  { label: 'Day', value:  GroupByTimeBucket.day },
+  { label: 'Month', value:  GroupByTimeBucket.month  },
+  { label: 'Year', value:  GroupByTimeBucket.year  },
+];
+
+export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }: FieldProps) => {
+  const styles = getStyling();
+
+  const onChange = useCallback(
+    (value: SelectableValue<GroupByOperationID | null>) => {
+      onConfigChange({
+        aggregations: config?.aggregations ?? [],
+        operation: value?.value ?? null,
+        timeBucket: config?.timeBucket ?? null,
+      });
+    },
+    [config, onConfigChange]
+  );
+
+  const onTimeBucketChange = useCallback((value: SelectableValue<GroupByTimeBucket | null>) => {
+    onConfigChange({
+      aggregations: config?.aggregations ?? [],
+      operation: config?.operation ?? null,
+      timeBucket: value?.value ?? null,
+    })
+  }, [config, onConfigChange])
+
+  return (
+    <div className={cx('gf-form-inline', styles.row)}>
+      <div className={cx('gf-form', styles.fieldName)}>
+        <div className={cx('gf-form-label', styles.rowSpacing)}>{fieldName}</div>
+      </div>
+
+      <div className={cx('gf-form', styles.cell)}>
+        <div className={cx('gf-form-spacing', styles.rowSpacing)}>
+          <Select
+            className="width-12"
+            options={options}
+            value={config?.operation}
+            placeholder="Ignored"
+            onChange={onChange}
+            isClearable
+          />
+        </div>
+      </div>
+
+      {config?.operation === GroupByOperationID.groupBy && (
+        <div className={cx('gf-form', 'gf-form--grow', styles.calculations)}>
+          <Select
+            className={cx('flex-grow-1', styles.rowSpacing)}
+            placeholder="Select Timeframe"
+            options={timeFrameOptions}
+            onChange={onTimeBucketChange}
+            isClearable
+          />
+        </div>
+      )}
+
+      {config?.operation === GroupByOperationID.aggregate && (
+        <div className={cx('gf-form', 'gf-form--grow', styles.calculations)}>
+          <StatsPicker
+            className={cx('flex-grow-1', styles.rowSpacing)}
+            placeholder="Select Stats"
+            allowMultiple
+            stats={config.aggregations}
+            onChange={(stats) => {
+              onConfigChange({ ...config, aggregations: stats as ReducerID[] });
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const getStyling = stylesFactory(() => {
+    const cell = css`
+      display: table-cell;
+    `;
+  
+    return {
+      row: css`
+        display: table-row;
+      `,
+      cell: cell,
+      rowSpacing: css`
+        margin-bottom: 4px;
+      `,
+      fieldName: css`
+        ${cell}
+        min-width: 250px;
+        white-space: nowrap;
+      `,
+      calculations: css`
+        ${cell}
+        width: 99%;
+      `,
+    };
+  });
+
+export const groupByTimeTransformRegistryItem: TransformerRegistryItem<GroupByTimeTransformerOptions> = {
+  id: DataTransformerID.groupByTime,
+  editor: GroupByTimeTransformerEditor,
+  transformation: standardTransformers.groupByTimeTransformer,
+  name: standardTransformers.groupByTimeTransformer.name,
+  description: standardTransformers.groupByTimeTransformer.description,
+  state: PluginState.alpha
+};

--- a/public/app/features/transformers/standardTransformers.ts
+++ b/public/app/features/transformers/standardTransformers.ts
@@ -9,6 +9,7 @@ import { concatenateTransformRegistryItem } from './editors/ConcatenateTransform
 import { convertFieldTypeTransformRegistryItem } from './editors/ConvertFieldTypeTransformerEditor';
 import { filterFieldsByNameTransformRegistryItem } from './editors/FilterByNameTransformerEditor';
 import { filterFramesByRefIdTransformRegistryItem } from './editors/FilterByRefIdTransformerEditor';
+import { groupByTimeTransformRegistryItem } from './editors/GroupByTimeTransformerEditor';
 import { groupByTransformRegistryItem } from './editors/GroupByTransformerEditor';
 import { groupingToMatrixTransformRegistryItem } from './editors/GroupingToMatrixTransformerEditor';
 import { histogramTransformRegistryItem } from './editors/HistogramTransformerEditor';
@@ -44,6 +45,7 @@ export const getStandardTransformers = (): Array<TransformerRegistryItem<any>> =
     calculateFieldTransformRegistryItem,
     labelsToFieldsTransformerRegistryItem,
     groupByTransformRegistryItem,
+    groupByTimeTransformRegistryItem,
     sortByTransformRegistryItem,
     mergeTransformerRegistryItem,
     histogramTransformRegistryItem,


### PR DESCRIPTION
**What is this feature?**

This PR adds a group by time transform. Many use cases require grouping into buckets by time frame rather than by value. In the past this would be delegated to the back end datasource. However, not all data sources support aggregation by time, especially APIs and other non-database datasources. This PR adds 3 options for time buckets: day, month, and year.

A video of this being used:

https://user-images.githubusercontent.com/199847/235082526-70a72126-5ab6-43ca-b173-40e40368e600.mov

**Why do we need this feature?**

Grouping by time is commonly used in a number of use cases. e.g. Tracking sales by day, investigating monthly trends, or looking at events spanning multiple years.

**Who is this feature for?**

Users that need time bucket grouping using data sources that don't support time bucket grouping.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
