### PR TITLE
Chore: Adding "allowed_groups" Configuration Parameter to Generic OAuth Method

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -721,6 +721,7 @@ token_url =
 api_url =
 teams_url =
 allowed_domains =
+allowed_groups =
 team_ids =
 allowed_organizations =
 tls_skip_verify_insecure = false

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -45,6 +45,7 @@ auth_url =
 token_url =
 api_url =
 allowed_domains = mycompany.com mycompany.org
+allowed_groups = ["Admins", "Software Engineers"]
 tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -86,6 +86,8 @@ Similarly, group mappings are made using [JMESPath](http://jmespath.org/examples
 
 Furthermore, Grafana will check for the presence of at least one of the teams specified via the `team_ids` configuration option using the [JMESPath](http://jmespath.org/examples.html) specified via the `team_ids_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the Teams endpoint specified via the `teams_url` configuration option (using `/teams` as a fallback endpoint). The result should be a string array of Grafana Team IDs. Using this setting ensures that only certain teams is allowed to authenticate to Grafana using your OAuth provider.
 
+You can limit access to only members of a given group or list of groups by setting the `allowed_groups` option.
+
 ### Login
 
 Customize user login using `login_attribute_path` configuration option. Order of operations is as follows:

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -31,6 +31,23 @@ type SocialGenericOAuth struct {
 	idTokenAttributeName string
 	teamIdsAttributePath string
 	teamIds              []string
+	allowedGroups        []string
+}
+
+func (s *SocialGenericOAuth) IsGroupMember(groups []string) bool {
+	if len(s.allowedGroups) == 0 {
+		return true
+	}
+
+	for _, allowedGroup := range s.allowedGroups {
+		for _, group := range groups {
+			if group == allowedGroup {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (s *SocialGenericOAuth) IsTeamMember(client *http.Client) bool {
@@ -180,6 +197,10 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 
 	if !s.IsOrganizationMember(client) {
 		return nil, errors.New("user not a member of one of the required organizations")
+	}
+
+	if !s.IsGroupMember(userInfo.Groups) {
+		return nil, errMissingGroupMembership
 	}
 
 	s.log.Debug("User info result", "result", userInfo)

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -214,6 +214,7 @@ func ProvideService(cfg *setting.Cfg,
 				teamIdsAttributePath: sec.Key("team_ids_attribute_path").String(),
 				teamIds:              sec.Key("team_ids").Strings(","),
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
+				allowedGroups:        util.SplitString(sec.Key("allowed_groups").String()),
 			}
 		}
 


### PR DESCRIPTION
**What is this feature?**
This PR introduces a new configuration parameter, `allowed_groups`, for the Generic OAuth method.

**Why do we need this feature?**
This new feature enhances the functionality of the Generic OAuth method by allowing the specification of groups that have access to the service. This allows for fine-tuned access control and increases security and specificity in permissions settings.

**Who is this feature for?**
This feature is beneficial for system administrators or developers who want to exert more precise control over who can access their services. It's especially useful in environments with a variety of user roles or teams that require different levels of access to the same services.

**Which issue(s) does this PR fix?**: 
This PR is not directly address any existing issues.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
