### PR TITLE
Loki Query Splitting: Enable tracking for split queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -287,17 +287,18 @@ export class LokiDatasource
       return runSplitQuery(this, fixedRequest);
     }
 
-    return this.runQuery(fixedRequest);
+    const startTime = new Date();
+    return this.runQuery(fixedRequest).pipe(tap((response) => trackQuery(response, fixedRequest, startTime)));
   }
 
   runQuery(fixedRequest: DataQueryRequest<LokiQuery> & { targets: LokiQuery[] }) {
-    const startTime = new Date();
-    return super.query(fixedRequest).pipe(
-      map((response) =>
-        transformBackendResult(response, fixedRequest.targets, this.instanceSettings.jsonData.derivedFields ?? [])
-      ),
-      tap((response) => trackQuery(response, fixedRequest, startTime))
-    );
+    return super
+      .query(fixedRequest)
+      .pipe(
+        map((response) =>
+          transformBackendResult(response, fixedRequest.targets, this.instanceSettings.jsonData.derivedFields ?? [])
+        )
+      );
   }
 
   runLiveQueryThroughBackend(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -291,7 +291,7 @@ export class LokiDatasource
     return this.runQuery(fixedRequest).pipe(tap((response) => trackQuery(response, fixedRequest, startTime)));
   }
 
