### PR TITLE
[v9.4.x] TimeSeries: Fix leading null-fill for missing intervals

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
@@ -174,10 +174,10 @@ describe('nullInsertThreshold Transformer', () => {
       refFieldPseudoMax: 1679815217157,
     });
 
-    expect(result.fields[0].values).toEqual([
+    expect(result.fields[0].values.toArray()).toStrictEqual([
       1679266800000, 1679353200000, 1679439600000, 1679526000000, 1679612400000, 1679698800000, 1679785200000,
     ]);
-    expect(result.fields[1].values).toEqual([null, null, 0, 1, 2, 3, 4]);
+    expect(result.fields[1].values.toArray()).toStrictEqual([null, null, 0, 1, 2, 3, 4]);
   });
 
   test('should insert trailing null at end +interval when timeRange.to.valueOf() exceeds threshold', () => {

--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, DataFrame, FieldType, incrRoundDn } from '@grafana/data';
+import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
 
 type InsertMode = (prev: number, next: number, threshold: number) => number;
 
@@ -108,11 +108,11 @@ function nullInsertThreshold(
   const len = refValues.length;
   const refValuesNew: number[] = [];
 
-  // Continiuously subtract the threshold from the first data
-  // point filling in insert values accordingly
+  // Continuously subtract the threshold from the first data point, filling in insert values accordingly
   if (refFieldPseudoMin != null && refFieldPseudoMin < refValues[0]) {
+    let preFillCount = Math.ceil((refValues[0] - refFieldPseudoMin) / threshold);
     // this will be 0 or 1 threshold increment left of visible range
-    let prevSlot = incrRoundDn(refFieldPseudoMin, threshold);
+    let prevSlot = refValues[0] - preFillCount * threshold;
 
     while (prevSlot < refValues[0]) {
       // (prevSlot - threshold) is used to simulate the previous 'real' data point, as getInsertValue expects
@@ -126,8 +126,7 @@ function nullInsertThreshold(
 
   let prevValue: number = refValues[0];
 
-  // Fill nulls when a value is greater than
-  // the threshold value
+  // Fill nulls when a value is greater than the threshold value
   for (let i = 1; i < len; i++) {
     const curValue = refValues[i];
 


### PR DESCRIPTION
Backport e5aeb7c32207733a257ae1ae70c6cba3278a337d from #67570