### PR TITLE
Alerting:Fix alert panel not rendering correct number for cloud rules instances

### DIFF
--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -80,7 +80,10 @@ export const AlertInstances = ({
     handleInstancesLimit(true);
     setDisplayInstances(true);
   };
-  const totalInstancesNumber = limitInstances ? grafanaFilteredInstancesTotal : filteredAlerts.length;
+  const totalInstancesGrafana = limitInstances ? grafanaFilteredInstancesTotal : filteredAlerts.length;
+  const totalInstancesNotGrafana = filteredAlerts.length;
+  const totalInstancesNumber = isGrafanaAlert ? totalInstancesGrafana : totalInstancesNotGrafana;
+
   const limitStatus = limitInstances
     ? `Showing ${INSTANCES_DISPLAY_LIMIT} of ${grafanaTotalInstances} instances`
     : `Showing all ${grafanaTotalInstances} instances`;


### PR DESCRIPTION

**What is this feature?**

This PR fix alert panel rendering undefined instead of number of instances for cloud rules

**Special notes for your reviewer:**
After the change:

<img width="611" alt="Screenshot 2023-04-28 at 12 23 38" src="https://user-images.githubusercontent.com/33540275/235124105-81923ffc-4551-4354-96a2-8209b89f083b.png">



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
