### PR TITLE
Google Cloud Monitor: send ServerTiming and metricDescriptors

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { GrafanaTheme2, SelectableValue, TimeRange } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { getSelectStyles, Select, AsyncSelect, useStyles2, useTheme2 } from '@grafana/ui';
+import { reportInteraction } from '@grafana/runtime';
 
 import CloudMonitoringDatasource from '../datasource';
 import { getAlignmentPickerData, getMetricType, setMetricType } from '../functions';
@@ -88,6 +89,9 @@ export function Editor({
     const loadMetricDescriptors = async () => {
       if (projectName) {
         const metricDescriptors = await datasource.getMetricTypes(projectName);
+        reportInteraction('cloud-monitoring-metric-descriptors-loaded', {
+          count: metricDescriptors.length,
+        });
         const services = getServicesList(metricDescriptors);
         setMetricDescriptors(metricDescriptors);
         setServices(services);

--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -5,8 +5,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue, TimeRange } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
-import { getSelectStyles, Select, AsyncSelect, useStyles2, useTheme2 } from '@grafana/ui';
 import { reportInteraction } from '@grafana/runtime';
+import { getSelectStyles, Select, AsyncSelect, useStyles2, useTheme2 } from '@grafana/ui';
 
 import CloudMonitoringDatasource from '../datasource';
 import { getAlignmentPickerData, getMetricType, setMetricType } from '../functions';


### PR DESCRIPTION
**What is this feature?**
In working to address #67682 I noticed a few things that would have been useful to have at the beginning of the debugging process. This PR adds two of them:

1. Implements the `Server-Timing` header for Cloud Monitoring's `doRequest` loop. This header will surface in the network tab of the browser dev tools which can be useful for engineers, support engineers, or even customers.
2. Report the total size of the `metricDescriptors` returned. Google has a cap of around [35k descriptors](https://cloud.google.com/monitoring/quotas) per project (this doesn't seem to count the existing default descriptors which is about 6k). 