### PR TITLE
RBAC: Fix SearchUsersPermissions when the filter is empty

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -252,15 +252,8 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, user *user.SignedI
 	basicPermissions := map[string][]accesscontrol.Permission{}
 	for role, basicRole := range s.roles {
 		for i := range basicRole.Permissions {
-			if options.ActionPrefix != "" {
-				if strings.HasPrefix(basicRole.Permissions[i].Action, options.ActionPrefix) {
-					basicPermissions[role] = append(basicPermissions[role], basicRole.Permissions[i])
-				}
-			}
-			if options.Action != "" {
-				if basicRole.Permissions[i].Action == options.Action {
-					basicPermissions[role] = append(basicPermissions[role], basicRole.Permissions[i])
-				}
+			if PermissionMatchesSearchOptions(basicRole.Permissions[i], options) {
+				basicPermissions[role] = append(basicPermissions[role], basicRole.Permissions[i])
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**
This PR fixes `SearchUsersPermissions` RAM permissions filtering when the `accesscontrol.SearchOptions` is empty/default.

**Why do we need this feature?**
The previous filtering method only worked when any of the filters was defined.

**Who is this feature for?**



**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
