### PR TITLE
WIP: PoC of representing nanosecond-precision time-ranges in grafana

### DIFF
--- a/packages/grafana-data/src/datetime/index.ts
+++ b/packages/grafana-data/src/datetime/index.ts
@@ -6,6 +6,7 @@ export * from './timezones';
 export * from './formats';
 export * from './formatter';
 export * from './parser';
+export * from './nano';
 export * from './durationutil';
 export { dateMath, rangeUtil };
 export { type DateTimeOptions, setTimeZoneResolver, type TimeZoneResolver, getTimeZone } from './common';

--- a/packages/grafana-data/src/datetime/nano.test.ts
+++ b/packages/grafana-data/src/datetime/nano.test.ts
@@ -1,0 +1,84 @@
+import { isISONanoString, toISONanoString, fromISONanoString } from './nano';
+
+import { dateTime, ISO_8601 } from '.';
+
+describe('isISONanoString', () => {
+  it('should reject invalid strings', () => {
+    expect(isISONanoString('')).toBe(false);
+    expect(isISONanoString('haha')).toBe(false);
+    expect(isISONanoString('now')).toBe(false);
+    expect(isISONanoString('now-2h')).toBe(false);
+  });
+
+  it('should accept valid strings without a nanosecond part', () => {
+    expect(isISONanoString('2023-06-14T07:49:50.123Z')).toBe(true);
+    expect(isISONanoString('+232023-06-14T07:49:50.123Z')).toBe(true);
+    expect(isISONanoString('-232023-06-14T07:49:50.123Z')).toBe(true);
+  });
+  it('should accept valid strings with a nanosecond part', () => {
+    expect(isISONanoString('2023-06-14T07:49:50.123456789Z')).toBe(true);
+    expect(isISONanoString('+232023-06-14T07:49:50.123456789Z')).toBe(true);
+    expect(isISONanoString('-232023-06-14T07:49:50.123456789Z')).toBe(true);
+
+    expect(isISONanoString('2023-06-14T07:49:50.123000018Z')).toBe(true);
+    expect(isISONanoString('+232023-06-14T07:49:50.123000018Z')).toBe(true);
+    expect(isISONanoString('-232023-06-14T07:49:50.123000018Z')).toBe(true);
+  });
+});
+
+describe('toISONanoString', () => {
+  const test = (msText: string, nano: number, expected: string) =>
+    expect(toISONanoString(dateTime(msText, ISO_8601), nano)).toBe(expected);
+  it('should work with nanoseconds', () => {
+    test('2023-06-14T07:49:50.123Z', 456789, '2023-06-14T07:49:50.123456789Z');
+    test('+232023-06-14T07:49:50.123Z', 456789, '+232023-06-14T07:49:50.123456789Z');
+    test('-232023-06-14T07:49:50.123Z', 456789, '-232023-06-14T07:49:50.123456789Z');
+  });
+
+  it('should work with small nanosecond numbers', () => {
+    test('2023-06-14T07:49:50.123Z', 18, '2023-06-14T07:49:50.123000018Z');
+    test('+232023-06-14T07:49:50.123Z', 18, '+232023-06-14T07:49:50.123000018Z');
+    test('-232023-06-14T07:49:50.123Z', 18, '-232023-06-14T07:49:50.123000018Z');
+  });
+
+  it('should work without nanoseconds', () => {
+    test('2023-06-14T07:49:50.123Z', 0, '2023-06-14T07:49:50.123Z');
+    test('+232023-06-14T07:49:50.123Z', 0, '+232023-06-14T07:49:50.123Z');
+    test('-232023-06-14T07:49:50.123Z', 0, '-232023-06-14T07:49:50.123Z');
+  });
+});
+
+describe('fromISONanoString', () => {
+  const test = (text: string, expectedMsText: string, expectedNano: number) => {
+    const output = fromISONanoString(text);
+    expect(output).not.toBeNull();
+    if (output == null) {
+      // need to make typescript happy
+      throw new Error('should not happen');
+    }
+    expect(output[0].toISOString()).toBe(expectedMsText);
+    expect(output[1]).toBe(expectedNano);
+  };
+
+  it('should reject invalid strings', () => {
+    expect(fromISONanoString('haha')).toBeNull();
+  });
+
+  it('should work with nanoseconds', () => {
+    test('2023-06-14T07:49:50.123456789Z', '2023-06-14T07:49:50.123Z', 456789);
+    test('+232023-06-14T07:49:50.123456789Z', '+232023-06-14T07:49:50.123Z', 456789);
+    test('-232023-06-14T07:49:50.123456789Z', '-232023-06-14T07:49:50.123Z', 456789);
+  });
+
+  it('should work with small nanosecond numbers', () => {
+    test('2023-06-14T07:49:50.123000018Z', '2023-06-14T07:49:50.123Z', 18);
+    test('+232023-06-14T07:49:50.123000018Z', '+232023-06-14T07:49:50.123Z', 18);
+    test('-232023-06-14T07:49:50.123000018Z', '-232023-06-14T07:49:50.123Z', 18);
+  });
+
+  it('should work without nanoseconds', () => {
+    test('2023-06-14T07:49:50.123Z', '2023-06-14T07:49:50.123Z', 0);
+    test('+232023-06-14T07:49:50.123Z', '+232023-06-14T07:49:50.123Z', 0);
+    test('-232023-06-14T07:49:50.123Z', '-232023-06-14T07:49:50.123Z', 0);
+  });
+});

