### PR TITLE
Plugins: Remove dead CLI code and use pkg/plugins for uninstall process

### DIFF
--- a/pkg/cmd/grafana-cli/commands/cli.go
+++ b/pkg/cmd/grafana-cli/commands/cli.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
-// RunCLI is the entrypoint for the grafana-cli command. It returns the exit code for the grafana-cli program.
+// CLICommand is the entrypoint for the grafana-cli command. It returns the exit code for the grafana-cli program.
 func CLICommand(version string) *cli.Command {
 	return &cli.Command{
 		Name:  "cli",

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/repo"
 	"github.com/grafana/grafana/pkg/plugins/storage"
 )
@@ -100,6 +102,21 @@ func installPlugin(ctx context.Context, pluginID, version string, c utils.Comman
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// uninstallPlugin removes the plugin directory
+func uninstallPlugin(_ context.Context, pluginID string, c utils.CommandLine) error {
+	logger.Infof("Removing plugin: %v\n", pluginID)
+
+	pluginPath := filepath.Join(c.PluginDirectory(), pluginID)
+	fs := plugins.NewLocalFS(pluginPath)
+
+	logger.Debugf("Removing directory %v\n", pluginPath)
+	err := fs.Remove()
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/grafana-cli/commands/remove_command.go
+++ b/pkg/cmd/grafana-cli/commands/remove_command.go
@@ -1,31 +1,25 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
-var removePlugin func(pluginPath, id string) error = services.RemoveInstalledPlugin
-
 func (cmd Command) removeCommand(c utils.CommandLine) error {
-	pluginPath := c.PluginDirectory()
-
-	plugin := c.Args().First()
-	if plugin == "" {
+	pluginID := c.Args().First()
+	if pluginID == "" {
 		return errors.New("missing plugin parameter")
 	}
 
-	err := removePlugin(pluginPath, plugin)
-
+	err := uninstallPlugin(context.Background(), pluginID, c)
 	if err != nil {
 		if strings.Contains(err.Error(), "no such file or directory") {
 			return fmt.Errorf("plugin does not exist")
 		}
-
 		return err
 	} else {
 		logRestartNotice()

--- a/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
@@ -49,15 +49,16 @@ func (cmd Command) upgradeAllCommand(c utils.CommandLine) error {
 		}
 	}
 
+	ctx := context.Background()
 	for _, p := range pluginsToUpgrade {
 		logger.Infof("Updating %v \n", p.ID)
 
-		err := services.RemoveInstalledPlugin(pluginsDir, p.ID)
+		err = uninstallPlugin(ctx, p.ID, c)
 		if err != nil {
 			return err
 		}
 
-		err = installPlugin(context.Background(), p.ID, "", c)
+		err = installPlugin(ctx, p.ID, "", c)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -14,9 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
-type GrafanaComClient struct {
-	retryCount int
-}
+type GrafanaComClient struct{}
 
 func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plugin, error) {
 	logger.Debugf("getting plugin metadata from: %v pluginId: %v \n", repoUrl, pluginId)

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -1,15 +1,12 @@
 package services
 
 import (
-	"bufio"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"runtime"
 
@@ -40,77 +37,6 @@ func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plug
 	}
 
 	return data, nil
-}
-
-func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error) {
-	// Try handling URL as a local file path first
-	if _, err := os.Stat(url); err == nil {
-		// We can ignore this gosec G304 warning since `url` stems from command line flag "pluginUrl". If the
-		// user shouldn't be able to read the file, it should be handled through filesystem permissions.
-		// nolint:gosec
-		f, err := os.Open(url)
-		if err != nil {
-			return fmt.Errorf("%v: %w", "Failed to read plugin archive", err)
-		}
-		_, err = io.Copy(tmpFile, f)
-		if err != nil {
-			return fmt.Errorf("%v: %w", "Failed to copy plugin archive", err)
-		}
-		return nil
-	}
-
-	client.retryCount = 0
-
-	defer func() {
-		if r := recover(); r != nil {
-			client.retryCount++
-			if client.retryCount < 3 {
-				logger.Info("Failed downloading. Will retry once.")
-				err = tmpFile.Truncate(0)
-				if err != nil {
-					return
-				}
-				_, err = tmpFile.Seek(0, 0)
-				if err != nil {
-					return
-				}
-				err = client.DownloadFile(pluginName, tmpFile, url, checksum)
-			} else {
-				client.retryCount = 0
-				failure := fmt.Sprintf("%v", r)
-				if failure == "runtime error: makeslice: len out of range" {
-					err = fmt.Errorf("corrupt HTTP response from source, please try again")
-				} else {
-					panic(r)
-				}
-			}
-		}
-	}()
-
-	// Using no timeout here as some plugins can be bigger and smaller timeout would prevent to download a plugin on
-	// slow network. As this is CLI operation hanging is not a big of an issue as user can just abort.
-	bodyReader, err := sendRequest(HttpClientNoTimeout, url)
-	if err != nil {
-		return fmt.Errorf("%v: %w", "Failed to send request", err)
-	}
-	defer func() {
-		if err := bodyReader.Close(); err != nil {
-			logger.Warn("Failed to close body", "err", err)
-		}
-	}()
-
-	w := bufio.NewWriter(tmpFile)
-	h := sha256.New()
-	if _, err = io.Copy(w, io.TeeReader(bodyReader, h)); err != nil {
-		return fmt.Errorf("%v: %w", "failed to compute SHA256 checksum", err)
-	}
-	if err := w.Flush(); err != nil {
-		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
-	}
-	if len(checksum) > 0 && checksum != fmt.Sprintf("%x", h.Sum(nil)) {
-		return fmt.Errorf("expected SHA256 checksum does not match the downloaded archive - please contact security@grafana.com")
-	}
-	return nil
 }
 
 func (client *GrafanaComClient) ListAllPlugins(repoUrl string) (models.PluginRepo, error) {

--- a/pkg/cmd/grafana-cli/services/services.go
+++ b/pkg/cmd/grafana-cli/services/services.go
@@ -15,12 +15,11 @@ import (
 )
 
 var (
-	IoHelper            models.IoUtil = IoUtilImp{}
-	HttpClient          http.Client
-	HttpClientNoTimeout http.Client
-	GrafanaVersion      string
-	ErrNotFoundError    = errors.New("404 not found error")
-	Logger              *logger.CLILogger
+	IoHelper         models.IoUtil = IoUtilImp{}
+	HttpClient       http.Client
+	GrafanaVersion   string
+	ErrNotFoundError = errors.New("404 not found error")
+	Logger           *logger.CLILogger
 )
 
 type BadRequestError struct {
@@ -37,9 +36,7 @@ func (e *BadRequestError) Error() string {
 
 func Init(version string, skipTLSVerify bool, debugMode bool) {
 	GrafanaVersion = version
-
 	HttpClient = makeHttpClient(skipTLSVerify, 10*time.Second)
-	HttpClientNoTimeout = makeHttpClient(skipTLSVerify, 0)
 	Logger = logger.New(debugMode)
 }
 
@@ -73,7 +70,7 @@ func ReadPlugin(pluginDir, pluginName string) (models.InstalledPlugin, error) {
 		pluginDataPath := filepath.Join(pluginDir, pluginName, "plugin.json")
 		data, err = IoHelper.ReadFile(pluginDataPath)
 		if err != nil {
-			return models.InstalledPlugin{}, errors.New("Could not find dist/plugin.json or plugin.json on  " + pluginName + " in " + pluginDir)
+			return models.InstalledPlugin{}, errors.New("Could not find dist/plugin.json or plugin.json for " + pluginName + " in " + pluginDir)
 		}
 	}
 
@@ -104,17 +101,4 @@ func GetLocalPlugins(pluginDir string) []models.InstalledPlugin {
 	}
 
 	return result
-}
-
-func RemoveInstalledPlugin(pluginPath, pluginName string) error {
-	logger.Infof("Removing plugin: %v\n", pluginName)
-	pluginDir := filepath.Join(pluginPath, pluginName)
-
-	_, err := IoHelper.Stat(pluginDir)
-	if err != nil {
-		return err
-	}
-
-	logger.Debugf("Removing directory %v\n", pluginDir)
-	return IoHelper.RemoveAll(pluginDir)
 }

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"os"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
@@ -27,7 +25,6 @@ type CommandLine interface {
 
 type ApiClient interface {
 	GetPlugin(pluginId, repoUrl string) (models.Plugin, error)
-	DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error)
 	ListAllPlugins(repoUrl string) (models.PluginRepo, error)
 }
 


### PR DESCRIPTION
**What is this feature?**

Tidying up plugin related code in the Grafana CLI packages

**Why do we need this feature?**

Some of the code is dead / duplicated

**Who is this feature for?**

Plugins Platform


**Special notes for your reviewer:**
This is the first of probably a few PRs, in the interest of keeping the change sets smaller

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
