### PR TITLE
Loki: Add functionality to revert to initial query in log context

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -225,7 +225,7 @@ describe('LokiContextUi', () => {
     // We select parsed label and label3="value3" should appear
     const parsedLabelsInput = screen.getAllByRole('combobox')[1];
     await userEvent.click(parsedLabelsInput);
-    fireEvent.keyDown(parsedLabelsInput, { key: 'Enter' });
+    await userEvent.type(parsedLabelsInput, '{enter}');
     expect(screen.getByText('label3="value3"')).toBeInTheDocument();
 
     // We click on revert button and label3="value3" should disappear

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -229,7 +229,7 @@ describe('LokiContextUi', () => {
     expect(screen.getByText('label3="value3"')).toBeInTheDocument();
 
     // We click on revert button and label3="value3" should disappear
-    const revertButton = screen.getByTestId('Revert to initial log context query.');
+    const revertButton = screen.getByTestId('revert-button');
     await userEvent.click(revertButton);
     await waitFor(() => {
       expect(screen.queryByText('label3="value3"')).not.toBeInTheDocument();

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -229,7 +229,7 @@ describe('LokiContextUi', () => {
     expect(screen.getByText('label3="value3"')).toBeInTheDocument();
 
     // We click on revert button and label3="value3" should disappear
-    const revertButton = screen.getByTitle('Revert to initial log context query.');
+    const revertButton = screen.getByTestId('Revert to initial log context query.');
     await userEvent.click(revertButton);
     await waitFor(() => {
       expect(screen.queryByText('label3="value3"')).not.toBeInTheDocument();

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -194,6 +194,9 @@ export function LokiContextUi(props: LokiContextUiProps) {
         tooltip="Revert to initial log context query."
         onClick={(e) => {
           e.stopPropagation();
+          reportInteraction('grafana_explore_logs_loki_log_context_reverted', {
+            logRowUid: row.uid,
+          });
           setContextFilters((contextFilters) => {
             return contextFilters.map((contextFilter) => ({
               ...contextFilter,

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
@@ -181,31 +181,28 @@ export function LokiContextUi(props: LokiContextUiProps) {
 
   return (
     <div className={styles.wrapper}>
-      <Button
-        data-testid="Revert to initial log context query."
-        icon="history-alt"
-        variant="secondary"
-        className={cx(
-          styles.iconButton,
-          css`
-            visibility: ${isInitialQuery ? 'hidden' : 'visible'};
-          `
-        )}
-        tooltip="Revert to initial log context query."
-        onClick={(e) => {
-          e.stopPropagation();
-          reportInteraction('grafana_explore_logs_loki_log_context_reverted', {
-            logRowUid: row.uid,
-          });
-          setContextFilters((contextFilters) => {
-            return contextFilters.map((contextFilter) => ({
-              ...contextFilter,
-              // For revert to initial query we need to enable all labels and disable all parsed labels
-              enabled: !contextFilter.fromParser,
-            }));
-          });
-        }}
-      />
+      <Tooltip content={'Revert to initial log context query.'}>
+        <div className={styles.iconButton}>
+          <Button
+            data-testid="revert-button"
+            icon="history-alt"
+            variant="secondary"
+            disabled={isInitialQuery}
+            onClick={(e) => {
+              reportInteraction('grafana_explore_logs_loki_log_context_reverted', {
+                logRowUid: row.uid,
+              });
+              setContextFilters((contextFilters) => {
+                return contextFilters.map((contextFilter) => ({
+                  ...contextFilter,
+                  // For revert to initial query we need to enable all labels and disable all parsed labels
+                  enabled: !contextFilter.fromParser,
+                }));
+              });
+            }}
+          />
+        </div>
+      </Tooltip>
 
       <Collapse
         collapsible={true}

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -1,10 +1,10 @@
-import { css } from '@emotion/css';
-import React, { useCallback, useEffect, useState } from 'react';
+import { css, cx } from '@emotion/css';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { GrafanaTheme2, LogRowModel, SelectableValue } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Collapse, Icon, Label, MultiSelect, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Collapse, Icon, Label, MultiSelect, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import store from 'app/core/store';
 
 import { RawQuery } from '../../prometheus/querybuilder/shared/RawQuery';
@@ -54,6 +54,7 @@ function getStyles(theme: GrafanaTheme2) {
       text-align: start;
       line-break: anywhere;
       margin-top: -${theme.spacing(0.25)};
+      max-width: calc(100% - 50px);
     `,
     ui: css`
       background-color: ${theme.colors.background.secondary};
@@ -64,6 +65,11 @@ function getStyles(theme: GrafanaTheme2) {
     `,
     queryDescription: css`
       margin-left: ${theme.spacing(0.5)};
+    `,
+    button: css`
+      position: absolute;
+      top: ${theme.spacing(1)};
+      right: ${theme.spacing(1)};
     `,
   };
 }
@@ -83,6 +89,16 @@ export function LokiContextUi(props: LokiContextUiProps) {
   const timerHandle = React.useRef<number>();
   const previousInitialized = React.useRef<boolean>(false);
   const previousContextFilters = React.useRef<ContextFilter[]>([]);
+
+  const isInitialQuery = useMemo(() => {
+    // Initial query has all regular labels enabled and all parsed labels disabled
+    if (initialized && contextFilters.some((filter) => filter.fromParser === filter.enabled)) {
+      return false;
+    }
+
+    return true;
+  }, [contextFilters, initialized]);
+
   useEffect(() => {
     if (!initialized) {
       return;
@@ -176,18 +192,45 @@ export function LokiContextUi(props: LokiContextUiProps) {
         }}
         label={
           <div className={styles.query}>
-            <RawQuery
-              lang={{ grammar: lokiGrammar, name: 'loki' }}
-              query={logContextProvider.processContextFiltersToExpr(
-                row,
-                contextFilters.filter(({ enabled }) => enabled),
-                origQuery
-              )}
-              className={styles.rawQuery}
-            />
+            {initialized ? (
+              <RawQuery
+                lang={{ grammar: lokiGrammar, name: 'loki' }}
+                query={logContextProvider.processContextFiltersToExpr(
+                  row,
+                  contextFilters.filter(({ enabled }) => enabled),
+                  origQuery
+                )}
+                className={styles.rawQuery}
+              />
+            ) : (
+              <Spinner />
+            )}
             <Tooltip content="The initial log context query is created from all labels defining the stream for the selected log line. Use the editor below to customize the log context query.">
               <Icon name="info-circle" size="sm" className={styles.queryDescription} />
             </Tooltip>
+            <Button
+              icon="history-alt"
+              variant="secondary"
+              className={cx(
+                styles.button,
+                css`
+                  visibility: ${isInitialQuery ? 'hidden' : 'visible'};
+                `
+              )}
+              tooltip="Revert to initial log context query."
+              onClick={(e) => {
+                e.stopPropagation();
+                setContextFilters((contextFilters) => {
+                  return contextFilters.map((contextFilter) => {
+                    return {
+                      ...contextFilter,
+                      // For revert to initial query we need to enable all labels and disable all parsed labels
+                      enabled: !contextFilter.fromParser,
+                    };
+                  });
+                });
+              }}
+            />
           </div>
         }
       >

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -182,7 +182,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
   return (
     <div className={styles.wrapper}>
       <Button
-        title="Revert to initial log context query."
+        data-testid="Revert to initial log context query."
         icon="history-alt"
         variant="secondary"
         className={cx(

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -195,13 +195,11 @@ export function LokiContextUi(props: LokiContextUiProps) {
         onClick={(e) => {
           e.stopPropagation();
           setContextFilters((contextFilters) => {
-            return contextFilters.map((contextFilter) => {
-              return {
-                ...contextFilter,
-                // For revert to initial query we need to enable all labels and disable all parsed labels
-                enabled: !contextFilter.fromParser,
-              };
-            });
+            return contextFilters.map((contextFilter) => ({
+              ...contextFilter,
+              // For revert to initial query we need to enable all labels and disable all parsed labels
+              enabled: !contextFilter.fromParser,
+            }));
           });
         }}
       />


### PR DESCRIPTION
**What is this feature?**

In this PR, we are introducing `Revert to initial query button`. The goal is to give users a quick way to reset query to initial query after they changed it.

**Why do we need this feature?**

This button is going to be crucial in `preserve labels from previous context session` functionality. - https://github.com/grafana/grafana/issues/68089

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/68089

https://github.com/grafana/grafana/assets/30407135/fcebcab5-e6ad-4be7-b74a-28bbd34dac16

**Special notes for your reviewer:**

- The button had to be removed from `Collapse` component because `Collapse` is `button` and there is css `button in button` conflict. Therefore I had to move it from `Collapse`. 
- Currently, the button only appears when you change the query. I have also considered showing button all the time but there were couple of issues:
  - Tooltip doesn't show up if button is disabled. So you end up with disabled button and you don't understand its purpose. Also, this means that nowhere in grafana we use tooltip for disabled button (I don't think we have many disabled buttons in general) and therefore we would have to customize code and create new pattern.
  - for me it can seem confusing if you have there button if you've never changed the log context query and you don't see editor.
  So I decided to only show it when query is changed. We can re-evaluate this, if someone have strong feelings about it. 
 
