### PR TITLE
Dashboards: Remove Explore option from panel menu when panel's datasource uid is "-- Dashboard --"

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -25,6 +25,7 @@ import {
 } from 'app/features/dashboard/utils/panel';
 import { InspectTab } from 'app/features/inspector/types';
 import { isPanelModelLibraryPanel } from 'app/features/library-panels/guard';
+import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
 import { store } from 'app/store/store';
 
 import { navigateToExplore } from '../../explore/state/main';
@@ -144,7 +145,7 @@ export function getPanelMenu(
   if (
     contextSrv.hasAccessToExplore() &&
     !(panel.plugin && panel.plugin.meta.skipDataQuery) &&
-    panel.datasource?.uid !== '-- Dashboard --'
+    panel.datasource?.uid !== SHARED_DASHBOARD_QUERY
   ) {
     menu.push({
       text: t('panel.header-menu.explore', `Explore`),

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -141,7 +141,11 @@ export function getPanelMenu(
     shortcut: 'p s',
   });
 
-  if (contextSrv.hasAccessToExplore() && !(panel.plugin && panel.plugin.meta.skipDataQuery)) {
+  if (
+    contextSrv.hasAccessToExplore() &&
+    !(panel.plugin && panel.plugin.meta.skipDataQuery) &&
+    panel.datasource?.uid !== '-- Dashboard --'
+  ) {
     menu.push({
       text: t('panel.header-menu.explore', `Explore`),
       iconClassName: 'compass',


### PR DESCRIPTION
**What is this feature?**

Since Explore doesn't support the dashboard datasource, I've disabled the Explore option in panel menu. 

In future, we should support all the source queries used by the dashboard data source and generate a link to Explore using them instead. I've created a follow-up ticket that will address that: https://github.com/grafana/grafana/issues/69167

**Example**

Panel with `-- Dashboard --` uid:
![Screenshot 2023-05-24 at 1 44 15 PM](https://github.com/grafana/grafana/assets/58232930/e2014302-c26c-46bd-bb0c-252ba5b8531e)

All other panels:
![Screenshot 2023-05-24 at 1 45 23 PM](https://github.com/grafana/grafana/assets/58232930/66cea9d6-cb84-49d8-aafa-a7dca03f4df1)


Fixes https://github.com/grafana/grafana/issues/61620

**Please check that:**
- [ ] It works as expected from a user's perspective.

