### PR TITLE
docs: Canvas: Update docs for v10

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -54,7 +54,7 @@ When building a canvas panel, you can connect elements together to create more c
 
 {{< video-embed src="/media/docs/grafana/canvas-connections-9-4-0.mp4" max-width="750px" caption="Canvas connections demo" >}}
 
-Connections support setting both their size and color based on fixed or field values. To do so, enter into panel edit mode, select the connection, and modify the connection's properties in the panel editor.
+You can set both the size and color of connections based on fixed or field values. To do so, enter into panel edit mode, select the connection, and modify the connection's properties in the panel editor.
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-0-canvas-service-graph.png" max-width="750px" caption="Canvas service graph" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -54,6 +54,10 @@ When building a canvas panel, you can connect elements together to create more c
 
 {{< video-embed src="/media/docs/grafana/canvas-connections-9-4-0.mp4" max-width="750px" caption="Canvas connections demo" >}}
 
+Connections support setting both their size and color based on fixed or field values. To do so, enter into panel edit mode, select the connection, and modify the connection's properties in the panel editor.
+
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-canvas-service-graph.png" max-width="750px" caption="Canvas service graph" >}}
+
 ## Canvas editing
 
 ### Inline editor


### PR DESCRIPTION
Update canvas docs for v10 to include newly added [connection properties](https://github.com/grafana/grafana/pull/64360).

Included image:
<img width="924" alt="screenshot-grafana-10-0-canvas-service-graph" src="https://user-images.githubusercontent.com/22381771/236067670-24953d83-d6e5-41af-9f30-69aff7b17b06.png">

Fixes #67611
