### PR TITLE
Alerting: Omit "description" and "summary" from default email template annotations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -433,7 +433,6 @@ lerna.json @grafana/frontend-ops
 /public/app/types/ @grafana/grafana-frontend-platform
 /public/dashboards/ @grafana/dashboards-squad
 /public/fonts/ @grafana/alerting-squad-frontend
-/public/emails/ @grafana/grafana-frontend-platform
 /public/gazetteer/ @ryantxu
 /public/img/ @grafana/grafana-frontend-platform
 /public/lib/ @grafana/grafana-frontend-platform
@@ -618,6 +617,7 @@ embed.go @grafana/grafana-as-code
 /docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md @grafanabot
 /pkg/services/featuremgmt/toggles_gen.csv @grafanabot
 /pkg/services/featuremgmt/toggles_gen.go @grafanabot
+/public/emails/ @grafanabot
 
 # Conf
 /conf/defaults.ini @torkelo

--- a/emails/templates/partials/alerting/instance_details.mjml
+++ b/emails/templates/partials/alerting/instance_details.mjml
@@ -1,47 +1,47 @@
 <!-- Image from external service -->
-<mj-raw> {{ if .ImageURL }} </mj-raw>
+<mj-raw>{{ if .ImageURL }}</mj-raw>
 <mj-section padding="0">
   <mj-column border-bottom="1px solid #2f3037">
     <mj-image href="{{ .ImageURL }}" src="{{ .ImageURL }}" padding="0" />
   </mj-column>
 </mj-section>
-<mj-raw> {{ end }} </mj-raw>
+<mj-raw>{{ end }}</mj-raw>
 
 <!-- Embedded Image -->
-<mj-raw> {{ if .EmbeddedImage }} </mj-raw>
+<mj-raw>{{ if .EmbeddedImage }}</mj-raw>
 <mj-section padding="0">
   <mj-column border-bottom="1px solid #2f3037">
     <mj-image src="cid:{{ .EmbeddedImage }}" padding="0" />
   </mj-column>
 </mj-section>
-<mj-raw> {{ end }} </mj-raw>
+<mj-raw>{{ end }}</mj-raw>
 
 <mj-section padding="0" text-align="left">
   <mj-column>
     <!-- Summary -->
-    <mj-raw> {{ if .Annotations.summary }} </mj-raw>
+    <mj-raw>{{ if .Annotations.summary }}</mj-raw>
     <mj-text>
       <strong>Summary</strong>
     </mj-text>
     <mj-text> {{- .Annotations.summary -}} </mj-text>
-    <mj-raw> {{ end }} </mj-raw>
+    <mj-raw>{{ end }}</mj-raw>
 
     <!-- Description -->
-    <mj-raw> {{ if .Annotations.description }} </mj-raw>
+    <mj-raw>{{ if .Annotations.description }}</mj-raw>
     <mj-text>
       <strong>Description</strong>
     </mj-text>
     <mj-text>
-      <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
+      <mj-raw>{{ range $line := (splitList "\n" .Annotations.description) }}</mj-raw>
       {{ $line }}<br />
-      <mj-raw> {{ end }} </mj-raw>
+      <mj-raw>{{ end }}</mj-raw>
     </mj-text>
-    <mj-raw> {{ end }} </mj-raw>
+    <mj-raw>{{ end }}</mj-raw>
   </mj-column>
 </mj-section>
 
 <!-- Values -->
-<mj-raw> {{ if .Values }} </mj-raw>
+<mj-raw>{{ if .Values }}</mj-raw>
 <mj-section padding="0" text-align="left">
   <mj-column>
     <mj-text>
@@ -52,38 +52,38 @@
 <mj-section padding="0 25px" text-align="left">
   <mj-column padding="10px" background-color="#111217" border="1px solid #2f3037">
     <mj-text>
-      <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
+      <mj-raw>{{ range $refID, $value := .Values }}</mj-raw>
       {{ $refID }}={{ $value }}&nbsp;
-      <mj-raw> {{ end }} </mj-raw>
+      <mj-raw>{{ end }}</mj-raw>
     </mj-text>
   </mj-column>
 </mj-section>
-<mj-raw> {{ end }} </mj-raw>
+<mj-raw>{{ end }}</mj-raw>
 
 <!-- Labels and annotations -->
 <mj-section>
   <mj-column>
     <!-- Labels -->
-    <mj-raw> {{ if .Labels.SortedPairs }} </mj-raw>
+    <mj-raw>{{ if .Labels.SortedPairs }}</mj-raw>
     <mj-text>
       <strong>Labels</strong>
     </mj-text>
 
     <mj-table color="white">
-      <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
+      <mj-raw>{{ range .Labels.SortedPairs }}</mj-raw>
       <tr>
         <td>
           <strong>{{ .Name }}</strong>
         </td>
         <td>{{ .Value }}</td>
       </tr>