-  runQuery(fixedRequest: DataQueryRequest<LokiQuery> & { targets: LokiQuery[] }) {
+  runQuery(fixedRequest: DataQueryRequest<LokiQuery>) {
     return super
       .query(fixedRequest)
       .pipe(

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -81,8 +81,6 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
 
-type LokiGroupedRequest = Array<{ request: DataQueryRequest<LokiQuery>; partition: TimeRange[] }>;
-
 export function runSplitGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest) {
   let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -227,7 +227,10 @@ export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequ
 
   const startTime = new Date();
   return runSplitGroupedQueries(datasource, requests).pipe(
-    last(),
-    tap((response) => trackGroupedQueries(response, requests, startTime))
+    tap((response) => {
+      if (response.state === LoadingState.Done) {
+        trackGroupedQueries(response, requests, request, startTime);
+      }
+    })
   );
 }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,5 +1,5 @@
 import { groupBy, partition } from 'lodash';
-import { last, Observable, Subscriber, Subscription, tap } from 'rxjs';
+import { Observable, Subscriber, Subscription, tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -1,0 +1,112 @@
+import { getQueryOptions } from 'test/helpers/getQueryOptions';
+
+import { dateTime } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
+
+import { partitionTimeRange } from './querySplitting';
+import { trackGroupedQueries } from './tracking';
+import { LokiGroupedRequest, LokiQuery } from './types';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+const baseTarget = {
+  resolution: 1,
+  editorMode: QueryEditorMode.Builder,
+};
+const range = {
+  from: dateTime('2023-02-08T05:00:00.000Z'),
+  to: dateTime('2023-02-10T06:00:00.000Z'),
+  raw: {
+    from: dateTime('2023-02-08T05:00:00.000Z'),
+    to: dateTime('2023-02-10T06:00:00.000Z'),
+  },
+};
+const requests: LokiGroupedRequest[] = [
+  {
+    request: {
+      ...getQueryOptions<LokiQuery>({
+        targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A', ...baseTarget }],
+        range,
+      }),
+      app: 'explore',
+    },
+    partition: partitionTimeRange(true, range, 60000, 1, 24 * 60 * 60 * 1000),
+  },
+  {
+    request: {
+      ...getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{a="b"}', refId: 'B', maxLines: 10, ...baseTarget }],
+        range,
+      }),
+      app: 'explore',
+    },
+    partition: partitionTimeRange(false, range, 60000, 1, 24 * 60 * 60 * 1000),
+  },
+];
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date('Wed May 17 2023 17:20:12 GMT+0200'));
+});
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+test('Tracks grouped queries', () => {
+  trackGroupedQueries({ data: [] }, requests, new Date());
+
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
+    app: 'explore',
+    bytes_processed: 0,
+    editor_mode: 'builder',
+    grafana_version: '1.0',
+    has_data: false,
+    has_error: false,
+    legend: undefined,
+    line_limit: undefined,
+    obfuscated_query: 'count_over_time({Identifier=String}[1m])',
+    parsed_query:
+      'LogQL,Expr,MetricExpr,RangeAggregationExpr,RangeOp,CountOverTime,LogRangeExpr,Selector,Matchers,Matcher,Identifier,Eq,String,Range,Duration',
+    query_type: 'metric',
+    query_vector_type: undefined,
+    resolution: 1,
+    simultaneously_executed_query_count: 1,
+    simultaneously_hidden_query_count: 0,
+    splitting_groups: 2,
+    splitting_max_requests: 3,
+    splitting_partition_size: 3,
+    splitting_total_requests: 6,
+    time_range_from: '2023-02-08T05:00:00.000Z',
+    time_range_to: '2023-02-10T06:00:00.000Z',
+    time_taken: 0,
+  });
+
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
+    app: 'explore',
+    bytes_processed: 0,
+    editor_mode: 'builder',
+    grafana_version: '1.0',
+    has_data: false,
+    has_error: false,
+    legend: undefined,
+    line_limit: 10,
+    obfuscated_query: '{Identifier=String}',
+    parsed_query: 'LogQL,Expr,LogExpr,Selector,Matchers,Matcher,Identifier,Eq,String',
+    query_type: 'logs',
+    query_vector_type: undefined,
+    resolution: 1,
+    simultaneously_executed_query_count: 1,
+    simultaneously_hidden_query_count: 0,
+    splitting_groups: 2,
+    splitting_max_requests: 3,
+    splitting_partition_size: 3,
+    splitting_total_requests: 6,
+    time_range_from: '2023-02-08T05:00:00.000Z',
+    time_range_to: '2023-02-10T06:00:00.000Z',
+    time_taken: 0,
+  });
+});

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -30,7 +30,10 @@ const requests: LokiGroupedRequest[] = [
   {
     request: {
       ...getQueryOptions<LokiQuery>({
-        targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A', ...baseTarget }],
+        targets: [
+          { expr: 'count_over_time({a="b"}[1m])', refId: 'A', ...baseTarget },
+          { expr: '{hidden="true"}', refId: 'C', ...baseTarget, hide: true },
+        ],
         range,
       }),
       app: 'explore',
@@ -75,7 +78,32 @@ test('Tracks grouped queries', () => {
     query_vector_type: undefined,
     resolution: 1,
     simultaneously_executed_query_count: 1,
-    simultaneously_hidden_query_count: 0,
+    simultaneously_hidden_query_count: 1,
+    splitting_groups: 2,
+    splitting_max_requests: 3,
+    splitting_partition_size: 3,
+    splitting_total_requests: 6,
+    time_range_from: '2023-02-08T05:00:00.000Z',
+    time_range_to: '2023-02-10T06:00:00.000Z',
+    time_taken: 0,
+  });
+
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
+    app: 'explore',
+    bytes_processed: 0,
+    editor_mode: 'builder',
+    grafana_version: '1.0',
+    has_data: false,
+    has_error: false,
+    legend: undefined,
+    line_limit: undefined,
+    obfuscated_query: '{Identifier=String}',
+    parsed_query: 'LogQL,Expr,LogExpr,Selector,Matchers,Matcher,Identifier,Eq,String',
+    query_type: 'logs',
+    query_vector_type: undefined,
+    resolution: 1,
+    simultaneously_executed_query_count: 1,
+    simultaneously_hidden_query_count: 1,
     splitting_groups: 2,
     splitting_max_requests: 3,
     splitting_partition_size: 3,

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -6,7 +6,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
 
 import { partitionTimeRange } from './querySplitting';
-import { trackGroupedQueries } from './tracking';
+import { trackGroupedQueries, trackQuery } from './tracking';
 import { LokiGroupedRequest, LokiQuery } from './types';
 
 jest.mock('@grafana/runtime', () => ({
@@ -58,6 +58,35 @@ beforeAll(() => {
 afterAll(() => {
   jest.useRealTimers();
 });
+beforeEach(() => {
+  jest.mocked(reportInteraction).mockClear();
+});
+
+test('Tracks queries', () => {
+  trackQuery({ data: [] }, requests[1].request, new Date());
+
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
+    app: 'explore',
+    bytes_processed: 0,
+    editor_mode: 'builder',
+    grafana_version: '1.0',
+    has_data: false,
+    has_error: false,
+    is_split: false,
+    legend: undefined,
+    line_limit: 10,
+    obfuscated_query: '{Identifier=String}',
+    parsed_query: 'LogQL,Expr,LogExpr,Selector,Matchers,Matcher,Identifier,Eq,String',
+    query_type: 'logs',
+    query_vector_type: undefined,
+    resolution: 1,
+    simultaneously_executed_query_count: 1,
+    simultaneously_hidden_query_count: 0,
+    time_range_from: '2023-02-08T05:00:00.000Z',
+    time_range_to: '2023-02-10T06:00:00.000Z',
+    time_taken: 0,
+  });
+});
 
 test('Tracks grouped queries', () => {
   trackGroupedQueries({ data: [] }, requests, new Date());
@@ -69,6 +98,7 @@ test('Tracks grouped queries', () => {
     grafana_version: '1.0',
     has_data: false,
     has_error: false,
+    is_split: true,
     legend: undefined,
     line_limit: undefined,
     obfuscated_query: 'count_over_time({Identifier=String}[1m])',
@@ -79,10 +109,10 @@ test('Tracks grouped queries', () => {
     resolution: 1,
     simultaneously_executed_query_count: 1,
     simultaneously_hidden_query_count: 1,
-    splitting_groups: 2,
-    splitting_max_requests: 3,
-    splitting_partition_size: 3,
-    splitting_total_requests: 6,
+    split_query_group_count: 2,
+    split_query_largest_partition_size: 3,
+    split_query_partition_size: 3,
+    split_query_total_request_count: 6,
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
@@ -95,6 +125,7 @@ test('Tracks grouped queries', () => {
     grafana_version: '1.0',
     has_data: false,
     has_error: false,
+    is_split: true,
     legend: undefined,
     line_limit: undefined,
     obfuscated_query: '{Identifier=String}',
@@ -104,10 +135,10 @@ test('Tracks grouped queries', () => {
     resolution: 1,
     simultaneously_executed_query_count: 1,
     simultaneously_hidden_query_count: 1,
-    splitting_groups: 2,
-    splitting_max_requests: 3,
-    splitting_partition_size: 3,
-    splitting_total_requests: 6,
+    split_query_group_count: 2,
+    split_query_largest_partition_size: 3,
+    split_query_partition_size: 3,
+    split_query_total_request_count: 6,
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
@@ -120,6 +151,7 @@ test('Tracks grouped queries', () => {
     grafana_version: '1.0',
     has_data: false,
     has_error: false,
+    is_split: true,
     legend: undefined,
     line_limit: 10,
     obfuscated_query: '{Identifier=String}',
@@ -129,10 +161,10 @@ test('Tracks grouped queries', () => {
     resolution: 1,
     simultaneously_executed_query_count: 1,
     simultaneously_hidden_query_count: 0,
-    splitting_groups: 2,
-    splitting_max_requests: 3,
-    splitting_partition_size: 3,
-    splitting_total_requests: 6,
+    split_query_group_count: 2,
+    split_query_largest_partition_size: 3,
+    split_query_partition_size: 3,
+    split_query_total_request_count: 6,
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -146,7 +146,7 @@ const calculateTotalBytes = (response: DataQueryResponse): number => {
 
 export function trackQuery(
   response: DataQueryResponse,
-  request: DataQueryRequest<LokiQuery> & { targets: LokiQuery[] },
+  request: DataQueryRequest<LokiQuery>,
   startTime: Date,
   extraPayload: Record<string, unknown> = {}
 ): void {

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -183,6 +183,7 @@ export function trackQuery(
       time_range_to: request?.range?.to?.toISOString(),
       time_taken: Date.now() - startTime.getTime(),
       bytes_processed: totalBytes,
+      is_split: false,
       ...extraPayload,
     });
   }
@@ -197,13 +198,14 @@ export function trackGroupedQueries(
     split_query_group_count: requests.length,
     split_query_largest_partition_size: Math.max(...requests.map(({ partition }) => partition.length)),
     split_query_total_request_count: requests.reduce((total, { partition }) => total + partition.length, 0),
+    is_split: true,
   };
 
   for (const group of requests) {
     const split_query_partition_size = group.partition.length;
     trackQuery(response, group.request, startTime, {
       ...splittingPayload,
-      splitting_partition_size,
+      split_query_partition_size,
     });
   }
 }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -200,7 +200,7 @@ export function trackGroupedQueries(
   };
 
   for (const group of requests) {
-    const splitting_partition_size = group.partition.length;
+    const split_query_partition_size = group.partition.length;
     trackQuery(response, group.request, startTime, {
       ...splittingPayload,
       splitting_partition_size,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -195,7 +195,7 @@ export function trackGroupedQueries(
 ): void {
   const splittingPayload = {
     split_query_group_count: requests.length,
-    splitting_max_requests: Math.max(...requests.map(({ partition }) => partition.length)),
+    split_query_largest_partition_size: Math.max(...requests.map(({ partition }) => partition.length)),
     splitting_total_requests: requests.reduce((total, { partition }) => total + partition.length, 0),
   };
 

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -194,7 +194,7 @@ export function trackGroupedQueries(
   startTime: Date
 ): void {
   const splittingPayload = {
-    splitting_groups: requests.length,
+    split_query_group_count: requests.length,
     splitting_max_requests: Math.max(...requests.map(({ partition }) => partition.length)),
     splitting_total_requests: requests.reduce((total, { partition }) => total + partition.length, 0),
   };

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -196,7 +196,7 @@ export function trackGroupedQueries(
   const splittingPayload = {
     split_query_group_count: requests.length,
     split_query_largest_partition_size: Math.max(...requests.map(({ partition }) => partition.length)),
-    splitting_total_requests: requests.reduce((total, { partition }) => total + partition.length, 0),
+    split_query_total_request_count: requests.reduce((total, { partition }) => total + partition.length, 0),
   };
 
   for (const group of requests) {

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData, QueryResultMeta, ScopedVars } from '@grafana/data';
+import { DataQuery, DataQueryRequest, DataSourceJsonData, QueryResultMeta, ScopedVars, TimeRange } from '@grafana/data';
 
 import { Loki as LokiQueryFromSchema, LokiQueryType, SupportingQueryType, LokiQueryDirection } from './dataquery.gen';
 
@@ -160,3 +160,5 @@ export interface ContextFilter {
   fromParser: boolean;
   description?: string;
 }
+
+export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[] };


### PR DESCRIPTION
This PR adds support to tracking execution stats of split queries. This is done by adding a new function that reads grouped requests, builds extra payload related with query splitting, and uses the existing tracking function to report it.

The new payload includes:

- splitting_groups: The amount of generated groups (logs, metric, instant, and subgroups by chunk duration and resolution.
- splitting_max_requests: The largest partition size when splitting time ranges.
- splitting_partition_size: The partition size of the group where the query is.
- splitting_total_requests: The total amount of requests sent among all groups.

![capture](https://github.com/grafana/grafana/assets/1069378/79af27cc-7dc4-41fe-ae60-c8d71b1af3cc)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67508

**Special notes for your reviewer:**

With and without query splitting enabled (by feature flag), we should send execution reports.