### PR TITLE
Alerting: Make two boxes in template form adaptative to the screen 

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { default as React, useState } from 'react';
 import { Provider } from 'react-redux';
+import { AutoSizerProps } from 'react-virtualized-auto-sizer';
 
 import { configureStore } from 'app/store/configureStore';
 
@@ -27,6 +28,10 @@ jest.mock('@grafana/ui', () => ({
     return <input data-testid="mockeditor" value={value} onChange={(e) => onBlur(e.currentTarget.value)} />;
   },
 }));
+
+jest.mock('react-virtualized-auto-sizer', () => {
+  return ({ children }: AutoSizerProps) => children({ height: 1, width: 1 });
+});
 
 const PayloadEditorWithState = () => {
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Badge, Button, CodeEditor, Icon, Tooltip, useStyles2 } from '@grafana/ui';
@@ -86,17 +87,22 @@ export function PayloadEditor({
             <Icon name="info-circle" className={styles.tooltip} size="xl" />
           </Tooltip>
         </div>
-
-        <CodeEditor
-          width={640}
-          height={363}
-          language={'json'}
-          showLineNumbers={true}
-          showMiniMap={false}
-          value={payload}
-          readOnly={false}
-          onBlur={setPayload}
-        />
+        <AutoSizer disableHeight>
+          {({ width }) => (
+            <div className={styles.editorWrapper}>
+              <CodeEditor
+                width={width}
+                height={362}
+                language={'json'}
+                showLineNumbers={true}
+                showMiniMap={false}
+                value={payload}
+                readOnly={false}
+                onBlur={setPayload}
+              />
+            </div>
+          )}
+        </AutoSizer>
 
         <div className={styles.buttonsWrapper}>
           <Button
@@ -159,27 +165,38 @@ const AlertTemplateDataTable = () => {
 };
 const getStyles = (theme: GrafanaTheme2) => ({
   jsonEditor: css`
-    width: 605px;
-    height: 363px;
+    width: 100%;
+    height: 100%;
   `,
   buttonsWrapper: css`
     margin-top: ${theme.spacing(1)};
     display: flex;
+    flex-wrap: wrap;
   `,
   button: css`
     flex: none;
     width: fit-content;
     padding-right: ${theme.spacing(1)};
     margin-right: ${theme.spacing(1)};
+    margin-bottom: ${theme.spacing(1)};
   `,
   title: css`
     font-weight: ${theme.typography.fontWeightBold};
+    heigth: 41px;
+    padding-top: 10px;
+    padding-left: ${theme.spacing(2)};
+    margin-top: 19px;
   `,
   wrapper: css`
-    padding-top: 38px;
+    flex: 1;
+    min-width: 450px;
   `,
   tooltip: css`
     padding-left: ${theme.spacing(1)};
+  `,
+  editorWrapper: css`
+    width: min-content;
+    padding-top: 7px;
   `,
   editor: css`
     display: flex;

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -45,6 +45,7 @@ describe('TemplatePreview component', () => {
   it('Should render error if payload has wrong format', async () => {
     render(
       <TemplatePreview
+        width={50}
         payload={'bla bla bla'}
         templateName="potato"
         payloadFormatError={'Unexpected token b in JSON at position 0'}
@@ -61,6 +62,7 @@ describe('TemplatePreview component', () => {
     const setError = jest.fn();
     render(
       <TemplatePreview
+        width={50}
         payload={'{"a":"b"}'}
         templateName="potato"
         payloadFormatError={'Unexpected token b in JSON at position 0'}
@@ -76,6 +78,7 @@ describe('TemplatePreview component', () => {
   it('Should render error if payload has wrong format rendering the preview', async () => {
     render(
       <TemplatePreview
+        width={50}
         payload={'potatos and cherries'}
         templateName="potato"
         payloadFormatError={'Unexpected token b in JSON at position 0'}
@@ -95,6 +98,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponseRejected(server);
     render(
       <TemplatePreview
+        width={50}
         payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}
@@ -118,6 +122,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponse(server, response);
     render(
       <TemplatePreview
+        width={50}
         payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}
@@ -143,6 +148,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponse(server, response);
     render(
       <TemplatePreview
+        width={50}
         payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}


### PR DESCRIPTION
**What is this feature?**

This PR makes two editors in template form to be aligned on the same line when possible (fixed a minimum width of 450px so the editors don't become too tight).

**Why do we need this feature?**

Having two editors at the same line it's better for the user as it can compare information easily.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67574

**Special notes for your reviewer:**

**Before:**

[before1.webm](https://user-images.githubusercontent.com/33540275/236763498-ece597b3-253c-4ceb-bdf1-802ee1874691.webm)

**After:** 

[after5.webm](https://user-images.githubusercontent.com/33540275/236778699-ad96c82e-e809-4446-83c8-5a68e40e5c36.webm)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
