### PR TITLE
Alerting: Survey changes

### DIFF
--- a/public/app/features/alerting/unified/Analytics.test.ts
+++ b/public/app/features/alerting/unified/Analytics.test.ts
@@ -4,16 +4,17 @@ import { getBackendSrv } from '@grafana/runtime';
 import { isNewUser, USER_CREATION_MIN_DAYS } from './Analytics';
 
 jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: jest.fn().mockReturnValue({
     get: jest.fn(),
   }),
 }));
 
 describe('isNewUser', function () {
-  it('should return true if the user has been created within the last two weeks', async () => {
+  it('should return true if the user has been created within the last week', async () => {
     const newUser = {
       id: 1,
-      createdAt: dateTime().subtract(14, 'days'),
+      createdAt: dateTime().subtract(6, 'days'),
     };
 
     getBackendSrv().get = jest.fn().mockResolvedValue(newUser);

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -4,7 +4,7 @@ import { getBackendSrv } from '@grafana/runtime';
 import { config, reportInteraction } from '@grafana/runtime/src';
 import { contextSrv } from 'app/core/core';
 
-export const USER_CREATION_MIN_DAYS = 15;
+export const USER_CREATION_MIN_DAYS = 7;
 
 export const LogMessages = {
   filterByLabel: 'filtering alert instances by label',

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -2,6 +2,7 @@ import { dateTime } from '@grafana/data';
 import { faro, LogLevel as GrafanaLogLevel } from '@grafana/faro-web-sdk';
 import { getBackendSrv } from '@grafana/runtime';
 import { config, reportInteraction } from '@grafana/runtime/src';
+import { contextSrv } from 'app/core/core';
 
 export const USER_CREATION_MIN_DAYS = 15;
 
@@ -59,6 +60,20 @@ export async function isNewUser() {
     return true; //if no date is returned, we assume the user is new to prevent tracking actions
   }
 }
+
+export const trackRuleListNavigation = async (
+  props: AlertRuleTrackingProps = {
+    grafana_version: config.buildInfo.version,
+    org_id: contextSrv.user.orgId,
+    user_id: contextSrv.user.id,
+  }
+) => {
+  const isNew = await isNewUser();
+  if (isNew) {
+    return;
+  }
+  reportInteraction('grafana_alerting_navigation', props);
+};
 
 export const trackNewAlerRuleFormSaved = async (props: AlertRuleTrackingProps) => {
   const isNew = await isNewUser();

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'app/types';
 
 import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 
-import { LogMessages } from './Analytics';
+import { LogMessages, trackRuleListNavigation } from './Analytics';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { NoRulesSplash } from './components/rules/NoRulesCTA';
 import { INSTANCES_DISPLAY_LIMIT } from './components/rules/RuleDetails';
@@ -76,6 +76,7 @@ const RuleList = withErrorBoundary(
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
+        trackRuleListNavigation();
         await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
       }
     }, [loading, limitAlerts, dispatch]);

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -13,7 +13,7 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
-import { LogMessages, trackNewAlerRuleFormCancelled, trackNewAlerRuleFormError } from '../../Analytics';
+import { LogMessages, trackNewAlerRuleFormError } from '../../Analytics';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { deleteRuleAction, saveRuleFormAction } from '../../state/actions';
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
@@ -183,13 +183,6 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
 
   const cancelRuleCreation = () => {
     logInfo(LogMessages.cancelSavingAlertRule);
-    if (!existing) {
-      trackNewAlerRuleFormCancelled({
-        grafana_version: config.buildInfo.version,
-        org_id: contextSrv.user.orgId,
-        user_id: contextSrv.user.id,
-      });
-    }
   };
   const evaluateEveryInForm = watch('evaluateEvery');
   useEffect(() => setEvaluateEvery(evaluateEveryInForm), [evaluateEveryInForm]);

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,7 +1,7 @@
 import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
-import { config, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
@@ -32,9 +32,8 @@ import {
   RulerRulesConfigDTO,
 } from 'app/types/unified-alerting-dto';
 
-import { contextSrv } from '../../../../core/core';
 import { backendSrv } from '../../../../core/services/backend_srv';
-import { logInfo, LogMessages, trackNewAlerRuleFormSaved, withPerformanceLogging } from '../Analytics';
+import { logInfo, LogMessages, withPerformanceLogging } from '../Analytics';
 import {
   addAlertManagers,
   createOrUpdateSilence,
@@ -511,14 +510,6 @@ export const saveRuleFormAction = createAsyncThunk(
           }
 
           logInfo(LogMessages.successSavingAlertRule, { type, isNew: (!existing).toString() });
-
-          if (!existing) {
-            trackNewAlerRuleFormSaved({
-              grafana_version: config.buildInfo.version,
-              org_id: contextSrv.user.orgId,
-              user_id: contextSrv.user.id,
-            });
-          }
 
           if (redirectOnSave) {
             locationService.push(redirectOnSave);


### PR DESCRIPTION
**What is this feature?**

After a trial period we decided not to restrict the triggering of the user survey to certain flows (such as alert rule creation/cancelling it) but instead expand it to show always at the rule list view page. Certain conditions still apply:

- The user should not be new (at least 7 days since account creation)
- It should only trigger once (configured in Intercom)
- We should restart its triggering after 2 months so that we can compare responses after feature releases (configured in Intercom)

**Why do we need this feature?**

We were noticing users leave feedback related to other parts of the app and not only pertinent to the user flows that triggered it. For this reason it would make more sense to not tie it to a specific set of actions, but provide a common place where general feedback can be sent.

**Who is this feature for?**

All cloud users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/488
