### PR TITLE
Nested folders: Clear selection state when navigating to a different folder

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render as rtlRender, screen } from '@testing-library/react';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -10,7 +10,7 @@ import { getRouteComponentProps } from 'app/core/navigation/__mocks__/routeProps
 import BrowseDashboardsPage, { Props } from './BrowseDashboardsPage';
 import { wellFormedTree } from './fixtures/dashboardsTreeItem.fixture';
 import * as permissions from './permissions';
-const [mockTree, { dashbdD }] = wellFormedTree();
+const [mockTree, { dashbdD, folderA }] = wellFormedTree();
 
 jest.mock('react-virtualized-auto-sizer', () => {
   return {
@@ -97,5 +97,24 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
     // Check the actions are now visible
     expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('navigating into a child item resets the selected state', async () => {
+    render(<BrowseDashboardsPage {...props} />);
+
+    const checkbox = await screen.findByTestId(selectors.pages.BrowseDashbards.table.checkbox(folderA.item.uid));
+    await userEvent.click(checkbox);
+
+    // Check the actions are now visible
+    expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('link', { name: folderA.item.title }));
+
+    // Check the actions are no longer visible
+    waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Move' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -38,16 +38,16 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
   const [searchState, stateManager] = useSearchStateManager();
   const isSearching = stateManager.hasSearchFilters();
 
-  useEffect(() => stateManager.initStateFromUrl(folderUID), [folderUID, stateManager]);
-
-  // Clear selected state when folderUID changes
   useEffect(() => {
+    stateManager.initStateFromUrl(folderUID);
+
+    // Clear selected state when folderUID changes
     dispatch(
       setAllSelection({
         isSelected: false,
       })
     );
-  }, [dispatch, folderUID]);
+  }, [dispatch, folderUID, stateManager]);
 
   useEffect(() => {
     // Clear the search results when we leave SearchView to prevent old results flashing

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -6,6 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { useDispatch } from 'app/types';
 
 import { buildNavModel } from '../folders/state/navModel';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
@@ -18,7 +19,7 @@ import { BrowseView } from './components/BrowseView';
 import { CreateNewButton } from './components/CreateNewButton';
 import { SearchView } from './components/SearchView';
 import { getFolderPermissions } from './permissions';
-import { useHasSelection } from './state';
+import { setAllSelection, useHasSelection } from './state';
 
 export interface BrowseDashboardsPageRouteParams {
   uid?: string;
@@ -31,12 +32,22 @@ export interface Props extends GrafanaRouteComponentProps<BrowseDashboardsPageRo
 
 const BrowseDashboardsPage = memo(({ match }: Props) => {
   const { uid: folderUID } = match.params;
+  const dispatch = useDispatch();
 
   const styles = useStyles2(getStyles);
   const [searchState, stateManager] = useSearchStateManager();
   const isSearching = stateManager.hasSearchFilters();
 
   useEffect(() => stateManager.initStateFromUrl(folderUID), [folderUID, stateManager]);
+
+  // Clear selected state when folderUID changes
+  useEffect(() => {
+    dispatch(
+      setAllSelection({
+        isSelected: false,
+      })
+    );
+  }, [dispatch, folderUID]);
 
   useEffect(() => {
     // Clear the search results when we leave SearchView to prevent old results flashing

--- a/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
@@ -48,12 +48,14 @@ export function wellFormedFolder(
   itemPartial?: Partial<DashboardViewItem>
 ): DashboardsTreeItem<DashboardViewItem> {
   const random = Chance(seed);
+  const uid = random.guid();
 
   return {
     item: {
       kind: 'folder',
       title: random.sentence({ words: 3 }),
-      uid: random.guid(),
+      uid,
+      url: `/dashboards/f/${uid}`,
       ...itemPartial,
     },
     level: 0,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- clears the selection state when `folderUID` changes
- adds a unit test to prevent regressions

**Why do we need this feature?**

- prevent accidental deletion of folders/dashboards

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
