### PR TITLE
InfluxDB: Fix adding FROM statement when the measurement is an empty string

### DIFF
--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -64,13 +64,17 @@ export class InfluxQueryBuilder {
       measurement = this.target.measurement;
       policy = this.target.policy;
 
-      if (!measurement.match('^/.*/')) {
+      if (!measurement.match(/^\/.*\/|^$/)) {
         measurement = '"' + measurement + '"';
 
         if (policy && policy !== 'default') {
           policy = '"' + policy + '"';
           measurement = policy + '.' + measurement;
         }
+      }
+
+      if (measurement === '') {
+        return 'SHOW FIELD KEYS';
       }
 
       return 'SHOW FIELD KEYS FROM ' + measurement;
@@ -89,7 +93,9 @@ export class InfluxQueryBuilder {
         measurement = policy + '.' + measurement;
       }
 
-      query += ' FROM ' + measurement;
+      if (measurement !== '') {
+        query += ' FROM ' + measurement;
+      }
     }
 
     if (withKey) {

--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -64,6 +64,7 @@ export class InfluxQueryBuilder {
       measurement = this.target.measurement;
       policy = this.target.policy;
 
+      // If there is a measurement and it is not empty string
       if (!measurement.match(/^\/.*\/|^$/)) {
         measurement = '"' + measurement + '"';
 

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -213,5 +213,13 @@ describe('InfluxQueryBuilder', () => {
       const query = builder.buildExploreQuery('TAG_KEYS');
       expect(query).toBe(`SHOW TAG KEYS WHERE "app" == ''`);
     });
+
+    it('should not add FROM statement if the measurement empty', () => {
+      const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
+      let query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe('SHOW TAG KEYS');
+      query = builder.buildExploreQuery('FIELDS');
+      expect(query).toBe('SHOW FIELD KEYS');
+    });
   });
 });


### PR DESCRIPTION
**What is this feature?**

When we send a query with empty `FROM` statement like `SHOW FIELD KEYS FROM ""` we receive `{"results":[{"statement_id":0,"error":"invalid measurement"}]}`. It is a bug on InfluxDB side but to prevent errors piling up this PR introduces not sending empty `FROM` statement. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/5623

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
