### PR TITLE
Docs: Fix minor mistakes and rephrase "Manage your alert notifications" entry

### DIFF
--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -12,12 +12,12 @@ weight: 160
 
 Choosing how, when, and where to send your alert notifications is an important part of setting up your alerting system. These decisions will have a direct impact on your ability to resolve issues quickly and not miss anything important.
 
-As a first step, define your contact points; where to send your alert notifications to. A contact point can be a set of destinations for matching notifications. Add notification templates to contact points for reuse and consistent messaging in your notifications.
+As a first step, define your contact points; where to send your alert notifications to. A contact point is a set of one or more [integrations]({{< relref "./manage-contact-points/configure-integrations/" >}}) that will be used together to deliver notifications. Add notification templates to contact points for reuse and consistent messaging in your notifications.
 
-Next, create a notification policy which is a set of rules for where, when and how your alerts are routed to contact points. In a notification policy, you define where to send your alert notifications by choosing one of the contact points you created.Add mute timings to your notification policy. A mute timing is a recurring interval of time during which you don’t want any notifications to be sent out.
+Next, create a notification policy which is a set of rules for where, when and how your alerts are routed to contact points. In a notification policy, you define where to send your alert notifications by choosing one of the contact points you created. Add mute timings to your notification policy. A mute timing is a recurring interval of time during which you don’t want any notifications to be sent out.
 
-You can also add silences to stop notifications from one or more alert rules. The difference between a silence and a mute timing is that a silence only lasts for only a specified window of time.
+You can also add silences to stop notifications from one or more alert rules. The difference between a silence and a mute timing is that a silence only lasts for a specified window of time.
 
-When an alert rule fires, the alert ruler sends alert instances to the Alertmanager; one alert rule can trigger multiple individual alert instances.
+When an alert rule fires, the ruler sends alert instances to the Alertmanager; one alert rule can trigger multiple individual alert instances.
 
 The Alertmanager receives these alert instances and then handles silences, groups alerts, and sends notifications to your contact points as defined in the notification policy.

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -12,7 +12,7 @@ weight: 160
 
 Choosing how, when, and where to send your alert notifications is an important part of setting up your alerting system. These decisions will have a direct impact on your ability to resolve issues quickly and not miss anything important.
 
-As a first step, define your contact points; where to send your alert notifications to. A contact point is a set of one or more [integrations]({{< relref "./manage-contact-points/configure-integrations/" >}}) that will be used together to deliver notifications. Add notification templates to contact points for reuse and consistent messaging in your notifications.
+As a first step, define your contact points; where to send your alert notifications to. A contact point is a set of one or more [integrations]({{< relref "./manage-contact-points/configure-integrations/" >}}) that are used to deliver notifications. Add notification templates to contact points for reuse and consistent messaging in your notifications.
 
 Next, create a notification policy which is a set of rules for where, when and how your alerts are routed to contact points. In a notification policy, you define where to send your alert notifications by choosing one of the contact points you created. Add mute timings to your notification policy. A mute timing is a recurring interval of time during which you don’t want any notifications to be sent out.
 


### PR DESCRIPTION
This PR addresses some small things in our docs for managing contact points:
- Link to integrations entry
- Missing space added
- Duplicate word removed
