### PR TITLE
LibraryPanels: Don't include ScopedVars with persisted model

### DIFF
--- a/public/app/features/library-panels/state/api.ts
+++ b/public/app/features/library-panels/state/api.ts
@@ -64,7 +64,7 @@ export async function getLibraryPanel(uid: string, isHandled = false): Promise<L
     schemaVersion: 35, // should be saved in the library panel
     panels: [result.model],
   });
-  const model = dash.panels[0].getSaveModel(); // migrated panel
+  const { scopedVars, ...model } = dash.panels[0].getSaveModel(); // migrated panel
   dash.destroy(); // kill event listeners
   return {
     ...result,

--- a/public/app/features/library-panels/utils.ts
+++ b/public/app/features/library-panels/utils.ts
@@ -21,7 +21,7 @@ export async function saveAndRefreshLibraryPanel(panel: PanelModel, folderUid: s
 }
 
 function toPanelSaveModel(panel: PanelModel): any {
-  let panelSaveModel = panel.getSaveModel();
+  let { scopedVars, ...panelSaveModel } = panel.getSaveModel();
   panelSaveModel = {
     libraryPanel: {
       name: panel.title,


### PR DESCRIPTION
Removes ScopedVars from library panel before saving.
Unfortunately this highlights another issue in that repeats are processed before library panels are resolved, so if a library panel is repeated by a variable, that variable's value needs to be refreshed or changed for repeats to be processed.
I think it's possible this is a regression introduced during the library panel frontend move, but I'd have to investigate.

Closes #65518

Note: I've marked this as a breaking change since I guess it's possible someone somewhere depended on this behavior.