### PR TITLE
Text component idea

### DIFF
--- a/packages/grafana-ui/src/components/Text/Text.story.internal.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.story.internal.tsx
@@ -6,7 +6,7 @@ import { VerticalGroup } from '../Layout/Layout';
 
 import { Text } from './Text';
 import mdx from './Text.mdx';
-import { H1, H2, H3, H4, H5, H6, Span, P, Legend } from './TextElements';
+import { H1, H2, H3, H4, H5, H6, P, Legend } from './TextElements';
 
 const meta: Meta = {
   title: 'General/Text',
@@ -15,7 +15,7 @@ const meta: Meta = {
     docs: {
       page: mdx,
     },
-    controls: { exclude: ['as'] },
+    controls: {},
   },
   argTypes: {
     variant: { control: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', undefined] },
@@ -56,9 +56,10 @@ export const Example: Story = () => {
         <H4>h4. Heading</H4>
         <H5>h5. Heading</H5>
         <H6>h6. Heading</H6>
-        <P>This is a paragraph</P>
+        <P>
+          This is a paragraph with <Text weight="bold">emphasis</Text>{' '}
+        </P>
         <Legend>This is a legend</Legend>
-        <Span>This is a span</Span>
       </StoryExample>
     </VerticalGroup>
   );

--- a/packages/grafana-ui/src/components/Text/Text.test.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.test.tsx
@@ -1,35 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { createTheme, ThemeTypographyVariantTypes } from '@grafana/data';
+import { createTheme } from '@grafana/data';
 
 import { Text } from './Text';
 
 describe('Text', () => {
   it('renders correctly', () => {
-    render(<Text as={'h1'}>This is a text component</Text>);
+    render(<Text>This is a text component</Text>);
     expect(screen.getByText('This is a text component')).toBeInTheDocument();
   });
-  it('keeps the element type but changes its styles', () => {
-    const customVariant: keyof ThemeTypographyVariantTypes = 'body';
-    render(
-      <Text as={'h1'} variant={customVariant}>
-        This is a text component
-      </Text>
-    );
-    const theme = createTheme();
-    const textComponent = screen.getByRole('heading');
-    expect(textComponent).toBeInTheDocument();
-    expect(textComponent).toHaveStyle(`fontSize: ${theme.typography.body.fontSize}`);
-  });
+
   it('has the selected colour', () => {
     const customColor = 'info';
     const theme = createTheme();
-    render(
-      <Text as={'h1'} color={customColor}>
-        This is a text component
-      </Text>
-    );
+    render(<Text color={customColor}>This is a text component</Text>);
     const textComponent = screen.getByRole('heading');
     expect(textComponent).toHaveStyle(`color:${theme.colors.info.text}`);
   });

--- a/packages/grafana-ui/src/components/Text/Text.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.tsx
@@ -1,28 +1,15 @@
-import { css } from '@emotion/css';
-import React, { createElement, CSSProperties, useCallback } from 'react';
-
-import { GrafanaTheme2, ThemeTypographyVariantTypes } from '@grafana/data';
+import React, { useCallback } from 'react';
 
 import { useStyles2 } from '../../themes';
 
-export interface TextProps {
-  /** Defines what HTML element is defined underneath */
-  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p' | 'legend';
-  /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
-  variant: keyof ThemeTypographyVariantTypes;
-  /** Override the default weight for the used variant */
-  weight?: 'light' | 'regular' | 'medium' | 'bold';
-  /** Color to use for text */
-  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
-  /** Use to cut the text off with ellipsis if there isn't space to show all of it. On hover shows the rest of the text */
-  truncate?: boolean;
-  /** Whether to align the text to left, center or right */
-  textAlignment?: CSSProperties['textAlign'];
+import { getTextStyles, TextStyleProps } from './style';
+
+export interface TextProps extends TextStyleProps {
   children: React.ReactNode;
 }
 
 export const Text = React.forwardRef<HTMLElement, TextProps>(
-  ({ as, variant, weight, color, truncate, textAlignment, children }, ref) => {
+  ({ variant, weight, color, truncate, textAlignment, children }, ref) => {
     const styles = useStyles2(
       useCallback(
         (theme) => getTextStyles(theme, variant, color, weight, truncate, textAlignment),
@@ -30,77 +17,12 @@ export const Text = React.forwardRef<HTMLElement, TextProps>(
       )
     );
 
-    return createElement(
-      as,
-      {
-        className: styles,
-        ref,
-      },
-      children
+    return (
+      <span ref={ref} className={styles}>
+        {children}
+      </span>
     );
   }
 );
 
 Text.displayName = 'Text';
-
-const getTextStyles = (
-  theme: GrafanaTheme2,
-  variant: keyof ThemeTypographyVariantTypes,
-  color?: TextProps['color'],
-  weight?: TextProps['weight'],
-  truncate?: TextProps['truncate'],
-  textAlignment?: TextProps['textAlignment']
-) => {
-  return css([
-    {
-      ...theme.typography[variant],
-    },
-    {
-      margin: 0,
-      padding: 0,
-    },
-    color && {
-      color: customColor(color, theme),
-    },
-    weight && {
-      fontWeight: customWeight(weight, theme),
-    },
-    truncate && {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    },
-    textAlignment && {
-      textAlign: textAlignment,
-    },
-  ]);
-};
-
-const customWeight = (weight: TextProps['weight'], theme: GrafanaTheme2): number => {
-  switch (weight) {
-    case 'bold':
-      return theme.typography.fontWeightBold;
-    case 'medium':
-      return theme.typography.fontWeightMedium;
-    case 'light':
-      return theme.typography.fontWeightLight;
-    case 'regular':
-    case undefined:
-      return theme.typography.fontWeightRegular;
-  }
-};
-
-const customColor = (color: TextProps['color'], theme: GrafanaTheme2): string | undefined => {
-  switch (color) {
-    case 'error':
-      return theme.colors.error.text;
-    case 'success':
-      return theme.colors.success.text;
-    case 'info':
-      return theme.colors.info.text;
-    case 'warning':
-      return theme.colors.warning.text;
-    default:
-      return color ? theme.colors.text[color] : undefined;
-  }
-};

--- a/packages/grafana-ui/src/components/Text/TextElements.tsx
+++ b/packages/grafana-ui/src/components/Text/TextElements.tsx
@@ -1,59 +1,60 @@
-import React from 'react';
+import React, { createElement, forwardRef, useCallback } from 'react';
+import { useStyles2 } from 'src/themes';
 
-import { Text, TextProps } from './Text';
+import { ThemeTypographyVariantTypes } from '@grafana/data';
 
-interface TextElementsProps extends Omit<TextProps, 'as'> {}
+import { getTextStyles, TextStyleProps } from './style';
 
-export const H1 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h1" {...props} variant={props.variant || 'h1'} ref={ref} />;
-});
+type TextElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'legend';
 
+interface TextElementProps extends TextStyleProps {
+  children: React.ReactNode;
+}
+
+function createTextElement(element: TextElement, defaultVariant: keyof ThemeTypographyVariantTypes) {
+  const TextElement = forwardRef<HTMLElement, TextElementProps>(function Heading(props, ref) {
+    const { variant, weight, color, truncate, textAlignment, children } = props;
+
+    const styles = useStyles2(
+      useCallback(
+        (theme) => getTextStyles(theme, variant ?? defaultVariant, color, weight, truncate, textAlignment),
+        [color, textAlignment, truncate, weight, variant]
+      )
+    );
+
+    return createElement(
+      element,
+      {
+        className: styles,
+        ref,
+      },
+      children
+    );
+  });
+
+  return TextElement;
+}
+
+export const H1 = createTextElement('h1', 'h1');
 H1.displayName = 'H1';
 
-export const H2 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h2" {...props} variant={props.variant || 'h2'} ref={ref} />;
-});
-
+export const H2 = createTextElement('h2', 'h2');
 H2.displayName = 'H2';
 
-export const H3 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h3" {...props} variant={props.variant || 'h3'} ref={ref} />;
-});
-
+export const H3 = createTextElement('h3', 'h3');
 H3.displayName = 'H3';
 
-export const H4 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h4" {...props} variant={props.variant || 'h4'} ref={ref} />;
-});
-
+export const H4 = createTextElement('h4', 'h4');
 H4.displayName = 'H4';
 
-export const H5 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h5" {...props} variant={props.variant || 'h5'} ref={ref} />;
-});
-
+export const H5 = createTextElement('h5', 'h5');
 H5.displayName = 'H5';
 
