### PR TITLE
Plugins: Correct the usage of mutex for gRPC plugin implementation

### DIFF
--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -52,7 +52,7 @@ func (p *grpcPlugin) Logger() log.Logger {
 	return p.logger
 }
 
-func (p *grpcPlugin) Start(ctx context.Context) error {
+func (p *grpcPlugin) Start(_ context.Context) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -85,7 +85,7 @@ func (p *grpcPlugin) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *grpcPlugin) Stop(ctx context.Context) error {
+func (p *grpcPlugin) Stop(_ context.Context) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -109,8 +109,8 @@ func (p *grpcPlugin) Exited() bool {
 }
 
 func (p *grpcPlugin) Decommission() error {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
 	p.decommissioned = true
 
@@ -118,6 +118,8 @@ func (p *grpcPlugin) Decommission() error {
 }
 
 func (p *grpcPlugin) IsDecommissioned() bool {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
 	return p.decommissioned
 }
 


### PR DESCRIPTION
Just came across this (hadn't actually experienced any issues with this)

Note: This has been this way for quite a few versions, but can just backport to 10.0.x I think