### PR TITLE
Prometheus: Heatmap Format with No Data

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -620,7 +620,7 @@ export function getOriginalMetricName(labelData: { [key: string]: string }) {
 }
 
 function mergeHeatmapFrames(frames: DataFrame[]): DataFrame[] {
-  if (frames.length === 0 || (frames.length === 1 && frames[0].fields.length === 0)) {
+  if (frames.length === 0 || (frames.length === 1 && frames[0].length === 0)) {
     return [];
   }
 

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -620,7 +620,7 @@ export function getOriginalMetricName(labelData: { [key: string]: string }) {
 }
 
 function mergeHeatmapFrames(frames: DataFrame[]): DataFrame[] {
-  if (frames.length === 0) {
+  if (frames.length === 0 || (frames.length === 1 && frames[0].fields.length === 0)) {
     return [];
   }
 


### PR DESCRIPTION
What this PR does / why we need it:
Currently, when setting a Prometheus datasource format to heatmap in query options, when no data is available, the panel crashes.

Before:
![May-23-2023 17-08-43](https://github.com/grafana/grafana/assets/60050885/4d1d6b3f-dad0-4516-b8bb-9ba19422f394)

After:
![May-23-2023 17-07-01](https://github.com/grafana/grafana/assets/60050885/6f2ab3f4-9b6a-454c-b9df-b0d2d40fc99d)

Closes https://github.com/grafana/support-escalations/issues/5684