### PR TITLE
Fix Enterprise Datasources link on Grafana Enterprise page

### DIFF
--- a/docs/sources/introduction/grafana-enterprise.md
+++ b/docs/sources/introduction/grafana-enterprise.md
@@ -13,7 +13,7 @@ weight: 200
 
 Grafana Enterprise is a commercial edition of Grafana that includes additional features not found in the open source version.
 
-Building on everything you already know and love about Grafana open source, Grafana Enterprise includes [exclusive datasource plugins]({{< relref "#enterprise-plugins">}}) and [additional features]({{< relref "#enterprise-features">}}). You also get 24x7x365 support and training from the core Grafana team.
+Building on everything you already know and love about Grafana open source, Grafana Enterprise includes [exclusive datasource plugins]({{< relref "#enterprise-data-sources">}}) and [additional features]({{< relref "#enterprise-features">}}). You also get 24x7x365 support and training from the core Grafana team.
 
 To learn more about Grafana Enterprise, refer to [our product page](https://grafana.com/enterprise).
 


### PR DESCRIPTION
Fixed broken link on this page https://grafana.com/docs/grafana/latest/introduction/grafana-enterprise/.
The actual title is `Enterprise data sources`.