### PR TITLE
DS Picker: Use custom scrollbar

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -8,7 +8,7 @@ import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { DataSourceJsonData } from '@grafana/schema';
-import { Button, Icon, Input, ModalsController, Portal, useStyles2 } from '@grafana/ui';
+import { Button, CustomScrollbar, Icon, Input, ModalsController, Portal, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
 
@@ -212,19 +212,21 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
 
   return (
     <div style={props.style} ref={ref} className={styles.container}>
-      <DataSourceList
-        {...props}
-        enableKeyboardNavigation
-        className={styles.dataSourceList}
-        current={current}
-        onChange={changeCallback}
-        filter={(ds) => matchDataSourceWithSearch(ds, filterTerm)}
-        onClickEmptyStateCTA={() =>
-          reportInteraction(INTERACTION_EVENT_NAME, {
-            item: INTERACTION_ITEM.CONFIG_NEW_DS_EMPTY_STATE,
-          })
-        }
-      ></DataSourceList>
+      <CustomScrollbar>
+        <DataSourceList
+          {...props}
+          enableKeyboardNavigation
+          className={styles.dataSourceList}
+          current={current}
+          onChange={changeCallback}
+          filter={(ds) => matchDataSourceWithSearch(ds, filterTerm)}
+          onClickEmptyStateCTA={() =>
+            reportInteraction(INTERACTION_EVENT_NAME, {
+              item: INTERACTION_ITEM.CONFIG_NEW_DS_EMPTY_STATE,
+            })
+          }
+        ></DataSourceList>
+      </CustomScrollbar>
       <div className={styles.footer}>
         <ModalsController>
           {({ showModal, hideModal }) => (
@@ -267,7 +269,6 @@ PickerContent.displayName = 'PickerContent';
 function getStylesPickerContent(theme: GrafanaTheme2) {
   return {
     container: css`
-      overflow-y: auto;
       display: flex;
       flex-direction: column;
       max-width: 480px;
@@ -279,7 +280,6 @@ function getStylesPickerContent(theme: GrafanaTheme2) {
     `,
     dataSourceList: css`
       flex: 1;
-      overflow: scroll;
     `,
     footer: css`
       flex: 0;


### PR DESCRIPTION
Use a custom scrollbar to avoid inconsistencies with the rest of the scroll bar of the UI.

Fixes #68825 