### PR TITLE
CI: Run `trigger-test-release` only on PRs against main

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -535,6 +535,7 @@ steps:
   image: grafana/build-container:1.7.4
   name: trigger-test-release
   when:
+    branch: main
     paths:
       include:
       - .drone.yml
@@ -7109,6 +7110,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 28926d32b4ccd19d11c3e3840598c480fb22f1ff1456387c27f3794e3592b006
+hmac: b672e3a75c9e262486985d34c31c246dd5dfb291324c53b99588a3da5f92abf5
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1618,6 +1618,7 @@ def trigger_test_release():
             "repo": [
                 "grafana/grafana",
             ],
+            "branch": "main",
         },
     }
 


### PR DESCRIPTION
**What is this feature?**

Runs `trigger-test-release` only on PRs against main. `v0.0.0-test` release builds are all over the place now since they also get triggered from versioned branches. Now that `9.2-10.x` are in sync we only actually need to test main.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
