### PR TITLE
[WIP] API key migration refactoring to fix unexpected behavior

### DIFF
--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -398,9 +398,6 @@ func (s *ServiceAccountsStoreImpl) MigrateApiKey(ctx context.Context, orgId int6
 	for _, key := range basicKeys {
 		if keyId == key.ID {
 			err := s.CreateServiceAccountFromApikey(ctx, key)
-			// TODO: remove this sleep in PR
-			// Simulate a long-running operation
-			time.Sleep(2 * time.Second)
 			if err != nil {
 				s.log.Error("converting to service account failed with error", "keyId", keyId, "error", err)
 				return err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Showcasing a potential bug we have when migrating API keys to service accounts.

```bash
-b3aa-8bc4f9501382 reason="connection closed" elapsed=4m57.986020625s
WARN [05-24|09:06:04] API key not loaded                       logger=serviceaccounts.store err="context canceled"
failed to migrate API key 4 to service account: failed to migrate API key to service account token: context canceled
ERROR[05-24|09:06:04] Operation timed out, please retry        logger=context userId=1 orgId=1 uname=admin error="operation timed out, please retry" remote_addr=[::1] traceID=
```

this is the error we get back from context cancellation now.

https://github.com/grafana/grafana/assets/7727602/fec0ba3d-3626-47d9-b3ad-a26649c3caea

proposals:
**Increase the HTTP server's timeout**: not really possible for us

**Asynchronous processing:** This would prevent the HTTP request from timing out. However, we would need to implement some way of monitoring the progress of the migration and handling any errors that occur.

**Batch processing with checkpoints:** If the function is interrupted, it could resume from the last checkpoint when it's called again

**Client-side retries:** We could implement a retry mechanism on the client side. The client could call the API repeatedly until all API keys have been migrated

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
