### PR TITLE
Utils: Add helper to check valid k8s CRD names

### DIFF
--- a/pkg/util/names.go
+++ b/pkg/util/names.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 )
 
-var validNamePattern = regexp.MustCompile(`^[a-z][-a-z0-9|-]*`).MatchString
+var validNamePattern = regexp.MustCompile(`^[a-z][a-z0-9\-]*$`).MatchString
 
 // IsValidCK8sCRDName checks if a name can be used for a kubernetes CRD resource
 // * contain at most 63 characters

--- a/pkg/util/names.go
+++ b/pkg/util/names.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+)
+
+var validNamePattern = regexp.MustCompile(`^[a-z][-a-z0-9|-]*`).MatchString
+
+// IsValidCK8sCRDName checks if a name can be used for a kubernetes CRD resource
+// * contain at most 63 characters
+// * start with a lowercase alpha character
+// * contain only lowercase alphanumeric characters or '-'
+func IsValidCK8sCRDName(name string) bool {
+	return validNamePattern(name) && len(name) < 64
+}
+
+// GrafanaUIDToK8sName defines a consistent mapping between Grafana UIDs and k8s compatible names
+func GrafanaUIDToK8sName(uid string) string {
+	if IsValidCK8sCRDName(uid) {
+		return uid // OK, so just use it directly
+	}
+
+	h := sha256.New()
+	_, _ = h.Write([]byte(uid))
+	bs := h.Sum(nil)
+	return fmt.Sprintf("g%x", bs[:12])
+}