--- a/packages/grafana-data/src/datetime/nano.ts
+++ b/packages/grafana-data/src/datetime/nano.ts
@@ -1,0 +1,75 @@
+import { TimeRange } from '..';
+
+import { DateTime, dateTime, ISO_8601 } from './moment_wrapper';
+
+/**
+ * checks if the string is a valid data-iso-string, with an optional nanosecond-part.
+ * please note that the spec allows `new Date().toISOString()` to also return
+ * 6digit year-numbers, so we need to handle those too
+ * ( see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString )
+ */
+const ISO_NANO_REGEX = /^(?:\d{4}|(?:[+-]\d{6}))-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(?:\d{6})?Z$/;
+
+export function isISONanoString(value: string): boolean {
+  return ISO_NANO_REGEX.test(value);
+}
+
+/**
+ * Helper function to parse an iso-date-string that may contain a nanosecond-part
+ */
+export function fromISONanoString(value: string): [DateTime, number] | null {
+  // we assume the string is a valid iso-string, and check where the dot is.
+  if (value.at(-5) === '.') {
+    // no nanosecond part
+    return [dateTime(value, ISO_8601), 0];
+  }
+
+  if (value.at(-11) === '.') {
+    const mainPart = value.slice(0, -7);
+    const nanoPart = value.slice(-7, -1);
+    return [dateTime(mainPart + 'Z', ISO_8601), Number(nanoPart)];
+  }
+
+  // invalid iso string
+  return null;
+}
+
+/**
+ * Helper function to create an iso-date-string with a nanosecond-part
+ */
+export function toISONanoString(value: DateTime, nano: number): string {
+  // first we convert to a millisecond-precision iso-string,
+  // this always ends with `Thh:mm:ss.sssZ`
+  const isoValue = value.toISOString();
+  if (nano === 0) {
+    return isoValue;
+  }
+
+  const nanoText = nano.toString().padStart(6, '0');
+
+  return isoValue.slice(0, -1) + nanoText + 'Z';
+}
+
+export function createTimeRangeWithNano(from: DateTime, to: DateTime, fromNano: number, toNano: number): TimeRange {
+  if (fromNano === 0 && toNano === 0) {
+    return {
+      from,
+      to,
+      raw: {
+        from,
+        to,
+      },
+    };
+  }
+
+  return {
+    from,
+    to,
+    fromNano,
+    toNano,
+    raw: {
+      from: toISONanoString(from, fromNano),
+      to: toISONanoString(to, toNano),
+    },
+  };
+}

