### PR TITLE
[v9.2.x] CI: Run `trigger-test-release` only on PRs against main (#68794)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -516,6 +516,7 @@ steps:
   image: grafana/build-container:1.7.4
   name: trigger-test-release
   when:
+    branch: main
     paths:
       include:
       - .drone.yml
@@ -6504,6 +6505,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 462fc8e153052bdb786a26a31e1f5884cf9ad55999da14e7f5db315568c7f882
+hmac: 5d9d1b858347f4565eb9e6fc5f53cac8dec18048824cfc851cdc4c334ef23c9a
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1596,6 +1596,7 @@ def trigger_test_release():
             "repo": [
                 "grafana/grafana",
             ],
+            "branch": "main",
         },
     }
 


### PR DESCRIPTION
Run trigger-test-release only on PRs against main

(cherry picked from commit 623c014cda01146df43fdadd525e8e3b3c6d9fcd)

# Conflicts:
#	.drone.yml

Backports #68794