### PR TITLE
RBAC: Add a function to delete external service roles

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -40,6 +40,8 @@ type Service interface {
 	DeclareFixedRoles(registrations ...RoleRegistration) error
 	// SaveExternalServiceRole creates or updates an external service's role and assigns it to a given service account id.
 	SaveExternalServiceRole(ctx context.Context, cmd SaveExternalServiceRoleCommand) error
+	// DeleteExternalServiceRole removes an external service's role and its assignment.
+	DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error
 	//IsDisabled returns if access control is enabled or not
 	IsDisabled() bool
 }

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/api"
@@ -63,6 +64,7 @@ type store interface {
 	GetUsersBasicRoles(ctx context.Context, userFilter []int64, orgID int64) (map[int64][]string, error)
 	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error
 	SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error
+	DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error
 }
 
 // Service is the service implementing role based access control.
@@ -416,7 +418,7 @@ func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol
 	}
 
 	if !s.features.IsEnabled(featuremgmt.FlagExternalServiceAuth) {
-		s.log.Debug("registering external service role is behind a feature flag, enable it to use this feature.")
+		s.log.Debug("registering an external service role is behind a feature flag, enable it to use this feature.")
 		return nil
 	}
 
@@ -425,4 +427,20 @@ func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol
 	}
 
 	return s.store.SaveExternalServiceRole(ctx, cmd)
+}
+
+func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
+	// If accesscontrol is disabled no need to delete the external service role
+	if accesscontrol.IsDisabled(s.cfg) {
+		return nil
+	}
+
+	if !s.features.IsEnabled(featuremgmt.FlagExternalServiceAuth) {
+		s.log.Debug("deleting an external service role is behind a feature flag, enable it to use this feature.")
+		return nil
+	}
+
+	slug := slugify.Slugify(externalServiceID)
+
+	return s.store.DeleteExternalServiceRole(ctx, slug)
 }

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -852,3 +852,55 @@ func TestService_SaveExternalServiceRole(t *testing.T) {
 		})
 	}
 }
+
+func TestService_DeleteExternalServiceRole(t *testing.T) {
+	tests := []struct {
+		name              string
+		initCmd           *accesscontrol.SaveExternalServiceRoleCommand
+		externalServiceID string
+		wantErr           bool
+	}{
+		{
+			name:              "handles deleting role that doesn't exist",
+			externalServiceID: "App 1",
+			wantErr:           false,
+		},
+		{
+			name: "handles deleting role that exists",
+			initCmd: &accesscontrol.SaveExternalServiceRoleCommand{
+				Global:            true,
+				ServiceAccountID:  2,
+				ExternalServiceID: "App 1",
+				Permissions:       []accesscontrol.Permission{{Action: "users:read", Scope: "users:id:1"}},
+			},
+			externalServiceID: "App 1",
+			wantErr:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ac := setupTestEnv(t)
+			ac.features = featuremgmt.WithFeatures(featuremgmt.FlagExternalServiceAuth)
+
+			if tt.initCmd != nil {
+				err := ac.SaveExternalServiceRole(ctx, *tt.initCmd)
+				require.NoError(t, err)
+			}
+
+			err := ac.DeleteExternalServiceRole(ctx, tt.externalServiceID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.initCmd != nil {
+				// Check that the permissions and assignment are stored correctly
+				perms, errGetPerms := ac.getUserPermissions(ctx, &user.SignedInUser{OrgID: tt.initCmd.OrgID, UserID: 2}, accesscontrol.Options{})
+				require.NoError(t, errGetPerms)
+				assert.Empty(t, perms)
+			}
+		})
+	}
+}

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -896,7 +896,7 @@ func TestService_DeleteExternalServiceRole(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.initCmd != nil {
-				// Check that the permissions and assignment are stored correctly
+				// Check that the permissions and assignment are removed correctly
 				perms, errGetPerms := ac.getUserPermissions(ctx, &user.SignedInUser{OrgID: tt.initCmd.OrgID, UserID: 2}, accesscontrol.Options{})
 				require.NoError(t, errGetPerms)
 				assert.Empty(t, perms)

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -57,6 +57,10 @@ func (f FakeService) SaveExternalServiceRole(ctx context.Context, cmd accesscont
 	return f.ExpectedErr
 }
 
+func (f FakeService) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
+	return f.ExpectedErr
+}
+
 var _ accesscontrol.AccessControl = new(FakeAccessControl)
 
 type FakeAccessControl struct {
@@ -100,6 +104,10 @@ func (f FakeStore) DeleteUserPermissions(ctx context.Context, orgID, userID int6
 }
 
 func (f FakeStore) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error {
+	return f.ExpectedErr
+}
+
+func (f FakeStore) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	return f.ExpectedErr
 }
 

--- a/pkg/services/accesscontrol/database/externalservices_test.go
+++ b/pkg/services/accesscontrol/database/externalservices_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -186,6 +187,116 @@ func TestAccessControlStore_SaveExternalServiceRole(t *testing.T) {
 				})
 				require.NoError(t, errDBSession)
 			}
