### PR TITLE
loki: devenv: add test-data for regexes

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -160,6 +160,7 @@ function getRandomNanosecPart() {
 const sharedLabels = {
   source: 'data',
   instance: 'server\\1',
+  re: 'one.two$three^four', // to test regex escaping
   job: '"grafana/data"'
 };
 


### PR DESCRIPTION
we sometimes need to test whether we correctly escape queries like `{lbl="a\\.b\\.c\\.d"}`, so i added a new label to the test-data that has characters that need regex-escaping.