-      <mj-raw> {{ end }} </mj-raw>
+      <mj-raw>{{ end }}</mj-raw>
     </mj-table>
 
-    <mj-raw> {{ end }} </mj-raw>
+    <mj-raw>{{ end }}</mj-raw>
 
     <!-- Annotations, we exclude "description" and "summary" because those have their own dedicated section -->
-    <mj-raw> {{ if (without .Annotations.SortedPairs.Names "description" "summary") }} </mj-raw>
+    <mj-raw>{{ if (without .Annotations.SortedPairs.Names "description" "summary") }}</mj-raw>
     <mj-text>
       <strong>Annotations</strong>
     </mj-text>
@@ -97,11 +97,11 @@
         </td>
         <td>{{ .Value }}</td>
       </tr>
-      <mj-raw> {{ end }} </mj-raw>
-      <mj-raw> {{ end }} </mj-raw>
+      <mj-raw>{{ end }}</mj-raw>
+      <mj-raw>{{ end }}</mj-raw>
     </mj-table>
 
-    <mj-raw> {{ end }} </mj-raw>
+    <mj-raw>{{ end }}</mj-raw>
   </mj-column>
 </mj-section>
 

--- a/emails/templates/partials/alerting/instance_details.mjml
+++ b/emails/templates/partials/alerting/instance_details.mjml
@@ -1,71 +1,47 @@
 <!-- Image from external service -->
-<mj-raw>
-  {{ if .ImageURL }}
-</mj-raw>
+<mj-raw> {{ if .ImageURL }} </mj-raw>
 <mj-section padding="0">
   <mj-column border-bottom="1px solid #2f3037">
     <mj-image href="{{ .ImageURL }}" src="{{ .ImageURL }}" padding="0" />
   </mj-column>
 </mj-section>
-<mj-raw>
-  {{ end }}
-</mj-raw>
+<mj-raw> {{ end }} </mj-raw>
 
 <!-- Embedded Image -->
-<mj-raw>
-  {{ if .EmbeddedImage }}
-</mj-raw>
+<mj-raw> {{ if .EmbeddedImage }} </mj-raw>
 <mj-section padding="0">
   <mj-column border-bottom="1px solid #2f3037">
     <mj-image src="cid:{{ .EmbeddedImage }}" padding="0" />
   </mj-column>
 </mj-section>
-<mj-raw>
-  {{ end }}
-</mj-raw>
+<mj-raw> {{ end }} </mj-raw>
 
 <mj-section padding="0" text-align="left">
   <mj-column>
     <!-- Summary -->
-    <mj-raw>
-      {{ if .Annotations.summary }}
-    </mj-raw>
+    <mj-raw> {{ if .Annotations.summary }} </mj-raw>
     <mj-text>
       <strong>Summary</strong>
     </mj-text>
-    <mj-text>
-      {{- .Annotations.summary -}}
-    </mj-text>
-    <mj-raw>
-      {{ end }}
-    </mj-raw>
+    <mj-text> {{- .Annotations.summary -}} </mj-text>
+    <mj-raw> {{ end }} </mj-raw>
 
     <!-- Description -->
-    <mj-raw>
-      {{ if .Annotations.description }}
-    </mj-raw>
+    <mj-raw> {{ if .Annotations.description }} </mj-raw>
     <mj-text>
       <strong>Description</strong>
     </mj-text>
     <mj-text>
-      <mj-raw>
-        {{ range $line := (splitList "\n" .Annotations.description) }}
-      </mj-raw>
+      <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
       {{ $line }}<br />
-      <mj-raw>
-        {{ end }}
-      </mj-raw>
+      <mj-raw> {{ end }} </mj-raw>
     </mj-text>
-    <mj-raw>
-      {{ end }}
-    </mj-raw>
+    <mj-raw> {{ end }} </mj-raw>
   </mj-column>
 </mj-section>
 
 <!-- Values -->
-<mj-raw>
-  {{ if .Values }}
-</mj-raw>
+<mj-raw> {{ if .Values }} </mj-raw>
 <mj-section padding="0" text-align="left">
   <mj-column>
     <mj-text>
@@ -76,80 +52,56 @@
 <mj-section padding="0 25px" text-align="left">
   <mj-column padding="10px" background-color="#111217" border="1px solid #2f3037">
     <mj-text>
-      <mj-raw>
-        {{ range $refID, $value := .Values }}
-      </mj-raw>
+      <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
       {{ $refID }}={{ $value }}&nbsp;
-      <mj-raw>
-        {{ end }}
-      </mj-raw>
+      <mj-raw> {{ end }} </mj-raw>
     </mj-text>
   </mj-column>
 </mj-section>
