### PR TITLE
Elasticsearch: Remove unused date_histogram aggregation in logs query

### DIFF
--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -338,21 +338,21 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 		b.AddSearchAfter(value)
 	}
 
-	// For log query, we add a date histogram aggregation
-	aggBuilder := b.Agg()
-	q.BucketAggs = append(q.BucketAggs, &BucketAgg{
-		Type:  dateHistType,
-		Field: defaultTimeField,
-		ID:    "1",
-		Settings: simplejson.NewFromAny(map[string]interface{}{
-			"interval": "auto",
-		}),
-	})
-	bucketAgg := q.BucketAggs[0]
-	bucketAgg.Settings = simplejson.NewFromAny(
-		bucketAgg.generateSettingsForDSL(),
-	)
-	_ = addDateHistogramAgg(aggBuilder, bucketAgg, from, to, defaultTimeField)
+	// // For log query, we add a date histogram aggregation
+	// aggBuilder := b.Agg()
+	// q.BucketAggs = append(q.BucketAggs, &BucketAgg{
+	// 	Type:  dateHistType,
+	// 	Field: defaultTimeField,
+	// 	ID:    "1",
+	// 	Settings: simplejson.NewFromAny(map[string]interface{}{
+	// 		"interval": "auto",
+	// 	}),
+	// })
+	// bucketAgg := q.BucketAggs[0]
+	// bucketAgg.Settings = simplejson.NewFromAny(
+	// 	bucketAgg.generateSettingsForDSL(),
+	// )
+	// _ = addDateHistogramAgg(aggBuilder, bucketAgg, from, to, defaultTimeField)
 }
 
 func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defaultTimeField string) {

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1313,18 +1313,6 @@ func TestExecuteElasticsearchDataQuery(t *testing.T) {
 			require.Equal(t, sr.Sort["@timestamp"], map[string]string{"order": "desc", "unmapped_type": "boolean"})
 			require.Equal(t, sr.Sort["_doc"], map[string]string{"order": "desc"})
 			require.Equal(t, sr.CustomProps["script_fields"], map[string]interface{}{})
-
-			firstLevel := sr.Aggs[0]
-			require.Equal(t, firstLevel.Key, "1")
-			require.Equal(t, firstLevel.Aggregation.Type, "date_histogram")
-
-			hAgg := firstLevel.Aggregation.Aggregation.(*es.DateHistogramAgg)
-			require.Equal(t, hAgg.ExtendedBounds.Max, toMs)
-			require.Equal(t, hAgg.ExtendedBounds.Min, fromMs)
-			require.Equal(t, hAgg.Field, "@timestamp")
-			require.Equal(t, hAgg.Format, es.DateFormatEpochMS)
-			require.Equal(t, hAgg.FixedInterval, "$__interval_msms")
-			require.Equal(t, hAgg.MinDocCount, 0)
 		})
 
 		t.Run("With log query with limit should return query with correct size", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
@@ -27,21 +27,6 @@
         "order": "desc"
       }
     },
-  "aggs": 
-    {
-      "1": {
-        "date_histogram": {
-          "field": "testtime",
-          "fixed_interval": "1000ms",
-          "format": "epoch_millis",
-          "min_doc_count": 0,
-          "extended_bounds": {
-            "min": 1668422437218,
-            "max": 1668422625668
-          }
-        }
-      }
-    },
   "highlight": 
     {
       "pre_tags": [


### PR DESCRIPTION
Fixes #68734.

I run the following tests:

- `go test -v ./pkg/...` (successful)
- `yarn test` (successful)

I did not find `e2e` tests for the elasticsearch plugin, but I may have missed them.
