### PR TITLE
TablePanel: Do not allow auto-reset

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -120,6 +120,7 @@ export const Table = memo((props: Props) => {
       data: memoizedData,
       disableResizing: !resizable,
       stateReducer: stateReducer,
+      autoResetPage: false,
       initialState: getInitialState(initialSortBy, memoizedColumns),
       autoResetFilters: false,
       sortTypes: {

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -41,7 +41,6 @@ export function TablePanel(props: Props) {
   const tableElement = (
     <Table
       height={tableHeight}
-      // This calculation is to accommodate the optionally rendered Row Numbers Column
       width={width}
       data={main}
       noHeader={!options.showHeader}


### PR DESCRIPTION
There are situations where the Table panel will enter an infinite loop because `react-table` will continuously call a `resetPage` state action. This is an edge case that seems to only happen in certain situations and only with snapshot data, I presume.

I've had trouble even reproducing this in dev as the error was not immediately obvious and would not appear, compared to a prod env.

Steps to reproduce:
1. Create a source panel with snapshot data (either using drag and drop or the datagrid panel)
2. Create a second panel that uses the Dashboard DS and choose the first panel as ds.
3. At this point, in a prod env, a react error 185 - maximum depth exceeded - should pop up.
4. In a dev env, clicking `Annotations` in the query editor and then back to `All data` will trigger the same error.

I'm still looking into possible negative impact of adding this flag, if any