### PR TITLE
FlameGraph: Debounce search update preventing too frequent rerenders 

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraphHeader.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraphHeader.tsx
@@ -55,12 +55,12 @@ const FlameGraphHeader = ({
     setSelectedBarIndex(0);
     setRangeMin(0);
     setRangeMax(1);
+    // We could set only one and wait them to sync but there is no need to debounce this.
     setSearch('');
+    setLocalSearch('');
   };
 
   const [localSearch, setLocalSearch] = useSearchInput(search, setSearch);
-
-  console.log('rendering', localSearch, search);
 
   return (
     <div className={styles.header}>
@@ -100,7 +100,6 @@ function useSearchInput(
   const [localSearchState, setLocalSearchState] = useState(search);
   const prevSearch = usePrevious(search);
 
-  console.log('in useSearchInput', localSearchState, search);
   // Debouncing cause changing parent search triggers rerender on both the flamegraph and table
   useDebounce(
     () => {

--- a/public/app/plugins/panel/flamegraph/components/FlameGraphHeader.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraphHeader.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
-import { useDebounce } from 'react-use';
+import useDebounce from 'react-use/lib/useDebounce';
 
 import { GrafanaTheme2, CoreApp } from '@grafana/data';
 import { Button, Input, RadioButtonGroup, useStyles2 } from '@grafana/ui';


### PR DESCRIPTION
Search input updated the search state sync which means every char rerendered the whole component, both table and the graph.

This change makes the parent state change debounced while keeping bidirectional updates from table item selection.