### PR TITLE
PageHeader: Set h1 style from wrapping element

### DIFF
--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -20,7 +20,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle }: Pr
   const styles = useStyles2(getStyles);
   const sub = subTitle ?? navItem.subTitle;
 
-  const titleElement = renderTitle ? renderTitle(navItem.text) : <h1 className={styles.pageTitle}>{navItem.text}</h1>;
+  const titleElement = renderTitle ? renderTitle(navItem.text) : <h1>{navItem.text}</h1>;
 
   return (
     <div className={styles.pageHeader}>
@@ -51,6 +51,10 @@ const getStyles = (theme: GrafanaTheme2) => {
     title: css({
       display: 'flex',
       flexDirection: 'row',
+      h1: {
+        display: 'flex',
+        marginBottom: 0,
+      },
     }),
     actions: css({
       display: 'flex',
@@ -72,10 +76,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       gap: theme.spacing(1),
       marginBottom: theme.spacing(2),
-    }),
-    pageTitle: css({
-      display: 'flex',
-      marginBottom: 0,
     }),
     subTitle: css({
       position: 'relative',


### PR DESCRIPTION
When we want to customize the page title in order to add images after title for example (or a pen icon to implement the edit name)
consumers of Page/PluginPage would need to duplicate the h1 styling (that removes bottom margin).

This moves the styling from the h1 element to the wrapping element


