### PR TITLE
AzureMonitor: Correctly set resource parameter for Logs queries

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -353,7 +353,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 				ResultFormat *dataquery.AzureMonitorQueryAzureLogAnalyticsResultFormat "json:\"resultFormat,omitempty\""
 				Workspace    *string                                                   "json:\"workspace,omitempty\""
 			}{
-				Resources: queryJSONModel.AzureTraces.Resources,
+				Resources: []string{queryJSONModel.AzureTraces.Resources[0]},
 				Query:     &query.TraceLogsExploreQuery,
 			},
 			QueryType: &logsQueryType,
@@ -405,7 +405,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger 
 		"query":    query.Query,
 		"timespan": timespan,
 	}
-	if len(query.Resources) > 1 {
+	if len(query.Resources) > 1 && query.QueryType == string(dataquery.AzureQueryTypeAzureLogAnalytics) {
 		body["workspaces"] = query.Resources
 	}
 	jsonValue, err := json.Marshal(body)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -162,14 +162,20 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 				}
 			}
 
-			queryString = buildTracesQuery(operationId, queryJSONModel.AzureTraces.TraceTypes, queryJSONModel.AzureTraces.Filters, &resultFormat, resourcesMap)
+			queryResources := make([]string, 0)
+			for resource, _ := range resourcesMap {
+				queryResources = append(queryResources, resource)
+			}
+			sort.Strings(queryResources)
+
+			queryString = buildTracesQuery(operationId, queryJSONModel.AzureTraces.TraceTypes, queryJSONModel.AzureTraces.Filters, &resultFormat, queryResources)
 			traceIdVariable := "${__data.fields.traceID}"
 			if operationId == "" {
-				traceExploreQuery = buildTracesQuery(traceIdVariable, queryJSONModel.AzureTraces.TraceTypes, queryJSONModel.AzureTraces.Filters, &resultFormat, resourcesMap)
-				traceLogsExploreQuery = buildTracesLogsQuery(traceIdVariable, resourcesMap)
+				traceExploreQuery = buildTracesQuery(traceIdVariable, queryJSONModel.AzureTraces.TraceTypes, queryJSONModel.AzureTraces.Filters, &resultFormat, queryResources)
+				traceLogsExploreQuery = buildTracesLogsQuery(traceIdVariable, queryResources)
 			} else {
 				traceExploreQuery = queryString
-				traceLogsExploreQuery = buildTracesLogsQuery(operationId, resourcesMap)
+				traceLogsExploreQuery = buildTracesLogsQuery(operationId, queryResources)
 			}
 			traceExploreQuery, err = macros.KqlInterpolate(logger, query, dsInfo, traceExploreQuery, "TimeGenerated")
 			if err != nil {
@@ -674,7 +680,7 @@ func encodeQuery(rawQuery string) (string, error) {
 	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
 }
 
-func buildTracesQuery(operationId string, traceTypes []string, filters []types.TracesFilters, resultFormat *string, resources map[string]bool) string {
+func buildTracesQuery(operationId string, traceTypes []string, filters []types.TracesFilters, resultFormat *string, resources []string) string {
 	types := traceTypes
 	if len(types) == 0 {
 		types = Tables
@@ -696,7 +702,7 @@ func buildTracesQuery(operationId string, traceTypes []string, filters []types.T
 	resourcesQuery := strings.Join(filteredTypes, ",")
 	if len(resources) > 0 {
 		intermediate := make([]string, 0)
-		for resource := range resources {
+		for _, resource := range resources {
 			resourceSplit := strings.SplitAfter(resource, "/")
 			resourceName := resourceSplit[len(resourceSplit)-1]
 			for _, table := range filteredTypes {
@@ -768,13 +774,13 @@ func buildTracesQuery(operationId string, traceTypes []string, filters []types.T
 	return baseQuery + whereClause + propertiesStaticQuery + errorProperty + propertiesQuery + filtersClause + projectClause
 }
 
-func buildTracesLogsQuery(operationId string, resources map[string]bool) string {
+func buildTracesLogsQuery(operationId string, resources []string) string {
 	types := Tables
 	sort.Strings(types)
 	selectors := "union " + strings.Join(types, ",\n") + "\n"
 	if len(resources) > 0 {
 		intermediate := make([]string, 0)
-		for resource := range resources {
+		for _, resource := range resources {
 			resourceSplit := strings.SplitAfter(resource, "/")
 			resourceName := resourceSplit[len(resourceSplit)-1]
 			for _, table := range types {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -163,7 +163,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			}
 
 			queryResources := make([]string, 0)
-			for resource, _ := range resourcesMap {
+			for resource := range resourcesMap {
 				queryResources = append(queryResources, resource)
 			}
 			sort.Strings(queryResources)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1256,7 +1256,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("does not pass multiple resources", func(t *testing.T) {
+	t.Run("does not pass multiple resources for traces queries", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		from := time.Now()
 		to := from.Add(3 * time.Hour)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1223,6 +1223,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
 			Resources: []string{"r1", "r2"},
 			Query:     "Perf",
+			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
 		})
 		require.NoError(t, err)
 		expectedBody := `{"query":"Perf","timespan":"0001-01-01T00:00:00Z/0001-01-01T00:00:00Z","workspaces":["r1","r2"]}`
@@ -1240,6 +1241,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
 			Resources: []string{"r1", "r2"},
 			Query:     "Perf",
+			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
 			TimeRange: backend.TimeRange{
 				From: from,
 				To:   to,
@@ -1247,6 +1249,27 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		})
 		require.NoError(t, err)
 		expectedBody := fmt.Sprintf(`{"query":"Perf","timespan":"%s/%s","workspaces":["r1","r2"]}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		if !cmp.Equal(string(body), expectedBody) {
+			t.Errorf("Unexpected Body: %v", cmp.Diff(string(body), expectedBody))
+		}
+	})
+
+	t.Run("does not pass multiple resources", func(t *testing.T) {
+		ds := AzureLogAnalyticsDatasource{}
+		from := time.Now()
+		to := from.Add(3 * time.Hour)
+		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+			Resources: []string{"r1", "r2"},
+			QueryType: string(dataquery.AzureQueryTypeAzureTraces),
+			TimeRange: backend.TimeRange{
+				From: from,
+				To:   to,
+			},
+		})
+		require.NoError(t, err)
+		expectedBody := fmt.Sprintf(`{"query":"","timespan":"%s/%s"}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {


### PR DESCRIPTION
Ensure only logs queries have the `resources` property set as for traces queries the resources are built as a part of the query.