### PR TITLE
Alerting: Allow to tab onto elements for a11y

### DIFF
--- a/public/app/features/alerting/unified/components/HoverCard.tsx
+++ b/public/app/features/alerting/unified/components/HoverCard.tsx
@@ -57,6 +57,8 @@ export const HoverCard = ({
                 wrapperClassName={classnames(styles.popover(arrow ? 1.25 : 0), wrapperClassName)}
                 onMouseLeave={hidePopper}
                 onMouseEnter={showPopper}
+                onFocus={showPopper}
+                onBlur={hidePopper}
                 referenceElement={popoverRef.current}
                 renderArrow={
                   arrow
@@ -70,6 +72,8 @@ export const HoverCard = ({
               ref: popoverRef,
               onMouseEnter: showPopper,
               onMouseLeave: hidePopper,
+              onFocus: showPopper,
+              onBlur: hidePopper,
             })}
           </>
         );

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -88,12 +88,12 @@ function Token({ content, description, type }: TokenProps) {
       disabled={disableCard}
       content={
         <div className={styles.hoverTokenItem}>
-          <Badge text={<>{type}</>} color={'blue'} /> {description && <code>{description}</code>}
+          <Badge tabIndex={0} text={<>{type}</>} color={'blue'} /> {description && <code>{description}</code>}
         </div>
       }
     >
       <span>
-        <Badge className={styles.token} text={content} color={'blue'} />
+        <Badge tabIndex={0} className={styles.token} text={content} color={'blue'} />
       </span>
     </HoverCard>
   );

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -203,7 +203,7 @@ const RulesFilter = ({ onFilterCleared = () => undefined }: RulesFilerProps) => 
                     <Stack gap={0.5}>
                       <span>Search</span>
                       <HoverCard content={<SearchQueryHelp />}>
-                        <Icon name="info-circle" size="sm" />
+                        <Icon name="info-circle" size="sm" tabIndex={0} />
                       </HoverCard>
                     </Stack>
                   </Label>


### PR DESCRIPTION
**What is this feature?**

Allows to tab onto the Search tooltip and the rule description tokens which is relevant to comply with https://www.w3.org/WAI/WCAG21/quickref/#keyboard

**Why do we need this feature?**

Improve accessibility.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64052

![2023-05-02 16 50 55](https://user-images.githubusercontent.com/6271380/235770769-a0eba326-1f86-4977-86ab-756cdb503761.gif)
![2023-05-02 16 50 11](https://user-images.githubusercontent.com/6271380/235770819-fdb4f5df-28f5-4948-a1ac-952ff64f89f4.gif)

