### PR TITLE
Chore: remove `UserIDFilter` from team queries

### DIFF
--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -169,17 +168,6 @@ func (hs *HTTPServer) SearchTeams(c *contextmodel.ReqContext) response.Response 
 	queryResult.PerPage = perPage
 
 	return response.JSON(http.StatusOK, queryResult)
-}
-
-// UserFilter returns the user ID used in a filter when querying a team
-// 1. If the user is a viewer or editor, this will return the user's ID.
-// 2. If the user is an admin, this will return models.FilterIgnoreUser (0)
-func userFilter(c *contextmodel.ReqContext) int64 {
-	userIdFilter := c.SignedInUser.UserID
-	if c.OrgRole == org.RoleAdmin {
-		userIdFilter = team.FilterIgnoreUser
-	}
-	return userIdFilter
 }
 
 // swagger:route GET /teams/{team_id} teams getTeamByID

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -137,17 +137,10 @@ func (hs *HTTPServer) SearchTeams(c *contextmodel.ReqContext) response.Response 
 		page = 1
 	}
 
-	// Using accesscontrol the filtering is done based on user permissions
-	userIDFilter := team.FilterIgnoreUser
-	if hs.AccessControl.IsDisabled() {
-		userIDFilter = userFilter(c)
-	}
-
 	query := team.SearchTeamsQuery{
 		OrgID:        c.OrgID,
 		Query:        c.Query("query"),
 		Name:         c.Query("name"),
-		UserIDFilter: userIDFilter,
 		Page:         page,
 		Limit:        perPage,
 		SignedInUser: c.SignedInUser,
@@ -205,18 +198,11 @@ func (hs *HTTPServer) GetTeamByID(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusBadRequest, "teamId is invalid", err)
 	}
 
-	// Using accesscontrol the filtering has already been performed at middleware layer
-	userIdFilter := team.FilterIgnoreUser
-	if hs.AccessControl.IsDisabled() {
-		userIdFilter = userFilter(c)
-	}
-
 	query := team.GetTeamByIDQuery{
 		OrgID:        c.OrgID,
 		ID:           teamId,
 		SignedInUser: c.SignedInUser,
 		HiddenUsers:  hs.Cfg.HiddenUsers,
-		UserIdFilter: userIdFilter,
 	}
 
 	queryResult, err := hs.teamService.GetTeamByID(c.Req.Context(), &query)

