### PR TITLE
Connections: Rename "Your data source" to "Data source" page

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,9 +126,9 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/plugins/:id/edit", middleware.CanAdminPlugins(hs.Cfg), hs.Index) // deprecated
 	r.Get("/plugins/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
 
-	r.Get("/connections/your-datasources", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
-	r.Get("/connections/your-datasources/new", authorize(reqOrgAdmin, datasources.NewPageAccess), hs.Index)
-	r.Get("/connections/your-datasources/edit/*", authorize(reqOrgAdmin, datasources.EditPageAccess), hs.Index)
+	r.Get("/connections/datasources", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/connections/datasources/new", authorize(reqOrgAdmin, datasources.NewPageAccess), hs.Index)
+	r.Get("/connections/datasources/edit/*", authorize(reqOrgAdmin, datasources.EditPageAccess), hs.Index)
 	r.Get("/connections", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/add-new-connection", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg), hs.Index)

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -490,12 +490,12 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 			Children: []*navtree.NavLink{},
 		})
 
-		// Your data sources
+		// Data sources
 		children = append(children, &navtree.NavLink{
-			Id:       "connections-your-datasources",
-			Text:     "Your data sources",
+			Id:       "connections-datasources",
+			Text:     "Data sources",
 			SubTitle: "View and manage your connected data source connections",
-			Url:      baseUrl + "/your-datasources",
+			Url:      baseUrl + "/datasources",
 			Children: []*navtree.NavLink{},
 		})
 	}

--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -55,7 +55,7 @@ describe('Connections', () => {
     expect(await screen.findByText('Add new connection')).toBeVisible();
     expect(await screen.findByText('Browse and create new connections')).toBeVisible();
 
-    // Should not render the "Your datasources" page
+    // Should not render the "datasources" page
     expect(screen.queryByText('Manage your existing datasource connections')).not.toBeInTheDocument();
   });
 

--- a/public/app/features/connections/__mocks__/store.navIndex.mock.ts
+++ b/public/app/features/connections/__mocks__/store.navIndex.mock.ts
@@ -235,15 +235,15 @@ export const navIndex: NavIndex = {
         url: '/connections/add-new-connection',
       },
       {
-        id: 'connections-your-datasources',
-        text: 'Your data sources',
+        id: 'connections-datasources',
+        text: 'Data sources',
         subTitle: 'Manage your existing datasource connections',
-        url: '/connections/your-datasources',
+        url: '/connections/datasources',
       },
       {
-        id: 'standalone-plugin-page-/connections/your-infrastructure',
-        text: 'Your infrastructure',
-        url: '/connections/your-infrastructure',
+        id: 'standalone-plugin-page-/connections/infrastructure',
+        text: 'Infrastructure',
+        url: '/connections/infrastructure',
         pluginId: 'grafana-easystart-app',
       },
     ],
@@ -255,16 +255,16 @@ export const navIndex: NavIndex = {
       sortWeight: -2000,
     },
   },
