### PR TITLE
CHANGELOG: Fix CHANGELOG lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-- **Explore:** Update table min height  (#67321). [#67332](https://github.com/grafana/grafana/issues/67332), [@adrapereira](https://github.com/adrapereira)
+- **Explore:** Update table min height (#67321). [#67332](https://github.com/grafana/grafana/issues/67332), [@adrapereira](https://github.com/adrapereira)
 - **DataLinks:** Encoded URL fixed. [#67291](https://github.com/grafana/grafana/issues/67291), [@juanicabanas](https://github.com/juanicabanas)
 
 <!-- 9.5.2 END -->


### PR DESCRIPTION
**What is this feature?**


Fixes a lint error on `main` for the changelog, by running `yarn run prettier:write`.