-<mj-raw>
-  {{ end }}
-</mj-raw>
+<mj-raw> {{ end }} </mj-raw>
 
 <!-- Labels and annotations -->
 <mj-section>
   <mj-column>
     <!-- Labels -->
-    <mj-raw>
-      {{ if .Labels.SortedPairs }}
-    </mj-raw>
+    <mj-raw> {{ if .Labels.SortedPairs }} </mj-raw>
     <mj-text>
       <strong>Labels</strong>
     </mj-text>
 
     <mj-table color="white">
-      <mj-raw>
-        {{ range .Labels.SortedPairs }}
-      </mj-raw>
+      <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
       <tr>
         <td>
           <strong>{{ .Name }}</strong>
         </td>
-        <td>
-          {{ .Value }}
-        </td>
+        <td>{{ .Value }}</td>
       </tr>
-      <mj-raw>
-        {{ end }}
-      </mj-raw>
+      <mj-raw> {{ end }} </mj-raw>
     </mj-table>
 
-    <mj-raw>
-      {{ end }}
-    </mj-raw>
+    <mj-raw> {{ end }} </mj-raw>
 
-    <!-- Annotations -->
-    <mj-raw>
-      {{ if .Annotations.SortedPairs }}
-    </mj-raw>
+    <!-- Annotations, we exclude "description" and "summary" because those have their own dedicated section -->
+    <mj-raw> {{ if (without .Annotations.SortedPairs.Names "description" "summary") }} </mj-raw>
     <mj-text>
       <strong>Annotations</strong>
     </mj-text>
 
     <mj-table color="white">
-      <mj-raw>
-        {{ range .Annotations.SortedPairs }}
-      </mj-raw>
+      <mj-raw>{{ range .Annotations.SortedPairs }}</mj-raw>
+      <mj-raw>{{ if and (ne .Name "description") (ne .Name "summary") }}</mj-raw>
       <tr>
         <td>
           <strong>{{ .Name }}</strong>
         </td>
-        <td>
-          {{ .Value }}
-        </td>
+        <td>{{ .Value }}</td>
       </tr>
-      <mj-raw>
-        {{ end }}
-      </mj-raw>
+      <mj-raw> {{ end }} </mj-raw>
+      <mj-raw> {{ end }} </mj-raw>
     </mj-table>
 
-    <mj-raw>
-      {{ end }}
-    </mj-raw>
+    <mj-raw> {{ end }} </mj-raw>
   </mj-column>
 </mj-section>
 
@@ -178,9 +130,7 @@
   <mj-raw>{{ end }}</mj-raw>
   <mj-raw>{{ if .PanelURL }}</mj-raw>
   <mj-column>
-    <mj-button align="center" href="{{ .PanelURL }}" padding="0" inner-padding="5px 12px">
-      View panel
-    </mj-button>
+    <mj-button align="center" href="{{ .PanelURL }}" padding="0" inner-padding="5px 12px"> View panel </mj-button>
   </mj-column>
   <mj-raw>{{ end }}</mj-raw>
 </mj-section>
@@ -189,7 +139,8 @@
 <mj-section border-top="1px solid #2f3037" padding="5px 0">
   <mj-column>
     <mj-text color="#91929e">
-      Observed <strong>{{ ago .StartsAt }}</strong> before this notification was delivered, at <strong>{{ .StartsAt }}</strong>
+      Observed <strong>{{ ago .StartsAt }}</strong> before this notification was delivered, at
+      <strong>{{ .StartsAt }}</strong>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -470,13 +470,9 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                    <mj-raw>
-                                      {{ range $line := (splitList "\n" .Annotations.description) }}
-                                    </mj-raw>
+                                    <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
                                     {{ $line }}<br>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </div>
                                 </td>
                               </tr>
@@ -533,12 +529,8 @@
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                            <mj-raw>
-                                              {{ range $refID, $value := .Values }}
-                                            </mj-raw>
-                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw>
-                                              {{ end }}
-                                            </mj-raw>
+                                            <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
+                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw> {{ end }} </mj-raw>
                                           </div>
                                         </td>
                                       </tr>
@@ -576,24 +568,18 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw>
-                                      {{ range .Labels.SortedPairs }}
-                                    </mj-raw>
+                                    <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>
-                                        {{ .Value }}
-                                      </td>
+                                      <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </table>
                                 </td>
                               </tr>
-                              {{ end }}{{ if .Annotations.SortedPairs }}
+                              {{ end }}{{ if (without .Annotations.SortedPairs.Names "description" "summary") }}
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;"><strong>Annotations</strong></div>
@@ -602,20 +588,16 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw>
-                                      {{ range .Annotations.SortedPairs }}
-                                    </mj-raw>
+                                    <mj-raw>{{ range .Annotations.SortedPairs }}</mj-raw>
+                                    <mj-raw>{{ if and (ne .Name "description") (ne .Name "summary") }}</mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>
-                                        {{ .Value }}
-                                      </td>
+                                      <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </table>
                                 </td>
                               </tr>
