### PR TITLE
docs/serviceaccount.md - Incorrect key "role" for creating token

### DIFF
--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -106,7 +106,7 @@ Authorization: Basic YWRtaW46YWRtaW4=
 {
   "name": "grafana",
   "role": "Viewer",
-  "isDisabled" : false
+  "isDisabled": false
 }
 ```
 
@@ -280,8 +280,7 @@ Content-Type: application/json
 Authorization: Basic YWRtaW46YWRtaW4=
 
 {
-	"name": "grafana",
-	"role": "Viewer"
+	"name": "grafana"
 }
 ```
 


### PR DESCRIPTION
The key "role" in the JSON body doesn't make sense for creating service account *tokens* (and the method will happily create one without it). It is only required for creating the service account itself.