### PR TITLE
Settings: Support custom response headers via environment variables

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -86,6 +86,23 @@ cdn_url =
 read_timeout = 0
 
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
+# If you're editing the configuration file directly, using the [server.custom_response_headers] section is
+# recommended for ease of use.
+#
+# Two formats are supported:
+# 1. The simple format limited to ASCII characters (excluding commas) where fields are separated by commas
+#    and keys are separated from values at the first = within each field.
+#    Example: Server-Site=EU2, Server-ID=citrus
+# 2. A JSON object consisting of only string keys and string values.
+#    Example: {"Server-Site": "EU2", "Server-ID": "citrus"}
+custom_response_headers =
+
+# This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
+# Because of technical limitations, these fields cannot be provided as environment variables, see instead
+# the custom_response_header property in the [server] section if you're using command-line or environment
+# variables to set custom response headers.
+#
+# Values in this section takes precedence over values set in the [server] section.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2
@@ -159,7 +176,7 @@ query_retries = 0
 # For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
 transaction_retries = 5
 
-# Set to true to add metrics and tracing for database queries. 
+# Set to true to add metrics and tracing for database queries.
 instrument_queries = false
 
 #################################### Cache server #############################
@@ -422,7 +439,7 @@ datasource_limit = 5000
 
 ################################### SQL Data Sources #####################
 [sql_datasources]
-# Default maximum number of open connections maintained in the connection pool 
+# Default maximum number of open connections maintained in the connection pool
 # when connecting to SQL based data sources
 max_open_conns_default = 100
 
@@ -431,7 +448,7 @@ max_open_conns_default = 100
 max_idle_conns_default = 100
 
 # Default maximum connection lifetime used when connecting
-# to SQL based data sources. 
+# to SQL based data sources.
 max_conn_lifetime_default = 14400
 
 #################################### Users ###############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -87,6 +87,23 @@
 ;read_timeout = 0
 
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
+# If you're editing the configuration file directly, using the [server.custom_response_headers] section is
+# recommended for ease of use.
+#
+# Two formats are supported:
+# 1. The simple format limited to ASCII characters (excluding commas) where fields are separated by commas
+#    and keys are separated from values at the first = within each field.
+#    Example: Server-Site=EU2, Server-ID=citrus
+# 2. A JSON object consisting of only string keys and string values.
+#    Example: {"Server-Site": "EU2", "Server-ID": "citrus"}
+;custom_response_headers =
+
+# This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
+# Because of technical limitations, these fields cannot be provided as environment variables, see instead
+# the custom_response_header property in the [server] section if you're using command-line options or
+# environment variables to set custom response headers.
+#
+# Values in this section takes precedence over values set in the [server] section.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2
@@ -161,7 +178,7 @@
 # For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
 ;transaction_retries = 5
 
-# Set to true to add metrics and tracing for database queries. 
+# Set to true to add metrics and tracing for database queries.
 ;instrument_queries = false
 
 ################################### Data sources #########################

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1824,10 +1824,19 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)
 
+	cfg.CustomResponseHeaders = make(map[string]string)
+	if crh := server.Key("custom_response_headers").String(); len(crh) != 0 {
+		kvs, err := util.KeyValue(crh)
+		if err != nil {
+			return fmt.Errorf("error parsing server.custom_response_headers: %w", err)
+		}
+		for key, value := range kvs {
+			cfg.CustomResponseHeaders[key] = value
+		}
+	}
+
 	headersSection := cfg.Raw.Section("server.custom_response_headers")
 	keys := headersSection.Keys()
-	cfg.CustomResponseHeaders = make(map[string]string, len(keys))
-
 	for _, key := range keys {
 		cfg.CustomResponseHeaders[key.Name()] = key.Value()
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // StringsFallback2 returns the first of two not empty strings.
@@ -45,6 +47,84 @@ func SplitString(str string) []string {
 	}
 
 	return strings.Fields(strings.ReplaceAll(str, ",", " "))
+}
+
+var (
+	ErrParsingAsJSON = errutil.NewBase(errutil.StatusBadRequest, "strings.JSON", errutil.WithPublicMessage("Failed to parse JSON payload"))
+	ErrInvalidChar   = errutil.NewBase(errutil.StatusBadRequest, "strings.invalidCharacter").
+				MustTemplate("invalid character {{ .Public.charcode }} in key value set. use json when characters other than ASCII 0x21-0x7e excluding ',' are required",
+			errutil.WithPublic("Invalid character {{ .Public.charcode }}."))
+	ErrMissingValue = errutil.NewBase(errutil.StatusBadRequest, "strings.missingValue").
+			MustTemplate("missing value for key {{ .Public.key }} in key value set",
+			errutil.WithPublic("Missing value for {{ .Public.key }}."))
+
+	charsetKeyValueStrings = &unicode.RangeTable{
+		R16: []unicode.Range16{
+			{
+				Lo:     0x20,
+				Hi:     0x2b,
+				Stride: 1,
+			},
+			// skips ,
+			{
+				Lo:     0x2d,
+				Hi:     0x7e,
+				Stride: 1,
+			},
+		},
+	}
+)
+
+// KeyValue splits a string into a map[string]string.
+// Supports two styles: Either key value pairs are separated by commas
+// and keys are separated from values with equal-signs or if the map's
+// structure contains special characters JSON representation can be
+// used.
+//
+// Format options:
+//
+//	KeyValue("Key1=Value1, Key2=Value2, Key3=Value3") # map[string]string{"Key1": "Value1", "Key2": "Value2", "Key3": "Value3"}
+//	KeyValue(`{"Key1": "Value1", "Key2": "Value2", "Key3": "Value3"}`) # map[string]string{"Key1": "Value1", "Key2": "Value2", "Key3": "Value3"}
+func KeyValue(str string) (map[string]string, error) {
+	if len(str) == 0 {
+		return map[string]string{}, nil
+	}
+
+	if strings.Index(strings.TrimSpace(str), "{") == 0 {
+		var res map[string]string
+		err := json.Unmarshal([]byte(str), &res)
+		if err != nil {
+			return nil, ErrParsingAsJSON.Errorf("failed to parse json key-value map: %w", err)
+		}
+		return res, nil
+	}
+
+	pairs := strings.Split(str, ",")
+	res := make(map[string]string)
+	for _, pair := range pairs {
+		for _, c := range pair {
+			if !unicode.Is(charsetKeyValueStrings, c) {
+				return nil, ErrInvalidChar.Build(errutil.TemplateData{
+					Public: map[string]interface{}{"charcode": fmt.Sprintf("%U", c)},
+				})
+			}
+		}
+
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			key := kv[0]
+			if len(key) > 39 {
+				key = key[:37] + "..."
+			}
+
+			return nil, ErrMissingValue.Build(errutil.TemplateData{
+				Public: map[string]interface{}{"key": key},
+			})
+		}
+
+		res[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+	}
+	return res, nil
 }
 
 // GetAgeString returns a string representing certain time from years to minutes.

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/util/errutil"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func TestStringsFallback2(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Defines _custom_response_headers_ as a configuration field under the _[server]_ section in addition to as its own section _[server.custom_response_headers]_.

**Why do we need this feature?**

There's no way to send a custom response header using `GF_SERVER_CUSTOM_RESPONSE_HEADERS` or `GF_SERVER_CUSTOM_RESPONSE_HEADERS_HEADER_NAME` and that's not a solvable problem since the keys are unpredictable and can have any number of denormalizations.

**Who is this feature for?**

Grafana operators that use the custom_response_headers configuration option.

**Which issue(s) does this PR fix?**:

Fixes #67230.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
