### PR TITLE
Alerting: Fix matching labels with spaces in their values

### DIFF
--- a/public/app/features/alerting/unified/utils/alertmanager.test.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.test.ts
@@ -90,6 +90,17 @@ describe('Alertmanager utils', () => {
       ]);
     });
 
+    it('should parse with spaces in the value', () => {
+      expect(parseMatchers('foo=bar bazz')).toEqual<Matcher[]>([
+        {
+          name: 'foo',
+          value: 'bar bazz',
+          isRegex: false,
+          isEqual: true,
+        },
+      ]);
+    });
+
     it('should return nothing for invalid operator', () => {
       expect(parseMatchers('foo=!bar')).toEqual([]);
     });

--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -167,7 +167,7 @@ export function matcherToObjectMatcher(matcher: Matcher): ObjectMatcher {
 }
 
 export function parseMatchers(matcherQueryString: string): Matcher[] {
-  const matcherRegExp = /\b([\w.-]+)(=~|!=|!~|=(?="?\w))"?([^"\n,} ]*)"?/g;
+  const matcherRegExp = /\b([\w.-]+)(=~|!=|!~|=(?="?\w))"?([^"\n,}]*)"?/g;
   const matchers: Matcher[] = [];
 
   matcherQueryString.replace(matcherRegExp, (_, key, operator, value) => {


### PR DESCRIPTION
**What is this feature?**

Allows to filter silences matchers by labels that contain spaces.

**Why do we need this feature?**

In the Silences filter, searching by matchers that contain spaces in the value section isn't working.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/6047

![2023-05-23 14 35 21](https://github.com/grafana/grafana/assets/6271380/3ace24a4-f949-4dfc-b3e2-4c0d59e05f79)

