### PR TITLE
Auth: Use PKCE by default (If OAuth provider supports PKCE)

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -162,7 +162,7 @@ query_retries = 0
 # For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
 transaction_retries = 5
 
-# Set to true to add metrics and tracing for database queries. 
+# Set to true to add metrics and tracing for database queries.
 instrument_queries = false
 
 #################################### Cache server #############################
@@ -611,6 +611,7 @@ role_attribute_strict = false
 allow_assign_grafana_admin = false
 skip_org_role_sync = false
 tls_skip_verify_insecure = false
+use_pkce = true
 
 #################################### Google Auth #########################
 [auth.google]
@@ -629,6 +630,7 @@ allowed_domains =
 hosted_domain =
 skip_org_role_sync = false
 tls_skip_verify_insecure = false
+use_pkce = true
 
 #################################### Grafana.com Auth ####################
 # legacy key names (so they work in env variables)
@@ -670,6 +672,7 @@ role_attribute_strict = false
 allow_assign_grafana_admin = false
 force_use_graph_api = false
 tls_skip_verify_insecure = false
+use_pkce = true
 
 #################################### Okta OAuth #######################
 [auth.okta]
@@ -691,6 +694,7 @@ role_attribute_strict = false
 allow_assign_grafana_admin = false
 skip_org_role_sync = false
 tls_skip_verify_insecure = false
+use_pkce = true
 
 #################################### Generic OAuth #######################
 [auth.generic_oauth]
@@ -1013,8 +1017,8 @@ ha_peers = ""
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ha_peer_timeout = 15s
 
-# The label is an optional string to include on each packet and stream. 
-# It uniquely identifies the cluster and prevents cross-communication 
+# The label is an optional string to include on each packet and stream.
+# It uniquely identifies the cluster and prevents cross-communication
 # issues when sending gossip messages in an enviromenet with multiple clusters.
 ha_label =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -164,7 +164,7 @@
 # For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
 ;transaction_retries = 5
 
-# Set to true to add metrics and tracing for database queries. 
+# Set to true to add metrics and tracing for database queries.
 ;instrument_queries = false
 
 ################################### Data sources #########################
@@ -599,6 +599,7 @@
 ;allow_assign_grafana_admin = false
 ;skip_org_role_sync = false
 ;tls_skip_verify_insecure = false
+;use_pkce = true
 
 #################################### Google Auth ##########################
 [auth.google]
@@ -616,6 +617,7 @@
 ;allowed_domains =
 ;hosted_domain =
 ;skip_org_role_sync = false
+;use_pkce = true
 
 #################################### Grafana.com Auth ####################
 [auth.grafana_com]
@@ -646,6 +648,7 @@
 ;allowed_groups =
 ;role_attribute_strict = false
 ;allow_assign_grafana_admin = false
+;use_pkce = true
 # prevent synchronizing users organization roles
 ;skip_org_role_sync = false
 
@@ -667,6 +670,7 @@
 ;role_attribute_strict = false
 ;allow_assign_grafana_admin = false
 ;skip_org_role_sync = false
+;use_pkce = true
 
 #################################### Generic OAuth ##########################
 [auth.generic_oauth]
@@ -983,8 +987,8 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;ha_peer_timeout = "15s"
 
-# The label is an optional string to include on each packet and stream. 
-# It uniquely identifies the cluster and prevents cross-communication 
+# The label is an optional string to include on each packet and stream.
+# It uniquely identifies the cluster and prevents cross-communication
 # issues when sending gossip messages in an enviromenet with multiple clusters.
 ;ha_label =
 


### PR DESCRIPTION
**What is this feature?**

- Use PKCE by default (If Oauth provider supports)
  - Add `use_pkce = true` to defaults.ini
  - Add `use_pkce = true` to sample.ini

**Why do we need this feature?**

- PKCE is going to be a required part of OAuth 2.1 which means that in the near future it'll be something that'll be required by authorization servers.
- And some OAuth provider supports PKCE.
  - see #22122
    - also see #39948

**Who is this feature for?**

- Users who use an Oauth provider

**Which issue(s) does this PR fix?**:

- Fixes #68073

**Special notes for your reviewer:**

- It is recommended that this be done during a major release.
- suggest labels
  - https://github.com/grafana/grafana/labels/area%2Fauth%2Foauth
  - https://github.com/grafana/grafana/labels/breaking%20change
  - https://github.com/grafana/grafana/labels/add%20to%20changelog
  - https://github.com/grafana/grafana/labels/no-backport

- You can fallback to the previous behavior by setting environment variables
  - `GF_AUTH_AZUREAD_USE_PKCE: false`
  - `GF_AUTH_GITLAB_USE_PKCE: false`
  - `GF_AUTH_GOOGLE_USE_PKCE: false`
  - `GF_AUTH_OKTA_USE_PKCE: false`

- Github and Generic should not be changed yet(May not support PKCE).

### screenshots(gitlab)

- if `GF_AUTH_GITLAB_USE_PKCE` not set, then use_pkce = true(default)

![image](https://github.com/grafana/grafana/assets/10738333/75da8a81-fde2-4e65-ad7f-13b48cd1d88a)

### screenshots(okta)

  - set `GF_AUTH_OKTA_USE_PKCE: false`, then use_pkce = false(override)

![image](https://github.com/grafana/grafana/assets/10738333/ce241286-c162-453e-ba0a-186efb8bd38a)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
