### PR TITLE
RBAC: remove rbac disabled from preferences tests

### DIFF
--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -189,7 +189,6 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
 
 func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 
 	dashSvc := dashboards.NewFakeDashboardService(t)
 	qResult := &dashboards.Dashboard{UID: "home", ID: 1}
@@ -240,7 +239,6 @@ func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
 
 func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
 		hs.Cfg = cfg
@@ -250,8 +248,9 @@ func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
 	input := strings.NewReader(testPatchOrgPreferencesCmd)
 	t.Run("Returns 200 on success", func(t *testing.T) {
 		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPatch, patchOrgPreferencesUrl, input), &user.SignedInUser{
-			OrgID:   1,
-			OrgRole: org.RoleAdmin,
+			OrgID:       1,
+			OrgRole:     org.RoleAdmin,
+			Permissions: map[int64]map[string][]string{1: {accesscontrol.ActionOrgsPreferencesWrite: {}}},
 		})
 		response, err := server.SendJSON(req)
 		require.NoError(t, err)
@@ -262,8 +261,9 @@ func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
 	input = strings.NewReader(testPatchOrgPreferencesCmdBad)
 	t.Run("Returns 400 with bad data", func(t *testing.T) {
 		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPatch, patchOrgPreferencesUrl, input), &user.SignedInUser{
-			OrgID:   1,
-			OrgRole: org.RoleAdmin,
+			OrgID:       1,
+			OrgRole:     org.RoleAdmin,
+			Permissions: map[int64]map[string][]string{1: {accesscontrol.ActionOrgsPreferencesWrite: {}}},
 		})
 		response, err := server.SendJSON(req)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Removes RBACenabled from preferences tests and adds the necessary permissions needed to interact with the preferences.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana-enterprise/issues/5019

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
