### PR TITLE
Add errorSource to plugin metrics

### DIFF
--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -82,7 +82,7 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 
 	logger.Info("Plugin Request Completed")
 
-	updateMetrics(pluginCtx.PluginID, endpoint, string(cfg.Target), elapsed, status, "none")
+	updateMetrics(pluginCtx.PluginID, endpoint, string(cfg.Target), elapsed, status, noneSource)
 	logDatasourceRequests(ctx, cfg, pluginCtx, endpoint, status, elapsed, timeBeforePluginRequest, err)
 
 	return err

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -132,7 +132,7 @@ func getErrorSource(status string, resp *backend.QueryDataResponse) errorSource 
 	}
 
 	if status == statusCancelled {
-		return externalSource
+		return noneSource
 	}
 
 	// If there is different errorSource from the list of responses, we want to return the most severe one.

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -79,8 +79,6 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	elapsed := time.Since(start)
 	status := getStatus(err)
 
-	logger.Info("Plugin Request Completed")
-
 	updateMetrics(pluginCtx.PluginID, endpoint, string(cfg.Target), elapsed, status, string(noneSource))
 	logDatasourceRequests(ctx, cfg, pluginCtx, endpoint, status, elapsed, timeBeforePluginRequest, err)
 
@@ -94,7 +92,6 @@ func InstrumentQueryDataRequest(ctx context.Context, cfg Cfg, pluginCtx *backend
 	resp, err := fn()
 
 	elapsed := time.Since(start)
-	logger.Info("Plugin Request Completed")
 
 	status := getStatus(err)
 	errorSource := getErrorSource(status, resp)

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -140,7 +140,7 @@ func getErrorSource(status string, resp *backend.QueryDataResponse) errorSource 
 
 	// If there is different errorSource from the list of responses, we want to return the most severe one.
 	// The priority order is: pluginSource > databaseSource > externalSource > noneSource
-	var errorSource errorSource = noneSource
+	var errorSource = noneSource
 	for _, res := range resp.Responses {
 		responseErrorSource := getErrorSourceForResponse(res)
 

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -116,14 +116,14 @@ func getErrorSource(status string, resp *backend.QueryDataResponse) errorSource 
 		return userSource
 	}
 
-	highestStatusCode := 0
+	var highestStatusCode backend.Status = 0
 	for _, res := range resp.Responses {
 		if res.Error != nil {
 			return grafanaSource
 		}
 
-		if res.Status >= 400 && int(res.Status) > highestStatusCode {
-			highestStatusCode = int(res.Status)
+		if res.Status > highestStatusCode {
+			highestStatusCode = res.Status
 		}
 	}
 

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation_test.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation_test.go
@@ -1,0 +1,125 @@
+package instrumentation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func checkErrorSource(t *testing.T, expected, actual errorSource) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("expected errorSource to be %v, but got %v", expected, actual)
+	}
+}
+
+func TestGetErrorSourceForResponse(t *testing.T) {
+	t.Run("A response that return an error should return pluginSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: fmt.Errorf("error")})
+		checkErrorSource(t, pluginSource, errorSource)
+	})
+
+	t.Run("A response with an http satus code > 500 should return databaseSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 500})
+		checkErrorSource(t, databaseSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 503})
+		checkErrorSource(t, databaseSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 507})
+		checkErrorSource(t, databaseSource, errorSource)
+	})
+
+	t.Run("A response with an http satus related to auth (401, 402, 403, 407), should return externalSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 401})
+		checkErrorSource(t, externalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 402})
+		checkErrorSource(t, externalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 403})
+		checkErrorSource(t, externalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 407})
+		checkErrorSource(t, externalSource, errorSource)
+	})
+
+	t.Run("A response with an http satus of 4xx but not related to auth (401, 402, 403, 407), should return pluginSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 400})
+		checkErrorSource(t, pluginSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 404})
+		checkErrorSource(t, pluginSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 405})
+		checkErrorSource(t, pluginSource, errorSource)
+	})
+
+	t.Run("A response without error and with an http status of 2xx, should return noneSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 200})
+		checkErrorSource(t, noneSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 201})
+		checkErrorSource(t, noneSource, errorSource)
+	})
+}
+
+func TestGetErrorSource(t *testing.T) {
+	t.Run("If status of backend.QueryDataResponse is statusError, then errorSource is pluginSource ", func(t *testing.T) {
+		errorSource := getErrorSource(statusError, nil)
+		checkErrorSource(t, pluginSource, errorSource)
+	})
+
+	t.Run("If status of backend.QueryDataResponse is statusCancelled, then errorSource is externalSource ", func(t *testing.T) {
+		errorSource := getErrorSource(statusCancelled, nil)
+		checkErrorSource(t, externalSource, errorSource)
+	})
+
+	t.Run("If status of backend.QueryDataResponse is statusOK, then errorSource is the most severe response's errorSource: pluginSource > databaseSource > externalSource > noneSource", func(t *testing.T) {
+		errorSource := getErrorSource(statusCancelled, nil)
+		checkErrorSource(t, externalSource, errorSource)
+
+		errorSource = getErrorSource(statusOK, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"A": {Error: fmt.Errorf("error")},
+				"B": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, pluginSource, errorSource)
+
+		errorSource = getErrorSource(statusOK, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"A": {Error: nil, Status: 400},
+				"B": {Error: nil, Status: 500},
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, pluginSource, errorSource)
+
+		errorSource = getErrorSource(statusOK, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"B": {Error: nil, Status: 500},
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, databaseSource, errorSource)
+
+		errorSource = getErrorSource(statusOK, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, externalSource, errorSource)
+
+		errorSource = getErrorSource(statusOK, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, noneSource, errorSource)
+	})
+}

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -52,11 +52,10 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		totalBytes += float64(len(v.JSON))
 	}
 
