### PR TITLE
docs: Geomap: Update docs to include link to official github discussion

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -35,6 +35,8 @@ weight: 600
 
 The Geomap panel visualization allows you to view and customize the world map using geospatial data. You can configure various overlay styles and map view settings to easily focus on the important location-based characteristics of the data.
 
+> We would love your feedback on Geomap. Please check out the [Github discussion](https://github.com/grafana/grafana/discussions/62159) and join the conversation.
+
 {{< figure src="/static/img/docs/geomap-panel/geomap-example-8-1-0.png" max-width="1200px" caption="Geomap panel" >}}
 
 ## Map View


### PR DESCRIPTION
Update Geomap docs to include call to action to share feedback in the [officially supported github discussion](https://github.com/grafana/grafana/discussions/62159)

Similar to what we are currently doing with canvas which has been successful so far
<img width="781" alt="Screenshot 2023-05-03 at 5 05 58 PM" src="https://user-images.githubusercontent.com/22381771/236076656-c37b810f-81dc-40e9-874b-e8bd818da5c0.png">
