### PR TITLE
Elasticsearch: Run version check thorugh backend if enableElasticsearchBackendQuerying enabled

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -178,7 +178,7 @@ func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*es.DatasourceInfo
 	return &instance, nil
 }
 
-func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {	
+func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	logger := eslog.FromContext(ctx)
 	// allowed paths for resource calls:
 	// - empty string for fetching db version

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -221,8 +221,8 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 
 	return sender.Send(&backend.CallResourceResponse{
 		Status: response.StatusCode,
-		// We are sending back original req headers, as we don't want to expose any possibly confidential headers
-		Headers: req.Headers,
+		// We are not sending response headers, as we don't want to expose any possibly confidential headers
+		Headers: make(map[string][]string),
 		Body:    body,
 	})
 }

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -218,7 +218,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return err
 	}
-	
+
 	responseHeaders := map[string][]string{
 		"content-type": {"application/json"},
 	}
@@ -228,7 +228,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	}
 
 	return sender.Send(&backend.CallResourceResponse{
-		Status: response.StatusCode,
+		Status:  response.StatusCode,
 		Headers: responseHeaders,
 		Body:    body,
 	})

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -218,11 +218,18 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return err
 	}
+	
+	responseHeaders := map[string][]string{
+		"content-type": {"application/json"},
+	}
+
+	if response.Header.Get("Content-Encoding") != "" {
+		responseHeaders["content-encoding"] = []string{response.Header.Get("Content-Encoding")}
+	}
 
 	return sender.Send(&backend.CallResourceResponse{
 		Status: response.StatusCode,
-		// We are not sending response headers, as we don't want to expose any possibly confidential headers
-		Headers: make(map[string][]string),
+		Headers: responseHeaders,
 		Body:    body,
 	})
 }

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -178,7 +178,8 @@ func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*es.DatasourceInfo
 	return &instance, nil
 }
 
-func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {	
+	logger := eslog.FromContext(ctx)
 	// allowed paths for resource calls:
 	// - empty string for fetching db version
 	if req.Path != "" {
@@ -213,6 +214,12 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			logger.Warn("Failed to close response body", "err", err)
+		}
+	}()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -30,7 +30,7 @@ import {
   LogRowContextOptions,
   SupplementaryQueryOptions,
 } from '@grafana/data';
-import { DataSourceWithBackend, getDataSourceSrv, config, BackendSrvRequest } from '@grafana/runtime';
+import { DataSourceWithBackend, getDataSourceSrv, config } from '@grafana/runtime';
 import { queryLogsVolume } from 'app/core/logsModel';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -739,12 +739,9 @@ export class ElasticDatasource
 
   private getDatabaseVersionUncached(): Promise<SemVer | null> {
     // we want this function to never fail
-    let getDbVersionObservable;
-    if (config.featureToggles.enableElasticsearchBackendQuerying) {
-      getDbVersionObservable = from(this.getResource(''));
-    } else {
-      getDbVersionObservable = this.legacyQueryRunner.request('GET', '/');
-    }
+    const getDbVersionObservable = config.featureToggles.enableElasticsearchBackendQuerying
+      ? from(this.getResource(''))
+      : this.legacyQueryRunner.request('GET', '/');
 
     return lastValueFrom(getDbVersionObservable).then(
       (data) => {


### PR DESCRIPTION
In this PR, we are introducing `CallResource` to backend and use it to run `getDatabaseVersionUncached` trough resource call if `enableElasticsearchBackendQuerying` is enabled.

Part of #54011

How to test this:

1. Enable `enableElasticsearchBackendQuerying`
1. Open ES settings, click on `Save & Test` and observe no errors
1. Open network tab and inspect if `resources/` looks good - the response includes version
1. Open Explore to see if there are no errors
1. Open network tab and inspect if `resources/` looks good - the response includes version