### PR TITLE
Auth: Fix visibility of the Invite button on /admin/users page

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -91,7 +91,7 @@ func (hs *HTTPServer) AddOrgInvite(c *contextmodel.ReqContext) response.Response
 	}
 
 	if hs.Cfg.DisableLoginForm {
-		return response.Error(400, "Cannot invite when login is disabled.", nil)
+		return response.Error(400, "Cannot invite external user when login is disabled.", nil)
 	}
 
 	cmd := tempuser.CreateTempUserCommand{}

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -65,9 +65,9 @@ describe('Render', () => {
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute('href', 'some/url');
   });
 
-  it('should not show invite button when disableLoginForm is set', () => {
-    const originalDisableLoginForm = config.disableLoginForm;
-    config.disableLoginForm = true;
+  it('should not show invite button when externalUserMngInfo is set', () => {
+    const originalExternalUserMngInfo = config.externalUserMngInfo;
+    config.externalUserMngInfo = 'truthy';
 
     setup({
       canInvite: true,
@@ -75,6 +75,6 @@ describe('Render', () => {
 
     expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
     // Reset the disableLoginForm mock to its original value
-    config.disableLoginForm = originalDisableLoginForm;
+    config.externalUserMngInfo = originalExternalUserMngInfo;
   });
 });

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -49,8 +49,8 @@ export const UsersActionBarUnconnected = ({
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
   const canAddToOrg: boolean = contextSrv.hasAccess(AccessControlAction.OrgUsersAdd, canInvite);
-  // backend rejects invitations if the login form is disabled
-  const showInviteButton: boolean = canAddToOrg && !config.disableLoginForm;
+  // Hide Invite button in case users are managed externally
+  const showInviteButton: boolean = canAddToOrg && !config.externalUserMngInfo;
 
   return (
     <div className="page-action-bar" data-testid="users-action-bar">


### PR DESCRIPTION
**What is this feature?**
This PR fixes the visibility check for the `Invite` button on the `/admin/users/` page by hiding it when the users are externally managed (in case for Cloud), otherwise it is visible.

**Why do we need this feature?**
https://github.com/grafana/grafana/pull/67031 introduced an other check (`!config.disableLoginForm`) for deciding whether the button should be visible or not , but existing users can still be invited to the organization regardless of the `disableLoginForm` config.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
