### PR TITLE
Render analytics identifiers

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -326,6 +326,8 @@ func IdentityFromSignedInUser(id string, usr *user.SignedInUser, params ClientPa
 		Teams:          usr.Teams,
 		ClientParams:   params,
 		Permissions:    usr.Permissions,
+		AuthModule:     usr.ExternalAuthModule,
+		AuthID:         usr.ExternalAuthID,
 	}
 }
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -392,6 +392,8 @@ func syncSignedInUserToIdentity(usr *user.SignedInUser, identity *authn.Identity
 	identity.LastSeenAt = usr.LastSeenAt
 	identity.IsDisabled = usr.IsDisabled
 	identity.IsGrafanaAdmin = &usr.IsGrafanaAdmin
+	identity.AuthID = usr.ExternalAuthID
+	identity.AuthModule = usr.ExternalAuthModule
 }
 
 func shouldUpdateLastSeen(t time.Time) bool {

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -3,6 +3,9 @@ package contexthandler
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -110,6 +113,25 @@ func FromContext(c context.Context) *contextmodel.ReqContext {
 	return nil
 }
 
+func hashUserIdentifier(identifier string, secret string) string {
+	key := []byte(secret)
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(identifier))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func setSignedInUser(reqContext *contextmodel.ReqContext, identity *authn.Identity, intercomSecret string) {
+	reqContext.SignedInUser = identity.SignedInUser()
+	if identity.AuthID != "" {
+		reqContext.SignedInUser.Analytics.Identifier = identity.AuthID
+	} else {
+		reqContext.SignedInUser.Analytics.Identifier = identity.Email + "@" + setting.AppUrl
+	}
+	if intercomSecret != "" {
+		reqContext.SignedInUser.Analytics.IntercomIdentifier = hashUserIdentifier(identity.AuthID, intercomSecret)
+	}
+}
+
 // Middleware provides a middleware to initialize the request context.
 func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +173,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 				reqContext.LookupTokenErr = err
 			} else {
 				reqContext.UserToken = identity.SessionToken
-				reqContext.SignedInUser = identity.SignedInUser()
+				setSignedInUser(reqContext, identity, h.Cfg.IntercomSecret)
 				reqContext.IsSignedIn = !identity.IsAnonymous
 				reqContext.AllowAnonymous = identity.IsAnonymous
 				reqContext.IsRenderCall = identity.AuthModule == login.RenderModule

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -216,6 +216,11 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 	_, err = rbacSect.NewKey("permission_cache", "false")
 	require.NoError(t, err)
 
+	analyticsSect, err := cfg.NewSection("analytics")
+	require.NoError(t, err)
+	_, err = analyticsSect.NewKey("intercom_secret", "intercom_secret_at_config")
+	require.NoError(t, err)
+
 	getOrCreateSection := func(name string) (*ini.Section, error) {
 		section, err := cfg.GetSection(name)
 		if err != nil {

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
 
@@ -41,6 +43,39 @@ func TestIntegrationIndexView(t *testing.T) {
 
 		assert.Empty(t, resp.Header.Get("Content-Security-Policy"))
 		assert.Regexp(t, `<script nonce=""`, html)
+	})
+
+	t.Run("Test the exposed user data contains the analytics identifiers", func(t *testing.T) {
+		grafDir, cfgPath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+			EnableFeatureToggles: []string{"authnService"},
+		})
+
+		addr, store := testinfra.StartGrafana(t, grafDir, cfgPath)
+		createdUser := testinfra.CreateUser(t, store, user.CreateUserCommand{
+			Login:    "admin",
+			Password: "admin",
+			Email:    "admin@grafana.com",
+			OrgID:    1,
+		})
+
+		// insert user_auth relationship
+		queryString := "INSERT INTO 'main'.'user_auth' ('id', 'user_id', 'auth_module', 'auth_id', 'created', 'o_auth_access_token', 'o_auth_refresh_token', 'o_auth_token_type', 'o_auth_expiry', 'o_auth_id_token') VALUES ('1', '%d', 'oauth_grafana_com', 'test-id-oauth-grafana', '2023-03-13 14:08:11', '', '', '', '', '');"
+		query := fmt.Sprintf(queryString, createdUser.ID)
+		_, err := store.GetEngine().Exec(query)
+		require.NoError(t, err)
+
+		// nolint:bodyclose
+		response, html := makeRequest(t, addr, "admin", "admin")
+		assert.Equal(t, 200, response.StatusCode)
+
+		// parse User.Analytics HTML view into user.AnalyticsSettings model
+		parsedHTML := strings.Split(html, "analytics\":")[1]
+		parsedHTML = strings.Split(parsedHTML, "},\n")[0]
+
+		var analyticsSettings user.AnalyticsSettings
+		require.NoError(t, json.Unmarshal([]byte(parsedHTML), &analyticsSettings))
+
+		require.Equal(t, "test-id-oauth-grafana", analyticsSettings.Identifier)
 	})
 }
 

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -59,8 +59,7 @@ func TestIntegrationIndexView(t *testing.T) {
 		})
 
 		// insert user_auth relationship
-		queryString := "INSERT INTO \"main\".\"user_auth\" (\"id\", \"user_id\", \"auth_module\", \"auth_id\", \"created\", \"o_auth_access_token\", \"o_auth_refresh_token\", \"o_auth_token_type\", \"o_auth_expiry\", \"o_auth_id_token\") VALUES (\"1\", \"%d\", \"oauth_grafana_com\", \"test-id-oauth-grafana\", \"2023-03-13 14:08:11\", \"\", \"\", \"\", \"\", \"\");"
-		query := fmt.Sprintf(queryString, createdUser.ID)
+		query := fmt.Sprintf(`INSERT INTO "user_auth" ("user_id", "auth_module", "auth_id", "created") VALUES ('%d', 'oauth_grafana_com', 'test-id-oauth-grafana', '2023-03-13 14:08:11')`, createdUser.ID)
 		_, err := store.GetEngine().Exec(query)
 		require.NoError(t, err)
 

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -59,7 +59,7 @@ func TestIntegrationIndexView(t *testing.T) {
 		})
 
 		// insert user_auth relationship
-		queryString := "INSERT INTO 'main'.'user_auth' ('id', 'user_id', 'auth_module', 'auth_id', 'created', 'o_auth_access_token', 'o_auth_refresh_token', 'o_auth_token_type', 'o_auth_expiry', 'o_auth_id_token') VALUES ('1', '%d', 'oauth_grafana_com', 'test-id-oauth-grafana', '2023-03-13 14:08:11', '', '', '', '', '');"
+		queryString := "INSERT INTO \"main\".\"user_auth\" (\"id\", \"user_id\", \"auth_module\", \"auth_id\", \"created\", \"o_auth_access_token\", \"o_auth_refresh_token\", \"o_auth_token_type\", \"o_auth_expiry\", \"o_auth_id_token\") VALUES (\"1\", \"%d\", \"oauth_grafana_com\", \"test-id-oauth-grafana\", \"2023-03-13 14:08:11\", \"\", \"\", \"\", \"\", \"\");"
 		query := fmt.Sprintf(queryString, createdUser.ID)
 		_, err := store.GetEngine().Exec(query)
 		require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Appends analytics identifiers upon rendering HTML template

**Why do we need this feature?**

With the new AuthNService, this functionality was lost.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/grafana-enterprise/issues/5045

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
