### PR TITLE
elasticsearch: improved deprecation warning

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Alert } from '@grafana/ui';
+
 import { useDispatch } from '../../../hooks/useStatelessReducer';
 import { IconButton } from '../../IconButton';
 import { useQuery } from '../ElasticsearchQueryContext';
@@ -30,12 +32,10 @@ export const MetricAggregationsEditor = ({ nextId }: Props) => {
             return <QueryEditorSpecialMetricRow key={`${metric.type}-${metric.id}`} name="Raw Data" metric={metric} />;
           case 'raw_document':
             return (
-              <QueryEditorSpecialMetricRow
-                key={`${metric.type}-${metric.id}`}
-                name="Raw Document"
-                metric={metric}
-                info="(NOTE: Raw document query type is deprecated)"
-              />
+              <>
+                <QueryEditorSpecialMetricRow key={`${metric.type}-${metric.id}`} name="Raw Document" metric={metric} />
+                <Alert title="The 'Raw Document' query type is deprecated." />
+              </>
             );
           default:
             return (

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -34,7 +34,7 @@ export const MetricAggregationsEditor = ({ nextId }: Props) => {
             return (
               <>
                 <QueryEditorSpecialMetricRow key={`${metric.type}-${metric.id}`} name="Raw Document" metric={metric} />
-                <Alert title="The 'Raw Document' query type is deprecated." />
+                <Alert severity="warning" title="The 'Raw Document' query type is deprecated." />
               </>
             );
           default:

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorSpecialMetricRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorSpecialMetricRow.tsx
@@ -9,10 +9,9 @@ import { SettingsEditor } from './MetricAggregationsEditor/SettingsEditor';
 type Props = {
   name: string;
   metric: MetricAggregation;
-  info?: string;
 };
 
-export const QueryEditorSpecialMetricRow = ({ name, metric, info }: Props) => {
+export const QueryEditorSpecialMetricRow = ({ name, metric }: Props) => {
   // this widget is only used in scenarios when there is only a single
   // metric, so the array of "previousMetrics" (meaning all the metrics
   // before the current metric), is an ampty-array
@@ -26,11 +25,6 @@ export const QueryEditorSpecialMetricRow = ({ name, metric, info }: Props) => {
         </InlineLabel>
       </InlineSegmentGroup>
       <SettingsEditor metric={metric} previousMetrics={previousMetrics} />
-      {info != null && (
-        <InlineSegmentGroup>
-          <InlineLabel>{info}</InlineLabel>
-        </InlineSegmentGroup>
-      )}
     </InlineFieldRow>
   );
 };


### PR DESCRIPTION
in the elasticsearch query editor, the "raw document" mode is deprecated, and we show a deprecation-notice. this PR improves the way we display the deprecation notice.
<img width="577" alt="deprecate" src="https://user-images.githubusercontent.com/51989/236465985-4349d2d1-4737-4c18-8866-2f830d3e5960.png">


how to test:
1. go to the query editor
2. choose the raw-document mode
3. verify it still works
4. verify that you see the deprecation message
5. go to the other modes (metrics, logs, raw-data), verify they still work