### PR TITLE
XYChart: Use fixed opacity, reduce memory pressure

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5953,11 +5953,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Do not use any type assertions.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Do not use any type assertions.", "12"],
-      [0, 0, 0, "Do not use any type assertions.", "13"],
-      [0, 0, 0, "Do not use any type assertions.", "14"],
-      [0, 0, 0, "Do not use any type assertions.", "15"]
+      [0, 0, 0, "Do not use any type assertions.", "11"]
     ],
     "public/app/polyfills/old-mediaquerylist.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]


### PR DESCRIPTION
this is a precurser to a much larger perf fix for huge datasets in https://github.com/grafana/grafana/pull/67878.

this optimizes our "slow" path to reduce the size of the upcoming changes for a fast path. it also removes an internal per-point alpha calc that we don't plan to support. alpha will always be static and per series. only color will be per point.

this saves about 5% in CPU which may not seem significant, except in this customer dataset, that 5% is 600ms. however, the memory pressure is significantly better. going from 581MB peak to 415MB peak, with similar savings on the bottom end.

before:

![image](https://github.com/grafana/grafana/assets/43234/19406bbf-6f02-4c54-ab53-8e1d4620e349)

after:

![image](https://github.com/grafana/grafana/assets/43234/1b435639-148d-48f0-9551-23763f4cf13c)
