### PR TITLE
Update error message when Alertmanager configuration override

### DIFF
--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -580,7 +580,7 @@ export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlert
 
           if (!isLatestConfigEmpty && oldLastConfigsDiffer) {
             throw new Error(
-              'It seems configuration has been recently updated. Please reload page and try again to make sure that recent changes are not overwritten.'
+              'A newer Alertmanager configuration is available. Please reload the page and try again to not overwrite recent changes.'
             );
           }
           await updateAlertManagerConfig(alertManagerSourceName, addDefaultsToAlertmanagerConfig(newConfig));


### PR DESCRIPTION
Improved the UX issue mentioned in https://github.com/grafana/grafana/issues/66907