### PR TITLE
Docs: Update run behind proxy docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -238,9 +238,8 @@ callback URL to be correct).
 
 Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
 
-By enabling this setting and using a subpath in `root_url` above, e.g.
-`root_url = http://localhost:3000/grafana`, Grafana is accessible on
-`http://localhost:3000/grafana`.
+By enabling this setting and using a subpath in `root_url` above, e.g.`root_url = http://localhost:3000/grafana`, Grafana is accessible on `http://localhost:3000/grafana`. If accessed without subpath Grafana will redirect to
+an URL with the subpath.
 
 ### router_logging
 

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -106,14 +106,12 @@ server {
   index index.html index.htm;
 
   location /grafana/ {
-    rewrite  ^/grafana/(.*)  /$1 break;
     proxy_set_header Host $http_host;
     proxy_pass http://grafana;
   }
 
   # Proxy Grafana Live WebSocket connections.
   location /grafana/api/live/ {
-    rewrite  ^/grafana/(.*)  /$1 break;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
@@ -121,6 +119,12 @@ server {
     proxy_pass http://grafana;
   }
 }
+```
+
+If your Grafana configuration does not set `serve_from_sub_path` to true then you need to add a rewrite rule to each location block:
+
+```
+ rewrite  ^/grafana/(.*)  /$1 break;
 ```
 
 ## Configure HAProxy


### PR DESCRIPTION
The run behind proxy docs where badly updated last year
to include URL rewrite while also containing instructions
to set `serve_from_sub_path = true`.

These two options can conflict.
