### PR TITLE
RBAC: Do not search for parents of the root folder

### DIFF
--- a/pkg/services/dashboards/accesscontrol.go
+++ b/pkg/services/dashboards/accesscontrol.go
@@ -196,6 +196,9 @@ func resolveDashboardScope(ctx context.Context, folderDB folder.FolderStore, org
 }
 
 func GetInheritedScopes(ctx context.Context, orgID int64, folderUID string, folderSvc folder.Service) ([]string, error) {
+	if folderUID == ac.GeneralFolderUID {
+		return nil, nil
+	}
 	ancestors, err := folderSvc.GetParents(ctx, folder.GetParentsQuery{
 		UID:   folderUID,
 		OrgID: orgID,


### PR DESCRIPTION
**What is this feature?**

Do not query for parents of root aka General folder - this folder doesn't actually exist in the DB, so an error will be surfaced when searching for its parents.

**Why do we need this feature?**

To correctly list folder parents for General or root folder.

**Who is this feature for?**

Users who use nested folders.
