### PR TITLE
DataFrame: Add dataplane numeric types to DataFrameType enum

### DIFF
--- a/packages/grafana-data/src/types/dataFrameTypes.ts
+++ b/packages/grafana-data/src/types/dataFrameTypes.ts
@@ -13,6 +13,11 @@ export enum DataFrameType {
 
   TimeSeriesMulti = 'timeseries-multi',
 
+  /** Numeric types: https://grafana.github.io/dataplane/contract/numeric */
+  NumericWide = 'numeric-wide',
+  NumericMulti = 'numeric-multi',
+  NumericLong = 'numeric-long',
+
   /** Directory listing */
   DirectoryListing = 'directory-listing',
 


### PR DESCRIPTION
 - https://grafana.github.io/dataplane/contract/numeric
 - https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/frame_type.go

