### PR TITLE
Preferences: Can reset timezone preference back to default correctly

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
@@ -103,6 +103,7 @@ export const TimePickerFooter = (props: Props) => {
                   }
                 }}
                 onBlur={onToggleChangeTimeSettings}
+                menuShouldPortal={false}
               />
             </section>
           ) : (

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -41,7 +41,7 @@ export const TimeZonePicker = (props: Props) => {
     includeInternal = false,
     disabled = false,
     inputId,
-    menuShouldPortal = false,
+    menuShouldPortal = true,
     openMenuOnFocus = true,
   } = props;
   const groupedTimeZones = useTimeZones(includeInternal);

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -108,7 +108,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
   };
 
   onTimeZoneChanged = (timezone?: string) => {
-    if (!timezone) {
+    if (typeof timezone !== 'string') {
       return;
     }
     this.setState({ timezone: timezone });

--- a/public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx
@@ -105,7 +105,6 @@ export const TimeRegionEditor = ({ value, onChange }: Props) => {
           includeInternal={true}
           onChange={(v) => onTimezoneChange(v)}
           onBlur={() => setEditing(false)}
-          menuShouldPortal={true}
           openMenuOnFocus={false}
           width={100}
           autoFocus


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- correctly allows the default value (`""`) in `onTimeZoneChanged` in `SharedPreferences`
- fixes the unit test that should have caught this regression
  - this wasn't correctly selecting the timezone in the test because it was using the `selectOptionInTest` util
  - this util expects the menu to be portalled, but the `TimeZonePicker` menu was not by default
  - this also explains the bug we were seeing where the menu was being overlaid by the topnav navigation
  - inverts the portalling logic in `TimeZonePicker` to portal by default
    - there is one place currently (inside the `TimeRangePicker` overlay on a dashboard) where we don't want to portal. 
    - we could probably portal and fix the logic inside `TimeRangePicker`, but that should probably be tackled separately
    - the other 5 or 6 places where `TimeZonePicker` is used will benefit from the improved positioning behaviour when portalled (have also checked `grafana-enterprise`)

**Why do we need this feature?**

- so users can revert to the default timezone
- better positioning logic for `TimeZonePicker` menus

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/68556

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
