### PR TITLE
Loki: Update `LokiOperationOrder`

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -91,7 +91,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.Parsers,
       renderer: (model, def, innerExpr) => `${innerExpr} | json ${model.params.join(', ')}`.trim(),
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -104,7 +104,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.Parsers,
       renderer: pipelineRenderer,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -126,7 +126,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.Parsers,
       renderer: (model, def, innerExpr) => `${innerExpr} | regexp \`${model.params[0]}\``,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -148,7 +148,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.Parsers,
       renderer: (model, def, innerExpr) => `${innerExpr} | pattern \`${model.params[0]}\``,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -161,7 +161,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.Parsers,
       renderer: pipelineRenderer,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -183,7 +183,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       defaultParams: [''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.PipeOperations,
       renderer: (model, def, innerExpr) => `${innerExpr} | line_format \`${model.params[0]}\``,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -204,7 +204,7 @@ Example: \`{{.status_code}} - {{.message}}\`
       defaultParams: ['', ''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.LineFormats,
+      orderRank: LokiOperationOrder.PipeOperations,
       renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=${model.params[0]}`,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
@@ -399,7 +399,7 @@ Example: \`\`error_level=\`level\` \`\`
       defaultParams: ['', '=', ''],
       alternativesKey: 'label filter',
       category: LokiVisualQueryOperationCategory.LabelFilters,
-      orderRank: LokiOperationOrder.LabelFilters,
+      orderRank: LokiOperationOrder.PipeOperations,
       renderer: labelFilterRenderer,
       addOperationHandler: addLokiOperation,
       explainHandler: () => `Label expression filter allows filtering using original and extracted labels.`,
@@ -420,7 +420,7 @@ Example: \`\`error_level=\`level\` \`\`
       defaultParams: ['', '=', ''],
       alternativesKey: 'label filter',
       category: LokiVisualQueryOperationCategory.LabelFilters,
-      orderRank: LokiOperationOrder.LabelFilters,
+      orderRank: LokiOperationOrder.PipeOperations,
       renderer: (model, def, innerExpr) =>
         `${innerExpr} | ${model.params[0]} ${model.params[1]} ip(\`${model.params[2]}\`)`,
       addOperationHandler: addLokiOperation,

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -95,8 +95,9 @@ export enum LokiOperationId {
 
 export enum LokiOperationOrder {
   LineFilters = 1,
-  LineFormats = 2,
-  LabelFilters = 3,
+  Parsers = 2,
+  PipeOperations = 3,
+  // Unwrap is a special case, as it is usually the last operation, so the order is after pipeOperations
   Unwrap = 4,
   NoErrors = 5,
   RangeVectorFunction = 5,


### PR DESCRIPTION
In this PR, we are updating name and orders in` LokiOperationOrder` to use more descriptive naming:

1. We are renaming `LineFormats` to `Parsers` and keep the order as `2`. This way, parsers are always added as a first pipe operation. 2 operation - `line_format` and `label_format` were removed from this category and moved to `PipeOperations`
3. We are renaming `LabelFilters` to `PipeOperations` and use this as a category for all pipe operations, including label filters.
4. Initially, I wanted to remove `Unwrap` category, but I've decided to keep it and I've added comment on why.