### PR TITLE
QueryRow: Make toggle actions screen-readers accessible

### DIFF
--- a/e2e/panels-suite/panelEdit_queries.spec.ts
+++ b/e2e/panels-suite/panelEdit_queries.spec.ts
@@ -65,7 +65,7 @@ e2e.scenario({
     });
 
     // Disable row with refId A
-    e2e.components.QueryEditorRow.actionButton('Disable/enable query').eq(1).should('be.visible').click();
+    e2e.components.QueryEditorRow.actionButton('Disable query').eq(1).should('be.visible').click();
 
     expectInspectorResultAndClose((keys) => {
       const length = keys.length;
@@ -73,7 +73,7 @@ e2e.scenario({
     });
 
     // Enable row with refId B
-    e2e.components.QueryEditorRow.actionButton('Disable/enable query').eq(1).should('be.visible').click();
+    e2e.components.QueryEditorRow.actionButton('Disable query').eq(1).should('be.visible').click();
 
     expectInspectorResultAndClose((keys) => {
       const length = keys.length;

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -193,7 +193,7 @@ export const Components = {
     rows: 'Query editor row',
   },
   QueryEditorRow: {
-    actionButton: (title: string) => `${title} query operation action`,
+    actionButton: (title: string) => `${title}`,
     title: (refId: string) => `Query editor row title ${refId}`,
     container: (refId: string) => `Query editor row ${refId}`,
   },

--- a/public/app/core/components/QueryOperationRow/QueryOperationAction.test.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationAction.test.tsx
@@ -1,24 +1,24 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 
-import { QueryOperationAction, QueryOperationActionProps } from './QueryOperationAction';
-
-const setup = (propOverrides?: Partial<QueryOperationActionProps>) => {
-  const props: QueryOperationActionProps = {
-    icon: 'panel-add',
-    title: 'test',
-    onClick: jest.fn(),
-    disabled: false,
-    ...propOverrides,
-  };
-
-  render(<QueryOperationAction {...props} />);
-};
+import { QueryOperationAction, QueryOperationToggleAction } from './QueryOperationAction';
 
 describe('QueryOperationAction tests', () => {
+  function setup(propOverrides?: Partial<ComponentPropsWithoutRef<typeof QueryOperationAction>>) {
+    const props: ComponentPropsWithoutRef<typeof QueryOperationAction> = {
+      icon: 'panel-add',
+      title: 'test',
+      onClick: jest.fn(),
+      disabled: false,
+      ...propOverrides,
+    };
+
+    render(<QueryOperationAction {...props} />);
+  }
+
   it('should render component', () => {
     setup();
 
@@ -49,5 +49,38 @@ describe('QueryOperationAction tests', () => {
     await userEvent.click(queryButton);
 
     expect(clickSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('QueryOperationToggleAction', () => {
+  function setup(active: boolean) {
+    const props: ComponentPropsWithoutRef<typeof QueryOperationToggleAction> = {
+      icon: 'panel-add',
+      title: 'test',
+      onClick: () => {},
+      active,
+    };
+
+    return render(<QueryOperationToggleAction {...props} />);
+  }
+
+  it('should correctly set pressed state', () => {
+    setup(false);
+
+    expect(
+      screen.getByRole('button', {
+        name: selectors.components.QueryEditorRow.actionButton('test'),
+        pressed: false,
+      })
+    ).toBeInTheDocument();
+
+    setup(true);
+
+    expect(
+      screen.getByRole('button', {
+        name: selectors.components.QueryEditorRow.actionButton('test'),
+        pressed: true,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
@@ -5,33 +5,43 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { IconButton, IconName, useStyles2 } from '@grafana/ui';
 
-export interface QueryOperationActionProps {
+interface BaseQueryOperationActionProps {
   icon: IconName;
   title: string;
   onClick: (e: React.MouseEvent) => void;
   disabled?: boolean;
-  active?: boolean;
 }
 
-export const QueryOperationAction = ({ icon, active, disabled, title, onClick }: QueryOperationActionProps) => {
+function BaseQueryOperationAction(props: QueryOperationActionProps | QueryOperationToggleActionProps) {
   const styles = useStyles2(getStyles);
 
   return (
-    <div className={cx(styles.icon, active && styles.active)}>
+    <div className={cx(styles.icon, 'active' in props && props.active && styles.active)}>
       <IconButton
-        name={icon}
-        tooltip={title}
+        name={props.icon}
+        tooltip={props.title}
         className={styles.icon}
-        disabled={!!disabled}
-        onClick={onClick}
+        disabled={!!props.disabled}
+        onClick={props.onClick}
         type="button"
-        aria-label={selectors.components.QueryEditorRow.actionButton(title)}
+        aria-label={selectors.components.QueryEditorRow.actionButton(props.title)}
+        {...('active' in props && { 'aria-pressed': props.active })}
       />
     </div>
   );
-};
+}
 
-QueryOperationAction.displayName = 'QueryOperationAction';
+interface QueryOperationActionProps extends BaseQueryOperationActionProps {}
+export function QueryOperationAction(props: QueryOperationActionProps) {
+  return <BaseQueryOperationAction {...props} />;
+}
+
+interface QueryOperationToggleActionProps extends BaseQueryOperationActionProps {
+  active: boolean;
+}
+export const QueryOperationToggleAction = (props: QueryOperationToggleActionProps) => {
+  return <BaseQueryOperationAction {...props} />;
+};
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -5,7 +5,10 @@ import { DataFrame, DataTransformerConfig, TransformerRegistryItem, FrameMatcher
 import { reportInteraction } from '@grafana/runtime';
 import { HorizontalGroup } from '@grafana/ui';
 import { OperationRowHelp } from 'app/core/components/QueryOperationRow/OperationRowHelp';
-import { QueryOperationAction } from 'app/core/components/QueryOperationRow/QueryOperationAction';
+import {
+  QueryOperationAction,
+  QueryOperationToggleAction,
+} from 'app/core/components/QueryOperationRow/QueryOperationAction';
 import {
   QueryOperationRow,
   QueryOperationRowRenderProps,
@@ -37,7 +40,7 @@ export const TransformationOperationRow = ({
 }: TransformationOperationRowProps) => {
   const [showDebug, toggleDebug] = useToggle(false);
   const [showHelp, toggleHelp] = useToggle(false);
-  const disabled = configs[index].transformation.disabled;
+  const disabled = !!configs[index].transformation.disabled;
   const filter = configs[index].transformation.filter != null;
   const showFilter = filter || data.length > 1;
 
@@ -85,28 +88,28 @@ export const TransformationOperationRow = ({
     return (
       <HorizontalGroup align="center" width="auto">
         {uiConfig.state && <PluginStateInfo state={uiConfig.state} />}
-        <QueryOperationAction
+        <QueryOperationToggleAction
           title="Show/hide transform help"
           icon="info-circle"
           onClick={instrumentToggleCallback(toggleHelp, 'help', showHelp)}
           active={showHelp}
         />
         {showFilter && (
-          <QueryOperationAction
+          <QueryOperationToggleAction
             title="Filter"
             icon="filter"
             onClick={instrumentToggleCallback(toggleFilter, 'filter', filter)}
             active={filter}
           />
         )}
-        <QueryOperationAction
+        <QueryOperationToggleAction
           title="Debug"
           disabled={!isOpen}
           icon="bug"
           onClick={instrumentToggleCallback(toggleDebug, 'debug', showDebug)}
           active={showDebug}
         />
-        <QueryOperationAction
+        <QueryOperationToggleAction
           title="Disable/Enable transformation"
           icon={disabled ? 'eye-slash' : 'eye'}
           onClick={instrumentToggleCallback(() => onDisableToggle(index), 'disabled', disabled)}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -89,7 +89,7 @@ export const TransformationOperationRow = ({
       <HorizontalGroup align="center" width="auto">
         {uiConfig.state && <PluginStateInfo state={uiConfig.state} />}
         <QueryOperationToggleAction
-          title="Show/hide transform help"
+          title="Show transform help"
           icon="info-circle"
           onClick={instrumentToggleCallback(toggleHelp, 'help', showHelp)}
           active={showHelp}
@@ -110,7 +110,7 @@ export const TransformationOperationRow = ({
           active={showDebug}
         />
         <QueryOperationToggleAction
-          title="Disable/Enable transformation"
+          title="Disable transformation"
           icon={disabled ? 'eye-slash' : 'eye'}
           onClick={instrumentToggleCallback(() => onDisableToggle(index), 'disabled', disabled)}
           active={disabled}

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -25,7 +25,10 @@ import { selectors } from '@grafana/e2e-selectors';
 import { AngularComponent, getAngularLoader, getDataSourceSrv } from '@grafana/runtime';
 import { Badge, ErrorBoundaryAlert, HorizontalGroup } from '@grafana/ui';
 import { OperationRowHelp } from 'app/core/components/QueryOperationRow/OperationRowHelp';
-import { QueryOperationAction } from 'app/core/components/QueryOperationRow/QueryOperationAction';
+import {
+  QueryOperationAction,
+  QueryOperationToggleAction,
+} from 'app/core/components/QueryOperationRow/QueryOperationAction';
 import {
   QueryOperationRow,
   QueryOperationRowRenderProps,
@@ -430,14 +433,14 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   renderActions = (props: QueryOperationRowRenderProps) => {
     const { query, hideDisableQuery = false } = this.props;
     const { hasTextEditMode, datasource, showingHelp } = this.state;
-    const isDisabled = query.hide;
+    const isDisabled = !!query.hide;
 
     const hasEditorHelp = datasource?.components?.QueryEditorHelp;
 
     return (
       <HorizontalGroup width="auto">
         {hasEditorHelp && (
-          <QueryOperationAction
+          <QueryOperationToggleAction
             title="Toggle data source help"
             icon="question-circle"
             onClick={this.onToggleHelp}
@@ -456,7 +459,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         {this.renderExtraActions()}
         <QueryOperationAction title="Duplicate query" icon="copy" onClick={this.onCopyQuery} />
         {!hideDisableQuery ? (
-          <QueryOperationAction
+          <QueryOperationToggleAction
             title="Disable/enable query"
             icon={isDisabled ? 'eye-slash' : 'eye'}
             active={isDisabled}

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -441,7 +441,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       <HorizontalGroup width="auto">
         {hasEditorHelp && (
           <QueryOperationToggleAction
-            title="Toggle data source help"
+            title="Show data source help"
             icon="question-circle"
             onClick={this.onToggleHelp}
             active={showingHelp}
@@ -460,7 +460,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         <QueryOperationAction title="Duplicate query" icon="copy" onClick={this.onCopyQuery} />
         {!hideDisableQuery ? (
           <QueryOperationToggleAction
-            title="Disable/enable query"
+            title="Disable query"
             icon={isDisabled ? 'eye-slash' : 'eye'}
             active={isDisabled}
             onClick={this.onDisableQuery}

--- a/public/app/features/query/components/QueryEditorRows.test.tsx
+++ b/public/app/features/query/components/QueryEditorRows.test.tsx
@@ -114,10 +114,7 @@ describe('QueryEditorRows', () => {
     renderScenario({ onAddQuery, onQueryCopied });
     const queryEditorRows = await screen.findAllByTestId('query-editor-row');
     queryEditorRows.map(async (childQuery) => {
-      const duplicateQueryButton = queryByLabelText(
-        childQuery,
-        'Duplicate query query operation action'
-      ) as HTMLElement;
+      const duplicateQueryButton = queryByLabelText(childQuery, 'Duplicate query') as HTMLElement;
 
       expect(duplicateQueryButton).toBeInTheDocument();
 
@@ -135,7 +132,7 @@ describe('QueryEditorRows', () => {
 
     const queryEditorRows = await screen.findAllByTestId('query-editor-row');
     queryEditorRows.map(async (childQuery) => {
-      const deleteQueryButton = queryByLabelText(childQuery, 'Remove query query operation action') as HTMLElement;
+      const deleteQueryButton = queryByLabelText(childQuery, 'Remove query') as HTMLElement;
 
       expect(deleteQueryButton).toBeInTheDocument();
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A number of query operation rows are toggle action (i.e. enable/disable query, query help, filters in transformations) but are announced by screenreaders as normal buttons instead of toggle buttons, this makes it difficult for screen readers users to differentiate between each state.


This PR splits `QueryOperationAction`  into 2 different components: `QueryOperationAction` and `QueryOperationToggleAction`. While `QueryOperationAction`'s name is unchanged it now doesn't support and `active` property, and `QueryOperationToggleAction` adds the proper `pressed` aria attribute according to the `active` prop.

While we could've simply added the `pressed` aria prop to the previous implementation based on the presence of the `active` (which was optional), i thought having 2 separate components that serves their own specific purposes made them more resilient as in it'd now be impossible to switch between a toggle and non-toggle button, given that in `QueryOperationToggleAction` the `active` prop is now required.

ie. the following would be possible keeping a single component but doesn't make much sense semantically.
```tsx
<QueryOperationAction
  {...active && {active}}
/>
```

![Screenshot 2023-05-08 at 13 52 15](https://user-images.githubusercontent.com/1170767/236829077-2cd6445e-2e35-4f19-96b2-4c59c2b3530d.png)


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #66564

**Special notes for your reviewer:**

in some cases, we label elements with text such as `Enable/disable query`, this is less than ideal as a screen read would announce the button as `Enable/Disable query, toggle button, pressed` which doesn't help understanding the current state, we should probably only label those element with their "active" state. for instance the enable/disable toggle button, if labeled "Disable query" would be announced as `Disable query, toggle button, pressed` when the query is disabled and `Disable query, toggle button` when enabled, making for a way better experience.
same goes for the data source help, where `Show data source help, toggle button[, pressed]` would make more sense than the current `Toggle data source help, toggle button[, pressed]`, although this is a bit clearer.

also, all those buttons are labeled with fixed  `query operation action` suffix, this results in a weird experience in 2 cases:
1. in transformations, we the button is not operating on a query, so the label doesn't make any sense
2. we currently have quite weird labels for operation rows that are a bit noisy:
![Screenshot 2023-05-08 at 14 07 36](https://user-images.githubusercontent.com/1170767/236832191-378185d0-faab-4e19-b9be-94a9fbdf3a4f.png)

i'd say that removing the `query operation action` suffix would be the best approach here, but it'd break e2e selectors. opinions?

**UPDATE**:
updated the PR to remove the `query operation action` suffix from the labels and relevant tests

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
