### PR TITLE
Nested folders: remove behaviour where selecting all children selects parent

### DIFF
--- a/public/app/features/browse-dashboards/state/reducers.test.ts
+++ b/public/app/features/browse-dashboards/state/reducers.test.ts
@@ -201,56 +201,6 @@ describe('browse-dashboards reducers', () => {
       });
     });
 
-    it('selects ancestors when all their children are now selected', () => {
-      const state = createInitialState();
-
-      const rootDashboard = wellFormedDashboard(1).item;
-      const parentFolder = wellFormedFolder(2).item;
-      const childDashboard = wellFormedDashboard(3, {}, { parentUID: parentFolder.uid }).item;
-      const childFolder = wellFormedFolder(4, {}, { parentUID: parentFolder.uid }).item;
-      const grandchildDashboard = wellFormedDashboard(5, {}, { parentUID: childFolder.uid }).item;
-
-      state.rootItems = [parentFolder, rootDashboard];
-      state.childrenByParentUID[parentFolder.uid] = [childDashboard, childFolder];
-      state.childrenByParentUID[childFolder.uid] = [grandchildDashboard];
-
-      // Selected the deepest grandchild dashboard
-      setItemSelectionState(state, {
-        type: 'setItemSelectionState',
-        payload: { item: grandchildDashboard, isSelected: true },
-      });
-
-      expect(state.selectedItems).toEqual({
-        $all: false,
-        dashboard: {
-          [grandchildDashboard.uid]: true,
-        },
-        folder: {
-          [parentFolder.uid]: false,
-          [childFolder.uid]: true, // is selected because all it's children (grandchildDashboard) is selected
-        },
-        panel: {},
-      });
-
-      setItemSelectionState(state, {
-        type: 'setItemSelectionState',
-        payload: { item: childDashboard, isSelected: true },
-      });
-
-      expect(state.selectedItems).toEqual({
-        $all: false,
-        dashboard: {
-          [childDashboard.uid]: true,
-          [grandchildDashboard.uid]: true,
-        },
-        folder: {
-          [parentFolder.uid]: true, // is now selected because we also selected its other child
-          [childFolder.uid]: true,
-        },
-        panel: {},
-      });
-    });
-
     it('selects the $all header checkbox when all descendants are now selected', () => {
       const state = createInitialState();
 
@@ -264,16 +214,16 @@ describe('browse-dashboards reducers', () => {
 
       state.selectedItems.dashboard = { [rootDashboard.uid]: true, [childDashboardA.uid]: true };
 
-      // Selected the deepest grandchild dashboard
+      // Selects the root folder
       setItemSelectionState(state, {
         type: 'setItemSelectionState',
-        payload: { item: childDashboardB, isSelected: true },
+        payload: { item: rootFolder, isSelected: true },
       });
 
       expect(state.selectedItems.$all).toBeTruthy();
     });
 
-    it('unselects the $all header checkbox a descendant is unselected', () => {
+    it('unselects the $all header checkbox if a descendant is unselected', () => {
       const state = createInitialState();
 
       const rootDashboard = wellFormedDashboard(1).item;

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -78,14 +78,7 @@ export function setItemSelectionState(
       break;
     }
 
-    if (isSelected) {
-      // If we're selecting an item, check all ancestors and see if all their children are
-      // now selected and update them appropriately
-      const children = state.childrenByParentUID[parent.uid];
-
-      const allChildrenSelected = children?.every((v) => state.selectedItems[v.kind][v.uid]) ?? false;
-      state.selectedItems[parent.kind][parent.uid] = allChildrenSelected;
-    } else {
+    if (!isSelected) {
       // A folder cannot be selected if any of it's children are unselected
       state.selectedItems[parent.kind][parent.uid] = false;
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes the behaviour where selecting all a parent's children would automatically select the parent

**Why do we need this feature?**

- so we can empty a folder/move a single item from a folder

**Who is this feature for?**

- anyone using nested folders

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
