### PR TITLE
Template Variables: Input field in dashboard does not send network requests for query var with ${__searchFilter}

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -64,20 +64,24 @@ export const filterOrSearchOptions = (
     const { id, queryValue } = getVariablesState(rootStateKey, getState()).optionsPicker;
     const identifier: KeyedVariableIdentifier = { id, rootStateKey: rootStateKey, type: 'query' };
     const variable = getVariable(identifier, getState());
-    if (!hasOptions(variable)) {
+
+    if (!('options' in variable)) {
       return;
     }
 
-    const { query, options } = variable;
     dispatch(toKeyedAction(rootStateKey, updateSearchQuery(searchQuery)));
 
     if (trim(queryValue) === trim(searchQuery)) {
       return;
     }
 
-    if (containsSearchFilter(query)) {
+    const { query, options } = variable;
+
+    let queryTarget = typeof query === 'string' ? query : query.target;
+    if (containsSearchFilter(queryTarget)) {
       return searchForOptionsWithDebounce(dispatch, getState, searchQuery, rootStateKey);
     }
+
     return dispatch(toKeyedAction(rootStateKey, updateOptionsAndFilter(options)));
   };
 };

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -77,7 +77,7 @@ export const filterOrSearchOptions = (
 
     const { query, options } = variable;
 
-    let queryTarget = typeof query === 'string' ? query : query.target;
+    const queryTarget = typeof query === 'string' ? query : query.target;
     if (containsSearchFilter(queryTarget)) {
       return searchForOptionsWithDebounce(dispatch, getState, searchQuery, rootStateKey);
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allows `query` in a Query variable to be an object with `target` key inside of it, instead of just a string. This is a new development after https://github.com/grafana/grafana/pull/52341, but the autocomplete search with ${__searchFilter} does not accommodate for a query inside a variable to be of type [`GraphiteQuery`](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/graphite/types.ts#L13) instead of a string.  
<img width="231" alt="image" src="https://user-images.githubusercontent.com/13227501/236220484-69775dfb-0b74-4824-836d-fa30b2de2846.png">


**Why do we need this feature?**

To be able to repopulate the autocomplete results of a query in a Query template variable that makes use of the `${__searchFilter}` filter. 

**Who is this feature for?**

Query variable users that use `${__searchFilter}` with a Graphite datasource. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #60688

**Special notes for your reviewer:**

Dashboard to test it with:

<details>
<summary> JSON </summary>
<pre>
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 460,
  "links": [],
  "liveNow": false,
  "panels": [],
  "refresh": "",
  "revision": 1,
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "selected": false,
          "text": "graphiteStats",
          "value": "graphiteStats"
        },
        "datasource": {
          "type": "graphite",
          "uid": "P6798F81BB5440721"
        },
        "definition": "stats.statsd.${__searchFilter}",
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "query0",
        "options": [],
        "query": {
          "queryType": "Default",
          "refId": "A",
          "target": "stats.statsd.${__searchFilter}"
        },
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "type": "query"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "#60688 __searchFilter query var",
  "uid": "zozJ3uKVz",
  "version": 11,
  "weekStart": ""
}
</pre>
</details>

Need a running Graphite DS.

Please check that:
- [ ] It works as expected from a user's perspective.
