### PR TITLE
PanelQueryRunner: Ensure same transformations before reusing lastProcessedFrames

### DIFF
--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -95,7 +95,7 @@ export class PanelQueryRunner {
     let lastFieldConfig: ApplyFieldOverrideOptions | undefined = undefined;
     let lastProcessedFrames: DataFrame[] = [];
     let lastRawFrames: DataFrame[] = [];
-    let lastTransfromations: DataTransformerConfig[] | undefined;
+    let lastTransformations: DataTransformerConfig[] | undefined;
     let isFirstPacket = true;
     let lastConfigRev = -1;
 
@@ -116,13 +116,13 @@ export class PanelQueryRunner {
         if (
           data.series === lastRawFrames &&
           lastFieldConfig?.fieldConfig === fieldConfig?.fieldConfig &&
-          lastTransfromations === transformations
+          lastTransformations === transformations
         ) {
           return of({ ...data, structureRev, series: lastProcessedFrames });
         }
 
         lastFieldConfig = fieldConfig;
-        lastTransfromations = transformations;
+        lastTransformations = transformations;
         lastRawFrames = data.series;
         let dataWithTransforms = of(data);
 

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -95,6 +95,7 @@ export class PanelQueryRunner {
     let lastFieldConfig: ApplyFieldOverrideOptions | undefined = undefined;
     let lastProcessedFrames: DataFrame[] = [];
     let lastRawFrames: DataFrame[] = [];
+    let lastTransfromations: DataTransformerConfig[] | undefined;
     let isFirstPacket = true;
     let lastConfigRev = -1;
 
@@ -110,12 +111,18 @@ export class PanelQueryRunner {
     return this.subject.pipe(
       mergeMap((data: PanelData) => {
         let fieldConfig = this.dataConfigSource.getFieldOverrideOptions();
+        let transformations = this.dataConfigSource.getTransformations();
 
-        if (data.series === lastRawFrames && lastFieldConfig?.fieldConfig === fieldConfig?.fieldConfig) {
+        if (
+          data.series === lastRawFrames &&
+          lastFieldConfig?.fieldConfig === fieldConfig?.fieldConfig &&
+          lastTransfromations === transformations
+        ) {
           return of({ ...data, structureRev, series: lastProcessedFrames });
         }
 
         lastFieldConfig = fieldConfig;
+        lastTransfromations = transformations;
         lastRawFrames = data.series;
         let dataWithTransforms = of(data);
 


### PR DESCRIPTION
fixes this regression from https://github.com/grafana/grafana/pull/67768 when manipulating Transformation options and panel not updating:


https://github.com/grafana/grafana/assets/43234/18b7a84c-5e73-479c-9956-f13471c00e98