### PR TITLE
Fix documentation error regarding required JWT claim 'sub'

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -36,7 +36,9 @@ header_name = X-JWT-Assertion
 
 ## Configure login claim
 
-To identify the user, some of the claims needs to be selected as a login info. The subject claim called `"sub"` is mandatory and needs to specify a claim that contains either a username or an email of the Grafana user.
+To identify the user, some of the claims needs to be selected as a login info. The subject claim called `"sub"` is mandatory and needs to identify the principal that is the subject of the JWT. 
+
+Typically, the subject claim called `"sub"` would be used as a login but it might also be set to some application specific claim.
 
 ```ini
 # [auth.jwt]

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -36,9 +36,7 @@ header_name = X-JWT-Assertion
 
 ## Configure login claim
 
-To identify the user, some of the claims needs to be selected as a login info. You could specify a claim that contains either a username or an email of the Grafana user.
-
-Typically, the subject claim called `"sub"` would be used as a login but it might also be set to some application specific claim.
+To identify the user, some of the claims needs to be selected as a login info. The subject claim called `"sub"` is mandatory and needs to specify a claim that contains either a username or an email of the Grafana user.
 
 ```ini
 # [auth.jwt]


### PR DESCRIPTION
This pull request fixes an error in the documentation regarding the required claim for JWT authentication. Currently, the documentation states that the 'sub' claim is optional, but in reality, it is required in order to use JWT authentication properly.

After reviewing the code, it became clear that the 'sub' claim was being used in several places to identify the user and authorize access to protected resources. Without this claim, the authentication process would fail, and users would be denied access to the system.

![image](https://user-images.githubusercontent.com/104002657/236830196-78db6ad1-2c62-4e72-8e6e-60c8877419eb.png)


To ensure that users can properly authenticate using JWT, this pull request updates the documentation to reflect the true requirement for the 'sub' claim. Specifically, the documentation now states that this claim is required in order to use JWT authentication properly.

By making this change, we can ensure that users have the correct information and can successfully authenticate using JWT.
