### PR TITLE
RBAC: Remove legacy AC editor and admin role on new dashboard route

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -46,7 +46,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/dashboard/new',
-      roles: () => contextSrv.evaluatePermission(() => ['Editor', 'Admin'], [AccessControlAction.DashboardsCreate]),
+      roles: () => contextSrv.evaluatePermission(() => [], [AccessControlAction.DashboardsCreate]),
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.New,
       component: SafeDynamicImport(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
- removes the orgroles on new dashboard route for legacy AC


**Why do we need this feature?**
When RBAC is disabled and you grant a edit permission for viewers in a folder. they are unable to create a new dashboard as it is protected by the orgRoles 'Editor', 'Admin'. This removes this constraints

This allows viewers, even without dashboard permissions, to access the routes. It would enable them to create dashboards but not save them thx to the permissions on the backend.

**Who is this feature for?**
Azuregrafanasupport

**Which issue(s) does this PR fix?**:
