### PR TITLE
Build: Update plugin installation in custom Dockerfile

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -43,6 +43,7 @@ ARG GF_INSTALL_PLUGINS=""
 RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
       OLDIFS=$IFS; \
       IFS=','; \
+      set -e ; \
       for plugin in ${GF_INSTALL_PLUGINS}; do \
         IFS=$OLDIFS; \
         if expr match "$plugin" '.*\;.*'; then \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There is [a for loop](https://github.com/grafana/grafana/blob/b96a2c1b62f347c30fa576fb3767624fcb5d6251/packaging/docker/custom/Dockerfile#LL46C39-L46C39) in the plugin installation layer in the custom Dockerfile. The problem is that if the installation of any plugin except the last one faces an error (e.g., Network error and etc.), the layer will continue to run and the image is built successfully, and the user may not be aware of the missing plugins in the image.

This PR adds the `set -e` command to the layer to exit the layer with a non-zero code in case of any failure in the loop and prevent the image from building successfully.

**Why do we need this feature?**

Users should be certain about the successful installation of all plugins, especially for the CI/CD pipelines.

**Who is this feature for?**

Anyone who uses the custom Dockerfile for pre-installed plugins.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
