### PR TITLE
TimeSeries: Fix leading null-fill for missing intervals

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
@@ -1,4 +1,4 @@
-import { DataFrame, FieldType, incrRoundDn } from '@grafana/data';
+import { DataFrame, FieldType } from '@grafana/data';
 
 type InsertMode = (prev: number, next: number, threshold: number) => number;
 
@@ -108,11 +108,11 @@ function nullInsertThreshold(
   const len = refValues.length;
   const refValuesNew: number[] = [];
 
-  // Continiuously subtract the threshold from the first data
-  // point filling in insert values accordingly
+  // Continiuously subtract the threshold from the first data point, filling in insert values accordingly
   if (refFieldPseudoMin != null && refFieldPseudoMin < refValues[0]) {
+    let preFillCount = Math.ceil((refValues[0] - refFieldPseudoMin) / threshold);
     // this will be 0 or 1 threshold increment left of visible range
-    let prevSlot = incrRoundDn(refFieldPseudoMin, threshold);
+    let prevSlot = refValues[0] - preFillCount * threshold;
 
     while (prevSlot < refValues[0]) {
       // (prevSlot - threshold) is used to simulate the previous 'real' data point, as getInsertValue expects
@@ -126,8 +126,7 @@ function nullInsertThreshold(
 
   let prevValue: number = refValues[0];
 
-  // Fill nulls when a value is greater than
-  // the threshold value
+  // Fill nulls when a value is greater than the threshold value
   for (let i = 1; i < len; i++) {
     const curValue = refValues[i];
 

--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
@@ -108,7 +108,7 @@ function nullInsertThreshold(
   const len = refValues.length;
   const refValuesNew: number[] = [];
 
-  // Continiuously subtract the threshold from the first data point, filling in insert values accordingly
+  // Continuously subtract the threshold from the first data point, filling in insert values accordingly
   if (refFieldPseudoMin != null && refFieldPseudoMin < refValues[0]) {
     let preFillCount = Math.ceil((refValues[0] - refFieldPseudoMin) / threshold);
     // this will be 0 or 1 threshold increment left of visible range


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5565