### PR TITLE
Alerting: Fix export button variant

### DIFF
--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -118,6 +118,7 @@ const RuleList = withErrorBoundary(
               <Stack direction="row" gap={0.5}>
                 {canReadProvisioning && (
                   <LinkButton
+                    variant="secondary"
                     href={createUrl('/api/v1/provisioning/alert-rules/export', {
                       download: 'true',
                       format: 'yaml',


### PR DESCRIPTION
**What is this feature?**

According to the design system guidelines, we should avoid having two primary buttons in the same group.
This PR fixes `Export` button in alert list view to be `secondary` as we have the another button as a `primary` (Create alert rule button). 

**Special notes for your reviewer:**

After the change: 

<img width="453" alt="Screenshot 2023-05-03 at 16 37 30" src="https://user-images.githubusercontent.com/33540275/235951774-8f7a2011-9479-43c1-afe2-e1935b811737.png">
 


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
