### PR TITLE
PluginExtensions: Make context read only with a proxy instead of object freeze

### DIFF
--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -6,7 +6,7 @@ import {
 } from '@grafana/data';
 
 import type { PluginExtensionRegistry } from './types';
-import { isPluginExtensionLinkConfig, deepFreeze, logWarning, generateExtensionId, getEventHelpers } from './utils';
+import { isPluginExtensionLinkConfig, readOnlyProxy, logWarning, generateExtensionId, getEventHelpers } from './utils';
 import { assertIsNotPromise, assertLinkPathIsValid, assertStringProps, isPromise } from './validators';
 
 type GetExtensions = ({
@@ -21,7 +21,7 @@ type GetExtensions = ({
 
 // Returns with a list of plugin extensions for the given extension point
 export const getPluginExtensions: GetExtensions = ({ context, extensionPointId, registry }) => {
-  const frozenContext = context ? deepFreeze(context) : {};
+  const frozenContext = context ? readOnlyProxy(context) : {};
   const registryItems = registry[extensionPointId] ?? [];
   // We don't return the extensions separated by type, because in that case it would be much harder to define a sort-order for them.
   const extensions: PluginExtension[] = [];

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -6,7 +6,13 @@ import {
 } from '@grafana/data';
 
 import type { PluginExtensionRegistry } from './types';
-import { isPluginExtensionLinkConfig, readOnlyProxy, logWarning, generateExtensionId, getEventHelpers } from './utils';
+import {
+  isPluginExtensionLinkConfig,
+  getReadOnlyProxy,
+  logWarning,
+  generateExtensionId,
+  getEventHelpers,
+} from './utils';
 import { assertIsNotPromise, assertLinkPathIsValid, assertStringProps, isPromise } from './validators';
 
 type GetExtensions = ({
@@ -21,7 +27,7 @@ type GetExtensions = ({
 
 // Returns with a list of plugin extensions for the given extension point
 export const getPluginExtensions: GetExtensions = ({ context, extensionPointId, registry }) => {
-  const frozenContext = context ? readOnlyProxy(context) : {};
+  const frozenContext = context ? getReadOnlyProxy(context) : {};
   const registryItems = registry[extensionPointId] ?? [];
   // We don't return the extensions separated by type, because in that case it would be much harder to define a sort-order for them.
   const extensions: PluginExtension[] = [];

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -1,6 +1,6 @@
 import { PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
 
-import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, readOnlyProxy } from './utils';
+import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, getReadOnlyProxy } from './utils';
 
 describe('Plugin Extensions / Utils', () => {
   describe('deepFreeze()', () => {
@@ -220,9 +220,9 @@ describe('Plugin Extensions / Utils', () => {
     });
   });
 
-  describe('readOnlyProxy()', () => {
+  describe('getReadOnlyProxy()', () => {
     it('should not be possible to modify values in proxied object', () => {
-      const proxy = readOnlyProxy({ a: 'a' });
+      const proxy = getReadOnlyProxy({ a: 'a' });
 
       expect(() => {
         proxy.a = 'b';
@@ -230,7 +230,7 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should not be possible to modify values in proxied array', () => {
-      const proxy = readOnlyProxy([1, 2, 3]);
+      const proxy = getReadOnlyProxy([1, 2, 3]);
 
       expect(() => {
         proxy[0] = 2;
@@ -238,7 +238,7 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should not be possible to modify nested objects in proxied object', () => {
-      const proxy = readOnlyProxy({
+      const proxy = getReadOnlyProxy({
         a: {
           c: 'c',
         },
@@ -251,7 +251,7 @@ describe('Plugin Extensions / Utils', () => {
     });
 
     it('should not be possible to modify nested arrays in proxied object', () => {
-      const proxy = readOnlyProxy({
+      const proxy = getReadOnlyProxy({
         a: {
           c: ['c', 'd'],
         },
@@ -266,7 +266,7 @@ describe('Plugin Extensions / Utils', () => {
     it('should be possible to modify source object', () => {
       const source = { a: 'b' };
 
-      readOnlyProxy(source);
+      getReadOnlyProxy(source);
       source.a = 'c';
 
       expect(source.a).toBe('c');
@@ -275,7 +275,7 @@ describe('Plugin Extensions / Utils', () => {
     it('should be possible to modify source array', () => {
       const source = ['a', 'b'];
 
-      readOnlyProxy(source);
+      getReadOnlyProxy(source);
       source[0] = 'c';
 
       expect(source[0]).toBe('c');
@@ -284,7 +284,7 @@ describe('Plugin Extensions / Utils', () => {
     it('should be possible to modify nedsted objects in source object', () => {
       const source = { a: { b: 'c' } };
 
-      readOnlyProxy(source);
+      getReadOnlyProxy(source);
       source.a.b = 'd';
 
       expect(source.a.b).toBe('d');
@@ -293,14 +293,14 @@ describe('Plugin Extensions / Utils', () => {
     it('should be possible to modify nedsted arrays in source object', () => {
       const source = { a: { b: ['c', 'd'] } };
 
-      readOnlyProxy(source);
+      getReadOnlyProxy(source);
       source.a.b[0] = 'd';
 
       expect(source.a.b[0]).toBe('d');
     });
 
     it('should be possible to call functions in proxied object', () => {
-      const proxy = readOnlyProxy({
+      const proxy = getReadOnlyProxy({
         a: () => 'testing',
       });
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -1,6 +1,6 @@
 import { PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
 
-import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, readOnlyProxy } from './utils';
+import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, toReadOnlyProxy } from './utils';
 
 describe('Plugin Extensions / Utils', () => {
   describe('deepFreeze()', () => {
@@ -220,28 +220,14 @@ describe('Plugin Extensions / Utils', () => {
     });
   });
 
-  describe('readOnlyProxy()', () => {
-    test('testing', () => {
-      const value = {
-        a: 'a',
-        b: {
-          c: 'c',
-        },
-      };
-
-      const proxy = readOnlyProxy(value);
-      expect(proxy.a).toBe('a');
-      expect(proxy.b.c).toBe('c');
+  describe('toReadOnlyProxy()', () => {
+    it('should not be able to modify values on proxied object', () => {
+      const value = { a: 'a' };
+      const proxy = toReadOnlyProxy(value);
 
       expect(() => {
         proxy.a = 'b';
       }).toThrowError(TypeError);
-
-      expect(() => {
-        proxy.b.c = 'd';
-      }).toThrowError(TypeError);
-
-      expect(proxy.b).toBe(proxy.b);
     });
   });
 });

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -1,6 +1,6 @@
 import { PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
 
-import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn } from './utils';
+import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, readOnlyProxy } from './utils';
 
 describe('Plugin Extensions / Utils', () => {
   describe('deepFreeze()', () => {
@@ -217,6 +217,31 @@ describe('Plugin Extensions / Utils', () => {
         // Logs the errors
         expect(console.warn).toHaveBeenCalledWith('Error: TEST');
       }).not.toThrow();
+    });
+  });
+
+  describe('readOnlyProxy()', () => {
+    test('testing', () => {
+      const value = {
+        a: 'a',
+        b: {
+          c: 'c',
+        },
+      };
+
+      const proxy = readOnlyProxy(value);
+      expect(proxy.a).toBe('a');
+      expect(proxy.b.c).toBe('c');
+
+      expect(() => {
+        proxy.a = 'b';
+      }).toThrowError(TypeError);
+
+      expect(() => {
+        proxy.b.c = 'd';
+      }).toThrowError(TypeError);
+
+      expect(proxy.b).toBe(proxy.b);
     });
   });
 });

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -157,6 +157,6 @@ function isRecord(value: unknown): value is Record<string | number | symbol, unk
   return typeof value === 'object' && value !== null;
 }
 
-function isReadOnlyProxy(value: unknown): boolean {
+export function isReadOnlyProxy(value: unknown): boolean {
   return isRecord(value) && value[_isProxy] === true;
 }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -121,7 +121,7 @@ const _isProxy = Symbol('isReadOnlyProxy');
  * @param obj The object to make read only
  * @returns A new read only object, does not modify the original object
  */
-export function toReadOnlyProxy<T extends object>(obj: T): T {
+export function readOnlyProxy<T extends object>(obj: T): T {
   if (!obj || typeof obj !== 'object' || isReadOnlyProxy(obj)) {
     return obj;
   }
@@ -143,7 +143,7 @@ export function toReadOnlyProxy<T extends object>(obj: T): T {
 
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
-          cache.set(value, toReadOnlyProxy(value));
+          cache.set(value, readOnlyProxy(value));
         }
         return cache.get(value);
       }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -121,19 +121,18 @@ const _isProxy = Symbol('isReadOnlyProxy');
  * @param obj The object to make read only
  * @returns A new read only object, does not modify the original object
  */
-export function readOnlyProxy<T extends object>(obj: T): T {
+export function getReadOnlyProxy<T extends object>(obj: T): T {
   if (!obj || typeof obj !== 'object' || isReadOnlyProxy(obj)) {
     return obj;
   }
 
   const cache = new WeakMap();
-  const readonly = () => false;
 
   return new Proxy(obj, {
-    defineProperty: readonly,
-    deleteProperty: readonly,
-    isExtensible: readonly,
-    set: readonly,
+    defineProperty: () => false,
+    deleteProperty: () => false,
+    isExtensible: () => false,
+    set: () => false,
     get(target, prop, receiver) {
       if (prop === _isProxy) {
         return true;
@@ -143,7 +142,7 @@ export function readOnlyProxy<T extends object>(obj: T): T {
 
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
-          cache.set(value, readOnlyProxy(value));
+          cache.set(value, getReadOnlyProxy(value));
         }
         return cache.get(value);
       }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -153,6 +153,10 @@ export function toReadOnlyProxy<T extends object>(obj: T): T {
   });
 }
 
+function isRecord(value: unknown): value is Record<string | number | symbol, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function isReadOnlyProxy(value: unknown): boolean {
-  return value instanceof Proxy && value[_isProxy] === true;
+  return isRecord(value) && value[_isProxy] === true;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR will change the way we ensure that the context passed to plugins in the UI extensions can not be modified. Instead of making a copy and freezing the context we will wrap the context in a proxy that prevents it from being modified.

It will throw a TypeError if you try to modify the values passed in the context. This is a non-breaking change since the plugin developer will be able to use the context the same way as before.

**Why do we need this feature?**

In this #67509 we add the panel data to the context. The panel data can potentially contain a lot of data which makes it far from optimal to copy and freeze. Instead we keep the same underlying data but wrap it in a proxy that will make it impossible to modify the underlying data.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
