### PR TITLE
Authentication UI: Remove auth settings

### DIFF
--- a/public/app/features/auth-config/AuthConfigPage.tsx
+++ b/public/app/features/auth-config/AuthConfigPage.tsx
@@ -11,7 +11,7 @@ import { StoreState } from 'app/types';
 import ConfigureAuthCTA from './components/ConfigureAuthCTA';
 import { ProviderCard } from './components/ProviderCard';
 import { loadSettings } from './state/actions';
-import { filterAuthSettings, getProviderUrl } from './utils';
+import { getProviderUrl } from './utils';
 
 import { getRegisteredAuthProviders } from '.';
 
@@ -20,9 +20,8 @@ interface OwnProps {}
 export type Props = OwnProps & ConnectedProps<typeof connector>;
 
 function mapStateToProps(state: StoreState) {
-  const { settings, isLoading, providerStatuses } = state.authConfig;
+  const { isLoading, providerStatuses } = state.authConfig;
   return {
-    settings,
     isLoading,
     providerStatuses,
   };
@@ -34,12 +33,7 @@ const mapDispatchToProps = {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-export const AuthConfigPageUnconnected = ({
-  settings,
-  providerStatuses,
-  isLoading,
-  loadSettings,
-}: Props): JSX.Element => {
+export const AuthConfigPageUnconnected = ({ providerStatuses, isLoading, loadSettings }: Props): JSX.Element => {
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
@@ -54,7 +48,6 @@ export const AuthConfigPageUnconnected = ({
   const availableProviders = authProviders.filter(
     (p) => !providerStatuses[p.id]?.enabled && !providerStatuses[p.id]?.configured
   );
-  const authSettings = filterAuthSettings(settings);
   const firstAvailableProvider = availableProviders?.length ? availableProviders[0] : null;
 
   return (
@@ -98,29 +91,6 @@ export const AuthConfigPageUnconnected = ({
                 configPath={provider.configPath}
               />
             ))}
-          </div>
-        )}
-        {!isEmpty(authSettings) && (
-          <div className={styles.settingsSection}>
-            <h3>Settings</h3>
-            <table className="filter-table">
-              <tbody>
-                {Object.entries(authSettings).map(([sectionName, sectionSettings], i) => (
-                  <React.Fragment key={`section-${i}`}>
-                    <tr>
-                      <td className="admin-settings-section">{sectionName}</td>
-                      <td />
-                    </tr>
-                    {Object.entries(sectionSettings).map(([settingName, settingValue], j) => (
-                      <tr key={`property-${j}`}>
-                        <td className={styles.settingName}>{settingName}</td>
-                        <td className={styles.settingName}>{settingValue}</td>
-                      </tr>
-                    ))}
-                  </React.Fragment>
-                ))}
-              </tbody>
-            </table>
           </div>
         )}
       </Page.Contents>

--- a/public/app/features/auth-config/utils.ts
+++ b/public/app/features/auth-config/utils.ts
@@ -1,14 +1,5 @@
-import { Settings } from 'app/types';
-
 import { BASE_PATH } from './constants';
 import { AuthProviderInfo } from './types';
-
-export function filterAuthSettings(settings: Settings) {
-  const authSettings: Settings = Object.fromEntries(
-    Object.entries(settings).filter(([sectionName]) => sectionName === 'auth')
-  );
-  return authSettings;
-}
 
 export function getProviderUrl(provider: AuthProviderInfo) {
   return BASE_PATH + (provider.configPath || provider.id);


### PR DESCRIPTION
**What is this feature?**

After some discussions, we decided to remove read-only auth settings from the configuration page since it does not bring any value and creates some messiness in HG.

**Why do we need this feature?**

It makes config page more clear.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
