### PR TITLE
PanelQueryRunner: BUG REPRO

### DIFF
--- a/public/app/plugins/panel/xychart/XYChartPanel2.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel2.tsx
@@ -10,6 +10,7 @@ import {
   reduceField,
   ReducerID,
   getDisplayProcessor,
+  DataFrame,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
@@ -33,7 +34,19 @@ import { PanelOptions, ScatterHoverEvent, ScatterSeries } from './types';
 type Props = PanelProps<PanelOptions>;
 const TOOLTIP_OFFSET = 10;
 
+let prevPanelDataSeries: DataFrame[] | undefined;
+
 export const XYChartPanel2 = (props: Props) => {
+  console.log({
+    'props.data.state': props.data.state,
+    'props.data.series === prevPanelDataSeries': props.data.series === prevPanelDataSeries,
+  });
+  prevPanelDataSeries = props.data.series;
+
+  return <>Hello</>;
+};
+
+export const XYChartPanel3 = (props: Props) => {
   const [error, setError] = useState<string | undefined>();
   const [series, setSeries] = useState<ScatterSeries[]>([]);
   const [builder, setBuilder] = useState<UPlotConfigBuilder | undefined>();

--- a/public/app/plugins/panel/xychart/XYChartPanel2.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel2.tsx
@@ -40,6 +40,7 @@ export const XYChartPanel2 = (props: Props) => {
   console.log({
     'props.data.state': props.data.state,
     'props.data.series === prevPanelDataSeries': props.data.series === prevPanelDataSeries,
+    'props.data.series[0] === prevPanelDataSeries[0]': props.data.series?.[0] === prevPanelDataSeries?.[0],
   });
   prevPanelDataSeries = props.data.series;
 


### PR DESCRIPTION
NOT FOR MERGING. this is just here for easy issue repro.

it looks like we may have a PQR bug that causes all panels with any queries over 200ms to double-render with "new" data rather than `lastResult`. this likely affects the vast majority of all queries in production and all viz panels that rely on referential integrity of `data.series` across panel re-renders.

https://github.com/grafana/grafana/blob/d31d1576fbcbb2ee5e19de3e9d6bc4af1047d659/public/app/features/query/state/runRequest.ts#L175-L178

here is a simple demo dashboard that can be used with the stubbed XYChart panel in this PR. it uses a testdata CSV file that can simulate a slow response when network throttling is enabled in Chrome devtools:

<details><summary>prevData !== nextData</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 651,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "scaleDistribution": {
              "type": "linear"
            },
            "show": "points"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "series": [],
        "seriesMapping": "auto",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvFileName": "weight_height.csv",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_file"
        }
      ],
      "title": "Panel Title",
      "type": "xychart"
    }
  ],
  "refresh": "",
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "prevData !== nextData",
  "uid": "f0f65d87-6996-432e-bae2-dc7988354d54",
  "version": 2,
  "weekStart": ""
}
```
</details>

what i expect to happen, is that during slow queries (when panelData.state === Loading), i get the same `data.series` during the initial panel re-render (before any new data actually arrives over network). what actually happens is that the data is not equal to `lastResult`, which causes us to re-render many viz panels as if the data had actually changed. we then render a second time once the request completes with the real new data.

https://user-images.githubusercontent.com/43234/235565729-a9cb0ab6-7481-4f47-9cd5-c13831a7ccb1.mp4