### PR TITLE
AzureMonitor: Ensure legacy properties containing template variables are correctly migrated

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/__mocks__/query.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/query.ts
@@ -10,6 +10,7 @@ export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>):
       type: 'grafana-azure-monitor-datasource',
       uid: 'AAAAA11111BBBBB22222CCCC',
     },
+    ...overrides,
 
     azureLogAnalytics: {
       query:
@@ -53,7 +54,5 @@ export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>):
       region: '',
       ...overrides?.azureMonitor,
     },
-
-    ...overrides,
   };
 }

--- a/public/app/plugins/datasource/azuremonitor/__mocks__/query.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/query.ts
@@ -10,7 +10,6 @@ export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>):
       type: 'grafana-azure-monitor-datasource',
       uid: 'AAAAA11111BBBBB22222CCCC',
     },
-    ...overrides,
 
     azureLogAnalytics: {
       query:
@@ -54,5 +53,7 @@ export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>):
       region: '',
       ...overrides?.azureMonitor,
     },
+
+    ...overrides,
   };
 }

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -213,6 +213,7 @@ describe('AzureMonitorDatasource', () => {
           metricDefinition: '$metric',
           resourceGroup: '$resourcegroup',
           resourceName: '$resourcename',
+          metricNamespace: undefined,
         },
       });
       const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -183,6 +183,46 @@ describe('AzureMonitorDatasource', () => {
         },
       });
     });
+
+    it('should migrate legacy properties before interpolation', () => {
+      templateSrv.init([
+        {
+          id: 'resourcegroup',
+          name: 'resourcegroup',
+          current: {
+            value: `test-rg`,
+          },
+        },
+        {
+          id: 'resourcename',
+          name: 'resourcename',
+          current: {
+            value: `test-resource`,
+          },
+        },
+        {
+          id: 'metric',
+          name: 'metric',
+          current: {
+            value: `test-ns`,
+          },
+        },
+      ]);
+      const query = createMockQuery({
+        azureMonitor: {
+          metricDefinition: '$metric',
+          resourceGroup: '$resourcegroup',
+          resourceName: '$resourcename',
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          metricNamespace: 'test-ns',
+          resources: [{ resourceGroup: 'test-rg', resourceName: 'test-resource' }],
+        },
+      });
+    });
   });
 
   describe('When performing getMetricNamespaces', () => {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -87,7 +87,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
     const preMigrationQuery = target.azureMonitor;
 
     if (!preMigrationQuery) {
-      // return target;
       throw new Error('Query is not a valid Azure Monitor Metrics query');
     }
 

--- a/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
@@ -25,7 +25,7 @@ export default function migrateQuery(query: AzureMonitorQuery): AzureMonitorQuer
     workingQuery = migrateToDefaultNamespace(workingQuery);
     workingQuery = migrateDimensionToDimensionFilter(workingQuery);
     workingQuery = migrateDimensionFilterToArray(workingQuery);
-    workingQuery = migrateDimensionToResourceObj(workingQuery);
+    workingQuery = migrateResourceUriToResourceObj(workingQuery);
   }
 
   if (workingQuery.azureMonitor?.resourceGroup || workingQuery.azureMonitor?.resourceName) {
@@ -154,7 +154,7 @@ function migrateDimensionFilterToArray(query: AzureMonitorQuery): AzureMonitorQu
   return query;
 }
 
-function migrateDimensionToResourceObj(query: AzureMonitorQuery): AzureMonitorQuery {
+function migrateResourceUriToResourceObj(query: AzureMonitorQuery): AzureMonitorQuery {
   if (query.azureMonitor?.resourceUri && !query.azureMonitor.resourceUri.startsWith('$')) {
     const details = parseResourceDetails(query.azureMonitor.resourceUri);
     const isWellFormedUri = details?.subscription && details?.resourceGroup && details?.resourceName;


### PR DESCRIPTION
This PR adds a fix to ensure that if a legacy property contains a template variable the superseding property will be appropriately interpolated. This mainly fixes a bug that occurs if an expression query is used in conjunction with an older Azure Monitor query as the typical migration flow does not take place.

Fixes grafana/support-escalations#5899