### PR TITLE
Alert: Remove fix for custom content close button

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -172,11 +172,9 @@ const getStyles = (
     `,
     buttonWrapper: css`
       margin-left: ${theme.spacing(1)};
-      background: none;
       display: flex;
       align-items: center;
       align-self: center;
-      background: ${theme.colors.background.primary};
     `,
     close: css`
       position: relative;


### PR DESCRIPTION
Removing the button background fix from https://github.com/grafana/grafana/pull/67589 as it made the button visibility / contrast worse 