### PR TITLE
Docs: Clarify precedence of Grafana settings

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml-ui/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml-ui/index.md
@@ -18,7 +18,7 @@ The Grafana SAML UI provides the following advantages over configuring SAML in t
 - It doesn't require Grafana to be restarted after a configuration update
 - Access to the SAML UI only requires access to authentication settings, so it can be used by users with limited access to Grafana's configuration
 
-> **Note:** Configuration in the UI takes precedence over the configuration in the Grafana configuration file. SAML settings from the UI will override any SAML configuration set in the Grafana configuration file.
+> **Note:** Any configuration changes made through the Grafana user interface (UI) will take precedence over settings specified in the Grafana configuration file or through environment variables. This means that if you modify any configuration settings in the UI, they will override any corresponding settings set via environment variables or defined in the configuration file. For more information on how Grafana determines the order of precedence for its settings, please refer to the [Settings update at runtime]({{< relref "../../configure-grafana/settings-updates-at-runtime/" >}}).
 
 > **Note:** Disabling the UI does not affect any configuration settings that were previously set up through the UI. Those settings will continue to function as intended even with the UI disabled.
 


### PR DESCRIPTION
**What is this change?**

It is possible to define Grafana settings in the following main places:
- Configuration file
- Environment variables
- Using API (at the moment, only SAML settings are supported)

The new SAML UI is using the API to update settings and it's important to clarify the difference and precedence that Grafana takes into consideration when loading the settings. 

The precedence is the following:
- First anything defined with the API / UI
- Environment variables second
- Configuration file third

The update clarifies the above, as well as points to the existing docs which talks about this in detail.
