### PR TITLE
RBAC: Refine validation of external services permissions

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -271,9 +271,23 @@ func (cmd *SaveExternalServiceRoleCommand) Validate() error {
 		return fmt.Errorf("invalid org id %d for global role %t", cmd.OrgID, cmd.Global)
 	}
 
+	// Check and deduplicate permissions
 	if cmd.Permissions == nil || len(cmd.Permissions) == 0 {
 		return errors.New("no permissions provided")
 	}
+	dedupMap := map[Permission]bool{}
+	dedup := make([]Permission, 0, len(cmd.Permissions))
+	for i := range cmd.Permissions {
+		if len(cmd.Permissions[i].Action) == 0 {
+			return errors.New("external service %v requests a permission with no Action")
+		}
+		if dedupMap[cmd.Permissions[i]] {
+			continue
+		}
+		dedupMap[cmd.Permissions[i]] = true
+		dedup = append(dedup, cmd.Permissions[i])
+	}
+	cmd.Permissions = dedup
 
 	if cmd.ServiceAccountID <= 0 {
 		return fmt.Errorf("invalid service account id %d", cmd.ServiceAccountID)

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -279,7 +279,7 @@ func (cmd *SaveExternalServiceRoleCommand) Validate() error {
 	dedup := make([]Permission, 0, len(cmd.Permissions))
 	for i := range cmd.Permissions {
 		if len(cmd.Permissions[i].Action) == 0 {
-			return errors.New("external service %v requests a permission with no Action")
+			return fmt.Errorf("external service %v requests a permission with no Action", cmd.ExternalServiceID)
 		}
 		if dedupMap[cmd.Permissions[i]] {
 			continue

--- a/pkg/services/accesscontrol/models_test.go
+++ b/pkg/services/accesscontrol/models_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestSaveExternalServiceRoleCommand_Validate(t *testing.T) {
 	tests := []struct {
-		name    string
-		cmd     SaveExternalServiceRoleCommand
-		wantID  string
-		wantErr bool
+		name            string
+		cmd             SaveExternalServiceRoleCommand
+		wantID          string
+		wantPermissions []Permission
+		wantErr         bool
 	}{
 		{
 			name: "invalid global statement",
@@ -64,6 +65,32 @@ func TestSaveExternalServiceRoleCommand_Validate(t *testing.T) {
 			wantErr: false,
 			wantID:  "thisis-a-very-strange-app-name",
 		},
+		{
+			name: "invalid empty Action",
+			cmd: SaveExternalServiceRoleCommand{
+				OrgID:             1,
+				ExternalServiceID: "app 1",
+				ServiceAccountID:  2,
+				Permissions:       []Permission{{Action: "", Scope: "users:id:1"}},
+			},
+			wantID:  "app-1",
+			wantErr: true,
+		},
+		{
+			name: "permission deduplication",
+			cmd: SaveExternalServiceRoleCommand{
+				OrgID:             1,
+				ExternalServiceID: "app 1",
+				ServiceAccountID:  2,
+				Permissions: []Permission{
+					{Action: "users:read", Scope: "users:id:1"},
+					{Action: "users:read", Scope: "users:id:1"},
+				},
+			},
+			wantErr:         false,
+			wantID:          "app-1",
+			wantPermissions: []Permission{{Action: "users:read", Scope: "users:id:1"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,6 +102,9 @@ func TestSaveExternalServiceRoleCommand_Validate(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tt.wantID, tt.cmd.ExternalServiceID)
+			if tt.wantPermissions != nil {
+				require.ElementsMatch(t, tt.wantPermissions, tt.cmd.Permissions)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the scope of External Services authentication, we are allowing plugins to register their own roles. This PRs adds an extract check to permissions and de-duplicate them should there be duplications.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
