### PR TITLE
A11y: fix insufficient color contrast

### DIFF
--- a/.pa11yci-pr.conf.js
+++ b/.pa11yci-pr.conf.js
@@ -62,7 +62,7 @@ var config = {
       url: '${HOST}/login',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 13,
+      threshold: 12,
     },
     {
       url: '${HOST}/login',
@@ -74,7 +74,7 @@ var config = {
         "click element button[aria-label='Login button']",
         "wait for element [aria-label='Skip change password button'] to be visible",
       ],
-      threshold: 14,
+      threshold: 13,
       rootElement: '.main-view',
     },
     {
@@ -101,49 +101,49 @@ var config = {
       rootElement: '.main-view',
       // the unified alerting promotion alert's content contrast is too low
       // see https://github.com/grafana/grafana/pull/41829
-      threshold: 6,
+      threshold: 4,
     },
     {
       url: '${HOST}/datasources',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 3,
+      threshold: 0,
     },
     {
       url: '${HOST}/org/users',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 1,
+      threshold: 0,
     },
     {
       url: '${HOST}/org/teams',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 1,
+      threshold: 0,
     },
     {
       url: '${HOST}/plugins',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 3,
+      threshold: 0,
     },
     {
       url: '${HOST}/org',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 1,
+      threshold: 0,
     },
     {
       url: '${HOST}/org/apikeys',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 4,
+      threshold: 2,
     },
     {
       url: '${HOST}/dashboards',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 1,
+      threshold: 0,
     },
   ],
 };


### PR DESCRIPTION
**What is this feature?**

To check if the color contrast in `ConnectionsRedirectNotice` is still failing the pa11y checks.

**Why do we need this feature?**

To check if this issue with the color contrast is related to these external bugs: [pa11y reports false positives for color contrast](https://github.com/pa11y/pa11y/issues/633) & [pa11y reports an axe warning as an error](https://github.com/pa11y/pa11y/issues/623)

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
