### PR TITLE
TopSearchBar: Fix TopSearchBar if [help] enabled = false

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -8,13 +8,12 @@ import { getFooterLinks } from '../../Footer/Footer';
 import { HelpModal } from '../../help/HelpModal';
 
 export const enrichHelpItem = (helpItem: NavModelItem) => {
-  const onOpenShortcuts = () => {
-    appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
-  };
-
   let menuItems = helpItem.children || [];
 
   if (helpItem.id === 'help') {
+    const onOpenShortcuts = () => {
+      appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
+    };
     helpItem.children = [
       ...menuItems,
       ...getFooterLinks(),

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
@@ -26,7 +26,8 @@ export const TopSearchBar = React.memo(function TopSearchBar() {
   const navIndex = useSelector((state) => state.navIndex);
   const location = useLocation();
 
-  const helpNode = enrichHelpItem(cloneDeep(navIndex['help']));
+  const helpNode = cloneDeep(navIndex['help']);
+  const enrichedHelpNode = helpNode ? enrichHelpItem(helpNode) : undefined;
   const profileNode = navIndex['profile'];
 
   let homeUrl = config.appSubUrl || '/';
@@ -49,8 +50,8 @@ export const TopSearchBar = React.memo(function TopSearchBar() {
 
       <TopSearchBarSection align="right">
         <QuickAdd />
-        {helpNode && (
-          <Dropdown overlay={() => <TopNavBarMenu node={helpNode} />} placement="bottom-end">
+        {enrichedHelpNode && (
+          <Dropdown overlay={() => <TopNavBarMenu node={enrichedHelpNode} />} placement="bottom-end">
             <ToolbarButton iconOnly icon="question-circle" aria-label="Help" />
           </Dropdown>
         )}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
STR:
1: set in `grafana.ini`:
```toml
[help]
enabled = false
```
2. Login
3. There will be error: 
```
TypeError: Cannot read properties of undefined (reading 'children')
    at am (utils.ts:11:28)
    at TopSearchBar.tsx:30:28
```

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
