### PR TITLE
NestedFolders: Fetch access control metadata for folder view

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -36,7 +36,7 @@ export const browseDashboardsAPI = createApi({
   baseQuery: createBackendSrvBaseQuery({ baseURL: '/api' }),
   endpoints: (builder) => ({
     getFolder: builder.query<FolderDTO, string>({
-      query: (folderUID) => ({ url: `/folders/${folderUID}` }),
+      query: (folderUID) => ({ url: `/folders/${folderUID}`, params: { accesscontrol: true } }),
     }),
     getAffectedItems: builder.query<DescendantCount, DashboardTreeSelection>({
       queryFn: async (selectedItems) => {


### PR DESCRIPTION
Fixes an issue in new Browse Dashboards where checkboes aren't show when you click through into Folder View.

We weren't requesting the access control metadata required to determine if user has permission to select items (to move or delete), so the permissions defaulted to deny.

Fixes https://github.com/grafana/grafana/issues/67741