### PR TITLE
Alerting: Use standard validation/error pattern on group selection

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -169,6 +169,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 inputId="group"
                 key={`my_unique_select_key__${selectedGroup?.title ?? ''}`}
                 {...field}
+                invalid={Boolean(folder) && !selectedGroup.value}
                 loadOptions={debouncedSearch}
                 loadingMessage={'Loading groups...'}
                 defaultOptions={groupOptions}


### PR DESCRIPTION
**What is this feature?**

When there's a validation error, the border of the input and select elements should be red as per the design system standards.

**Why do we need this feature?**

In some cases, like when choosing an Evaluation Group, the border was not shown.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

The Folder selection element should also display a red border but it doesn't provide the `invalid` option in order to set it.

![image](https://user-images.githubusercontent.com/6271380/236045707-93eb0dd3-b7a3-4734-a70b-2ff0743e2917.png)
