### PR TITLE
[v9.5.x] Tempo: Escape regex-sensitive characters in span name before building promql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-- **Explore:** Update table min height  (#67321). [#67332](https://github.com/grafana/grafana/issues/67332), [@adrapereira](https://github.com/adrapereira)
+- **Explore:** Update table min height (#67321). [#67332](https://github.com/grafana/grafana/issues/67332), [@adrapereira](https://github.com/adrapereira)
 - **DataLinks:** Encoded URL fixed. [#67291](https://github.com/grafana/grafana/issues/67291), [@juanicabanas](https://github.com/juanicabanas)
 
 <!-- 9.5.2 END -->

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -31,6 +31,7 @@ import {
   makeServiceGraphViewRequest,
   makeTempoLink,
   getFieldConfig,
+  getEscapedSpanNames,
 } from './datasource';
 import mockJson from './mockJsonResponse.json';
 import mockServiceGraph from './mockServiceGraph.json';
@@ -588,6 +589,20 @@ describe('Tempo service graph view', () => {
   it('should build link expr correctly', () => {
     let builtQuery = buildLinkExpr('topk(5, sum(rate(traces_spanmetrics_calls_total{}[$__range])) by (span_name))');
     expect(builtQuery).toBe('sum(rate(traces_spanmetrics_calls_total{}[$__rate_interval]))');
+  });
+
+  it('should escape span names correctly', () => {
+    const spanNames = [
+      '/actuator/health/**',
+      '$type + [test]|HTTP POST - post',
+      'server.cluster.local:9090^/sample.test(.*)?',
+    ];
+    let escaped = getEscapedSpanNames(spanNames);
+    expect(escaped).toEqual([
+      '/actuator/health/\\\\*\\\\*',
+      '\\\\$type \\\\+ \\\\[test\\\\]\\\\|HTTP POST - post',
+      'server\\\\.cluster\\\\.local:9090\\\\^/sample\\\\.test\\\\(\\\\.\\\\*\\\\)\\\\?',
+    ]);
   });
 
   it('should get field config correctly', () => {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -597,7 +597,7 @@ function errorAndDurationQuery(
   let serviceGraphViewMetrics = [];
   let errorRateBySpanName = '';
   let durationsBySpanName: string[] = [];
-  const spanNames = rateResponse.data[0][0]?.fields[1]?.values.toArray() ?? [];
+  const spanNames = getEscapedSpanNames(rateResponse.data[0][0]?.fields[1]?.values.toArray() ?? []);
 
   if (spanNames.length > 0) {
     errorRateBySpanName = buildExpr(errorRateMetric, 'span_name=~"' + spanNames.join('|') + '"', request);
@@ -661,6 +661,10 @@ function makePromLink(title: string, expr: string, datasourceUid: string, instan
       datasourceName: getDatasourceSrv().getDataSourceSettingsByUid(datasourceUid)?.name ?? '',
     },
   };
+}
+
+export function getEscapedSpanNames(values: string[]) {
+  return values.map((value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\\\$&'));
 }
 
 export function getFieldConfig(


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/66301 to 9.5.x