### PR TITLE
Grafana/ui: Fix margin in RadioButtonGroup option when only icon is present

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -75,6 +75,7 @@ export function RadioButtonGroup<T>({
       {options.map((opt, i) => {
         const isItemDisabled = disabledOptions && opt.value && disabledOptions.includes(opt.value);
         const icon = opt.icon ? toIconName(opt.icon) : undefined;
+        const hasNonIconPart = Boolean(opt.imgUrl || opt.label || opt.component);
 
         return (
           <RadioButton
@@ -91,7 +92,7 @@ export function RadioButtonGroup<T>({
             fullWidth={fullWidth}
             ref={value === opt.value ? activeButtonRef : undefined}
           >
-            {icon && <Icon name={icon} className={styles.icon} />}
+            {icon && <Icon name={icon} className={cx(hasNonIconPart && styles.icon)} />}
             {opt.imgUrl && <img src={opt.imgUrl} alt={opt.label} className={styles.img} />}
             {opt.label} {opt.component ? <opt.component /> : null}
           </RadioButton>


### PR DESCRIPTION
There was always a bit of margin for icon even if there was no other content making icon only option a bit off center.
Before:
<img width="105" alt="Screenshot 2023-05-23 at 15 22 39" src="https://github.com/grafana/grafana/assets/1014802/b68ae761-49d6-4fbc-a19b-073462675569">

After:
<img width="89" alt="Screenshot 2023-05-23 at 15 22 47" src="https://github.com/grafana/grafana/assets/1014802/a58778ae-3e2a-4daf-8a18-16be87e7ccad">
