### PR TITLE
AuthN: Fix render auth when clientTokenRotation is enabled

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -204,8 +204,10 @@ export class ContextSrv {
 
   // schedules a job to perform token ration in the background
   private scheduleTokenRotationJob() {
-    // only schedule job if feature toggle is enabled and user is signed in
-    if (config.featureToggles.clientTokenRotation && this.isSignedIn) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const isRenderRequest = !!urlParams.get('render');
+    // only schedule job if feature toggle is enabled, user is signed in and it's not a render request
+    if (config.featureToggles.clientTokenRotation && this.isSignedIn && !isRenderRequest) {
       // get the time token is going to expire
       let expires = this.getSessionExpiry();
 


### PR DESCRIPTION
**What is this feature?**
Modifies how the client token rotation functionality works on the frontend: the page does not schedule a token rotation job in case the request contains the `render` query string.

**Why do we need this feature?**
Without this Grafana Image Renderer is not working, because the token rotation job would fail when the renderer renders the html page.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
