### PR TITLE
Cloudwatch: Fix description of plugin

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/README.md
+++ b/public/app/plugins/datasource/cloudwatch/README.md
@@ -1,6 +1,6 @@
 # CloudWatch data source - native plugin
 
-Grafana ships with **built in** support for CloudWatch. Simply add it as a data source and are ready to build dashboards for your CloudWatch metrics.
+Grafana ships with **built in** support for CloudWatch. Simply add it as a data source and you are ready to build dashboards for your CloudWatch metrics and logs.
 
 Read more about it here:
 


### PR DESCRIPTION
**What is this feature?**

Some wording fixes on the Cloudwatch Datasource Description Page.

Before:
![Screenshot 2023-05-03 at 10 51 43 AM](https://user-images.githubusercontent.com/6620164/235953487-c2bb68f4-fb92-4502-85f8-1a214da96b31.png)

After:
![Screenshot 2023-05-03 at 10 53 01 AM](https://user-images.githubusercontent.com/6620164/235953914-60332f53-9c68-4b42-b5ca-53ba29279422.png)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
