### PR TITLE
Docs: fix proxy link, returning 404

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/proxy/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/proxy/index.md
@@ -18,7 +18,7 @@ To make use of this functionality, you need to deploy a socks5 proxy server that
 ## Known limitations
 
 - You can configure only one socks5 proxy per Grafana instance
-- All built-in core data sources are compatible, but not all external data sources are. For a list of supported data sources, refer to [private data source connect]({{< ref "/docs/grafana-cloud/data-configuration/configure-private-datasource-connect/#known-limitations" >}}).
+- All built-in core data sources are compatible, but not all external data sources are. For a list of supported data sources, refer to [private data source connect](/docs/grafana-cloud/data-configuration/configure-private-datasource-connect/#known-limitations).
 
 ## Before you begin
 

--- a/docs/sources/setup-grafana/configure-grafana/proxy/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/proxy/index.md
@@ -39,6 +39,6 @@ To complete this task, you must first deploy a socks proxy server that supports 
 
 1. Set up a data source and configure it to send data source connections through the proxy.
 
-   To configure your data sources to send connections through the proxy, `enableSecureSocksProxy=true` must be specified in the data source json. You can do this in the [API]({{< relref "../../../developers/http_api/data_source" >}}) or use [file based provisioning]({{< relref "../../../administration/provisioning/#data-sources" >}}).
+   To configure your data sources to send connections through the proxy, `enableSecureSocksProxy=true` must be specified in the data source json. You can do this in the [API]({{< relref "../../../developers/http_api/data_source" >}}) or use [file based provisioning]({{< relref "../../../administration/provisioning#data-sources" >}}).
 
    Additionally, you can set the socks5 username and password by adding `secureSocksProxyUsername` in the data source json and `secureSocksProxyPassword` in the secure data source json.


### PR DESCRIPTION
This PR fixes a 404 found on the [configure proxy page](https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/proxy/#known-limitations). It uses the [same way](https://github.com/grafana/grafana/blob/0565c3440fe6553f2ef2a29a5f027fb20e8a7f68/docs/sources/setup-grafana/configure-security/export-logs.md?plain=1#LL20C28-L20C28) that the [usage insights page](https://grafana.com/docs/grafana/next/setup-grafana/configure-security/export-logs/#export-logs-of-usage-insights) links to the cloud docs.