### PR TITLE
Docker: Add `mode` label when building docker images

### DIFF
--- a/pkg/build/cmd/builddocker.go
+++ b/pkg/build/cmd/builddocker.go
@@ -41,7 +41,7 @@ func BuildDocker(c *cli.Context) error {
 		useUbuntu)
 
 	for _, arch := range buildConfig.Docker.Architectures {
-		if _, err := docker.BuildImage(version, arch, ".", useUbuntu, shouldSave, edition); err != nil {
+		if _, err := docker.BuildImage(version, arch, ".", useUbuntu, shouldSave, edition, metadata.ReleaseMode.Mode); err != nil {
 			return cli.Exit(err.Error(), 1)
 		}
 	}

--- a/pkg/build/docker/build.go
+++ b/pkg/build/docker/build.go
@@ -56,7 +56,7 @@ func verifyArchive(archive string) error {
 
 // BuildImage builds a Docker image.
 // The image tag is returned.
-func BuildImage(version string, arch config.Architecture, grafanaDir string, useUbuntu, shouldSave bool, edition config.Edition) ([]string, error) {
+func BuildImage(version string, arch config.Architecture, grafanaDir string, useUbuntu, shouldSave bool, edition config.Edition, mode config.VersionMode) ([]string, error) {
 	var baseArch string
 
 	switch arch {
@@ -127,6 +127,7 @@ func BuildImage(version string, arch config.Architecture, grafanaDir string, use
 		"--no-cache",
 		"--file", "../../Dockerfile",
 		".",
+		"--label", fmt.Sprintf("mode=%s", string(mode)),
 	}
 
 	//nolint:gosec


### PR DESCRIPTION
**What is this feature?**

Adds `mode` label when building the docker image. Mode can be `pull_request/main/branch/tag`. This way we can inspect the images and query them based on the event that produced them

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-delivery/issues/143

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
