### PR TITLE
Chore: Change dev sourcemaps to work around firefox warning

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -20,9 +20,9 @@ const esbuildOptions = {
   format: undefined,
 };
 
-module.exports = (env = {}) =>
-  merge(common, {
-    devtool: 'inline-source-map',
+module.exports = (env = {}) => {
+  return merge(common, {
+    devtool: 'eval-source-map',
     mode: 'development',
 
     entry: {
@@ -121,3 +121,4 @@ module.exports = (env = {}) =>
       }),
     ],
   });
+};


### PR DESCRIPTION
There's _some_ issue with source maps in Firefox. When Firefox attempts to reference a source map, we get this big ugly distracting warning (the yellow one)

<img width="770" alt="Screenshot 2023-05-05 at 4 33 34 pm" src="https://user-images.githubusercontent.com/46142/236502907-64a9d698-d01f-4e5a-a357-7f2b9c83b19e.png">

I'm not sure exactly what this means, and whether there's a more helpful error message that's getting truncated. What I do know is that the base64 blob is a sourcemap.

Changing the type of sourcemaps in dev seems to avoid the issue.  Here's what [webpack docs](https://webpack.js.org/configuration/devtool/) say about these two options:

 - `eval-source-map`
   - Each module is executed with eval() and a SourceMap is added as a DataUrl to the eval(). Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. It yields the best quality SourceMaps for development.
   - Recommended choice for development builds with high quality SourceMaps.
   - build: slowest
   - rebuild: ok
 - `inline-source-map`
   - A SourceMap is added as a DataUrl to the bundle. Not ideal for development nor production. They are needed for some special cases, i. e. for some 3rd party tools.
   - Possible choice when publishing a single file
   - build: slowest
   - rebuild: slowest

Build time comparison (initial build, not a `--watch` rebuild) (over 10 tests each using [hyperfine](https://github.com/sharkdp/hyperfine)):

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `eval-source-map` | 4.843 ± 0.069 | 4.749 | 4.976 | 1.00 |
| `inline-source-map` | 5.251 ± 0.091 | 5.077 | 5.395 | 1.08 ± 0.02 |

I don't have any stats for rebuild, as that's harder to automate benchmarking.
