### PR TITLE
StateTimeline: Support hideFrom field config

### DIFF
--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "2.8.1-sdk",
+  "version": "2.8.4-sdk",
   "main": "./index.js",
   "type": "commonjs"
 }

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -444,6 +444,9 @@ export function prepareTimelineFields(
 
     const fields: Field[] = [];
     for (let field of nullToValue(nulledFrame).fields) {
+      if (field.config.custom?.hideFrom?.viz) {
+        continue;
+      }
       switch (field.type) {
         case FieldType.time:
           isTimeseries = true;
@@ -558,6 +561,7 @@ export function getFieldLegendItem(fields: Field[], theme: GrafanaTheme2): VizLe
   const thresholds = fieldConfig.thresholds;
 
   // If thresholds are enabled show each step in the legend
+  // This ignores the hide from legend since the range is valid
   if (colorMode === FieldColorModeId.Thresholds && thresholds?.steps && thresholds.steps.length > 1) {
     return getThresholdItems(fieldConfig, theme);
   }
@@ -567,15 +571,17 @@ export function getFieldLegendItem(fields: Field[], theme: GrafanaTheme2): VizLe
     return undefined; // eventually a color bar
   }
 
-  let stateColors: Map<string, string | undefined> = new Map();
+  const stateColors: Map<string, string | undefined> = new Map();
 
   fields.forEach((field) => {
-    field.values.forEach((v) => {
-      let state = field.display!(v);
-      if (state.color) {
-        stateColors.set(state.text, state.color!);
-      }
-    });
+    if (!field.config.custom?.hideFrom?.legend) {
+      field.values.forEach((v) => {
+        let state = field.display!(v);
+        if (state.color) {
+          stateColors.set(state.text, state.color!);
+        }
+      });
+    }
   });
 
   stateColors.forEach((color, label) => {

--- a/public/app/plugins/panel/state-timeline/module.tsx
+++ b/public/app/plugins/panel/state-timeline/module.tsx
@@ -60,6 +60,8 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(StateTimelinePanel)
           shouldApply: (f) => f.type !== FieldType.time,
           process: identityOverrideProcessor,
         });
+
+      commonOptionsBuilder.addHideFrom(builder);
     },
   })
   .setPanelOptions((builder) => {

--- a/public/app/plugins/panel/status-history/module.tsx
+++ b/public/app/plugins/panel/status-history/module.tsx
@@ -40,6 +40,8 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(StatusHistoryPanel)
             step: 1,
           },
         });
+
+      commonOptionsBuilder.addHideFrom(builder);
     },
   })
   .setPanelOptions((builder) => {


### PR DESCRIPTION
This updates the state timeline and status history panels so that hide from "viz" works as expected:

![2023-05-16_11-58-38 (1)](https://github.com/grafana/grafana/assets/705951/7473a77a-19fc-4958-8f2b-6d8199c0cb1b)

The legend is still a bit weird, but i think works as well as it can for now
