### PR TITLE
Panels: Change untitled panel menu text

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -54,7 +54,9 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32, on
           <Icon name="expand-arrows" className={styles.draggableIcon} />
         </div>
       )}
-      {!title && <h6 className={cx(styles.untitled, { [styles.draggable]: !!dragClass }, dragClass)}>Untitled</h6>}
+      {!title && (
+        <h6 className={cx(styles.untitled, { [styles.draggable]: !!dragClass }, dragClass)}>Panel&nbsp;menu</h6>
+      )}
       {children}
       {menu && (
         <PanelMenu


### PR DESCRIPTION
This changes the hover text when a panel does not have a title

Before:
![2023-05-16_12-11-03 (1)](https://github.com/grafana/grafana/assets/705951/758efcf1-0617-415f-9207-183d2dd61828)

After:
![2023-05-16_12-09-30 (1)](https://github.com/grafana/grafana/assets/705951/9dffb926-74fc-46bb-ac10-3517b67d37bf)


the "untitled" is a bit distracting and only makes sense if you are thinking that panels should have titles