### PR TITLE
Explore: Remove localStorage key migration for logs volume

### DIFF
--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -38,21 +38,6 @@ export const loadSupplementaryQueries = (): SupplementaryQueries => {
   };
 
   for (const type of supplementaryQueryTypes) {
-    if (type === SupplementaryQueryType.LogsVolume) {
-      // TODO: Remove this in 10.0 (#61626)
-      // For LogsVolume we need to migrate old key to new key. So check for old key:
-      // If we have old key: 1) use it 2) migrate to new key 3) delete old key
-      // If not, continue with new key
-      const oldLogsVolumeEnabledKey = 'grafana.explore.logs.enableVolumeHistogram';
-      const shouldBeEnabled = store.get(oldLogsVolumeEnabledKey);
-      if (shouldBeEnabled) {
-        supplementaryQueries[type] = { enabled: shouldBeEnabled === 'true' ? true : false };
-        storeSupplementaryQueryEnabled(shouldBeEnabled === 'true', SupplementaryQueryType.LogsVolume);
-        localStorage.removeItem(oldLogsVolumeEnabledKey);
-        continue;
-      }
-    }
-
     // We want to skip LogsSample and default it to false for now to trigger it only on user action
     if (type === SupplementaryQueryType.LogsSample) {
       continue;


### PR DESCRIPTION
This PR removed the migration of old localStorage to key to the new one for logs volume enabled/disabled preference. 

@ifrost added a lot of context in https://github.com/grafana/grafana/issues/61626#issuecomment-1542609390

> This [PR](https://github.com/grafana/grafana/pull/61298) changed the name of the key used in browser local storage to determine if log volume is "enabled" (enabled => the panel is opened and log volume loads automatically with the query / disabled => the panel is collapsed and log volume is loaded only when the user opens the panel; the setting is updated each time the panel is collapsed/opened). 
> 
> The PR also added the code to migrate the setting, which means if logs volume was enabled using the old key, it'd save the setting under a new key. The migration worked in 9.4 and 9.5 meaning users who opened Explore at least once have their settings migrated (migration happens when pane settings are loaded).
> 
> With @ivanahuckova we agreed that the migration logic is not needed to be kept longer than until Grafana 10.0.0. If this is still acceptable, we can remove [this block of code](https://github.com/grafana/grafana/blob/main/public/app/features/explore/utils/supplementaryQueries.ts#L41). 
> 
> The impact: in worst case scenario if a user had log volume disabled before 9.4 and upgraded straight to 10.0, the log volume will be enabled (as it's the default setting).
> 

Fixes https://github.com/grafana/grafana/issues/61626

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.