### PR TITLE
Drawer: Introduce a size property that set's width percentage and minWidth 

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.mdx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.mdx
@@ -21,10 +21,20 @@ onClose = () => {
 };
 
 return (
-  <Drawer title="This a Drawer" width="60%" onClose={this.onClose}>
+  <Drawer title="This a Drawer" size="md" onClose={this.onClose}>
     <div>Put your Drawer content here</div>
   </Drawer>
 );
 ```
+
+## Sizes
+
+The Drawer supports 3 sizes: `sm`, `md`, and `lg`. This option defines a width in percentage and as well as a min-width.
+
+- sm: width = 25vh and min-width = 384px
+- md: width = 50vh and min-width = 568px
+- lg: width = 75vh and min-width = 744px
+
+## Props
 
 <Props of={Drawer} />

--- a/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
@@ -22,7 +22,6 @@ const meta: ComponentMeta<typeof Drawer> = {
   args: {
     closeOnMaskClick: true,
     scrollableContent: false,
-    width: '40%',
     expandable: false,
     subtitle: 'This is a subtitle.',
   },
@@ -176,6 +175,7 @@ export const InLine: ComponentStory<typeof Drawer> = (args) => {
 InLine.args = {
   title: 'Drawer title inline',
   inline: true,
+  size: 'sm',
 };
 
 export const WithTabs: ComponentStory<typeof Drawer> = (args) => {
@@ -206,6 +206,7 @@ export const WithTabs: ComponentStory<typeof Drawer> = (args) => {
     </>
   );
 };
+
 WithTabs.args = {
   title: 'Drawer title with tabs',
 };

--- a/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
@@ -141,43 +141,6 @@ LongContent.args = {
   title: 'Drawer title with long content',
 };
 
-export const InLine: ComponentStory<typeof Drawer> = (args) => {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <>
-      <div
-        style={{
-          height: '300px',
-          width: '500px',
-          border: '1px solid white',
-          position: 'relative',
-          overflow: 'hidden',
-        }}
-      >
-        <Button onClick={() => setIsOpen(true)}>Open drawer</Button>
-        {isOpen && (
-          <Drawer {...args} onClose={() => setIsOpen(false)}>
-            <ul>
-              <li>this</li>
-              <li>is</li>
-              <li>a</li>
-              <li>list</li>
-              <li>of</li>
-              <li>menu</li>
-              <li>items</li>
-            </ul>
-          </Drawer>
-        )}
-      </div>
-    </>
-  );
-};
-InLine.args = {
-  title: 'Drawer title inline',
-  inline: true,
-  size: 'sm',
-};
-
 export const WithTabs: ComponentStory<typeof Drawer> = (args) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('options');

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -20,7 +20,7 @@ export interface Props {
   subtitle?: ReactNode;
   /** Should the Drawer be closable by clicking on the mask, defaults to true */
   closeOnMaskClick?: boolean;
-  /** Render the drawer inside a container on the page */
+  /** @deprecated */
   inline?: boolean;
   /**
    * @deprecated use the size property instead
@@ -28,7 +28,12 @@ export interface Props {
   width?: number | string;
   /** Should the Drawer be expandable to full width */
   expandable?: boolean;
-  /** Specifies the width and min-width */
+  /**
+   * Specifies the width and min-width.
+   * sm = width 25vw & min-width 384px
+   * md = width 50vw & min-width 568px
+   * lg = width 75vw & min-width 744px
+   **/
   size?: 'sm' | 'md' | 'lg';
   /** Tabs */
   tabs?: React.ReactNode;
@@ -81,7 +86,7 @@ export function Drawer({
       onClose={onClose}
       placement="right"
       width={fixedWidth}
-      getContainer={inline ? false : '.main-view'}
+      getContainer={'.main-view'}
       className={styles.drawerContent}
       rootClassName={rootClass}
       motion={{
@@ -188,7 +193,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         '.rc-drawer-content-wrapper': {
           label: 'drawer-lg',
           width: '75vw',
-          minWidth: theme.spacing(83),
+          minWidth: theme.spacing(93),
 
           [theme.breakpoints.down('md')]: {
             width: `calc(100% - ${theme.spacing(2)}) !important`,

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -70,10 +70,9 @@ export function Drawer({
     setIsOpen(true);
   }, []);
 
-  // deprecated width width prop now defaults to empty string which make the size prop take over
+  // deprecated width prop now defaults to empty string which make the size prop take over
   const fixedWidth = isExpanded ? '100%' : width ?? '';
-  const useSizeWidth = !fixedWidth && !isExpanded;
-  const rootClass = cx(styles.drawer, useSizeWidth && styles.sizes[size]);
+  const rootClass = cx(styles.drawer, !fixedWidth && styles.sizes[size]);
   const content = <div className={styles.content}>{children}</div>;
 
   return (

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -195,7 +195,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       lg: css({
         '.rc-drawer-content-wrapper': {
           label: 'drawer-lg',
-          width: '70vw',
+          width: '75vw',
           minWidth: theme.spacing(83),
 
           [theme.breakpoints.down('md')]: {

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -172,7 +172,8 @@ const getStyles = (theme: GrafanaTheme2) => {
         box-shadow: ${theme.shadows.z3};
 
         ${theme.breakpoints.down('sm')} {
-          width: 100% !important;
+          width: calc(100% - ${theme.spacing(2)}) !important;
+          min-width: 0 !important;
         }
       }
     `,
