### PR TITLE
ResourcePicker: Fix missing border bug on cancel button

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.tsx
@@ -144,7 +144,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       border-radius: ${theme.shape.borderRadius()};
       box-shadow: ${theme.shadows.z3};
       background: ${theme.colors.background.primary};
-      border: 1px solid ${theme.colors.border.medium};
+      border: 1px solid ${theme.colors.border.weak};
 
       .ColorPickerPopover__tab {
         width: 50%;

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -5,8 +5,9 @@ import { useOverlay } from '@react-aria/overlays';
 import React, { createRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
 import { getBackendSrv } from '@grafana/runtime';
-import { Button, ButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, ButtonGroup, Modal, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { MediaType, PickerTabType, ResourceFolderName } from '../types';
@@ -98,12 +99,11 @@ export const ResourcePickerPopover = (props: Props) => {
           </div>
           <div className={styles.resourcePickerPopoverContent}>
             {renderPicker()}
-            <ButtonGroup className={styles.buttonGroup}>
-              <Button className={styles.button} variant={'secondary'} onClick={() => onClose()} fill="outline">
+            <div className={styles.buttonRow}>
+              <Button variant={'secondary'} onClick={() => onClose()} fill="outline">
                 Cancel
               </Button>
               <Button
-                className={styles.button}
                 variant={newValue && newValue !== value ? 'primary' : 'secondary'}
                 onClick={() => {
                   if (upload) {
@@ -133,7 +133,7 @@ export const ResourcePickerPopover = (props: Props) => {
               >
                 Select
               </Button>
-            </ButtonGroup>
+            </div>
           </div>
         </div>
       </section>
@@ -146,7 +146,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     border-radius: ${theme.shape.borderRadius()};
     box-shadow: ${theme.shadows.z3};
     background: ${theme.colors.background.primary};
-    border: 1px solid ${theme.colors.border.medium};
+    border: 1px solid ${theme.colors.border.weak};
   `,
   resourcePickerPopoverTab: css`
     width: 50%;
@@ -185,11 +185,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: 100%;
     border-radius: ${theme.shape.borderRadius()} ${theme.shape.borderRadius()} 0 0;
   `,
-  buttonGroup: css`
-    align-self: center;
-    flex-direction: row;
-  `,
-  button: css`
-    margin: 12px 20px 5px;
-  `,
+  buttonRow: css({
+    display: 'flex',
+    justifyContent: 'center',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1),
+  }),
 });

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -5,9 +5,8 @@ import { useOverlay } from '@react-aria/overlays';
 import React, { createRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
 import { getBackendSrv } from '@grafana/runtime';
-import { Button, ButtonGroup, Modal, useStyles2 } from '@grafana/ui';
+import { Button, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { MediaType, PickerTabType, ResourceFolderName } from '../types';


### PR DESCRIPTION
bug caused by incorrect use of ButtonGroup (this component is for merging multiple buttons into one) 

Before: 
![image](https://github.com/grafana/grafana/assets/10999/2bd0dfe6-e4eb-4df7-8519-0b0547dbc1c9)

After:

![Screenshot from 2023-05-24 12-48-08](https://github.com/grafana/grafana/assets/10999/a90a798e-c921-408f-a27e-038293a42e3b)