--- a/packages/grafana-data/src/types/time.ts
+++ b/packages/grafana-data/src/types/time.ts
@@ -14,7 +14,9 @@ export interface RawTimeRange {
 
 export interface TimeRange {
   from: DateTime;
+  fromNano?: number;
   to: DateTime;
+  toNano?: number;
   raw: RawTimeRange;
 }
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -189,6 +189,13 @@ class DataSourceWithBackend<
     if (range) {
       body.from = range.from.valueOf().toString();
       body.to = range.to.valueOf().toString();
+      const fromNano = range.fromNano ?? 0;
+      const toNano = range.toNano ?? 0;
+      if (fromNano !== 0 || toNano !== 0) {
+        body.from += fromNano.toString().padStart(6, '0');
+        body.to += toNano.toString().padStart(6, '0');
+        body.timeFormat = 'ns';
+      }
     }
 
     if (config.featureToggles.queryOverLive) {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -8,6 +8,7 @@ import {
   dateTimeParse,
   GrafanaTheme2,
   isDateTime,
+  isISONanoString,
   rangeUtil,
   RawTimeRange,
   TimeRange,
@@ -215,6 +216,10 @@ function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean
 
   if (dateMath.isMathString(value)) {
     return dateMath.isValid(value);
+  }
+
+  if (isISONanoString(value)) {
+    return true;
   }
 
   const parsed = dateTimeParse(value, { roundUp, timeZone });

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -66,7 +66,8 @@ type MetricRequest struct {
 	// To End time in epoch timestamps in milliseconds or relative using Grafana time units.
 	// required: true
 	// example: now
-	To string `json:"to"`
+	To         string `json:"to"`
+	TimeFormat string `json:"timeFormat"`
 	// queries.refId – Specifies an identifier of the query. Is optional and default to “A”.
 	// queries.datasourceId – Specifies the data source to be queried. Each query in the request must have an unique datasourceId.
 	// queries.maxDataPoints - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.

--- a/pkg/tsdb/testdatasource/testdata.go
+++ b/pkg/tsdb/testdatasource/testdata.go
@@ -2,6 +2,7 @@ package testdatasource
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -57,6 +58,9 @@ type Service struct {
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	r := req.Queries[0].TimeRange
+	fmt.Println("---------- from:", r.From)
+	fmt.Println("----------   to:", r.To)
 	return s.queryMux.QueryData(ctx, req)
 }
 

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -16,6 +16,7 @@ import {
   toDataFrame,
   MutableDataFrame,
   AnnotationQuery,
+  createTimeRangeWithNano,
 } from '@grafana/data';
 import { DataSourceWithBackend, getBackendSrv, getGrafanaLiveSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { getSearchFilterScopedVar } from 'app/features/variables/utils';
@@ -129,6 +130,7 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
     if (backendQueries.length) {
       const backendOpts = {
         ...options,
+        range: createTimeRangeWithNano(options.range.from, options.range.to, 123654, 123654),
         targets: backendQueries,
       };
       streams.push(super.query(backendOpts));


### PR DESCRIPTION
this is just a proof-of-concept of representing nanosecond-precision time-ranges in grafana.

the basic idea is that, while javascript's limitations on large integers does not allow us to represent nanosecond-precision time as a large integer (this is possible in `go`), we will keep the current millisecond-precision integer, and add a new field that contains the missing "precision" as a number between `0` and `999999`.

in short, it modifies the javascript `TimeRange` structure to be:
```ts
interface TimeRange {
   from: DateTime;
   fromNano?: number;
   to: DateTime;
   toNano?: number;
   raw: { ... }
 }
```
(we can store `raw.from` and `raw.to` as iso-strings-containing-nanoseconds)
and does a similar change to the json-body of the ajax-requests going to `/api/ds/query`.

this is just a proof of concept to make sure the idea can work, we modify the test-datasource so that when it sends a request, it is always shifted by `123654` nanoseconds, and reports these timestamps in the `go` code to the console.