### PR TITLE
Logs: Added copy-to-clipboard fallback support and visual feedback after copying

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -116,7 +116,7 @@ export class LogRowMessage extends PureComponent<Props> {
               icon="copy"
               variant="secondary"
               fill="text"
-              size="sm"
+              size="md"
               getText={this.getLogText}
               tooltip="Copy"
               tooltipPlacement="top"

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { LogRowModel, findHighlightChunksInText, CoreApp } from '@grafana/data';
-import { IconButton, Tooltip } from '@grafana/ui';
+import { ClipboardButton, IconButton, Tooltip } from '@grafana/ui';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowStyles } from './getLogRowStyles';
@@ -65,6 +65,16 @@ export class LogRowMessage extends PureComponent<Props> {
     onOpenContext(this.props.row);
   };
 
+  onLogRowClick = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  };
+
+  getLogText = () => {
+    const { row, prettifyLogMessage } = this.props;
+    const { raw } = row;
+    return restructureLog(raw, prettifyLogMessage);
+  };
+
   render() {
     const { row, wrapLogMessage, prettifyLogMessage, showContextToggle, styles } = this.props;
     const { hasAnsi, raw } = row;
@@ -94,16 +104,23 @@ export class LogRowMessage extends PureComponent<Props> {
             className={cx('log-row-menu', styles.rowMenu, {
               [styles.rowMenuWithContextButton]: shouldShowContextToggle,
             })}
-            onClick={(e) => e.stopPropagation()}
+            onClick={this.onLogRowClick}
           >
             {shouldShowContextToggle && (
               <Tooltip placement="top" content={'Show context'}>
                 <IconButton size="md" name="gf-show-context" onClick={this.onShowContextClick} />
               </Tooltip>
             )}
-            <Tooltip placement="top" content={'Copy'}>
-              <IconButton size="md" name="copy" onClick={() => navigator.clipboard.writeText(restructuredEntry)} />
-            </Tooltip>
+            <ClipboardButton
+              className={styles.copyLogButton}
+              icon="copy"
+              variant="secondary"
+              fill="text"
+              size="sm"
+              getText={this.getLogText}
+              tooltip="Copy"
+              tooltipPlacement="top"
+            />
           </span>
         </td>
       </>

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import memoizeOne from 'memoize-one';
 import tinycolor from 'tinycolor2';
 
-import { GrafanaTheme2, LogLevel } from '@grafana/data';
+import { colorManipulator, GrafanaTheme2, LogLevel } from '@grafana/data';
 import { styleMixins } from '@grafana/ui';
 
 export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
@@ -141,6 +141,13 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
     `,
     copyLogButton: css`
       padding: 0 0 0 ${theme.spacing(0.5)};
+      height: ${theme.spacing(3)};
+      width: ${theme.spacing(3.25)};
+      overflow: hidden;
+      &:hover {
+          background-color: ${colorManipulator.alpha(theme.colors.text.primary, 0.12)};
+        }
+      }
     `,
     //Log details specific CSS
     logDetailsContainer: css`

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -143,7 +143,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       padding: 0 0 0 ${theme.spacing(0.5)};
       height: ${theme.spacing(3)};
       width: ${theme.spacing(3.25)};
-      line-height: ${theme.spacing(2.75)};
+      line-height: ${theme.spacing(2.5)};
       overflow: hidden;
       &:hover {
           background-color: ${colorManipulator.alpha(theme.colors.text.primary, 0.12)};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -143,6 +143,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       padding: 0 0 0 ${theme.spacing(0.5)};
       height: ${theme.spacing(3)};
       width: ${theme.spacing(3.25)};
+      line-height: ${theme.spacing(2.75)};
       overflow: hidden;
       &:hover {
           background-color: ${colorManipulator.alpha(theme.colors.text.primary, 0.12)};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -139,6 +139,9 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       width: 100%;
       text-align: left;
     `,
+    copyLogButton: css`
+      padding: 0 0 0 ${theme.spacing(0.5)};
+    `,
     //Log details specific CSS
     logDetailsContainer: css`
       label: logs-row-details-table;


### PR DESCRIPTION
This PR changes the copy log button to use the `ClipboardButton` component, which has a fallback for old navigators or Grafana instances being loaded via HTTP, which disables the clipboard API.

![2023-05-23 11 14 56](https://github.com/grafana/grafana/assets/1069378/8ac9efac-cf98-4a1c-8fee-4b3522560751)

![imagen](https://github.com/grafana/grafana/assets/1069378/a579f039-6bf5-41bc-b82e-1d66f537531f)

As a byproduct of this change, the user now gets a visual confirmation when the log row has been copied.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67819

**Special notes for your reviewer:**

The underlying functionality should remain unchanged.