### PR TITLE
Breadcrumbs: Don't add breadcrumb for the current tab

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -144,22 +144,5 @@ describe('breadcrumb utils', () => {
         { text: 'My page', href: '/my-page' },
       ]);
     });
-
-    it('Should add breadcrumbs for child pages that have not set parentItem', () => {
-      const pageNav: NavModelItem = {
-        text: 'My page',
-        url: '/my-page',
-        children: [
-          { text: 'A', url: '/a', active: true },
-          { text: 'B', url: '/b' },
-        ],
-      };
-
-      expect(buildBreadcrumbs(mockHomeNav, pageNav, mockHomeNav)).toEqual([
-        { text: 'Home', href: '/home' },
-        { text: 'My page', href: '/my-page' },
-        { text: 'A', href: '/a' },
-      ]);
-    });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -30,18 +30,7 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
   }
 
   if (pageNav) {
-    if (pageNav.url && pageNav.children) {
-      const child = pageNav.children.find((child) => child.active);
-      if (child) {
-        addCrumbs(child);
-        // Some pages set up children but they are not connected to parent pageNav
-        if (child.parentItem !== pageNav) {
-          addCrumbs(pageNav);
-        }
-      }
-    } else {
-      addCrumbs(pageNav);
-    }
+    addCrumbs(pageNav);
   }
 
   addCrumbs(sectionNav);


### PR DESCRIPTION
Not sure why I added this, it is useful for pages with many tabs to find your way back to the "home" / default tab. But with scene drilldowns creating deep breadcrumbs, anything we can do to limit the number is good. It's also not great for mobile views because if we show the current tab, we have to have 3 breadcrumbs to find your way back to your the parent "page". 

Before: 
![image](https://github.com/grafana/grafana/assets/10999/d61de4d2-d14e-485d-b41b-71a765b74fda)

After:
![Screenshot from 2023-05-10 16-25-29](https://github.com/grafana/grafana/assets/10999/ef54bbaf-30fb-45ce-b5ef-6d0890a69611)
