### PR TITLE
[v9.5.x] CI: Run `trigger-test-release` only on PRs against main (#68794)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -533,6 +533,7 @@ steps:
   image: grafana/build-container:1.7.4
   name: trigger-test-release
   when:
+    branch: main
     paths:
       include:
       - .drone.yml
@@ -6640,6 +6641,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 05af55208c21568bbc1acad4b92bb0303f376b09424632465a33a33c628e751e
+hmac: 541233e1209bc0f77b276f22f97e9b79bc8300d80f03e617ab78558ffdf78a6c
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1608,6 +1608,7 @@ def trigger_test_release():
             "repo": [
                 "grafana/grafana",
             ],
+            "branch": "main",
         },
     }
 


### PR DESCRIPTION
Run trigger-test-release only on PRs against main

(cherry picked from commit 623c014cda01146df43fdadd525e8e3b3c6d9fcd)

# Conflicts:
#	.drone.yml

Backports #68794