### PR TITLE
Footer: Change from `-beta` to `-preview` 

### DIFF
--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -40,11 +40,11 @@ export let getFooterLinks = (): FooterLink[] => {
 };
 
 export function getVersionMeta(version: string) {
-  const isBeta = version.includes('-beta');
+  const isPreview = version.includes('-preview');
 
   return {
     hasReleaseNotes: true,
-    isBeta,
+    isPreview,
   };
 }
 


### PR DESCRIPTION
**What is this feature?**

Changed the version suffix string from `-beta` to `-preview` in the page footer. 

**Why do we need this feature?**

https://grafana.com/docs/release-life-cycle/

**Who is this feature for?**

Everyone, for versions >= G10.

**Which issue(s) does this PR fix?**:

Fixes #68346

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
