### PR TITLE
TimeSeries: Fix centeredZero y axis ranging when all values are 0

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -173,6 +173,12 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
           let absMin = Math.abs(dataMin!);
           let absMax = Math.abs(dataMax!);
           let max = Math.max(absMin, absMax);
+
+          // flat 0
+          if (max === 0) {
+            max = 80;
+          }
+
           dataMin = -max;
           dataMax = max;
         }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/68824

![image](https://github.com/grafana/grafana/assets/43234/42bbdee7-c188-4ec0-a75d-b28e50b899b4)