### PR TITLE
Docs: Correct capitalization of openSUSE

### DIFF
--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -25,7 +25,7 @@ Grafana supports the following operating systems:
 
 - [Debian/Ubuntu]({{< relref "debian/" >}})
 - [Red Hat/RHEL/Fedora]({{< relref "redhat-rhel-fedora/" >}})
-- [SUSE/OpenSUSE]({{< relref "suse-opensuse/" >}})
+- [SUSE/openSUSE]({{< relref "suse-opensuse/" >}})
 - [macOS]({{< relref "mac/" >}})
 - [Windows]({{< relref "windows/" >}})
 

--- a/docs/sources/setup-grafana/installation/suse-opensuse/index.md
+++ b/docs/sources/setup-grafana/installation/suse-opensuse/index.md
@@ -1,13 +1,13 @@
 ---
-description: Install guide for Grafana on SUSE or OpenSUSE.
-title: Install Grafana on SUSE or OpenSUSE
+description: Install guide for Grafana on SUSE or openSUSE.
+title: Install Grafana on SUSE or openSUSE
 menuTitle: SUSE or openSUSE
 weight: 450
 ---
 
-# Install Grafana on SUSE or OpenSUSE
+# Install Grafana on SUSE or openSUSE
 
-This topic explains how to install Grafana dependencies, install Grafana on SUSE or OpenSUSE and start the Grafana server on your system.
+This topic explains how to install Grafana dependencies, install Grafana on SUSE or openSUSE and start the Grafana server on your system.
 
 You can install Grafana using a YUM repository, using RPM, or by downloading a binary `.tar.gz` file.
 

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -58,7 +58,7 @@ To restart the Grafana server, run the following commands:
 sudo systemctl restart grafana-server
 ```
 
-> **Note:** SUSE or OpenSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
+> **Note:** SUSE or openSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
 
 ### Start the Grafana server using init.d
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -115,14 +115,14 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 1. Perform one of the following steps based on your installation.
 
-   - If you [downloaded an RPM package](https://grafana.com/grafana/download) to install Grafana, then complete the steps documented in [Install Grafana on Red Hat, RHEL, or Fedora]({{< relref "../../setup-grafana/installation/redhat-rhel-fedora/" >}}) or [Install Grafana on SUSE or OpenSUSE]({{< relref "../../setup-grafana/installation/suse-opensuse/" >}}) to upgrade Grafana.
+   - If you [downloaded an RPM package](https://grafana.com/grafana/download) to install Grafana, then complete the steps documented in [Install Grafana on Red Hat, RHEL, or Fedora]({{< relref "../../setup-grafana/installation/redhat-rhel-fedora/" >}}) or [Install Grafana on SUSE or openSUSE]({{< relref "../../setup-grafana/installation/suse-opensuse/" >}}) to upgrade Grafana.
    - If you used the Grafana YUM repository, run the following command:
 
      ```bash
      sudo yum update grafana
      ```
 
-   - If you installed Grafana on OpenSUSE or SUSE, run the following command:
+   - If you installed Grafana on openSUSE or SUSE, run the following command:
 
      ```bash
      sudo zypper update


### PR DESCRIPTION
**What is this feature?**

Corrects capitalization of openSUSE

```
grep -rnw "OpenSUSE" .
./sources/shared/upgrade/upgrade-common-tasks.md:118: 
./sources/shared/upgrade/upgrade-common-tasks.md:125: 
./sources/setup-grafana/installation/suse-opensuse/index.md:2
./sources/setup-grafana/installation/suse-opensuse/index.md:3:
./sources/setup-grafana/installation/suse-opensuse/index.md:8:
./sources/setup-grafana/installation/suse-opensuse/index.md:10:
./sources/setup-grafana/installation/_index.md:28:
```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
