### PR TITLE
Chore: Remove 'PerformanceBackend: flushing' log

### DIFF
--- a/public/app/core/services/echo/backends/PerformanceBackend.ts
+++ b/public/app/core/services/echo/backends/PerformanceBackend.ts
@@ -32,11 +32,6 @@ export class PerformanceBackend implements EchoBackend<PerformanceEvent, Perform
       return;
     }
 
-    // Currently we don't have an API for sending the metrics hence logging to console in dev environment
-    if (process.env.NODE_ENV === 'development') {
-      console.log('PerformanceBackend flushing:', this.buffer);
-    }
-
     backendSrv.post('/api/frontend-metrics', {
       events: this.buffer,
     });


### PR DESCRIPTION
Removes the "PerformanceBackend: flushing" message + stats that gets logged during development as it doesn't really have much value any more.