--- a/pkg/util/names_test.go
+++ b/pkg/util/names_test.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidK8sName(t *testing.T) {
+	// too long
+	require.Equal(t, false, IsValidK8sName("a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))
+
+	require.Equal(t, false, IsValidK8sName(""))          // too short
+	require.Equal(t, false, IsValidK8sName("001"))       // numeric first
+	require.Equal(t, false, IsValidK8sName("XMuLlpZ4k")) // uppercase not OK
+	require.Equal(t, false, IsValidK8sName("-a"))        // dash is ok
+
+	// OK names
+	require.Equal(t, true, IsValidK8sName("hello-world")) // dash is ok
+	require.Equal(t, true, IsValidK8sName("xulipzwk"))    // lower OK
+	require.Equal(t, true, IsValidK8sName("a"))           // lower OK
+	require.Equal(t, true, IsValidK8sName("fe38343c-cfca-49d3-b76e-af0e6add9a2a"))
+}
+
+func TestGrafanaUIDToK8sName(t *testing.T) {
+	require.Equal(t, "g7a3e6b16cb75f48fb897eff3", GrafanaUIDToK8sName("001"))       // uppercase not OK
+	require.Equal(t, "g148d11beead6f8ff530eb763", GrafanaUIDToK8sName("XMuLlpZ4k")) // uppercase not OK
+	require.Equal(t, "xulipzwk", GrafanaUIDToK8sName("xulipzwk"))                   // lower OK
+	require.Equal(t, "fe38343c-cfca-49d3-b76e-af0e6add9a2a", GrafanaUIDToK8sName("fe38343c-cfca-49d3-b76e-af0e6add9a2a"))
+}

--- a/pkg/util/names_test.go
+++ b/pkg/util/names_test.go
@@ -6,25 +6,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsValidK8sName(t *testing.T) {
+func TestIsValidCK8sCRDName(t *testing.T) {
 	// too long
-	require.Equal(t, false, IsValidK8sName("a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))
+	require.Equal(t, false, IsValidCK8sCRDName("a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))
 
-	require.Equal(t, false, IsValidK8sName(""))          // too short
-	require.Equal(t, false, IsValidK8sName("001"))       // numeric first
-	require.Equal(t, false, IsValidK8sName("XMuLlpZ4k")) // uppercase not OK
-	require.Equal(t, false, IsValidK8sName("-a"))        // dash is ok
+	require.Equal(t, false, IsValidCK8sCRDName(""))            // too short
+	require.Equal(t, false, IsValidCK8sCRDName("001"))         // numeric first
+	require.Equal(t, false, IsValidCK8sCRDName("XMuLlpZ4k"))   // uppercase not OK
+	require.Equal(t, false, IsValidCK8sCRDName("-a"))          // dash is ok
+	require.Equal(t, false, IsValidCK8sCRDName("hello/world")) // punctuation
+	require.Equal(t, false, IsValidCK8sCRDName("hello?world")) // punctuation
+	require.Equal(t, false, IsValidCK8sCRDName("hello world")) // punctuation
 
 	// OK names
-	require.Equal(t, true, IsValidK8sName("hello-world")) // dash is ok
-	require.Equal(t, true, IsValidK8sName("xulipzwk"))    // lower OK
-	require.Equal(t, true, IsValidK8sName("a"))           // lower OK
-	require.Equal(t, true, IsValidK8sName("fe38343c-cfca-49d3-b76e-af0e6add9a2a"))
+	require.Equal(t, true, IsValidCK8sCRDName("hello-world")) // dash is ok
+	require.Equal(t, true, IsValidCK8sCRDName("xulipzwk"))    // lower OK
+	require.Equal(t, true, IsValidCK8sCRDName("a"))           // lower OK
+	require.Equal(t, true, IsValidCK8sCRDName("fe38343c-cfca-49d3-b76e-af0e6add9a2a"))
 }
 
 func TestGrafanaUIDToK8sName(t *testing.T) {
-	require.Equal(t, "g7a3e6b16cb75f48fb897eff3", GrafanaUIDToK8sName("001"))       // uppercase not OK
-	require.Equal(t, "g148d11beead6f8ff530eb763", GrafanaUIDToK8sName("XMuLlpZ4k")) // uppercase not OK
-	require.Equal(t, "xulipzwk", GrafanaUIDToK8sName("xulipzwk"))                   // lower OK
+	// Invalid names create hash functions
+	require.Equal(t, "g7a3e6b16cb75f48fb897eff3", GrafanaUIDToK8sName("001"))
+	require.Equal(t, "g148d11beead6f8ff530eb763", GrafanaUIDToK8sName("XMuLlpZ4k"))
+	require.Equal(t, "g4b68ab3847feda7d6c62c1fb", GrafanaUIDToK8sName("X"))
+
+	// Valid are used directly
+	require.Equal(t, "xulipzwk", GrafanaUIDToK8sName("xulipzwk"))
+	require.Equal(t, "a", GrafanaUIDToK8sName("a"))
 	require.Equal(t, "fe38343c-cfca-49d3-b76e-af0e6add9a2a", GrafanaUIDToK8sName("fe38343c-cfca-49d3-b76e-af0e6add9a2a"))
 }

--- a/pkg/util/names_test.go
+++ b/pkg/util/names_test.go
@@ -13,7 +13,7 @@ func TestIsValidCK8sCRDName(t *testing.T) {
 	require.Equal(t, false, IsValidCK8sCRDName(""))            // too short
 	require.Equal(t, false, IsValidCK8sCRDName("001"))         // numeric first
 	require.Equal(t, false, IsValidCK8sCRDName("XMuLlpZ4k"))   // uppercase not OK
-	require.Equal(t, false, IsValidCK8sCRDName("-a"))          // dash is ok
+	require.Equal(t, false, IsValidCK8sCRDName("-a"))          // can not start with dash
 	require.Equal(t, false, IsValidCK8sCRDName("hello/world")) // punctuation
 	require.Equal(t, false, IsValidCK8sCRDName("hello?world")) // punctuation
 	require.Equal(t, false, IsValidCK8sCRDName("hello world")) // punctuation


### PR DESCRIPTION
**What is this feature?**

As we consider a transition to k8s resource model, understanding the real world constraints on CRD resource names is helpful.  

The grafana UID is semantically equivalent to a k8s name: it is unique within org+kind, but not globally unique.


**Why do we need this feature?**

This adds a utility function to check if a string is a valid k8s CRD name


TODO:
- [ ] Verify these are real constraints, I found them though trial+error but are not listed on https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
