### PR TITLE
Docs: Add a note about disabling SAML UI

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml-ui/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml-ui/index.md
@@ -20,6 +20,8 @@ The Grafana SAML UI provides the following advantages over configuring SAML in t
 
 > **Note:** Configuration in the UI takes precedence over the configuration in the Grafana configuration file. SAML settings from the UI will override any SAML configuration set in the Grafana configuration file.
 
+> **Note:** Disabling the UI does not affect any configuration settings that were previously set up through the UI. Those settings will continue to function as intended even with the UI disabled.
+
 ## Before you begin
 
 To follow this guide, you need:


### PR DESCRIPTION
**What is this feature?**

Adds a small note in the SAML UI configuration page indicating that disabling UI would still keep existing configuration working.

**Why do we need this feature?**

Despite the fact that we will have the feature always enabled, the feature flag would still be in the configuration file and users might find it and decide to disable - so a note about the side effect would be helpful in this case.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/5039

