### PR TITLE
Alerting: Fix stale query preview error

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -16,7 +16,7 @@ import { VizWrapper } from './VizWrapper';
 export interface RecordingRuleEditorProps {
   queries: AlertQuery[];
   onChangeQuery: (updatedQueries: AlertQuery[]) => void;
-  runQueries: (queries: AlertQuery[]) => void;
+  runQueries: () => void;
   panelData: Record<string, PanelData>;
   dataSourceName: string;
 }
@@ -94,7 +94,7 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
           queries={queries}
           app={CoreApp.UnifiedAlerting}
           onChange={handleChangedQuery}
-          onRunQuery={() => runQueries(queries)}
+          onRunQuery={runQueries}
           datasource={dataSource}
         />
       )}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { getDefaultRelativeTimeRange } from '@grafana/data';

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -136,8 +136,8 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
       // Most data sources triggers onChange and onRunQueries consecutively
       // It means our reducer state is always one step behind when runQueries is invoked
       // Invocation cycle => onChange -> dispatch(setDataQueries) -> onRunQueries -> setDataQueries Reducer
-      // No matter if we use query or getValues('queries') their state is always stale when we invoke runQueries
-      // As a workaround we use this ref which is updated immediately in onChange and used in runQueries
+      // As a workaround we update form values as soon as possible to avoid stale state
+      // This way we can access up to date queries in runQueriesPreview without waiting for re-render
       setValue('queries', updatedQueries, { shouldValidate: false });
 
       dispatch(setDataQueries(updatedQueries));

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAlertQueryRunner.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAlertQueryRunner.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { LoadingState, PanelData } from '@grafana/data';
+
+import { AlertQuery } from '../../../../../../types/unified-alerting-dto';
+import { AlertingQueryRunner } from '../../../state/AlertingQueryRunner';
+
+export function useAlertQueryRunner() {
+  const [queryPreviewData, setQueryPreviewData] = useState<Record<string, PanelData>>({});
+
+  const runner = useRef(new AlertingQueryRunner());
+
+  useEffect(() => {
+    const currentRunner = runner.current;
+
+    currentRunner.get().subscribe((data) => {
+      setQueryPreviewData(data);
+    });
+
+    return () => {
+      currentRunner.destroy();
+    };
+  }, []);
+
+  const clearPreviewData = useCallback(() => {
+    setQueryPreviewData({});
+  }, []);
+
+  const cancelQueries = useCallback(() => {
+    runner.current.cancel();
+  }, []);
+
+  const runQueries = useCallback((queriesToPreview: AlertQuery[]) => {
+    runner.current.run(queriesToPreview);
+  }, []);
+
+  const isPreviewLoading = useMemo(() => {
+    return Object.values(queryPreviewData).some((d) => d.state === LoadingState.Loading);
+  }, [queryPreviewData]);
+
+  return { queryPreviewData, runQueries, cancelQueries, isPreviewLoading, clearPreviewData };
+}


### PR DESCRIPTION
**What is this feature?**
This PR fixes using stale state of queries for the `eval` endpoint

**Why do we need this feature?**
To display appropriate visualization of queries on the rule creation form


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
