### PR TITLE
devenv:loki faster test-data generation

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -176,8 +176,8 @@ async function sendOldLogs() {
     const timestampNs = `${timestampMs}${getRandomNanosecPart()}`;
     globalCounter += 1;
     const item = getRandomLogItem(globalCounter)
-    await lokiSendLogLine(timestampNs, JSON.stringify(item), {place:'moon', ...sharedLabels});
-    await lokiSendLogLine(timestampNs, logFmtLine(item), {place:'luna', ...sharedLabels});
+    await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'old', place:'moon', ...sharedLabels});
+    await lokiSendLogLine(timestampNs, logFmtLine(item), {age:'old', place:'luna', ...sharedLabels});
   };
 }
 
@@ -187,18 +187,16 @@ async function sendNewLogs() {
     const nowMs = new Date().getTime();
     const timestampNs = `${nowMs}${getRandomNanosecPart()}`;
     const item = getRandomLogItem(globalCounter)
-    await lokiSendLogLine(timestampNs, JSON.stringify(item), {place:'moon', ...sharedLabels});
-    await lokiSendLogLine(timestampNs, logFmtLine(item), {place:'luna', ...sharedLabels});
+    await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'new', place:'moon', ...sharedLabels});
+    await lokiSendLogLine(timestampNs, logFmtLine(item), {age:'new', place:'luna', ...sharedLabels});
     const sleepDuration  = 200 + Math.random() * 800; // between 0.2 and 1 seconds
     await sleep(sleepDuration);
   }
 }
 
 async function main() {
-  // first we send logs to build a last-7-days log-data
-  await sendOldLogs();
-  // then keep sending new data forever
-  await sendNewLogs();
+  // we generate both old-logs and new-logs at the same time
+  await Promise.all([sendOldLogs(), sendNewLogs()])
 }
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast


### PR DESCRIPTION
when we use `make devenv sources=loki`, we generate two kinds of test-data :

1. we populate old data, for the last 7 days, this is mostly used to test features like query splitting
2. we generate new data forever, this is mostly used when you need the "last 5 minutes" data to keep changing, for example, streaming.

currently, we first generate [1], then we generate [2]. [1] takes a little while, so if all you need is [2], you need to wait.
this PR changes this to generate both [1] and [2] at the same time.

(NOTE: i had to add labels to differentiate logs made by [1] and [2], this is needed otherwise Loki complains that the "time gap" is too big between logs)