### PR TITLE
All: Remove make gen-cue from main dev flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ gen-cue: ## Do all CUE/Thema code generation
 	go generate ./public/app/plugins/gen.go
 	go generate ./pkg/kindsys/report.go
 
-gen-go: $(WIRE) gen-cue
+gen-go: $(WIRE)
 	@echo "generate go files"
 	$(WIRE) gen -tags $(WIRE_TAGS) ./pkg/server
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This removes `make gen-cue` from the interactive developer loop, `make run`.

**Why do we need this feature?**

99% of changes to Grafana do not involve changes to kind definitions/cue files, so re-running `make gen-cue` is usually unnecessary. Time to execute `make gen-cue` is creeping up considerably (we're working on that separately), so it's really impacting folks' dev cycle.

We'll re-enable this once we have a hashing system in place that lets us predict whether running codegen is necessary or not. Until then, it'll be up to developers to manually run `make gen-cue` when they need to. CI will fail if they don't, so there's no actual risk of desync happening on `main`.

**Who is this feature for?**

All Grafana developers.