### PR TITLE
Heatmap: Handle unsorted timestamps in calculate mode

### DIFF
--- a/public/app/features/transformers/calculateHeatmap/heatmap.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.ts
@@ -15,6 +15,7 @@ import {
   durationToMilliseconds,
   parseDuration,
 } from '@grafana/data';
+import { isLikelyAscendingVector } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import {
   ScaleDistribution,
   HeatmapCellLayout,
@@ -325,7 +326,7 @@ export function calculateHeatmapFromData(frames: DataFrame[], options: HeatmapCa
   };
 
   const heat2d = heatmap(xs, ys, {
-    xSorted: true,
+    xSorted: isLikelyAscendingVector(xs),
     xTime: xField.type === FieldType.time,
     xMode: xBucketsCfg.mode,
     xSize:


### PR DESCRIPTION
Fixes #62070

don't assume timestamps are ordered in Calculate mode (they won't be when we have multiple frames).