@@ -979,13 +961,9 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                    <mj-raw>
-                                      {{ range $line := (splitList "\n" .Annotations.description) }}
-                                    </mj-raw>
+                                    <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
                                     {{ $line }}<br>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </div>
                                 </td>
                               </tr>
@@ -1042,12 +1020,8 @@
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                            <mj-raw>
-                                              {{ range $refID, $value := .Values }}
-                                            </mj-raw>
-                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw>
-                                              {{ end }}
-                                            </mj-raw>
+                                            <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
+                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw> {{ end }} </mj-raw>
                                           </div>
                                         </td>
                                       </tr>
@@ -1085,24 +1059,18 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw>
-                                      {{ range .Labels.SortedPairs }}
-                                    </mj-raw>
+                                    <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>
-                                        {{ .Value }}
-                                      </td>
+                                      <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </table>
                                 </td>
                               </tr>
-                              {{ end }}{{ if .Annotations.SortedPairs }}
+                              {{ end }}{{ if (without .Annotations.SortedPairs.Names "description" "summary") }}
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;"><strong>Annotations</strong></div>
@@ -1111,20 +1079,16 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw>
-                                      {{ range .Annotations.SortedPairs }}
-                                    </mj-raw>
+                                    <mj-raw>{{ range .Annotations.SortedPairs }}</mj-raw>
+                                    <mj-raw>{{ if and (ne .Name "description") (ne .Name "summary") }}</mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
-                                      <td>
-                                        {{ .Value }}
-                                      </td>
+                                      <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw>
-                                      {{ end }}
-                                    </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw> {{ end }} </mj-raw>
                                   </table>
                                 </td>
                               </tr>

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -470,9 +470,9 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                    <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
+                                    <mj-raw>{{ range $line := (splitList "\n" .Annotations.description) }}</mj-raw>
                                     {{ $line }}<br>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </div>
                                 </td>
                               </tr>
@@ -529,8 +529,8 @@
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                            <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
-                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw> {{ end }} </mj-raw>
+                                            <mj-raw>{{ range $refID, $value := .Values }}</mj-raw>
+                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw>{{ end }}</mj-raw>
                                           </div>
                                         </td>
                                       </tr>
@@ -568,14 +568,14 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
+                                    <mj-raw>{{ range .Labels.SortedPairs }}</mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
                                       <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </table>
                                 </td>
                               </tr>
@@ -596,8 +596,8 @@
                                       </td>
                                       <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw> {{ end }} </mj-raw>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </table>
                                 </td>
                               </tr>
@@ -961,9 +961,9 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                    <mj-raw> {{ range $line := (splitList "\n" .Annotations.description) }} </mj-raw>
+                                    <mj-raw>{{ range $line := (splitList "\n" .Annotations.description) }}</mj-raw>
                                     {{ $line }}<br>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </div>
                                 </td>
                               </tr>
@@ -1020,8 +1020,8 @@
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.5;text-align:left;color:#FFFFFF;">
-                                            <mj-raw> {{ range $refID, $value := .Values }} </mj-raw>
-                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw> {{ end }} </mj-raw>
+                                            <mj-raw>{{ range $refID, $value := .Values }}</mj-raw>
+                                            {{ $refID }}={{ $value }}&nbsp; <mj-raw>{{ end }}</mj-raw>
                                           </div>
                                         </td>
                                       </tr>
@@ -1059,14 +1059,14 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:white;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                    <mj-raw> {{ range .Labels.SortedPairs }} </mj-raw>
+                                    <mj-raw>{{ range .Labels.SortedPairs }}</mj-raw>
                                     <tr>
                                       <td>
                                         <strong>{{ .Name }}</strong>
                                       </td>
                                       <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </table>
                                 </td>
                               </tr>
@@ -1087,8 +1087,8 @@
                                       </td>
                                       <td>{{ .Value }}</td>
                                     </tr>
-                                    <mj-raw> {{ end }} </mj-raw>
-                                    <mj-raw> {{ end }} </mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
+                                    <mj-raw>{{ end }}</mj-raw>
                                   </table>
                                 </td>
                               </tr>


### PR DESCRIPTION
**What is this feature?**

This PR makes a small change to the default email template for alerting by omitting "description" and "summary" from the annotations.

These annotations have a dedicated section in the email template where white-spaces are preserved and don't need to be repeated as part of the set of annotations.

<img width="645" alt="image" src="https://github.com/grafana/grafana/assets/868844/a3138288-1126-4b6a-8bb4-699f0f070770">
