### PR TITLE
Revert: Allow editors to access GET /datasources

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -392,7 +392,7 @@ func (hs *HTTPServer) registerRoutes() {
 			idScope := datasources.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
 			uidScope := datasources.ScopeProvider.GetResourceScopeUID(ac.Parameter(":uid"))
 			nameScope := datasources.ScopeProvider.GetResourceScopeName(ac.Parameter(":name"))
-			datasourceRoute.Get("/", authorize(reqEditorRole, ac.EvalPermission(datasources.ActionRead)), routing.Wrap(hs.GetDataSources))
+			datasourceRoute.Get("/", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionRead)), routing.Wrap(hs.GetDataSources))
 			datasourceRoute.Post("/", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionCreate)), quota(string(datasources.QuotaTargetSrv)), routing.Wrap(hs.AddDataSource))
 			datasourceRoute.Put("/:id", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, idScope)), routing.Wrap(hs.UpdateDataSourceByID))
 			datasourceRoute.Put("/uid/:uid", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(hs.UpdateDataSourceByUID))


### PR DESCRIPTION
This reverts commit 5a830c43c0f4793726b9826aee063da114e88738.

**why/what**
During a escalation the API endpoint was downgraded from admin to editor. This reverts this change as it was part of a implementation that the dashboard team made to call the API during a new dashboard. This has been removed from their team https://github.com/grafana/support-escalations/issues/5900#issuecomment-1551301789 and we can upgrade the permissions back again to admin