### PR TITLE
Loki: Add support for distinct operation in autocomplete and query builder

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -388,6 +388,32 @@ describe('getCompletions', () => {
     ]);
     expect(functionCompletions).toHaveLength(3);
   });
+
+  test('Returns completion options when the situation is AFTER_DISTINCT', async () => {
+    const situation: Situation = { type: 'AFTER_DISTINCT', logQuery: '{label="value"}' };
+    const completions = await getCompletions(situation, completionProvider);
+
+    expect(completions).toEqual([
+      {
+        insertText: 'extracted',
+        label: 'extracted',
+        triggerOnInsert: false,
+        type: 'LABEL_NAME',
+      },
+      {
+        insertText: 'place',
+        label: 'place',
+        triggerOnInsert: false,
+        type: 'LABEL_NAME',
+      },
+      {
+        insertText: 'source',
+        label: 'source',
+        triggerOnInsert: false,
+        type: 'LABEL_NAME',
+      },
+    ]);
+  });
 });
 
 describe('getAfterSelectorCompletions', () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -124,6 +124,12 @@ const afterSelectorCompletions = [
     type: 'PIPE_OPERATION',
     documentation: 'Operator docs',
   },
+  {
+    documentation: 'Operator docs',
+    insertText: '| distinct',
+    label: 'distinct',
+    type: 'PIPE_OPERATION',
+  },
 ];
 
 function buildAfterSelectorCompletions(

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -363,7 +363,6 @@ export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  console.log(situation.type);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -288,6 +288,13 @@ export async function getAfterSelectorCompletions(
     documentation: explainOperator(LokiOperationId.Decolorize),
   });
 
+  completions.push({
+    type: 'PIPE_OPERATION',
+    label: 'distinct',
+    insertText: `${prefix}distinct`,
+    documentation: explainOperator(LokiOperationId.Distinct),
+  });
+
   // Let's show label options only if query has parser
   if (hasQueryParser) {
     extractedLabelKeys.forEach((key) => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -347,10 +347,23 @@ async function getAfterUnwrapCompletions(
   return [...labelCompletions, ...UNWRAP_FUNCTION_COMPLETIONS];
 }
 
+async function getAfterDistinctCompletions(logQuery: string, dataProvider: CompletionDataProvider) {
+  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(logQuery);
+  const labelCompletions: Completion[] = extractedLabelKeys.map((label) => ({
+    type: 'LABEL_NAME',
+    label,
+    insertText: label,
+    triggerOnInsert: false,
+  }));
+
+  return [...labelCompletions];
+}
+
 export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
+  console.log(situation.type);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':
@@ -381,6 +394,8 @@ export async function getCompletions(
       return getAfterUnwrapCompletions(situation.logQuery, dataProvider);
     case 'IN_AGGREGATION':
       return [...FUNCTION_COMPLETIONS, ...AGGREGATION_COMPLETIONS];
+    case 'AFTER_DISTINCT':
+      return getAfterDistinctCompletions(situation.logQuery, dataProvider);
     default:
       throw new NeverCaseError(situation);
   }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -264,4 +264,16 @@ describe('situation', () => {
       ],
     });
   });
+
+  it('identifies AFTER_DISTINCT autocomplete situations', () => {
+    assertSituation('{label="value"} | logfmt | distinct^', {
+      type: 'AFTER_DISTINCT',
+      logQuery: '{label="value"} | logfmt ',
+    });
+
+    assertSituation('{label="value"} | logfmt | distinct id,^', {
+      type: 'AFTER_DISTINCT',
+      logQuery: '{label="value"} | logfmt ',
+    });
+  });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -20,6 +20,8 @@ import {
   LiteralExpr,
   MetricExpr,
   UnwrapExpr,
+  DistinctFilter,
+  DistinctLabel,
 } from '@grafana/lezer-logql';
 
 import { getLogQueryFromMetricsQuery } from '../../../queryUtils';
