### PR TITLE
Elasticsearch: Implement filter query to not run hidden queries trough backend

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -631,6 +631,13 @@ export class ElasticDatasource
     return this.legacyQueryRunner.query(request);
   }
 
+  filterQuery(query: ElasticsearchQuery): boolean {
+    if (query.hide) {
+      return false;
+    }
+    return true;
+  }
+
   isMetadataField(fieldName: string) {
     return ELASTIC_META_FIELDS.includes(fieldName);
   }


### PR DESCRIPTION
I've missed adding implementation of simple `filterQuery` method to filter hidden queries when run trough `DataSourceWithBackendImplementation`. 

Part of https://github.com/grafana/grafana/issues/68428