### PR TITLE
Correlations: Add links to prometheus dataframe where labels are split out

### DIFF
--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -1,5 +1,7 @@
 import { DataFrame, DataLinkConfigOrigin } from '@grafana/data';
 
+import { formatValueName } from '../explore/PrometheusListView/ItemLabels';
+
 import { CorrelationData } from './useCorrelations';
 
 type DataFrameRefIdToDataSourceUid = Record<string, string>;
@@ -21,7 +23,14 @@ export const attachCorrelationsToDataFrames = (
     if (!frameRefId) {
       return;
     }
-    const dataSourceUid = dataFrameRefIdToDataSourceUid[frameRefId];
+    let dataSourceUid = dataFrameRefIdToDataSourceUid[frameRefId];
+
+    // rawPrometheus queries append a value to refId to a separate dataframe for the table view
+    if (dataSourceUid === undefined && dataFrame.meta?.preferredVisualisationType === 'rawPrometheus') {
+      const formattedRefID = formatValueName(frameRefId);
+      dataSourceUid = dataFrameRefIdToDataSourceUid[formattedRefID];
+    }
+
     const sourceCorrelations = correlations.filter((correlation) => correlation.source.uid === dataSourceUid);
     decorateDataFrameWithInternalDataLinks(dataFrame, sourceCorrelations);
   });

--- a/public/app/features/explore/PrometheusListView/ItemLabels.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemLabels.tsx
@@ -24,7 +24,7 @@ const getItemLabelsStyles = (theme: GrafanaTheme2, expanded: boolean) => {
   };
 };
 
-const formatValueName = (name: string): string => {
+export const formatValueName = (name: string): string => {
   if (name.includes(InstantQueryRefIdIndex)) {
     return name.replace(InstantQueryRefIdIndex, '');
   }


### PR DESCRIPTION
**What is this feature?**

When prometheus queries are ran in explore, individual fields are kept in the "labels" section of the data frame except for one dataframe that breaks out the labels for displaying a table. That dataframe gets `-Instant` appended onto the refId, which causes the datasource lookup to not work and returned undefined.

This adds logic where if the datasource comes back undefined, it checks on if its from a prometheus query and if so, removes the `-Instant` part of the refID to do the datasource lookup. Then the correlation is added to the dataframe as normal and the data link shows up in the prometheus table.

**Why do we need this feature?**

So the prometheus explore visualization can show data links.

**Who is this feature for?**

For enabling correlations with prometheus datasources as the source.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

You will need the 'correlations' feature flag enabled, and a prometheus datasource that is editable.

I would recommend using `job` as a variable.

![Screenshot 2023-05-03 at 9 23 33 AM](https://user-images.githubusercontent.com/1533128/235945190-db8b896a-2b7c-4e0d-906e-1098a250d264.png)
![Screenshot 2023-05-03 at 9 23 47 AM](https://user-images.githubusercontent.com/1533128/235945194-14f39aaa-d46e-4fd7-8e02-8cd0b3adcb13.png)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