--- a/pkg/api/team_members_test.go
+++ b/pkg/api/team_members_test.go
@@ -1,9 +1,6 @@
 package api
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -11,116 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
-	"github.com/grafana/grafana/pkg/services/licensing"
-	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/org/orgimpl"
-	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
-	"github.com/grafana/grafana/pkg/services/team"
-	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/team/teamtest"
-	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
-
-type TeamGuardianMock struct {
-	result error
-}
-
-func (t *TeamGuardianMock) CanAdmin(ctx context.Context, orgId int64, teamId int64, user *user.SignedInUser) error {
-	return t.result
-}
-
-func (t *TeamGuardianMock) DeleteByUser(ctx context.Context, userID int64) error {
-	return t.result
-}
-
-func setUpGetTeamMembersHandler(t *testing.T, sqlStore *sqlstore.SQLStore) {
-	const testOrgID int64 = 1
-	var userCmd user.CreateUserCommand
-	teamSvc := teamimpl.ProvideService(sqlStore, setting.NewCfg())
-	team, err := teamSvc.CreateTeam("group1 name", "test1@test.com", testOrgID)
-	require.NoError(t, err)
-	quotaService := quotaimpl.ProvideService(sqlStore, sqlStore.Cfg)
-	orgService, err := orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotaService)
-	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(sqlStore, orgService, sqlStore.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
-	require.NoError(t, err)
-
-	for i := 0; i < 3; i++ {
-		userCmd = user.CreateUserCommand{
-			Email: fmt.Sprint("user", i, "@test.com"),
-			Name:  fmt.Sprint("user", i),
-			Login: fmt.Sprint("loginuser", i),
-		}
-		// user
-		user, err := usrSvc.Create(context.Background(), &userCmd)
-		require.NoError(t, err)
-		err = teamSvc.AddTeamMember(user.ID, testOrgID, team.ID, false, 1)
-		require.NoError(t, err)
-	}
-}
-
-func TestTeamMembersAPIEndpoint_userLoggedIn(t *testing.T) {
-	hs := setupSimpleHTTPServer(nil)
-	settings := hs.Cfg
-	sqlStore := db.InitTestDB(t)
-	sqlStore.Cfg = settings
-
-	hs.SQLStore = sqlStore
-	hs.teamService = teamimpl.ProvideService(sqlStore, settings)
-	hs.License = &licensing.OSSLicensingService{}
-	hs.teamGuardian = &TeamGuardianMock{}
-	mock := dbtest.NewFakeDB()
-
-	loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "api/teams/1/members",
-		"api/teams/:teamId/members", org.RoleAdmin, func(sc *scenarioContext) {
-			setUpGetTeamMembersHandler(t, sqlStore)
-
-			sc.handlerFunc = hs.GetTeamMembers
-			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
-
-			require.Equal(t, http.StatusOK, sc.resp.Code)
-
-			var resp []team.TeamMemberDTO
-			err := json.Unmarshal(sc.resp.Body.Bytes(), &resp)
-			require.NoError(t, err)
-			assert.Len(t, resp, 3)
-		}, mock)
-
-	t.Run("Given there is two hidden users", func(t *testing.T) {
-		settings.HiddenUsers = map[string]struct{}{
-			"user1":       {},
-			testUserLogin: {},
-		}
-		t.Cleanup(func() { settings.HiddenUsers = make(map[string]struct{}) })
-
-		loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "api/teams/1/members",
-			"api/teams/:teamId/members", org.RoleAdmin, func(sc *scenarioContext) {
-				setUpGetTeamMembersHandler(t, sqlStore)
-
-				sc.handlerFunc = hs.GetTeamMembers
-				sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
-
-				require.Equal(t, http.StatusOK, sc.resp.Code)
-
-				var resp []team.TeamMemberDTO
-				err := json.Unmarshal(sc.resp.Body.Bytes(), &resp)
-				require.NoError(t, err)
-				assert.Len(t, resp, 3)
-				assert.Equal(t, "loginuser0", resp[0].Login)
-				assert.Equal(t, "loginuser1", resp[1].Login)
-				assert.Equal(t, "loginuser2", resp[2].Login)
-			}, mock)
-	})
-}
 
 func TestAddTeamMembersAPIEndpoint(t *testing.T) {
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login"
@@ -41,10 +42,11 @@ import (
 func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
+	sqlStore.Cfg = settings
 	hs := &HTTPServer{
 		Cfg:           settings,
 		SQLStore:      sqlStore,
-		AccessControl: acmock.New(),
+		AccessControl: acimpl.ProvideAccessControl(settings),
 	}
 
 	mockResult := user.SearchUserQueryResult{
@@ -56,6 +58,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	}
 	mock := dbtest.NewFakeDB()
 	userMock := usertest.NewUserServiceFake()
+
 	loggedInUserScenario(t, "When calling GET on", "api/users/1", "api/users/:id", func(sc *scenarioContext) {
 		fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
 		secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
@@ -67,6 +70,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		)
 		hs.authInfoService = srv
 		orgSvc, err := orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotatest.New(false, nil))
+		require.NoError(t, err)
 		require.NoError(t, err)
 		userSvc, err := userimpl.ProvideService(sqlStore, orgSvc, sc.cfg, nil, nil, quotatest.New(false, nil), supportbundlestest.NewFakeBundleService())
 		require.NoError(t, err)

--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -58,7 +58,6 @@ type GetTeamByIDQuery struct {
 	ID           int64
 	SignedInUser *user.SignedInUser
 	HiddenUsers  map[string]struct{}
-	UserIdFilter int64
 }
 
 // FilterIgnoreUser is used in a get / search teams query when the caller does not want to filter teams by user ID / membership
@@ -76,7 +75,6 @@ type SearchTeamsQuery struct {
 	Limit        int
 	Page         int
 	OrgID        int64 `xorm:"org_id"`
-	UserIDFilter int64 `xorm:"user_id_filter"`
 	SignedInUser *user.SignedInUser
 	HiddenUsers  map[string]struct{}
 }

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -420,9 +420,9 @@ func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	type searchTeamsTestCase struct {
-		desc             string
-		query            *team.SearchTeamsQuery
-		expectedNumUsers int
+		desc              string
+		query             *team.SearchTeamsQuery
+		expectedTeamCount int
 	}
 
 	tests := []searchTeamsTestCase{
@@ -435,7 +435,7 @@ func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 					Permissions: map[int64]map[string][]string{1: {ac.ActionTeamsRead: {ac.ScopeTeamsAll}}},
 				},
 			},
-			expectedNumUsers: 10,
+			expectedTeamCount: 10,
 		},
 		{
 			desc: "should return no teams",
@@ -446,7 +446,7 @@ func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 					Permissions: map[int64]map[string][]string{1: {ac.ActionTeamsRead: {""}}},
 				},
 			},
