### PR TITLE
Alerting: fix moment when rule list navigation is tracked

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -7,7 +7,7 @@ import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { DataSourceSrv, locationService, logInfo, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { ContextSrv, contextSrv, setContextSrv } from 'app/core/services/context_srv';
+import { contextSrv } from 'app/core/services/context_srv';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import * as actions from 'app/features/alerting/unified/state/actions';
 import { AccessControlAction } from 'app/types';

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -7,7 +7,7 @@ import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { DataSourceSrv, locationService, logInfo, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { contextSrv } from 'app/core/services/context_srv';
+import { ContextSrv, contextSrv, setContextSrv } from 'app/core/services/context_srv';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import * as actions from 'app/features/alerting/unified/state/actions';
 import { AccessControlAction } from 'app/types';
@@ -41,6 +41,7 @@ jest.mock('./api/ruler');
 jest.mock('../../../core/hooks/useMediaQueryChange');
 jest.spyOn(ruleActionButtons, 'matchesWidth').mockReturnValue(false);
 jest.mock('app/core/core', () => ({
+  ...jest.requireActual('app/core/core'),
   appEvents: {
     subscribe: () => {
       return { unsubscribe: () => {} };

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -76,10 +76,13 @@ const RuleList = withErrorBoundary(
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        trackRuleListNavigation();
         await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
       }
     }, [loading, limitAlerts, dispatch]);
+
+    useEffect(() => {
+      trackRuleListNavigation();
+    }, []);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -81,7 +81,7 @@ const RuleList = withErrorBoundary(
     }, [loading, limitAlerts, dispatch]);
 
     useEffect(() => {
-      trackRuleListNavigation();
+      trackRuleListNavigation().catch(() => {});
     }, []);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS


### PR DESCRIPTION
**What is this feature?**

We need to track when users load the rules list page so that we can show the user survey at that point. This PR makes a change so that it is only tracked once, as previously it was being tracked several times, every time the rules were refetched.

**Why do we need this feature?**

To only track this event once per page view.

**Who is this feature for?**

All not-new users.

**Which issue(s) does this PR fix?**:

Related to #68043 