### PR TITLE
Alerting: Fixes Alert list panel "ungrouped" regression

### DIFF
--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.test.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CombinedRuleWithLocation } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { UnifiedAlertListOptions } from '../types';
+
+import GroupedView, { UNGROUPED_KEY } from './GroupedView';
+
+describe('Grouped view', () => {
+  const rules: CombinedRuleWithLocation[] = [
+    {
+      promRule: {
+        type: PromRuleType.Alerting,
+        alerts: [
+          // @ts-ignore
+          { labels: { job: 'job-1', severity: 'high' } },
+          // @ts-ignore
+          { labels: { job: 'job-2', severity: 'low' } },
+        ],
+      },
+    },
+    {
+      promRule: {
+        type: PromRuleType.Alerting,
+        alerts: [
+          // @ts-ignore
+          { labels: { foo: 'bar', severity: 'low' } },
+        ],
+      },
+    },
+  ];
+
+  it('should group instances by label(s) correctly', () => {
+    // @ts-ignore
+    const options: UnifiedAlertListOptions = {
+      groupBy: ['job', 'severity'],
+    };
+
+    render(<GroupedView rules={rules} options={options} />);
+    expect(screen.getByTestId('job=job-1&severity=high')).toBeInTheDocument();
+    expect(screen.getByTestId('job=job-2&severity=low')).toBeInTheDocument();
+    expect(screen.getByTestId(UNGROUPED_KEY)).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -5,7 +5,7 @@ import { AlertLabel } from 'app/features/alerting/unified/components/AlertLabel'
 import { getAlertingRule } from 'app/features/alerting/unified/utils/rules';
 import { Alert } from 'app/types/unified-alerting';
 
-import { AlertingRule, CombinedRuleWithLocation } from '../../../../types/unified-alerting';
+import { CombinedRuleWithLocation } from '../../../../types/unified-alerting';
 import { AlertInstances } from '../AlertInstances';
 import { getStyles } from '../UnifiedAlertList';
 import { GroupedRules, UnifiedAlertListOptions } from '../types';
@@ -88,7 +88,7 @@ function parseMapKey(key: string): Array<[string, string]> {
 }
 
 function alertHasEveryLabelForCombinedRules(rule: CombinedRuleWithLocation, groupByKeys: string[]) {
-  const alertingRule: AlertingRule | null = getAlertingRule(rule);
+  const alertingRule = getAlertingRule(rule);
   return groupByKeys.every((key) => {
     return (alertingRule?.alerts ?? []).some((alert) => alert.labels[key]);
   });

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -25,9 +25,8 @@ const GroupedModeView = ({ rules, options }: Props) => {
   const groupedRules = useMemo<GroupedRules>(() => {
     const groupedRules = new Map<string, Alert[]>();
 
-    const hasInstancesWithMatchingLabels = (rule: CombinedRuleWithLocation) => {
-      return groupBy ? alertHasEveryLabelForCombinedRules(rule, groupBy) : true;
-    };
+    const hasInstancesWithMatchingLabels = (rule: CombinedRuleWithLocation) =>
+      groupBy ? alertHasEveryLabelForCombinedRules(rule, groupBy) : true;
 
     rules.forEach((rule) => {
       const alertingRule = getAlertingRule(rule);

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -16,7 +16,7 @@ type Props = {
   options: UnifiedAlertListOptions;
 };
 
-const UNGROUPED_KEY = '';
+const UNGROUPED_KEY = '__ungrouped__';
 
 const GroupedModeView = ({ rules, options }: Props) => {
   const styles = useStyles2(getStyles);
@@ -67,8 +67,9 @@ const GroupedModeView = ({ rules, options }: Props) => {
           <div>
             <div className={styles.customGroupDetails}>
               <div className={styles.alertLabels}>
-                {key && parseMapKey(key).map(([key, value]) => <AlertLabel key={key} labelKey={key} value={value} />)}
-                {!key && 'No grouping'}
+                {key !== UNGROUPED_KEY &&
+                  parseMapKey(key).map(([key, value]) => <AlertLabel key={key} labelKey={key} value={value} />)}
+                {key === UNGROUPED_KEY && 'No grouping'}
               </div>
             </div>
             <AlertInstances alerts={alerts} options={options} />

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -16,7 +16,7 @@ type Props = {
   options: UnifiedAlertListOptions;
 };
 
-const UNGROUPED_KEY = '__ungrouped__';
+export const UNGROUPED_KEY = '__ungrouped__';
 
 const GroupedModeView = ({ rules, options }: Props) => {
   const styles = useStyles2(getStyles);
@@ -63,7 +63,7 @@ const GroupedModeView = ({ rules, options }: Props) => {
   return (
     <>
       {Array.from(groupedRules).map(([key, alerts]) => (
-        <li className={styles.alertRuleItem} key={key}>
+        <li className={styles.alertRuleItem} key={key} data-testid={key}>
           <div>
             <div className={styles.customGroupDetails}>
               <div className={styles.alertLabels}>


### PR DESCRIPTION
**What is this feature?**

A previous regression had removed the "ungrouped" group when using a "custom grouping" in the alert list panel.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/66814

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.