### PR TITLE
Search: Fix Folder View not loading dashboards

### DIFF
--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -54,7 +54,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       eventTrackingNamespace: folderUid ? 'manage_dashboards' : 'dashboard_search',
     });
 
-    if (doInitialSearch && this.hasSearchFilters()) {
+    if (doInitialSearch) {
       this.doSearch();
     }
   }


### PR DESCRIPTION
Fixes a regression I introduced in https://github.com/grafana/grafana/pull/67193 where Folder View is not loading it's children because it would only do the search for children if there were search filters applied (has a search query, tags, isStarred, or a sorting option)