@@ -188,7 +189,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         '.rc-drawer-content-wrapper': {
           label: 'drawer-md',
           width: '50vw',
-          minWidth: theme.spacing(53),
+          minWidth: theme.spacing(60),
         },
       }),
       lg: css({
@@ -196,6 +197,11 @@ const getStyles = (theme: GrafanaTheme2) => {
           label: 'drawer-lg',
           width: '70vw',
           minWidth: theme.spacing(83),
+
+          [theme.breakpoints.down('md')]: {
+            width: `calc(100% - ${theme.spacing(2)}) !important`,
+            minWidth: 0,
+          },
         },
       }),
     },

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
@@ -22,10 +22,14 @@ export interface Props {
   closeOnMaskClick?: boolean;
   /** Render the drawer inside a container on the page */
   inline?: boolean;
-  /** Either a number in px or a string with unit postfix */
+  /**
+   * @deprecated use the size property instead
+   **/
   width?: number | string;
   /** Should the Drawer be expandable to full width */
   expandable?: boolean;
+  /** Specifies the width and min-width */
+  size?: 'sm' | 'md' | 'lg';
   /** Tabs */
   tabs?: React.ReactNode;
   /** Set to true if the component rendered within in drawer content has its own scroll */
@@ -42,14 +46,14 @@ export function Drawer({
   scrollableContent = false,
   title,
   subtitle,
-  width = '40%',
+  width,
+  size = 'md',
   expandable = false,
   tabs,
 }: Props) {
-  const drawerStyles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const currentWidth = isExpanded ? '100%' : width;
   const overlayRef = React.useRef(null);
   const { dialogProps, titleProps } = useDialog({}, overlayRef);
   const { overlayProps } = useOverlay(
@@ -66,7 +70,13 @@ export function Drawer({
     setIsOpen(true);
   }, []);
 
-  const content = <div className={drawerStyles.content}>{children}</div>;
+  // deprecated width width prop now defaults to empty string which make the size prop take over
+  const fixedWidth = isExpanded ? '100%' : width ?? '';
+  const useSizeWidth = !fixedWidth && !isExpanded;
+  const rootClass = cx(styles.drawer, useSizeWidth && styles.sizes[size]);
+
+  const content = <div className={styles.content}>{children}</div>;
+
   const style: CSSProperties = {};
   if (inline) {
     style.position = 'absolute';
@@ -77,20 +87,20 @@ export function Drawer({
       open={isOpen}
       onClose={onClose}
       placement="right"
-      width={currentWidth}
+      width={fixedWidth}
       getContainer={inline ? undefined : 'body'}
       style={style}
-      className={drawerStyles.drawerContent}
-      rootClassName={drawerStyles.drawer}
+      className={styles.drawerContent}
+      rootClassName={rootClass}
       motion={{
         motionAppear: true,
-        motionName: drawerStyles.drawerMotion,
+        motionName: styles.drawerMotion,
       }}
-      maskClassName={drawerStyles.mask}
+      maskClassName={styles.mask}
       maskClosable={closeOnMaskClick}
       maskMotion={{
         motionAppear: true,
-        motionName: drawerStyles.maskMotion,
+        motionName: styles.maskMotion,
       }}
     >
       <FocusScope restoreFocus contain autoFocus>
@@ -100,14 +110,14 @@ export function Drawer({
               ? selectors.components.Drawer.General.title(title)
               : selectors.components.Drawer.General.title('no title')
           }
-          className={drawerStyles.container}
+          className={styles.container}
           {...overlayProps}
           {...dialogProps}
           ref={overlayRef}
         >
           {typeof title === 'string' && (
-            <div className={drawerStyles.header}>
-              <div className={drawerStyles.actions}>
+            <div className={styles.header}>
+              <div className={styles.actions}>
                 {expandable && !isExpanded && (
                   <IconButton
                     name="angle-left"
@@ -131,16 +141,16 @@ export function Drawer({
                   aria-label={selectors.components.Drawer.General.close}
                 />
               </div>
-              <div className={drawerStyles.titleWrapper}>
+              <div className={styles.titleWrapper}>
                 <h3 {...titleProps}>{title}</h3>
                 {typeof subtitle === 'string' && <div className="muted">{subtitle}</div>}
                 {typeof subtitle !== 'string' && subtitle}
-                {tabs && <div className={drawerStyles.tabsWrapper}>{tabs}</div>}
+                {tabs && <div className={styles.tabsWrapper}>{tabs}</div>}
               </div>
             </div>
           )}
           {typeof title !== 'string' && title}
-          <div className={drawerStyles.contentScroll}>
+          <div className={styles.contentScroll}>
             {!scrollableContent ? content : <CustomScrollbar autoHeightMin="100%">{content}</CustomScrollbar>}
           </div>
         </div>
@@ -166,6 +176,29 @@ const getStyles = (theme: GrafanaTheme2) => {
         }
       }
     `,
+    sizes: {
+      sm: css({
+        '.rc-drawer-content-wrapper': {
+          label: 'drawer-sm',
+          width: '25vw',
+          minWidth: theme.spacing(48),
+        },
+      }),
+      md: css({
+        '.rc-drawer-content-wrapper': {
+          label: 'drawer-md',
+          width: '50vw',
+          minWidth: theme.spacing(53),
+        },
+      }),
+      lg: css({
+        '.rc-drawer-content-wrapper': {
+          label: 'drawer-lg',
+          width: '70vw',
+          minWidth: theme.spacing(83),
+        },
+      }),
+    },
     drawerContent: css`
       background-color: ${theme.colors.background.primary} !important;
       display: flex;

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -45,7 +45,6 @@ export interface Props {
 
 export function Drawer({
   children,
-  inline = false,
   onClose,
   closeOnMaskClick = true,
   scrollableContent = false,

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -3,7 +3,7 @@ import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import RcDrawer from 'rc-drawer';
-import React, { CSSProperties, ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -74,13 +74,7 @@ export function Drawer({
   const fixedWidth = isExpanded ? '100%' : width ?? '';
   const useSizeWidth = !fixedWidth && !isExpanded;
   const rootClass = cx(styles.drawer, useSizeWidth && styles.sizes[size]);
-
   const content = <div className={styles.content}>{children}</div>;
-
-  const style: CSSProperties = {};
-  if (inline) {
-    style.position = 'absolute';
-  }
 
   return (
     <RcDrawer
@@ -88,8 +82,7 @@ export function Drawer({
       onClose={onClose}
       placement="right"
       width={fixedWidth}
-      getContainer={inline ? undefined : 'body'}
-      style={style}
+      getContainer={inline ? false : '.main-view'}
       className={styles.drawerContent}
       rootClassName={rootClass}
       motion={{
@@ -189,7 +182,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         '.rc-drawer-content-wrapper': {
           label: 'drawer-md',
           width: '50vw',
-          minWidth: theme.spacing(60),
+          minWidth: theme.spacing(66),
         },
       }),
       lg: css({

--- a/public/app/core/components/AppChrome/News/NewsContainer.tsx
+++ b/public/app/core/components/AppChrome/News/NewsContainer.tsx
@@ -22,7 +22,12 @@ export function NewsContainer({ className }: NewsContainerProps) {
     <>
       <ToolbarButton className={className} onClick={onChildClick} iconOnly icon="rss" aria-label="News" />
       {showNewsDrawer && (
-        <Drawer title={t('news.title', 'Latest from the blog')} scrollableContent onClose={onToggleShowNewsDrawer}>
+        <Drawer
+          title={t('news.title', 'Latest from the blog')}
+          scrollableContent
+          onClose={onToggleShowNewsDrawer}
+          size="md"
+        >
           <NewsWrapper feedUrl={DEFAULT_FEED_URL} />
         </Drawer>
       )}

--- a/public/app/core/components/AppChrome/News/NewsContainer.tsx
+++ b/public/app/core/components/AppChrome/News/NewsContainer.tsx
@@ -26,7 +26,7 @@ export function NewsContainer({ className }: NewsContainerProps) {
           title={t('news.title', 'Latest from the blog')}
           scrollableContent
           onClose={onToggleShowNewsDrawer}
-          size="sm"
+          size="md"
         >
           <NewsWrapper feedUrl={DEFAULT_FEED_URL} />
         </Drawer>

--- a/public/app/core/components/AppChrome/News/NewsContainer.tsx
+++ b/public/app/core/components/AppChrome/News/NewsContainer.tsx
@@ -26,7 +26,7 @@ export function NewsContainer({ className }: NewsContainerProps) {
           title={t('news.title', 'Latest from the blog')}
           scrollableContent
           onClose={onToggleShowNewsDrawer}
-          size="md"
+          size="sm"
         >
           <NewsWrapper feedUrl={DEFAULT_FEED_URL} />
         </Drawer>

--- a/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
+++ b/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
@@ -72,7 +72,7 @@ export function HelpWizard({ panel, plugin, onClose }: Props) {
   return (
     <Drawer
       title={`Get help with this panel`}
-      width="90%"
+      size="lg"
       onClose={onClose}
       expandable
       scrollableContent

--- a/public/app/features/dashboard/components/Inspector/InspectContent.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectContent.tsx
@@ -68,7 +68,6 @@ export const InspectContent = ({
     <Drawer
       title={title}
       subtitle={data && formatStats(data)}
-      width="50%"
       onClose={onClose}
       expandable
       scrollableContent

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -131,7 +131,6 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     <Drawer
       title={title}
       onClose={onDismiss}
-      width={'40%'}
       subtitle={dashboard.title}
       tabs={
         <TabsBar>


### PR DESCRIPTION
Fixes #27426
 
Trying to solve the problem of our drawer that scale poorly on smaller screens as we only set a fixed percentage width right now, and 40% or 50% of a small screen is way to small for many of our drawers. 

* Add size prop with values `sm` | `md` | `lg`  and deprecate width prop 
* size prop sets percentage-based width AND min-width 
* Adds media query to improve handling large drawer with high min-width on smaller screens
* Adjust media query to leave a small margin where you can still see background to make it more clear you are in a drawer even on very small screens (before it was 100%). 
* Deprecates inline drawers that have been broken for 2 years (https://github.com/grafana/grafana/issues/39390)
* Update Storybook & mdx 

Open question:

* Maybe with this we can remove the "expandable" feature? (the chevron which when clicked expands the drawer to 100%). That interaction could be a bit unnecessary after this PR and would simplify the drawer header. 

[New-Features-in-v7-4---gdev-dashboards---Dashboards---Grafana.webm](https://user-images.githubusercontent.com/10999/236156161-7d41fcc8-b719-463b-9511-1fe42cf9916f.webm)

Example of a problem drawer:
![Screenshot from 2023-05-04 10-52-45](https://user-images.githubusercontent.com/10999/236156947-85079a1b-bae7-4b24-b2b5-48a3c09da194.png)
