### PR TITLE
Alerting: Fix unique violation when updating rule group with title chains/cycles

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -350,29 +350,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *contextmodel.ReqContext, groupKey
 		finalChanges = store.UpdateCalculatedRuleFields(groupChanges)
 		logger.Debug("updating database with the authorized changes", "add", len(finalChanges.New), "update", len(finalChanges.New), "delete", len(finalChanges.Delete))
 
-		if len(finalChanges.Update) > 0 || len(finalChanges.New) > 0 {
-			updates := make([]ngmodels.UpdateRule, 0, len(finalChanges.Update))
-			inserts := make([]ngmodels.AlertRule, 0, len(finalChanges.New))
-			for _, update := range finalChanges.Update {
-				logger.Debug("updating rule", "rule_uid", update.New.UID, "diff", update.Diff.String())
-				updates = append(updates, ngmodels.UpdateRule{
-					Existing: update.Existing,
-					New:      *update.New,
-				})
-			}
-			for _, rule := range finalChanges.New {
-				inserts = append(inserts, *rule)
-			}
-			_, err = srv.store.InsertAlertRules(tranCtx, inserts)
-			if err != nil {
-				return fmt.Errorf("failed to add rules: %w", err)
-			}
-			err = srv.store.UpdateAlertRules(tranCtx, updates)
-			if err != nil {
-				return fmt.Errorf("failed to update rules: %w", err)
-			}
-		}
-
+		// Delete first as this could prevent future unique constraint violations.
 		if len(finalChanges.Delete) > 0 {
 			UIDs := make([]string, 0, len(finalChanges.Delete))
 			for _, rule := range finalChanges.Delete {
@@ -381,6 +359,32 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *contextmodel.ReqContext, groupKey
 
 			if err = srv.store.DeleteAlertRulesByUID(tranCtx, c.SignedInUser.OrgID, UIDs...); err != nil {
 				return fmt.Errorf("failed to delete rules: %w", err)
+			}
+		}
+
+		if len(finalChanges.Update) > 0 {
+			updates := make([]ngmodels.UpdateRule, 0, len(finalChanges.Update))
+			for _, update := range finalChanges.Update {
+				logger.Debug("updating rule", "rule_uid", update.New.UID, "diff", update.Diff.String())
+				updates = append(updates, ngmodels.UpdateRule{
+					Existing: update.Existing,
+					New:      *update.New,
+				})
+			}
+			err = srv.store.UpdateAlertRules(tranCtx, updates)
+			if err != nil {
+				return fmt.Errorf("failed to update rules: %w", err)
+			}
+		}
+
+		if len(finalChanges.New) > 0 {
+			inserts := make([]ngmodels.AlertRule, 0, len(finalChanges.New))
+			for _, rule := range finalChanges.New {
+				inserts = append(inserts, *rule)
+			}
+			_, err = srv.store.InsertAlertRules(tranCtx, inserts)
+			if err != nil {
+				return fmt.Errorf("failed to add rules: %w", err)
 			}
 		}
 

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -261,51 +261,57 @@ func (service *AlertRuleService) ReplaceRuleGroup(ctx context.Context, orgID int
 
 	return service.xact.InTransaction(ctx, func(ctx context.Context) error {
 		// Delete first as this could prevent future unique constraint violations.
-		for _, del := range delta.Delete {
-			// check that provenance is not changed in an invalid way
-			storedProvenance, err := service.provenanceStore.GetProvenance(ctx, del, orgID)
-			if err != nil {
-				return err
+		if len(delta.Delete) > 0 {
+			for _, del := range delta.Delete {
+				// check that provenance is not changed in an invalid way
+				storedProvenance, err := service.provenanceStore.GetProvenance(ctx, del, orgID)
+				if err != nil {
+					return err
+				}
+				if canUpdate := canUpdateProvenanceInRuleGroup(storedProvenance, provenance); !canUpdate {
+					return fmt.Errorf("cannot update with provided provenance '%s', needs '%s'", provenance, storedProvenance)
+				}
 			}
-			if canUpdate := canUpdateProvenanceInRuleGroup(storedProvenance, provenance); !canUpdate {
-				return fmt.Errorf("cannot update with provided provenance '%s', needs '%s'", provenance, storedProvenance)
-			}
-		}
-		if err := service.deleteRules(ctx, orgID, delta.Delete...); err != nil {
-			return err
-		}
-
-		updates := make([]models.UpdateRule, 0, len(delta.Update))
-		for _, update := range delta.Update {
-			// check that provenance is not changed in an invalid way
-			storedProvenance, err := service.provenanceStore.GetProvenance(ctx, update.New, orgID)
-			if err != nil {
-				return err
-			}
-			if canUpdate := canUpdateProvenanceInRuleGroup(storedProvenance, provenance); !canUpdate {
-				return fmt.Errorf("cannot update with provided provenance '%s', needs '%s'", provenance, storedProvenance)
-			}
-			updates = append(updates, models.UpdateRule{
-				Existing: update.Existing,
-				New:      *update.New,
-			})
-		}
-		if err = service.ruleStore.UpdateAlertRules(ctx, updates); err != nil {
-			return fmt.Errorf("failed to update alert rules: %w", err)
-		}
-		for _, update := range delta.Update {
-			if err := service.provenanceStore.SetProvenance(ctx, update.New, orgID, provenance); err != nil {
+			if err := service.deleteRules(ctx, orgID, delta.Delete...); err != nil {
 				return err
 			}
 		}
 
-		uids, err := service.ruleStore.InsertAlertRules(ctx, withoutNilAlertRules(delta.New))
-		if err != nil {
-			return fmt.Errorf("failed to insert alert rules: %w", err)
+		if len(delta.Update) > 0 {
+			updates := make([]models.UpdateRule, 0, len(delta.Update))
+			for _, update := range delta.Update {
+				// check that provenance is not changed in an invalid way
+				storedProvenance, err := service.provenanceStore.GetProvenance(ctx, update.New, orgID)
+				if err != nil {
+					return err
+				}
+				if canUpdate := canUpdateProvenanceInRuleGroup(storedProvenance, provenance); !canUpdate {
+					return fmt.Errorf("cannot update with provided provenance '%s', needs '%s'", provenance, storedProvenance)
+				}
+				updates = append(updates, models.UpdateRule{
+					Existing: update.Existing,
+					New:      *update.New,
+				})
+			}
+			if err = service.ruleStore.UpdateAlertRules(ctx, updates); err != nil {
+				return fmt.Errorf("failed to update alert rules: %w", err)
+			}
+			for _, update := range delta.Update {
+				if err := service.provenanceStore.SetProvenance(ctx, update.New, orgID, provenance); err != nil {
+					return err
+				}
+			}
 		}
-		for uid := range uids {
-			if err := service.provenanceStore.SetProvenance(ctx, &models.AlertRule{UID: uid}, orgID, provenance); err != nil {
-				return err
+
+		if len(delta.New) > 0 {
+			uids, err := service.ruleStore.InsertAlertRules(ctx, withoutNilAlertRules(delta.New))
+			if err != nil {
+				return fmt.Errorf("failed to insert alert rules: %w", err)
+			}
+			for uid := range uids {
+				if err := service.provenanceStore.SetProvenance(ctx, &models.AlertRule{UID: uid}, orgID, provenance); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -187,8 +187,8 @@ func TestAlertRuleService(t *testing.T) {
 		require.Len(t, readGroup.Rules, 2)
 		require.Equal(t, "overlap-test-rule-2", readGroup.Rules[0].Title)
 		require.Equal(t, "overlap-test-rule-3", readGroup.Rules[1].Title)
-		require.Equal(t, int64(2), readGroup.Rules[0].Version)
-		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+		require.Equal(t, int64(3), readGroup.Rules[0].Version)
+		require.Equal(t, int64(3), readGroup.Rules[1].Version)
 	})
 
 	t.Run("updating a group to swap the name of two rules should not throw unique constraint", func(t *testing.T) {
@@ -219,7 +219,7 @@ func TestAlertRuleService(t *testing.T) {
 		require.Equal(t, "swap-test-rule-2", readGroup.Rules[0].Title)
 		require.Equal(t, "swap-test-rule-1", readGroup.Rules[1].Title)
 		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
-		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+		require.Equal(t, int64(3), readGroup.Rules[1].Version)
 	})
 
 	t.Run("updating a group that has a rule name cycle should not throw unique constraint", func(t *testing.T) {
@@ -253,8 +253,8 @@ func TestAlertRuleService(t *testing.T) {
 		require.Equal(t, "cycle-test-rule-3", readGroup.Rules[1].Title)
 		require.Equal(t, "cycle-test-rule-1", readGroup.Rules[2].Title)
 		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
-		require.Equal(t, int64(2), readGroup.Rules[1].Version)
-		require.Equal(t, int64(2), readGroup.Rules[2].Version)
+		require.Equal(t, int64(3), readGroup.Rules[1].Version)
+		require.Equal(t, int64(3), readGroup.Rules[2].Version)
 	})
 
 	t.Run("updating a group that has multiple rule name cycles should not throw unique constraint", func(t *testing.T) {
@@ -297,10 +297,10 @@ func TestAlertRuleService(t *testing.T) {
 		require.Equal(t, "multi-cycle-test-rule-5", readGroup.Rules[3].Title)
 		require.Equal(t, "multi-cycle-test-rule-3", readGroup.Rules[4].Title)
 		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
-		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+		require.Equal(t, int64(3), readGroup.Rules[1].Version)
 		require.Equal(t, int64(3), readGroup.Rules[2].Version) // Needed an extra update to break the update cycle.
-		require.Equal(t, int64(2), readGroup.Rules[3].Version)
-		require.Equal(t, int64(2), readGroup.Rules[4].Version)
+		require.Equal(t, int64(3), readGroup.Rules[3].Version)
+		require.Equal(t, int64(3), readGroup.Rules[4].Version)
 	})
 
 	t.Run("updating a group to recreate a rule using the same name should not throw unique constraint", func(t *testing.T) {

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -160,6 +160,210 @@ func TestAlertRuleService(t *testing.T) {
 		require.Equal(t, int64(2), readGroup.Rules[0].Version)
 	})
 
+	t.Run("updating a group to temporarily overlap rule names should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "overlap-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("overlap-test-rule-1", orgID),
+				dummyRule("overlap-test-rule-2", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "overlap-test")
+		require.NoError(t, err)
+
+		updatedGroup.Rules[0].Title = "overlap-test-rule-2"
+		updatedGroup.Rules[1].Title = "overlap-test-rule-3"
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "overlap-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 2)
+		require.Equal(t, "overlap-test-rule-2", readGroup.Rules[0].Title)
+		require.Equal(t, "overlap-test-rule-3", readGroup.Rules[1].Title)
+		require.Equal(t, int64(2), readGroup.Rules[0].Version)
+		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+	})
+
+	t.Run("updating a group to swap the name of two rules should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "swap-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("swap-test-rule-1", orgID),
+				dummyRule("swap-test-rule-2", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "swap-test")
+		require.NoError(t, err)
+
+		updatedGroup.Rules[0].Title = "swap-test-rule-2"
+		updatedGroup.Rules[1].Title = "swap-test-rule-1"
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "swap-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 2)
+		require.Equal(t, "swap-test-rule-2", readGroup.Rules[0].Title)
+		require.Equal(t, "swap-test-rule-1", readGroup.Rules[1].Title)
+		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
+		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+	})
+
+	t.Run("updating a group that has a rule name cycle should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "cycle-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("cycle-test-rule-1", orgID),
+				dummyRule("cycle-test-rule-2", orgID),
+				dummyRule("cycle-test-rule-3", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "cycle-test")
+		require.NoError(t, err)
+
+		updatedGroup.Rules[0].Title = "cycle-test-rule-2"
+		updatedGroup.Rules[1].Title = "cycle-test-rule-3"
+		updatedGroup.Rules[2].Title = "cycle-test-rule-1"
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "cycle-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 3)
+		require.Equal(t, "cycle-test-rule-2", readGroup.Rules[0].Title)
+		require.Equal(t, "cycle-test-rule-3", readGroup.Rules[1].Title)
+		require.Equal(t, "cycle-test-rule-1", readGroup.Rules[2].Title)
+		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
+		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+		require.Equal(t, int64(2), readGroup.Rules[2].Version)
+	})
+
+	t.Run("updating a group that has multiple rule name cycles should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "multi-cycle-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("multi-cycle-test-rule-1", orgID),
+				dummyRule("multi-cycle-test-rule-2", orgID),
+
+				dummyRule("multi-cycle-test-rule-3", orgID),
+				dummyRule("multi-cycle-test-rule-4", orgID),
+				dummyRule("multi-cycle-test-rule-5", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "multi-cycle-test")
+		require.NoError(t, err)
+
+		updatedGroup.Rules[0].Title = "multi-cycle-test-rule-2"
+		updatedGroup.Rules[1].Title = "multi-cycle-test-rule-1"
+
+		updatedGroup.Rules[2].Title = "multi-cycle-test-rule-4"
+		updatedGroup.Rules[3].Title = "multi-cycle-test-rule-5"
+		updatedGroup.Rules[4].Title = "multi-cycle-test-rule-3"
+
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "multi-cycle-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 5)
+		require.Equal(t, "multi-cycle-test-rule-2", readGroup.Rules[0].Title)
+		require.Equal(t, "multi-cycle-test-rule-1", readGroup.Rules[1].Title)
+		require.Equal(t, "multi-cycle-test-rule-4", readGroup.Rules[2].Title)
+		require.Equal(t, "multi-cycle-test-rule-5", readGroup.Rules[3].Title)
+		require.Equal(t, "multi-cycle-test-rule-3", readGroup.Rules[4].Title)
+		require.Equal(t, int64(3), readGroup.Rules[0].Version) // Needed an extra update to break the update cycle.
+		require.Equal(t, int64(2), readGroup.Rules[1].Version)
+		require.Equal(t, int64(3), readGroup.Rules[2].Version) // Needed an extra update to break the update cycle.
+		require.Equal(t, int64(2), readGroup.Rules[3].Version)
+		require.Equal(t, int64(2), readGroup.Rules[4].Version)
+	})
+
+	t.Run("updating a group to recreate a rule using the same name should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "recreate-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("recreate-test-rule-1", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup := models.AlertRuleGroup{
+			Title:     "recreate-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("recreate-test-rule-1", orgID),
+			},
+		}
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "recreate-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 1)
+		require.Equal(t, "recreate-test-rule-1", readGroup.Rules[0].Title)
+		require.Equal(t, int64(1), readGroup.Rules[0].Version)
+	})
+
+	t.Run("updating a group to create a rule that temporarily overlaps an existing should not throw unique constraint", func(t *testing.T) {
+		var orgID int64 = 1
+		group := models.AlertRuleGroup{
+			Title:     "create-overlap-test",
+			Interval:  60,
+			FolderUID: "my-namespace",
+			Rules: []models.AlertRule{
+				dummyRule("create-overlap-test-rule-1", orgID),
+			},
+		}
+		err := ruleService.ReplaceRuleGroup(context.Background(), orgID, group, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+		updatedGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "create-overlap-test")
+		require.NoError(t, err)
+		updatedGroup.Rules[0].Title = "create-overlap-test-rule-2"
+		updatedGroup.Rules = append(updatedGroup.Rules, dummyRule("create-overlap-test-rule-1", orgID))
+
+		err = ruleService.ReplaceRuleGroup(context.Background(), orgID, updatedGroup, 0, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		readGroup, err := ruleService.GetRuleGroup(context.Background(), orgID, "my-namespace", "create-overlap-test")
+		require.NoError(t, err)
+		require.NotEmpty(t, readGroup.Rules)
+		require.Len(t, readGroup.Rules, 2)
+		require.Equal(t, "create-overlap-test-rule-2", readGroup.Rules[0].Title)
+		require.Equal(t, "create-overlap-test-rule-1", readGroup.Rules[1].Title)
+		require.Equal(t, int64(2), readGroup.Rules[0].Version)
+		require.Equal(t, int64(1), readGroup.Rules[1].Version)
+	})
+
 	t.Run("updating a group by updating a rule should not remove dashboard and panel ids", func(t *testing.T) {
 		dashboardUid := "huYnkl7H"
 		panelId := int64(5678)

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -258,12 +258,13 @@ func (st DBstore) preventIntermediateUniqueConstraintViolations(sess *db.Session
 			titleUpdates = append(titleUpdates, update)
 		}
 	}
-	// This short circuit detects when no intermediate unique constraint violations are possible.
-	// It may return false positives, but never false negatives.
+
+	// If there is no overlap then an intermediate unique constraint violation is not possible. If there is an overlap,
+	// then there is the possibility of intermediate unique constraint violation.
 	if !newTitlesOverlapExisting(titleUpdates) {
-		// No possibility of an intermediate unique constraint violation.
 		return nil
 	}
+	st.Logger.Debug("detected possible intermediate unique constraint violation, creating temporary title updates", "updates", len(titleUpdates))
 
 	for _, update := range titleUpdates {
 		r := update.Existing

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -182,7 +182,6 @@ func (st DBstore) InsertAlertRules(ctx context.Context, rules []ngmodels.AlertRu
 // UpdateAlertRules is a handler for updating alert rules.
 func (st DBstore) UpdateAlertRules(ctx context.Context, rules []ngmodels.UpdateRule) error {
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-
 		reorderedRules, err := st.reorderUpdates(sess, rules)
 		if err != nil {
 			return err

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -252,7 +252,6 @@ func (st DBstore) reorderUpdates(sess *db.Session, rules []ngmodels.UpdateRule) 
 	processedUpdates := make(map[string]struct{}, len(rules))
 	chains := findTitleUpdateChains(rules)
 	for _, chain := range chains {
-
 		// If the chain is a cycle, we need to add an intermediate update to a fake value to break the cycle. Otherwise, there is
 		// no valid order to update the rules that won't violate the unique constraint.
 		// Ex. Assuming Rule A, B, and C exist, and we have an update chain of RuleA -> RuleB -> RuleC -> RuleA. We need to break the cycle

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
@@ -38,6 +39,7 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 		SQLStore:      sqlStore,
 		Cfg:           cfg.UnifiedAlerting,
 		FolderService: setupFolderService(t, sqlStore, cfg),
+		Logger:        &logtest.Fake{},
 	}
 	generator := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval), models.WithUniqueID())
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -358,9 +358,10 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 	require.Len(t, createdRuleGroup.Rules, 2)
 
 	t.Run("trying to create alert with same title under same folder should fail", func(t *testing.T) {
-		rules := newTestingRuleConfig(t)
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+		rulesWithUID.Rules = append(rulesWithUID.Rules, rules.Rules[0]) // Create new copy of first rule.
 
-		status, body := apiClient.PostRulesGroup(t, "folder1", &rules)
+		status, body := apiClient.PostRulesGroup(t, "folder1", &rulesWithUID)
 		assert.Equal(t, http.StatusInternalServerError, status)
 
 		var res map[string]interface{}
@@ -369,12 +370,10 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 	})
 
 	t.Run("trying to update an alert to the title of an existing alert in the same folder should fail", func(t *testing.T) {
-		rules := newTestingRuleConfig(t)
-		rules.Rules[0].GrafanaManagedAlert.UID = createdRuleGroup.Rules[0].GrafanaManagedAlert.UID
-		rules.Rules[1].GrafanaManagedAlert.UID = createdRuleGroup.Rules[1].GrafanaManagedAlert.UID
-		rules.Rules[1].GrafanaManagedAlert.Title = "AlwaysFiring"
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = "AlwaysFiring"
 
-		status, body := apiClient.PostRulesGroup(t, "folder1", &rules)
+		status, body := apiClient.PostRulesGroup(t, "folder1", &rulesWithUID)
 		assert.Equal(t, http.StatusInternalServerError, status)
 
 		var res map[string]interface{}

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -387,6 +387,28 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		assert.Equal(t, http.StatusAccepted, status)
 		require.JSONEq(t, `{"message":"rule group updated successfully"}`, body)
 	})
+
+	t.Run("trying to swap titles of existing alerts in the same folder should work", func(t *testing.T) {
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+		title0 := rulesWithUID.Rules[0].GrafanaManagedAlert.Title
+		title1 := rulesWithUID.Rules[1].GrafanaManagedAlert.Title
+		rulesWithUID.Rules[0].GrafanaManagedAlert.Title = title1
+		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = title0
+
+		status, body := apiClient.PostRulesGroup(t, "folder1", &rulesWithUID)
+		assert.Equal(t, http.StatusAccepted, status)
+		require.JSONEq(t, `{"message":"rule group updated successfully"}`, body)
+	})
+
+	t.Run("trying to update titles of existing alerts in a chain in the same folder should work", func(t *testing.T) {
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+		rulesWithUID.Rules[0].GrafanaManagedAlert.Title = rulesWithUID.Rules[1].GrafanaManagedAlert.Title
+		rulesWithUID.Rules[1].GrafanaManagedAlert.Title = "something new"
+
+		status, body := apiClient.PostRulesGroup(t, "folder1", &rulesWithUID)
+		assert.Equal(t, http.StatusAccepted, status)
+		require.JSONEq(t, `{"message":"rule group updated successfully"}`, body)
+	})
 }
 
 func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {


### PR DESCRIPTION
Fixes: #66158

The uniqueness constraint for titles within an org+folder is enforced on every update within a transaction instead of on commit (deferred constraint). This means that there could be a set of updates that will throw a unique constraint violation in an intermediate step even though the final state is valid. For example, a chain of updates RuleA -> RuleB -> RuleC could fail if not executed in the correct order, or a swap of titles RuleA <-> RuleB cannot be executed in any order without violating the constraint.

The exact solution to this is complex and requires determining directed paths and cycles in the update graph, adding in temporary updates to break cycles, and then executing the updates in reverse topological order (see first commit in PR if curious).

This is not implemented here.

Instead, we choose a simpler solution that works in all cases but might perform more updates than necessary. This simpler solution makes a determination of whether an intermediate collision could occur and if so, adds a temporary title on all updated rules to break any cycles and remove the need for specific ordering.

In addition, we make sure diffs are executed in the following order: DELETES, UPDATES, INSERTS.

The alternatives to this added complexity are:

1) On update delete entire rule group and reinsert. This is simple and straightforward, but requires removing our optimistic locking strategy for pessimistic.
2) Remove the title uniqueness constraint from the table. Then we can either enforce in application code or not enforce it at all. Not enforcing it could cause users to mistakenly group notifications for alerts of the same name.

Note: Deferred constraints are not really a viable option here as SQLite and MySQL do not support them at the moment.