### PR TITLE
Command Palette: Prevent stale search results from overwriting newer results

### DIFF
--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -87,9 +87,9 @@ export function useSearchResults(searchQuery: string, isShowing: boolean) {
 
   // Hit dashboards API
   useEffect(() => {
+    const timestamp = Date.now();
     if (isShowing && searchQuery.length > 0) {
       setIsFetchingSearchResults(true);
-      const timestamp = Date.now();
       debouncedSearch(searchQuery).then((resultActions) => {
         // Only update the state if this is the most recent request
         // We don't need to worry about clearing the isFetching state either
@@ -102,6 +102,8 @@ export function useSearchResults(searchQuery: string, isShowing: boolean) {
       });
     } else {
       setSearchResults([]);
+      setIsFetchingSearchResults(false);
+      lastRequestTimestamp.current = timestamp;
     }
   }, [isShowing, searchQuery]);
 

--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -1,5 +1,5 @@
 import debounce from 'debounce-promise';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { locationUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -83,14 +83,22 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
 export function useSearchResults(searchQuery: string, isShowing: boolean) {
   const [searchResults, setSearchResults] = useState<CommandPaletteAction[]>([]);
   const [isFetchingSearchResults, setIsFetchingSearchResults] = useState(false);
+  const lastRequestTimestamp = useRef<number>();
 
   // Hit dashboards API
   useEffect(() => {
     if (isShowing && searchQuery.length > 0) {
       setIsFetchingSearchResults(true);
+      const timestamp = Date.now();
       debouncedSearch(searchQuery).then((resultActions) => {
-        setSearchResults(resultActions);
-        setIsFetchingSearchResults(false);
+        // Only update the state if this is the most recent request
+        // We don't need to worry about clearing the isFetching state either
+        // If there's a later request in progress, this will clear it for us
+        if (!lastRequestTimestamp.current || timestamp > lastRequestTimestamp.current) {
+          setSearchResults(resultActions);
+          setIsFetchingSearchResults(false);
+          lastRequestTimestamp.current = timestamp;
+        }
       });
     } else {
       setSearchResults([]);

--- a/public/app/features/commandPalette/actions/useActions.ts
+++ b/public/app/features/commandPalette/actions/useActions.ts
@@ -30,10 +30,8 @@ export default function useActions(searchQuery: string) {
         .catch((err) => {
           console.error('Error loading recent dashboard actions', err);
         });
-    } else {
-      setRecentDashboardActions([]);
     }
   }, [searchQuery]);
 
-  return [...recentDashboardActions, ...navTreeActions];
+  return searchQuery ? navTreeActions : [...recentDashboardActions, ...navTreeActions];
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- in some cases, search results can be returned in a different order from what they were triggered in
- how to repro:
  1. make sure you're in an org with a fair few dashboards. my main org locally works fine so i assume yours would too
  1. open command palette
  1. throttle network to slow 3g
  1. type a single common letter (e.g. e)
  1. as soon as the spinner appears, quickly finish typing a more specific search. i have a dashboard with esc in the name
- only updates the search results state if it's the most recent request

**Why do we need this feature?**

- prevent stale requests overwriting the search state

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
