### PR TITLE
Accessibility: Make QueryOptions in Phlare and Parca accessible

### DIFF
--- a/public/app/plugins/datasource/parca/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/parca/QueryEditor/QueryOptions.tsx
@@ -1,9 +1,9 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React from 'react';
 import { useToggle } from 'react-use';
 
 import { CoreApp, GrafanaTheme2 } from '@grafana/data';
-import { Icon, useStyles2, RadioButtonGroup, Field } from '@grafana/ui';
+import { Icon, useStyles2, RadioButtonGroup, Field, clearButtonStyles, Button } from '@grafana/ui';
 
 import { Query } from '../types';
 
@@ -35,10 +35,11 @@ export function QueryOptions({ query, onQueryTypeChange, app }: Props) {
   const [isOpen, toggleOpen] = useToggle(false);
   const styles = useStyles2(getStyles);
   const options = getOptions(app);
+  const buttonStyles = useStyles2(clearButtonStyles);
 
   return (
     <Stack gap={0} direction="column">
-      <div className={styles.header} onClick={toggleOpen} title="Click to edit options">
+      <Button className={cx(styles.header, buttonStyles)} onClick={toggleOpen} title="Click to edit options">
         <div className={styles.toggle}>
           <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
         </div>
@@ -48,7 +49,7 @@ export function QueryOptions({ query, onQueryTypeChange, app }: Props) {
             <span>Type: {query.queryType}</span>
           </div>
         )}
-      </div>
+      </Button>
       {isOpen && (
         <div className={styles.body}>
           <Field label={'Query Type'}>

--- a/public/app/plugins/datasource/phlare/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/phlare/QueryEditor/QueryOptions.tsx
@@ -1,9 +1,9 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React from 'react';
 import { useToggle } from 'react-use';
 
 import { CoreApp, GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Icon, useStyles2, RadioButtonGroup, MultiSelect, Input } from '@grafana/ui';
+import { Icon, useStyles2, RadioButtonGroup, MultiSelect, Input, clearButtonStyles, Button } from '@grafana/ui';
 
 import { Query } from '../types';
 
@@ -43,10 +43,11 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
         value: l,
       }))
     : [];
+  const buttonStyles = useStyles2(clearButtonStyles);
 
   return (
     <Stack gap={0} direction="column">
-      <div className={styles.header} onClick={toggleOpen} title="Click to edit options">
+      <Button className={cx(styles.header, buttonStyles)} onClick={toggleOpen} title="Click to edit options">
         <div className={styles.toggle}>
           <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
         </div>
@@ -60,7 +61,7 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
               ))}
           </div>
         )}
-      </div>
+      </Button>
       {isOpen && (
         <div className={styles.body}>
           <EditorField label={'Query Type'}>


### PR DESCRIPTION
**What is this feature?**

Fixes accessibility issues for QueryOptions in Phlare and Parca.

**Why do we need this feature?**

To allow users to navigate the query options toggle using their keyboard.

**Who is this feature for?**

Grafana users.

Fixes https://github.com/grafana/grafana/issues/61532 & https://github.com/grafana/grafana/issues/68514

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