-export const H6 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h6" {...props} variant={props.variant || 'h6'} ref={ref} />;
-});
-
+export const H6 = createTextElement('h6', 'h6');
 H6.displayName = 'H6';
 
-export const P = React.forwardRef<HTMLParagraphElement, TextElementsProps>((props, ref) => {
-  return <Text as="p" {...props} variant={props.variant || 'body'} ref={ref} />;
-});
-
+export const P = createTextElement('p', 'body');
 P.displayName = 'P';
 
-export const Span = React.forwardRef<HTMLSpanElement, TextElementsProps>((props, ref) => {
-  return <Text as="span" {...props} variant={props.variant || 'bodySmall'} ref={ref} />;
-});
-
-Span.displayName = 'Span';
-
-export const Legend = React.forwardRef<HTMLLegendElement, TextElementsProps>((props, ref) => {
-  return <Text as="legend" {...props} variant={props.variant || 'bodySmall'} ref={ref} />;
-});
-
+export const Legend = createTextElement('legend', 'bodySmall');
 Legend.displayName = 'Legend';

--- a/packages/grafana-ui/src/components/Text/style.ts
+++ b/packages/grafana-ui/src/components/Text/style.ts
@@ -1,0 +1,83 @@
+import { css } from '@emotion/css';
+import { CSSProperties } from 'react';
+
+import { GrafanaTheme2, ThemeTypographyVariantTypes } from '@grafana/data';
+
+export interface TextStyleProps {
+  /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
+  variant: keyof ThemeTypographyVariantTypes;
+
+  /** Override the default weight for the used variant */
+  weight?: 'light' | 'regular' | 'medium' | 'bold';
+
+  /** Color to use for text */
+  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
+
+  /** Use to cut the text off with ellipsis if there isn't space to show all of it. On hover shows the rest of the text */
+  truncate?: boolean;
+
+  /** Whether to align the text to left, center or right */
+  textAlignment?: CSSProperties['textAlign'];
+}
+
+export const getTextStyles = (
+  theme: GrafanaTheme2,
+  variant: TextStyleProps['variant'],
+  color?: TextStyleProps['color'],
+  weight?: TextStyleProps['weight'],
+  truncate?: TextStyleProps['truncate'],
+  textAlignment?: TextStyleProps['textAlignment']
+) => {
+  return css([
+    {
+      ...theme.typography[variant],
+    },
+    {
+      margin: 0,
+      padding: 0,
+    },
+    color && {
+      color: customColor(color, theme),
+    },
+    weight && {
+      fontWeight: customWeight(weight, theme),
+    },
+    truncate && {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    textAlignment && {
+      textAlign: textAlignment,
+    },
+  ]);
+};
+
+const customWeight = (weight: TextStyleProps['weight'], theme: GrafanaTheme2): number => {
+  switch (weight) {
+    case 'bold':
+      return theme.typography.fontWeightBold;
+    case 'medium':
+      return theme.typography.fontWeightMedium;
+    case 'light':
+      return theme.typography.fontWeightLight;
+    case 'regular':
+    case undefined:
+      return theme.typography.fontWeightRegular;
+  }
+};
+
+const customColor = (color: TextStyleProps['color'], theme: GrafanaTheme2): string | undefined => {
+  switch (color) {
+    case 'error':
+      return theme.colors.error.text;
+    case 'success':
+      return theme.colors.success.text;
+    case 'info':
+      return theme.colors.info.text;
+    case 'warning':
+      return theme.colors.warning.text;
+    default:
+      return color ? theme.colors.text[color] : undefined;
+  }
+};

--- a/packages/grafana-ui/src/components/Text/style.ts
+++ b/packages/grafana-ui/src/components/Text/style.ts
@@ -5,7 +5,7 @@ import { GrafanaTheme2, ThemeTypographyVariantTypes } from '@grafana/data';
 
 export interface TextStyleProps {
   /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
-  variant: keyof ThemeTypographyVariantTypes;
+  variant?: keyof ThemeTypographyVariantTypes;
 
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
@@ -22,14 +22,14 @@ export interface TextStyleProps {
 
 export const getTextStyles = (
   theme: GrafanaTheme2,
-  variant: TextStyleProps['variant'],
+  variant?: TextStyleProps['variant'],
   color?: TextStyleProps['color'],
   weight?: TextStyleProps['weight'],
   truncate?: TextStyleProps['truncate'],
   textAlignment?: TextStyleProps['textAlignment']
 ) => {
   return css([
-    {
+    variant && {
       ...theme.typography[variant],
     },
     {


### PR DESCRIPTION
 - Split text styles into a function to reuse between all typographic components
 - Removes `as` from Text. Point of Text is to apply inline styles to some text, for example `Welcome back <Text weight="bold">Josh</Text>`
 - Use a 'component factory' for generating all the header components


### Examples

```tsx
<H2>Alerting</H2>
<P>You have <Text color="error" weight="bold">3 failing alerts</Text><P>
```