### PR TITLE
Chore: remove pre tags from DOMPurify config

### DIFF
--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -33,13 +33,13 @@ const sanitizeTextPanelWhitelist = new xss.FilterXSS({
 /**
  * Return a sanitized string that is going to be rendered in the browser to prevent XSS attacks.
  * Note that sanitized tags will be removed, such as "<script>".
- * We don't allow form, pre, or input elements.
+ * We don't allow form or input elements.
  */
 export function sanitize(unsanitizedString: string): string {
   try {
     return DOMPurify.sanitize(unsanitizedString, {
       USE_PROFILES: { html: true },
-      FORBID_TAGS: ['form', 'input', 'pre'],
+      FORBID_TAGS: ['form', 'input'],
     });
   } catch (error) {
     console.error('String could not be sanitized', unsanitizedString);


### PR DESCRIPTION
* Remove `pre` tags from the disallow list to follow [grafana/oncall](https://github.com/grafana/oncall/blob/4c5c4f20149b1fad9bf49ec4baa7f181719aad30/grafana-plugin/src/utils/sanitize.ts#L6)