### PR TITLE
Alerting: Fix action buttons label and placement in several views following standard and being consistent with the rest of the ui

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -125,7 +125,7 @@ const ui = {
     intervalInput: byRole('textbox', {
       name: /Rule group evaluation interval Evaluation interval should be smaller or equal to 'For' values for existing rules in this group./i,
     }),
-    saveButton: byRole('button', { name: /Save changes/ }),
+    saveButton: byRole('button', { name: /Save evaluation interval/ }),
   },
 };
 

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -68,7 +68,7 @@ const ui = {
     matcherOperatorSelect: byLabelText('operator'),
     matcherOperator: (operator: MatcherOperator) => byText(operator, { exact: true }),
     addMatcherButton: byRole('button', { name: 'Add matcher' }),
-    submit: byText('Submit'),
+    submit: byText(/save silence/i),
     createdBy: byText(/created by \*/i),
   },
 };

--- a/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
+++ b/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, ConfirmModal, TextArea, HorizontalGroup, Field, Form } from '@grafana/ui';
+import { Button, ConfirmModal, Field, Form, HorizontalGroup, TextArea } from '@grafana/ui';
 
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 
@@ -60,7 +60,7 @@ export const ConfigEditor = ({
 
               <HorizontalGroup>
                 <Button type="submit" variant="primary" disabled={loading}>
-                  Save
+                  Save configuration
                 </Button>
                 {onReset && (
                   <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { Alert, Field, FieldSet, Input, Button, LinkButton, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, FieldSet, Input, LinkButton, useStyles2 } from '@grafana/ui';
 import {
   AlertmanagerConfig,
   AlertManagerCortexConfig,
@@ -152,6 +152,9 @@ const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
                 />
               </Field>
               <MuteTimingTimeInterval />
+              <Button type="submit" className={styles.submitButton}>
+                Save timing
+              </Button>
               <LinkButton
                 type="button"
                 variant="secondary"
@@ -159,9 +162,6 @@ const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
               >
                 Cancel
               </LinkButton>
-              <Button type="submit" className={styles.submitButton}>
-                {muteTiming ? 'Save' : 'Submit'}
-              </Button>
             </FieldSet>
           </form>
         </FormProvider>
@@ -175,7 +175,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: 400px;
   `,
   submitButton: css`
-    margin-left: ${theme.spacing(1)};
+    margin-right: ${theme.spacing(1)};
   `,
 });
 

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -153,7 +153,7 @@ const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
               </Field>
               <MuteTimingTimeInterval />
               <Button type="submit" className={styles.submitButton}>
-                Save timing
+                Save mute timing
               </Button>
               <LinkButton
                 type="button"

--- a/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
@@ -62,7 +62,7 @@ const useAddPolicyModal = (
             onSubmit={(newRoute) => parentRoute && handleAdd(newRoute, parentRoute)}
             actionButtons={
               <Modal.ButtonRow>
-                <Button type="submit">Add policy</Button>
+                <Button type="submit">Save policy</Button>
                 <Button type="button" variant="secondary" onClick={handleDismiss}>
                   Cancel
                 </Button>

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -212,7 +212,6 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
                         href={makeAMLink('alerting/notifications', alertManagerSourceName)}
                         variant="secondary"
                         type="button"
-                        fill="outline"
                       >
                         Cancel
                       </LinkButton>

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
-import { useForm, FormProvider, FieldErrors, Validate } from 'react-hook-form';
+import { FieldErrors, FormProvider, useForm, Validate } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Field, Input, LinkButton, useStyles2 } from '@grafana/ui';
@@ -175,7 +175,6 @@ export function ReceiverForm<R extends ChannelValues>({
             )}
             <LinkButton
               disabled={loading}
-              fill="outline"
               variant="secondary"
               data-testid="cancel-button"
               href={makeAMLink('alerting/notifications', alertManagerSourceName)}

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -4,8 +4,8 @@ import { DeepMap, FieldError, FormProvider, useForm, useFormContext, UseFormWatc
 import { Link } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { logInfo, config } from '@grafana/runtime';
-import { Button, ConfirmModal, CustomScrollbar, Spinner, useStyles2, HorizontalGroup, Field, Input } from '@grafana/ui';
+import { config, logInfo } from '@grafana/runtime';
+import { Button, ConfirmModal, CustomScrollbar, Field, HorizontalGroup, Input, Spinner, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
 import { useCleanup } from 'app/core/hooks/useCleanup';
@@ -198,6 +198,24 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
     <FormProvider {...formAPI}>
       <form onSubmit={(e) => e.preventDefault()} className={styles.form}>
         <HorizontalGroup height="auto" justify="flex-end">
+          <Button
+            variant="primary"
+            type="button"
+            onClick={handleSubmit((values) => submit(values, false), onInvalid)}
+            disabled={submitState.loading}
+          >
+            {submitState.loading && <Spinner className={styles.buttonSpinner} inline={true} />}
+            Save rule
+          </Button>
+          <Button
+            variant="primary"
+            type="button"
+            onClick={handleSubmit((values) => submit(values, true), onInvalid)}
+            disabled={submitState.loading}
+          >
+            {submitState.loading && <Spinner className={styles.buttonSpinner} inline={true} />}
+            Save rule and exit
+          </Button>
           <Link to={returnTo}>
             <Button
               variant="secondary"
@@ -224,24 +242,6 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
               Edit YAML
             </Button>
           )}
-          <Button
-            variant="primary"
-            type="button"
-            onClick={handleSubmit((values) => submit(values, false), onInvalid)}
-            disabled={submitState.loading}
-          >
-            {submitState.loading && <Spinner className={styles.buttonSpinner} inline={true} />}
-            Save
-          </Button>
-          <Button
-            variant="primary"
-            type="button"
-            onClick={handleSubmit((values) => submit(values, true), onInvalid)}
-            disabled={submitState.loading}
-          >
-            {submitState.loading && <Spinner className={styles.buttonSpinner} inline={true} />}
-            Save and exit
-          </Button>
         </HorizontalGroup>
         <div className={styles.contentOuter}>
           <CustomScrollbar autoHeightMin="100%" hideHorizontalTrack={true}>

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -217,13 +217,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
             Save rule and exit
           </Button>
           <Link to={returnTo}>
-            <Button
-              variant="secondary"
-              disabled={submitState.loading}
-              type="button"
-              fill="outline"
-              onClick={cancelRuleCreation}
-            >
+            <Button variant="secondary" disabled={submitState.loading} type="button" onClick={cancelRuleCreation}>
               Cancel
             </Button>
           </Link>

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -6,15 +6,15 @@ import { FixedSizeList } from 'react-window';
 
 import { GrafanaTheme2 } from '@grafana/data/src';
 import {
-  FilterInput,
-  LoadingPlaceholder,
-  useStyles2,
-  Icon,
-  Modal,
-  Button,
   Alert,
+  Button,
   clearButtonStyles,
+  FilterInput,
+  Icon,
+  LoadingPlaceholder,
+  Modal,
   Tooltip,
+  useStyles2,
 } from '@grafana/ui';
 
 import { dashboardApi } from '../../api/dashboardApi';
@@ -230,9 +230,6 @@ export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDis
         </div>
       </div>
       <Modal.ButtonRow>
-        <Button type="button" variant="secondary" onClick={onDismiss}>
-          Cancel
-        </Button>
         <Button
           type="button"
           variant="primary"
@@ -244,6 +241,9 @@ export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDis
           }}
         >
           Confirm
+        </Button>
+        <Button type="button" variant="secondary" onClick={onDismiss}>
+          Cancel
         </Button>
       </Modal.ButtonRow>
     </Modal>

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -375,20 +375,14 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
             <div className={styles.modalButtons}>
               <Modal.ButtonRow>
                 <Button
-                  variant="secondary"
-                  type="button"
-                  disabled={loading}
-                  onClick={() => onClose(false)}
-                  fill="outline"
-                >
-                  Close
-                </Button>
-                <Button
                   type="button"
                   disabled={!isDirty || loading}
                   onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
                 >
-                  {loading ? 'Saving...' : 'Save changes'}
+                  {loading ? 'Saving...' : 'Save evaluation interval'}
+                </Button>
+                <Button variant="secondary" type="button" disabled={loading} onClick={() => onClose(false)}>
+                  Cancel
                 </Button>
               </Modal.ButtonRow>
             </div>

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
@@ -166,11 +166,11 @@ describe('Rules group tests', () => {
 
       await userEvent.click(ui.editGroupButton.get());
 
-      expect(screen.getByText('Close')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
 
-      await userEvent.click(screen.getByText('Close'));
+      await userEvent.click(screen.getByText('Cancel'));
 
-      expect(screen.queryByText('Close')).not.toBeInTheDocument();
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
       expect(logInfo).toHaveBeenCalledWith(LogMessages.leavingRuleGroupEdit);
     });
   });

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -1,17 +1,17 @@
 import { css, cx } from '@emotion/css';
 import { isEqual, pickBy } from 'lodash';
 import React, { useMemo, useState } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useDebounce } from 'react-use';
 
 import {
-  DefaultTimeZone,
-  parseDuration,
-  intervalToAbbreviatedDurationString,
   addDurationToDate,
   dateTime,
-  isValidDate,
+  DefaultTimeZone,
   GrafanaTheme2,
+  intervalToAbbreviatedDurationString,
+  isValidDate,
+  parseDuration,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Button, Field, FieldSet, Input, LinkButton, TextArea, useStyles2 } from '@grafana/ui';
@@ -23,7 +23,7 @@ import { useURLSearchParams } from '../../hooks/useURLSearchParams';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { createOrUpdateSilenceAction } from '../../state/actions';
 import { SilenceFormFields } from '../../types/silence-form';
-import { matcherToMatcherField, matcherFieldToMatcher } from '../../utils/alertmanager';
+import { matcherFieldToMatcher, matcherToMatcherField } from '../../utils/alertmanager';
 import { parseQueryParamMatchers } from '../../utils/matchers';
 import { makeAMLink } from '../../utils/misc';
 import { initialAsyncRequestState } from '../../utils/redux';
@@ -246,7 +246,7 @@ export const SilencesEditor = ({ silence, alertManagerSourceName }: Props) => {
               Saving...
             </Button>
           )}
-          {!loading && <Button type="submit">Submit</Button>}
+          {!loading && <Button type="submit">Save silence</Button>}
           <LinkButton
             href={makeAMLink('alerting/silences', alertManagerSourceName)}
             variant={'secondary'}

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -247,11 +247,7 @@ export const SilencesEditor = ({ silence, alertManagerSourceName }: Props) => {
             </Button>
           )}
           {!loading && <Button type="submit">Save silence</Button>}
-          <LinkButton
-            href={makeAMLink('alerting/silences', alertManagerSourceName)}
-            variant={'secondary'}
-            fill="outline"
-          >
+          <LinkButton href={makeAMLink('alerting/silences', alertManagerSourceName)} variant={'secondary'}>
             Cancel
           </LinkButton>
         </div>

--- a/public/test/helpers/alertingRuleEditor.tsx
+++ b/public/test/helpers/alertingRuleEditor.tsx
@@ -25,7 +25,7 @@ export const ui = {
     expr: byTestId('expr'),
   },
   buttons: {
-    save: byRole('button', { name: 'Save' }),
+    save: byRole('button', { name: 'Save rule' }),
     addAnnotation: byRole('button', { name: /Add info/ }),
     addLabel: byRole('button', { name: /Add label/ }),
     // alert type buttons


### PR DESCRIPTION
**What is this feature?**

This PR updates action buttons labels and placement in several views following standard and being consistent with the rest of the ui.
Standard:

- order: Save {noun}" (`primary`) , "Cancel" (`secondary`) at the bottom of the workflow
- buttons for resets or removing : `destructive` variant at the right side of the buttons group
- secondary buttons without outline


[Figma document](https://www.figma.com/file/1f91vXfh82kvrphRHloYPp/UIAudit_Designs?type=design&node-id=1-2844&t=Cixs0le7RiEGvT6m-0)

**Why do we need this feature?**

UI has to be consistent.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

All users.

**Special notes for your reviewer:**

in alert rule form:

<img width="1073" alt="Screenshot 2023-05-04 at 16 28 31" src="https://user-images.githubusercontent.com/33540275/236238479-e0cabb0e-1a3b-49b1-b6b0-d157ec76958e.png">
edit evaluation group modal:

<img width="426" alt="Screenshot 2023-05-04 at 15 50 57" src="https://user-images.githubusercontent.com/33540275/236239973-17c87243-f382-4d9c-8165-ff2149be47d7.png">

in templates form:

<img width="325" alt="Screenshot 2023-05-04 at 15 55 49" src="https://user-images.githubusercontent.com/33540275/236238776-f887ac7a-ab0c-4923-9864-24c4165f80d8.png">

in contact points form:

<img width="529" alt="Screenshot 2023-05-04 at 15 55 11" src="https://user-images.githubusercontent.com/33540275/236238934-425b0b4c-6da1-44fc-b1d4-6c1210b504e3.png">

selecting dashboard and panel:

<img width="665" alt="Screenshot 2023-05-04 at 15 54 01" src="https://user-images.githubusercontent.com/33540275/236239077-a5259a96-e147-4d31-861a-0ecd96a35dd6.png">

in silences form:
<img width="471" alt="Screenshot 2023-05-04 at 16 32 32" src="https://user-images.githubusercontent.com/33540275/236239532-bd4b24b4-8d7d-406e-8847-0720e10b7f11.png">


in mute timings:

<img width="351" alt="Screenshot 2023-05-04 at 09 45 20" src="https://user-images.githubusercontent.com/33540275/236143534-d0d8f9ee-5381-4e83-9558-354d74b62517.png">




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
