### PR TITLE
Plugins: Pass panel data in plugin extension context

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -1,6 +1,7 @@
 import { DataQuery } from '@grafana/schema';
 
 import { ScopedVars } from './ScopedVars';
+import { PanelData } from './panel';
 import { RawTimeRange, TimeZone } from './time';
 
 // Plugin Extensions types
@@ -78,6 +79,7 @@ export type PluginExtensionPanelContext = {
   dashboard: Dashboard;
   targets: DataQuery[];
   scopedVars?: ScopedVars;
+  data?: PanelData;
 };
 
 type Dashboard = {

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -1,4 +1,13 @@
-import { PanelMenuItem, PluginExtensionPanelContext, PluginExtensionTypes } from '@grafana/data';
+import {
+  dateTime,
+  FieldType,
+  LoadingState,
+  PanelData,
+  PanelMenuItem,
+  PluginExtensionPanelContext,
+  PluginExtensionTypes,
+  toDataFrame,
+} from '@grafana/data';
 import { getPluginExtensions } from '@grafana/runtime';
 import config from 'app/core/config';
 import * as actions from 'app/features/explore/state/main';
@@ -189,6 +198,26 @@ describe('getPanelMenu()', () => {
     });
 
     it('should pass context with correct values when configuring extension', () => {
+      const data: PanelData = {
+        series: [
+          toDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time },
+              { name: 'score', type: FieldType.number },
+            ],
+          }),
+        ],
+        timeRange: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: {
+            from: 'now',
+            to: 'now-1h',
+          },
+        },
+        state: LoadingState.Done,
+      };
+
       const panel = new PanelModel({
         type: 'timeseries',
         id: 1,
@@ -206,6 +235,9 @@ describe('getPanelMenu()', () => {
             text: 'a',
             value: 'a',
           },
+        },
+        queryRunner: {
+          getLastResult: jest.fn(() => data),
         },
       });
 
@@ -250,6 +282,7 @@ describe('getPanelMenu()', () => {
             value: 'a',
           },
         },
+        data,
       };
 
       expect(getPluginExtensions).toBeCalledWith(expect.objectContaining({ context }));

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -342,5 +342,6 @@ function createExtensionContext(panel: PanelModel, dashboard: DashboardModel): P
     },
     targets: panel.targets,
     scopedVars: panel.scopedVars,
+    data: panel.getQueryRunner().getLastResult(),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Similar to https://github.com/grafana/grafana/pull/65861, this passes the panel's data as part of the context object used when configuring extension links.

**Why do we need this feature?**

This is useful if the plugin wants to conditionally show the link depending on the presence or absence of certain features in the data. For example in the ML plugin we only want to offer Outlier Detection links for a query if the query returned more than 3 series.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
