### PR TITLE
Trend: Add gdev dashboard

### DIFF
--- a/devenv/dev-dashboards/panel-trend/trend_example.json
+++ b/devenv/dev-dashboards/panel-trend/trend_example.json
@@ -1,0 +1,183 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "PD8C576611E62080A"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "Torque (NM)",
+            "axisPlacement": "auto",
+            "axisSoftMax": 280,
+            "axisSoftMin": 80,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power (kW)"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Power (kW)"
+              },
+              {
+                "id": "custom.axisSoftMax",
+                "value": 120
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Speed (RPM)"
+            },
+            "properties": [
+              {
+                "id": "custom.axisLabel",
+                "value": "Speed (RPM)"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 11,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "Speed (RPM)"
+      },
+      "targets": [
+        {
+          "csvContent": "Speed (RPM),Torque (NM),Power (kW)\n0,,\n500,,\n800,180,20\n1500,215,40\n2000,227,50\n2500,230,62\n3000,233,75\n3500,236,86\n4000,234,92\n4500,230,100\n5000,220,107\n5500,210,110\n6000,178,106\n6500,120,92\n7000,,\n",
+          "datasource": {
+            "type": "testdata",
+            "uid": "PD8C576611E62080A"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Engine Power and Torque Curves",
+      "type": "trend"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "gdev",
+    "panel-tests",
+    "trend"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Trend panel example",
+  "uid": "b36b5576-2e3d-4b0c-8dce-e79514d99345",
+  "version": 4,
+  "weekStart": ""
+}

--- a/devenv/dev-dashboards/panel-trend/trend_example.json
+++ b/devenv/dev-dashboards/panel-trend/trend_example.json
@@ -165,6 +165,7 @@
   "tags": [
     "gdev",
     "panel-tests",
+    "graph-ng",
     "trend"
   ],
   "templating": {

--- a/devenv/dev-dashboards/panel-trend/trend_example.json
+++ b/devenv/dev-dashboards/panel-trend/trend_example.json
@@ -176,7 +176,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Trend panel example",
+  "title": "Panel Tests - Trend",
   "uid": "b36b5576-2e3d-4b0c-8dce-e79514d99345",
   "version": 4,
   "weekStart": ""

--- a/devenv/dev-dashboards/panel-trend/trend_example.json
+++ b/devenv/dev-dashboards/panel-trend/trend_example.json
@@ -57,7 +57,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -800,5 +800,12 @@ local dashboard = grafana.dashboard;
         id: 0,
       }
     },
+    dashboard.new('trend_example', import '../dev-dashboards/panel-trend/trend_example.json') +
+    resource.addMetadata('folder', 'dev-dashboards') +
+    {
+      spec+: {
+        id: 0,
+      }
+    },
   ],
 } 

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -793,5 +793,12 @@ local dashboard = grafana.dashboard;
         id: 0,
       }
     },
+    dashboard.new('trend_example', import '../dev-dashboards/panel-trend/trend_example') +
+    resource.addMetadata('folder', 'dev-dashboards') +
+    {
+      spec+: {
+        id: 0,
+      }
+    },
   ],
 } 

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -793,12 +793,5 @@ local dashboard = grafana.dashboard;
         id: 0,
       }
     },
-    dashboard.new('trend_example', import '../dev-dashboards/panel-trend/trend_example') +
-    resource.addMetadata('folder', 'dev-dashboards') +
-    {
-      spec+: {
-        id: 0,
-      }
-    },
   ],
 } 


### PR DESCRIPTION
Add gdev dashboard for the trend panel. Extracted out of https://github.com/grafana/grafana/pull/67794 to unblock docs to being merged in while jsonnet issue is figured out.

![screenshot-grafana-10-0-trend-panel-new-colors](https://github.com/grafana/grafana/assets/22381771/4c164842-2567-4ede-90a2-f1697695e270)
