### PR TITLE
NavBar: app chrome state wrongly overwritten when ds modal is opened

### DIFF
--- a/packages/grafana-ui/src/components/Modal/ModalsContext.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalsContext.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-interface ModalsContextState {
+export interface ModalsContextState {
   component: React.ComponentType<any> | null;
   props: any;
   showModal: <T>(component: React.ComponentType<T>, props: T) => void;

--- a/public/app/features/admin/UserListPublicDashboardPage/DashboardsListModalButton.tsx
+++ b/public/app/features/admin/UserListPublicDashboardPage/DashboardsListModalButton.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data/src';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { Button, LoadingPlaceholder, Modal, ModalsController, useStyles2 } from '@grafana/ui/src';
-import { generatePublicDashboardUrl } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
+import {
+  generatePublicDashboardConfigUrl,
+  generatePublicDashboardUrl,
+} from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
 
 import { useGetActiveUserDashboardsQuery } from '../../dashboard/api/publicDashboardApi';
 
@@ -37,7 +40,7 @@ export const DashboardsListModal = ({ email, onDismiss }: { email: string; onDis
               <span className={styles.urlsDivider}>•</span>
               <a
                 className={cx('external-link', styles.url)}
-                href={`/d/${dash.dashboardUid}?shareView=share`}
+                href={generatePublicDashboardConfigUrl(dash.dashboardUid)}
                 onClick={onDismiss}
               >
                 Public dashboard settings

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { FC, ReactNode, useContext, useEffect } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
@@ -13,7 +13,6 @@ import {
   useForceUpdate,
   Tag,
   ToolbarButtonRow,
-  ModalsContext,
   ConfirmModal,
 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
@@ -26,7 +25,6 @@ import { t, Trans } from 'app/core/internationalization';
 import { setStarred } from 'app/core/reducers/navBarTree';
 import { AddPanelButton } from 'app/features/dashboard/components/AddPanelButton/AddPanelButton';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
-import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
@@ -36,6 +34,7 @@ import { DashboardMetaChangedEvent, ShowModalReactEvent } from 'app/types/events
 
 import { DashNavButton } from './DashNavButton';
 import { DashNavTimeControls } from './DashNavTimeControls';
+import { ShareButton } from './ShareButton';
 
 const mapDispatchToProps = {
   setStarred,
@@ -53,7 +52,6 @@ export interface OwnProps {
   hideTimePicker: boolean;
   folderTitle?: string;
   title: string;
-  shareModalActiveTab?: string;
   onAddPanel: () => void;
 }
 
@@ -80,7 +78,6 @@ export const DashNav = React.memo<Props>((props) => {
   // this ensures the component rerenders when the location changes
   useLocation();
   const forceUpdate = useForceUpdate();
-  const { showModal, hideModal } = useContext(ModalsContext);
 
   // We don't really care about the event payload here only that it triggeres a re-render of this component
   useBusEvent(props.dashboard.events, DashboardMetaChangedEvent);
@@ -165,23 +162,6 @@ export const DashNav = React.memo<Props>((props) => {
   };
 
   // Open/Close
-  useEffect(() => {
-    const dashboard = props.dashboard;
-    const shareModalActiveTab = props.shareModalActiveTab;
-    const { canShare } = dashboard.meta;
-
-    if (canShare && shareModalActiveTab) {
-      // automagically open modal
-      showModal(ShareModal, {
-        dashboard,
-        onDismiss: hideModal,
-        activeTab: shareModalActiveTab,
-      });
-    }
-    return () => {
-      hideModal();
-    };
-  }, [showModal, hideModal, props.dashboard, props.shareModalActiveTab]);
 
   const renderLeftActions = () => {
     const { dashboard, kioskMode } = props;
@@ -209,23 +189,7 @@ export const DashNav = React.memo<Props>((props) => {
     }
 
     if (canShare) {
-      buttons.push(
-        <ModalsController key="button-share">
-          {({ showModal, hideModal }) => (
-            <DashNavButton
-              tooltip={t('dashboard.toolbar.share', 'Share dashboard or panel')}
-              icon="share-alt"
-              iconSize="lg"
-              onClick={() => {
-                showModal(ShareModal, {
-                  dashboard,
-                  onDismiss: hideModal,
-                });
-              }}
-            />
-          )}
-        </ModalsController>
-      );
+      buttons.push(<ShareButton key="button-share" dashboard={dashboard} />);
     }
 
     if (dashboard.meta.publicDashboardEnabled) {

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -161,8 +161,6 @@ export const DashNav = React.memo<Props>((props) => {
     return playlistSrv.isPlaying;
   };
 
-  // Open/Close
-
   const renderLeftActions = () => {
     const { dashboard, kioskMode } = props;
     const { canStar, canShare, isStarred } = dashboard.meta;

--- a/public/app/features/dashboard/components/DashNav/ShareButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/ShareButton.tsx
@@ -1,0 +1,42 @@
+import React, { useContext, useEffect } from 'react';
+
+import { ModalsContext } from '@grafana/ui';
+import { useQueryParams } from 'app/core/hooks/useQueryParams';
+import { t } from 'app/core/internationalization';
+import { DashboardModel } from 'app/features/dashboard/state';
+
+import { ShareModal } from '../ShareModal';
+
+import { DashNavButton } from './DashNavButton';
+
+export const ShareButton = ({ dashboard }: { dashboard: DashboardModel }) => {
+  const [queryParams] = useQueryParams();
+  const { showModal, hideModal } = useContext(ModalsContext);
+
+  useEffect(() => {
+    if (!!queryParams.shareView) {
+      showModal(ShareModal, {
+        dashboard,
+        onDismiss: hideModal,
+        activeTab: String(queryParams.shareView),
+      });
+    }
+    return () => {
+      hideModal();
+    };
+  }, [showModal, hideModal, dashboard, queryParams.shareView]);
+
+  return (
+    <DashNavButton
+      tooltip={t('dashboard.toolbar.share', 'Share dashboard or panel')}
+      icon="share-alt"
+      iconSize="lg"
+      onClick={() => {
+        showModal(ShareModal, {
+          dashboard,
+          onDismiss: hideModal,
+        });
+      }}
+    />
+  );
+};

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -52,7 +52,7 @@ function getTabs(panel?: PanelModel, activeTab?: string) {
   }
 
   if (Boolean(config.featureToggles['publicDashboards'])) {
-    tabs.push({ label: 'Public dashboard', value: 'share-public-dashboard', component: SharePublicDashboard });
+    tabs.push({ label: 'Public dashboard', value: 'public-dashboard', component: SharePublicDashboard });
   }
 
   const at = tabs.find((t) => t.value === activeTab);

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { reportInteraction } from '@grafana/runtime/src';
-import { Modal, ModalTabsHeader, TabContent } from '@grafana/ui';
+import { locationService, reportInteraction } from '@grafana/runtime/src';
+import { Modal, ModalsContext, ModalTabsHeader, TabContent } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/core';
 import { t } from 'app/core/internationalization';
@@ -52,7 +52,7 @@ function getTabs(panel?: PanelModel, activeTab?: string) {
   }
 
   if (Boolean(config.featureToggles['publicDashboards'])) {
-    tabs.push({ label: 'Public dashboard', value: 'share', component: SharePublicDashboard });
+    tabs.push({ label: 'Public dashboard', value: 'share-public-dashboard', component: SharePublicDashboard });
   }
 
   const at = tabs.find((t) => t.value === activeTab);
@@ -86,6 +86,8 @@ function getInitialState(props: Props): State {
 }
 
 export class ShareModal extends React.Component<Props, State> {
+  static contextType = ModalsContext;
+
   constructor(props: Props) {
     super(props);
     this.state = getInitialState(props);
@@ -93,6 +95,10 @@ export class ShareModal extends React.Component<Props, State> {
 
   componentDidMount() {
     reportInteraction('grafana_dashboards_share_modal_viewed');
+  }
+
+  componentWillUnmount() {
+    locationService.partial({ shareView: null });
   }
 
   onSelectTab: React.ComponentProps<typeof ModalTabsHeader>['onChangeTab'] = (t) => {

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { locationService, reportInteraction } from '@grafana/runtime/src';
-import { Modal, ModalsContext, ModalTabsHeader, TabContent } from '@grafana/ui';
+import { Modal, ModalTabsHeader, TabContent } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/core';
 import { t } from 'app/core/internationalization';
@@ -86,8 +86,6 @@ function getInitialState(props: Props): State {
 }
 
 export class ShareModal extends React.Component<Props, State> {
-  static contextType = ModalsContext;
-
   constructor(props: Props) {
     super(props);
     this.state = getInitialState(props);

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
@@ -77,7 +77,7 @@ export const generatePublicDashboardUrl = (accessToken: string): string => {
 };
 
 export const generatePublicDashboardConfigUrl = (dashboardUid: string): string => {
-  return `/d/${dashboardUid}?shareView=share-public-dashboard`;
+  return `/d/${dashboardUid}?shareView=public-dashboard`;
 };
 
 export const validEmailRegex = /^[A-Z\d._%+-]+@[A-Z\d.-]+\.[A-Z]{2,}$/i;

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
@@ -76,4 +76,8 @@ export const generatePublicDashboardUrl = (accessToken: string): string => {
   return `${getConfig().appUrl}public-dashboards/${accessToken}`;
 };
 
+export const generatePublicDashboardConfigUrl = (dashboardUid: string): string => {
+  return `/d/${dashboardUid}?shareView=share-public-dashboard`;
+};
+
 export const validEmailRegex = /^[A-Z\d._%+-]+@[A-Z\d.-]+\.[A-Z]{2,}$/i;

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -64,7 +64,6 @@ export type DashboardPageRouteSearchParams = {
   editPanel?: string;
   viewPanel?: string;
   editview?: string;
-  shareView?: string;
   panelType?: string;
   inspect?: string;
   from?: string;
@@ -454,7 +453,6 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
                 onAddPanel={this.onAddPanel}
                 kioskMode={kioskMode}
                 hideTimePicker={dashboard.timepicker.hidden}
-                shareModalActiveTab={this.props.queryParams.shareView}
               />
             </header>
           )}

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -155,6 +155,7 @@ export function DataSourceModal({
                 item: INTERACTION_ITEM.CONFIG_NEW_DS,
                 src: analyticsInteractionSrc,
               });
+              onDismiss();
             }}
           />
         </div>

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.tsx
@@ -8,7 +8,10 @@ import { Link, ButtonGroup, LinkButton, Icon, Tag, useStyles2, Tooltip, useTheme
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useListPublicDashboardsQuery } from 'app/features/dashboard/api/publicDashboardApi';
-import { generatePublicDashboardUrl } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
+import {
+  generatePublicDashboardConfigUrl,
+  generatePublicDashboardUrl,
+} from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
 import { isOrgAdmin } from 'app/features/plugins/admin/permissions';
 import { AccessControlAction } from 'app/types';
 
@@ -82,7 +85,7 @@ export const PublicDashboardListTable = () => {
                     <LinkButton
                       fill="text"
                       size={responsiveSize}
-                      href={`/d/${pd.dashboardUid}?shareView=share`}
+                      href={generatePublicDashboardConfigUrl(pd.dashboardUid)}
                       title="Configure public dashboard"
                       disabled={isOrphaned}
                       data-testid={selectors.ListItem.configButton}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The DashNav was using the ModalsContext. That's because from the public dashboard list table (/dashboard/public), there's a button that redirects the user to the specific public dashboard configuration (which is a modal).
Since the ds picker updates that context, the DashNav component was being rerendered and, therefore, updating the toolbar buttons.  

**Why do we need this feature?**

The toolbar was showing the dashboard buttons instead of the panel edit buttons

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#67805](https://github.com/grafana/grafana/issues/67805)

**Special notes for your reviewer:**

- I modified where the ModalsContext is used. I think it's responsibility of the ShareButton to open or not the ShareModal component. With this, an update on the ModalsContext doesn't rerender the DashNav.
- I created a function to get the public dashboard configuration url


https://user-images.githubusercontent.com/11707172/236598307-53739eb0-4c08-409a-b8ca-df846b917cd3.mov



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
