### PR TITLE
Flamegraph: Fix tooltip positioning

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
@@ -161,8 +161,15 @@ const FlameGraph = ({
           );
 
           if (barIndex !== -1 && !isNaN(levelIndex) && !isNaN(barIndex)) {
-            tooltipRef.current.style.left = e.clientX + 10 + 'px';
             tooltipRef.current.style.top = e.clientY + 'px';
+            if (document.documentElement.clientWidth - e.clientX < 400) {
+              tooltipRef.current.style.right = document.documentElement.clientWidth - e.clientX + 15 + 'px';
+              tooltipRef.current.style.left = 'auto';
+            } else {
+              tooltipRef.current.style.left = e.clientX + 15 + 'px';
+              tooltipRef.current.style.right = 'auto';
+            }
+
             setTooltipItem(levels[levelIndex][barIndex]);
           }
         }

--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraphTooltip.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraphTooltip.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/css';
 import React, { LegacyRef } from 'react';
 
-import { useStyles2, Tooltip } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
 
 import { FlameGraphDataContainer, LevelItem } from './dataTransform';
 
@@ -19,26 +20,18 @@ const FlameGraphTooltip = ({ data, tooltipRef, item, totalTicks }: Props) => {
   if (item) {
     const tooltipData = getTooltipData(data, item, totalTicks);
     content = (
-      <Tooltip
-        content={
-          <div>
-            <p>{data.getLabel(item.itemIndex)}</p>
-            <p className={styles.lastParagraph}>
-              {tooltipData.unitTitle}
-              <br />
-              Total: <b>{tooltipData.unitValue}</b> ({tooltipData.percentValue}%)
-              <br />
-              Self: <b>{tooltipData.unitSelf}</b> ({tooltipData.percentSelf}%)
-              <br />
-              Samples: <b>{tooltipData.samples}</b>
-            </p>
-          </div>
-        }
-        placement={'right'}
-        show={true}
-      >
-        <span></span>
-      </Tooltip>
+      <div className={styles.tooltipContent}>
+        <p>{data.getLabel(item.itemIndex)}</p>
+        <p className={styles.lastParagraph}>
+          {tooltipData.unitTitle}
+          <br />
+          Total: <b>{tooltipData.unitValue}</b> ({tooltipData.percentValue}%)
+          <br />
+          Self: <b>{tooltipData.unitSelf}</b> ({tooltipData.percentSelf}%)
+          <br />
+          Samples: <b>{tooltipData.samples}</b>
+        </p>
+      </div>
     );
   }
 
@@ -93,14 +86,31 @@ export const getTooltipData = (data: FlameGraphDataContainer, item: LevelItem, t
   };
 };
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   tooltip: css`
+    title: tooltip;
     position: fixed;
   `,
+  tooltipContent: css`
+    title: tooltipContent;
+    background-color: ${theme.components.tooltip.background};
+    border-radius: ${theme.shape.radius.default};
+    border: 1px solid ${theme.components.tooltip.background};
+    box-shadow: ${theme.shadows.z2};
+    color: ${theme.components.tooltip.text};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    padding: ${theme.spacing(0.5, 1)};
+    transition: opacity 0.3s;
+    z-index: ${theme.zIndex.tooltip};
+    max-width: 400px;
+    overflow-wrap: break-word;
+  `,
   lastParagraph: css`
+    title: lastParagraph;
     margin-bottom: 0;
   `,
   name: css`
+    title: name;
     margin-bottom: 10px;
   `,
 });


### PR DESCRIPTION
Tooltip that is shown when hovering over flamegraph nodes had the wrong position. This was broken by https://github.com/grafana/grafana/pull/64428 but mainly because the positioning relied on double rendering of the component so the actual repositioning was done on remount. The Tooltip component itself isn't working in a way that would allow it to track moving trigger element.

This rewrites this to use a simple fixed-positioned div with the same styling as the tooltip.