### PR TITLE
Dashboards: Make the home dashboard non-editable (by default)

### DIFF
--- a/public/dashboards/home.json
+++ b/public/dashboards/home.json
@@ -62,6 +62,7 @@
     "from": "now-6h",
     "to": "now"
   },
+  "editable": false,
   "timepicker": {
     "hidden": true,
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],


### PR DESCRIPTION
The new double add button layout leads me to editing the homepage all the time now.

Before:
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/705951/236929423-7b874f98-ff2c-4312-982a-b208c51e67dd.png">

Since we do not support saving the home page, we should not allow editing it

After:
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/705951/236928712-dfaf9df8-0e62-401a-8a55-8e968ddd71a0.png">
