### PR TITLE
DSPicker: Align open advanced button to right

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -220,11 +220,6 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
         }
       ></DataSourceList>
       <div className={styles.footer}>
-        {onClickAddCSV && config.featureToggles.editPanelCSVDragAndDrop && (
-          <Button variant="secondary" size="sm" onClick={clickAddCSVCallback}>
-            Add csv or spreadsheet
-          </Button>
-        )}
         <ModalsController>
           {({ showModal, hideModal }) => (
             <Button
@@ -252,6 +247,11 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
             </Button>
           )}
         </ModalsController>
+        {onClickAddCSV && config.featureToggles.editPanelCSVDragAndDrop && (
+          <Button variant="secondary" size="sm" onClick={clickAddCSVCallback}>
+            Add csv or spreadsheet
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -278,6 +278,7 @@ function getStylesPickerContent(theme: GrafanaTheme2) {
     footer: css`
       flex: 0;
       display: flex;
+      flex-direction: row-reverse;
       justify-content: space-between;
       padding: ${theme.spacing(1.5)};
       border-top: 1px solid ${theme.colors.border.weak};


### PR DESCRIPTION
When CSV upload disabled BEFORE ⛔ |When CSV upload enabled 🟢|When CSV upload disabled 🟢 |
|-|-|-|
![Captura de pantalla 2023-05-12 a las 17 42 40](https://github.com/grafana/grafana/assets/5699976/ad10390f-f94c-4831-8191-08a98147a4ee)|![Captura de pantalla 2023-05-12 a las 17 39 46](https://github.com/grafana/grafana/assets/5699976/909e7a51-f53f-437d-8ef6-b7ec76504a43)|![Captura de pantalla 2023-05-12 a las 17 39 53](https://github.com/grafana/grafana/assets/5699976/9bbd5a28-0b8d-4f80-9823-329f1d2e2d76)

**Problem**
* When CSV upload was disabled, the button didn't keep aligned to the right

**Solution**
* We just start the flow from the right, and this solves the issue when an element is not present