### PR TITLE
datasource: do not send raw-range to server

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -187,7 +187,6 @@ class DataSourceWithBackend<
     const body: any = { queries };
 
     if (range) {
-      body.range = range;
       body.from = range.from.valueOf().toString();
       body.to = range.to.valueOf().toString();
     }


### PR DESCRIPTION
the backend-datasource sends 3 time-range related fields to the go-server:
- from
- to
- range


the last, `range` is the whole javascript timerange object. 

looking at the go-structures at https://github.com/grafana/grafana/blob/caba15648808b48a00bbe1fb56d58c070821ade7/pkg/api/dtos/models.go#L61-L81 the `range` values is not read by the backend.

so i think we can remove it.