### PR TITLE
Prometheus: Fix Query Inspector expression range value

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -247,7 +247,10 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
       refId,
       fields,
       // Prometheus specific UI for instant queries
-      meta: { ...dfs[0].meta, preferredVisualisationType: 'rawPrometheus' as PreferredVisualisationType },
+      meta: {
+        ...dataFramesByRefId[refId][0].meta,
+        preferredVisualisationType: 'rawPrometheus' as PreferredVisualisationType,
+      },
       length: timeField.values.length,
     };
   });


### PR DESCRIPTION
**What is this feature?**
The query inspector was showing wrong range values for prometheus queries with different ranges. This PR is fixing this problem. 

**Who is this feature for?**

All prometheus users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67890

**Special notes for your reviewer:**
#### How to test
- Go explore and add two queries with different ranges
  - `avg_over_time(access_evaluation_duration_bucket[$__interval])`
  - `avg_over_time(access_evaluation_duration_bucket[5m])`
- Open Query Inspector and click `Query` tab
- Click Refresh and see the range oof the second query is the same with the first one
- Switch to this branch and refresh the page and check the inspector panel again

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
