### PR TITLE
CloudMonitor: Show template variables by default

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -257,7 +257,13 @@ export function Editor({
                 onChange={onMetricTypeChange}
                 value={[...metrics, ...variableOptionGroup.options].find((s) => s.value === metricType)}
                 loadOptions={debounceFilter}
-                defaultOptions={metrics.slice(0, 100)}
+                defaultOptions={[
+                  {
+                    label: 'Template Variables',
+                    options: variableOptionGroup.options,
+                  },
+                  ...metrics.slice(0, 100),
+                ]}
                 placeholder="Select Metric"
                 inputId={`${refId}-select-metric`}
                 disabled={service === ''}


### PR DESCRIPTION
This adds template variables as options for the `AsyncSelect` as part of the `defaultOption` prop which allows the user to select a template variable without having to trigger another query.

ref #67682 