### PR TITLE
CI: Add `.drone.yml` in pathschanged trigger for `lint_backend` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -437,6 +437,7 @@ trigger:
     include:
     - pkg/**
     - packaging/**
+    - .drone.yml
     - conf/**
     - go.sum
     - go.mod
@@ -6995,6 +6996,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 4a99b404fa59910566c088700c4aacf6cc00de65aa8955f58f7dc3e313f932c8
+hmac: 580387ea6dbe3182c71aac875bf9f114e3edc7d8cb8a67e6da7502433f9560be
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -105,6 +105,7 @@ def pr_pipelines():
                 include_paths = [
                     "pkg/**",
                     "packaging/**",
+                    ".drone.yml",
                     "conf/**",
                     "go.sum",
                     "go.mod",


### PR DESCRIPTION
**What is this feature?**

Triggers `lint_backend` pipeline on `.drone.yml` file changes. 

**Why do we need this feature?**

It seems that upon Go upgrades, linter doesn't run as it should, the errors are hidden and are only found when we merge to main/versioned branches.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
