### PR TITLE
Plugins: Allow extensions to configure multiple links

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -26,6 +26,8 @@ export type PluginExtensionLink = PluginExtension & {
 // Objects used for registering extensions (in app plugins)
 // --------------------------------------------------------
 
+export type ConfiguredPluginExtension<E> = Partial<{ title: string; description: string } & E>;
+
 export type PluginExtensionConfig<Context extends object = object, ExtraProps extends object = object> = Pick<
   PluginExtension,
   'title' | 'description'
@@ -38,7 +40,7 @@ export type PluginExtensionConfig<Context extends object = object, ExtraProps ex
     // (Optional) A function that can be used to configure the extension dynamically based on the extension point's context
     configure?: (
       context?: Readonly<Context>
-    ) => Partial<{ title: string; description: string } & ExtraProps> | undefined;
+    ) => ConfiguredPluginExtension<ExtraProps> | Array<ConfiguredPluginExtension<ExtraProps>> | undefined;
   };
 
 export type PluginExtensionLinkConfig<Context extends object = object> = PluginExtensionConfig<

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.ts
@@ -83,6 +83,36 @@ describe('getPluginExtensions()', () => {
     expect(extension.path).toBe(`/a/${pluginId}/updated-path`);
   });
 
+  test('should be possible to return multiple extensions with the configure() function', () => {
+    link2.configure = jest.fn().mockImplementation(() => [
+      {
+        title: 'Updated title',
+        description: 'Updated description',
+        path: `/a/${pluginId}/updated-path`,
+      },
+      {
+        title: 'Second updated title',
+        description: 'Second updated description',
+        path: `/a/${pluginId}/updated-path-2`,
+      },
+    ]);
+
+    const registry = createPluginExtensionRegistry([{ pluginId, extensionConfigs: [link2] }]);
+    const { extensions } = getPluginExtensions({ registry, extensionPointId: extensionPoint2 });
+    const [extension1, extension2] = extensions;
+
+    assertPluginExtensionLink(extension1);
+    assertPluginExtensionLink(extension2);
+
+    expect(link2.configure).toHaveBeenCalledTimes(1);
+    expect(extension1.title).toBe('Updated title');
+    expect(extension1.description).toBe('Updated description');
+    expect(extension1.path).toBe(`/a/${pluginId}/updated-path`);
+    expect(extension2.title).toBe('Second updated title');
+    expect(extension2.description).toBe('Second updated description');
+    expect(extension2.path).toBe(`/a/${pluginId}/updated-path-2`);
+  });
+
   test('should hide the extension if it tries to override not-allowed properties with the configure() function', () => {
     link2.configure = jest.fn().mockImplementation(() => ({
       // The following props are not allowed to override


### PR DESCRIPTION
**What is this feature?**

This PR updates the type signature of `PluginExtensionConfig`'s `configure` method to allow plugins to return multiple configured extension links from `configure`.

**Why do we need this feature?**

There are some use cases in #66294, but to briefly summarise: certain extension points, such as panel menus, pass additional context such as the queries in the panel. Plugins (such as the ML plugin) may want to add an extension point to the menu for each query in the panel; for example, to link to create a ML forecast for a specific query in the panel. This is not currently possible because the plugin can only return a single link, and so must choose a single one of the queries.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

Fixes #66294, but that's a discussion so I don't think it will be auto-linked!

**Special notes for your reviewer:**

A couple of decisions made in this PR:

- it must be fully backwards compatible with returning a single link (all current tests continue to pass)
- if _any_ of the returned links are invalid, all links for that extension are ignored, continuing the 'safest option in case the extension is going wrong' theme mentioned in a comment

Example:

![Multiple panel extensions](https://user-images.githubusercontent.com/5464991/235107756-e2001b0c-3cce-44b0-bbee-3350825db60e.gif)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
