### PR TITLE
Tracing: Rename reset to clear for consistency

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.test.tsx
@@ -40,7 +40,7 @@ describe('<NewTracePageSearchBar>', () => {
       setShowSpanFilterMatchesOnly: jest.fn(),
       setFocusedSpanIdForSearch: jest.fn(),
       datasourceType: '',
-      reset: jest.fn(),
+      clear: jest.fn(),
       totalSpans: 100,
     };
 
@@ -55,13 +55,13 @@ describe('<NewTracePageSearchBar>', () => {
     render(<NewTracePageSearchBarWithProps matches={[]} />);
     const nextResButton = screen.queryByRole('button', { name: 'Next result button' });
     const prevResButton = screen.queryByRole('button', { name: 'Prev result button' });
-    const resetFiltersButton = screen.getByRole('button', { name: 'Reset filters button' });
+    const clearFiltersButton = screen.getByRole('button', { name: 'Clear filters button' });
     expect(nextResButton).toBeInTheDocument();
     expect(prevResButton).toBeInTheDocument();
-    expect(resetFiltersButton).toBeInTheDocument();
+    expect(clearFiltersButton).toBeInTheDocument();
     expect((nextResButton as HTMLButtonElement)['disabled']).toBe(true);
     expect((prevResButton as HTMLButtonElement)['disabled']).toBe(true);
-    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
+    expect((clearFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
   });
 
   it('renders total spans', async () => {

--- a/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/NewTracePageSearchBar.tsx
@@ -28,7 +28,7 @@ export type TracePageSearchBarProps = {
   setShowSpanFilterMatchesOnly: (showMatchesOnly: boolean) => void;
   setFocusedSpanIdForSearch: Dispatch<SetStateAction<string>>;
   datasourceType: string;
-  reset: () => void;
+  clear: () => void;
   totalSpans: number;
 };
 
@@ -40,7 +40,7 @@ export default memo(function NewTracePageSearchBar(props: TracePageSearchBarProp
     setShowSpanFilterMatchesOnly,
     setFocusedSpanIdForSearch,
     datasourceType,
-    reset,
+    clear,
     totalSpans,
   } = props;
   const [currentSpanIndex, setCurrentSpanIndex] = useState(-1);
@@ -93,7 +93,7 @@ export default memo(function NewTracePageSearchBar(props: TracePageSearchBarProp
   };
 
   const buttonEnabled = spanFilterMatches && spanFilterMatches?.size > 0;
-  const resetEnabled = useMemo(() => {
+  const clearEnabled = useMemo(() => {
     return (
       (search.serviceName && search.serviceName !== '') ||
       (search.spanName && search.spanName !== '') ||
@@ -130,16 +130,16 @@ export default memo(function NewTracePageSearchBar(props: TracePageSearchBarProp
     <div className={styles.searchBar}>
       <div className={styles.buttons}>
         <>
-          <div className={styles.resetButton}>
+          <div className={styles.clearButton}>
             <Button
               variant="destructive"
-              disabled={!resetEnabled}
+              disabled={!clearEnabled}
               type="button"
               fill="outline"
-              aria-label="Reset filters button"
-              onClick={reset}
+              aria-label="Clear filters button"
+              onClick={clear}
             >
-              Reset
+              Clear
             </Button>
             <div className={styles.matchesOnly}>
               <Switch
@@ -199,7 +199,7 @@ export const getStyles = () => {
       justify-content: flex-end;
       margin: 5px 0 0 0;
     `,
-    resetButton: css`
+    clearButton: css`
       order: 1;
     `,
     nextPrevButtons: css`

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
@@ -183,9 +183,9 @@ describe('SpanFilters', () => {
 
   it('should allow resetting filters', async () => {
     render(<SpanFiltersWithProps />);
-    const resetFiltersButton = screen.getByRole('button', { name: 'Reset filters button' });
-    expect(resetFiltersButton).toBeInTheDocument();
-    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
+    const clearFiltersButton = screen.getByRole('button', { name: 'Clear filters button' });
+    expect(clearFiltersButton).toBeInTheDocument();
+    expect((clearFiltersButton as HTMLButtonElement)['disabled']).toBe(true);
 
     const serviceValue = screen.getByLabelText('Select service name');
     const spanValue = screen.getByLabelText('Select span name');
@@ -196,8 +196,8 @@ describe('SpanFilters', () => {
     await selectAndCheckValue(user, tagKey, 'TagKey0');
     await selectAndCheckValue(user, tagValue, 'TagValue0');
 
-    expect((resetFiltersButton as HTMLButtonElement)['disabled']).toBe(false);
-    await user.click(resetFiltersButton);
+    expect((clearFiltersButton as HTMLButtonElement)['disabled']).toBe(false);
+    await user.click(clearFiltersButton);
     expect(screen.queryByText('Service0')).not.toBeInTheDocument();
     expect(screen.queryByText('Span0')).not.toBeInTheDocument();
     expect(screen.queryByText('TagKey0')).not.toBeInTheDocument();

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -66,7 +66,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
   const [tagKeys, setTagKeys] = useState<Array<SelectableValue<string>>>();
   const [tagValues, setTagValues] = useState<{ [key: string]: Array<SelectableValue<string>> }>({});
 
-  const reset = useCallback(() => {
+  const clear = useCallback(() => {
     setServiceNames(undefined);
     setSpanNames(undefined);
     setTagKeys(undefined);
@@ -75,8 +75,8 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
   }, [setSearch]);
 
   useEffect(() => {
-    reset();
-  }, [reset, trace]);
+    clear();
+  }, [clear, trace]);
 
   if (!trace) {
     return null;
@@ -369,7 +369,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
           setShowSpanFilterMatchesOnly={setShowSpanFilterMatchesOnly}
           setFocusedSpanIdForSearch={setFocusedSpanIdForSearch}
           datasourceType={datasourceType}
-          reset={reset}
+          clear={clear}
           totalSpans={trace.spans.length}
         />
       </Collapse>


### PR DESCRIPTION
**What is this feature?**

Rename reset to clear text on span filters clear button.

**Why do we need this feature?**

For consistency as the text clear is used across Grafana. 

**Who is this feature for?**

Span filter users.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
