### PR TITLE
Pyroscope: Change the data source id with migrations

### DIFF
--- a/pkg/plugins/backendplugin/coreplugin/registry.go
+++ b/pkg/plugins/backendplugin/coreplugin/registry.go
@@ -29,23 +29,23 @@ import (
 )
 
 const (
-	CloudWatch      = "cloudwatch"
-	CloudMonitoring = "stackdriver"
-	AzureMonitor    = "grafana-azure-monitor-datasource"
-	Elasticsearch   = "elasticsearch"
-	Graphite        = "graphite"
-	InfluxDB        = "influxdb"
-	Loki            = "loki"
-	OpenTSDB        = "opentsdb"
-	Prometheus      = "prometheus"
-	Tempo           = "tempo"
-	TestData        = "testdata"
-	PostgreSQL      = "postgres"
-	MySQL           = "mysql"
-	MSSQL           = "mssql"
-	Grafana         = "grafana"
-	Phlare          = "phlare"
-	Parca           = "parca"
+	CloudWatch       = "cloudwatch"
+	CloudMonitoring  = "stackdriver"
+	AzureMonitor     = "grafana-azure-monitor-datasource"
+	Elasticsearch    = "elasticsearch"
+	Graphite         = "graphite"
+	InfluxDB         = "influxdb"
+	Loki             = "loki"
+	OpenTSDB         = "opentsdb"
+	Prometheus       = "prometheus"
+	Tempo            = "tempo"
+	TestData         = "testdata"
+	PostgreSQL       = "postgres"
+	MySQL            = "mysql"
+	MSSQL            = "mssql"
+	Grafana          = "grafana"
+	GrafanaPyroscope = "grafana-pyroscope"
+	Parca            = "parca"
 )
 
 func init() {
@@ -69,23 +69,23 @@ func ProvideCoreRegistry(am *azuremonitor.Service, cw *cloudwatch.CloudWatchServ
 	pr *prometheus.Service, t *tempo.Service, td *testdatasource.Service, pg *postgres.Service, my *mysql.Service,
 	ms *mssql.Service, graf *grafanads.Service, phlare *phlare.Service, parca *parca.Service) *Registry {
 	return NewRegistry(map[string]backendplugin.PluginFactoryFunc{
-		CloudWatch:      asBackendPlugin(cw.Executor),
-		CloudMonitoring: asBackendPlugin(cm),
-		AzureMonitor:    asBackendPlugin(am),
-		Elasticsearch:   asBackendPlugin(es),
-		Graphite:        asBackendPlugin(grap),
-		InfluxDB:        asBackendPlugin(idb),
-		Loki:            asBackendPlugin(lk),
-		OpenTSDB:        asBackendPlugin(otsdb),
-		Prometheus:      asBackendPlugin(pr),
-		Tempo:           asBackendPlugin(t),
-		TestData:        asBackendPlugin(td),
-		PostgreSQL:      asBackendPlugin(pg),
-		MySQL:           asBackendPlugin(my),
-		MSSQL:           asBackendPlugin(ms),
-		Grafana:         asBackendPlugin(graf),
-		Phlare:          asBackendPlugin(phlare),
-		Parca:           asBackendPlugin(parca),
+		CloudWatch:       asBackendPlugin(cw.Executor),
+		CloudMonitoring:  asBackendPlugin(cm),
+		AzureMonitor:     asBackendPlugin(am),
+		Elasticsearch:    asBackendPlugin(es),
+		Graphite:         asBackendPlugin(grap),
+		InfluxDB:         asBackendPlugin(idb),
+		Loki:             asBackendPlugin(lk),
+		OpenTSDB:         asBackendPlugin(otsdb),
+		Prometheus:       asBackendPlugin(pr),
+		Tempo:            asBackendPlugin(t),
+		TestData:         asBackendPlugin(td),
+		PostgreSQL:       asBackendPlugin(pg),
+		MySQL:            asBackendPlugin(my),
+		MSSQL:            asBackendPlugin(ms),
+		Grafana:          asBackendPlugin(graf),
+		GrafanaPyroscope: asBackendPlugin(phlare),
+		Parca:            asBackendPlugin(parca),
 	})
 }
 

--- a/pkg/plugins/manager/manager_integration_test.go
+++ b/pkg/plugins/manager/manager_integration_test.go
@@ -218,7 +218,7 @@ func verifyCorePluginCatalogue(t *testing.T, ctx context.Context, ps *store.Serv
 		"jaeger":                           {},
 		"mixed":                            {},
 		"zipkin":                           {},
-		"phlare":                           {},
+		"grafana-pyroscope":                {},
 		"parca":                            {},
 	}
 

--- a/pkg/plugins/pfs/corelist/corelist_load_gen.go
+++ b/pkg/plugins/pfs/corelist/corelist_load_gen.go
@@ -45,7 +45,7 @@ func corePlugins(rt *thema.Runtime) []pfs.ParsedPlugin {
 		parsePluginOrPanic("public/app/plugins/datasource/mssql", "mssql", rt),
 		parsePluginOrPanic("public/app/plugins/datasource/mysql", "mysql", rt),
 		parsePluginOrPanic("public/app/plugins/datasource/parca", "parca", rt),
-		parsePluginOrPanic("public/app/plugins/datasource/phlare", "phlare", rt),
+		parsePluginOrPanic("public/app/plugins/datasource/phlare", "grafana_pyroscope", rt),
 		parsePluginOrPanic("public/app/plugins/datasource/postgres", "postgres", rt),
 		parsePluginOrPanic("public/app/plugins/datasource/prometheus", "prometheus", rt),
 		parsePluginOrPanic("public/app/plugins/datasource/tempo", "tempo", rt),

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -17,7 +17,7 @@ seqs: [
 				// grafana.com, then the plugin `id` has to follow the naming
 				// conventions.
 				id: string & strings.MinRunes(1)
-				id: =~"^([0-9a-z]+\\-([0-9a-z]+\\-)?(\(strings.Join([ for t in _types {t}], "|"))))|(alertGroups|alertlist|annolist|barchart|bargauge|candlestick|canvas|dashlist|debug|datagrid|gauge|geomap|gettingstarted|graph|heatmap|histogram|icon|live|logs|news|nodeGraph|piechart|pluginlist|stat|state-timeline|status-history|table|table-old|text|timeseries|trend|traces|welcome|xychart|alertmanager|cloudwatch|dashboard|elasticsearch|grafana|grafana-azure-monitor-datasource|graphite|influxdb|jaeger|loki|mixed|mssql|mysql|opentsdb|postgres|prometheus|stackdriver|tempo|testdata|zipkin|phlare|parca)$"
+				id: =~"^([0-9a-z]+\\-([0-9a-z]+\\-)?(\(strings.Join([ for t in _types {t}], "|"))))|(alertGroups|alertlist|annolist|barchart|bargauge|candlestick|canvas|dashlist|debug|datagrid|gauge|geomap|gettingstarted|graph|heatmap|histogram|icon|live|logs|news|nodeGraph|piechart|pluginlist|stat|state-timeline|status-history|table|table-old|text|timeseries|trend|traces|welcome|xychart|alertmanager|cloudwatch|dashboard|elasticsearch|grafana|grafana-azure-monitor-datasource|graphite|influxdb|jaeger|loki|mixed|mssql|mysql|opentsdb|postgres|prometheus|stackdriver|tempo|testdata|zipkin|grafana-pyroscope|parca)$"
 
 				// Human-readable name of the plugin that is shown to the user in
 				// the UI.
@@ -144,7 +144,7 @@ seqs: [
 				}
 
 				// Schema definition for the plugin.json file. Used primarily for schema validation.
-				$schema?: string 
+				$schema?: string
 
 				// For data source plugins, if the plugin supports alerting. Requires `backend` to be set to `true`.
 				alerting?: bool

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -96,6 +96,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	AddExternalAlertmanagerToDatasourceMigration(mg)
 
 	addFolderMigrations(mg)
+	changePhlareIdToGrafanaPyroscope(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/phlare_to_grafana_pyroscope_rename.go
+++ b/pkg/services/sqlstore/migrations/phlare_to_grafana_pyroscope_rename.go
@@ -1,0 +1,12 @@
+package migrations
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func changePhlareIdToGrafanaPyroscope(mg *migrator.Migrator) {
+	mg.AddMigration("update datasource type",
+		migrator.NewRawSQLMigration("").
+			SQLite(`UPDATE data_source SET type='grafana-pyroscope' WHERE type='phlare';`).
+			Postgres(`UPDATE data_source SET type='grafana-pyroscope' WHERE type='phlare';`).
+			Mysql(`UPDATE data_source SET type='grafana-pyroscope' WHERE type='phlare';`),
+	)
+}

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -646,7 +646,7 @@
   {
     "name": "Grafana Pyroscope",
     "type": "datasource",
-    "id": "phlare",
+    "id": "grafana-pyroscope",
     "enabled": true,
     "pinned": false,
     "info": {
@@ -677,7 +677,7 @@
     },
     "latestVersion": "",
     "hasUpdate": false,
-    "defaultNavUrl": "/plugins/phlare/",
+    "defaultNavUrl": "/plugins/grafana-pyroscope/",
     "category": "profiling",
     "state": "",
     "signature": "internal",

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -198,7 +198,7 @@ describe('DashboardModel', () => {
     });
 
     it('dashboard schema version should be set to latest', () => {
-      expect(model.schemaVersion).toBe(38);
+      expect(model.schemaVersion).toBe(39);
     });
 
     it('graph thresholds should be migrated', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -78,7 +78,7 @@ export class DashboardMigrator {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;
     const panelUpgrades: PanelSchemeUpgradeHandler[] = [];
-    this.dashboard.schemaVersion = 38;
+    this.dashboard.schemaVersion = 39;
 
     if (oldVersion === this.dashboard.schemaVersion) {
       return;
@@ -842,6 +842,10 @@ export class DashboardMigrator {
       });
     }
 
+    if (oldVersion < 39) {
+      panelUpgrades.push(migratePhlareIdToGrafanaPyroscope);
+    }
+
     if (panelUpgrades.length === 0) {
       return;
     }
@@ -1360,6 +1364,21 @@ function ensureXAxisVisibility(panel: PanelModel) {
           },
         ],
       };
+    }
+  }
+
+  return panel;
+}
+
+// We renamed and changed the phlare data source id to grafana-pyroscope
+function migratePhlareIdToGrafanaPyroscope(panel: PanelModel) {
+  if (panel.datasource?.type === 'phlare') {
+    panel.datasource.type = 'grafana-pyroscope';
+  }
+
+  for (const target of panel.targets) {
+    if (target.datasource?.type === 'phlare') {
+      target.datasource.type = 'grafana-pyroscope';
     }
   }
 

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -1376,9 +1376,12 @@ function migratePhlareIdToGrafanaPyroscope(panel: PanelModel) {
     panel.datasource.type = 'grafana-pyroscope';
   }
 
-  for (const target of panel.targets) {
-    if (target.datasource?.type === 'phlare') {
-      target.datasource.type = 'grafana-pyroscope';
+  // Even though targets are not optional, because we use any upstream we have to check it.
+  if (panel.targets) {
+    for (const target of panel.targets) {
+      if (target.datasource?.type === 'phlare') {
+        target.datasource.type = 'grafana-pyroscope';
+      }
     }
   }
 

--- a/public/app/plugins/datasource/phlare/plugin.json
+++ b/public/app/plugins/datasource/phlare/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "datasource",
   "name": "Grafana Pyroscope",
-  "id": "phlare",
+  "id": "grafana-pyroscope",
   "category": "profiling",
 
   "metrics": true,


### PR DESCRIPTION
After [renaming Phlare data source to Grafana Pyroscope](https://github.com/grafana/grafana/pull/66989) the ID was still `phlare`. This change the ID and adds migrations to change dashboards and data sources in DB to the new ID.

To test:

- While on main branch, create Grafana Pyroscope datasource and a dashboard with Flamegraph panel with query from that data source
- Checkout this branch and restart
- Data source and dashboard should still work without any errors

# Release notice breaking change

Due to renaming of the Phlare data source to Grafana Pyroscope also the type ID changed from `phlare` to `grafana-pyroscope`. This affects any provisioning of the data source, where the property `type: phlare` has to be changed to `type: grafana-pyroscope`. This also affects alerts, recorded queries and query history which will need to be recreated.

Dashboard panels and any instances of the old Phlare data source should be automatically migrated and don't require any user action.