-	var resp *backend.QueryDataResponse
-	err := instrumentation.InstrumentQueryDataRequest(ctx, &req.PluginContext, instrumentation.Cfg{
+	resp, err := instrumentation.InstrumentQueryDataRequest(ctx, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
-	}, totalBytes, func() (innerErr error) {
+	}, &req.PluginContext, totalBytes, func() (resp *backend.QueryDataResponse, innerErr error) {
 		resp, innerErr = p.QueryData(ctx, req)
 		return
 	})

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -56,8 +56,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
 	}, &req.PluginContext, totalBytes, func() (resp *backend.QueryDataResponse, innerErr error) {
-		resp, innerErr = p.QueryData(ctx, req)
-		return
+		return p.QueryData(ctx, req)
 	})
 
 	if err != nil {

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -120,12 +120,14 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 	dr := &backend.DataResponse{
 		Frames: data.Frames{},
 		Error:  nil,
+		Status: 0,
 	}
 
 	if q.InstantQuery {
 		res := s.instantQuery(traceCtx, client, q, headers)
 		dr.Error = res.Error
 		dr.Frames = res.Frames
+		dr.Status = res.Status
 	}
 
 	if q.RangeQuery {
@@ -138,6 +140,9 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 			}
 		}
 		dr.Frames = append(dr.Frames, res.Frames...)
+		if res.Status > dr.Status {
+			dr.Status = res.Status
+		}
 	}
 
 	if q.ExemplarQuery {
@@ -148,6 +153,9 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 			logger.Error("Exemplar query failed", "query", q.Expr, "err", res.Error)
 		}
 		dr.Frames = append(dr.Frames, res.Frames...)
+		if res.Status > dr.Status {
+			dr.Status = res.Status
+		}
 	}
 
 	return dr

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -53,6 +53,8 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		r = s.processExemplars(ctx, q, r)
 	}
 
+	r.Status = backend.Status(res.StatusCode)
+
 	return r
 }
 


### PR DESCRIPTION
Add an `errorSource` label to plugins metrics. This is to help setting SLOs and Alert for plugin requests.

Similar to this:
https://docs.google.com/document/d/1_8KSW3O6R-0hzcVq9VPj9iLoB064NEdJDIEe0uh58Zo/edit

But for plugin request.


Logic:
  If plugin request return an error => errorSource = plugin
  If there is no error, then it depends on the different http status code returned by the database:
    - 500 => errorSource = database
    - 401, 402, 403, 407 => errorSource = external (could be config or infra)
    - 4xx => errorSource = plugin
   
If there is multiple responses from the database, with different errorSource, then we return the most sever one.
The priority is: pluginSource > databaseSource > externalSource > noneSource

That is the default implementation, it fits prometheus and probably others http databases. The next step would be to update plugin-sdk-go to add a way for plugins to override the default implementation.