### PR TITLE
Chore: Remove nth-child warning from dev mode

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/page.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/page.ts
@@ -88,12 +88,7 @@ export function getPageStyles(theme: GrafanaTheme2) {
       margin-bottom: ${theme.spacing(2)};
       display: flex;
       align-items: flex-start;
-
-      > a,
-      > button,
-      > div:nth-child(2) {
-        margin-left: ${theme.spacing(2)};
-      }
+      gap: ${theme.spacing(2)};
     }
 
     .page-action-bar--narrow {


### PR DESCRIPTION
Minor refactor of some global styles to remove the :nth-child that was causing console warnings during dev mode.

<img width="845" alt="Screenshot 2023-05-05 at 2 49 36 pm" src="https://user-images.githubusercontent.com/46142/236476290-8710cfce-c63b-4647-8536-1ba34c53b808.png">

<img width="846" alt="Screenshot 2023-05-05 at 2 49 29 pm" src="https://user-images.githubusercontent.com/46142/236476303-184d46f1-fa3b-4afb-9974-198867f287c9.png">
