### PR TITLE
Datasource: Move the Delete data source button back to the bottom

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4484,7 +4484,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
     "public/app/plugins/datasource/jaeger/testResponse.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2595,9 +2595,6 @@ exports[`better eslint`] = {
     "public/app/features/datasources/components/BasicSettings.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
-    "public/app/features/datasources/components/ButtonRow.tsx:5381": [
-      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
-    ],
     "public/app/features/datasources/components/DataSourceReadOnlyMessage.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
@@ -4487,8 +4484,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/plugins/datasource/jaeger/testResponse.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -20,7 +20,7 @@ export const Pages = {
     name: 'Data source settings page name input field',
     delete: 'Data source settings page Delete button',
     readOnly: 'Data source settings page read only message',
-    saveAndTest: 'Data source settings page Save and Test button',
+    saveAndTest: 'data-testid Data source settings page Save and Test button',
     alert: 'Data source settings page Alert',
   },
   DataSources: {

--- a/public/app/features/datasources/components/ButtonRow.test.tsx
+++ b/public/app/features/datasources/components/ButtonRow.test.tsx
@@ -23,12 +23,12 @@ describe('<ButtonRow>', () => {
   it('should render component', () => {
     setup();
 
-    expect(screen.getByRole('button', { name: selectors.pages.DataSource.delete })).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.pages.DataSource.delete)).toBeInTheDocument();
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
   it('should render save & test', () => {
     setup({ canSave: true });
 
-    expect(screen.getByRole('button', { name: selectors.pages.DataSource.saveAndTest })).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.pages.DataSource.saveAndTest)).toBeInTheDocument();
   });
 });

--- a/public/app/features/datasources/components/ButtonRow.test.tsx
+++ b/public/app/features/datasources/components/ButtonRow.test.tsx
@@ -8,6 +8,8 @@ import { ButtonRow, Props } from './ButtonRow';
 const setup = (propOverrides?: object) => {
   const props: Props = {
     canSave: false,
+    canDelete: true,
+    onDelete: jest.fn(),
     onSubmit: jest.fn(),
     onTest: jest.fn(),
   };
@@ -21,6 +23,7 @@ describe('<ButtonRow>', () => {
   it('should render component', () => {
     setup();
 
+    expect(screen.getByRole('button', { name: selectors.pages.DataSource.delete })).toBeInTheDocument();
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
   it('should render save & test', () => {

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -19,7 +19,7 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Pr
         variant="destructive"
         disabled={!canDelete}
         onClick={onDelete}
-        aria-label={selectors.pages.DataSource.delete}
+        data-testid={selectors.pages.DataSource.delete}
       >
         Delete
       </Button>
@@ -29,7 +29,7 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Pr
           variant="primary"
           disabled={!canSave}
           onClick={onSubmit}
-          aria-label={selectors.pages.DataSource.saveAndTest}
+          data-testid={selectors.pages.DataSource.saveAndTest}
         >
           Save &amp; test
         </Button>

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -5,13 +5,24 @@ import { Button } from '@grafana/ui';
 
 export interface Props {
   canSave: boolean;
+  canDelete: boolean;
+  onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onSubmit: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onTest: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export function ButtonRow({ canSave, onSubmit, onTest }: Props) {
+export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Props) {
   return (
     <div className="gf-form-button-row">
+      <Button
+        type="button"
+        variant="destructive"
+        disabled={!canDelete}
+        onClick={onDelete}
+        aria-label={selectors.pages.DataSource.delete}
+      >
+        Delete
+      </Button>
       {canSave && (
         <Button
           type="submit"

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -108,7 +108,7 @@ export function EditDataSourceView({
   onUpdate,
 }: ViewProps) {
   const { plugin, loadError, testingStatus, loading } = dataSourceSettings;
-  const { readOnly, hasWriteRights } = dataSourceRights;
+  const { readOnly, hasWriteRights, hasDeleteRights } = dataSourceRights;
   const hasDataSource = dataSource.id > 0;
 
   const dsi = getDataSourceSrv()?.getInstanceSettings(dataSource.uid);
@@ -179,7 +179,12 @@ export function EditDataSourceView({
 
       <DataSourceTestingStatus testingStatus={testingStatus} exploreUrl={exploreUrl} dataSource={dataSource} />
 
-      <ButtonRow onSubmit={onSubmit} onTest={onTest} canSave={!readOnly && hasWriteRights} />
+      <ButtonRow
+        onSubmit={onSubmit}
+        onTest={onTest}
+        onDelete={onDelete}
+        canDelete={!readOnly && hasDeleteRights}
+        canSave={!readOnly && hasWriteRights} />
     </form>
   );
 }

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -184,7 +184,8 @@ export function EditDataSourceView({
         onTest={onTest}
         onDelete={onDelete}
         canDelete={!readOnly && hasDeleteRights}
-        canSave={!readOnly && hasWriteRights} />
+        canSave={!readOnly && hasWriteRights}
+      />
     </form>
   );
 }

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Button, LinkButton, useStyles2 } from '@grafana/ui';
+import { LinkButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
 
-import { useDataSource, useDataSourceRights, useDeleteLoadedDataSource } from '../state';
+import { useDataSource } from '../state';
 import { trackCreateDashboardClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
@@ -26,12 +26,7 @@ interface Props {
 export function EditDataSourceActions({ uid }: Props) {
   const styles = useStyles2(getStyles);
   const dataSource = useDataSource(uid);
-  const onDelete = useDeleteLoadedDataSource();
-
-  const { readOnly, hasDeleteRights } = useDataSourceRights(uid);
   const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
-
-  const canDelete = !readOnly && hasDeleteRights;
 
   return (
     <>
@@ -71,10 +66,6 @@ export function EditDataSourceActions({ uid }: Props) {
           Explore
         </LinkButton>
       )}
-
-      <Button type="button" variant="destructive" disabled={!canDelete} onClick={onDelete} className={styles.button}>
-        Delete
-      </Button>
     </>
   );
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR reverts moving the `Delete` button to the page header as per this discussion with Torkel: https://raintank-corp.slack.com/archives/C048ZCR9CVD/p1682578425188719

So we're now back to this.
<img width="2120" alt="Screenshot 2023-04-28 at 19 32 25" src="https://user-images.githubusercontent.com/112862936/235215928-8d278639-5e48-4e5d-b9a4-724b24a6a3b1.png">

There's a longer discussion about how the final header should look like in the attached slack link, but this is what we agreed on with Torkel for now.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
