### PR TITLE
PluginCatalog: Update message about insufficient permissions

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsWarning.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsWarning.tsx
@@ -58,8 +58,7 @@ export const InstallControlsWarning = ({ plugin, pluginStatus, latestCompatibleV
   }
 
   if (!hasPermission && !isExternallyManaged) {
-    const message = `You do not have permission to ${pluginStatus} this plugin.`;
-    return <div className={styles.message}>{message}</div>;
+    return <div className={styles.message}>{statusToMessage(pluginStatus)}</div>;
   }
 
   if (!plugin.isPublished) {
@@ -101,3 +100,17 @@ export const getStyles = (theme: GrafanaTheme2) => {
     `,
   };
 };
+
+function statusToMessage(status: PluginStatus): string {
+  switch (status) {
+    case PluginStatus.INSTALL:
+    case PluginStatus.REINSTALL:
+      return `You do not have permission to install this plugin.`;
+    case PluginStatus.UNINSTALL:
+      return `You do not have permission to uninstall this plugin.`;
+    case PluginStatus.UPDATE:
+      return `You do not have permission to update this plugin.`;
+    default:
+      return `You do not have permission to manage this plugin.`;
+  }
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Improves error message in plugin catalog when use has insufficient permissions to manage plugins.


**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #67655

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
