### PR TITLE
Search: Fix Search returning results out of order

### DIFF
--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -232,7 +232,6 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
 
     this.lastSearchPromise = this.lastSearchPromise
       .then(() => searchPromise)
-      // searchPromise
       .then((result) => this.setState({ result, loading: false }))
       .catch((error) => {
         reportSearchFailedQueryInteraction(this.state.eventTrackingNamespace, {

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -39,6 +39,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   updateLocation = debounce((query) => locationService.partial(query, true), 300);
   doSearchWithDebounce = debounce(() => this.doSearch(), 300);
   lastQuery?: SearchQuery;
+  lastSearchPromise: Promise<void> = Promise.resolve();
 
   initStateFromUrl(folderUid?: string, doInitialSearch = true) {
     const stateFromUrl = parseRouteParams(locationService.getSearchObject());
@@ -224,29 +225,24 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
 
     this.setState({ loading: true });
 
-    if (this.state.starred) {
-      getGrafanaSearcher()
-        .starred(this.lastQuery)
-        .then((result) => this.setState({ result, loading: false }))
-        .catch((error) => {
-          reportSearchFailedQueryInteraction(this.state.eventTrackingNamespace, {
-            ...trackingInfo,
-            error: error?.message,
-          });
-          this.setState({ loading: false });
+    const searcher = getGrafanaSearcher();
+
+    // Issue this search now, but wait until previous searches have resolved to update it in the state
+    const searchPromise = this.state.starred ? searcher.starred(this.lastQuery) : searcher.search(this.lastQuery);
+
+    this.lastSearchPromise = this.lastSearchPromise
+      .then(() => searchPromise)
+      // searchPromise
+      .then((result) => this.setState({ result, loading: false }))
+      .catch((error) => {
+        reportSearchFailedQueryInteraction(this.state.eventTrackingNamespace, {
+          ...trackingInfo,
+          error: error?.message,
         });
-    } else {
-      getGrafanaSearcher()
-        .search(this.lastQuery)
-        .then((result) => this.setState({ result, loading: false }))
-        .catch((error) => {
-          reportSearchFailedQueryInteraction(this.state.eventTrackingNamespace, {
-            ...trackingInfo,
-            error: error?.message,
-          });
-          this.setState({ loading: false });
-        });
-    }
+        this.setState({ loading: false });
+
+        return Promise.resolve(); // make sure this.lastSearchPromise is always resolved
+      });
   }
 
   // This gets the possible tags from within the query results


### PR DESCRIPTION
SearchStateManager will set the search results for the last query returned. If the search API responds "out of order", then this would show search results out of order. This is particularly noticeable when searching instance with many results, depending on how fast you type. For example, if trying to search for `debugging`:

 - You type the `d` and wait just a _little_ bit (300ms), we `GET search?query=d`
 - You finish typing `debugger, we `GET search?query=debugger`
 - `GET search?query=debugger` returns first because it has less results, and we render these in UI
 - `GET search?query=d` finally returns, and we _these_ results, losing the results issued last

This is especially annoying as because the first search typically has more results, it's more likely to return _later_. This has always been a subtle problem, but I believe nestedFolders has a performance impact that makes this more apparent.

This PR changes SearchStateManager to keep the previous promises, and wait until it's resolved until resolving the _new_ search promise.