### PR TITLE
Add requestIdleCallback shim

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -55,6 +55,7 @@ import { EventManager } from './event_manager';
 import GraphTooltip from './graph_tooltip';
 import { convertToHistogramData } from './histogram';
 import { GraphCtrl } from './module';
+import { requestIdleCallback } from './request-idle-callback';
 import { ThresholdManager } from './threshold_manager';
 import { TimeRegionManager } from './time_region_manager';
 import { isLegacyGraphHoverEvent } from './utils';

--- a/public/app/plugins/panel/graph/request-idle-callback.ts
+++ b/public/app/plugins/panel/graph/request-idle-callback.ts
@@ -1,0 +1,16 @@
+// Shim from https://developers.google.com/web/updates/2015/08/using-requestidlecallback
+function requestIdleCallbackShim(cb: any) {
+  const start = Date.now();
+  return setTimeout(function () {
+    cb({
+      didTimeout: false,
+      timeRemaining: function () {
+        return Math.max(0, 50 - (Date.now() - start))
+      },
+    })
+  }, 1)
+}
+
+export const requestIdleCallback = typeof window !== "undefined"
+  ? window.requestIdleCallback || requestIdleCallbackShim
+  : requestIdleCallbackShim


### PR DESCRIPTION
`requestIdleCallback` is not supported in safari

https://developer.chrome.com/blog/using-requestidlecallback/ https://gist.github.com/paullewis/55efe5d6f05434a96c36

![image](https://user-images.githubusercontent.com/327717/236222201-4d9a3da0-d940-438b-9cb9-72bf54499ffd.png)

