### PR TITLE
Chore: Fix dev-dashboard codegen

### DIFF
--- a/devenv/jsonnet/dev-dashboards.go
+++ b/devenv/jsonnet/dev-dashboards.go
@@ -50,7 +50,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		err = fs.Verify(context.Background(), "")
+		err = fs.Write(context.Background(), "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error while writing generated code to disk:\n%s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
Fix dev-dashboard codegen. Recent [changes](https://github.com/grafana/grafana/pull/68072) caused code-gen for gdev dashboards to fail.

Not sure whether or not this needs to be backported to v10.0.x or not