### PR TITLE
Grafana Toolkit: Prevent MODULE_NOT_FOUND errors

### DIFF
--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -42,6 +42,7 @@
     "@types/node": "16.11.26",
     "chalk": "^4.1.2",
     "commander": "^9.2.0",
+    "ts-node": "^9.1.0",
     "tslib": "2.5.0",
     "typescript": "4.8.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,6 +3102,7 @@ __metadata:
     "@types/node": 16.11.26
     chalk: ^4.1.2
     commander: ^9.2.0
+    ts-node: ^9.1.0
     tslib: 2.5.0
     typescript: 4.8.2
   bin:
@@ -31033,7 +31034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:^0.5.16":
+"source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.17":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -32878,6 +32879,27 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 7d1aa7aa3ae1c0459c4922ed0dbfbade442cfe0c25aebaf620cdf1774f112c8d7a9b14934cb6719274917f35b2c503ba87bcaf5e16a0d39ba0f68ce3e7728363
+  languageName: node
+  linkType: hard
+
+"ts-node@npm:^9.1.0":
+  version: 9.1.1
+  resolution: "ts-node@npm:9.1.1"
+  dependencies:
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    source-map-support: ^0.5.17
+    yn: 3.1.1
+  peerDependencies:
+    typescript: ">=2.7"
+  bin:
+    ts-node: dist/bin.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 356e2647b8b1e6ab00380c0537fa569b63bd9b6f006cc40fd650f81fae1817bd8fecc075300036950d8f45c1d85b95be33cd1e48a1a424a7d86c3dbb42bf60e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds back ts-node dependency in grafana/toolkit package which is required [here](https://github.com/grafana/grafana/blob/main/packages/grafana-toolkit/bin/grafana-toolkit.js#L36-L39).

**Why do we need this feature?**

Without it attempting to run any command results in:

```
npx @grafana/toolkit@canary plugin:create
Need to install the following packages:
  @grafana/toolkit@10.0.0-113980pre
Ok to proceed? (y) y
Running in local/linked mode
node:internal/modules/cjs/loader:1050
  throw err;
  ^

Error: Cannot find module 'ts-node'
Require stack:
- /Users/jackwestbrook/.npm/_npx/749d62a4ecaf5b14/node_modules/@grafana/toolkit/bin/grafana-toolkit.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1047:15)
    at Module._load (node:internal/modules/cjs/loader:893:27)
    at Module.require (node:internal/modules/cjs/loader:1113:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at entrypoint (/Users/jackwestbrook/.npm/_npx/749d62a4ecaf5b14/node_modules/@grafana/toolkit/bin/grafana-toolkit.js:36:5)
    at Object.<anonymous> (/Users/jackwestbrook/.npm/_npx/749d62a4ecaf5b14/node_modules/@grafana/toolkit/bin/grafana-toolkit.js:49:9)
    at Module._compile (node:internal/modules/cjs/loader:1226:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1280:10)
    at Module.load (node:internal/modules/cjs/loader:1089:32)
    at Module._load (node:internal/modules/cjs/loader:930:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/jackwestbrook/.npm/_npx/749d62a4ecaf5b14/node_modules/@grafana/toolkit/bin/grafana-toolkit.js'
  ]
}

Node.js v18.14.0
```

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related: #55997

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
