### PR TITLE
docs: reverse what's new order in TOC

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -9,7 +9,7 @@ keywords:
   - '9.2'
   - release notes
 title: What's new in Grafana v9.2
-weight: 100
+weight: -33
 ---
 
 # What's new in Grafana v9.2

--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -9,7 +9,7 @@ keywords:
   - '9.2'
   - release notes
 title: What's new in Grafana v9.2
-weight: -33
+weight: 100
 ---
 
 # What's new in Grafana v9.2

--- a/docs/sources/whatsnew/whats-new-in-v9-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-3.md
@@ -9,7 +9,7 @@ keywords:
   - '9.3'
   - release notes
 title: What's new in Grafana v9.3
-weight: 90
+weight: -34
 ---
 
 # What’s new in Grafana v9.3

--- a/docs/sources/whatsnew/whats-new-in-v9-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-3.md
@@ -9,7 +9,7 @@ keywords:
   - '9.3'
   - release notes
 title: What's new in Grafana v9.3
-weight: -33
+weight: 90
 ---
 
 # What’s new in Grafana v9.3

--- a/docs/sources/whatsnew/whats-new-in-v9-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-4.md
@@ -7,7 +7,7 @@ keywords:
   - '9.4'
   - release notes
 title: What's new in Grafana v9.4
-weight: -33
+weight: 80
 ---
 
 # What’s new in Grafana v9.4

--- a/docs/sources/whatsnew/whats-new-in-v9-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-4.md
@@ -7,7 +7,7 @@ keywords:
   - '9.4'
   - release notes
 title: What's new in Grafana v9.4
-weight: 80
+weight: -35
 ---
 
 # What’s new in Grafana v9.4

--- a/docs/sources/whatsnew/whats-new-in-v9-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-5.md
@@ -7,7 +7,7 @@ keywords:
   - '9.5'
   - release notes
 title: What's new in Grafana v9.5
-weight: 70
+weight: -36
 ---
 
 # What’s new in Grafana v9.5

--- a/docs/sources/whatsnew/whats-new-in-v9-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-5.md
@@ -7,7 +7,7 @@ keywords:
   - '9.5'
   - release notes
 title: What's new in Grafana v9.5
-weight: -33
+weight: 70
 ---
 
 # What’s new in Grafana v9.5


### PR DESCRIPTION
Updates page weights of _What's New_ pages shown in main docs TOC using original convention to reverse order of pages (newest to oldest).