### PR TITLE
Prometheus: Class added for encyclopedia on open for fullstory

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -131,6 +131,7 @@ export function MetricSelect({
       return (
         <div
           {...props.innerProps}
+          className="metric-encyclopedia-open"
           onKeyDown={(e) => {
             // if there is no metric and the m.e. is enabled, open the modal
             if (e.code === 'Enter') {
@@ -139,10 +140,10 @@ export function MetricSelect({
           }}
         >
           {
-            <div className={`${styles.customOption} ${isFocused}`}>
+            <div className={`${styles.customOption} ${isFocused} metric-encyclopedia-open`}>
               <div>
-                <div>{option.label}</div>
-                <div className={styles.customOptionDesc}>{option.description}</div>
+                <div className="metric-encyclopedia-open">{option.label}</div>
+                <div className={`${styles.customOptionDesc} metric-encyclopedia-open`}>{option.description}</div>
               </div>
               <Button
                 variant="primary"
@@ -150,6 +151,7 @@ export function MetricSelect({
                 size="sm"
                 onClick={() => setState({ ...state, metricsModalOpen: true })}
                 icon="book"
+                className="metric-encyclopedia-open"
               >
                 Open
               </Button>


### PR DESCRIPTION
This PR is to add a class to the custom metric encyclopedia option in the metric select to test that Full Story can read the event that the modal has been opened from the select on click.

The option is comprised of a number of elements that could be targeted for the class so I am giving every element in the custom option the class so that we can test that Full story can capture this.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
