### PR TITLE
Dashboard: Change add panel button to fill to remove outline border

### DIFF
--- a/public/app/features/dashboard/components/AddPanelButton/AddPanelButton.tsx
+++ b/public/app/features/dashboard/components/AddPanelButton/AddPanelButton.tsx
@@ -27,7 +27,7 @@ export const AddPanelButton = ({ dashboard }: Props) => {
       <Button
         icon="panel-add"
         size="lg"
-        fill="outline"
+        fill="text"
         className={cx(styles.button, styles.buttonIcon, styles.buttonText)}
         data-testid={selectors.components.PageToolbar.itemButton('Add panel button')}
       >


### PR DESCRIPTION
Removes the outline border of the add panel button as the outline boarder was a bit distracting when viewing  / using dashboards and stood out in a way that felt out of place. 

![Screenshot from 2023-05-08 13-50-53](https://user-images.githubusercontent.com/10999/236837110-0e40c2b0-7471-48f1-9b05-4690fe31563c.png)
