### PR TITLE
Fixes #50767

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -665,7 +665,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			}{
 				{SaveError: dashboards.ErrDashboardNotFound, ExpectedStatusCode: 404},
 				{SaveError: dashboards.ErrFolderNotFound, ExpectedStatusCode: 400},
-				{SaveError: dashboards.ErrDashboardWithSameUIDExists, ExpectedStatusCode: 400},
+				{SaveError: dashboards.ErrDashboardWithSameUIDExists, ExpectedStatusCode: 409},
 				{SaveError: dashboards.ErrDashboardWithSameNameInFolderExists, ExpectedStatusCode: 412},
 				{SaveError: dashboards.ErrDashboardVersionMismatch, ExpectedStatusCode: 412},
 				{SaveError: dashboards.ErrDashboardTitleEmpty, ExpectedStatusCode: 400},

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -373,6 +373,9 @@ func getExistingDashboardByIDOrUIDForUpdate(sess *db.Session, dash *dashboards.D
 		if overwrite {
 			dash.SetVersion(existing.Version)
 		} else {
+			if dash.Version == 0 && !dashWithIdExists {
+				return false, dashboards.ErrDashboardWithSameUIDExists
+			}
 			return isParentFolderChanged, dashboards.ErrDashboardVersionMismatch
 		}
 	}

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -29,7 +29,7 @@ var (
 	}
 	ErrDashboardWithSameUIDExists = DashboardErr{
 		Reason:     "A dashboard with the same uid already exists",
-		StatusCode: 400,
+		StatusCode: 409,
 	}
 	ErrDashboardWithSameNameInFolderExists = DashboardErr{
 		Reason:     "A dashboard with the same name in the folder already exists",

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -494,7 +494,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 						}
 
 						err := callSaveWithError(t, cmd, sc.sqlStore)
-						assert.Equal(t, dashboards.ErrDashboardVersionMismatch, err)
+						assert.Equal(t, dashboards.ErrDashboardWithSameUIDExists, err)
 					})
 
 				permissionScenario(t, "When updating an existing dashboard by uid with current version", canSave,


### PR DESCRIPTION
**What is this feature?**

Returns a correct status code and error message

**Why do we need this feature?**
The status code and the error message are misleading.

**Who is this feature for?**

For users who sends POST /api/folders with an existing UID without version number

**Which issue(s) does this PR fix?**:

#50767 


Fixes #50767 



