### PR TITLE
Timeseries: Graph series override stack migration

### DIFF
--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -263,7 +263,7 @@ export function graphToTimeseriesOptions(angular: any): {
           case 'stack':
             rule.properties.push({
               id: 'custom.stacking',
-              value: { mode: StackingMode.Normal, group: v },
+              value: getStackingFromOverrides(v),
             });
             break;
           case 'color':
@@ -711,7 +711,7 @@ function migrateHideFrom(panel: {
   }
 }
 
-function getLegendHideFromOverride(reducer: ReducerID.allIsZero | ReducerID.allIsNull) {
+const getLegendHideFromOverride = (reducer: ReducerID.allIsZero | ReducerID.allIsNull) => {
   return {
     matcher: {
       id: FieldMatcherID.byValue,
@@ -732,4 +732,11 @@ function getLegendHideFromOverride(reducer: ReducerID.allIsZero | ReducerID.allI
       },
     ],
   };
-}
+};
+
+const getStackingFromOverrides = (value: Boolean | string) => {
+  return {
+    mode: value ? StackingMode.Normal : StackingMode.None,
+    group: isString(value) ? value : 'A',
+  };
+};

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -711,7 +711,7 @@ function migrateHideFrom(panel: {
   }
 }
 
-const getLegendHideFromOverride = (reducer: ReducerID.allIsZero | ReducerID.allIsNull) => {
+function getLegendHideFromOverride(reducer: ReducerID.allIsZero | ReducerID.allIsNull) {
   return {
     matcher: {
       id: FieldMatcherID.byValue,
@@ -732,11 +732,12 @@ const getLegendHideFromOverride = (reducer: ReducerID.allIsZero | ReducerID.allI
       },
     ],
   };
-};
+}
 
-const getStackingFromOverrides = (value: Boolean | string) => {
+function getStackingFromOverrides(value: Boolean | string) {
+  const defaultGroupName = defaultGraphConfig.stacking?.group;
   return {
     mode: value ? StackingMode.Normal : StackingMode.None,
-    group: isString(value) ? value : 'A',
+    group: isString(value) ? value : defaultGroupName,
   };
-};
+}


### PR DESCRIPTION
The old graph's series override stack migration seemed to always set the stack mode to normal. This PR is updating the migration to take into the account the actual settings.

https://github.com/grafana/grafana/assets/88068998/7dd03578-963c-4560-b250-d203b5857f74


Fixes #67284 

**Testing steps:**
- Create a Graph panel [or use test panel [json](https://github.com/grafana/grafana/files/11480825/graph.json.tx)]
- From Series override section click "Add series override"
- Play around with Stack options - true/false/value
- Migrate to Timeseries
- Expected result: the overrides should match


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
