### PR TITLE
Accessibility: Adds aria tags to VizTooltip so screen readers announce them

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -100,6 +100,8 @@ export const VizTooltipContainer = ({
         transform: `translate(${placement.x}px, ${placement.y}px)`,
         transition: 'transform ease-out 0.1s',
       }}
+      aria-live="polite"
+      aria-atomic="true"
       {...otherProps}
       className={cx(styles.wrapper, className)}
     >


### PR DESCRIPTION
**What is this feature?**

This adds `aria-live` to the `VizTooltipContainer` so that it is read out to screen readers when it shows up on screen. Also added `aria-atomic` for it to always read the whole content and not only what has changed, otherwise only the timestamp and values that changed would be read out.

Before:

https://github.com/grafana/grafana/assets/100691367/1a347f29-08b6-4e89-b414-78690b8e601f

After:

https://github.com/grafana/grafana/assets/100691367/4da06333-bed1-41ee-a5cd-2f5482358949

**Why do we need this feature?**

So that users with screen readers can get the information about the data.

**Who is this feature for?**

Screen reader users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #66549

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
