### PR TITLE
Graph: Fix bug with showing/hiding the legend

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -136,9 +136,14 @@ class GraphElement {
 
     if (!this.panel.legend.show) {
       if (this.legendElem.hasChildNodes()) {
-        this.legendElemRoot.unmount();
+        this.legendElemRoot.render(null);
       }
-      this.renderPanel();
+      // we need to wait for react to finish rendering before we can render the legend
+      // this is a slightly worse version of the `renderCallback` logic we use below
+      // the problem here is we can't pass a `renderCallback` since we don't want to render the legend at all.
+      setTimeout(() => {
+        this.renderPanel();
+      });
       return;
     }
 

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -138,9 +138,9 @@ class GraphElement {
       if (this.legendElem.hasChildNodes()) {
         this.legendElemRoot.render(null);
       }
-      // we need to wait for react to finish rendering before we can render the legend
+      // we need to wait for react to finish rendering the legend before we can render the graph
       // this is a slightly worse version of the `renderCallback` logic we use below
-      // the problem here is we can't pass a `renderCallback` since we don't want to render the legend at all.
+      // the problem here is there's nothing to pass a `renderCallback` to since we don't want to render the legend at all.
       setTimeout(() => {
         this.renderPanel();
       });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Fixes a bug with showing/hiding the legend
- graph is an angular component. legend is a react component.
- we can only render graph **after** legend is rendered, else we end up with bugs like https://github.com/grafana/grafana/pull/67912
- when rendering both, the legend component is passed a callback to render the entire panel. this ensures that the legend renders **then** the graph renders
- when hiding the legend, there is nothing to pass a render callback to 😅 
- previously we were unmounting the whole react root. but then we have to track whether it's been unmounted and needs recreating. 
- instead, let's only unmount the react root `onPanelTeardown` and render `null` when hiding the legend
- this works and the legend is hidden correctly, **but** we're left with a bug where it won't update the graph positioning unless another render happens. 
- so we wrap `renderPanel` in a `setTimeout` to ensure it happens on the next cycle of the event loop after react has finished rendering. 
- obviously this isn't very good but it is basically what's happening on every render when the legend is showing 🤷 
  
**Why do we need this feature?**

- so people can show/hide the legend without having to refresh the page 😬 

**Who is this feature for?**

- anyone still using graph 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/68735

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
