### PR TITLE
Plugins: Bump Plugin SDK version and address instance management breaking changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/grafana/alerting v0.0.0-20230428095912-33c5aa68a5ba
 	github.com/grafana/grafana-aws-sdk v0.15.0
 	github.com/grafana/grafana-azure-sdk-go v1.7.0
-	github.com/grafana/grafana-plugin-sdk-go v0.160.0
+	github.com/grafana/grafana-plugin-sdk-go v0.162.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-plugin v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -1067,6 +1067,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW3
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/grafana-plugin-sdk-go v0.160.0 h1:jELbsqee5kRz9vD1hZeP8+984xMZDU/M6uGv0RhOR34=
 github.com/grafana/grafana-plugin-sdk-go v0.160.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
+github.com/grafana/grafana-plugin-sdk-go v0.162.0 h1:ij2ARWohf0IoK9yCVC1Wup4Gp6zwBq2AueVXRYsv/to=
+github.com/grafana/grafana-plugin-sdk-go v0.162.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
 github.com/grafana/kindsys v0.0.0-20230323180930-c2a9ced5c751 h1:X5jwaMcpUMQ+xv7fKhs9U+oBxfo2x+x8GpHWybDSgk0=
 github.com/grafana/kindsys v0.0.0-20230323180930-c2a9ced5c751/go.mod h1:213a3clTiegHfheYcLPLeEyHv/azK/fAF67OEbzuLzw=
 github.com/grafana/kindsys v0.0.0-20230427152021-bb328815be7a h1:i2YhC6eTyDp+7Ftv5c6VZDUQskmKX4oIPGf38qfiZiU=

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -69,7 +69,7 @@ func (s *httpServiceProxy) Do(rw http.ResponseWriter, req *http.Request, cli *ht
 func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (types.DatasourceInfo, error) {
 	ctx := req.Context()
 	pluginContext := httpadapter.PluginConfigFromContext(ctx)
-	i, err := s.im.Get(pluginContext)
+	i, err := s.im.Get(ctx, pluginContext)
 	if err != nil {
 		return types.DatasourceInfo{}, err
 	}

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -162,8 +162,8 @@ type azDatasourceExecutor interface {
 	ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client)
 }
 
-func (s *Service) getDataSourceFromPluginReq(req *backend.QueryDataRequest) (types.DatasourceInfo, error) {
-	i, err := s.im.Get(req.PluginContext)
+func (s *Service) getDataSourceFromPluginReq(ctx context.Context, req *backend.QueryDataRequest) (types.DatasourceInfo, error) {
+	i, err := s.im.Get(ctx, req.PluginContext)
 	if err != nil {
 		return types.DatasourceInfo{}, err
 	}
@@ -185,7 +185,7 @@ func (s *Service) newQueryMux() *datasource.QueryTypeMux {
 		dst := dsType
 		mux.HandleFunc(dsType, func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 			executor := s.executors[dst]
-			dsInfo, err := s.getDataSourceFromPluginReq(req)
+			dsInfo, err := s.getDataSourceFromPluginReq(ctx, req)
 			if err != nil {
 				return nil, err
 			}
@@ -199,8 +199,8 @@ func (s *Service) newQueryMux() *datasource.QueryTypeMux {
 	return mux
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (types.DatasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (types.DatasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return types.DatasourceInfo{}, err
 	}
@@ -321,7 +321,7 @@ func parseSubscriptions(res *http.Response) ([]string, error) {
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -113,7 +113,7 @@ type fakeInstance struct {
 	settings types.AzureMonitorSettings
 }
 
-func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
+func (f *fakeInstance) Get(_ context.Context, _ backend.PluginContext) (instancemgmt.Instance, error) {
 	return types.DatasourceInfo{
 		Cloud:    f.cloud,
 		Routes:   f.routes,
@@ -122,7 +122,7 @@ func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.In
 	}, nil
 }
 
-func (f *fakeInstance) Do(pluginContext backend.PluginContext, fn instancemgmt.InstanceCallbackFunc) error {
+func (f *fakeInstance) Do(_ context.Context, _ backend.PluginContext, _ instancemgmt.InstanceCallbackFunc) error {
 	return nil
 }
 

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -82,7 +82,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return nil, err
 	}
 
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -637,8 +637,8 @@ func addConfigData(frames data.Frames, dl string, unit string, period string) da
 	return frames
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloud-monitoring/resource_handler.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler.go
@@ -397,7 +397,7 @@ func writeResponse(rw http.ResponseWriter, code int, msg string) {
 func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (*datasourceInfo, error) {
 	ctx := req.Context()
 	pluginContext := httpadapter.PluginConfigFromContext(ctx)
-	i, err := s.im.Get(pluginContext)
+	i, err := s.im.Get(ctx, pluginContext)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/tsdb/cloud-monitoring/resource_handler_test.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler_test.go
@@ -95,13 +95,13 @@ type fakeInstance struct {
 	services map[string]datasourceService
 }
 
-func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
+func (f *fakeInstance) Get(_ context.Context, _ backend.PluginContext) (instancemgmt.Instance, error) {
 	return &datasourceInfo{
 		services: f.services,
 	}, nil
 }
 
-func (f *fakeInstance) Do(pluginContext backend.PluginContext, fn instancemgmt.InstanceCallbackFunc) error {
+func (f *fakeInstance) Do(_ context.Context, _ backend.PluginContext, _ instancemgmt.InstanceCallbackFunc) error {
 	return nil
 }
 

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -19,7 +20,7 @@ type annotationEvent struct {
 	Text  string
 }
 
-func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginContext, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
+func (e *cloudWatchExecutor) executeAnnotationQuery(ctx context.Context, pluginCtx backend.PluginContext, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 	statistic := ""
 
@@ -48,7 +49,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 	actionPrefix := model.ActionPrefix
 	alarmNamePrefix := model.AlarmNamePrefix
 
-	cli, err := e.getCWClient(pluginCtx, model.Region)
+	cli, err := e.getCWClient(ctx, pluginCtx, model.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -118,9 +118,9 @@ type cloudWatchExecutor struct {
 	resourceHandler backend.CallResourceHandler
 }
 
-func (e *cloudWatchExecutor) getRequestContext(pluginCtx backend.PluginContext, region string) (models.RequestContext, error) {
+func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx backend.PluginContext, region string) (models.RequestContext, error) {
 	r := region
-	instance, err := e.getInstance(pluginCtx)
+	instance, err := e.getInstance(ctx, pluginCtx)
 	if region == defaultRegion {
 		if err != nil {
 			return models.RequestContext{}, err
@@ -128,7 +128,7 @@ func (e *cloudWatchExecutor) getRequestContext(pluginCtx backend.PluginContext, 
 		r = instance.Settings.Region
 	}
 
-	sess, err := e.newSession(pluginCtx, r)
+	sess, err := e.newSession(ctx, pluginCtx, r)
 	if err != nil {
 		return models.RequestContext{}, err
 	}
@@ -171,7 +171,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	var result *backend.QueryDataResponse
 	switch model.Type {
 	case annotationQuery:
-		result, err = e.executeAnnotationQuery(req.PluginContext, model, q)
+		result, err = e.executeAnnotationQuery(ctx, req.PluginContext, model, q)
 	case logAction:
 		result, err = e.executeLogActions(ctx, logger, req)
 	case timeSeriesQuery:
@@ -188,13 +188,13 @@ func (e *cloudWatchExecutor) CheckHealth(ctx context.Context, req *backend.Check
 	metricsTest := "Successfully queried the CloudWatch metrics API."
 	logsTest := "Successfully queried the CloudWatch logs API."
 
-	err := e.checkHealthMetrics(req.PluginContext)
+	err := e.checkHealthMetrics(ctx, req.PluginContext)
 	if err != nil {
 		status = backend.HealthStatusError
 		metricsTest = fmt.Sprintf("CloudWatch metrics query failed: %s", err.Error())
 	}
 
-	err = e.checkHealthLogs(req.PluginContext)
+	err = e.checkHealthLogs(ctx, req.PluginContext)
 	if err != nil {
 		status = backend.HealthStatusError
 		logsTest = fmt.Sprintf("CloudWatch logs query failed: %s", err.Error())
@@ -206,7 +206,7 @@ func (e *cloudWatchExecutor) CheckHealth(ctx context.Context, req *backend.Check
 	}, nil
 }
 
-func (e *cloudWatchExecutor) checkHealthMetrics(pluginCtx backend.PluginContext) error {
+func (e *cloudWatchExecutor) checkHealthMetrics(ctx context.Context, pluginCtx backend.PluginContext) error {
 	namespace := "AWS/Billing"
 	metric := "EstimatedCharges"
 	params := &cloudwatch.ListMetricsInput{
@@ -214,7 +214,7 @@ func (e *cloudWatchExecutor) checkHealthMetrics(pluginCtx backend.PluginContext)
 		MetricName: &metric,
 	}
 
-	session, err := e.newSession(pluginCtx, defaultRegion)
+	session, err := e.newSession(ctx, pluginCtx, defaultRegion)
 	if err != nil {
 		return err
 	}
@@ -223,8 +223,8 @@ func (e *cloudWatchExecutor) checkHealthMetrics(pluginCtx backend.PluginContext)
 	return err
 }
 
-func (e *cloudWatchExecutor) checkHealthLogs(pluginCtx backend.PluginContext) error {
-	session, err := e.newSession(pluginCtx, defaultRegion)
+func (e *cloudWatchExecutor) checkHealthLogs(ctx context.Context, pluginCtx backend.PluginContext) error {
+	session, err := e.newSession(ctx, pluginCtx, defaultRegion)
 	if err != nil {
 		return err
 	}
@@ -233,8 +233,8 @@ func (e *cloudWatchExecutor) checkHealthLogs(pluginCtx backend.PluginContext) er
 	return err
 }
 
-func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region string) (*session.Session, error) {
-	instance, err := e.getInstance(pluginCtx)
+func (e *cloudWatchExecutor) newSession(ctx context.Context, pluginCtx backend.PluginContext, region string) (*session.Session, error) {
+	instance, err := e.getInstance(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +272,8 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 	return sess, nil
 }
 
-func (e *cloudWatchExecutor) getInstance(pluginCtx backend.PluginContext) (*DataSource, error) {
-	i, err := e.im.Get(pluginCtx)
+func (e *cloudWatchExecutor) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*DataSource, error) {
+	i, err := e.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -282,16 +282,16 @@ func (e *cloudWatchExecutor) getInstance(pluginCtx backend.PluginContext) (*Data
 	return &instance, nil
 }
 
-func (e *cloudWatchExecutor) getCWClient(pluginCtx backend.PluginContext, region string) (cloudwatchiface.CloudWatchAPI, error) {
-	sess, err := e.newSession(pluginCtx, region)
+func (e *cloudWatchExecutor) getCWClient(ctx context.Context, pluginCtx backend.PluginContext, region string) (cloudwatchiface.CloudWatchAPI, error) {
+	sess, err := e.newSession(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
 	return NewCWClient(sess), nil
 }
 
-func (e *cloudWatchExecutor) getCWLogsClient(pluginCtx backend.PluginContext, region string) (cloudwatchlogsiface.CloudWatchLogsAPI, error) {
-	sess, err := e.newSession(pluginCtx, region)
+func (e *cloudWatchExecutor) getCWLogsClient(ctx context.Context, pluginCtx backend.PluginContext, region string) (cloudwatchlogsiface.CloudWatchLogsAPI, error) {
+	sess, err := e.newSession(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +301,8 @@ func (e *cloudWatchExecutor) getCWLogsClient(pluginCtx backend.PluginContext, re
 	return logsClient, nil
 }
 
-func (e *cloudWatchExecutor) getEC2Client(pluginCtx backend.PluginContext, region string) (models.EC2APIProvider, error) {
-	sess, err := e.newSession(pluginCtx, region)
+func (e *cloudWatchExecutor) getEC2Client(ctx context.Context, pluginCtx backend.PluginContext, region string) (models.EC2APIProvider, error) {
+	sess, err := e.newSession(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -310,9 +310,9 @@ func (e *cloudWatchExecutor) getEC2Client(pluginCtx backend.PluginContext, regio
 	return newEC2Client(sess), nil
 }
 
-func (e *cloudWatchExecutor) getRGTAClient(pluginCtx backend.PluginContext, region string) (resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI,
+func (e *cloudWatchExecutor) getRGTAClient(ctx context.Context, pluginCtx backend.PluginContext, region string) (resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI,
 	error) {
-	sess, err := e.newSession(pluginCtx, region)
+	sess, err := e.newSession(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -96,7 +96,7 @@ func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, logger log.L
 }
 
 func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logger log.Logger, logsQuery models.LogsQuery, query backend.DataQuery, pluginCtx backend.PluginContext) (*data.Frame, error) {
-	instance, err := e.getInstance(pluginCtx)
+	instance, err := e.getInstance(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logger log.Lo
 		region = logsQuery.Region
 	}
 
-	logsClient, err := e.getCWLogsClient(pluginCtx, region)
+	logsClient, err := e.getCWLogsClient(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -36,14 +36,14 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 
 		region := logsQuery.Region
 		if logsQuery.Region == "" || region == defaultRegion {
-			instance, err := e.getInstance(req.PluginContext)
+			instance, err := e.getInstance(ctx, req.PluginContext)
 			if err != nil {
 				return nil, err
 			}
 			logsQuery.Region = instance.Settings.Region
 		}
 
-		logsClient, err := e.getCWLogsClient(req.PluginContext, region)
+		logsClient, err := e.getCWLogsClient(ctx, req.PluginContext, region)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"sort"
@@ -47,6 +48,7 @@ func TestQuery_Regions(t *testing.T) {
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		resp, err := executor.handleGetRegions(
+			context.Background(),
 			backend.PluginContext{
 				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
 			}, url.Values{
@@ -105,10 +107,12 @@ func Test_handleGetRegions_regionCache(t *testing.T) {
 		cli.On("DescribeRegions", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		_, err := executor.handleGetRegions(
+			context.Background(),
 			backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}}, nil)
 		require.NoError(t, err)
 
 		_, err = executor.handleGetRegions(
+			context.Background(),
 			backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}}, nil)
 		require.NoError(t, err)
 
@@ -160,6 +164,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		resp, err := executor.handleGetEc2InstanceAttribute(
+			context.Background(),
 			backend.PluginContext{
 				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
 			}, url.Values{
@@ -237,6 +242,7 @@ func TestQuery_EBSVolumeIDs(t *testing.T) {
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		resp, err := executor.handleGetEbsVolumeIds(
+			context.Background(),
 			backend.PluginContext{
 				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
 			}, url.Values{
@@ -303,6 +309,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		resp, err := executor.handleGetResourceArns(
+			context.Background(),
 			backend.PluginContext{
 				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
 			}, url.Values{

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -12,9 +13,9 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
-type RequestContextFactoryFunc func(pluginCtx backend.PluginContext, region string) (reqCtx RequestContext, err error)
+type RequestContextFactoryFunc func(ctx context.Context, pluginCtx backend.PluginContext, region string) (reqCtx RequestContext, err error)
 
-type RouteHandlerFunc func(pluginCtx backend.PluginContext, reqContextFactory RequestContextFactoryFunc, parameters url.Values) ([]byte, *HttpError)
+type RouteHandlerFunc func(ctx context.Context, pluginCtx backend.PluginContext, reqContextFactory RequestContextFactoryFunc, parameters url.Values) ([]byte, *HttpError)
 
 type RequestContext struct {
 	MetricsClientProvider MetricsClientProvider

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,7 +29,7 @@ func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
 	return mux
 }
 
-type handleFn func(pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error)
+type handleFn func(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error)
 
 func handleResourceReq(handleFunc handleFn) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
@@ -39,7 +40,7 @@ func handleResourceReq(handleFunc handleFn) func(rw http.ResponseWriter, req *ht
 			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
-		data, err := handleFunc(pluginContext, req.URL.Query())
+		data, err := handleFunc(ctx, pluginContext, req.URL.Query())
 		if err != nil {
 			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
 			return

--- a/pkg/tsdb/cloudwatch/routes/accounts.go
+++ b/pkg/tsdb/cloudwatch/routes/accounts.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,13 +13,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-func AccountsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func AccountsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	region := parameters.Get("region")
 	if region == "" {
 		return nil, models.NewHttpError("error in AccountsHandler", http.StatusBadRequest, fmt.Errorf("region is required"))
 	}
 
-	service, err := newAccountsService(pluginCtx, reqCtxFactory, region)
+	service, err := newAccountsService(ctx, pluginCtx, reqCtxFactory, region)
 	if err != nil {
 		return nil, models.NewHttpError("error in AccountsHandler", http.StatusInternalServerError, err)
 	}
@@ -45,8 +46,8 @@ func AccountsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.Reque
 // newAccountService is an account service factory.
 //
 // Stubbable by tests.
-var newAccountsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
-	oamClient, err := reqCtxFactory(pluginCtx, region)
+var newAccountsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
+	oamClient, err := reqCtxFactory(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/routes/accounts_test.go
+++ b/pkg/tsdb/cloudwatch/routes/accounts_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func Test_accounts_route(t *testing.T) {
 				IsMonitoringAccount: true,
 			},
 		}}, nil)
-		newAccountsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
+		newAccountsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
 			return &mockAccountsService, nil
 		}
 
@@ -63,7 +64,7 @@ func Test_accounts_route(t *testing.T) {
 		mockAccountsService := mocks.AccountsServiceMock{}
 		mockAccountsService.On("GetAccountsForCurrentUserOrRole").Return([]resources.ResourceResponse[resources.Account](nil),
 			fmt.Errorf("%w: %s", services.ErrAccessDeniedException, "some AWS message"))
-		newAccountsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
+		newAccountsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
 			return &mockAccountsService, nil
 		}
 
@@ -81,7 +82,7 @@ func Test_accounts_route(t *testing.T) {
 	t.Run("returns 500 when accounts service returns unknown error", func(t *testing.T) {
 		mockAccountsService := mocks.AccountsServiceMock{}
 		mockAccountsService.On("GetAccountsForCurrentUserOrRole").Return([]resources.ResourceResponse[resources.Account](nil), fmt.Errorf("some error"))
-		newAccountsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
+		newAccountsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
 			return &mockAccountsService, nil
 		}
 

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -11,13 +12,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-func DimensionKeysHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func DimensionKeysHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	dimensionKeysRequest, err := resources.GetDimensionKeysRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(pluginCtx, reqCtxFactory, dimensionKeysRequest.Region)
+	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, dimensionKeysRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusInternalServerError, err)
 	}
@@ -44,8 +45,8 @@ func DimensionKeysHandler(pluginCtx backend.PluginContext, reqCtxFactory models.
 // newListMetricsService is an list metrics service factory.
 //
 // Stubbable by tests.
-var newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
-	metricClient, err := reqCtxFactory(pluginCtx, region)
+var newListMetricsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+	metricClient, err := reqCtxFactory(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,7 +33,7 @@ func Test_DimensionKeys_Route(t *testing.T) {
 				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "NodeID", Value: "Shared"}) &&
 				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "stage", Value: "QueryCommit"})
 		})).Return([]resources.ResourceResponse[string]{}, nil).Once()
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()
@@ -67,7 +68,7 @@ func Test_DimensionKeys_Route(t *testing.T) {
 	t.Run("return 500 if GetDimensionKeysByDimensionFilter returns an error", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
 		mockListMetricsService.On("GetDimensionKeysByDimensionFilter", mock.Anything).Return([]resources.ResourceResponse[string]{}, fmt.Errorf("some error"))
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()

--- a/pkg/tsdb/cloudwatch/routes/dimension_values.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -10,13 +11,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
-func DimensionValuesHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func DimensionValuesHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	dimensionValuesRequest, err := resources.GetDimensionValuesRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(pluginCtx, reqCtxFactory, dimensionValuesRequest.Region)
+	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, dimensionValuesRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +28,7 @@ func Test_DimensionValues_Route(t *testing.T) {
 				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "NodeID", Value: "Shared"}) &&
 				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "stage", Value: "QueryCommit"})
 		})).Return([]resources.ResourceResponse[string]{}, nil).Once()
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()
@@ -39,7 +40,7 @@ func Test_DimensionValues_Route(t *testing.T) {
 	t.Run("returns 500 if GetDimensionValuesByDimensionFilter returns an error", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
 		mockListMetricsService.On("GetDimensionValuesByDimensionFilter", mock.Anything).Return([]resources.ResourceResponse[string]{}, fmt.Errorf("some error"))
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()

--- a/pkg/tsdb/cloudwatch/routes/log_group_fields.go
+++ b/pkg/tsdb/cloudwatch/routes/log_group_fields.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -10,13 +11,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
-func LogGroupFieldsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func LogGroupFieldsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	request, err := resources.ParseLogGroupFieldsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in LogGroupFieldsHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newLogGroupsService(pluginCtx, reqCtxFactory, request.Region)
+	service, err := newLogGroupsService(ctx, pluginCtx, reqCtxFactory, request.Region)
 	if err != nil {
 		return nil, models.NewHttpError("newLogGroupsService error", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/log_group_fields_test.go
+++ b/pkg/tsdb/cloudwatch/routes/log_group_fields_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ import (
 
 func TestLogGroupFieldsRoute(t *testing.T) {
 	mockFeatures := mocks.MockFeatures{}
-	reqCtxFunc := func(pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
+	reqCtxFunc := func(_ context.Context, pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
 		return models.RequestContext{Features: &mockFeatures}, err
 	}
 	t.Run("returns 400 if an invalid LogGroupFieldsRequest is used", func(t *testing.T) {
@@ -31,7 +32,7 @@ func TestLogGroupFieldsRoute(t *testing.T) {
 	t.Run("returns 500 if GetLogGroupFields method fails", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroupFields", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroupField]{}, fmt.Errorf("error from api"))
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -62,7 +63,7 @@ func TestLogGroupFieldsRoute(t *testing.T) {
 				},
 			},
 		}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 

--- a/pkg/tsdb/cloudwatch/routes/log_groups.go
+++ b/pkg/tsdb/cloudwatch/routes/log_groups.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -12,13 +13,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-func LogGroupsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func LogGroupsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	request, err := resources.ParseLogGroupsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
 	}
 
-	service, err := newLogGroupsService(pluginCtx, reqCtxFactory, request.Region)
+	service, err := newLogGroupsService(ctx, pluginCtx, reqCtxFactory, request.Region)
 	if err != nil {
 		return nil, models.NewHttpError("newLogGroupsService error", http.StatusInternalServerError, err)
 	}
@@ -39,8 +40,8 @@ func LogGroupsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.Requ
 // newLogGroupsService is a describe log groups service factory.
 //
 // Stubbable by tests.
-var newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
-	reqCtx, err := reqCtxFactory(pluginCtx, region)
+var newLogGroupsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+	reqCtx, err := reqCtxFactory(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/routes/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/routes/log_groups_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +25,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	mockFeatures := mocks.MockFeatures{}
 	mockFeatures.On("IsEnabled", featuremgmt.FlagCloudWatchCrossAccountQuerying).Return(false)
-	reqCtxFunc := func(pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
+	reqCtxFunc := func(_ context.Context, pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
 		return models.RequestContext{Features: &mockFeatures}, err
 	}
 
@@ -37,7 +38,7 @@ func TestLogGroupsRoute(t *testing.T) {
 			},
 			AccountId: utils.Pointer("111"),
 		}}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -68,7 +69,7 @@ func TestLogGroupsRoute(t *testing.T) {
 					AccountId: utils.Pointer("222"),
 				},
 			}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -99,7 +100,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -115,7 +116,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -135,7 +136,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -153,7 +154,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -170,7 +171,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -188,7 +189,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -206,7 +207,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 
@@ -225,7 +226,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
 			Return([]resources.ResourceResponse[resources.LogGroup]{}, fmt.Errorf("some error"))
-		newLogGroupsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
 

--- a/pkg/tsdb/cloudwatch/routes/metrics.go
+++ b/pkg/tsdb/cloudwatch/routes/metrics.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -11,13 +12,13 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-func MetricsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func MetricsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	metricsRequest, err := resources.GetMetricsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(pluginCtx, reqCtxFactory, metricsRequest.Region)
+	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, metricsRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/metrics_test.go
+++ b/pkg/tsdb/cloudwatch/routes/metrics_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +20,7 @@ func Test_Metrics_Route(t *testing.T) {
 	t.Run("calls GetMetricsByNamespace when a CustomNamespaceRequestType is passed", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
 		mockListMetricsService.On("GetMetricsByNamespace", mock.Anything).Return([]resources.ResourceResponse[resources.Metric]{}, nil)
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()
@@ -69,7 +70,7 @@ func Test_Metrics_Route(t *testing.T) {
 	t.Run("returns 500 if GetMetricsByNamespace returns an error", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
 		mockListMetricsService.On("GetMetricsByNamespace", mock.Anything).Return([]resources.ResourceResponse[resources.Metric]{}, fmt.Errorf("some error"))
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+		newListMetricsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
 		rr := httptest.NewRecorder()

--- a/pkg/tsdb/cloudwatch/routes/middleware.go
+++ b/pkg/tsdb/cloudwatch/routes/middleware.go
@@ -18,7 +18,7 @@ func ResourceRequestMiddleware(handleFunc models.RouteHandlerFunc, logger log.Lo
 
 		ctx := req.Context()
 		pluginContext := httpadapter.PluginConfigFromContext(ctx)
-		json, httpError := handleFunc(pluginContext, reqCtxFactory, req.URL.Query())
+		json, httpError := handleFunc(ctx, pluginContext, reqCtxFactory, req.URL.Query())
 		if httpError != nil {
 			logger.Error("error handling resource request", "error", httpError.Message)
 			respondWithError(rw, httpError)

--- a/pkg/tsdb/cloudwatch/routes/middleware_test.go
+++ b/pkg/tsdb/cloudwatch/routes/middleware_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +18,7 @@ func Test_Middleware(t *testing.T) {
 	t.Run("rejects POST method", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/dimension-keys?region=us-east-1", nil)
-		handler := http.HandlerFunc(ResourceRequestMiddleware(func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+		handler := http.HandlerFunc(ResourceRequestMiddleware(func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 			return []byte{}, nil
 		}, logger, nil))
 		handler.ServeHTTP(rr, req)
@@ -28,7 +29,7 @@ func Test_Middleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/some-path", nil)
 		var testPluginContext backend.PluginContext
-		handler := http.HandlerFunc(ResourceRequestMiddleware(func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+		handler := http.HandlerFunc(ResourceRequestMiddleware(func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 			testPluginContext = pluginCtx
 			return []byte{}, nil
 		}, logger, nil))
@@ -39,7 +40,7 @@ func Test_Middleware(t *testing.T) {
 	t.Run("should propagate handler error to response", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/some-path", nil)
-		handler := http.HandlerFunc(ResourceRequestMiddleware(func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+		handler := http.HandlerFunc(ResourceRequestMiddleware(func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 			return []byte{}, models.NewHttpError("error", http.StatusBadRequest, fmt.Errorf("error from handler"))
 		}, logger, nil))
 		handler.ServeHTTP(rr, req)

--- a/pkg/tsdb/cloudwatch/routes/namespaces.go
+++ b/pkg/tsdb/cloudwatch/routes/namespaces.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -13,8 +14,8 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-func NamespacesHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, _ url.Values) ([]byte, *models.HttpError) {
-	reqCtx, err := reqCtxFactory(pluginCtx, "default")
+func NamespacesHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, _ url.Values) ([]byte, *models.HttpError) {
+	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "default")
 	if err != nil {
 		return nil, models.NewHttpError("error in NamespacesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/namespaces_test.go
+++ b/pkg/tsdb/cloudwatch/routes/namespaces_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,7 +16,7 @@ import (
 
 func Test_Namespaces_Route(t *testing.T) {
 	customNamespaces := ""
-	factoryFunc := func(pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
+	factoryFunc := func(_ context.Context, pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
 		return models.RequestContext{
 			Settings: models.CloudWatchSettings{
 				Namespace: customNamespaces,

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -31,7 +31,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, logger 
 		return nil, fmt.Errorf("invalid time range: start time must be before end time")
 	}
 
-	instance, err := e.getInstance(req.PluginContext)
+	instance, err := e.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, logger 
 				}
 			}()
 
-			client, err := e.getCWClient(req.PluginContext, region)
+			client, err := e.getCWClient(ctx, req.PluginContext, region)
 			if err != nil {
 				return err
 			}

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -39,7 +39,7 @@ func ProvideService(httpClientProvider httpclient.Provider) *Service {
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
@@ -168,8 +168,8 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 	}
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*es.DatasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*es.DatasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		return fmt.Errorf("invalid resource URL: %s", req.Path)
 	}
 
-	ds, err := s.getDSInfo(req.PluginContext)
+	ds, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -76,8 +76,8 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 	}
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	logger := logger.FromContext(ctx)
 
 	// get datasource info from context
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -291,10 +291,10 @@ func TestConvertResponses(t *testing.T) {
 
 type fakeInstanceManager struct{}
 
-func (f fakeInstanceManager) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
+func (f fakeInstanceManager) Get(_ context.Context, _ backend.PluginContext) (instancemgmt.Instance, error) {
 	return datasourceInfo{}, nil
 }
 
-func (f fakeInstanceManager) Do(pluginContext backend.PluginContext, fn instancemgmt.InstanceCallbackFunc) error {
+func (f fakeInstanceManager) Do(_ context.Context, _ backend.PluginContext, _ instancemgmt.InstanceCallbackFunc) error {
 	return nil
 }

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -20,7 +20,7 @@ const (
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
 	logger := logger.FromContext(ctx)
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return getHealthCheckMessage(logger, "error getting datasource info", err)
 	}

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -93,7 +93,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	logger := logger.FromContext(ctx)
 	logger.Debug("Received a query request", "numQueries", len(req.Queries))
 
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +195,8 @@ func (s *Service) createRequest(ctx context.Context, logger log.Logger, dsInfo *
 	return req, nil
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*models.DatasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*models.DatasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/influxdb/mocks_test.go
+++ b/pkg/tsdb/influxdb/mocks_test.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -47,7 +48,7 @@ type fakeInstance struct {
 	fakeRoundTripper RoundTripper
 }
 
-func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
+func (f *fakeInstance) Get(_ context.Context, _ backend.PluginContext) (instancemgmt.Instance, error) {
 	fp := &fakeHttpClientProvider{
 		opts: sdkhttpclient.Options{
 			Timeouts: &sdkhttpclient.DefaultTimeoutOptions,
@@ -78,7 +79,7 @@ func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.In
 	}, nil
 }
 
-func (f *fakeInstance) Do(pluginContext backend.PluginContext, fn instancemgmt.InstanceCallbackFunc) error {
+func (f *fakeInstance) Do(_ context.Context, _ backend.PluginContext, _ instancemgmt.InstanceCallbackFunc) error {
 	return nil
 }
 

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -95,7 +95,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 }
 
 func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		result := backend.NewQueryDataResponse()
 		return result, err
@@ -213,8 +213,8 @@ func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts 
 	return frames, nil
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/loki/streaming.go
+++ b/pkg/tsdb/loki/streaming.go
@@ -15,8 +15,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-func (s *Service) SubscribeStream(_ context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusNotFound,
@@ -60,7 +60,7 @@ func (s *Service) SubscribeStream(_ context.Context, req *backend.SubscribeStrea
 
 // Single instance for each channel (results are shared with all listeners)
 func (s *Service) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -35,8 +35,8 @@ func ProvideService(cfg *setting.Cfg) *Service {
 	}
 }
 
-func (s *Service) getDataSourceHandler(pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDataSourceHandler(ctx context.Context, pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s *Service) getDataSourceHandler(pluginCtx backend.PluginContext) (*sqleng
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	dsHandler, err := s.getDataSourceHandler(req.PluginContext)
+	dsHandler, err := s.getDataSourceHandler(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (t *mssqlQueryResultTransformer) TransformQueryError(logger log.Logger, err
 
 // CheckHealth pings the connected SQL database
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsHandler, err := s.getDataSourceHandler(req.PluginContext)
+	dsHandler, err := s.getDataSourceHandler(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -142,8 +142,8 @@ func newInstanceSettings(cfg *setting.Cfg, httpClientProvider httpclient.Provide
 	}
 }
 
-func (s *Service) getDataSourceHandler(pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDataSourceHandler(ctx context.Context, pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (s *Service) getDataSourceHandler(pluginCtx backend.PluginContext) (*sqleng
 
 // CheckHealth pings the connected SQL database
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsHandler, err := s.getDataSourceHandler(req.PluginContext)
+	dsHandler, err := s.getDataSourceHandler(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	dsHandler, err := s.getDataSourceHandler(req.PluginContext)
+	dsHandler, err := s.getDataSourceHandler(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -83,7 +83,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		logger.Debug("OpenTsdb request", "params", tsdbQuery)
 	}
 
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -252,8 +252,8 @@ func (s *Service) buildMetric(query backend.DataQuery) map[string]interface{} {
 	return metric
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/parca/service.go
+++ b/pkg/tsdb/parca/service.go
@@ -31,8 +31,8 @@ type Service struct {
 	im instancemgmt.InstanceManager
 }
 
-func (s *Service) getInstance(pluginCtx backend.PluginContext) (*ParcaDatasource, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*ParcaDatasource, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/phlare/service.go
+++ b/pkg/tsdb/phlare/service.go
@@ -33,8 +33,8 @@ type Service struct {
 	im instancemgmt.InstanceManager
 }
 
-func (s *Service) getInstance(pluginCtx backend.PluginContext) (*PhlareDatasource, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*PhlareDatasource, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider, ac accesscontro
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 }
 
 func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStr
 }
 
 func (s *Service) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (s *Service) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 
 // PublishStream is called when a client sends a message to the stream.
 func (s *Service) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -34,8 +34,8 @@ type Service struct {
 	im         instancemgmt.InstanceManager
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*sqleng.DataSource
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (t *postgresQueryResultTransformer) TransformQueryError(_ log.Logger, err e
 
 // CheckHealth pings the connected SQL database
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsHandler, err := s.getDSInfo(req.PluginContext)
+	dsHandler, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/prometheus/healthcheck.go
+++ b/pkg/tsdb/prometheus/healthcheck.go
@@ -24,7 +24,7 @@ var logger log.Logger = log.New("tsdb.prometheus")
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
 	logger := logger.FromContext(ctx)
-	ds, err := s.getInstance(req.PluginContext)
+	ds, err := s.getInstance(ctx, req.PluginContext)
 
 	// check that the datasource exists
 	if err != nil {

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -81,7 +81,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return &backend.QueryDataResponse{}, fmt.Errorf("query contains no queries")
 	}
 
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	i, err := s.getInstance(req.PluginContext)
+	i, err := s.getInstance(ctx, req.PluginContext)
 	if err != nil {
 		return err
 	}
@@ -117,8 +117,8 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	return sender.Send(resp)
 }
 
-func (s *Service) getInstance(pluginCtx backend.PluginContext) (*instance, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginContext) (*instance, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/tempo/tempo.go
+++ b/pkg/tsdb/tempo/tempo.go
@@ -67,7 +67,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return result, err
 	}
 
-	dsInfo, err := s.getDSInfo(req.PluginContext)
+	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +135,8 @@ func (s *Service) createRequest(ctx context.Context, dsInfo *datasourceInfo, tra
 	return req, nil
 }
 
-func (s *Service) getDSInfo(pluginCtx backend.PluginContext) (*datasourceInfo, error) {
-	i, err := s.im.Get(pluginCtx)
+func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {
+	i, err := s.im.Get(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What is this feature?**
Bumps grafana-plugin-go-sdk from `0.160.0` to `0.162.0` and addressed the breaking changes listed [here](https://github.com/grafana/grafana-plugin-sdk-go/releases/tag/v0.162.0)

The changes are simply propagating `context.Context` from core plugin handlers to the plugin instance manager calls.

**Why do we need this feature?**
`0.162.0` has important changes that are better to address sooner rather than later

**Who is this feature for?**

Grafana plugin developers

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
