### PR TITLE
HelpWizard: Show snapshot preview regardless of scenes feature toggle

### DIFF
--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -80,7 +80,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
 
     let scene: SceneObject | undefined = undefined;
 
-    if (config.featureToggles.scenes && !panel.isAngularPlugin()) {
+    if (!panel.isAngularPlugin()) {
       try {
         const oldModel = new DashboardModel(snapshot);
         const dash = createDashboardSceneFromDashboardModel(oldModel);


### PR DESCRIPTION
This PR removes the scenes feature flag check when showing a preview in the help wizard.  Follow up from https://github.com/grafana/grafana/pull/64936

<img width="1728" alt="image" src="https://github.com/grafana/grafana/assets/705951/118ad87e-2194-44f6-9823-97a8b2fdb296">

Not urgent, but I think we should have something in 10x that uses scenes without feature toggles.  This is safe because it has no user saved behaviors, and is also gated by a `try { } catch` 