### PR TITLE
GrafanaUI: Expose Text component

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -12,8 +12,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '../../themes';
 import { Button } from '../Button';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
-//import { IconButton } from '../IconButton/IconButton';
-import { Text } from '../Text/Text';
+import { H3 } from '../Text/TextElements';
 
 export interface Props {
   children: ReactNode;
@@ -124,9 +123,7 @@ export function Drawer({
                 />
               </div>
               <div className={styles.titleWrapper}>
-                <Text as="h3" {...titleProps}>
-                  {title}
-                </Text>
+                <H3 {...titleProps}>{title}</H3>
                 {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
                 {tabs && <div className={styles.tabsWrapper}>{tabs}</div>}
               </div>

--- a/packages/grafana-ui/src/components/Text/Text.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.internal.story.tsx
@@ -6,7 +6,7 @@ import { VerticalGroup } from '../Layout/Layout';
 
 import { Text } from './Text';
 import mdx from './Text.mdx';
-import { H1, H2, H3, H4, H5, H6, Span, P, Legend, TextModifier } from './TextElements';
+import { H1, H2, H3, H4, H5, H6, P } from './TextElements';
 
 const meta: Meta = {
   title: 'General/Text',
@@ -18,7 +18,7 @@ const meta: Meta = {
     controls: { exclude: ['as'] },
   },
   argTypes: {
-    variant: { control: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', undefined] },
+    variant: { control: 'select', options: ['body', 'bodySmall', undefined] },
     weight: {
       control: 'select',
       options: ['bold', 'medium', 'light', 'regular', undefined],
@@ -49,7 +49,7 @@ const meta: Meta = {
 export const Example: StoryFn = () => {
   return (
     <VerticalGroup>
-      <StoryExample name="Header, paragraph, span and legend elements">
+      <StoryExample name="Headings and paragraph elements">
         <H1>h1. Heading</H1>
         <H2>h2. Heading</H2>
         <H3>h3. Heading</H3>
@@ -57,8 +57,6 @@ export const Example: StoryFn = () => {
         <H5>h5. Heading</H5>
         <H6>h6. Heading</H6>
         <P>This is a paragraph</P>
-        <Legend>This is a legend</Legend>
-        <Span>This is a span</Span>
       </StoryExample>
     </VerticalGroup>
   );
@@ -87,39 +85,21 @@ HeadingComponent.args = {
   children: 'This is a H1 component',
 };
 
-export const LegendComponent: StoryFn = (args) => {
-  return (
-    <div style={{ width: '300px' }}>
-      <Legend variant={args.variant} weight={args.weight} textAlignment={args.textAlignment} {...args}>
-        {args.children}
-      </Legend>
-    </div>
-  );
-};
-
-LegendComponent.args = {
-  variant: undefined,
-  weight: 'bold',
-  textAlignment: 'center',
-  truncate: false,
-  color: 'error',
-  children: 'This is a lengend component',
-};
-
-export const TextModifierComponent: StoryFn = (args) => {
+export const TextComponent: StoryFn = (args) => {
   return (
     <div style={{ width: '300px' }}>
       <H6 variant={args.variant} weight={args.weight} textAlignment={args.textAlignment} {...args}>
-        {args.children}{' '}
-        <TextModifier weight="bold" color="error">
+        {args.children}
+        <Text weight="bold" color="error">
           {' '}
-          with a part of its text modified{' '}
-        </TextModifier>
+          with a part of its text with a different style
+        </Text>
+        !
       </H6>
     </div>
   );
 };
-TextModifierComponent.args = {
+TextComponent.args = {
   variant: undefined,
   weight: 'light',
   textAlignment: 'center',

--- a/packages/grafana-ui/src/components/Text/Text.test.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.test.tsx
@@ -1,36 +1,38 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { createTheme, ThemeTypographyVariantTypes } from '@grafana/data';
+import { createTheme } from '@grafana/data';
 
 import { Text } from './Text';
+import { H2 } from './TextElements';
 
 describe('Text', () => {
   it('renders correctly', () => {
-    render(<Text as={'h1'}>This is a text component</Text>);
+    render(<Text>This is a text component</Text>);
     expect(screen.getByText('This is a text component')).toBeInTheDocument();
   });
-  it('keeps the element type but changes its styles', () => {
-    const customVariant: keyof ThemeTypographyVariantTypes = 'body';
-    render(
-      <Text as={'h1'} variant={customVariant}>
-        This is a text component
-      </Text>
-    );
+
+  it('styles text with variants', () => {
+    render(<Text variant="body">This is a text component</Text>);
     const theme = createTheme();
-    const textComponent = screen.getByRole('heading');
-    expect(textComponent).toBeInTheDocument();
-    expect(textComponent).toHaveStyle(`fontSize: ${theme.typography.body.fontSize}`);
+    const textComponent = screen.getByText('This is a text component');
+    expect(textComponent).toHaveStyle({ fontSize: theme.typography.body.fontSize });
   });
+
   it('has the selected colour', () => {
-    const customColor = 'info';
+    render(<Text color="secondary">This is a text component</Text>);
     const theme = createTheme();
-    render(
-      <Text as={'h1'} color={customColor}>
-        This is a text component
-      </Text>
-    );
-    const textComponent = screen.getByRole('heading');
-    expect(textComponent).toHaveStyle(`color:${theme.colors.info.text}`);
+    const textComponent = screen.getByText('This is a text component');
+    expect(textComponent).toHaveStyle({ color: theme.colors.text.secondary });
+  });
+});
+
+describe('TextElements', () => {
+  it('renders headings correctly', () => {
+    render(<H2 variant="h1">Hello, world</H2>);
+    const theme = createTheme();
+    const heading = screen.getByRole('heading');
+    expect(heading.tagName).toBe('H2');
+    expect(heading).toHaveStyle({ fontSize: theme.typography.h1.fontSize });
   });
 });

--- a/packages/grafana-ui/src/components/Text/Text.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.tsx
@@ -1,106 +1,37 @@
-import { css } from '@emotion/css';
-import React, { createElement, CSSProperties, useCallback } from 'react';
+import React, { useMemo } from 'react';
 
-import { GrafanaTheme2, ThemeTypographyVariantTypes } from '@grafana/data';
+import { useTheme2 } from '../../themes';
 
-import { useStyles2 } from '../../themes';
+import { getTextStyles, TextStyleProps } from './styles';
 
-export interface TextProps {
-  /** Defines what HTML element is defined underneath */
-  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p' | 'legend';
-  /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
-  variant?: keyof ThemeTypographyVariantTypes;
-  /** Override the default weight for the used variant */
-  weight?: 'light' | 'regular' | 'medium' | 'bold';
-  /** Color to use for text */
-  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
-  /** Use to cut the text off with ellipsis if there isn't space to show all of it. On hover shows the rest of the text */
-  truncate?: boolean;
-  /** Whether to align the text to left, center or right */
-  textAlignment?: CSSProperties['textAlign'];
+export interface TextProps extends TextStyleProps {
   children: React.ReactNode;
+
+  /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
+  variant?: 'body' | 'bodySmall';
 }
 
 export const Text = React.forwardRef<HTMLElement, TextProps>(
-  ({ as, variant, weight, color, truncate, textAlignment, children }, ref) => {
-    const styles = useStyles2(
-      useCallback(
-        (theme) => getTextStyles(theme, variant, color, weight, truncate, textAlignment),
-        [color, textAlignment, truncate, weight, variant]
-      )
-    );
+  ({ children, weight, fontStyle, color, truncate, textAlignment, variant }, ref) => {
+    const theme = useTheme2();
 
-    return createElement(
-      as,
-      {
-        className: styles,
-        ref,
-      },
-      children
+    const styles = useMemo(() => {
+      return getTextStyles(theme, {
+        weight,
+        fontStyle,
+        color,
+        truncate,
+        textAlignment,
+        variant,
+      });
+    }, [theme, weight, fontStyle, color, truncate, textAlignment, variant]);
+
+    return (
+      <span ref={ref} className={styles}>
+        {children}
+      </span>
     );
   }
 );
 
 Text.displayName = 'Text';
-
-const getTextStyles = (
-  theme: GrafanaTheme2,
-  variant?: keyof ThemeTypographyVariantTypes,
-  color?: TextProps['color'],
-  weight?: TextProps['weight'],
-  truncate?: TextProps['truncate'],
-  textAlignment?: TextProps['textAlignment']
-) => {
-  return css([
-    variant && {
-      ...theme.typography[variant],
-    },
-    {
-      margin: 0,
-      padding: 0,
-    },
-    color && {
-      color: customColor(color, theme),
-    },
-    weight && {
-      fontWeight: customWeight(weight, theme),
-    },
-    truncate && {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    },
-    textAlignment && {
-      textAlign: textAlignment,
-    },
-  ]);
-};
-
-const customWeight = (weight: TextProps['weight'], theme: GrafanaTheme2): number => {
-  switch (weight) {
-    case 'bold':
-      return theme.typography.fontWeightBold;
-    case 'medium':
-      return theme.typography.fontWeightMedium;
-    case 'light':
-      return theme.typography.fontWeightLight;
-    case 'regular':
-    case undefined:
-      return theme.typography.fontWeightRegular;
-  }
-};
-
-const customColor = (color: TextProps['color'], theme: GrafanaTheme2): string | undefined => {
-  switch (color) {
-    case 'error':
-      return theme.colors.error.text;
-    case 'success':
-      return theme.colors.success.text;
-    case 'info':
-      return theme.colors.info.text;
-    case 'warning':
-      return theme.colors.warning.text;
-    default:
-      return color ? theme.colors.text[color] : undefined;
-  }
-};

--- a/packages/grafana-ui/src/components/Text/TextElements.tsx
+++ b/packages/grafana-ui/src/components/Text/TextElements.tsx
@@ -19,7 +19,7 @@ function createTextElement(element: TextElement, defaultVariant: keyof ThemeTypo
 
     const styles = useMemo(() => {
       return getTextStyles(theme, {
-        variant,
+        variant: variant ?? defaultVariant,
         weight,
         fontStyle,
         color,

--- a/packages/grafana-ui/src/components/Text/TextElements.tsx
+++ b/packages/grafana-ui/src/components/Text/TextElements.tsx
@@ -1,75 +1,63 @@
-import React from 'react';
+import React, { createElement, forwardRef, useMemo } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { ThemeTypographyVariantTypes } from '@grafana/data';
 
-import { Text, TextProps } from './Text';
+import { useTheme2 } from '../../themes';
 
-interface TextElementsProps extends Omit<TextProps, 'as'> {}
+import { getTextStyles, TextStyleProps } from './styles';
 
-interface TextModifierProps {
-  /** Override the default weight for the used variant */
-  weight?: 'light' | 'regular' | 'medium' | 'bold';
-  /** Color to use for text */
-  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
+type TextElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+
+interface TextElementProps extends TextStyleProps {
   children: React.ReactNode;
 }
 
-export const H1 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h1" {...props} variant={props.variant || 'h1'} ref={ref} />;
-});
+function createTextElement(element: TextElement, defaultVariant: keyof ThemeTypographyVariantTypes) {
+  const TextElement = forwardRef<HTMLElement, TextElementProps>(function Heading(props, ref) {
+    const { children, variant, weight, fontStyle, color, truncate, textAlignment } = props;
+    const theme = useTheme2();
 
+    const styles = useMemo(() => {
+      return getTextStyles(theme, {
+        variant,
+        weight,
+        fontStyle,
+        color,
+        truncate,
+        textAlignment,
+      });
+    }, [theme, variant, weight, fontStyle, color, truncate, textAlignment]);
+
+    return createElement(
+      element,
+      {
+        className: styles,
+        ref,
+      },
+      children
+    );
+  });
+
+  return TextElement;
+}
+
+export const H1 = createTextElement('h1', 'h1');
 H1.displayName = 'H1';
 
-export const H2 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h2" {...props} variant={props.variant || 'h2'} ref={ref} />;
-});
-
+export const H2 = createTextElement('h2', 'h2');
 H2.displayName = 'H2';
 
-export const H3 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h3" {...props} variant={props.variant || 'h3'} ref={ref} />;
-});
-
+export const H3 = createTextElement('h3', 'h3');
 H3.displayName = 'H3';
 
-export const H4 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h4" {...props} variant={props.variant || 'h4'} ref={ref} />;
-});
-
+export const H4 = createTextElement('h4', 'h4');
 H4.displayName = 'H4';
 
-export const H5 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h5" {...props} variant={props.variant || 'h5'} ref={ref} />;
-});
-
+export const H5 = createTextElement('h5', 'h5');
 H5.displayName = 'H5';
 
-export const H6 = React.forwardRef<HTMLHeadingElement, TextElementsProps>((props, ref) => {
-  return <Text as="h6" {...props} variant={props.variant || 'h6'} ref={ref} />;
-});
-
+export const H6 = createTextElement('h6', 'h6');
 H6.displayName = 'H6';
 
-export const P = React.forwardRef<HTMLParagraphElement, TextElementsProps>((props, ref) => {
-  return <Text as="p" {...props} variant={props.variant || 'body'} ref={ref} />;
-});
-
+export const P = createTextElement('p', 'body');
 P.displayName = 'P';
-
-export const Span = React.forwardRef<HTMLSpanElement, TextElementsProps>((props, ref) => {
-  return <Text as="span" {...props} variant={props.variant || 'bodySmall'} ref={ref} />;
-});
-
-Span.displayName = 'Span';
-
-export const Legend = React.forwardRef<HTMLLegendElement, TextElementsProps>((props, ref) => {
-  return <Text as="legend" {...props} variant={props.variant || 'bodySmall'} ref={ref} />;
-});
-
-Legend.displayName = 'Legend';
-
-export const TextModifier = React.forwardRef<HTMLSpanElement, TextModifierProps>((props, ref) => {
-  return <Text as="span" {...props} ref={ref} />;
-});
-
-TextModifier.displayName = 'TextModifier';

--- a/packages/grafana-ui/src/components/Text/styles.ts
+++ b/packages/grafana-ui/src/components/Text/styles.ts
@@ -1,0 +1,84 @@
+import { css } from '@emotion/css';
+import { CSSProperties } from 'react';
+
+import { GrafanaTheme2, ThemeTypographyVariantTypes } from '@grafana/data';
+
+export interface TextStyleProps {
+  /** Override the default weight for the used variant */
+  weight?: 'light' | 'regular' | 'medium' | 'bold';
+
+  /** Color to use for text */
+  color?: keyof GrafanaTheme2['colors']['text'] | 'error' | 'success' | 'warning' | 'info';
+
+  /** Font style, such as italics  */
+  fontStyle?: CSSProperties['fontStyle'];
+
+  /** Use to cut the text off with ellipsis if there isn't space to show all of it. On hover shows the rest of the text */
+  truncate?: boolean;
+
+  /** Whether to align the text to left, center or right */
+  textAlignment?: CSSProperties['textAlign'];
+
+  /** What typograpy variant should be used for the component. Only use if default variant for the defined element is not what is needed */
+  variant?: keyof ThemeTypographyVariantTypes;
+}
+
+export function getTextStyles(
+  theme: GrafanaTheme2,
+  { weight, color, fontStyle, truncate, textAlignment, variant }: TextStyleProps
+) {
+  return css([
+    variant && {
+      ...theme.typography[variant],
+    },
+    {
+      margin: 0,
+      padding: 0,
+    },
+    color && {
+      color: customColor(color, theme),
+    },
+    weight && {
+      fontWeight: customWeight(weight, theme),
+    },
+    fontStyle && {
+      fontStyle,
+    },
+    truncate && {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    textAlignment && {
+      textAlign: textAlignment,
+    },
+  ]);
+}
+const customWeight = (weight: TextStyleProps['weight'], theme: GrafanaTheme2): number => {
+  switch (weight) {
+    case 'bold':
+      return theme.typography.fontWeightBold;
+    case 'medium':
+      return theme.typography.fontWeightMedium;
+    case 'light':
+      return theme.typography.fontWeightLight;
+    case 'regular':
+    case undefined:
+      return theme.typography.fontWeightRegular;
+  }
+};
+
+const customColor = (color: TextStyleProps['color'], theme: GrafanaTheme2): string | undefined => {
+  switch (color) {
+    case 'error':
+      return theme.colors.error.text;
+    case 'success':
+      return theme.colors.success.text;
+    case 'info':
+      return theme.colors.info.text;
+    case 'warning':
+      return theme.colors.warning.text;
+    default:
+      return color ? theme.colors.text[color] : undefined;
+  }
+};

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -10,3 +10,4 @@
  */
 
 export * from './components/Text/TextElements';
+export * from './components/Text/Text';


### PR DESCRIPTION
The main piece of feedback [I have after using the new text components](https://github.com/grafana/grafana/pull/68532) is that `<TextVariant />` has an unweidly name, it doesn't do enough, and adding the rest of the props would just make it the same as Text anyway.

 - Exposes Text component
   - Text component can only be used with `body` and `bodySmall` variants. To get a heading variant, using a Heading component
 - Adds fontStyle for italic
     - 🤔 Wasn't sure about exposing `fontStyle`, or having a dedicated `italic` prop. Thoughts?
 - Uses 'function factory' to create Heading elements
 - Removed Span, Legend, and TextVariant components in favor of just using Text component directly
    - After exposing Text, Span and TextVariant become redundant. 
    - Span isn't really a semantic element - it's mainly just used when we want to style some inline text... which is what Text/TextVariant is 😅 
     - I did go a bit cowboy with removing Legend - it _felt_ like it was made just to expose `bodySmall` variant? Which can just be used with Text now. I think its much easier to start with less and add more later, than to have a component hanging around that we dont use.
 - Moves getStyles into function to reuse between typography components 

Usage:

```ts

<H2 variant="h1">Welcome back <Text weight="ultraBold">Josh</Text><H2>

<Text color="secondary" fontStyle="italic>No items</Text>

```

(ignore that we don't actually have an ultra-bold weight)

---

It's becoming more certain that I dislike the concept of an `as` prop:

 - `as` is a common convention for component libraries, but I think `<Text as="h3">Hello<Text/>` is confusing - does `as` control the HTML element, the variant appearance, or both?
 - I think props should do less things and be less magic - explicitness over convention.
 - Renaming it to something like `element` or `component` fixes this, but _to me_ it seems weird for a high-level component to have a `element` prop when we already have a way to communicate that information - the tag name!
 - A similar use case is Button vs LinkButton - we don't give them an `as` prop to control the element and instead we make a pre-packaged element
 - If we say that the behaviour of `as` is learnable (which is fair) if not untuitive, then surely we can say that knowing to use `<H1/>`, `<H2/>`, `<H3/>`, and `<Text />` is equally learnable, with the advantage of "the component tells you the element"?

I think `as` (or a different name) is fine for like an internal component that people can 'drop down to' infrequently if something higher-level doesn't fulfil their use case (`Box` component is a good example of this I think), but should not be a part of the common 'happy path' API for compoennts.