### PR TITLE
Docs: Update with annotations filtering and time regions

### DIFF
--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -90,6 +90,10 @@ When adding or editing an annotation, you can define a repeating time region by 
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-0-time-regions-annotations.png" max-width="600px" caption="Time regions business hours" >}}
 
+The above configuration will produce the following result in the Time series panel:
+
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-timeseries-time-regions.png" max-width="600px" caption="Time series time regions business hours" >}}
+
 ## Querying other data sources
 
 Annotation events are fetched via annotation queries. To add a new annotation query to a dashboard

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -80,7 +80,7 @@ In Grafana v5.3+ it's possible to use template variables in the tag query. So if
 
 ### Filter by panel
 
-You can configure to which panels to apply the annotations by choosing an option from the _Show in_ section. You can apply the annotations to `All panels` that support annotations, or filter specific panels by choosing `Selected panels` or `All panels except`. The annotations will be displayed accordingly.
+You can configure which panels to apply annotations to by choosing an option from the _Show in_ section. You can apply the annotations to `All panels` that support annotations, or filter specific panels by choosing `Selected panels` or `All panels except`. The annotations will be displayed accordingly.
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-0-annotation-filtering.png" max-width="600px" caption="Annotation filtering" >}}
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -82,7 +82,13 @@ In Grafana v5.3+ it's possible to use template variables in the tag query. So if
 
 You can configure to which panels to apply the annotations by choosing an option from the _Show in_ section. You can apply the annotations to `All panels` that support annotations, or filter specific panels by choosing `Selected panels` or `All panels except`. The annotations will be displayed accordingly.
 
-{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-annotation-filtering.png" max-width="750px" caption="Annotation filtering" >}}
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-annotation-filtering.png" max-width="600px" caption="Annotation filtering" >}}
+
+### Add time region
+
+When adding or editing an annotation, you can define a repeating time region by setting _Query type_ to `Time regions` - simply define the _From_/_To_ sections with the preferred days of the week and time. You also have the possibility to change the timezone - the default being set to dashboard's timezone.
+
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-time-regions-annotations.png" max-width="600px" caption="Time regions business hours" >}}
 
 ## Querying other data sources
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -78,6 +78,12 @@ In Grafana v5.3+ it's possible to use template variables in the tag query. So if
 
 {{< figure src="/static/img/docs/annotations/annotation_tag_filter_variable-8-1-0.png" max-width="600px" >}}
 
+### Filter by panel
+
+You can configure to which panels to apply the annotations by choosing an option from the _Show in_ section. You can apply the annotations to `All panels` that support annotations, or filter specific panels by choosing `Selected panels` or `All panels except`. The annotations will be displayed accordingly.
+
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-annotation-filtering.png" max-width="750px" caption="Annotation filtering" >}}
+
 ## Querying other data sources
 
 Annotation events are fetched via annotation queries. To add a new annotation query to a dashboard


### PR DESCRIPTION
Docs update covering annotations panel filtering and the time region support.

Images used:
**Filter by panel**

![screenshot-grafana-10-0-annotation-filtering](https://github.com/grafana/grafana/assets/88068998/ab1f5ea9-7d7c-4668-87ec-706f6b334d63)



**Business hours example**

![screenshot-grafana-10-0-time-regions-annotations](https://github.com/grafana/grafana/assets/88068998/3e6b7ea1-c9ba-47cd-bcf9-b5465a3d64d0)

**Time series  - business hours example**

<img width="1203" alt="screenshot-grafana-10-0-timeseries-time-regions" src="https://github.com/grafana/grafana/assets/88068998/117e5ce4-75b7-4c58-8e94-559385864285">



Fixes #67157

**Special notes for your reviewer:**
@imatwawana - The Annotations docs might need a revise, I'm not sure [this](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/) was the right place to place this bit, but also wasn't sure where else...

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
