### PR TITLE
Alerting: Fix panic in backtesting API when the testing interval is not times of evaluation interval

### DIFF
--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -26,10 +26,10 @@ var (
 	backtestingEvaluatorFactory = newBacktestingEvaluator
 )
 
-type callbackFunc = func(now time.Time, results eval.Results) error
+type callbackFunc = func(evaluationIndex int, now time.Time, results eval.Results) error
 
 type backtestingEvaluator interface {
-	Eval(ctx context.Context, from, to time.Time, interval time.Duration, callback callbackFunc) error
+	Eval(ctx context.Context, from time.Time, interval time.Duration, evaluations int, callback callbackFunc) error
 }
 
 type stateManager interface {
@@ -84,8 +84,11 @@ func (e *Engine) Test(ctx context.Context, user *user.SignedInUser, rule *models
 	tsField := data.NewField("Time", nil, make([]time.Time, length))
 	valueFields := make(map[string]*data.Field)
 
-	err = evaluator.Eval(ruleCtx, from, to, time.Duration(rule.IntervalSeconds)*time.Second, func(currentTime time.Time, results eval.Results) error {
-		idx := int(currentTime.Sub(from).Seconds()) / int(rule.IntervalSeconds)
+	err = evaluator.Eval(ruleCtx, from, time.Duration(rule.IntervalSeconds)*time.Second, length, func(idx int, currentTime time.Time, results eval.Results) error {
+		if idx >= length {
+			logger.Info("Unexpected evaluation. Skipping", "from", from, "to", to, "interval", rule.IntervalSeconds, "evaluationTime", currentTime, "evaluationIndex", idx, "expectedEvaluations", length)
+			return nil
+		}
 		states := stateManager.ProcessEvalResults(ruleCtx, currentTime, rule, results, nil)
 		tsField.Set(idx, currentTime)
 		for _, s := range states {
@@ -110,7 +113,7 @@ func (e *Engine) Test(ctx context.Context, user *user.SignedInUser, rule *models
 	for _, f := range valueFields {
 		fields = append(fields, f)
 	}
-	result := data.NewFrame("Backtesting results", fields...)
+	result := data.NewFrame("Testing results", fields...)
 
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/backtesting/engine_test.go
+++ b/pkg/services/ngalert/backtesting/engine_test.go
@@ -263,6 +263,36 @@ func TestEvaluatorTest(t *testing.T) {
 		})
 	})
 
+	t.Run("should not fail if 'to-from' is not times of interval", func(t *testing.T) {
+		from := time.Unix(0, 0)
+		to := from.Add(5 * ruleInterval)
+
+		states := []state.StateTransition{
+			{
+				State: &state.State{
+					CacheID:     "state-1",
+					Labels:      models.GenerateAlertLabels(rand.Intn(5)+1, "test-"),
+					State:       eval.Normal,
+					StateReason: util.GenerateShortUID(),
+				},
+			},
+		}
+
+		manager.stateCallback = func(now time.Time) []state.StateTransition {
+			return states
+		}
+
+		frame, err := engine.Test(context.Background(), nil, rule, from, to)
+		require.NoError(t, err)
+		expectedLen := frame.Rows()
+		for i := 0; i < 100; i++ {
+			jitter := time.Duration(rand.Int63n(ruleInterval.Milliseconds())) * time.Millisecond
+			frame, err = engine.Test(context.Background(), nil, rule, from, to.Add(jitter))
+			require.NoError(t, err)
+			require.Equalf(t, expectedLen, frame.Rows(), "jitter %v caused result to be different that base-line", jitter)
+		}
+	})
+
 	t.Run("should backfill field with nulls if a new dimension created in the middle", func(t *testing.T) {
 		from := time.Unix(0, 0)
 

--- a/pkg/services/ngalert/backtesting/engine_test.go
+++ b/pkg/services/ngalert/backtesting/engine_test.go
@@ -389,18 +389,16 @@ type fakeBacktestingEvaluator struct {
 	evalCallback func(now time.Time) (eval.Results, error)
 }
 
-func (f *fakeBacktestingEvaluator) Eval(_ context.Context, from, to time.Time, interval time.Duration, callback callbackFunc) error {
-	idx := 0
-	for now := from; now.Before(to); now = now.Add(interval) {
+func (f *fakeBacktestingEvaluator) Eval(_ context.Context, from time.Time, interval time.Duration, evaluations int, callback callbackFunc) error {
+	for idx, now := 0, from; idx < evaluations; idx, now = idx+1, now.Add(interval) {
 		results, err := f.evalCallback(now)
 		if err != nil {
 			return err
 		}
-		err = callback(now, results)
+		err = callback(idx, now, results)
 		if err != nil {
 			return err
 		}
-		idx++
 	}
 	return nil
 }

--- a/pkg/services/ngalert/backtesting/eval_data.go
+++ b/pkg/services/ngalert/backtesting/eval_data.go
@@ -37,10 +37,9 @@ func newDataEvaluator(refID string, frame *data.Frame) (*dataEvaluator, error) {
 	}, nil
 }
 
-func (d *dataEvaluator) Eval(_ context.Context, from, to time.Time, interval time.Duration, callback callbackFunc) error {
+func (d *dataEvaluator) Eval(_ context.Context, from time.Time, interval time.Duration, evaluations int, callback callbackFunc) error {
 	var resampled = make([]mathexp.Series, 0, len(d.data))
-
-	iterations := 0
+	to := from.Add(time.Duration(evaluations) * interval)
 	for _, s := range d.data {
 		// making sure the input data frame is aligned with the interval
 		r, err := s.Resample(d.refID, interval, d.downsampleFunction, d.upsampleFunction, from, to.Add(-interval)) // we want to query [from,to)
@@ -48,10 +47,9 @@ func (d *dataEvaluator) Eval(_ context.Context, from, to time.Time, interval tim
 			return err
 		}
 		resampled = append(resampled, r)
-		iterations = r.Len()
 	}
 
-	for i := 0; i < iterations; i++ {
+	for i := 0; i < evaluations; i++ {
 		result := make([]eval.Result, 0, len(resampled))
 		var now time.Time
 		for _, series := range resampled {
@@ -87,7 +85,7 @@ func (d *dataEvaluator) Eval(_ context.Context, from, to time.Time, interval tim
 				EvaluatedAt: now,
 			})
 		}
-		err := callback(now, result)
+		err := callback(i, now, result)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/backtesting/eval_data_test.go
+++ b/pkg/services/ngalert/backtesting/eval_data_test.go
@@ -96,11 +96,11 @@ func TestDataEvaluator_Eval(t *testing.T) {
 	t.Run("should use data points when frame resolution matches evaluation interval", func(t *testing.T) {
 		r := make([]results, 0, frame.Rows())
 
-		invterval := time.Second
+		interval := time.Second
 
-		resultsCount := int(to.Sub(from).Seconds() / invterval.Seconds())
+		resultsCount := int(to.Sub(from).Seconds() / interval.Seconds())
 
-		err = evaluator.Eval(context.Background(), from, to, time.Second, func(now time.Time, res eval.Results) error {
+		err = evaluator.Eval(context.Background(), from, time.Second, resultsCount, func(idx int, now time.Time, res eval.Results) error {
 			r = append(r, results{
 				now, res,
 			})
@@ -164,7 +164,7 @@ func TestDataEvaluator_Eval(t *testing.T) {
 			size := to.Sub(from).Milliseconds() / interval.Milliseconds()
 			r := make([]results, 0, size)
 
-			err = evaluator.Eval(context.Background(), from, to, interval, func(now time.Time, res eval.Results) error {
+			err = evaluator.Eval(context.Background(), from, interval, int(size), func(idx int, now time.Time, res eval.Results) error {
 				r = append(r, results{
 					now, res,
 				})
@@ -195,7 +195,7 @@ func TestDataEvaluator_Eval(t *testing.T) {
 			size := int(to.Sub(from).Seconds() / interval.Seconds())
 			r := make([]results, 0, size)
 
-			err = evaluator.Eval(context.Background(), from, to, interval, func(now time.Time, res eval.Results) error {
+			err = evaluator.Eval(context.Background(), from, interval, size, func(idx int, now time.Time, res eval.Results) error {
 				r = append(r, results{
 					now, res,
 				})
@@ -230,7 +230,7 @@ func TestDataEvaluator_Eval(t *testing.T) {
 		t.Run("should be noData until the frame interval", func(t *testing.T) {
 			newFrom := from.Add(-10 * time.Second)
 			r := make([]results, 0, int(to.Sub(newFrom).Seconds()))
-			err = evaluator.Eval(context.Background(), newFrom, to, time.Second, func(now time.Time, res eval.Results) error {
+			err = evaluator.Eval(context.Background(), newFrom, time.Second, cap(r), func(idx int, now time.Time, res eval.Results) error {
 				r = append(r, results{
 					now, res,
 				})
@@ -258,7 +258,7 @@ func TestDataEvaluator_Eval(t *testing.T) {
 		t.Run("should be the last value after the frame interval", func(t *testing.T) {
 			newTo := to.Add(10 * time.Second)
 			r := make([]results, 0, int(newTo.Sub(from).Seconds()))
-			err = evaluator.Eval(context.Background(), from, newTo, time.Second, func(now time.Time, res eval.Results) error {
+			err = evaluator.Eval(context.Background(), from, time.Second, cap(r), func(idx int, now time.Time, res eval.Results) error {
 				r = append(r, results{
 					now, res,
 				})
@@ -282,12 +282,10 @@ func TestDataEvaluator_Eval(t *testing.T) {
 	})
 	t.Run("should stop if callback error", func(t *testing.T) {
 		expectedError := errors.New("error")
-		evals := 0
-		err = evaluator.Eval(context.Background(), from, to, time.Second, func(now time.Time, res eval.Results) error {
-			if evals > 5 {
+		err = evaluator.Eval(context.Background(), from, time.Second, 6, func(idx int, now time.Time, res eval.Results) error {
+			if idx == 5 {
 				return expectedError
 			}
-			evals++
 			return nil
 		})
 		require.ErrorIs(t, err, expectedError)

--- a/pkg/services/ngalert/backtesting/eval_query.go
+++ b/pkg/services/ngalert/backtesting/eval_query.go
@@ -12,13 +12,13 @@ type queryEvaluator struct {
 	eval eval.ConditionEvaluator
 }
 
-func (d *queryEvaluator) Eval(ctx context.Context, from, to time.Time, interval time.Duration, callback callbackFunc) error {
-	for now := from; now.Before(to); now = now.Add(interval) {
+func (d *queryEvaluator) Eval(ctx context.Context, from time.Time, interval time.Duration, evaluations int, callback callbackFunc) error {
+	for idx, now := 0, from; idx < evaluations; idx, now = idx+1, now.Add(interval) {
 		results, err := d.eval.Evaluate(ctx, now)
 		if err != nil {
 			return err
 		}
-		err = callback(now, results)
+		err = callback(idx, now, results)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/backtesting/eval_query_test.go
+++ b/pkg/services/ngalert/backtesting/eval_query_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -18,8 +19,7 @@ func TestQueryEvaluator_Eval(t *testing.T) {
 	ctx := context.Background()
 	interval := time.Duration(rand.Int63n(9)+1) * time.Second
 	times := rand.Intn(11) + 5
-	to := time.Now()
-	from := to.Add(-time.Duration(times) * interval)
+	from := time.Now().Add(-time.Duration(times) * interval)
 
 	t.Run("should evaluate query", func(t *testing.T) {
 		m := &eval_mocks.ConditionEvaluatorMock{}
@@ -29,15 +29,20 @@ func TestQueryEvaluator_Eval(t *testing.T) {
 			eval: m,
 		}
 
-		intervals := make([]time.Time, 0, times)
+		intervals := make([]time.Time, times)
 
-		err := evaluator.Eval(ctx, from, to, interval, func(now time.Time, results eval.Results) error {
-			intervals = append(intervals, now)
+		err := evaluator.Eval(ctx, from, interval, times, func(idx int, now time.Time, results eval.Results) error {
+			intervals[idx] = now
 			return nil
 		})
 		require.NoError(t, err)
 		require.Len(t, intervals, times)
 
+		expected := from
+		for idx, actual := range intervals {
+			assert.Equalf(t, expected, actual, "item at index %d is not times of interval %v", idx, interval)
+			expected = expected.Add(interval)
+		}
 		m.AssertNumberOfCalls(t, "Evaluate", times)
 		for _, now := range intervals {
 			m.AssertCalled(t, "Evaluate", ctx, now)
@@ -57,7 +62,7 @@ func TestQueryEvaluator_Eval(t *testing.T) {
 
 			intervals := make([]time.Time, 0, times)
 
-			err := evaluator.Eval(ctx, from, to, interval, func(now time.Time, results eval.Results) error {
+			err := evaluator.Eval(ctx, from, interval, times, func(idx int, now time.Time, results eval.Results) error {
 				intervals = append(intervals, now)
 				return nil
 			})
@@ -76,7 +81,7 @@ func TestQueryEvaluator_Eval(t *testing.T) {
 
 			intervals := make([]time.Time, 0, times)
 
-			err := evaluator.Eval(ctx, from, to, interval, func(now time.Time, results eval.Results) error {
+			err := evaluator.Eval(ctx, from, interval, times, func(idx int, now time.Time, results eval.Results) error {
 				if len(intervals) > 3 {
 					return expectedError
 				}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR fixes a panic when backtesting API is called with a range that is not exactly times of intervals. 
For example, `from=10, to = 53, interval=10`

**Why do we need this feature?**
Fix panic
```
"error": "runtime error: index out of range [60] with length 60 - /opt/homebrew/Cellar/go/1.20.1/libexec/src/runtime/panic.go:113 (0x100e92ee7)\n\tgoPanicIndex: panic(boundsError{x: int64(x), signed: true, y: y, code: boundsIndex})\n/Users/soniaaguilarpeiron/go/pkg/mod/github.com/grafana/grafana-plugin-sdk-go@v0.160.0/data/vector.gen.go:890 (0x10133d033)\n\t(*timeTimeVector).Set: (*v)[idx] = i.(time.Time)\n/Users/soniaaguilarpeiron/go/pkg/mod/github.com/grafana/grafana-plugin-sdk-go@v0.160.0/data/field.go:145 (0x102d4a3bb)\n\t(*Field).Set: f.vector.Set(idx, val)\n/Users/soniaaguilarpeiron/Documents/projects/grafana/pkg/services/ngalert/backtesting/engine.go:90 (0x102d4a374)\n\t(*Engine).Test.func1: tsField.Set(idx, 
...
```


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/grafana/pull/57318 and https://github.com/grafana/grafana/issues/68615

**Special notes for your reviewer:**
To test this change you need to enable the feature flag `alertingBacktesting`

<details><summary>Example request</summary>

Replace `PD8C576611E62080A` with UID of `gdev-testdata` data source.

```json
{
    "annotations": {
        "additionalProp1": "string",
        "additionalProp2": "string",
        "additionalProp3": "string"
    },
    "condition": "C",
    "data": [
        {
            "refId": "A",
            "relativeTimeRange": {
                "from": 600,
                "to": 0
            },
            "queryType": "",
            "datasourceUid": "PD8C576611E62080A",
            "model": {
                "refId": "A",
                "hide": false,
                "datasource": {
                    "type": "testdata",
                    "uid": "PD8C576611E62080A"
                },
                "scenarioId": "random_walk",
                "seriesCount": 5,
                "labels": "series=series-$seriesIndex"
            }
        },
        {
            "refId": "B",
            "datasourceUid": "__expr__",
            "queryType": "",
            "model": {
                "refId": "B",
                "hide": false,
                "type": "reduce",
                "datasource": {
                    "uid": "__expr__",
                    "type": "__expr__"
                },
                "reducer": "last",
                "expression": "A"
            },
            "relativeTimeRange": {
                "from": 600,
                "to": 0
            }
        },
        {
            "refId": "C",
            "datasourceUid": "__expr__",
            "queryType": "",
            "model": {
                "refId": "C",
                "hide": false,
                "type": "threshold",
                "datasource": {
                    "uid": "__expr__",
                    "type": "__expr__"
                },
                "conditions": [
                    {
                        "type": "query",
                        "evaluator": {
                            "params": [
                                0
                            ],
                            "type": "gt"
                        }
                    }
                ],
                "expression": "B"
            },
            "relativeTimeRange": {
                "from": 600,
                "to": 0
            }
        }
    ],
    "for": "0s",
    "from": "2023-05-18T07:53:11.136Z",
    "to": "2023-05-18T08:03:12.136Z",
    "interval": "10s",
    "labels": {
        "additionalProp1": "string",
        "additionalProp2": "string",
        "additionalProp3": "string"
    },
    "no_data_state": "Alerting",
    "title": "string"
}
```
</details>


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
