### PR TITLE
Optional team filter when sending issue notification on Slack

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -7,4 +7,5 @@ test:
 
 # Alerting team
 area/alerting:
-  channel-label: C02B9MXQE0J
+  channel-label: C028MCV4R7C
+  exclude-github-team: alerting-squad

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,4 +1,4 @@
-name: Notify Slack channel based on issue label
+name: Notify Slack channel based on new issue label
 
 on:
   issues:
@@ -15,6 +15,7 @@ jobs:
         run: |
           # Default to null values.
           CHANNEL="null"
+          TEAM="null"
 
           echo "${{ github.event.label.name }} label added"
           export CURRENT_LABEL="${{ github.event.label.name }}" # Enable the use of the label in yq evaluations
@@ -25,10 +26,16 @@ jobs:
               CHANNEL=$(yq '.[env(CURRENT_LABEL)].channel-label' teams.yml)
               echo "Ready to send issue to channel ID ${CHANNEL}"
             fi
+
+            if [[ $(yq '.[env(CURRENT_LABEL)] | has("exclude-github-team")' teams.yml ) == true ]]; then
+              TEAM=$(yq '.[env(CURRENT_LABEL)].exclude-github-team' teams.yml)
+              echo "Will not send issue to channel if issue author is part of the team ${TEAM}"
+            fi
           fi
 
-          # set environment for next step
+          # set environment for next steps
           echo "CHANNEL=${CHANNEL}" >> $GITHUB_ENV
+          echo "TEAM=${TEAM}" >> $GITHUB_ENV
 
       - name: "Prepare payload"
         uses: frabert/replace-string-action@v2.0
@@ -40,15 +47,24 @@ jobs:
           replace-with: "'"
           flags: 'g'
 
+      - name: "Check that issue author is not part of the team"
+        if: ${{ env.TEAM != 'null' }}
+        uses: tspascoal/get-user-teams-membership@v2
+        id: checkUserMember
+        with:
+          username: ${{ github.event.issue.user.login }}
+          team: "${{ env.TEAM }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Send Slack notification"
-        if: ${{ env.CHANNEL != 'null' }}
+        if: ${{ (env.CHANNEL != 'null') && ((steps.checkUserMember.outputs.isTeamMember == 'false') || (env.TEAM != 'null')) }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: >
             {
               "icon_emoji": ":grafana:",
               "username": "Grafana issue labeled",
-              "text": "Issue \"${{ steps.preparePayload.outputs.replaced }}\" labeled \"${{ github.event.label.name }}\": ${{ github.event.issue.html_url }}",
+              "text": "Issue \"${{ steps.preparePayload.outputs.replaced }}\" labeled \"${{ github.event.label.name }}\": ${{ github.event.issue.html_url }}, please triage.",
               "channel": "${{ env.CHANNEL }}"
             }
         env:


### PR DESCRIPTION
This workflow is only used by the alerting squad at the moment. The addition of that filter will allow us to not receive notification when a team member creates an issue.