+		})
+	}
+}
+
+func TestAccessControlStore_DeleteExternalServiceRole(t *testing.T) {
+	extID := "app1"
+	tests := []struct {
+		name    string
+		init    func(t *testing.T, ctx context.Context, s *AccessControlStore)
+		id      string
+		wantErr bool
+	}{
+		{
+			name:    "delete no role",
+			id:      extID,
+			wantErr: false,
+		},
+		{
+			name: "delete local role",
+			init: func(t *testing.T, ctx context.Context, s *AccessControlStore) {
+				errSave := s.SaveExternalServiceRole(ctx, accesscontrol.SaveExternalServiceRoleCommand{
+					OrgID:             2,
+					ExternalServiceID: extID,
+					ServiceAccountID:  3,
+					Permissions: []accesscontrol.Permission{
+						{Action: "users:read", Scope: "users:id:1"},
+						{Action: "users:write", Scope: "users:id:1"},
+					},
+				})
+				require.NoError(t, errSave)
+			},
+			id:      extID,
+			wantErr: false,
+		},
+		{
+			name: "delete global role",
+			init: func(t *testing.T, ctx context.Context, s *AccessControlStore) {
+				errSave := s.SaveExternalServiceRole(ctx, accesscontrol.SaveExternalServiceRoleCommand{
+					Global:            true,
+					ExternalServiceID: extID,
+					ServiceAccountID:  3,
+					Permissions: []accesscontrol.Permission{
+						{Action: "users:read", Scope: "users:id:1"},
+						{Action: "users:write", Scope: "users:id:1"},
+					},
+				})
+				require.NoError(t, errSave)
+			},
+			id:      extID,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := &AccessControlStore{
+				sql: db.InitTestDB(t),
+			}
+			if tt.init != nil {
+				tt.init(t, ctx, s)
+			}
+			roleID := int64(-1)
+			err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+				role, err := getRoleByUID(ctx, sess, extServiceRoleUID(tt.id))
+				if err != nil && !errors.Is(err, accesscontrol.ErrRoleNotFound) {
+					return err
+				}
+				if role != nil {
+					roleID = role.ID
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			err = s.DeleteExternalServiceRole(ctx, tt.id)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Only check removal if the role existed before
+			if roleID == -1 {
+				return
+			}
+
+			// Assignments should be deleted
+			_ = s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+				var assignment accesscontrol.UserRole
+				count, err := sess.Where("role_id = ?", roleID).Count(&assignment)
+				require.NoError(t, err)
+				require.Zero(t, count)
+				return nil
+			})
+
+			// Permissions should be deleted
+			_ = s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+				var permission accesscontrol.Permission
+				count, err := sess.Where("role_id = ?", roleID).Count(&permission)
+				require.NoError(t, err)
+				require.Zero(t, count)
+				return nil
+			})
+
+			// Role should be deleted
+			_ = s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+				storedRole, err := getRoleByUID(ctx, sess, extServiceRoleUID(tt.id))
+				require.ErrorIs(t, err, accesscontrol.ErrRoleNotFound)
+				require.Nil(t, storedRole)
+				return nil
+			})
 		})
 	}
 }

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -31,6 +31,7 @@ type Calls struct {
 	SearchUsersPermissions         []interface{}
 	SearchUserPermissions          []interface{}
 	SaveExternalServiceRole        []interface{}
+	DeleteExternalServiceRole      []interface{}
 }
 
 type Mock struct {
@@ -58,6 +59,7 @@ type Mock struct {
 	SearchUsersPermissionsFunc         func(context.Context, *user.SignedInUser, int64, accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error)
 	SearchUserPermissionsFunc          func(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error)
 	SaveExternalServiceRoleFunc        func(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error
+	DeleteExternalServiceRoleFunc      func(ctx context.Context, externalServiceID string) error
 
 	scopeResolvers accesscontrol.Resolvers
 }
@@ -243,6 +245,15 @@ func (m *Mock) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.Sa
 	// Use override if provided
 	if m.SaveExternalServiceRoleFunc != nil {
 		return m.SaveExternalServiceRoleFunc(ctx, cmd)
+	}
+	return nil
+}
+
+func (m *Mock) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
+	m.Calls.DeleteExternalServiceRole = append(m.Calls.DeleteExternalServiceRole, []interface{}{ctx, externalServiceID})
+	// Use override if provided
+	if m.DeleteExternalServiceRoleFunc != nil {
+		return m.DeleteExternalServiceRoleFunc(ctx, externalServiceID)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We want to provide an OAuth2 based authentication server for external services (ex: plugins). One of our requirements is to automatically create service accounts with a restricted set of permissions.

**Why do we need this feature?**

With #66299 we added a function to create RBAC roles for external services.

In this pull request, we add a new function to the access control Service interface that allows deleting roles for external services.

In another pull request, we will use this function upon external service deletion (ex: plugin uninstall), to clean their permission appropriately.

Note that this is behind a feature toggle:
```
s.features.IsEnabled(featuremgmt.FlagExternalServiceAuth)
```

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
