### PR TITLE
Alerting: Fix condition on invalid interval dropdown

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -169,7 +169,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 inputId="group"
                 key={`my_unique_select_key__${selectedGroup?.title ?? ''}`}
                 {...field}
-                invalid={Boolean(folder) && !selectedGroup.value}
+                invalid={Boolean(folder) && !selectedGroup.title}
                 loadOptions={debouncedSearch}
                 loadingMessage={'Loading groups...'}
                 defaultOptions={groupOptions}


### PR DESCRIPTION
**What is this feature?**

Fixes the condition on the invalid state for the evaluation group interval dropdown.

**Why do we need this feature?**

An invalid state was showing even when a valid value was selected.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/67787

![2023-05-08 13 29 29](https://user-images.githubusercontent.com/6271380/236878565-3d5081f1-7ccc-494e-af99-6cec95514d25.gif)
