### PR TITLE
Grafana UI: Add loading state to TextArea component

### DIFF
--- a/packages/grafana-ui/src/components/TextArea/TextArea.tsx
+++ b/packages/grafana-ui/src/components/TextArea/TextArea.tsx
@@ -9,14 +9,18 @@ import { getFocusStyle, sharedInputStyle } from '../Forms/commonStyles';
 export interface Props extends Omit<HTMLProps<HTMLTextAreaElement>, 'size'> {
   /** Show an invalid state around the input */
   invalid?: boolean;
+  //** Manage the loading state */
+  loading?: boolean;
 }
 
-export const TextArea = React.forwardRef<HTMLTextAreaElement, Props>(({ invalid, className, ...props }, ref) => {
-  const theme = useTheme2();
-  const styles = getTextAreaStyle(theme, invalid);
+export const TextArea = React.forwardRef<HTMLTextAreaElement, Props>(
+  ({ invalid, loading, className, ...props }, ref) => {
+    const theme = useTheme2();
+    const styles = getTextAreaStyle(theme, invalid);
 
-  return <textarea {...props} className={cx(styles.textarea, className)} ref={ref} />;
-});
+    return <textarea {...props} className={cx(styles.textarea, className)} ref={ref} />;
+  }
+);
 
 const getTextAreaStyle = stylesFactory((theme: GrafanaTheme2, invalid = false) => {
   return {


### PR DESCRIPTION
**What is this feature?**

To add the `loading` prop to the `TextArea` component in order to be able to manage it.

**Why do we need this feature?**

To be able to manage the `loading` state of the `TextArea` component.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

Fixes #67986 

**Special notes for your reviewer:**
This PR adds the possibility to manage the `loading` state showing, for example, a spinner, but does not add this behaviour.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
