### PR TITLE
Heatmap: Fix color rendering for value ranges < 1

### DIFF
--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -967,7 +967,7 @@ export const boundedMinMax = (
 };
 
 export const valuesToFills = (values: number[], palette: string[], minValue: number, maxValue: number) => {
-  let range = Math.max(maxValue - minValue, 1);
+  let range = maxValue - minValue || 1;
 
   let paletteSize = palette.length;
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/65302

this was a 0-divisor guard (when min === max) made with the assumption that heatmap cells were always counts and could not be < 1.

<details><summary>heatmap-colors.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 658,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "custom": {
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "scaleDistribution": {
              "type": "linear"
            }
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "calculate": false,
        "cellGap": 1,
        "color": {
          "exponent": 0.5,
          "fill": "dark-orange",
          "mode": "scheme",
          "reverse": false,
          "scale": "exponential",
          "scheme": "Spectral",
          "steps": 64
        },
        "exemplars": {
          "color": "rgba(255,0,255,0.7)"
        },
        "filterValues": {
          "le": 1e-9
        },
        "legend": {
          "show": true
        },
        "rowsFrame": {
          "layout": "auto"
        },
        "tooltip": {
          "show": true,
          "yHistogram": false
        },
        "yAxis": {
          "axisPlacement": "left",
          "reverse": false
        }
      },
      "pluginVersion": "10.1.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          },\n          \"config\": {}\n        },\n        {\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1683669542644,\n          1683671942644,\n          1683674342644,\n          1683676742644,\n          1683679142644,\n          1683681542644,\n          1683683942644,\n          1683686342644,\n          1683688742644,\n          1683691142644\n        ],\n        [\n          20,\n          20.01,\n          20.02,\n          20.03,\n          20.04,\n          20.05,\n          20.06,\n          20.07,\n          20.08,\n          20.09\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "heatmap"
    }
  ],
  "refresh": false,
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2023-05-09T21:12:08.356Z",
    "to": "2023-05-10T04:06:09.539Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "heatmap-colors",
  "uid": "c43d1a41-98f0-45c5-bf21-b17eff49f55f",
  "version": 3,
  "weekStart": ""
}
```
</details>

before:

![image](https://github.com/grafana/grafana/assets/43234/b8bf3312-5549-4679-b1ad-f35cc775e460)

after:

![image](https://github.com/grafana/grafana/assets/43234/10060bae-abf3-4ad5-96f8-4c63a3835a91)
