### PR TITLE
Loki: Preserve pre-selected labels in the log context UI

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -185,12 +185,13 @@ export function LokiContextUi(props: LokiContextUiProps) {
       // We need to update filters based on preserved labels
       let arePreservedLabelsUsed = false;
       const newContextFilters = initContextFilters.map((contextFilter) => {
-        if (preservedLabels && preservedLabels.removedLabels.includes(contextFilter.label)) {
+        // We checked for undefined above
+        if (preservedLabels!.removedLabels.includes(contextFilter.label)) {
           arePreservedLabelsUsed = true;
           return { ...contextFilter, enabled: false };
         }
-
-        if (preservedLabels && preservedLabels.selectedExtractedLabels.includes(contextFilter.label)) {
+        // We checked for undefined above
+        if (preservedLabels!.selectedExtractedLabels.includes(contextFilter.label)) {
           arePreservedLabelsUsed = true;
           return { ...contextFilter, enabled: true };
         }


### PR DESCRIPTION
In this PR, we are introducing a new functionality to Loki log context UI. We are using local storage to save removed labels and added extracted labels and then use them in a new log context window. The main goal is to reduce repetition when users are going trough multiple log lines and they always have to select/remove same labels. 

Functionalities
- We've added button to reset query to initial query. It also deletes saved context labels from local storage
- We show standard Grafana notification when context is opened and previously selected labels were used
- If query with applied preserved labels will produce invalid stream selector without labels, we use original labels, we but don’t remove labels from local storage

https://github.com/grafana/grafana/assets/30407135/c727fcc1-8767-422a-94bf-abf6dbcaa292