### PR TITLE
Alerting: Change text on cloud AM email addresses for contact points

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -255,7 +255,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				},
 				{
 					Label:        "Addresses",
-					Description:  "You can enter multiple email addresses using a \";\" separator",
+					Description:  "You can enter multiple email addresses using a \";\", \"\\n\" or  \",\" separator",
 					Element:      ElementTypeTextArea,
 					PropertyName: "addresses",
 					Required:     true,

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -77,7 +77,12 @@ export const cloudNotifierTypes: NotifierDTO[] = [
     info: '',
     heading: 'Email settings',
     options: [
-      option('to', 'To', 'The email address to send notifications to.', { required: true }),
+      option(
+        'to',
+        'To',
+        'The email address to send notifications to. You can enter multiple addresses using a "," separator',
+        { required: true }
+      ),
       option('from', 'From', 'The sender address.'),
       option('smarthost', 'SMTP host', 'The SMTP host through which emails are sent.'),
       option('hello', 'Hello', 'The hostname to identify to the SMTP server.'),


### PR DESCRIPTION
**What is this feature?**

Improves the description text on allowed email formatting for cloud alert managers and grafana alertmanagers. For external ones, only `,` is allowed while for Grafana valid separators include `,`, `;` and `\n`.

**Why do we need this feature?**

Prior to this PR we didn't give any specification on what's the correct format for multiple email addresses for cloud alertmanagers while we only listed `,` for the Grafana one.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

After:

Grafana Alertmanager:
![image](https://github.com/grafana/grafana/assets/6271380/3ee9e87d-5a2c-403a-b22d-d6dce895b0fe)

External Alertmanager:
![image](https://github.com/grafana/grafana/assets/6271380/84573a4c-d8d1-4bc7-b1a1-c82705b65ef2)
