### PR TITLE
Tempo: Fix get label values based on CoreApp type

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -11,6 +11,7 @@ import {
   LoadingState,
   createDataFrame,
   PluginType,
+  CoreApp,
 } from '@grafana/data';
 import {
   BackendDataSourceResponse,
@@ -449,7 +450,7 @@ describe('Tempo service graph view', () => {
     });
     setDataSourceSrv(backendSrvWithPrometheus as any);
     const response = await lastValueFrom(
-      ds.query({ targets: [{ queryType: 'serviceMap' }], range: getDefaultTimeRange() } as any)
+      ds.query({ targets: [{ queryType: 'serviceMap' }], range: getDefaultTimeRange(), app: CoreApp.Explore } as any)
     );
 
     expect(response.data).toHaveLength(3);


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where we were incorrectly getting the label values for `errorAndDurationQuery` for explore only, not considering that queries may also come from non-explore.

**Why do we need this feature?**

To fix regex bug where values are not string in `getEscapedSpanNames` by getting proper span names.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/68440

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
