### PR TITLE
Pyroscope: Add authentication when calling backendType resource API

### DIFF
--- a/pkg/plugins/manager/manager_integration_test.go
+++ b/pkg/plugins/manager/manager_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
 
@@ -107,7 +108,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	ms := mssql.ProvideService(cfg)
 	sv2 := searchV2.ProvideService(cfg, db.InitTestDB(t), nil, nil, tracer, features, nil, nil, nil)
 	graf := grafanads.ProvideService(sv2, nil)
-	phlare := phlare.ProvideService(hcp)
+	phlare := phlare.ProvideService(hcp, acimpl.ProvideAccessControl(cfg))
 	parca := parca.ProvideService(hcp)
 
 	coreRegistry := coreplugin.ProvideCoreRegistry(am, cw, cm, es, grap, idb, lk, otsdb, pr, tmpo, td, pg, my, ms, graf, phlare, parca)

--- a/pkg/tsdb/phlare/service.go
+++ b/pkg/tsdb/phlare/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
 // Make sure PhlareDatasource implements required interfaces. This is important to do
@@ -41,15 +42,15 @@ func (s *Service) getInstance(pluginCtx backend.PluginContext) (*PhlareDatasourc
 	return in, nil
 }
 
-func ProvideService(httpClientProvider httpclient.Provider) *Service {
+func ProvideService(httpClientProvider httpclient.Provider, ac accesscontrol.AccessControl) *Service {
 	return &Service{
-		im: datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
+		im: datasource.NewInstanceManager(newInstanceSettings(httpClientProvider, ac)),
 	}
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider httpclient.Provider, ac accesscontrol.AccessControl) datasource.InstanceFactoryFunc {
 	return func(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return NewPhlareDatasource(httpClientProvider, settings)
+		return NewPhlareDatasource(httpClientProvider, settings, ac)
 	}
 }
 


### PR DESCRIPTION
With https://github.com/grafana/grafana/pull/66989 we also added an autodetection of the backend type to be used in the config page for easier setup. Because of how the config page works, we may not have the URL on the backend and so we send the URL in the query. This was implemented through `/resource` API which itself isn't guarded and would allow anybody to supply any URL. This adds simple auth check to make sure only users who already can create data source can use this resource call.

To test:
- Create a Grafana Pyroscope data source with admin/editor user.
- Check dev tools and copy the call which should look something like this `http://localhost:3000/api/datasources/uid/<ds-uid>/resources/backendType?url=http%3A%2F%2Flocalhost%3A4100`
- Sign in as different user which does not have editor permission.
- Paste the `backendType` URL into another tab and make sure you get 401 response.