### PR TITLE
Dashboards: Only refresh panels on panel edit exit if refresh is set

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2375,8 +2375,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -287,19 +287,16 @@ describe('timeSrv', () => {
     });
   });
 
-  describe('pauseAutoRefresh', () => {
-    it('should set autoRefreshPaused to true', () => {
-      _dashboard.refresh = '10s';
-      timeSrv.pauseAutoRefresh();
-      expect(timeSrv.autoRefreshPaused).toBe(true);
-    });
-  });
-
   describe('resumeAutoRefresh', () => {
-    it('should set refresh to empty value', () => {
-      timeSrv.autoRefreshPaused = true;
+    it('should set auto-refresh interval', () => {
+      timeSrv.setAutoRefresh('10s');
+      expect(timeSrv.refreshTimer).not.toBeUndefined();
+
+      timeSrv.stopAutoRefresh();
+      expect(timeSrv.refreshTimer).toBeUndefined();
+
       timeSrv.resumeAutoRefresh();
-      expect(timeSrv.autoRefreshPaused).toBe(false);
+      expect(timeSrv.refreshTimer).not.toBeUndefined();
     });
   });
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -25,7 +25,6 @@ export class TimeSrv {
   time: any;
   refreshTimer: any;
   refresh: any;
-  autoRefreshPaused = false;
   oldRefresh: string | null | undefined;
   timeModel?: TimeModel;
   timeAtLoad: any;
@@ -238,11 +237,7 @@ export class TimeSrv {
 
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(intervalMs);
-      if (this.autoRefreshPaused) {
-        this.queueRefresh = true;
-      } else {
-        this.refreshTimeModel();
-      }
+      this.refreshTimeModel();
     }, intervalMs);
 
     const refresh = this.contextSrv.getValidInterval(interval);
@@ -264,11 +259,7 @@ export class TimeSrv {
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(afterMs);
       if (this.contextSrv.isGrafanaVisible()) {
-        if (this.autoRefreshPaused) {
-          this.queueRefresh = true;
-        } else {
-          this.refreshTimeModel();
-        }
+        this.refreshTimeModel();
       } else {
         this.autoRefreshBlocked = true;
       }
@@ -279,18 +270,10 @@ export class TimeSrv {
     clearTimeout(this.refreshTimer);
   }
 
-  // store timeModel refresh value and pause auto-refresh in some places
-  // i.e panel edit
-  pauseAutoRefresh() {
-    this.autoRefreshPaused = true;
-  }
-
   // resume auto-refresh based on old dashboard refresh property
   resumeAutoRefresh() {
-    this.autoRefreshPaused = false;
-    if (this.queueRefresh) {
-      this.queueRefresh = false;
-      this.refreshTimeModel();
+    if (this.timeModel?.refresh) {
+      this.setAutoRefresh(this.timeModel.refresh);
     }
   }
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -23,7 +23,7 @@ import { getRefreshFromUrl } from '../utils/getRefreshFromUrl';
 
 export class TimeSrv {
   time: any;
-  refreshTimer: any;
+  refreshTimer: number | undefined;
   refresh: any;
   oldRefresh: string | null | undefined;
   timeModel?: TimeModel;
@@ -235,7 +235,7 @@ export class TimeSrv {
     const validInterval = this.contextSrv.getValidInterval(interval);
     const intervalMs = rangeUtil.intervalToMs(validInterval);
 
-    this.refreshTimer = setTimeout(() => {
+    this.refreshTimer = window.setTimeout(() => {
       this.startNextRefreshTimer(intervalMs);
       this.refreshTimeModel();
     }, intervalMs);
@@ -256,7 +256,7 @@ export class TimeSrv {
   }
 
   private startNextRefreshTimer(afterMs: number) {
-    this.refreshTimer = setTimeout(() => {
+    this.refreshTimer = window.setTimeout(() => {
       this.startNextRefreshTimer(afterMs);
       if (this.contextSrv.isGrafanaVisible()) {
         this.refreshTimeModel();
@@ -268,6 +268,7 @@ export class TimeSrv {
 
   stopAutoRefresh() {
     clearTimeout(this.refreshTimer);
+    this.refreshTimer = undefined;
   }
 
   // resume auto-refresh based on old dashboard refresh property

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -275,7 +275,9 @@ export class TimeSrv {
   // resume auto-refresh based on old dashboard refresh property
   resumeAutoRefresh() {
     this.autoRefreshPaused = false;
-    this.refreshTimeModel();
+    if (this.timeModel?.refresh) {
+      this.refreshTimeModel();
+    }
   }
 
   setTime(time: RawTimeRange, updateUrl = true) {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -256,6 +256,10 @@ export class TimeSrv {
     this.timeModel?.timeRangeUpdated(this.timeRange());
   }
 
+  get refreshQueued() {
+    return this.queueRefresh;
+  }
+
   private startNextRefreshTimer(afterMs: number) {
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(afterMs);

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -28,7 +28,6 @@ export class TimeSrv {
   oldRefresh: string | null | undefined;
   timeModel?: TimeModel;
   timeAtLoad: any;
-  private queueRefresh = false;
   private autoRefreshBlocked?: boolean;
 
   constructor(private contextSrv: ContextSrv) {
@@ -249,10 +248,6 @@ export class TimeSrv {
 
   refreshTimeModel() {
     this.timeModel?.timeRangeUpdated(this.timeRange());
-  }
-
-  get refreshQueued() {
-    return this.queueRefresh;
   }
 
   private startNextRefreshTimer(afterMs: number) {

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -1,6 +1,6 @@
 import { keys as _keys } from 'lodash';
 
-import { VariableHide } from '@grafana/data';
+import { dateTime, TimeRange, VariableHide } from '@grafana/data';
 import { defaultVariableModel } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -1158,8 +1158,35 @@ describe('exitViewPanel', () => {
   });
 });
 
-describe('exitPanelEditor', () => {
-  function getTestContext(pauseAutoRefresh = false) {
+describe('when initEditPanel is called', () => {
+  function getTestContext() {
+    const dashboard = createDashboardModelFixture();
+    const timeSrvMock = {
+      pauseAutoRefresh: jest.fn(),
+      resumeAutoRefresh: jest.fn(),
+      stopAutoRefresh: jest.fn(),
+    } as unknown as TimeSrv;
+    setTimeSrv(timeSrvMock);
+    return { dashboard, timeSrvMock };
+  }
+
+  it('should set panelInEdit', () => {
+    const { dashboard } = getTestContext();
+    dashboard.addPanel({ type: 'timeseries' });
+    dashboard.initEditPanel(dashboard.panels[0]);
+    expect(dashboard.panelInEdit).not.toBeUndefined();
+  });
+
+  it('should stop auto-refresh', () => {
+    const { dashboard, timeSrvMock } = getTestContext();
+    dashboard.addPanel({ type: 'timeseries' });
+    dashboard.initEditPanel(dashboard.panels[0]);
+    expect(timeSrvMock.stopAutoRefresh).toHaveBeenCalled();
+  });
+});
+
+describe('when exitPanelEditor is called', () => {
+  function getTestContext() {
     const panel = new PanelModel({ destroy: jest.fn() });
     const dashboard = createDashboardModelFixture();
     const timeSrvMock = {
@@ -1169,70 +1196,54 @@ describe('exitPanelEditor', () => {
     } as unknown as TimeSrv;
     dashboard.startRefresh = jest.fn();
     dashboard.panelInEdit = panel;
-    if (pauseAutoRefresh) {
-      timeSrvMock.autoRefreshPaused = true;
-    }
     setTimeSrv(timeSrvMock);
     return { dashboard, panel, timeSrvMock };
   }
 
-  describe('when called', () => {
-    it('then panelInEdit is set to undefined', () => {
-      const { dashboard } = getTestContext();
+  it('should set panelInEdit to undefined', () => {
+    const { dashboard } = getTestContext();
 
-      dashboard.exitPanelEditor();
+    dashboard.exitPanelEditor();
 
-      expect(dashboard.panelInEdit).toBeUndefined();
-    });
-
-    it('then destroy is called on panel', () => {
-      const { dashboard, panel } = getTestContext();
-
-      dashboard.exitPanelEditor();
-
-      expect(panel.destroy).toHaveBeenCalled();
-    });
-
-    it('then startRefresh is not called', () => {
-      const { dashboard } = getTestContext();
-
-      dashboard.exitPanelEditor();
-
-      expect(dashboard.startRefresh).not.toHaveBeenCalled();
-    });
-
-    it('then auto refresh property is resumed', () => {
-      const { dashboard, timeSrvMock } = getTestContext(true);
-      dashboard.exitPanelEditor();
-      expect(timeSrvMock.resumeAutoRefresh).toHaveBeenCalled();
-    });
+    expect(dashboard.panelInEdit).toBeUndefined();
   });
-});
 
-describe('initEditPanel', () => {
-  function getTestContext() {
-    const dashboard = createDashboardModelFixture();
-    const timeSrvMock = {
-      pauseAutoRefresh: jest.fn(),
-      resumeAutoRefresh: jest.fn(),
-    } as unknown as TimeSrv;
-    setTimeSrv(timeSrvMock);
-    return { dashboard, timeSrvMock };
-  }
+  it('should destroy panel', () => {
+    const { dashboard, panel } = getTestContext();
 
-  describe('when called', () => {
-    it('then panelInEdit is not undefined', () => {
-      const { dashboard } = getTestContext();
-      dashboard.addPanel({ type: 'timeseries' });
-      dashboard.initEditPanel(dashboard.panels[0]);
-      expect(dashboard.panelInEdit).not.toBeUndefined();
-    });
+    dashboard.exitPanelEditor();
 
-    it('then auto-refresh is paused', () => {
-      const { dashboard, timeSrvMock } = getTestContext();
-      dashboard.addPanel({ type: 'timeseries' });
-      dashboard.initEditPanel(dashboard.panels[0]);
-      expect(timeSrvMock.pauseAutoRefresh).toHaveBeenCalled();
-    });
+    expect(panel.destroy).toHaveBeenCalled();
+  });
+
+  it('should not call startRefresh', () => {
+    const { dashboard } = getTestContext();
+
+    dashboard.exitPanelEditor();
+
+    expect(dashboard.startRefresh).not.toHaveBeenCalled();
+  });
+
+  it('should call startRefresh if time range changed during edit', () => {
+    const { dashboard } = getTestContext();
+
+    const range: TimeRange = {
+      from: dateTime(new Date().getTime()).subtract(1, 'minutes'),
+      to: dateTime(new Date().getTime()),
+      raw: {
+        from: 'now-1m',
+        to: 'now',
+      },
+    };
+    dashboard.timeRangeUpdated(range);
+    dashboard.exitPanelEditor();
+
+    expect(dashboard.startRefresh).toHaveBeenCalled();
+  });
+
+  it('then auto refresh property is resumed', () => {
+    const { dashboard, timeSrvMock } = getTestContext();
+    dashboard.exitPanelEditor();
+    expect(timeSrvMock.resumeAutoRefresh).toHaveBeenCalled();
   });
 });

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -431,13 +431,16 @@ export class DashboardModel implements TimeModel {
   exitPanelEditor() {
     this.panelInEdit!.destroy();
     this.panelInEdit = undefined;
+
+    const refreshQueued = getTimeSrv().refreshQueued;
     getTimeSrv().resumeAutoRefresh();
 
     if (this.panelsAffectedByVariableChange || this.timeRangeUpdatedDuringEdit) {
-      this.startRefresh({
-        panelIds: this.panelsAffectedByVariableChange ?? [],
-        refreshAll: this.timeRangeUpdatedDuringEdit,
-      });
+      !refreshQueued &&
+        this.startRefresh({
+          panelIds: this.panelsAffectedByVariableChange ?? [],
+          refreshAll: this.timeRangeUpdatedDuringEdit,
+        });
       this.panelsAffectedByVariableChange = null;
       this.timeRangeUpdatedDuringEdit = false;
     }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -110,6 +110,7 @@ export class DashboardModel implements TimeModel {
   declare meta: DashboardMeta;
   events: EventBusExtended;
   private getVariablesFromState: GetVariables;
+  private timeRangeUpdatedDuringEdit = false;
 
   static nonPersistedProperties: { [str: string]: boolean } = {
     events: true,
@@ -126,6 +127,7 @@ export class DashboardModel implements TimeModel {
     appEventsSubscription: true,
     panelsAffectedByVariableChange: true,
     lastRefresh: true,
+    timeRangeUpdatedDuringEdit: true,
   };
 
   constructor(
@@ -379,6 +381,9 @@ export class DashboardModel implements TimeModel {
   timeRangeUpdated(timeRange: TimeRange) {
     this.events.publish(new TimeRangeUpdatedEvent(timeRange));
     dispatch(onTimeRangeUpdated(this.uid, timeRange));
+    if (this.panelInEdit) {
+      this.timeRangeUpdatedDuringEdit = true;
+    }
   }
 
   startRefresh(event: VariablesChangedEvent = { refreshAll: true, panelIds: [] }) {
@@ -419,7 +424,23 @@ export class DashboardModel implements TimeModel {
   initEditPanel(sourcePanel: PanelModel): PanelModel {
     getTimeSrv().pauseAutoRefresh();
     this.panelInEdit = sourcePanel.getEditClone();
+    this.timeRangeUpdatedDuringEdit = false;
     return this.panelInEdit;
+  }
+
+  exitPanelEditor() {
+    this.panelInEdit!.destroy();
+    this.panelInEdit = undefined;
+    getTimeSrv().resumeAutoRefresh();
+
+    if (this.panelsAffectedByVariableChange || this.timeRangeUpdatedDuringEdit) {
+      this.startRefresh({
+        panelIds: this.panelsAffectedByVariableChange ?? [],
+        refreshAll: this.timeRangeUpdatedDuringEdit,
+      });
+      this.panelsAffectedByVariableChange = null;
+      this.timeRangeUpdatedDuringEdit = false;
+    }
   }
 
   initViewPanel(panel: PanelModel) {
@@ -430,13 +451,6 @@ export class DashboardModel implements TimeModel {
   exitViewPanel(panel: PanelModel) {
     this.panelInView = undefined;
     panel.setIsViewing(false);
-    this.refreshIfPanelsAffectedByVariableChange();
-  }
-
-  exitPanelEditor() {
-    this.panelInEdit!.destroy();
-    this.panelInEdit = undefined;
-    getTimeSrv().resumeAutoRefresh();
     this.refreshIfPanelsAffectedByVariableChange();
   }
 


### PR DESCRIPTION
Quick fix to prevent full dashboard refresh on exiting panel edit if periodic refresh isn't set.

Closes #66838