### PR TITLE
Use URL to enable panel editor onboarding

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -43,7 +43,7 @@ export const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
             onClick={() => {
               const id = onCreateNewPanel(dashboard, initialDatasource);
               reportInteraction('dashboards_emptydashboard_clicked', { item: 'add_visualization' });
-              locationService.partial({ editPanel: id });
+              locationService.partial({ editPanel: id, firstPanel: true });
               dispatch(setInitialDatasource(undefined));
             }}
             disabled={!canCreate}

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -124,9 +124,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
         // TODO: Detect the first panel added into a new dashboard better.
         // This is flaky in case the UID is generated differently
-        isDataSourceModalOpen:
-          locationService.getLocation().pathname === '/dashboard/new' &&
-          locationService.getSearchObject().editPanel === '1',
+        isDataSourceModalOpen: !!locationService.getSearchObject().firstPanel,
       });
     } catch (error) {
       console.log('failed to load data source', error);
@@ -261,6 +259,11 @@ export class QueryGroup extends PureComponent<Props, State> {
     this.setState({ isHelpOpen: false });
   };
 
+  onCloseDataSourceModal = () => {
+    this.setState({ isDataSourceModalOpen: false });
+    locationService.partial({ firstPanel: null });
+  };
+
   renderMixedPicker = () => {
     return (
       <DataSourcePicker
@@ -289,15 +292,14 @@ export class QueryGroup extends PureComponent<Props, State> {
       current: this.props.options.dataSource,
       onChange: (ds: DataSourceInstanceSettings) => {
         this.onChangeDataSource(ds);
-        this.setState({ isDataSourceModalOpen: false });
+        this.onCloseDataSourceModal();
       },
     };
-    const onDismiss = () => this.setState({ isDataSourceModalOpen: false });
 
     return (
       <>
         {isDataSourceModalOpen && config.featureToggles.advancedDataSourcePicker && (
-          <DataSourceModal {...commonProps} onDismiss={onDismiss}></DataSourceModal>
+          <DataSourceModal {...commonProps} onDismiss={this.onCloseDataSourceModal}></DataSourceModal>
         )}
         <DataSourcePicker
           {...commonProps}


### PR DESCRIPTION
**Problem**
* The panel onboarding experience is only displayed for the first panel added to a dashboard
* Before, we were relying on the URL and the ID, but this is too flaky
* Also, when the component was unmounted, the internal state indicating if the modal was already shown was broken, because it was restarting to true

**Solution**
* Add a URL param when editing from the empty state, so the onboarding happens only once

**Ideal solution**
Move the onboarding into a new component, and do not use the QueryEditor. Probably this state can also be moved into the Redux, although I don't see the problem of doing it through URL beside the URL manipulation.

https://github.com/grafana/grafana/issues/66946 Here is the issue to work on a better solution. This is only to fix the nasty bug of the onboarding appearing all the time.
