### PR TITLE
Alerting: Fix banner button variant

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -264,6 +264,7 @@ function TemplatingGuideline() {
             href="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/"
             target="_blank"
             icon="external-link-alt"
+            variant="secondary"
           >
             Templating documentation
           </LinkButton>


### PR DESCRIPTION
What is this feature?

According to the design system guidelines, we should not have primary buttons in banners, instead they should either be `secondary` or text links. 
This PR changes the `Template documentation` button in Contact Points to be a secondary variant.

After the change:

![image](https://user-images.githubusercontent.com/6271380/235961252-126f443d-e1a8-41a7-9c44-ee2f3f80b48b.png)
