### PR TITLE
Grafana UI: Add invalid state to RadioButtonGroup

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
       page: mdx,
     },
     controls: {
-      exclude: ['className', 'options', 'value', 'onChange'],
+      exclude: ['className', 'options', 'value', 'onChange', 'onClick', 'id'],
     },
   },
   argTypes: {
@@ -52,6 +52,7 @@ export const RadioButtons: Story = (args) => {
           onChange={(v) => setSelected(v!)}
           size={args.size}
           fullWidth={args.fullWidth}
+          invalid={args.invalid}
         />
       </div>
       <div style={{ marginBottom: '32px' }}>
@@ -63,6 +64,7 @@ export const RadioButtons: Story = (args) => {
           value={selected}
           onChange={(v) => setSelected(v!)}
           size={args.size}
+          invalid={args.invalid}
         />
       </div>
       <div style={{ marginBottom: '32px' }}>
@@ -72,6 +74,7 @@ export const RadioButtons: Story = (args) => {
           value={selected}
           onChange={(v) => setSelected(v!)}
           size={args.size}
+          invalid={args.invalid}
         />
       </div>
     </div>
@@ -82,6 +85,7 @@ RadioButtons.args = {
   disabledOptions: '',
   size: 'md',
   fullWidth: true,
+  invalid: false,
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -21,6 +21,7 @@ export interface RadioButtonGroupProps<T> {
   fullWidth?: boolean;
   className?: string;
   autoFocus?: boolean;
+  invalid?: boolean;
 }
 
 export function RadioButtonGroup<T>({
@@ -35,6 +36,7 @@ export function RadioButtonGroup<T>({
   className,
   fullWidth = false,
   autoFocus = false,
+  invalid = false,
 }: RadioButtonGroupProps<T>) {
   const handleOnChange = useCallback(
     (option: SelectableValue) => {
@@ -69,7 +71,7 @@ export function RadioButtonGroup<T>({
   }, [autoFocus]);
 
   return (
-    <div className={cx(styles.radioGroup, fullWidth && styles.fullWidth, className)}>
+    <div className={cx(styles.radioGroup, fullWidth && styles.fullWidth, invalid && styles.invalid, className)}>
       {options.map((opt, i) => {
         const isItemDisabled = disabledOptions && opt.value && disabledOptions.includes(opt.value);
         const icon = opt.icon ? toIconName(opt.icon) : undefined;
@@ -122,5 +124,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       height: ${theme.spacing(2)};
       margin-right: ${theme.spacing(1)};
     `,
+    invalid: css({
+      border: `1px solid ${theme.colors.error.border}`,
+    }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

Add the `invalid` prop to the `RadioButtonGroup` component.

<img width="412" alt="Captura de pantalla 2023-05-10 a las 10 45 18" src="https://github.com/grafana/grafana/assets/65417731/ce2faca0-e242-47b4-a899-2f98db93153e">




**Why do we need this feature?**

To be able to manage its invalid state.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

Fixes #68182 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
