### PR TITLE
ResourcePicker: Fix selecting icons

### DIFF
--- a/public/app/features/dimensions/editors/ResourceCards.tsx
+++ b/public/app/features/dimensions/editors/ResourceCards.tsx
@@ -21,7 +21,7 @@ interface CellProps {
   };
 }
 
-function Cell(props: CellProps) {
+const MemoizedCell = memo(function Cell(props: CellProps) {
   const { columnIndex, rowIndex, style, data } = props;
   const { cards, columnCount, onChange, selected } = data;
   const singleColumnIndex = columnIndex + rowIndex * columnCount;
@@ -47,7 +47,7 @@ function Cell(props: CellProps) {
       )}
     </div>
   );
-}
+}, areEqual);
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => {
   return {
@@ -125,7 +125,7 @@ export const ResourceCards = (props: CardProps) => {
             itemData={{ cards, columnCount, onChange, selected: value }}
             className={styles.grid}
           >
-            {memo(Cell, areEqual)}
+            {MemoizedCell}
           </Grid>
         );
       }}


### PR DESCRIPTION
Before

https://github.com/grafana/grafana/assets/88068998/3366054e-b4c7-4382-8ae2-a116f7fa5a58


After

https://github.com/grafana/grafana/assets/88068998/7543a435-cef0-4706-b62f-42edf9a8829b


Fixes #67941

**Special notes for your reviewer:**
- Not sure if also a regression/happens just to me - seems to look different in the original video..

<img width="323" alt="Screenshot" src="https://github.com/grafana/grafana/assets/88068998/8952aeb4-67f1-4aa5-bb33-b36c7336d880">


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