-  'connections-your-datasources': {
-    id: 'connections-your-datasources',
-    text: 'Your data sources',
+  'connections-datasources': {
+    id: 'connections-datasources',
+    text: 'Data sources',
     subTitle: 'Manage your existing datasource connections',
-    url: '/connections/your-datasources',
+    url: '/connections/datasources',
   },
-  'standalone-plugin-page-/connections/your-infrastructure': {
-    id: 'standalone-plugin-page-/connections/your-infrastructure',
-    text: 'Your infrastructure',
-    url: '/connections/your-infrastructure',
+  'standalone-plugin-page-/connections/infrastructure': {
+    id: 'standalone-plugin-page-/connections/infrastructure',
+    text: 'Infrastructure',
+    url: '/connections/infrastructure',
     pluginId: 'grafana-easystart-app',
   },
   'connections-add-new-connection': {

--- a/public/app/features/connections/constants.ts
+++ b/public/app/features/connections/constants.ts
@@ -4,11 +4,11 @@ export const ROUTE_BASE_ID = 'connections';
 export const ROUTES = {
   Base: `/${ROUTE_BASE_ID}`,
 
-  // Your Datasources
-  DataSources: `/${ROUTE_BASE_ID}/your-datasources`,
-  DataSourcesNew: `/${ROUTE_BASE_ID}/your-datasources/new`,
-  DataSourcesEdit: `/${ROUTE_BASE_ID}/your-datasources/edit/:uid`,
-  DataSourcesDashboards: `/${ROUTE_BASE_ID}/your-datasources/edit/:uid/dashboards`,
+  // Data sources
+  DataSources: `/${ROUTE_BASE_ID}/datasources`,
+  DataSourcesNew: `/${ROUTE_BASE_ID}/datasources/new`,
+  DataSourcesEdit: `/${ROUTE_BASE_ID}/datasources/edit/:uid`,
+  DataSourcesDashboards: `/${ROUTE_BASE_ID}/datasources/edit/:uid/dashboards`,
 
   // Add new connection
   AddNewConnection: `/${ROUTE_BASE_ID}/add-new-connection`,

--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -23,12 +23,12 @@ export function useDataSourceSettingsNav(pageId?: string) {
     active: true,
     children: (nav.main.children || []).map((navModelItem) => ({
       ...navModelItem,
-      url: navModelItem.url?.replace('datasources/edit/', '/connections/your-datasources/edit/'),
+      url: navModelItem.url?.replace('datasources/edit/', '/connections/datasources/edit/'),
     })),
   };
 
   return {
-    navId: 'connections-your-datasources',
+    navId: 'connections-datasources',
     pageNav,
   };
 }

--- a/public/app/features/connections/pages/DataSourcesListPage.tsx
+++ b/public/app/features/connections/pages/DataSourcesListPage.tsx
@@ -11,7 +11,7 @@ export function DataSourcesListPage() {
 
   const actions = dataSourcesCount > 0 ? <DataSourceAddButton /> : undefined;
   return (
-    <Page navId={'connections-your-datasources'} actions={actions}>
+    <Page navId={'connections-datasources'} actions={actions}>
       <Page.Contents>
         <DataSourcesList />
       </Page.Contents>

--- a/public/app/features/connections/pages/NewDataSourcePage.tsx
+++ b/public/app/features/connections/pages/NewDataSourcePage.tsx
@@ -6,7 +6,7 @@ import { NewDataSource } from 'app/features/datasources/components/NewDataSource
 export function NewDataSourcePage() {
   return (
     <Page
-      navId={'connections-your-datasources'}
+      navId={'connections-datasources'}
       pageNav={{ text: 'Add data source', subTitle: 'Choose a data source type', active: true }}
     >
       <Page.Contents>

--- a/public/app/features/connections/tabs/ConnectData/NoAccessModal/NoAccessModal.tsx
+++ b/public/app/features/connections/tabs/ConnectData/NoAccessModal/NoAccessModal.tsx
@@ -91,7 +91,7 @@ export function NoAccessModal({ item, isOpen, onDismiss }: NoAccessModalProps) {
           <div>
             <p>
               Editors cannot add new connections. You may check to see if it is already configured in{' '}
-              <a href="/connections/your-datasources">Your data sources</a>.
+              <a href="/connections/datasources">Data sources</a>.
             </p>
             <p>To add a new connection, contact your Grafana admin.</p>
           </div>


### PR DESCRIPTION
This page was meant to be named "Data source" in [the previous PR]. I just made a mistake by naming it wrongly.

[the previous PR]: https://github.com/grafana/grafana/pull/66813/files

Relates to https://github.com/grafana/grafana/issues/67632

[Screencast from 2023-05-02 15-45-45.webm](https://user-images.githubusercontent.com/13637610/235685731-15008366-e1a6-4949-8006-c5a87057eff6.webm)
