### PR TITLE
Page: Remove toolbar prop as it's no longer needed

### DIFF
--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -24,7 +24,6 @@ export const Page: PageType = ({
   className,
   info,
   layout = PageLayoutType.Standard,
-  toolbar,
   scrollTop,
   scrollRef,
   ...otherProps
@@ -70,18 +69,10 @@ export const Page: PageType = ({
       )}
       {layout === PageLayoutType.Canvas && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={styles.canvasContent}>
-            {toolbar}
-            {children}
-          </div>
+          <div className={styles.canvasContent}>{children}</div>
         </CustomScrollbar>
       )}
-      {layout === PageLayoutType.Custom && (
-        <>
-          {toolbar}
-          {children}
-        </>
-      )}
+      {layout === PageLayoutType.Custom && children}
     </div>
   );
 };

--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -19,8 +19,6 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   subTitle?: React.ReactNode;
   /** Control the page layout. */
   layout?: PageLayoutType;
-  /** Something we can remove when we remove the old nav. */
-  toolbar?: React.ReactNode;
   /** Can be used to get the scroll container element to access scroll position */
   scrollRef?: RefCallback<HTMLDivElement>;
   /** Can be used to update the current scroll position */

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -429,12 +429,6 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     this.setState({ showSaveLibraryPanelModal: false });
   };
 
-  renderToolbar() {
-    return (
-      <AppChromeUpdate actions={<ToolbarButtonRow alignment="right">{this.renderEditorActions()}</ToolbarButtonRow>} />
-    );
-  }
-
   render() {
     const { initDone, uiState, theme, sectionNav, pageNav, className, updatePanelEditorUIState } = this.props;
     const styles = getStyles(theme, this.props);
@@ -449,9 +443,11 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
         pageNav={pageNav}
         aria-label={selectors.components.PanelEditor.General.content}
         layout={PageLayoutType.Custom}
-        toolbar={this.renderToolbar()}
         className={className}
       >
+        <AppChromeUpdate
+          actions={<ToolbarButtonRow alignment="right">{this.renderEditorActions()}</ToolbarButtonRow>}
+        />
         <div className={styles.wrapper}>
           <div className={styles.verticalSplitPanesWrapper}>
             {!uiState.isPanelOptionsVisible ? (

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -419,20 +419,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     const inspectPanel = this.getInspectPanel();
     const showSubMenu = !editPanel && !kioskMode && !this.props.queryParams.editview;
 
-    const toolbar = kioskMode !== KioskMode.Full && !queryParams.editview && (
-      <header data-testid={selectors.pages.Dashboard.DashNav.navV2}>
-        <DashNav
-          dashboard={dashboard}
-          title={dashboard.title}
-          folderTitle={dashboard.meta.folderTitle}
-          isFullscreen={!!viewPanel}
-          onAddPanel={this.onAddPanel}
-          kioskMode={kioskMode}
-          hideTimePicker={dashboard.timepicker.hidden}
-          shareModalActiveTab={this.props.queryParams.shareView}
-        />
-      </header>
-    );
+    const showToolbar = kioskMode !== KioskMode.Full && !queryParams.editview;
 
     const pageClassName = cx({
       'panel-in-fullscreen': Boolean(viewPanel),
@@ -453,11 +440,24 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
           navModel={sectionNav}
           pageNav={pageNav}
           layout={PageLayoutType.Canvas}
-          toolbar={toolbar}
           className={pageClassName}
           scrollRef={this.setScrollRef}
           scrollTop={updateScrollTop}
         >
+          {showToolbar && (
+            <header data-testid={selectors.pages.Dashboard.DashNav.navV2}>
+              <DashNav
+                dashboard={dashboard}
+                title={dashboard.title}
+                folderTitle={dashboard.meta.folderTitle}
+                isFullscreen={!!viewPanel}
+                onAddPanel={this.onAddPanel}
+                kioskMode={kioskMode}
+                hideTimePicker={dashboard.timepicker.hidden}
+                shareModalActiveTab={this.props.queryParams.shareView}
+              />
+            </header>
+          )}
           <DashboardPrompt dashboard={dashboard} />
           {initError && <DashboardFailed />}
           {showSubMenu && (

--- a/public/app/features/dashboard/containers/PublicDashboardPage.tsx
+++ b/public/app/features/dashboard/containers/PublicDashboardPage.tsx
@@ -104,12 +104,8 @@ const PublicDashboardPage = (props: Props) => {
   }
 
   return (
-    <Page
-      pageNav={{ text: dashboard.title }}
-      layout={PageLayoutType.Custom}
-      toolbar={<Toolbar dashboard={dashboard} />}
-      data-testid={selectors.page}
-    >
+    <Page pageNav={{ text: dashboard.title }} layout={PageLayoutType.Custom} data-testid={selectors.page}>
+      <Toolbar dashboard={dashboard} />
       {dashboardState.initError && <DashboardFailed initError={dashboardState.initError} />}
       <div className={styles.gridContainer}>
         <DashboardGrid dashboard={dashboard} isEditable={false} viewPanel={null} editPanel={null} hidePanelMenus />

--- a/public/app/features/scenes/dashboard/DashboardScene.tsx
+++ b/public/app/features/scenes/dashboard/DashboardScene.tsx
@@ -36,10 +36,10 @@ function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) 
       />
     );
   }
-  const pageToolbar = <AppChromeUpdate actions={toolbarActions} />;
 
   return (
-    <Page navId="scenes" pageNav={{ text: title }} layout={PageLayoutType.Canvas} toolbar={pageToolbar}>
+    <Page navId="scenes" pageNav={{ text: title }} layout={PageLayoutType.Canvas}>
+      <AppChromeUpdate actions={toolbarActions} />
       {controls && (
         <div className={styles.controls}>
           {controls.map((control) => (


### PR DESCRIPTION
This removes the toolbar prop from the Page component, it was only needed for
the old nav.


