### PR TITLE
[v9.3.x] CI: Move windows-tests into promotion pipeline (#68218)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -31,6 +31,10 @@ load(
 )
 load("scripts/drone/pipelines/github.star", "publish_github_pipeline")
 load("scripts/drone/pipelines/aws_marketplace.star", "publish_aws_marketplace_pipeline")
+load(
+    "scripts/drone/pipelines/windows.star",
+    "windows_test_backend",
+)
 load("scripts/drone/version.star", "version_branch_pipelines")
 load("scripts/drone/events/cron.star", "cronjobs")
 load("scripts/drone/vault.star", "secrets")
@@ -51,6 +55,10 @@ def main(_ctx):
         publish_artifacts_pipelines("public") +
         publish_npm_pipelines() +
         publish_packages_pipeline() +
+        [windows_test_backend({
+            "event": ["promote"],
+            "target": ["test-windows"],
+        }, "oss", "testing")] +
         artifacts_page_pipeline() +
         version_branch_pipelines() +
         integration_test_pipelines() +

--- a/.drone.yml
+++ b/.drone.yml
@@ -371,56 +371,6 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: pr-oss-test-backend-windows
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-services: []
-steps:
-- commands: []
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: windows-init
-- commands:
-  - go install github.com/google/wire/cmd/wire@v0.5.0
-  - wire gen -tags oss ./pkg/server
-  depends_on:
-  - windows-init
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: wire-install
-- commands:
-  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  failure: ignore
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: test-backend
-trigger:
-  event:
-  - pull_request
-  paths:
-    exclude:
-    - docs/**
-    - '*.md'
-    - pkg/**
-    - packaging/**
-    - go.sum
-    - go.mod
-    include: []
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-clone:
-  retries: 3
-depends_on: []
-environment:
-  EDITION: oss
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
 name: pr-lint-backend
 node:
   type: no-parallel
@@ -2004,126 +1954,6 @@ trigger:
     - latest.json
   repo:
   - grafana/grafana
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-clone:
-  retries: 3
-depends_on: []
-environment:
-  EDITION: oss
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
-name: main-oss-test-backend-windows
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-services: []
-steps:
-- commands: []
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: windows-init
-- commands:
-  - go install github.com/google/wire/cmd/wire@v0.5.0
-  - wire gen -tags oss ./pkg/server
-  depends_on:
-  - windows-init
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: wire-install
-- commands:
-  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  failure: ignore
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: test-backend
-trigger:
-  branch: main
-  event:
-  - push
-  paths:
-    exclude:
-    - '*.md'
-    - docs/**
-    - latest.json
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-clone:
-  disable: true
-depends_on: []
-environment:
-  EDITION: enterprise
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
-name: main-enterprise-test-backend-windows
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-services: []
-steps:
-- commands:
-  - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/windows/grabpl.exe
-    -OutFile grabpl.exe
-  image: grafana/ci-wix:0.1.1
-  name: grabpl
-- commands:
-  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
-  - cd grafana-enterprise
-  - git checkout main
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/ci-wix:0.1.1
-  name: clone
-- commands:
-  - cp -r grafana-enterprise C:\App\grafana-enterprise
-  - rm -r -force grafana-enterprise
-  - cp grabpl.exe C:\App\grabpl.exe
-  - rm -force grabpl.exe
-  - C:\App\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\App\grafana-enterprise
-  - cp C:\App\grabpl.exe grabpl.exe
-  depends_on:
-  - clone
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/ci-wix:0.1.1
-  name: windows-init
-- commands:
-  - go install github.com/google/wire/cmd/wire@v0.5.0
-  - wire gen -tags enterprise ./pkg/server
-  depends_on:
-  - windows-init
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: wire-install
-- commands:
-  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  failure: ignore
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: test-backend
-trigger:
-  branch: main
-  event:
-  - push
-  paths:
-    exclude:
-    - '*.md'
-    - docs/**
-    - latest.json
 type: docker
 volumes:
 - host:
@@ -4400,6 +4230,58 @@ clone:
   disable: true
 depends_on: []
 environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: testing-oss-test-backend-windows
+platform:
+  arch: amd64
+  os: windows
+  version: "1809"
+services: []
+steps:
+- commands:
+  - git clone "https://$$env:GITHUB_TOKEN@github.com/$$env:DRONE_REPO.git" .
+  - git checkout -f $$env:DRONE_COMMIT
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/ci-wix:0.1.1
+  name: clone
+- commands: []
+  depends_on:
+  - clone
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: windows-init
+- commands:
+  - go install github.com/google/wire/cmd/wire@v0.5.0
+  - wire gen -tags oss ./pkg/server
+  depends_on:
+  - windows-init
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: wire-install
+- commands:
+  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/grafana-ci-windows-test:0.1.0
+  name: test-backend
+trigger:
+  event:
+  - promote
+  target:
+  - test-windows
+type: docker
+volumes:
+- host:
+    path: //./pipe/docker_engine/
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
   EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
@@ -4883,114 +4765,6 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-oss-test-backend-windows
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-services: []
-steps:
-- commands: []
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: windows-init
-- commands:
-  - go install github.com/google/wire/cmd/wire@v0.5.0
-  - wire gen -tags oss ./pkg/server
-  depends_on:
-  - windows-init
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: wire-install
-- commands:
-  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  failure: ignore
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: test-backend
-trigger:
-  ref:
-  - refs/heads/v[0-9]*
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-clone:
-  disable: true
-depends_on: []
-environment:
-  EDITION: enterprise
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
-name: release-branch-enterprise-test-backend-windows
-platform:
-  arch: amd64
-  os: windows
-  version: "1809"
-services: []
-steps:
-- commands:
-  - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/windows/grabpl.exe
-    -OutFile grabpl.exe
-  image: grafana/ci-wix:0.1.1
-  name: grabpl
-- commands:
-  - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
-  - cd grafana-enterprise
-  - git checkout $$env:DRONE_BRANCH
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/ci-wix:0.1.1
-  name: clone
-- commands:
-  - cp -r grafana-enterprise C:\App\grafana-enterprise
-  - rm -r -force grafana-enterprise
-  - cp grabpl.exe C:\App\grabpl.exe
-  - rm -force grabpl.exe
-  - C:\App\grabpl.exe init-enterprise --github-token $$env:GITHUB_TOKEN C:\App\grafana-enterprise
-  - cp C:\App\grabpl.exe grabpl.exe
-  depends_on:
-  - clone
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/ci-wix:0.1.1
-  name: windows-init
-- commands:
-  - go install github.com/google/wire/cmd/wire@v0.5.0
-  - wire gen -tags enterprise ./pkg/server
-  depends_on:
-  - windows-init
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: wire-install
-- commands:
-  - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  failure: ignore
-  image: grafana/grafana-ci-windows-test:0.1.0
-  name: test-backend
-trigger:
-  ref:
-  - refs/heads/v[0-9]*
-type: docker
-volumes:
-- host:
-    path: //./pipe/docker_engine/
-  name: docker
----
-clone:
-  retries: 3
-depends_on: []
-environment:
-  EDITION: oss
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
 name: release-branch-oss-integration-tests
 node:
   type: no-parallel
@@ -5104,7 +4878,6 @@ clone:
 depends_on:
 - release-branch-oss-build-e2e-publish
 - release-branch-oss-test-frontend
-- release-branch-oss-test-backend-windows
 environment:
   EDITION: oss
 image_pull_secrets:
@@ -6763,6 +6536,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: c82042d35770caed3b56d264f9f40b41f4dbe04e9e9e1b8d89e3baead0c21bee
+hmac: 5af5b80e4d309abc1cfa8e4b5d90280e5918342f6313a053e4c10550a994d46d
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -32,7 +32,6 @@ load(
 load(
     "scripts/drone/pipelines/windows.star",
     "windows",
-    "windows_test_backend",
 )
 load(
     "scripts/drone/pipelines/trigger_downstream.star",
@@ -90,8 +89,6 @@ def main_pipelines():
         build_e2e(trigger, ver_mode),
         integration_tests(trigger, prefix = ver_mode, ver_mode = ver_mode),
         windows(trigger, edition = "oss", ver_mode = ver_mode),
-        windows_test_backend(trigger, "oss", ver_mode),
-        windows_test_backend(trigger, "enterprise", ver_mode),
         notify_pipeline(
             name = "notify-drone-changes",
             slack_channel = "slack-webhooks-test",

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -16,10 +16,6 @@ load(
     "integration_tests",
 )
 load(
-    "scripts/drone/pipelines/windows.star",
-    "windows_test_backend",
-)
-load(
     "scripts/drone/pipelines/build.star",
     "build_e2e",
 )
@@ -102,13 +98,6 @@ def pr_pipelines():
                     "devenv/**",
                 ],
             ),
-            ver_mode,
-        ),
-        windows_test_backend(
-            get_pr_trigger(
-                exclude_paths = ["pkg/**", "packaging/**", "go.sum", "go.mod"],
-            ),
-            "oss",
             ver_mode,
         ),
         lint_backend_pipeline(

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -61,10 +61,6 @@ load(
     "test_backend",
     "test_backend_enterprise",
 )
-load(
-    "scripts/drone/pipelines/windows.star",
-    "windows_test_backend",
-)
 load("scripts/drone/vault.star", "from_secret", "prerelease_bucket")
 
 ver_mode = "release"
@@ -234,9 +230,6 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
     ]
 
     if ver_mode not in ("release"):
-        pipelines.append(windows_test_backend(trigger, "oss", ver_mode))
-        pipelines.append(windows_test_backend(trigger, "enterprise", ver_mode))
-        windows_pipeline_dependencies.append("{}-oss-test-backend-windows".format(ver_mode))
         pipelines.append(pipeline(
             name = "{}-oss-integration-tests".format(ver_mode),
             edition = "oss",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -686,7 +686,6 @@ def test_backend_step(image = build_image):
 
 def windows_test_backend_step():
     step = test_backend_step(image = windows_go_image)
-    step["failure"] = "ignore"
     return step
 
 def test_backend_integration_step():
@@ -1359,6 +1358,19 @@ def publish_linux_packages_step(edition, package_manager = "deb"):
                 package_manager,
             ),
         },
+    }
+
+def windows_clone_step():
+    return {
+        "name": "clone",
+        "image": wix_image,
+        "environment": {
+            "GITHUB_TOKEN": from_secret("github_token"),
+        },
+        "commands": [
+            'git clone "https://$$env:GITHUB_TOKEN@github.com/$$env:DRONE_REPO.git" .',
+            "git checkout -f $$env:DRONE_COMMIT",
+        ],
     }
 
 def get_windows_steps(edition, ver_mode):


### PR DESCRIPTION
(cherry picked from commit acd02e8a4848091bd8f548478c430f3c5d707682)

Backport of https://github.com/grafana/grafana/pull/68218
