### PR TITLE
Trend: Filter out time fields

### DIFF
--- a/public/app/plugins/panel/trend/module.tsx
+++ b/public/app/plugins/panel/trend/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin } from '@grafana/data';
+import { Field, FieldType, PanelPlugin } from '@grafana/data';
 import { commonOptionsBuilder } from '@grafana/ui';
 
 import { defaultGraphConfig, getGraphFieldConfig } from '../timeseries/config';
@@ -20,6 +20,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(TrendPanel
       settings: {
         isClearable: true,
         placeholderText: 'First numeric value',
+        filter: (f: Field) => f.type === FieldType.number,
       },
     });
 

--- a/public/app/plugins/panel/trend/module.tsx
+++ b/public/app/plugins/panel/trend/module.tsx
@@ -20,7 +20,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(TrendPanel
       settings: {
         isClearable: true,
         placeholderText: 'First numeric value',
-        filter: (f: Field) => f.type === FieldType.number,
+        filter: (field: Field) => field.type === FieldType.number,
       },
     });
 


### PR DESCRIPTION
Filter out time fields for x field picker in trend panel. Otherwise user can select time for x which leads to a confusing / poor experience.

Before

https://github.com/grafana/grafana/assets/22381771/abff8496-065a-4740-8207-847463762bcb



After

https://github.com/grafana/grafana/assets/22381771/4502fafa-6ae4-48bb-8fbe-12f5acd1d46b


