### PR TITLE
FeatureFlags: Do not allow spaces in descriptions

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -507,7 +507,7 @@ var (
 		},
 		{
 			Name:         "faroDatasourceSelector",
-			Description:  "Enable the data source selector within the Frontend Apps section of the Frontend Observability ",
+			Description:  "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
 			State:        FeatureStateBeta,
 			FrontendOnly: true,
 			Owner:        appO11ySquad,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -308,7 +308,7 @@ const (
 	FlagAdvancedDataSourcePicker = "advancedDataSourcePicker"
 
 	// FlagFaroDatasourceSelector
-	// Enable the data source selector within the Frontend Apps section of the Frontend Observability 
+	// Enable the data source selector within the Frontend Apps section of the Frontend Observability
 	FlagFaroDatasourceSelector = "faroDatasourceSelector"
 
 	// FlagEnableDatagridEditing

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -39,6 +39,12 @@ func TestFeatureToggleFiles(t *testing.T) {
 			if flag.State == FeatureStateUnknown {
 				t.Errorf("standard toggles should not have an unknown state.  See: %s", flag.Name)
 			}
+			if flag.Description != strings.TrimSpace(flag.Description) {
+				t.Errorf("flag Description should not start/end with spaces.  See: %s", flag.Name)
+			}
+			if flag.Name != strings.TrimSpace(flag.Name) {
+				t.Errorf("flag Name should not start/end with spaces.  See: %s", flag.Name)
+			}
 		}
 	})
 


### PR DESCRIPTION
**What is this feature?**

Adds a test to make sure description does not contain spaces.

**Why do we need this feature?**

When trailing spaces exist in the source description, the codegen + linter will eventually complain.

**Who is this feature for?**

People trying to get PRs to pass tests unrelated to a feature flag added with trailing space
