### PR TITLE
[v10.0.x] CI: Run `trigger-test-release` only on PRs against main (#68794)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -535,6 +535,7 @@ steps:
   image: grafana/build-container:1.7.4
   name: trigger-test-release
   when:
+    branch: main
     paths:
       include:
       - .drone.yml
@@ -6777,6 +6778,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 6570f22f8d434e2908fb5ed9da778ebdadff1f2a038d1f09d97010522581c848
+hmac: ed191338009351d2bbedc1c00a176b2ef26314420166baaa93527d4e87b00aef
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1618,6 +1618,7 @@ def trigger_test_release():
             "repo": [
                 "grafana/grafana",
             ],
+            "branch": "main",
         },
     }
 


### PR DESCRIPTION
Run trigger-test-release only on PRs against main

(cherry picked from commit 623c014cda01146df43fdadd525e8e3b3c6d9fcd)

# Conflicts:
#	.drone.yml

Backports #68794