### PR TITLE
[v9.3.x] CI: Run `trigger-test-release` only on PRs against main (#68794)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -533,6 +533,7 @@ steps:
   image: grafana/build-container:1.7.4
   name: trigger-test-release
   when:
+    branch: main
     paths:
       include:
       - .drone.yml
@@ -6640,6 +6641,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 2bc7c889ac03617cb607b99b5416c559a952895a98e96900d25d254cfe20c03f
+hmac: f8b6fd63a00f5913cc21eb38767da2d3990496b574d66569584e051e51e985f4
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1608,6 +1608,7 @@ def trigger_test_release():
             "repo": [
                 "grafana/grafana",
             ],
+            "branch": "main",
         },
     }
 


### PR DESCRIPTION
Run trigger-test-release only on PRs against main

(cherry picked from commit 623c014cda01146df43fdadd525e8e3b3c6d9fcd)

# Conflicts:
#	.drone.yml

Backports #68794