### PR TITLE
Elasticsearch: Handle no-index case in backend mode

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -119,6 +119,12 @@ func TestClient_Index(t *testing.T) {
 		indexInRequest      []string
 	}{
 		{
+			name:                "empty string",
+			indexInDatasource:   "",
+			patternInDatasource: "",
+			indexInRequest:      []string{},
+		},
+		{
 			name:                "single string",
 			indexInDatasource:   "logs-*",
 			patternInDatasource: "",

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -35,7 +35,12 @@ type staticIndexPattern struct {
 }
 
 func (ip *staticIndexPattern) GetIndices(timeRange backend.TimeRange) ([]string, error) {
-	return []string{ip.indexName}, nil
+	name := ip.indexName
+	if name != "" {
+		return []string{name}, nil
+	} else {
+		return []string{}, nil
+	}
 }
 
 type intervalGenerator interface {

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -35,9 +35,8 @@ type staticIndexPattern struct {
 }
 
 func (ip *staticIndexPattern) GetIndices(timeRange backend.TimeRange) ([]string, error) {
-	name := ip.indexName
-	if name != "" {
-		return []string{name}, nil
+	if ip.indexName != "" {
+		return []string{ip.indexName}, nil
 	} else {
 		return []string{}, nil
 	}


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/68531

when the index-field is not filled out in the elastic datasource config, currently we send the following index-value to the database:
`index: [""]`

what we should be sending is:
`index: []` (maybe even not sending the index-entry at all, but this construct seems to work)


how to test:
1. adjust/create an elastic datasource where the index is set to empty-string, set pattern to `no pattern`
2. save, go to explore
3. run queries, they should work
4. (bonus points) verify that the request that is being sent from the go-server to the elastic-database, in fact, has the `index: []` part in it
5. go back and set the index to `logs-*` (for devenv-elastic). save
6. verify that it still works in explore