### PR TITLE
Alerting: Show export button for org admins

### DIFF
--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -1,4 +1,5 @@
 import { contextSrv } from 'app/core/services/context_srv';
+import { isOrgAdmin } from 'app/features/plugins/admin/permissions';
 import { AccessControlAction } from 'app/types';
 
 import { GRAFANA_RULES_SOURCE_NAME, isGrafanaRulesSource } from './datasource';
@@ -123,6 +124,6 @@ export function getRulesAccess() {
         rulesSourceName === GRAFANA_RULES_SOURCE_NAME ? contextSrv.hasEditPermissionInFolders : contextSrv.isEditor;
       return contextSrv.hasAccess(getRulesPermissions(rulesSourceName).update, permissionFallback);
     },
-    canReadProvisioning: contextSrv.hasAccess(provisioningPermissions.read, contextSrv.isGrafanaAdmin),
+    canReadProvisioning: contextSrv.hasAccess(provisioningPermissions.read, isOrgAdmin()),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where the Export button was not shown to org admins.

**Why do we need this feature?**

Org admins should be able to use this functionality. 

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/66052
