### PR TITLE
Node graph: Fix req/s in value

### DIFF
--- a/public/app/plugins/datasource/tempo/graphTransform.test.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.test.ts
@@ -77,7 +77,7 @@ describe('mapPromMetricsToServiceMap', () => {
       { name: 'id', values: ['db', 'app', 'lb'] },
       { name: 'title', values: ['db', 'app', 'lb'] },
       { name: 'mainstat', values: [1000, 2000, NaN] },
-      { name: 'secondarystat', values: [0.17, 0.33, NaN] },
+      { name: 'secondarystat', values: [10, 20, NaN] },
       { name: 'arc__success', values: [0.8, 0.25, 1] },
       { name: 'arc__failed', values: [0.2, 0.75, 0] },
     ]);
@@ -86,7 +86,7 @@ describe('mapPromMetricsToServiceMap', () => {
       { name: 'source', values: ['app', 'lb'] },
       { name: 'target', values: ['db', 'app'] },
       { name: 'mainstat', values: [1000, 2000] },
-      { name: 'secondarystat', values: [0.17, 0.33] },
+      { name: 'secondarystat', values: [10, 20] },
     ]);
   });
 
@@ -109,7 +109,7 @@ describe('mapPromMetricsToServiceMap', () => {
       { name: 'id', values: ['db', 'app', 'lb'] },
       { name: 'title', values: ['db', 'app', 'lb'] },
       { name: 'mainstat', values: [1000, 2000, NaN] },
-      { name: 'secondarystat', values: [0.17, 0.33, NaN] },
+      { name: 'secondarystat', values: [10, 20, NaN] },
       { name: 'arc__success', values: [0, 0, 1] },
       { name: 'arc__failed', values: [1, 1, 0] },
     ]);

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -307,7 +307,6 @@ function convertToDataFrames(
   edgesMap: Record<string, EdgeObject>,
   range: TimeRange
 ): { nodes: DataFrame; edges: DataFrame } {
-  const rangeMs = range.to.valueOf() - range.from.valueOf();
   const [nodes, edges] = createServiceMapDataFrames();
   for (const nodeId of Object.keys(nodesMap)) {
     const node = nodesMap[nodeId];
@@ -317,7 +316,7 @@ function convertToDataFrames(
       // NaN will not be shown in the node graph. This happens for a root client node which did not process
       // any requests itself.
       [Fields.mainStat]: node.total ? (node.seconds! / node.total) * 1000 : Number.NaN, // Average response time
-      [Fields.secondaryStat]: node.total ? Math.round((node.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
+      [Fields.secondaryStat]: node.total ? Math.round(node.total * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
       [Fields.arc + 'success']: node.total ? (node.total - Math.min(node.failed || 0, node.total)) / node.total : 1,
       [Fields.arc + 'failed']: node.total ? Math.min(node.failed || 0, node.total) / node.total : 0,
     });
@@ -329,7 +328,7 @@ function convertToDataFrames(
       [Fields.source]: edge.source,
       [Fields.target]: edge.target,
       [Fields.mainStat]: edge.total ? (edge.seconds! / edge.total) * 1000 : Number.NaN, // Average response time
-      [Fields.secondaryStat]: edge.total ? Math.round((edge.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
+      [Fields.secondaryStat]: edge.total ? Math.round(edge.total * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
     });
   }
 


### PR DESCRIPTION
:wave:  noticed that req/s stat in node graph is always close to 0.00 an does not match reality.

Seems [request rate is queried using an instant `rate()` query](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/tempo/datasource.ts#L732)  which already gives a req/s value. But it's later divided by number of seconds in given time range. If time range is more than one second, it produces a wrong value. Let me know if I musinderstand something :pray:  


 
