### PR TITLE
XYChart: Add time support to x axis

### DIFF
--- a/public/app/plugins/panel/xychart/XYChartPanel2.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel2.tsx
@@ -88,9 +88,11 @@ export const XYChartPanel2 = (props: Props) => {
   }, [props.data.series, error, series]);
 
   useEffect(() => {
-    if (oldOptions !== props.options || oldData?.structureRev !== props.data.structureRev) {
+    if (oldOptions !== props.options) {
       initSeries();
-    } else if (oldData !== props.data) {
+    }
+    if (oldOptions !== undefined && oldData !== props.data) {
+      initSeries();
       initFacets();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/plugins/panel/xychart/XYChartPanel2.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel2.tsx
@@ -91,7 +91,7 @@ export const XYChartPanel2 = (props: Props) => {
     if (oldOptions !== props.options) {
       initSeries();
     }
-    if (oldOptions !== undefined && oldData !== props.data) {
+    if (oldOptions !== undefined && oldData?.series !== props.data.series) {
       initSeries();
       initFacets();
     }

--- a/public/app/plugins/panel/xychart/dims.ts
+++ b/public/app/plugins/panel/xychart/dims.ts
@@ -21,7 +21,7 @@ export interface XYDimensions {
 }
 
 export function isGraphable(field: Field) {
-  return field.type === FieldType.number;
+  return field.type === FieldType.number || field.type === FieldType.time;
 }
 
 export function getXYDimensions(cfg?: XYDimensionConfig, data?: DataFrame[]): XYDimensions {
@@ -70,7 +70,6 @@ export function getXYDimensions(cfg?: XYDimensionConfig, data?: DataFrame[]): XY
     }
     fields.push(f);
   }
-
   return {
     x,
     fields: {

--- a/public/app/plugins/panel/xychart/dims.ts
+++ b/public/app/plugins/panel/xychart/dims.ts
@@ -70,6 +70,7 @@ export function getXYDimensions(cfg?: XYDimensionConfig, data?: DataFrame[]): XY
     }
     fields.push(f);
   }
+
   return {
     x,
     fields: {

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -591,14 +591,14 @@ const prepConfig = (
 
   const frames = getData();
   let xField = scatterSeries[0].x(scatterSeries[0].frame(frames));
-
+  // TODO isTime should be optionally set.
   builder.addScale({
     scaleKey: 'x',
-    isTime: false,
+    isTime: true,
     orientation: ScaleOrientation.Horizontal,
     direction: ScaleDirection.Right,
-    min: xField.config.min,
-    max: xField.config.max,
+    min: Math.min(...xField.values),
+    max: Math.max(...xField.values),
   });
 
   // why does this fall back to '' instead of null or undef?
@@ -655,7 +655,7 @@ const prepConfig = (
       facets: [
         {
           scale: 'x',
-          auto: true,
+          // auto: true,
         },
         {
           scale: scaleKey,
@@ -720,6 +720,8 @@ export function prepData(info: ScatterPanelInfo, data: DataFrame[], from?: numbe
         colorValues = Array(frame.length).fill(r);
         colorAlphaValues = Array(frame.length).fill(alpha(r as string, 0.5));
       }
+      console.log('in prep data', info);
+
       return [
         s.x(frame).values, // X
         s.y(frame).values, // Y


### PR DESCRIPTION
**What is this feature?**

The XYChart only supports "numeric" x-axis data, excl time axes. This feature makes the following changes:

1. X-axis of type time are rendered correctly
2. ... and auto-detected when constructing the panel
3. The axes range is updated when data is re-queried and min/max values have changed.

**Why do we need this feature?**

The XYChart can't render time x-axes correctly because `isTime` is hard-coded to `false`. You can manually set the x-axis to a time column, but this results in the following:
![image](https://user-images.githubusercontent.com/10717566/236674948-15c267b0-4d00-4a17-8610-662276c2915a.png)

This cannot be fixed with field overrides, so this panel cannot be used with time x axis.

**Who is this feature for?**

Users of basic XY Chart, for example when migrating users of the Jaeger UI over to Grafana. This is a blocker for many people as seeing a summary of many traces against time is a common workflow.
![image](https://user-images.githubusercontent.com/10717566/236675129-5e1c499a-d820-4aef-82c6-2530a1a5ea9e.png)

**Which issue(s) does this PR fix?**:
None currently filed.


**Testing**
I'm not sure how/whether this panel is automatically tested, so I did the following:
1. Use the TestData datasource with the random walk data, see before and after.
![image](https://user-images.githubusercontent.com/10717566/236674948-15c267b0-4d00-4a17-8610-662276c2915a.png)
![image](https://user-images.githubusercontent.com/10717566/236675424-dac38025-e403-4f38-9b20-703f0972a665.png)

2. Ensured that existing non-time-based panels continue to render correctly: 
![image](https://user-images.githubusercontent.com/10717566/236675397-218c2303-4c86-43b2-a794-80fd1d604030.png)

3. Trigger data reload and different frequencies, which flagged the fact that axes aren't updated correctly
4. Manually ensure that time-based x-axes are correctly picked up the AutoEditor when constructing the panel: 
![image](https://user-images.githubusercontent.com/10717566/236675569-c65c33ec-0681-4282-b696-8d99c08b85e3.png)


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
