### PR TITLE
Service graph: Fix error when service graph metrics are aggregated

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -744,7 +744,7 @@ function makePromServiceMapRequest(options: DataQueryRequest<TempoQuery>): DataQ
         refId: metric,
         // options.targets[0] is not correct here, but not sure what should happen if you have multiple queries for
         // service map at the same time anyway
-        expr: `rate(${metric}${options.targets[0].serviceMapQuery || ''}[$__range])`,
+        expr: `sum by (client, server) (rate(${metric}${options.targets[0].serviceMapQuery || ''}[$__range]))`,
         instant: true,
       };
     }),


### PR DESCRIPTION
When adaptive metrics aggregation is enabled for service graph metrics service graph errors out with `Query error
execution: Can't query aggregated metric traces_service_graph_request_failed_total without aggregation. Use an appropriate aggregation function to query these series, such as sum by (...) (rate(traces_service_graph_request_failed_total[5m])).`. It is required to wrap aggregate querie with `sum()` to make queries stable and let adapative metrics mechanism know which labels are in use.

This PR fixes the problem by wrapping queries with `sum by (server, client) (...)` as required