### PR TITLE
Navigation: Fix 'Page not found' when sending or going back from 'Invitate user' page

### DIFF
--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -35,7 +35,7 @@ export const UserInviteForm = () => {
 
   const onSubmit = async (formData: FormModel) => {
     await dispatch(addInvitee(formData)).unwrap();
-    locationService.push('/org/users/');
+    locationService.push('/admin/users/');
   };
 
   return (
@@ -67,7 +67,7 @@ export const UserInviteForm = () => {
             </FieldSet>
             <Stack>
               <Button type="submit">Submit</Button>
-              <LinkButton href={locationUtil.assureBaseUrl(getConfig().appSubUrl + '/org/users')} variant="secondary">
+              <LinkButton href={locationUtil.assureBaseUrl(getConfig().appSubUrl + '/admin/users')} variant="secondary">
                 Back
               </LinkButton>
             </Stack>


### PR DESCRIPTION

**What is this feature?**

On the 'Invitate User' page, when the form is submitted or when the user press the 'Back' button, the redirection shows a page with a `Page not found` title.

**Why do we need this feature?**

To redirect to the proper page and avoid getting a `Page not found`.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67481

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
