### PR TITLE
[Timeseries] Place legend to bottom when on <lg display

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -5,7 +5,7 @@ import { useMeasure } from 'react-use';
 import { GrafanaTheme2 } from '@grafana/data';
 import { LegendPlacement } from '@grafana/schema';
 
-import { useStyles2 } from '../../themes/ThemeContext';
+import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { getFocusStyles } from '../../themes/mixins';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 
@@ -30,6 +30,7 @@ export interface VizLayoutComponentType extends FC<VizLayoutProps> {
  * @beta
  */
 export const VizLayout: VizLayoutComponentType = ({ width, height, legend, children }) => {
+  const theme = useTheme2();
   const styles = useStyles2(getVizStyles);
   const containerStyle: CSSProperties = {
     display: 'flex',
@@ -50,7 +51,11 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     );
   }
 
-  const { placement, maxHeight = '35%', maxWidth = '60%' } = legend.props;
+  let { placement, maxHeight = '35%', maxWidth = '60%' } = legend.props;
+
+  if (document.body.clientWidth < theme.breakpoints.values.lg) {
+    placement = 'bottom';
+  }
 
   let size: VizSize | null = null;
 


### PR DESCRIPTION
**What is this feature?**

When viewing timeseries panels with right legend on mobile, the legend should be moved to bottom (the same way the original Graph panel did that)

**Why do we need this feature?**

Currently, it's kinda impossible to use Grafana on mobile since nothing really is visible

![image](https://github.com/grafana/grafana/assets/327717/09d22c39-06f9-423c-92e3-51ebc03a7ff7)

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/discussions/68755

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
