### PR TITLE
AzureMonitor: Clear queries if header value changes

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.test.tsx
@@ -88,7 +88,8 @@ describe('Azure Monitor QueryEditor', () => {
     await selectOptionInTest(metrics, 'Logs');
 
     expect(onChange).toHaveBeenCalledWith({
-      ...mockQuery,
+      refId: mockQuery.refId,
+      datasource: mockQuery.datasource,
       queryType: AzureQueryType.LogAnalytics,
     });
   });

--- a/public/app/plugins/datasource/azuremonitor/components/QueryHeader.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryHeader.tsx
@@ -21,11 +21,13 @@ export const QueryHeader = ({ query, onQueryChange }: QueryTypeFieldProps) => {
 
   const handleChange = useCallback(
     (change: SelectableValue<AzureQueryType>) => {
-      change.value &&
+      if (change.value && change.value !== query.queryType) {
         onQueryChange({
-          ...query,
+          refId: query.refId,
+          datasource: query.datasource,
           queryType: change.value,
         });
+      }
     },
     [onQueryChange, query]
   );


### PR DESCRIPTION
This PR updates the logic so that if a new query type is selected the existing query will be cleared. This is to prevent issues with the cross-over between the Logs and Traces query types.