### PR TITLE
Nested folders: Allow renaming a folder multiple times

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -155,6 +155,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 
 	// always expose the dashboard store sequential ID
 	f.ID = dashFolder.ID
+	f.Version = dashFolder.Version
 
 	return f, err
 }
@@ -351,6 +352,7 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 
 	// always expose the dashboard store sequential ID
 	foldr.ID = dashFolder.ID
+	foldr.Version = dashFolder.Version
 
 	return foldr, nil
 }


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Before nested folders, folders were treated as special kind of dashboards and they exposed a version number in the API that is used when updating a dashboard to prevent concurrent updates:
https://github.com/grafana/grafana/blob/e7a67e749c1c9efefaf20dd343e91d4788104473/pkg/services/dashboards/database/database.go#L441-L448
The UI fetches the version from the `GET /api/folder/<folder_uid>` response and passes it in `PUT api/folder/<folder_uid>` requests when updating the folder.

As part of the work in the nested folders: we introduced a table dedicated for folders (`folder`) and we have [decided](https://docs.google.com/document/d/1qonh75vgI0dYPU6acuwqQnXZ9T_8MHsyo-X4ZO2SiR4/edit#heading=h.baroacxh7pjq) that the version number is not relevant for folders therefore we didn't return the version (when `nestedFolders` flag was set).

In addition to this, when creating a nested folder, for keeping [backwards compatibility](https://docs.google.com/document/d/1trRt3KDJxBXa8khgmQgZB0n7KtVXE1UGX4v11FDBUv8/edit#heading=h.qdidspdfg89) we create an entry both in the `dashboard` table and in the new `folder` table.
Similarly, when we update a nested folder, we update the entry in the `dashboard` table too.

As a result, a folder couldn't be updated multiple times because it was blocked when executing the above code given the version was not set (zero)

**Why do we need this feature?**

We restore returning the folder version in `GET` and `PUT` responses even if the nested folders are enabled (until we stop storing folders in the `dashboard` table)

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
In order to reproduce the issue:
- Start grafana with nested folders enabled
- Rename the folder
- Try to rename the folder once again: it will fail with `the folder has been changed by someone else` error message

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
