### PR TITLE
Alerting: Add additional contact points for external AM

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -5984,7 +5984,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/types/appEvent.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -5984,9 +5984,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/types/appEvent.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -464,6 +464,7 @@ const INTEGRATION_ICONS: Record<string, IconName> = {
   telegram: 'telegram-alt',
 };
 
+// @TODO make this work for cloud AMs too
 const ContactPointsHoverDetails: FC<ContactPointDetailsProps> = ({
   alertManagerSourceName,
   contactPoint,

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -115,6 +115,7 @@ const OptionInput: FC<Props & { id: string; pathIndex?: string }> = ({
           {...register(name, {
             required: determineRequired(option, getValues, pathIndex),
             validate: (v) => (option.validationRule !== '' ? validateOption(v, option.validationRule) : true),
+            setValueAs: option.setValueAs,
           })}
           placeholder={option.placeholder}
         />
@@ -127,6 +128,7 @@ const OptionInput: FC<Props & { id: string; pathIndex?: string }> = ({
             <Select
               disabled={readOnly}
               {...field}
+              defaultValue={option.defaultValue}
               options={option.selectOptions ?? undefined}
               invalid={invalid}
               onChange={(value) => onChange(value.value)}

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -387,7 +387,7 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
       }),
       option('chat_id', 'Chat ID', 'ID of the chat where to send the messages', {
         required: true,
-        setValueAs: (value) => parseInt(value, 10),
+        setValueAs: (value) => (typeof value === 'string' ? parseInt(value, 10) : 0),
       }),
       option('message', 'Message', 'Message template', {
         placeholder: '{{ template "webex.default.message" .}}',

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -1,4 +1,4 @@
-import { NotificationChannelOption, NotifierDTO } from 'app/types';
+import { CloudNotifierType, NotificationChannelOption, NotifierDTO } from 'app/types';
 
 function option(
   propertyName: string,
@@ -69,7 +69,7 @@ const httpConfigOption: NotificationChannelOption = option(
   }
 );
 
-export const cloudNotifierTypes: NotifierDTO[] = [
+export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
   {
     name: 'Email',
     description: 'Send notification over SMTP',
@@ -350,6 +350,162 @@ export const cloudNotifierTypes: NotifierDTO[] = [
       httpConfigOption,
     ],
   },
+  {
+    name: 'Cisco Webex Teams',
+    description: 'Sends notifications to Cisco Webex Teams',
+    type: 'webex',
+    info: '',
+    heading: 'Cisco Webex Teams settings',
+    options: [
+      option('api_url', 'API URL', 'The Webex Teams API URL', {
+        placeholder: 'https://webexapis.com/v1/messages',
+      }),
+      option('room_id', 'Room ID', 'ID of the Webex Teams room where to send the messages', {
+        required: true,
+      }),
+      option('message', 'Message', 'Message template', {
+        placeholder: '{{ template "webex.default.message" .}}',
+      }),
+      {
+        ...httpConfigOption,
+        required: true,
+      },
+    ],
+  },
+  {
+    name: 'Telegram',
+    description: 'Sends notifications to Telegram',
+    type: 'telegram',
+    info: '',
+    heading: 'Telegram settings',
+    options: [
+      option('api_url', 'API URL', 'The Telegram API URL', {
+        placeholder: 'https://api.telegram.org',
+      }),
+      option('bot_token', 'Bot token', 'Telegram bot token', {
+        required: true,
+      }),
+      option('chat_id', 'Chat ID', 'ID of the chat where to send the messages', {
+        required: true,
+        setValueAs: (value) => parseInt(value, 10),
+      }),
+      option('message', 'Message', 'Message template', {
+        placeholder: '{{ template "webex.default.message" .}}',
+      }),
+      option('disable_notifications', 'Disable notifications', 'Disable telegram notifications', {
+        element: 'checkbox',
+      }),
+      option('parse_mode', 'Parse mode', 'Parse mode for telegram message', {
+        element: 'select',
+        defaultValue: { label: 'MarkdownV2', value: 'MarkdownV2' },
+        selectOptions: [
+          { label: 'MarkdownV2', value: 'MarkdownV2' },
+          { label: 'Markdown', value: 'Markdown' },
+          { label: 'HTML', value: 'HTML' },
+          { label: 'plain text', value: '' },
+        ],
+      }),
+      httpConfigOption,
+    ],
+  },
+  {
+    name: 'Amazon SNS',
+    description: 'Sends notifications to Amazon SNS',
+    type: 'sns',
+    info: '',
+    heading: 'Amazon SNS settings',
+    options: [
+      option('api_url', 'API URL', 'The Amazon SNS API URL'),
+      option(
+        'sigv4',
+        'SigV4 authentication',
+        "Configures AWS's Signature Verification 4 signing process to sign requests",
+        {
+          element: 'subform',
+          subformOptions: [
+            option(
+              'region',
+              'Region',
+              'The AWS region. If blank, the region from the default credentials chain is used'
+            ),
+            option(
+              'access_key',
+              'Access key',
+              'The AWS API access_key. If blank the environment variable "AWS_ACCESS_KEY_ID" is used'
+            ),
+            option(
+              'secret_key',
+              'Secret key',
+              'The AWS API secret_key. If blank the environment variable "AWS_ACCESS_SECRET_ID" is used'
+            ),
+            option('profile', 'Profile', 'Named AWS profile used to authenticate'),
+            option('role_arn', 'Rule ARN', 'AWS Role ARN, an alternative to using AWS API keys'),
+          ],
+        }
+      ),
+      option(
+        'topic_arn',
+        'SNS topic ARN',
+        "If you don't specify this value, you must specify a value for the phone_number or target_arn. If you are using a FIFO SNS topic you should set a message group interval longer than 5 minutes to prevent messages with the same group key being deduplicated by the SNS default deduplication window"
+      ),
+      option(
+        'phone_number',
+        'Phone number',
+        "Phone number if message is delivered via SMS in E.164 format. If you don't specify this value, you must specify a value for the topic_arn or target_arn"
+      ),
+      option(
+        'target_arn',
+        'Target ARN',
+        "The  mobile platform endpoint ARN if message is delivered via mobile notifications. If you don't specify this value, you must specify a value for the topic_arn or phone_number"
+      ),
+
+      option('subject', 'Subject', 'Subject line when the message is delivered to email endpoints', {
+        placeholder: '{{ template "sns.default.subject" .}}',
+      }),
+      option('message', 'Message', 'The message content of the SNS notification', {
+        placeholder: '{{ template "sns.default.message" .}}',
+      }),
+      option('attributes', 'Attributes', 'SNS message attributes', {
+        element: 'key_value_map',
+      }),
+      httpConfigOption,
+    ],
+  },
+  {
+    name: 'WeChat',
+    description: 'Sends notifications to WeChat',
+    type: 'wechat',
+    info: '',
+    heading: 'WeChat settings',
+    options: [
+      option('api_url', 'API URL', 'The WeChat API URL'),
+      option('api_secret', 'API Secret', 'The API key to use when talking to the WeChat API'),
+      option('corp_id', 'Corp ID', 'The corp id for authentication'),
+      option('message', 'Message', 'API request data as defined by the WeChat API', {
+        placeholder: '{{ template "wechat.default.message" . }}',
+      }),
+      option('message_type', 'Message type', 'Type of the message type', {
+        element: 'select',
+        defaultValue: { label: 'Text', value: 'text' },
+        selectOptions: [
+          { label: 'Text', value: 'text' },
+          { label: 'Markdown', value: 'markdown' },
+        ],
+      }),
+      option('agent_id', 'Agent ID', '', {
+        placeholder: '{{ template "wechat.default.agent_id" . }}',
+      }),
+      option('to_user', 'to user', '', {
+        placeholder: '{{ template "wechat.default.to_user" . }}',
+      }),
+      option('to_party', 'to party', '', {
+        placeholder: '{{ template "wechat.default.to_party" . }}',
+      }),
+      option('to_tag', 'to tag', '', {
+        placeholder: '{{ template "wechat.default.to_tag" . }}',
+      }),
+    ],
+  },
 ];
 
 export const globalConfigOptions: NotificationChannelOption[] = [
@@ -392,6 +548,8 @@ export const globalConfigOptions: NotificationChannelOption[] = [
   option('wechat_api_url', 'WeChat API URL', '', { placeholder: 'https://qyapi.weixin.qq.com/cgi-bin/' }),
   option('wechat_api_secret', 'WeChat API secret', ''),
   option('wechat_api_corp_id', 'WeChat API corp id', ''),
+  option('webex_api_url', 'Cisco Webex Teams API URL', ''),
+  option('telegram_api_url', 'The Telegram API URL', ''),
   httpConfigOption,
   option(
     'resolve_timeout',

--- a/public/app/plugins/datasource/alertmanager/consts.ts
+++ b/public/app/plugins/datasource/alertmanager/consts.ts
@@ -6,4 +6,8 @@ export const receiverTypeNames: Record<string, string> = {
   webhook: 'Webhook',
   victorops: 'VictorOps',
   wechat: 'WeChat',
+  discord: 'Discord',
+  webex: 'Cisco Webex Teams',
+  sns: 'Amazon SNS',
+  telegram: 'Telegram',
 };

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -65,13 +65,17 @@ export type CloudNotifierType =
   | 'opsgenie'
   | 'victorops'
   | 'webhook'
-  | 'wechat';
+  | 'wechat'
+  | 'webex'
+  | 'telegram'
+  | 'sns'
+  | 'discord';
 
 export type NotifierType = GrafanaNotifierType | CloudNotifierType;
-export interface NotifierDTO {
+export interface NotifierDTO<T = NotifierType> {
   name: string;
   description: string;
-  type: NotifierType;
+  type: T;
   heading: string;
   options: NotificationChannelOption[];
   info?: string;
@@ -131,10 +135,13 @@ export interface NotificationChannelOption {
   required: boolean;
   secure: boolean;
   selectOptions?: Array<SelectableValue<string>> | null;
+  defaultValue?: SelectableValue<string>;
   showWhen: { field: string; is: string };
   validationRule: string;
   subformOptions?: NotificationChannelOption[];
   dependsOn: string;
+  // react-hook-forms made me do this, they literally have the same type definition and we really can't know what type we get from "element"
+  setValueAs?: (value: any) => any;
 }
 
 export interface NotificationChannelState {

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -140,8 +140,7 @@ export interface NotificationChannelOption {
   validationRule: string;
   subformOptions?: NotificationChannelOption[];
   dependsOn: string;
-  // react-hook-forms made me do this, they literally have the same type definition and we really can't know what type we get from "element"
-  setValueAs?: (value: any) => any;
+  setValueAs?: (value: string | boolean) => string | number | boolean | null;
 }
 
 export interface NotificationChannelState {


### PR DESCRIPTION
**What is this feature?**

Adds support for additional *external* AlertManager contact points (not for the built-in Grafana Alertmanager)

* WeChat
* Amazon SNS
* Telegram
* Cisco Webex Teams

Ref – if anyone is interested to use these with an external vanilla Alertmanager or Mimir this PR will allow you to do so.

https://github.com/grafana/grafana/pull/67920
https://github.com/grafana/grafana/issues/12333