### PR TITLE
Analytics: Move auth modules trusted for providing Analytics ID to config

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -288,6 +288,11 @@ application_insights_endpoint_url =
 # Controls if the UI contains any links to user feedback forms
 feedback_links_enabled = true
 
+# Defines external auth providers (such as OAuth) whos ID is used to identify to analytics services
+[analytics.external_id_auth_modules]
+oauth_grafana_com = true
+oauth_grafananet = true
+
 #################################### Security ############################
 [security]
 # disable creation of admin user on first start of grafana

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"golang.org/x/exp/slices"
 )
 
 type store interface {
@@ -438,7 +439,8 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 			signedInUser.OrgName = "Org missing"
 		}
 
-		if signedInUser.ExternalAuthModule != "oauth_grafana_com" {
+		useForAnalyticsID := slices.Contains(ss.cfg.AnalyticsIDAuthModules, signedInUser.ExternalAuthModule)
+		if !useForAnalyticsID {
 			signedInUser.ExternalAuthID = ""
 		}
 

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -401,6 +401,25 @@ func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
 	require.Equal(t, "http://cdn.grafana.com/sub/grafana/v7.5.0-11124pre/", cfg.GetContentDeliveryURL("grafana"))
 }
 
+func TestAnalyticsIDAuthModules(t *testing.T) {
+	iniFile := ini.Empty()
+	cfg := NewCfg()
+
+	section, err := iniFile.NewSection("analytics.external_id_auth_modules")
+	require.NoError(t, err)
+
+	_, err = section.NewKey("oauth_provider_a", "true")
+	require.NoError(t, err)
+	_, err = section.NewKey("oauth_provider_b", "true")
+	require.NoError(t, err)
+	_, err = section.NewKey("oauth_provider_c", "false")
+	require.NoError(t, err)
+
+	err = readTrustedAnalyticsIDAuthModules(cfg, iniFile)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"oauth_provider_a", "oauth_provider_b"}, cfg.AnalyticsIDAuthModules)
+}
+
 // Adding a case for this in case we switch to proper semver version strings
 func TestGetCDNPathWithAlphaVersion(t *testing.T) {
 	var err error


### PR DESCRIPTION
**What is this feature?**

Instead of hard coding `oauth_grafana_com` as the only auth provider that is 'trusted' to provide an identifier for analytics, this PR moves that to config.

**Why do we need this feature?**

To make analytics more flexible and adaptive to changes, and so we can trust multiple providers if needed.

**Who is this feature for?**

Grafana Cloud/operators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Any of the approach here isn't set in stone. I'm not in love with the names of things, and I didn't know the right way to put these values into config (notice I'm using a dynamic set of keys, inspired by feature flags). Alternatives are more than welcome :)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
