### PR TITLE
InfluxDB: Fix querying retention policies on flux mode

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -169,7 +169,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   }
 
   async getRetentionPolicies(): Promise<string[]> {
-    if (this.retentionPolicies.length) {
+    // Only For InfluxQL Mode
+    if (this.isFlux || this.retentionPolicies.length) {
       return Promise.resolve(this.retentionPolicies);
     } else {
       return getAllPolicies(this).catch((err) => {


### PR DESCRIPTION
**What is this feature?**
Retention policies are being used only for InfluxDB mode. So we should not try to query them on flux mode. This PR is preventing that unnecessary query request.


**Why do we need this feature?**

To prevent unnecessary retention policy querying

**Who is this feature for?**

InfluxDB Flux mode users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67610

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
