### PR TITLE
Alerting: Prevent assigning duplicated query/expression names

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -181,7 +181,7 @@ export class QueryRows extends PureComponent<Props> {
                       query={query}
                       onChangeQuery={this.onChangeQuery}
                       onRemoveQuery={this.onRemoveQuery}
-                      queries={queries}
+                      queries={[...queries, ...expressions]}
                       onChangeDataSource={this.onChangeDataSource}
                       onDuplicateQuery={this.props.onDuplicateQuery}
                       onChangeTimeRange={this.onChangeTimeRange}


### PR DESCRIPTION
**What is this feature?**

Users are able to assign duplicated query/expression names which causes unexpected behavior.

**Why do we need this feature?**

This PR fixes that by considering the set of expressions when changing the query condition.

**Who is this feature for?**

All users.



**Which issue(s) does this PR fix?**:
Before:

https://github.com/grafana/grafana/assets/6271380/99d91d40-0cf8-47e7-832d-c6ea7f4ebcc5

After:

![2023-05-17 18 57 03](https://github.com/grafana/grafana/assets/6271380/cb0cfd80-5e9e-4c8e-820e-4641cb3d27d5)


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
