### PR TITLE
StatusHistory: Fix rendering of value-mapped null

### DIFF
--- a/packages/grafana-data/src/types/fieldColor.ts
+++ b/packages/grafana-data/src/types/fieldColor.ts
@@ -37,4 +37,4 @@ export interface FieldColor {
  */
 export type FieldColorSeriesByMode = 'min' | 'max' | 'last';
 
-export const FALLBACK_COLOR = 'gray';
+export const FALLBACK_COLOR = '#808080';

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -47,6 +47,7 @@ export interface TimelineCoreOptions {
   showValue: VisibilityMode;
   mergeValues?: boolean;
   isDiscrete: (seriesIdx: number) => boolean;
+  hasMappedNull: (seriesIdx: number) => boolean;
   getValueColor: (seriesIdx: number, value: unknown) => string;
   label: (seriesIdx: number) => string;
   getTimeRange: () => TimeRange;
@@ -64,6 +65,7 @@ export function getConfig(opts: TimelineCoreOptions) {
     mode,
     numSeries,
     isDiscrete,
+    hasMappedNull,
     rowHeight = 0,
     colWidth = 0,
     showValue,
@@ -210,6 +212,7 @@ export function getConfig(opts: TimelineCoreOptions) {
         let strokeWidth = round((series.width || 0) * uPlot.pxRatio);
 
         let discrete = isDiscrete(sidx);
+        let mappedNull = discrete && hasMappedNull(sidx);
 
         u.ctx.save();
         rect(u.ctx, u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
@@ -220,7 +223,7 @@ export function getConfig(opts: TimelineCoreOptions) {
             for (let ix = 0; ix < dataY.length; ix++) {
               let yVal = dataY[ix];
 
-              if (yVal != null) {
+              if (yVal != null || mappedNull) {
                 let left = Math.round(valToPosX(dataX[ix], scaleX, xDim, xOff));
 
                 let nextIx = ix;
@@ -262,7 +265,9 @@ export function getConfig(opts: TimelineCoreOptions) {
             //let xShift = align === 1 ? 0 : align === -1 ? barWid : barWid / 2;
 
             for (let ix = idx0; ix <= idx1; ix++) {
-              if (dataY[ix] != null) {
+              let yVal = dataY[ix];
+
+              if (yVal != null || mappedNull) {
                 // TODO: all xPos can be pre-computed once for all series in aligned set
                 let left = valToPosX(dataX[ix], scaleX, xDim, xOff);
 
@@ -278,7 +283,7 @@ export function getConfig(opts: TimelineCoreOptions) {
                   strokeWidth,
                   iy,
                   ix,
-                  dataY[ix],
+                  yVal,
                   discrete
                 );
               }
@@ -316,10 +321,13 @@ export function getConfig(opts: TimelineCoreOptions) {
             (series, dataX, dataY, scaleX, scaleY, valToPosX, valToPosY, xOff, yOff, xDim, yDim) => {
               let strokeWidth = round((series.width || 0) * uPlot.pxRatio);
 
+              let discrete = isDiscrete(sidx);
+              let mappedNull = discrete && hasMappedNull(sidx);
+
               let y = round(yOff + yMids[sidx - 1]);
 
               for (let ix = 0; ix < dataY.length; ix++) {
-                if (dataY[ix] != null) {
+                if (dataY[ix] != null || mappedNull) {
                   const boxRect = boxRectsBySeries[sidx - 1][ix];
 
                   if (!boxRect || boxRect.x >= xDim) {

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -31,6 +31,7 @@ import {
   VisibilityMode,
   TimelineValueAlignment,
   HideableFieldConfig,
+  MappingType,
 } from '@grafana/schema';
 import {
   FIXED_UNIT,
@@ -112,6 +113,14 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<UPlotConfigOptions> = (
     return !(mode && field.display && mode.startsWith('continuous-'));
   };
 
+  const hasMappedNull = (field: Field) => {
+    return (
+      field.config.mappings?.some(
+        (mapping) => mapping.type === MappingType.SpecialValue && mapping.options.match === 'null'
+      ) || false
+    );
+  };
+
   const getValueColorFn = (seriesIdx: number, value: unknown) => {
     const field = frame.fields[seriesIdx];
 
@@ -130,6 +139,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<UPlotConfigOptions> = (
     mode: mode!,
     numSeries: frame.fields.length - 1,
     isDiscrete: (seriesIdx) => isDiscrete(frame.fields[seriesIdx]),
+    hasMappedNull: (seriesIdx) => hasMappedNull(frame.fields[seriesIdx]),
     mergeValues,
     rowHeight: rowHeight,
     colWidth: colWidth,


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/6090

properly renders `null` value mappings rather than rendering gaps. (applies to both Status History and State Timeline)

<details><summary>status-history-mapped-null.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 688,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "fillOpacity": 70,
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 1
          },
          "mappings": [
            {
              "options": {
                "match": "null",
                "result": {
                  "color": "red",
                  "index": 0,
                  "text": "ssssss"
                }
              },
              "type": "special"
            }
          ],
          "thresholds": {
            "mode": "percentage",
            "steps": [
              {
                "color": "green"
              }
            ]
          },
          "unit": "short"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 11,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "maxDataPoints": 5,
      "options": {
        "colWidth": 0.9,
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "rowHeight": 0.9,
        "showValue": "always",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "7.5.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 3600000\n          }\n        },\n        {\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1616554800000,\n          1616558400000,\n          1616562000000,\n          1616565600000\n        ],\n        [\n          15.504261320560225,\n          16.17418504503572,\n          22.565185806353988,\n          19.85538682158332\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 3600000\n          }\n        },\n        {\n          \"name\": \"A-series1\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1616554800000,\n          1616558400000,\n          1616562000000,\n          1616565600000\n        ],\n        [\n          16.62564760031916,\n          21.271595723576564,\n          null,\n          23.66659222162027\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Status grid",
      "type": "status-history"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "fillOpacity": 70,
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 0,
            "spanNulls": false
          },
          "mappings": [
            {
              "options": {
                "match": "null",
                "result": {
                  "color": "red",
                  "index": 0,
                  "text": "ssssss"
                }
              },
              "type": "special"
            }
          ],
          "thresholds": {
            "mode": "percentage",
            "steps": [
              {
                "color": "green"
              }
            ]
          },
          "unit": "short"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 11,
        "w": 24,
        "x": 0,
        "y": 11
      },
      "id": 3,
      "maxDataPoints": 5,
      "options": {
        "alignValue": "left",
        "legend": {
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "mergeValues": false,
        "rowHeight": 0.9,
        "showValue": "auto",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "7.5.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 3600000\n          }\n        },\n        {\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1616554800000,\n          1616558400000,\n          1616562000000,\n          1616565600000\n        ],\n        [\n          15.504261320560225,\n          16.17418504503572,\n          22.565185806353988,\n          19.85538682158332\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 3600000\n          }\n        },\n        {\n          \"name\": \"A-series1\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1616554800000,\n          1616558400000,\n          1616562000000,\n          1616565600000\n        ],\n        [\n          16.62564760031916,\n          21.271595723576564,\n          null,\n          23.66659222162027\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Status grid",
      "type": "state-timeline"
    }
  ],
  "refresh": false,
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2021-03-24T03:00:00.000Z",
    "to": "2021-03-24T07:00:00.000Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "status-history-mapped-null",
  "uid": "cc47723b-173d-4df9-8d6d-3df0372ed029",
  "version": 6,
  "weekStart": ""
}
```
</details>

![image](https://github.com/grafana/grafana/assets/43234/bf027574-b0a5-4614-8c7e-641d47032aeb)

![image](https://github.com/grafana/grafana/assets/43234/e5b8a84b-fc57-41b9-a01d-4b11f1fde9e2)
