### PR TITLE
Elasticsearch: Fix derived fields label

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
@@ -97,6 +97,7 @@ export const DataLink = (props: Props) => {
         <FormField
           className={styles.urlDisplayLabelField}
           inputWidth={null}
+          labelWidth={7}
           label="URL Label"
           type="text"
           value={value.urlDisplayLabel}


### PR DESCRIPTION
Small PR to fix a label in the Elasticsearch derived fields labels.

From:
<img width="158" alt="Broken" src="https://user-images.githubusercontent.com/1069378/236856902-7f21b2ef-76a2-4ba2-9203-edebd4876450.png">

To:
<img width="504" alt="Fixed" src="https://user-images.githubusercontent.com/1069378/236856895-7df810b0-9e04-4ab5-8cf9-1b4b51eed961.png">

**How to reproduce**

Browse Elasticsearch data source settings, the label should look ok.