### PR TITLE
TopNav: Tone down shadow a bit in light theme

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -73,7 +73,7 @@ export function AppChrome({ children }: Props) {
 const getStyles = (theme: GrafanaTheme2) => {
   const shadow = theme.isDark
     ? `0 0.6px 1.5px rgb(0 0 0), 0 2px 4px rgb(0 0 0 / 40%), 0 5px 10px rgb(0 0 0 / 23%)`
-    : '0 0.6px 1.5px rgb(0 0 0 / 8%), 0 2px 4px rgb(0 0 0 / 6%), 0 5px 10px rgb(0 0 0 / 5%)';
+    : '0 2px 4px rgb(0 0 0 / 6%)';
 
   return {
     content: css({

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -73,7 +73,7 @@ export function AppChrome({ children }: Props) {
 const getStyles = (theme: GrafanaTheme2) => {
   const shadow = theme.isDark
     ? `0 0.6px 1.5px rgb(0 0 0), 0 2px 4px rgb(0 0 0 / 40%), 0 5px 10px rgb(0 0 0 / 23%)`
-    : '0 2px 4px rgb(0 0 0 / 6%)';
+    : '0 4px 8px rgb(0 0 0 / 4%)';
 
   return {
     content: css({


### PR DESCRIPTION
I think the shadow is a bit too strong / prominent in the light theme and can be toned down a bit.

Before: 
![Screenshot from 2023-05-11 09-59-23](https://github.com/grafana/grafana/assets/10999/f7cbb2b4-1367-4b31-98e7-f6530722ebf9)

After:
![Screenshot from 2023-05-11 09-59-28](https://github.com/grafana/grafana/assets/10999/b260e744-c3ff-4d5e-924c-7177db9de086)