@@ -125,6 +127,10 @@ export type Situation =
   | {
       type: 'AFTER_UNWRAP';
       logQuery: string;
+    }
+  | {
+      type: 'AFTER_DISTINCT';
+      logQuery: string;
     };
 
 type Resolver = {
@@ -190,6 +196,14 @@ const RESOLVERS: Resolver[] = [
   {
     path: [UnwrapExpr],
     fun: resolveAfterUnwrap,
+  },
+  {
+    path: [ERROR_NODE_ID, DistinctFilter],
+    fun: resolveAfterDistinct,
+  },
+  {
+    path: [ERROR_NODE_ID, DistinctLabel],
+    fun: resolveAfterDistinct,
   },
 ];
 
@@ -492,6 +506,29 @@ function resolveSelector(node: SyntaxNode, text: string, pos: number): Situation
   return {
     type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
     otherLabels,
+  };
+}
+
+function resolveAfterDistinct(node: SyntaxNode, text: string, pos: number): Situation | null {
+  let logQuery = getLogQueryFromMetricsQuery(text).trim();
+
+  let distinctFilterParent: SyntaxNode | null = null;
+  let parent = node.parent;
+  while (parent !== null) {
+    if (parent.type.id === PipelineStage) {
+      distinctFilterParent = parent;
+      break;
+    }
+    parent = parent.parent;
+  }
+
+  if (distinctFilterParent?.type.id === PipelineStage) {
+    logQuery = logQuery.slice(0, distinctFilterParent.from);
+  }
+
+  return {
+    type: 'AFTER_DISTINCT',
+    logQuery,
   };
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -5,6 +5,7 @@ import {
 import { QueryBuilderOperationDef, QueryBuilderOperationParamValue } from '../../prometheus/querybuilder/shared/types';
 
 import { binaryScalarOperations } from './binaryScalarOperations';
+import { DistinctParamEditor } from './components/DistinctParamEditor';
 import { UnwrapParamEditor } from './components/UnwrapParamEditor';
 import {
   addLokiOperation,
@@ -485,6 +486,28 @@ Example: \`\`error_level=\`level\` \`\`
       renderer: (op, def, innerExpr) => `${innerExpr} | decolorize`,
       addOperationHandler: addLokiOperation,
       explainHandler: () => `This will remove ANSI color codes from log lines.`,
+    },
+    {
+      id: LokiOperationId.Distinct,
+      name: 'Distinct',
+      params: [
+        {
+          name: 'String',
+          type: 'string',
+          hideName: true,
+          placeholder: 'label1, label2',
+          description: 'Comma separated list of labels to use for distinct filtering',
+          minWidth: 20,
+        },
+      ],
+      defaultParams: [''],
+      alternativesKey: 'format',
+      category: LokiVisualQueryOperationCategory.Formats,
+      orderRank: LokiOperationOrder.Unwrap,
+      renderer: (op, def, innerExpr) => `${innerExpr} | distinct ${op.params[0]}`,
+      addOperationHandler: addLokiOperation,
+      explainHandler: () =>
+        'Allows filtering log lines using their original and extracted labels to filter out duplicate label values. The first line occurrence of a distinct value is returned, and the others are dropped.',
     },
     ...binaryScalarOperations,
     {

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -5,7 +5,6 @@ import {
 import { QueryBuilderOperationDef, QueryBuilderOperationParamValue } from '../../prometheus/querybuilder/shared/types';
 
 import { binaryScalarOperations } from './binaryScalarOperations';
-import { DistinctParamEditor } from './components/DistinctParamEditor';
 import { UnwrapParamEditor } from './components/UnwrapParamEditor';
 import {
   addLokiOperation,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -1,3 +1,4 @@
+import { LabelParamEditor } from '../../prometheus/querybuilder/components/LabelParamEditor';
 import {
   createAggregationOperation,
   createAggregationOperationWithParam,
@@ -491,19 +492,18 @@ Example: \`\`error_level=\`level\` \`\`
       name: 'Distinct',
       params: [
         {
-          name: 'String',
+          name: 'Label',
           type: 'string',
-          hideName: true,
-          placeholder: 'label1, label2',
-          description: 'Comma separated list of labels to use for distinct filtering',
-          minWidth: 20,
+          restParam: true,
+          optional: true,
+          editor: LabelParamEditor,
         },
       ],
       defaultParams: [''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
       orderRank: LokiOperationOrder.Unwrap,
-      renderer: (op, def, innerExpr) => `${innerExpr} | distinct ${op.params[0]}`,
+      renderer: (op, def, innerExpr) => `${innerExpr} | distinct ${op.params.join(',')}`,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
         'Allows filtering log lines using their original and extracted labels to filter out duplicate label values. The first line occurrence of a distinct value is returned, and the others are dropped.',

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -716,6 +716,36 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
+
+  it('parses a log query with distinct and no labels', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | distinct')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Distinct, params: [] }],
+      })
+    );
+  });
+
+  it('parses a log query with distinct and labels', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | distinct id, email')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Distinct, params: ['id', 'email'] }],
+      })
+    );
+  });
 });
 
 function noErrors(query: LokiVisualQuery) {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -664,13 +664,12 @@ function handleDistinctFilter(
     exploringNode = exploringNode?.getChild(DistinctLabel);
   }
 
-  console.log(labels);
-
   if (labels.length) {
+    labels.reverse();
     return {
       operation: {
         id: LokiOperationId.Distinct,
-        params: [labels.join(', ')],
+        params: labels,
       },
     };
   }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -208,15 +208,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
     }
 
     case DistinctFilter: {
-      const { operation, error } = handleDistinctFilter(expr, node, context);
-      if (operation) {
-        visQuery.operations.push(operation);
-      }
-      // Show error for query patterns not supported in visual query builder
-      if (error) {
-        context.errors.push(createNotSupportedError(expr, node, error));
-      }
-
+      visQuery.operations.push(handleDistinctFilter(expr, node, context));
       break;
     }
 
@@ -649,11 +641,7 @@ function isEmptyQuery(query: LokiVisualQuery) {
   return false;
 }
 
-function handleDistinctFilter(
-  expr: string,
-  node: SyntaxNode,
-  context: Context
-): { operation?: QueryBuilderOperation; error?: string } {
+function handleDistinctFilter(expr: string, node: SyntaxNode, context: Context): QueryBuilderOperation {
   const labels: string[] = [];
   let exploringNode = node.getChild(DistinctLabel);
   while (exploringNode) {
@@ -663,16 +651,9 @@ function handleDistinctFilter(
     }
     exploringNode = exploringNode?.getChild(DistinctLabel);
   }
-
-  if (labels.length) {
-    labels.reverse();
-    return {
-      operation: {
-        id: LokiOperationId.Distinct,
-        params: labels,
-      },
-    };
-  }
-
-  return {};
+  labels.reverse();
+  return {
+    id: LokiOperationId.Distinct,
+    params: labels,
+  };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -38,6 +38,7 @@ export enum LokiOperationId {
   Regexp = 'regexp',
   Pattern = 'pattern',
   Unpack = 'unpack',
+  Distinct = 'distinct',
   LineFormat = 'line_format',
   LabelFormat = 'label_format',
   Decolorize = 'decolorize',


### PR DESCRIPTION
In https://github.com/grafana/loki/pull/8662 the DISTINCT filter was introduced, so we are adding support for it in both Code Editor and Query Builder.

- Automatically closes linked issue when the Pull Request is merged.

Fixes https://github.com/grafana/grafana/issues/68170

**Special notes for your reviewer:**

Added support for autocomplete with no previous labels:

![Autocomplete 1](https://github.com/grafana/grafana/assets/1069378/0f62cc77-e8fe-4d3f-b532-dc61adec2947)

Added support for autocomplete with selected labels:
![Autocomplete 2](https://github.com/grafana/grafana/assets/1069378/e2986e33-899e-46df-930b-7bb5c58eec41)

Added query builder support:
![Query Builder](https://github.com/grafana/grafana/assets/1069378/99d37a30-6ee9-4eeb-bd5a-7a43fce480b5)