### PR TITLE
Plugins: Adds preliminary support for UI Transformer plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-!
-
-[Grafana](docs/logo-horizontal.png)
+![Grafana](docs/logo-horizontal.png)
 
 The open-source platform for monitoring and observability
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Grafana](docs/logo-horizontal.png)
+!
+
+[Grafana](docs/logo-horizontal.png)
 
 The open-source platform for monitoring and observability
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -10,12 +10,12 @@
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin `id` has to follow the naming conventions.",
-      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)?(app|panel|datasource|secretsmanager)$"
+      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)?(app|panel|datasource|secretsmanager|transformer)$"
     },
     "type": {
       "type": "string",
       "description": "Plugin type.",
-      "enum": ["app", "datasource", "panel", "renderer", "secretsmanager"]
+      "enum": ["app", "datasource", "panel", "renderer", "secretsmanager", "transformer"]
     },
     "info": {
       "type": "object",

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -61,3 +61,4 @@ export {
   type PluginExtensionEventHelpers,
   type PluginExtensionPanelContext,
 } from './pluginExtensions';
+export * from './transformerPlugin'

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -18,6 +18,7 @@ export enum PluginType {
   app = 'app',
   renderer = 'renderer',
   secretsmanager = 'secretsmanager',
+  transformer = 'transformer',
 }
 
 /** Describes status of {@link https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/ | plugin signature} */

--- a/packages/grafana-data/src/types/transformerPlugin.ts
+++ b/packages/grafana-data/src/types/transformerPlugin.ts
@@ -1,0 +1,40 @@
+import {TransformerRegistryItem, TransformerUIProps} from '../transformations';
+import {KeyValue} from './data';
+import {GrafanaPlugin, PluginMeta} from './plugin';
+import {DataTransformerInfo} from "./transformations";
+import {ComponentType} from "react";
+
+export interface TransformerDef<TOptions> {
+  editor: ComponentType<TransformerUIProps<TOptions>>
+  transformation: DataTransformerInfo<TOptions>
+}
+
+export interface TransformerPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta<T> {
+  // TODO anything specific to transformers ?
+}
+
+export class TransformerPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<TransformerPluginMeta<T>> {
+  private _transformers: TransformerDef<any>[] = [];
+
+  constructor() {
+    super();
+  }
+
+  get transformers() : TransformerRegistryItem<any>[] {
+    const res = this._transformers.map(t => ({
+      editor: t.editor,
+      transformation: t.transformation,
+      name: t.transformation.name,
+      description: t.transformation.description,
+      id: this.meta.id + '-' + t.transformation.id,
+      state: t.transformation.state || this.meta.state,
+    }))
+    return res;
+  }
+
+  registerTransformer(transformer: TransformerDef<any>) {
+    this._transformers.push(transformer);
+    return this;
+  }
+}
+

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -17,6 +17,7 @@ import {
   systemDateFormats,
   SystemDateFormatSettings,
   NewThemeOptions,
+  TransformerPluginMeta,
 } from '@grafana/data';
 
 export interface AzureSettings {
@@ -37,6 +38,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   datasources: { [str: string]: DataSourceInstanceSettings } = {};
   panels: { [key: string]: PanelPluginMeta } = {};
   apps: Record<string, AppPluginConfig> = {};
+  transformers: { [key: string]: TransformerPluginMeta } = {};
   auth: AuthSettings = {};
   minRefreshInterval = '';
   appUrl = '';
@@ -171,6 +173,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
       datasources: {},
       windowTitlePrefix: 'Grafana - ',
       panels: {},
+      transformers: {},
       newPanelTitle: 'Panel Title',
       playlist_timespan: '1m',
       unsaved_changes_warning: true,

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -119,24 +119,25 @@ type FrontendSettingsSqlConnectionLimitsDTO struct {
 }
 
 type FrontendSettingsDTO struct {
-	DefaultDatasource          string                           `json:"defaultDatasource"`
-	Datasources                map[string]plugins.DataSourceDTO `json:"datasources"`
-	MinRefreshInterval         string                           `json:"minRefreshInterval"`
-	Panels                     map[string]plugins.PanelDTO      `json:"panels"`
-	Apps                       map[string]*plugins.AppDTO       `json:"apps"`
-	AppUrl                     string                           `json:"appUrl"`
-	AppSubUrl                  string                           `json:"appSubUrl"`
-	AllowOrgCreate             bool                             `json:"allowOrgCreate"`
-	AuthProxyEnabled           bool                             `json:"authProxyEnabled"`
-	LdapEnabled                bool                             `json:"ldapEnabled"`
-	JwtHeaderName              string                           `json:"jwtHeaderName"`
-	JwtUrlLogin                bool                             `json:"jwtUrlLogin"`
-	AlertingEnabled            bool                             `json:"alertingEnabled"`
-	AlertingErrorOrTimeout     string                           `json:"alertingErrorOrTimeout"`
-	AlertingNoDataOrNullValues string                           `json:"alertingNoDataOrNullValues"`
-	AlertingMinInterval        int64                            `json:"alertingMinInterval"`
-	LiveEnabled                bool                             `json:"liveEnabled"`
-	AutoAssignOrg              bool                             `json:"autoAssignOrg"`
+	DefaultDatasource          string                             `json:"defaultDatasource"`
+	Datasources                map[string]plugins.DataSourceDTO   `json:"datasources"`
+	MinRefreshInterval         string                             `json:"minRefreshInterval"`
+	Panels                     map[string]plugins.PanelDTO        `json:"panels"`
+	Apps                       map[string]*plugins.AppDTO         `json:"apps"`
+	Transformers               map[string]*plugins.TransformerDTO `json:"transformers"`
+	AppUrl                     string                             `json:"appUrl"`
+	AppSubUrl                  string                             `json:"appSubUrl"`
+	AllowOrgCreate             bool                               `json:"allowOrgCreate"`
+	AuthProxyEnabled           bool                               `json:"authProxyEnabled"`
+	LdapEnabled                bool                               `json:"ldapEnabled"`
+	JwtHeaderName              string                             `json:"jwtHeaderName"`
+	JwtUrlLogin                bool                               `json:"jwtUrlLogin"`
+	AlertingEnabled            bool                               `json:"alertingEnabled"`
+	AlertingErrorOrTimeout     string                             `json:"alertingErrorOrTimeout"`
+	AlertingNoDataOrNullValues string                             `json:"alertingNoDataOrNullValues"`
+	AlertingMinInterval        int64                              `json:"alertingMinInterval"`
+	LiveEnabled                bool                               `json:"liveEnabled"`
+	AutoAssignOrg              bool                               `json:"autoAssignOrg"`
 
 	VerifyEmailEnabled  bool `json:"verifyEmailEnabled"`
 	SigV4AuthEnabled    bool `json:"sigV4AuthEnabled"`

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -126,6 +126,7 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]interface{
 	m["stats.plugins.apps.count"] = s.appCount(ctx)
 	m["stats.plugins.panels.count"] = s.panelCount(ctx)
 	m["stats.plugins.datasources.count"] = s.dataSourceCount(ctx)
+	m["stats.plugins.transformer.count"] = s.transformerCount(ctx)
 	m["stats.alerts.count"] = statsResult.Alerts
 	m["stats.active_users.count"] = statsResult.ActiveUsers
 	m["stats.active_admins.count"] = statsResult.ActiveAdmins
@@ -347,4 +348,8 @@ func (s *Service) panelCount(ctx context.Context) int {
 
 func (s *Service) dataSourceCount(ctx context.Context) int {
 	return len(s.plugins.Plugins(ctx, plugins.DataSource))
+}
+
+func (s *Service) transformerCount(ctx context.Context) int {
+	return len(s.plugins.Plugins(ctx, plugins.Transformer))
 }

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -260,6 +260,15 @@ type AppDTO struct {
 	Preload bool   `json:"preload"`
 }
 
+type TransformerDTO struct {
+	ID           string `json:"id"`
+	Path         string `json:"path"`
+	Version      string `json:"version"`
+	Info         Info   `json:"info"`
+	ReleaseState string `json:"state"`
+	Module       string `json:"module"`
+}
+
 const (
 	signatureMissing  ErrorCode = "signatureMissing"
 	signatureModified ErrorCode = "signatureModified"

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -399,6 +399,10 @@ func (p *Plugin) StaticRoute() *StaticRoute {
 	return &StaticRoute{Directory: p.FS.Base(), PluginID: p.ID}
 }
 
+func (p *Plugin) IsTransformer() bool {
+	return p.Type == Transformer
+}
+
 func (p *Plugin) IsRenderer() bool {
 	return p.Type == Renderer
 }
@@ -441,6 +445,7 @@ var PluginTypes = []Type{
 	App,
 	Renderer,
 	SecretsManager,
+	Transformer,
 }
 
 type Type string
@@ -451,11 +456,12 @@ const (
 	App            Type = "app"
 	Renderer       Type = "renderer"
 	SecretsManager Type = "secretsmanager"
+	Transformer    Type = "transformer"
 )
 
 func (pt Type) IsValid() bool {
 	switch pt {
-	case DataSource, Panel, App, Renderer, SecretsManager:
+	case DataSource, Panel, App, Renderer, SecretsManager, Transformer:
 		return true
 	}
 	return false

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -77,7 +77,7 @@ import { DatasourceSrv } from './features/plugins/datasource_srv';
 import { createPluginExtensionRegistry } from './features/plugins/extensions/createPluginExtensionRegistry';
 import { getPluginExtensions } from './features/plugins/extensions/getPluginExtensions';
 import { importPanelPlugin, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
-import { preloadPlugins } from './features/plugins/pluginPreloader';
+import { preloadPlugins, loadTransformerPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
 import { initWindowRuntime } from './features/runtime/init';
@@ -189,6 +189,10 @@ export class GrafanaApp {
 
       // Preload selected app plugins
       const preloadResults = await preloadPlugins(config.apps);
+
+      // Register all transformation from Transformer plugins
+      await loadTransformerPlugins(config.transformers, standardTransformersRegistry )
+
 
       // Create extension registry out of the preloaded plugins
       const pluginExtensionGetter: GetPluginExtensions = (options) =>

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -30,6 +30,7 @@ export enum PluginIconName {
   panel = 'credit-card',
   renderer = 'capture',
   secretsmanager = 'key-skeleton-alt',
+  transformer  = 'process'
 }
 
 export interface CatalogPlugin extends WithAccessControlMetadata {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->


**What is this feature?**

This feature adds a simple (and maybe naive, but working) interface to implement Transformer plugins. 
For now, transformers have (almost) the same signature as the built-in ones. At initial Grafana loading, they are appended to the default once to be later available for use. The plugin interface allows multiple transformations to be added, to create for example packs of transformation. 
A quick usage example can be found in https://github.com/Willena/grafana-plugin-examples/blob/feature/transformer-plugin-example/examples/transformer-basic/src/module.ts


**Why do we need this feature?**

It allows implementing custom transformation plugin to extends list of Grafana built-in transformations. I (in 2021) suggested it, and it seems I'm not the only one interested in that functionality. 

For references: 
https://github.com/grafana/grafana/issues/36228#issuecomment-897077347
https://github.com/grafana/grafana/discussions/38540

**Who is this feature for?**

Transformers in the Grafana UI are very useful, but for domain specific transformations they are not very helpful as a custom piece of code would be required. 

**Which issue(s) does this PR fix?**:

Fixes #33154

**Special notes for your reviewer:**

Comments are very welcomed. I don't know if it is implemented the best way. 

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
