### PR TITLE
ToolbarButtonRow: prevent closure of overflow menu when interacting with portal elements

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButtonRow.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButtonRow.tsx
@@ -32,7 +32,7 @@ export const ToolbarButtonRow = forwardRef<HTMLDivElement, Props>(
         isOpen: showOverflowItems,
         shouldCloseOnInteractOutside: (element: Element) => {
           const portalContainer = getPortalContainer();
-          return !portalContainer.contains(element);
+          return !overflowRef.current?.contains(element) && !portalContainer.contains(element);
         },
       },
       overflowItemsRef

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButtonRow.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButtonRow.tsx
@@ -7,6 +7,7 @@ import React, { forwardRef, HTMLAttributes, useState, useRef, useLayoutEffect, c
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useTheme2 } from '../../themes';
+import { getPortalContainer } from '../Portal/Portal';
 
 import { ToolbarButton } from './ToolbarButton';
 export interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -29,7 +30,10 @@ export const ToolbarButtonRow = forwardRef<HTMLDivElement, Props>(
         onClose: () => setShowOverflowItems(false),
         isDismissable: true,
         isOpen: showOverflowItems,
-        shouldCloseOnInteractOutside: (element: Element) => !overflowRef.current?.contains(element),
+        shouldCloseOnInteractOutside: (element: Element) => {
+          const portalContainer = getPortalContainer();
+          return !portalContainer.contains(element);
+        },
       },
       overflowItemsRef
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- since https://github.com/grafana/grafana/pull/65361 was delivered, it's been impossible to use the add menu once it moves into the toolbar overflow menu (see before video)
  - this is due to the `shouldCloseOnInteractOutside` logic not really accounting for react portals
- update the logic to not close the overflow menu when interacting with any element in a portal
  - couldn't really think of a better way of doing this 😬
  - pros: can add a panel and select a time range correctly on mobile
  - cons: this **may** cause the overflow panel to not close when it should. although i can't really think of a real world example where this could currently happen.
  - feels like this is definitely a better situation to be in than something not working.
  
# before

https://github.com/grafana/grafana/assets/20999846/f5b85d3b-1435-41fe-8b1e-2e68bf7a2be5

# after

https://github.com/grafana/grafana/assets/20999846/61d9b250-67a9-47f9-9148-a7c9d66277cb

**Why do we need this feature?**

- so you can add a panel on mobile/small screens

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
