### PR TITLE
Correction of MySQL data source provisioning example

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -104,8 +104,8 @@ datasources:
     type: mysql
     url: localhost:3306
     user: grafana
+    database: grafana
     jsonData:
-      database: grafana
       maxOpenConns: 100 # Grafana v5.4+
       maxIdleConns: 100 # Grafana v5.4+
       maxIdleConnsAuto: true # Grafana v9.5.1+
@@ -124,9 +124,9 @@ datasources:
     type: mysql
     url: localhost:3306
     user: grafana
+    database: grafana
     jsonData:
       tlsAuth: true
-      database: grafana
       maxOpenConns: 100 # Grafana v5.4+
       maxIdleConns: 100 # Grafana v5.4+
       maxIdleConnsAuto: true # Grafana v9.5.1+
@@ -147,10 +147,10 @@ datasources:
     type: mysql
     url: localhost:3306
     user: grafana
+    database: grafana
     jsonData:
       tlsAuth: true
       skipTLSVerify: true
-      database: grafana
       maxOpenConns: 100 # Grafana v5.4+
       maxIdleConns: 100 # Grafana v5.4+
       maxIdleConnsAuto: true # Grafana v9.5.1+


### PR DESCRIPTION
Corrected yaml provision file examples

Current provision examples will provision MySQL database without `database` name defined
![image](https://github.com/grafana/grafana/assets/79632099/16b96fb3-ffb5-4fcd-9285-51191e060bb8)

When  `database` option is moved out of  `jsonData` section
![image](https://github.com/grafana/grafana/assets/79632099/48ee0d0f-f529-4133-b727-860edeebfce8)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