-			expectedNumUsers: 0,
+			expectedTeamCount: 0,
 		},
 		{
 			desc: "should return some teams",
@@ -461,7 +461,7 @@ func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 					}}},
 				},
 			},
-			expectedNumUsers: 3,
+			expectedTeamCount: 3,
 		},
 	}
 
@@ -478,8 +478,8 @@ func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			queryResult, err := teamSvc.SearchTeams(context.Background(), tt.query)
 			require.NoError(t, err)
-			assert.Len(t, queryResult.Teams, tt.expectedNumUsers)
-			assert.Equal(t, queryResult.TotalCount, int64(tt.expectedNumUsers))
+			assert.Len(t, queryResult.Teams, tt.expectedTeamCount)
+			assert.Equal(t, queryResult.TotalCount, int64(tt.expectedTeamCount))
 
 			if !hasWildcardScope(tt.query.SignedInUser, ac.ActionTeamsRead) {
 				for _, team := range queryResult.Teams {

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -369,13 +369,6 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				team1 := searchQueryResult.Teams[0]
 				require.EqualValues(t, team1.MemberCount, 2)
 
-				searchQueryFilteredByUser := &team.SearchTeamsQuery{OrgID: testOrgID, Page: 1, Limit: 10, UserIDFilter: userIds[0], SignedInUser: signedInUser, HiddenUsers: hiddenUsers}
-				searchQueryFilteredByUserResult, err := teamSvc.SearchTeams(context.Background(), searchQueryFilteredByUser)
-				require.NoError(t, err)
-				require.Equal(t, len(searchQueryFilteredByUserResult.Teams), 1)
-				team1 = searchQueryResult.Teams[0]
-				require.EqualValues(t, team1.MemberCount, 2)
-
 				getTeamQuery := &team.GetTeamByIDQuery{OrgID: testOrgID, ID: teamId, SignedInUser: signedInUser, HiddenUsers: hiddenUsers}
 				getTeamQueryResult, err := teamSvc.GetTeamByID(context.Background(), getTeamQuery)
 				require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Part 2 of cleaning up legacy access control for teams. This PR removes `UserIDFilter` from queries. `UserIDFilter` was used to only show teams that the user is a member of (unless the user is org admin). This has now been replaced by RBAC SQL filtering, and is redundant.

**Why do we need this feature?**

With Grafana 10 RBAC can't be disabled anymore, so we can start cleaning up legacy AC code.
