### PR TITLE
Barchart: Apply field visibility to traceID

### DIFF
--- a/public/app/plugins/panel/geomap/components/DataHoverView.tsx
+++ b/public/app/plugins/panel/geomap/components/DataHoverView.tsx
@@ -40,10 +40,14 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
   const fields = data.fields.map((f, idx) => {
     return { ...f, hovered: idx === columnIndex };
   });
-  // Put the traceID field in front.
   const visibleFields = fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
   const traceIDField = visibleFields.find((field) => field.name === 'traceID') || fields[0];
-  const orderedVisibleFields = [traceIDField, ...visibleFields.filter((field) => traceIDField !== field)];
+  const orderedVisibleFields = [];
+  // Only include traceID if it's visible and put it in front.
+  if (visibleFields.filter((field) => traceIDField === field).length > 0) {
+    orderedVisibleFields.push(traceIDField);
+  }
+  orderedVisibleFields.push(...visibleFields.filter((field) => traceIDField !== field));
 
   if (orderedVisibleFields.length === 0) {
     return null;


### PR DESCRIPTION
What this PR does / why we need it:
Currently, field override to first field in barchart doesn't allow the tooltip to be hidden.

![image](https://github.com/grafana/grafana/assets/60050885/5258ba16-4f3c-4de0-a24e-43aba308cc6b)

Before:
![May-16-2023 03-18-55](https://github.com/grafana/grafana/assets/60050885/f0621e7b-291b-48bb-a944-1fea45f6e668)

After:
![May-16-2023 03-15-21](https://github.com/grafana/grafana/assets/60050885/0cbb07c1-5c51-489f-ac80-0e219a46ec83)


Closes https://github.com/grafana/grafana/issues/62298