### PR TITLE
docs: add empty dashboard & Add dropdown screenshots

### DIFF
--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -26,6 +26,9 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 1. Click **Dashboards** in the left-side menu.
 1. Click **New** and select **New Dashboard**.
 1. On the empty dashboard, click **+ Add visualization**.
+
+   ![Empty dashboard state](/media/docs/grafana/dashboards/empty-dashboard-9.5.png)
+
 1. In the first line of the **Query** tab, click the dropdown list and select a data source.
 1. Write or construct a query in the query language of your data source.
 

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -55,6 +55,9 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 1. When you've finished editing your panel, click **Save** in the top right corner.
 1. Enter a name for your dashboard and select a folder, if applicable.
 1. Click **Save**.
+1. To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the dropdown.
+
+   ![Add dropdown](/media/docs/grafana/dashboards/screenshot-add-dropdown-9.5.png)
 
 ## Configure repeating rows
 

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -42,6 +42,9 @@ To create your first dashboard:
 1. Click **Dashboards** in the left-side menu.
 1. On the Dashboards page, click **New** and select **New Dashboard** from the dropdown menu.
 1. On the dashboard, click **+ Add visualization**.
+
+   ![Empty dashboard state](/media/docs/grafana/dashboards/empty-dashboard-9.5.png)
+
 1. In the New dashboard/Edit panel view, go to the **Query** tab.
 1. Configure your [query]({{< relref "../panels-visualizations/query-transform-data/#add-a-query" >}}) by selecting `-- Grafana --` from the data source selector.
 

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -55,6 +55,10 @@ To create your first dashboard:
 
 Congratulations, you have created your first dashboard and it is displaying results.
 
+To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the dropdown.
+
+    ![Add dropdown](/media/docs/grafana/dashboards/screenshot-add-dropdown-9.5.png)
+
 #### Next steps
 
 Continue to experiment with what you have built, try the [explore workflow]({{< relref "../explore/" >}}) or another visualization feature. Refer to [Data sources]({{< relref "../datasources/" >}}) for a list of supported data sources and instructions on how to [add a data source]({{< relref "../administration/data-source-management#add-a-data-source" >}}). The following topics will be of interest to you:

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -55,10 +55,6 @@ To create your first dashboard:
 
 Congratulations, you have created your first dashboard and it is displaying results.
 
-To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the dropdown.
-
-    ![Add dropdown](/media/docs/grafana/dashboards/screenshot-add-dropdown-9.5.png)
-
 #### Next steps
 
 Continue to experiment with what you have built, try the [explore workflow]({{< relref "../explore/" >}}) or another visualization feature. Refer to [Data sources]({{< relref "../datasources/" >}}) for a list of supported data sources and instructions on how to [add a data source]({{< relref "../administration/data-source-management#add-a-data-source" >}}). The following topics will be of interest to you:

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -24,6 +24,8 @@ weight: 1
 
 # Panel editor overview
 
+In the panel editor, you can update all the elements of a visualization including the data source, queries, time range, and visualization display options.
+
 ![Panel editor](/media/docs/grafana/panels-visualizations/screenshot-panel-editor-view.png)
 
 To add a panel in a new dashboard click **+ Add visualization** in the middle of the dashboard. To add a panel to an existing dashboard, click **Add** in the dashboard header and select **Visualization** in the dropdown:

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -26,6 +26,12 @@ weight: 1
 
 ![Panel editor](/media/docs/grafana/panels-visualizations/screenshot-panel-editor-view.png)
 
+To add a panel in a new dashboard click **+ Add visualization** in the middle of the dashboard. To add a panel to an existing dashboard, click **Add** in the dashboard header and select **Visualization** in the dropdown:
+
+![Add dropdown](/media/docs/grafana/dashboards/screenshot-add-dropdown-9.5.png)
+
+## Panel editor
+
 This section describes the areas of the Grafana panel editor.
 
 1. Panel header: The header section lists the dashboard in which the panel appears and the following controls:
@@ -49,7 +55,7 @@ This section describes the areas of the Grafana panel editor.
 
 1. Panel display options: The display options section contains tabs where you configure almost every aspect of your data visualization.
 
-## Open the panel inspect drawer
+## Panel inspect drawer
 
 The inspect drawer helps you understand and troubleshoot your panels. You can view the raw data for any panel, export that data to a comma-separated values (CSV) file, view query requests, and export panel and data JSON.
 


### PR DESCRIPTION
Per convo with @thanos-karachalios:
Adds screenshots of new empty dashboard state for 9.5 updates in _Build your first dashboard_ and _Create a dashboard_.
Adds screenshots of **Add** dropdown for 9.5 updates in _Create a dashboard_ and _Panel editor overview_.
Also adds intro text and updates headings in _Panel editor overview_.