### PR TITLE
DarkTheme: Fix dark theme shadows

### DIFF
--- a/packages/grafana-data/src/themes/createShadows.ts
+++ b/packages/grafana-data/src/themes/createShadows.ts
@@ -11,8 +11,8 @@ export interface ThemeShadows {
 export function createShadows(colors: ThemeColors): ThemeShadows {
   if (colors.mode === 'dark') {
     return {
-      z1: '0px 1px 2px rgba(1, 4, 9, 0.65)',
-      z2: '0px 4px 8px rgba(1, 4, 9, 0.65)',
+      z1: '0px 1px 2px rgba(1, 4, 9, 0.75)',
+      z2: '0px 4px 8px rgba(1, 4, 9, 0.75)',
       z3: '0px 8px 24px rgb(1, 4, 9)',
     };
   }

--- a/packages/grafana-data/src/themes/createShadows.ts
+++ b/packages/grafana-data/src/themes/createShadows.ts
@@ -11,9 +11,9 @@ export interface ThemeShadows {
 export function createShadows(colors: ThemeColors): ThemeShadows {
   if (colors.mode === 'dark') {
     return {
-      z1: '0px 1px 2px rgba(24, 26, 27, 0.75)',
-      z2: '0px 4px 8px rgba(24, 26, 27, 0.75)',
-      z3: '0px 8px 24px rgb(1,4,9)',
+      z1: '0px 1px 2px rgba(1, 4, 9, 0.65)',
+      z2: '0px 4px 8px rgba(1, 4, 9, 0.65)',
+      z3: '0px 8px 24px rgb(1, 4, 9)',
     };
   }
 


### PR DESCRIPTION
Noticed that our z1 and z2 shadows are completely invisible in the dark theme 

![Screenshot from 2023-05-12 12-03-30](https://github.com/grafana/grafana/assets/10999/16290e7c-6512-4e78-9f87-806af1a5466c)

Compared to light theme:
![Screenshot from 2023-05-12 12-00-49](https://github.com/grafana/grafana/assets/10999/0ac75c4d-1e2b-409f-8d80-8ea5f9eb2462)

I have no memory of being like this when we launched new themes in v8 but it looks like it according to github history, so pretty confused :) 

This means tooltips have no shadows in dark theme (and buttons and some other elements have no hover shadow)
![Screenshot from 2023-05-12 12-11-33](https://github.com/grafana/grafana/assets/10999/db7252f3-8f2a-41be-b5dd-cd6440c9702c)
![Screenshot from 2023-05-12 12-11-39](https://github.com/grafana/grafana/assets/10999/ffd43365-88a0-4988-8b8b-9793149223ef)

This PR proposes some z1-2 shadows that try to match the light theme shadows. 

![image](https://github.com/grafana/grafana/assets/10999/af1a1192-83d4-477c-8c37-8a2cdc41aba6)

Tooltip:
![image](https://github.com/grafana/grafana/assets/10999/8736c353-056b-4c30-b1a7-d48c2ff48932)

The z1 shadow on hover for buttons is barely visible still (But helps a little bit) 

![image](https://github.com/grafana/grafana/assets/10999/5669b209-150d-4e73-8e5e-8b5f02ffb837)

We don't use z2 that much (probably because it was invisible in dark theme). 

One place I found is the auto complete popup for data links 
![Screenshot from 2023-05-12 12-21-51](https://github.com/grafana/grafana/assets/10999/08ea0d51-91cf-4a2b-87df-753d7728c3c2)

Anyway. Happy to change it to something else but invisible like they are now I think is some kind of mistake :) 