### PR TITLE
DS Picker: Do not create extra history entries for panel onboarding

### DIFF
--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -65,7 +65,7 @@ export class QueryGroup extends PureComponent<Props, State> {
   querySubscription: Unsubscribable | null = null;
 
   state: State = {
-    isDataSourceModalOpen: false,
+    isDataSourceModalOpen: !!locationService.getSearchObject().firstPanel,
     isLoadingHelp: false,
     helpContent: null,
     isPickerOpen: false,
@@ -87,6 +87,11 @@ export class QueryGroup extends PureComponent<Props, State> {
     });
 
     this.setNewQueriesAndDatasource(options);
+
+    // Clean up the first panel flag since the modal is now open
+    if (!!locationService.getSearchObject().firstPanel) {
+      locationService.partial({ firstPanel: null }, true);
+    }
   }
 
   componentWillUnmount() {
@@ -117,14 +122,12 @@ export class QueryGroup extends PureComponent<Props, State> {
         datasource,
         ...q,
       }));
+
       this.setState({
         queries,
         dataSource: ds,
         dsSettings,
         defaultDataSource,
-        // TODO: Detect the first panel added into a new dashboard better.
-        // This is flaky in case the UID is generated differently
-        isDataSourceModalOpen: !!locationService.getSearchObject().firstPanel,
       });
     } catch (error) {
       console.log('failed to load data source', error);
@@ -261,7 +264,6 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   onCloseDataSourceModal = () => {
     this.setState({ isDataSourceModalOpen: false });
-    locationService.partial({ firstPanel: null });
   };
 
   renderMixedPicker = () => {


### PR DESCRIPTION
Fixes #67894

**Solution**
* Remove the query param `firstPanel` once is read and used to set the initial state of the component
* Avoid adding an extra history entry. 

**How to test**
1. Create a new dashboard
2. Click in "Add a visualization"
3. Close the modal
4. Click back, and the Edit panel view closes with the panel added to the dashboard

|Before|Fixed|
|-|-|
![2023-05-10 15 22 16](https://github.com/grafana/grafana/assets/5699976/4cf45636-4b50-40d2-b1a3-f2cbe2bc6aef)|![2023-05-10 15 22 58](https://github.com/grafana/grafana/assets/5699976/0ab2051d-250c-4c8f-850d-15e613c28c1a)
