### PR TITLE
Cloudwatch Logs: Ignore non-time grouping fields in expressions and alerts

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -333,7 +333,7 @@ func groupResponseFrame(frame *data.Frame, statsGroups []string) (data.Frames, e
 	// Check if we have time field though as it makes sense to split only for time series.
 	if hasTimeField(frame) {
 		if len(statsGroups) > 0 && len(frame.Fields) > 0 {
-			groupedFrames, err := groupResults(frame, statsGroups)
+			groupedFrames, err := groupResults(frame, statsGroups, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -163,7 +163,7 @@ func changeToStringField(lengthOfValues int, rows [][]*cloudwatchlogs.ResultFiel
 	return fieldValuesAsStrings
 }
 
-func groupResults(results *data.Frame, groupingFieldNames []string, removeNonNumeric bool) ([]*data.Frame, error) {
+func groupResults(results *data.Frame, groupingFieldNames []string, removeNonTime bool) ([]*data.Frame, error) {
 	groupingFields := make([]*data.Field, 0)
 	removeFieldIndices := make([]int, 0)
 
@@ -180,7 +180,7 @@ func groupResults(results *data.Frame, groupingFieldNames []string, removeNonNum
 					field = newField
 				}
 				// For expressions and alerts to work properly we need to remove non-time grouping fields
-				if removeNonNumeric && !field.Type().Time() {
+				if removeNonTime && !field.Type().Time() {
 					removeFieldIndices = append(removeFieldIndices, i)
 				}
 

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -163,12 +163,17 @@ func changeToStringField(lengthOfValues int, rows [][]*cloudwatchlogs.ResultFiel
 	return fieldValuesAsStrings
 }
 
-func groupResults(results *data.Frame, groupingFieldNames []string) ([]*data.Frame, error) {
+func groupResults(results *data.Frame, groupingFieldNames []string, removeNonNumeric bool) ([]*data.Frame, error) {
 	groupingFields := make([]*data.Field, 0)
+	removeFieldIndices := make([]int, 0)
 
 	for i, field := range results.Fields {
 		for _, groupingField := range groupingFieldNames {
 			if field.Name == groupingField {
+				// For expressions and alerts to work properly we need to remove non-number grouping fields
+				if removeNonNumeric && !field.Type().Numeric() && !field.Type().Time() {
+					removeFieldIndices = append(removeFieldIndices, i)
+				}
 				// convert numeric grouping field to string field
 				if field.Type().Numeric() {
 					newField, err := numericFieldToStringField(field)
@@ -192,14 +197,19 @@ func groupResults(results *data.Frame, groupingFieldNames []string) ([]*data.Fra
 	groupedDataFrames := make(map[string]*data.Frame)
 	for i := 0; i < rowLength; i++ {
 		groupKey := generateGroupKey(groupingFields, i)
+		// if group key doesn't exist create it
 		if _, exists := groupedDataFrames[groupKey]; !exists {
 			newFrame := results.EmptyCopy()
 			newFrame.Name = groupKey
 			newFrame.Meta = results.Meta
+			// remove grouping indices
+			newFrame.Fields = removeFieldsByIndex(newFrame.Fields, removeFieldIndices)
 			groupedDataFrames[groupKey] = newFrame
 		}
 
-		groupedDataFrames[groupKey].AppendRow(results.RowCopy(i)...)
+		// add row to frame
+		row := copyRowWithoutValues(results, i, removeFieldIndices)
+		groupedDataFrames[groupKey].AppendRow(row...)
 	}
 
 	newDataFrames := make([]*data.Frame, 0, len(groupedDataFrames))
@@ -208,6 +218,40 @@ func groupResults(results *data.Frame, groupingFieldNames []string) ([]*data.Fra
 	}
 
 	return newDataFrames, nil
+}
+
+// remove fields at the listed indices
+func removeFieldsByIndex(fields []*data.Field, removeIndices []int) []*data.Field {
+	newGroupingFields := make([]*data.Field, 0)
+	removeIndicesIndex := 0
+	for i, field := range fields {
+		if removeIndicesIndex < len(removeIndices) && i == removeIndices[removeIndicesIndex] {
+			removeIndicesIndex++
+			if removeIndicesIndex > len(removeIndices) {
+				newGroupingFields = append(newGroupingFields, fields[i+1:]...)
+				break
+			}
+			continue
+		}
+		newGroupingFields = append(newGroupingFields, field)
+	}
+	return newGroupingFields
+}
+
+// copy a row without the listed values
+func copyRowWithoutValues(f *data.Frame, rowIdx int, removeIndices []int) []interface{} {
+	vals := make([]interface{}, len(f.Fields)-len(removeIndices))
+	valsIdx := 0
+	removeIndicesIndex := 0
+	for i := range f.Fields {
+		if removeIndicesIndex < len(removeIndices) && i == removeIndices[removeIndicesIndex] {
+			removeIndicesIndex++
+			continue
+		}
+		vals[valsIdx] = f.CopyAt(i, rowIdx)
+		valsIdx++
+	}
+	return vals
 }
 
 func generateGroupKey(fields []*data.Field, row int) string {

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -170,10 +170,6 @@ func groupResults(results *data.Frame, groupingFieldNames []string, removeNonNum
 	for i, field := range results.Fields {
 		for _, groupingField := range groupingFieldNames {
 			if field.Name == groupingField {
-				// For expressions and alerts to work properly we need to remove non-number grouping fields
-				if removeNonNumeric && !field.Type().Numeric() && !field.Type().Time() {
-					removeFieldIndices = append(removeFieldIndices, i)
-				}
 				// convert numeric grouping field to string field
 				if field.Type().Numeric() {
 					newField, err := numericFieldToStringField(field)
@@ -182,6 +178,10 @@ func groupResults(results *data.Frame, groupingFieldNames []string, removeNonNum
 					}
 					results.Fields[i] = newField
 					field = newField
+				}
+				// For expressions and alerts to work properly we need to remove non-time grouping fields
+				if removeNonNumeric && !field.Type().Time() {
+					removeFieldIndices = append(removeFieldIndices, i)
 				}
 
 				groupingFields = append(groupingFields, field)

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -543,7 +543,7 @@ func TestGroupingResultsWithNumericField(t *testing.T) {
 	assert.ElementsMatch(t, expectedGroupedFrames, groupedResults)
 }
 
-func TestGroupingResultsWithRemoveNonNumericTrue(t *testing.T) {
+func TestGroupingResultsWithRemoveNonTimeTrue(t *testing.T) {
 	logField := data.NewField("@log", data.Labels{}, []*string{
 		aws.String("fakelog-a"),
 		aws.String("fakelog-b"),

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -544,52 +544,33 @@ func TestGroupingResultsWithNumericField(t *testing.T) {
 }
 
 func TestGroupingResultsWithRemoveNonNumericTrue(t *testing.T) {
-	timeA, err := time.Parse("2006-01-02 15:04:05.000", "2020-03-02 15:04:05.000")
-	require.NoError(t, err)
-	timeB, err := time.Parse("2006-01-02 15:04:05.000", "2020-03-02 16:04:05.000")
-	require.NoError(t, err)
-	timeVals := []*time.Time{
-		&timeA, &timeA, &timeA, &timeA, &timeB, &timeB, &timeB, &timeB,
-	}
-	timeField := data.NewField("@timestamp", data.Labels{}, timeVals)
-
 	logField := data.NewField("@log", data.Labels{}, []*string{
 		aws.String("fakelog-a"),
 		aws.String("fakelog-b"),
 		aws.String("fakelog-a"),
 		aws.String("fakelog-b"),
-		aws.String("fakelog-a"),
-		aws.String("fakelog-b"),
-		aws.String("fakelog-a"),
-		aws.String("fakelog-b"),
 	})
 
-	streamField := data.NewField("stream", data.Labels{}, []*string{
-		aws.String("stream-a"),
-		aws.String("stream-a"),
-		aws.String("stream-b"),
-		aws.String("stream-b"),
-		aws.String("stream-a"),
-		aws.String("stream-a"),
-		aws.String("stream-b"),
-		aws.String("stream-b"),
+	streamField := data.NewField("stream", data.Labels{}, []*int32{
+		aws.Int32(1),
+		aws.Int32(1),
+		aws.Int32(1),
+		aws.Int32(1),
 	})
 
 	countField := data.NewField("count", data.Labels{}, []*string{
 		aws.String("100"),
 		aws.String("150"),
-		aws.String("20"),
-		aws.String("34"),
 		aws.String("57"),
 		aws.String("62"),
-		aws.String("105"),
-		aws.String("200"),
 	})
 
+	timeA := time.Time{}
+	timeB := time.Time{}.Add(1 * time.Minute)
 	fakeDataFrame := &data.Frame{
 		Name: "CloudWatchLogsResponse",
 		Fields: []*data.Field{
-			timeField,
+			data.NewField("@timestamp", data.Labels{}, []*time.Time{&timeA, &timeA, &timeB, &timeB}),
 			logField,
 			streamField,
 			countField,
@@ -597,61 +578,26 @@ func TestGroupingResultsWithRemoveNonNumericTrue(t *testing.T) {
 		RefID: "",
 	}
 
-	groupedTimeVals := []*time.Time{
-		&timeA, &timeB,
-	}
-	groupedTimeField := data.NewField("@timestamp", data.Labels{}, groupedTimeVals)
-
-	groupedCountFieldAA := data.NewField("count", data.Labels{}, []*string{
-		aws.String("100"),
-		aws.String("57"),
-	})
-
-	groupedCountFieldBA := data.NewField("count", data.Labels{}, []*string{
-		aws.String("150"),
-		aws.String("62"),
-	})
-
-	groupedCountFieldAB := data.NewField("count", data.Labels{}, []*string{
-		aws.String("20"),
-		aws.String("105"),
-	})
-
-	groupedCountFieldBB := data.NewField("count", data.Labels{}, []*string{
-		aws.String("34"),
-		aws.String("200"),
-	})
-
 	expectedGroupedFrames := []*data.Frame{
 		{
-			Name: "fakelog-astream-a",
+			Name: "fakelog-a1",
 			Fields: []*data.Field{
-				groupedTimeField,
-				groupedCountFieldAA,
+				data.NewField("@timestamp", data.Labels{}, []*time.Time{&timeA, &timeB}),
+				data.NewField("count", data.Labels{}, []*string{
+					aws.String("100"),
+					aws.String("57"),
+				}),
 			},
 			RefID: "",
 		},
 		{
-			Name: "fakelog-bstream-a",
+			Name: "fakelog-b1",
 			Fields: []*data.Field{
-				groupedTimeField,
-				groupedCountFieldBA,
-			},
-			RefID: "",
-		},
-		{
-			Name: "fakelog-astream-b",
-			Fields: []*data.Field{
-				groupedTimeField,
-				groupedCountFieldAB,
-			},
-			RefID: "",
-		},
-		{
-			Name: "fakelog-bstream-b",
-			Fields: []*data.Field{
-				groupedTimeField,
-				groupedCountFieldBB,
+				data.NewField("@timestamp", data.Labels{}, []*time.Time{&timeA, &timeB}),
+				data.NewField("count", data.Labels{}, []*string{
+					aws.String("150"),
+					aws.String("62"),
+				}),
 			},
 			RefID: "",
 		},

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -60,7 +60,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 
 		var frames []*data.Frame
 		if len(logsQuery.StatsGroups) > 0 && len(dataframe.Fields) > 0 {
-			frames, err = groupResults(dataframe, logsQuery.StatsGroups)
+			frames, err = groupResults(dataframe, logsQuery.StatsGroups, true)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes a bug where CloudWatch Logs queries using `group by` can't be alerted on/used in expressions. The problem was that when we send a group by query to CloudWatch, it tells us the groups by adding the grouping fields to each row.  Alerts and expressions expect there to be only numeric information in the rows, so having the grouping strings there causes to error when processing the frames for alerts and expressions. This PR removes the non-time grouping fields from synchronous logs queries (aka expression and alert queries). We could probably remove them from all queries if we wanted, but I wanted to minimize the change in case users were using those fields.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63388 

**Special notes for your reviewer:**
I'm adding this to the 10.0.0 milestone because its a bug, but it's also kind of a feature since it's never worked? I can change it if we think we should.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
