### PR TITLE
Tempo: Update devenv

### DIFF
--- a/devenv/docker/blocks/tempo/docker-compose.yaml
+++ b/devenv/docker/blocks/tempo/docker-compose.yaml
@@ -16,6 +16,11 @@
       options:
         loki-url: 'http://localhost:3100/api/prom/push'
         labels: namespace
+        loki-relabel-config: |
+          - action: replace
+            source_labels: ["namespace","compose_service"]
+            separator: "/"
+            target_label: job
 
   app:
     image: grafana/tns-app:9c1ab38
@@ -38,6 +43,11 @@
       options:
         loki-url: 'http://localhost:3100/api/prom/push'
         labels: namespace
+        loki-relabel-config: |
+          - action: replace
+            source_labels: ["namespace","compose_service"]
+            separator: "/"
+            target_label: job
 
   loadgen:
     image: grafana/tns-loadgen:9c1ab38

--- a/devenv/docker/blocks/tempo/docker-compose.yaml
+++ b/devenv/docker/blocks/tempo/docker-compose.yaml
@@ -1,20 +1,3 @@
-x-logging: &default-logging
-  driver: loki
-  options:
-    loki-url: 'http://localhost:3100/api/prom/push'
-    labels: namespace
-    loki-relabel-config: |
-      - action: replace
-        source_labels: ["namespace","compose_service"]
-        separator: "/"
-        target_label: job
-      - action: replace
-        source_labels: ["container_name"]
-        target_label: instance
-
-version: "3"
-services:
-
   db:
     image: grafana/tns-db:9c1ab38
     command:
@@ -28,7 +11,11 @@ services:
       JAEGER_SAMPLER_PARAM: 1
     labels:
       namespace: tns
-    logging: *default-logging
+    logging: 
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+        labels: namespace
 
   app:
     image: grafana/tns-app:9c1ab38
@@ -46,7 +33,11 @@ services:
       JAEGER_SAMPLER_PARAM: 1
     labels:
       namespace: tns
-    logging: *default-logging
+    logging: 
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+        labels: namespace
 
   loadgen:
     image: grafana/tns-loadgen:9c1ab38
@@ -64,13 +55,16 @@ services:
       JAEGER_SAMPLER_PARAM: 1
     labels:
       namespace: tns
-    logging: *default-logging
+    logging: 
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+        labels: namespace
 
   tempo:
-    image: grafana/tempo:main-9a8474f
+    image: grafana/tempo:main-dcf8a2a
     command:
       - --config.file=/etc/tempo.yaml
-      - --search.enabled=true
     volumes:
       - ./docker/blocks/tempo/tempo.yaml:/etc/tempo.yaml
       - ./docker/blocks/tempo/tempo-data:/tmp/tempo
@@ -96,7 +90,11 @@ services:
       - "9090:9090"
     labels:
       namespace: monitoring
-    logging: *default-logging
+    logging: 
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+        labels: namespace
 
   loki:
     image: grafana/loki:main
@@ -108,4 +106,8 @@ services:
       - "3100:3100"
     labels:
       namespace: monitoring
-    logging: *default-logging
+    logging: 
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+        labels: namespace

--- a/devenv/docker/blocks/tempo/tempo.yaml
+++ b/devenv/docker/blocks/tempo/tempo.yaml
@@ -1,5 +1,3 @@
-metrics_generator_enabled: true
-
 server:
   http_listen_port: 3200
 


### PR DESCRIPTION
**What is this feature?**

Updates the Tempo devenv to work better with our make devenv script i.e. only provide services so that the script does not result in errors.

Also updates the Tempo image used to a more recent one and modifies the existing settings to suit the new image.

**Why do we need this feature?**

Better devenv for Tempo.

**Who is this feature for?**

Devs.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/68677

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
