### PR TITLE
fix broken link to packages_api

### DIFF
--- a/docs/sources/tutorials/build-a-data-source-plugin/index.md
+++ b/docs/sources/tutorials/build-a-data-source-plugin/index.md
@@ -311,7 +311,7 @@ Just like query editor, the form field in the config editor calls the registered
 
 So far, you've generated the data returned by the data source. A more realistic use case would be to fetch data from an external API.
 
-While you can use something like [axios](https://github.com/axios/axios) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make requests, we recommend using the [`getBackendSrv`](https://github.com/grafana/grafana/blob/main/packages/grafana-runtime/src/services/backendSrv.ts) function from the [grafana/runtime](https://github.com/grafana/grafana/tree/main/packages/grafana-runtime) package.
+While you can use something like [axios](https://github.com/axios/axios) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make requests, we recommend using the [`getBackendSrv`](https://github.com/grafana/grafana/blob/main/packages/grafana-runtime/src/services/backendSrv.ts) function from the [grafana/runtime](https://github.com/grafana/grafana/blob/main/packages/grafana-runtime) package.
 
 The main advantage of `getBackendSrv` is that it proxies requests through the Grafana server rather making the request from the browser. This is strongly recommended when making authenticated requests to an external API. For more information on authenticating external requests, refer to [Add authentication for data source plugins](/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/).
 

--- a/docs/sources/tutorials/build-a-data-source-plugin/index.md
+++ b/docs/sources/tutorials/build-a-data-source-plugin/index.md
@@ -311,7 +311,7 @@ Just like query editor, the form field in the config editor calls the registered
 
 So far, you've generated the data returned by the data source. A more realistic use case would be to fetch data from an external API.
 
-While you can use something like [axios](https://github.com/axios/axios) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make requests, we recommend using the [`getBackendSrv`](/docs/grafana/latest/packages_api/runtime/getbackendsrv/) function from the [grafana/runtime](/docs/grafana/latest/packages_api/runtime/) package.
+While you can use something like [axios](https://github.com/axios/axios) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make requests, we recommend using the [`getBackendSrv`](https://github.com/grafana/grafana/blob/main/packages/grafana-runtime/src/services/backendSrv.ts) function from the [grafana/runtime](https://github.com/grafana/grafana/tree/main/packages/grafana-runtime) package.
 
 The main advantage of `getBackendSrv` is that it proxies requests through the Grafana server rather making the request from the browser. This is strongly recommended when making authenticated requests to an external API. For more information on authenticating external requests, refer to [Add authentication for data source plugins](/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/).
 


### PR DESCRIPTION
Noticed these docs were still linking to deprecated `packages_api` docs, updated the link so no longer 404s