### PR TITLE
Prometheus: use metric select in query variable editor and add variables to dropdowns

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -10,7 +10,6 @@ import {
 } from '../migrations/variableMigration';
 import { MetricSelect } from '../querybuilder/components/MetricSelect';
 import { getMetrics } from '../querybuilder/components/PromQueryBuilder';
-import { PromVisualQuery } from '../querybuilder/types';
 import {
   PromOptions,
   PromQuery,

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -133,61 +133,67 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
   };
 
   return (
-    <InlineFieldRow>
-      <InlineField
-        label="Query Type"
-        labelWidth={20}
-        tooltip={
-          <div>The Prometheus data source plugin provides the following query types for template variables.</div>
-        }
-      >
-        <Select
-          placeholder="Select query type"
-          aria-label="Query type"
-          onChange={onQueryTypeChange}
-          onBlur={handleBlur}
-          value={qryType}
-          options={variableOptions}
-          width={25}
-        />
-      </InlineField>
+    <>
+      <InlineFieldRow>
+        <InlineField
+          label="Query Type"
+          labelWidth={20}
+          tooltip={
+            <div>The Prometheus data source plugin provides the following query types for template variables.</div>
+          }
+        >
+          <Select
+            placeholder="Select query type"
+            aria-label="Query type"
+            onChange={onQueryTypeChange}
+            onBlur={handleBlur}
+            value={qryType}
+            options={variableOptions}
+            width={25}
+          />
+        </InlineField>
+      </InlineFieldRow>
       {qryType === QueryType.LabelValues && (
         <>
-          <InlineField
-            label="Label"
-            labelWidth={20}
-            required
-            tooltip={
-              <div>
-                Returns a list of label values for the label name in all metrics unless the metric is specified.
-              </div>
-            }
-          >
-            <Select
-              aria-label="label-select"
-              onChange={onLabelChange}
-              onBlur={handleBlur}
-              value={label}
-              options={labelOptions}
-              width={25}
-              allowCustomValue
-            />
-          </InlineField>
-          <InlineField
-            label="Metric"
-            labelWidth={20}
-            tooltip={<div>Optional: returns a list of label values for the label name in the specified metric.</div>}
-          >
-            <Input
-              type="text"
-              aria-label="Metric selector"
-              placeholder="Optional metric selector"
-              value={metric}
-              onChange={onMetricChange}
-              onBlur={handleBlur}
-              width={25}
-            />
-          </InlineField>
+          <InlineFieldRow>
+            <InlineField
+              label="Label"
+              labelWidth={20}
+              required
+              tooltip={
+                <div>
+                  Returns a list of label values for the label name in all metrics unless the metric is specified.
+                </div>
+              }
+            >
+              <Select
+                aria-label="label-select"
+                onChange={onLabelChange}
+                onBlur={handleBlur}
+                value={label}
+                options={labelOptions}
+                width={25}
+                allowCustomValue
+              />
+            </InlineField>
+          </InlineFieldRow>
+          <InlineFieldRow>
+            <InlineField
+              label="Metric"
+              labelWidth={20}
+              tooltip={<div>Optional: returns a list of label values for the label name in the specified metric.</div>}
+            >
+              <Input
+                type="text"
+                aria-label="Metric selector"
+                placeholder="Optional metric selector"
+                value={metric}
+                onChange={onMetricChange}
+                onBlur={handleBlur}
+                width={100}
+              />
+            </InlineField>
+          </InlineFieldRow>
         </>
       )}
       {qryType === QueryType.MetricNames && (
@@ -259,7 +265,7 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
           </InlineField>
         </>
       )}
-    </InlineFieldRow>
+    </>
   );
 };
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -33,8 +33,6 @@ export interface Props {
 
 export const PROMETHEUS_QUERY_BUILDER_MAX_RESULTS = 1000;
 
-let prometheusMetricEncyclopedia = config.featureToggles.prometheusMetricEncyclopedia;
-
 export function MetricSelect({
   datasource,
   query,
@@ -52,6 +50,8 @@ export function MetricSelect({
     metricsModalOpen?: boolean;
     initialMetrics?: string[];
   }>({});
+
+  const prometheusMetricEncyclopedia = config.featureToggles.prometheusMetricEncyclopedia;
 
   const metricsModalOption: SelectableValue[] = [
     {
@@ -85,7 +85,7 @@ export function MetricSelect({
         return acc && (matcheSearch || browseOption);
       }, true);
     },
-    [variableEditor]
+    [prometheusMetricEncyclopedia, variableEditor]
   );
 
   const formatOptionLabel = useCallback(

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -28,6 +28,7 @@ export interface Props {
   datasource: PrometheusDatasource;
   labelsFilters: QueryBuilderLabelFilter[];
   variableEditor?: boolean;
+  onBlur?: () => void;
 }
 
 export const PROMETHEUS_QUERY_BUILDER_MAX_RESULTS = 1000;
@@ -42,6 +43,7 @@ export function MetricSelect({
   labelsFilters,
   metricLookupDisabled,
   variableEditor,
+  onBlur,
 }: Props) {
   const styles = useStyles2(getStyles);
   const [state, setState] = useState<{
@@ -235,6 +237,7 @@ export function MetricSelect({
         loadOptions={metricLookupDisabled ? metricLookupDisabledSearch : debouncedSearch}
         isLoading={state.isLoading}
         defaultOptions={state.metrics}
+        onBlur={onBlur ? onBlur : () => {}}
         onChange={({ value }) => {
           if (value) {
             // if there is no metric and the m.e. is enabled, open the modal

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -294,7 +294,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
  * @param datasource
  * @param query
  */
-async function getMetrics(
+export async function getMetrics(
   datasource: PrometheusDatasource,
   query: PromVisualQuery
 ): Promise<Array<{ value: string; description?: string }>> {

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 import { PromApplication } from '../../../types/unified-alerting-dto';
 
 import { Prometheus as GenPromQuery } from './dataquery.gen';
-import { QueryEditorMode } from './querybuilder/shared/types';
+import { QueryBuilderLabelFilter, QueryBuilderOperation, QueryEditorMode } from './querybuilder/shared/types';
 
 export interface PromQuery extends GenPromQuery, DataQuery {
   /**
@@ -191,6 +191,8 @@ export interface PromVariableQuery extends DataQuery {
   metric?: string;
   varQuery?: string;
   seriesQuery?: string;
+  labels?: QueryBuilderLabelFilter[];
+  operations?: QueryBuilderOperation[];
 }
 
 export type StandardPromVariableQuery = {


### PR DESCRIPTION
Closed in favor of https://github.com/grafana/grafana/pull/69884 which implements metric select with label filters

**What is this feature?**
Use the metric select in the Prom query variable editor and add variables to the options in the select drop downs (labels and metric for the label_values query type).

![Screenshot 2023-06-08 at 3 42 52 PM](https://github.com/grafana/grafana/assets/25674746/85a63e52-3b82-4ded-b5e1-4b935d706d4b)

![Screenshot 2023-06-08 at 3 43 00 PM](https://github.com/grafana/grafana/assets/25674746/369d960f-5ab2-4313-b2ac-d36d25db9144)


**Why do we need this feature?**
The previous metric input for the label_values query type was a text input that was too small. There was also a recent PR to allow for the label_values label input to accept variables. These changes add functionality to the query variable editor and allow the customer greater flexibility in creating a variable.

**Who is this feature for?**
Anyone using the prom query variable editor.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
