### PR TITLE
EchoSrv: Capture early events

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -799,7 +799,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"]
     ],
     "packages/grafana-runtime/src/services/LocationService.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -799,8 +799,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "packages/grafana-runtime/src/services/LocationService.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-runtime/src/services/EchoSrv.ts
+++ b/packages/grafana-runtime/src/services/EchoSrv.ts
@@ -122,14 +122,14 @@ let singletonInstance: EchoSrv;
  * @internal
  */
 export function setEchoSrv(instance: EchoSrv) {
-  singletonInstance = instance;
-
   // Check if there were any events reported to the FakeEchoSrv (before the main EchoSrv was initialized and track them)
-  if (instance.events) {
-    for (const event of instance.events) {
+  if (singletonInstance && singletonInstance.events) {
+    for (const event of singletonInstance.events) {
       instance.addEvent(event as Omit<EchoEvent, 'meta'>);
     }
   }
+
+  singletonInstance = instance;
 }
 
 /**

--- a/packages/grafana-runtime/src/services/EchoSrv.ts
+++ b/packages/grafana-runtime/src/services/EchoSrv.ts
@@ -122,7 +122,7 @@ let singletonInstance: EchoSrv;
  * @internal
  */
 export function setEchoSrv(instance: EchoSrv) {
-  // Check if there were any events reported to the FakeEchoSrv (before the main EchoSrv was initialized and track them)
+  // Check if there were any events reported to the FakeEchoSrv (before the main EchoSrv was initialized), and track them
   if (singletonInstance && singletonInstance.events) {
     for (const event of singletonInstance.events) {
       instance.addEvent(event as Omit<EchoEvent, 'meta'>);


### PR DESCRIPTION
### What does this PR do?

Captures events that were sent (probably accidentally) before the core `EchoSrv` got initialised, so it doesn't matter anymore if a service gets accidentally initialised before the EchoSrv (less error prone).