### PR TITLE
Dashboards: Improve delete dashboard performance due to slow annotations query

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -705,7 +705,6 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		"DELETE FROM dashboard WHERE id = ?",
 		"DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?",
 		"DELETE FROM dashboard_version WHERE dashboard_id = ?",
-		"DELETE FROM annotation WHERE org_id = ? AND dashboard_id = ?",
 		"DELETE FROM dashboard_provisioning WHERE dashboard_id = ?",
 		"DELETE FROM dashboard_acl WHERE dashboard_id = ?",
 	}
@@ -734,6 +733,11 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 	}
 
 	if err := d.deleteAlertDefinition(dashboard.ID, sess); err != nil {
+		return err
+	}
+
+	_, err = sess.Exec("DELETE FROM annotation WHERE dashboard_id = ? AND org_id = ?", dashboard.ID, dashboard.OrgID)
+	if err != nil {
 		return err
 	}
 
@@ -780,10 +784,15 @@ func (d *dashboardStore) deleteChildrenDashboardAssociations(sess *db.Session, d
 			"DELETE FROM dashboard_tag WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
 			"DELETE FROM star WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
 			"DELETE FROM dashboard_version WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
-			"DELETE FROM annotation WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
 			"DELETE FROM dashboard_provisioning WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
 			"DELETE FROM dashboard_acl WHERE dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)",
 		}
+
+		_, err = sess.Exec("DELETE FROM annotation WHERE org_id = ? AND dashboard_id IN (SELECT id FROM dashboard WHERE org_id = ? AND folder_id = ?)", dashboard.OrgID, dashboard.OrgID, dashboard.ID)
+		if err != nil {
+			return err
+		}
+
 		for _, sql := range childrenDeletes {
 			_, err := sess.Exec(sql, dashboard.OrgID, dashboard.ID)
 			if err != nil {

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -705,7 +705,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		"DELETE FROM dashboard WHERE id = ?",
 		"DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?",
 		"DELETE FROM dashboard_version WHERE dashboard_id = ?",
-		"DELETE FROM annotation WHERE dashboard_id = ?",
+		"DELETE FROM annotation WHERE org_id = ? AND dashboard_id = ?",
 		"DELETE FROM dashboard_provisioning WHERE dashboard_id = ?",
 		"DELETE FROM dashboard_acl WHERE dashboard_id = ?",
 	}

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -32,6 +32,7 @@ func addAnnotationMig(mg *Migrator) {
 			{Cols: []string{"org_id", "category_id"}, Type: IndexType},
 			{Cols: []string{"org_id", "dashboard_id", "panel_id", "epoch"}, Type: IndexType},
 			{Cols: []string{"org_id", "epoch"}, Type: IndexType},
+			{Cols: []string{"org_id", "dashboard_id"}, Type: IndexType},
 		},
 	}
 

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -32,7 +32,6 @@ func addAnnotationMig(mg *Migrator) {
 			{Cols: []string{"org_id", "category_id"}, Type: IndexType},
 			{Cols: []string{"org_id", "dashboard_id", "panel_id", "epoch"}, Type: IndexType},
 			{Cols: []string{"org_id", "epoch"}, Type: IndexType},
-			{Cols: []string{"org_id", "dashboard_id"}, Type: IndexType},
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

This feature adds an index on the dashboard_id column of the annotation table in the Grafana database. This change is aimed at improving performance when deleting dashboards, particularly when there are a large number of annotations associated with the dashboard.

**Why do we need this feature?**

Currently, when a dashboard is deleted in Grafana, the deletion process can be slow and cause a lock on the annotation table due to the lack of an index on the dashboard_id column. This can lead to delays in deleting dashboards and can potentially impact the overall performance of the Grafana instance. By adding an index on the dashboard_id column, we can significantly improve the performance of the deletion process and reduce the risk of lock contention.

I had an issue with not being able to delete the dashboard. I am running a service that creates and uses a lot of grafana dashboards.
- Grafana log at the time : logger=context userId=171 orgId=1 uname=xxx t=2023-05-10T04:43:26.852269912Z level=error msg="Failed to delete dashboard" error="Error 1205: Lock wait timeout exceeded; try restarting transaction"
- DB show processlist (Runs for 60 minutes, eventually doesn't run) : 
<img width="1406" alt="스크린샷 2023-05-10 오후 2 20 26" src="https://github.com/grafana/grafana/assets/28832461/d296636e-c227-4f88-9875-e4e2d558cd67">


**Who is this feature for?**

This feature is for anyone who uses Grafana and frequently creates and deletes dashboards, particularly those with a large number of annotations. This change will improve the overall performance of Grafana and reduce the likelihood of delays when deleting dashboards.