### PR TITLE
Loki Derived Fields: Refactor legacy form components and add validation

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -47,7 +47,7 @@ export const ConfigEditor = (props: Props) => {
       />
 
       <DerivedFields
-        value={options.jsonData.derivedFields}
+        fields={options.jsonData.derivedFields}
         onChange={(value) => onOptionsChange(setDerivedFields(options, value))}
       />
     </>

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
@@ -9,10 +9,7 @@ import { setDataSourceSrv } from '@grafana/runtime';
 import { DerivedField } from './DerivedField';
 
 const mockList = jest.fn();
-const validateMock = {
-  rule: jest.fn(),
-  errorMessage: '',
-};
+const validateMock = jest.fn();
 
 describe('DerivedField', () => {
   beforeEach(() => {
@@ -126,15 +123,12 @@ describe('DerivedField', () => {
       name: 'field-name',
       datasourceUid: 'test',
     };
-    const validate = {
-      rule: jest.fn().mockReturnValue(false),
-      errorMessage: 'Error message',
-    };
+    const validate = jest.fn().mockReturnValue(false);
     render(
       <DerivedField validateName={validate} value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />
     );
     userEvent.click(await screen.findByDisplayValue(value.name));
 
-    expect(await screen.findByText(validate.errorMessage)).toBeInTheDocument();
+    expect(await screen.findByText('The name is already in use')).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
@@ -8,6 +9,10 @@ import { setDataSourceSrv } from '@grafana/runtime';
 import { DerivedField } from './DerivedField';
 
 const mockList = jest.fn();
+const validateMock = {
+  rule: jest.fn(),
+  errorMessage: '',
+};
 
 describe('DerivedField', () => {
   beforeEach(() => {
@@ -54,7 +59,15 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.getByLabelText(selectors.components.DataSourcePicker.inputV2)).toBeInTheDocument();
@@ -68,7 +81,15 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.queryByLabelText(selectors.components.DataSourcePicker.inputV2)).not.toBeInTheDocument();
@@ -82,12 +103,38 @@ describe('DerivedField', () => {
     };
     // Render and wait for the Name field to be visible
     // using findBy to wait for asynchronous operations to complete
-    render(<DerivedField value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />);
+    render(
+      <DerivedField
+        validateName={validateMock}
+        value={value}
+        onChange={() => {}}
+        onDelete={() => {}}
+        suggestions={[]}
+      />
+    );
     expect(await screen.findByText('Name')).toBeInTheDocument();
     expect(mockList).toHaveBeenCalledWith(
       expect.objectContaining({
         tracing: true,
       })
     );
+  });
+
+  it('validates the field name', async () => {
+    const value = {
+      matcherRegex: '',
+      name: 'field-name',
+      datasourceUid: 'test',
+    };
+    const validate = {
+      rule: jest.fn().mockReturnValue(false),
+      errorMessage: 'Error message',
+    };
+    render(
+      <DerivedField validateName={validate} value={value} onChange={() => {}} onDelete={() => {}} suggestions={[]} />
+    );
+    userEvent.click(await screen.findByDisplayValue(value.name));
+
+    expect(await screen.findByText(validate.errorMessage)).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,11 +4,20 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, EventsWithValidation, LegacyForms, useStyles2, ValidationRule } from '@grafana/ui';
+import {
+  Button,
+  DataLinkInput,
+  EventsWithValidation,
+  Field,
+  Input,
+  LegacyForms,
+  useStyles2,
+  ValidationRule,
+} from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
-const { Switch, FormField, Input } = LegacyForms;
+const { Switch } = LegacyForms;
 
 const getStyles = (theme: GrafanaTheme2) => ({
   row: css`
@@ -64,34 +73,19 @@ export const DerivedField = (props: Props) => {
   return (
     <div className={className} data-testid="derived-field">
       <div className="gf-form">
-        <FormField
-          labelWidth={10}
-          className={styles.nameField}
-          inputEl={
-            <Input
-              value={value.name}
-              onChange={handleChange('name')}
-              placeholder="Field name"
-              validationEvents={{
-                [EventsWithValidation.onBlur]: [validateName],
-                [EventsWithValidation.onFocus]: [validateName],
-              }}
-            />
-          }
-          label="Name"
-        />
-        <FormField
-          labelWidth={10}
+        <Field className={styles.nameField} label="Name">
+          <Input value={value.name} onChange={handleChange('name')} placeholder="Field name" />
+        </Field>
+        <Field
           className={styles.regexField}
-          inputWidth={null}
           label="Regex"
-          type="text"
-          value={value.matcherRegex}
           onChange={handleChange('matcherRegex')}
-          tooltip={
-            'Use to parse and capture some part of the log message. You can use the captured groups in the template.'
-          }
-        />
+          //</div>tooltip={
+          //  'Use to parse and capture some part of the log message. You can use the captured groups in the template.'
+          //}
+        >
+          <Input value={value.matcherRegex} onChange={handleChange('matcherRegex')} />
+        </Field>
         <Button
           variant="destructive"
           title="Remove field"
@@ -104,34 +98,26 @@ export const DerivedField = (props: Props) => {
       </div>
 
       <div className="gf-form">
-        <FormField
-          labelWidth={10}
-          label={showInternalLink ? 'Query' : 'URL'}
-          inputEl={
-            <DataLinkInput
-              placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
-              value={value.url || ''}
-              onChange={(newValue) =>
-                onChange({
-                  ...value,
-                  url: newValue,
-                })
-              }
-              suggestions={suggestions}
-            />
-          }
-          className={styles.urlField}
-        />
-        <FormField
+        <Field label={showInternalLink ? 'Query' : 'URL'} className={styles.urlField}>
+          <DataLinkInput
+            placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
+            value={value.url || ''}
+            onChange={(newValue) =>
+              onChange({
+                ...value,
+                url: newValue,
+              })
+            }
+            suggestions={suggestions}
+          />
+        </Field>
+        <Field
           className={styles.urlDisplayLabelField}
-          labelWidth={10}
-          inputWidth={null}
           label="URL Label"
-          type="text"
-          value={value.urlDisplayLabel}
-          onChange={handleChange('urlDisplayLabel')}
-          tooltip={'Use to override the button label when this derived field is found in a log.'}
-        />
+          //tooltip={'Use to override the button label when this derived field is found in a log.'}
+        >
+          <Input value={value.urlDisplayLabel} onChange={handleChange('urlDisplayLabel')} />
+        </Field>
       </div>
 
       <div className={styles.row}>

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, Field, Input, LegacyForms, useStyles2 } from '@grafana/ui';
+import { Button, DataLinkInput, Field, Icon, Input, Label, LegacyForms, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
@@ -73,11 +73,13 @@ export const DerivedField = (props: Props) => {
         </Field>
         <Field
           className={styles.regexField}
-          label="Regex"
+          label={
+            <TooltipLabel
+              label="Regex"
+              content="Use to parse and capture some part of the log message. You can use the captured groups in the template."
+            />
+          }
           onChange={handleChange('matcherRegex')}
-          //</div>tooltip={
-          //  'Use to parse and capture some part of the log message. You can use the captured groups in the template.'
-          //}
         >
           <Input value={value.matcherRegex} onChange={handleChange('matcherRegex')} />
         </Field>
@@ -110,8 +112,12 @@ export const DerivedField = (props: Props) => {
         </Field>
         <Field
           className={styles.urlDisplayLabelField}
-          label="URL Label"
-          //tooltip={'Use to override the button label when this derived field is found in a log.'}
+          label={
+            <TooltipLabel
+              label="URL Label"
+              content="Use to override the button label when this derived field is found in a log."
+            />
+          }
         >
           <Input value={value.urlDisplayLabel} onChange={handleChange('urlDisplayLabel')} />
         </Field>
@@ -148,3 +154,12 @@ export const DerivedField = (props: Props) => {
     </div>
   );
 };
+
+const TooltipLabel = ({ content, label }: { content: string; label: string }) => (
+  <Label>
+    {label}
+    <Tooltip placement="top" content={content} theme="info">
+      <Icon tabIndex={0} name="info-circle" size="sm" style={{ marginLeft: '10px' }} />
+    </Tooltip>
+  </Label>
+);

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
@@ -65,7 +65,7 @@ export const DerivedField = (props: Props) => {
     });
   };
 
-  const invalidName = validateName(value.name);
+  const invalidName = !validateName(value.name);
 
   return (
     <div className={className} data-testid="derived-field">
@@ -128,15 +128,16 @@ export const DerivedField = (props: Props) => {
       <div className="gf-form">
         <Field label="Internal link" className={styles.internalLink}>
           <Switch
-            checked={showInternalLink}
-            onChange={() => {
-              if (showInternalLink) {
+            value={showInternalLink}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const checked = e.currentTarget.checked;
+              if (!checked) {
                 onChange({
                   ...value,
                   datasourceUid: undefined,
                 });
               }
-              setShowInternalLink(!showInternalLink);
+              setShowInternalLink(checked);
             }}
           />
         </Field>

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -153,6 +153,7 @@ export const DerivedField = (props: Props) => {
                 })
               }
               current={value.datasourceUid}
+              noDefault
             />
           </Field>
         )}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,16 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import {
-  Button,
-  DataLinkInput,
-  EventsWithValidation,
-  Field,
-  Input,
-  LegacyForms,
-  useStyles2,
-  ValidationRule,
-} from '@grafana/ui';
+import { Button, DataLinkInput, Field, Input, LegacyForms, useStyles2 } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
@@ -45,7 +36,7 @@ type Props = {
   onDelete: () => void;
   suggestions: VariableSuggestion[];
   className?: string;
-  validateName: ValidationRule;
+  validateName: (name: string) => boolean;
 };
 export const DerivedField = (props: Props) => {
   const { value, onChange, onDelete, suggestions, className, validateName } = props;
@@ -70,11 +61,13 @@ export const DerivedField = (props: Props) => {
     });
   };
 
+  const invalidName = validateName(value.name);
+
   return (
     <div className={className} data-testid="derived-field">
       <div className="gf-form">
-        <Field className={styles.nameField} label="Name">
-          <Input value={value.name} onChange={handleChange('name')} placeholder="Field name" />
+        <Field className={styles.nameField} label="Name" invalid={invalidName} error="The name is already in use">
+          <Input value={value.name} onChange={handleChange('name')} placeholder="Field name" invalid={invalidName} />
         </Field>
         <Field
           className={styles.regexField}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,11 +4,9 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, Field, Icon, Input, Label, LegacyForms, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, DataLinkInput, Field, Icon, Input, Label, Tooltip, useStyles2, Switch } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
-
-const { Switch } = LegacyForms;
 
 const getStyles = (theme: GrafanaTheme2) => ({
   row: css`
@@ -30,6 +28,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   urlDisplayLabelField: css`
     flex: 1;
   `,
+  internalLink: css`
+    margin-right: ${theme.spacing(1)};
+  `,
+  dataSource: css``,
 });
 
 type Props = {
@@ -123,32 +125,35 @@ export const DerivedField = (props: Props) => {
         </Field>
       </div>
 
-      <div className={styles.row}>
-        <Switch
-          label="Internal link"
-          checked={showInternalLink}
-          onChange={() => {
-            if (showInternalLink) {
-              onChange({
-                ...value,
-                datasourceUid: undefined,
-              });
-            }
-            setShowInternalLink(!showInternalLink);
-          }}
-        />
+      <div className="gf-form">
+        <Field label="Internal link" className={styles.internalLink}>
+          <Switch
+            checked={showInternalLink}
+            onChange={() => {
+              if (showInternalLink) {
+                onChange({
+                  ...value,
+                  datasourceUid: undefined,
+                });
+              }
+              setShowInternalLink(!showInternalLink);
+            }}
+          />
+        </Field>
 
         {showInternalLink && (
-          <DataSourcePicker
-            tracing={true}
-            onChange={(ds) =>
-              onChange({
-                ...value,
-                datasourceUid: ds.uid,
-              })
-            }
-            current={value.datasourceUid}
-          />
+          <Field label="" className={styles.dataSource}>
+            <DataSourcePicker
+              tracing={true}
+              onChange={(ds) =>
+                onChange({
+                  ...value,
+                  datasourceUid: ds.uid,
+                })
+              }
+              current={value.datasourceUid}
+            />
+          </Field>
         )}
       </div>
     </div>

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -17,9 +17,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   nameField: css`
     flex: 2;
+    margin-right: ${theme.spacing(0.5)};
   `,
   regexField: css`
     flex: 3;
+    margin-right: ${theme.spacing(0.5)};
   `,
   urlField: css`
     flex: 1;
@@ -79,15 +81,17 @@ export const DerivedField = (props: Props) => {
         >
           <Input value={value.matcherRegex} onChange={handleChange('matcherRegex')} />
         </Field>
-        <Button
-          variant="destructive"
-          title="Remove field"
-          icon="times"
-          onClick={(event) => {
-            event.preventDefault();
-            onDelete();
-          }}
-        />
+        <Field label="">
+          <Button
+            variant="destructive"
+            title="Remove field"
+            icon="times"
+            onClick={(event) => {
+              event.preventDefault();
+              onDelete();
+            }}
+          />
+        </Field>
       </div>
 
       <div className="gf-form">

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,15 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import {
-  Button,
-  DataLinkInput,
-  EventsWithValidation,
-  LegacyForms,
-  regexValidation,
-  useStyles2,
-  ValidationRule,
-} from '@grafana/ui';
+import { Button, DataLinkInput, EventsWithValidation, LegacyForms, useStyles2, ValidationRule } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
@@ -79,6 +71,7 @@ export const DerivedField = (props: Props) => {
             <Input
               value={value.name}
               onChange={handleChange('name')}
+              placeholder="Field name"
               validationEvents={{
                 [EventsWithValidation.onBlur]: [validateName],
                 [EventsWithValidation.onFocus]: [validateName],
@@ -86,7 +79,6 @@ export const DerivedField = (props: Props) => {
             />
           }
           label="Name"
-          type="text"
         />
         <FormField
           labelWidth={10}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -129,7 +129,7 @@ export const DerivedField = (props: Props) => {
           <Switch
             value={showInternalLink}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              const checked = e.currentTarget.checked;
+              const { checked } = e.currentTarget;
               if (!checked) {
                 onChange({
                   ...value,

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -4,11 +4,19 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, LegacyForms, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  DataLinkInput,
+  EventsWithValidation,
+  LegacyForms,
+  regexValidation,
+  useStyles2,
+  ValidationRule,
+} from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
-const { Switch, FormField } = LegacyForms;
+const { Switch, FormField, Input } = LegacyForms;
 
 const getStyles = (theme: GrafanaTheme2) => ({
   row: css`
@@ -36,9 +44,10 @@ type Props = {
   onDelete: () => void;
   suggestions: VariableSuggestion[];
   className?: string;
+  validateName: ValidationRule;
 };
 export const DerivedField = (props: Props) => {
-  const { value, onChange, onDelete, suggestions, className } = props;
+  const { value, onChange, onDelete, suggestions, className, validateName } = props;
   const styles = useStyles2(getStyles);
   const [showInternalLink, setShowInternalLink] = useState(!!value.datasourceUid);
   const previousUid = usePrevious(value.datasourceUid);
@@ -66,12 +75,18 @@ export const DerivedField = (props: Props) => {
         <FormField
           labelWidth={10}
           className={styles.nameField}
-          // A bit of a hack to prevent using default value for the width from FormField
-          inputWidth={null}
+          inputEl={
+            <Input
+              value={value.name}
+              onChange={handleChange('name')}
+              validationEvents={{
+                [EventsWithValidation.onBlur]: [validateName],
+                [EventsWithValidation.onFocus]: [validateName],
+              }}
+            />
+          }
           label="Name"
           type="text"
-          value={value.name}
-          onChange={handleChange('name')}
         />
         <FormField
           labelWidth={10}

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -81,7 +81,6 @@ export const DerivedField = (props: Props) => {
               content="Use to parse and capture some part of the log message. You can use the captured groups in the template."
             />
           }
-          onChange={handleChange('matcherRegex')}
         >
           <Input value={value.matcherRegex} onChange={handleChange('matcherRegex')} />
         </Field>

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -64,7 +64,7 @@ describe('DerivedFields', () => {
 
     userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
 
-    expect(await screen.findByText('Name already in use')).toBeInTheDocument();
+    expect(await screen.findAllByText('The name is already in use')).toHaveLength(2);
   });
 
   it('does not validate empty names as repeated', () => {
@@ -82,7 +82,7 @@ describe('DerivedFields', () => {
 
     userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
 
-    expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
+    expect(screen.queryByText('The name is already in use')).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -66,6 +66,24 @@ describe('DerivedFields', () => {
 
     expect(await screen.findByText('Name already in use')).toBeInTheDocument();
   });
+
+  it('does not validate empty names as repeated', () => {
+    const repeatedFields = [
+      {
+        matcherRegex: '',
+        name: '',
+      },
+      {
+        matcherRegex: '',
+        name: '',
+      },
+    ];
+    render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+
+    expect(screen.queryByText('Name already in use')).not.toBeInTheDocument();
+  });
 });
 
 const testFields = [

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DerivedFields } from './DerivedFields';
@@ -23,7 +24,7 @@ describe('DerivedFields', () => {
   });
 
   it('renders correctly when there are fields', async () => {
-    render(<DerivedFields value={testValue} onChange={() => {}} />);
+    render(<DerivedFields fields={testFields} onChange={() => {}} />);
 
     await waitFor(() => expect(screen.getAllByTestId('derived-field')).toHaveLength(2));
     expect(screen.getByText('Add')).toBeInTheDocument();
@@ -34,22 +35,40 @@ describe('DerivedFields', () => {
     const onChange = jest.fn();
     render(<DerivedFields onChange={onChange} />);
 
-    fireEvent.click(screen.getByText('Add'));
+    userEvent.click(screen.getByText('Add'));
 
     await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
   });
 
   it('removes a field', async () => {
     const onChange = jest.fn();
-    render(<DerivedFields value={testValue} onChange={onChange} />);
+    render(<DerivedFields fields={testFields} onChange={onChange} />);
 
-    fireEvent.click((await screen.findAllByTitle('Remove field'))[0]);
+    userEvent.click((await screen.findAllByTitle('Remove field'))[0]);
 
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith([testValue[1]]));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([testFields[1]]));
+  });
+
+  it('validates duplicated field names', async () => {
+    const repeatedFields = [
+      {
+        matcherRegex: '',
+        name: 'repeated',
+      },
+      {
+        matcherRegex: '',
+        name: 'repeated',
+      },
+    ];
+    render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
+
+    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+
+    expect(await screen.findByText('Name already in use')).toBeInTheDocument();
   });
 });
 
-const testValue = [
+const testFields = [
   {
     matcherRegex: 'regex1',
     name: 'test1',

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -32,7 +32,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
 
   const validateName = useCallback(
     (name: string) => {
-      return fields.filter((field) => field.name && field.name === name).length > 1;
+      return fields.filter((field) => field.name && field.name === name).length <= 1;
     },
     [fields]
   );

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { GrafanaTheme2, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
 import { Button, useTheme2 } from '@grafana/ui';
@@ -30,14 +30,12 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
 
   const [showDebug, setShowDebug] = useState(false);
 
-  const validateNameRule = useMemo(() => {
-    return {
-      rule: (name: string) => {
-        return fields.filter((field) => field.name && field.name === name).length <= 1;
-      },
-      errorMessage: 'Name already in use',
-    };
-  }, [fields]);
+  const validateName = useCallback(
+    (name: string) => {
+      return fields.filter((field) => field.name && field.name === name).length > 1;
+    },
+    [fields]
+  );
 
   return (
     <>
@@ -64,7 +62,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
                 newDerivedFields.splice(index, 1);
                 onChange(newDerivedFields);
               }}
-              validateName={validateNameRule}
+              validateName={validateName}
               suggestions={[
                 {
                   value: DataLinkBuiltInVars.valueRaw,

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -33,7 +33,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
   const validateNameRule = useMemo(() => {
     return {
       rule: (name: string) => {
-        return fields.filter((field) => field.name === name).length <= 1;
+        return fields.filter((field) => field.name && field.name === name).length <= 1;
       },
       errorMessage: 'Name already in use',
     };

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -83,7 +83,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
             icon="plus"
             onClick={(event) => {
               event.preventDefault();
-              const newDerivedFields = [...fields, { name: '', matcherRegex: '' }];
+              const newDerivedFields = [...fields, { name: '', matcherRegex: '', urlDisplayLabel: '', url: '' }];
               onChange(newDerivedFields);
             }}
           >

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -20,11 +20,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 type Props = {
-  value?: DerivedFieldConfig[];
+  fields?: DerivedFieldConfig[];
   onChange: (value: DerivedFieldConfig[]) => void;
 };
 
-export const DerivedFields = ({ value = [], onChange }: Props) => {
+export const DerivedFields = ({ fields = [], onChange }: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
@@ -33,11 +33,11 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
   const validateNameRule = useMemo(() => {
     return {
       rule: (name: string) => {
-        return value.filter((field) => field.name === name).length <= 1;
+        return fields.filter((field) => field.name === name).length <= 1;
       },
       errorMessage: 'Name already in use',
     };
-  }, [value]);
+  }, [fields]);
 
   return (
     <>
@@ -48,19 +48,19 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
       </div>
 
       <div className="gf-form-group">
-        {value.map((field, index) => {
+        {fields.map((field, index) => {
           return (
             <DerivedField
               className={styles.derivedField}
               key={index}
               value={field}
               onChange={(newField) => {
-                const newDerivedFields = [...value];
+                const newDerivedFields = [...fields];
                 newDerivedFields.splice(index, 1, newField);
                 onChange(newDerivedFields);
               }}
               onDelete={() => {
-                const newDerivedFields = [...value];
+                const newDerivedFields = [...fields];
                 newDerivedFields.splice(index, 1);
                 onChange(newDerivedFields);
               }}
@@ -85,14 +85,14 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
             icon="plus"
             onClick={(event) => {
               event.preventDefault();
-              const newDerivedFields = [...value, { name: '', matcherRegex: '' }];
+              const newDerivedFields = [...fields, { name: '', matcherRegex: '' }];
               onChange(newDerivedFields);
             }}
           >
             Add
           </Button>
 
-          {value.length > 0 && (
+          {fields.length > 0 && (
             <Button variant="secondary" type="button" onClick={() => setShowDebug(!showDebug)}>
               {showDebug ? 'Hide example log message' : 'Show example log message'}
             </Button>
@@ -106,7 +106,7 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
             className={css`
               margin-bottom: 10px;
             `}
-            derivedFields={value}
+            derivedFields={fields}
           />
         </div>
       )}

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { GrafanaTheme2, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
 import { Button, useTheme2 } from '@grafana/ui';
@@ -30,6 +30,15 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
 
   const [showDebug, setShowDebug] = useState(false);
 
+  const validateNameRule = useMemo(() => {
+    return {
+      rule: (name: string) => {
+        return value.filter((field) => field.name === name).length <= 1;
+      },
+      errorMessage: 'Name already in use',
+    };
+  }, [value]);
+
   return (
     <>
       <h3 className="page-heading">Derived fields</h3>
@@ -55,6 +64,7 @@ export const DerivedFields = ({ value = [], onChange }: Props) => {
                 newDerivedFields.splice(index, 1);
                 onChange(newDerivedFields);
               }}
+              validateName={validateNameRule}
               suggestions={[
                 {
                   value: DataLinkBuiltInVars.valueRaw,


### PR DESCRIPTION
Follow up of https://github.com/grafana/grafana/pull/67220  . Here, we refactor the form to use non-legacy components, and we display the name error in a more nicely way, as part of https://github.com/grafana/grafana/issues/65294

Also fixed a bug where the data source and internal bug would not be saved if the user did not select a data source.

https://user-images.githubusercontent.com/1069378/236854850-6b23e2c2-191e-4b09-9eda-055b1287d7e2.mov

It should be expected to work on follow up PRs related with https://github.com/grafana/grafana/issues/65294 as common components become available.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/52598

Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

Before:
<img width="994" alt="Before" src="https://user-images.githubusercontent.com/1069378/236855109-20b1611b-2abc-4a39-9836-d499b11473de.png">

After:
<img width="988" alt="After" src="https://user-images.githubusercontent.com/1069378/236855136-5d0dfbf9-658b-4cfc-8acd-64e4d29e3c63.png">

Please note that this form might become stacked in one column instead of two. The main purpose of this PR is to refactor legacy components and add missing validation.