### PR TITLE
Datasources: Extend  optional reporting

### DIFF
--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -48,11 +48,7 @@ export const reportInteraction = (interactionName: string, properties?: Record<s
     type: EchoEventType.Interaction,
     payload: {
       interactionName,
-      properties: {
-        url: location.href,
-        path: location.pathname,
-        ...properties,
-      },
+      properties,
     },
   });
 };

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -48,7 +48,11 @@ export const reportInteraction = (interactionName: string, properties?: Record<s
     type: EchoEventType.Interaction,
     payload: {
       interactionName,
-      properties,
+      properties: {
+        url: location.href,
+        path: location.pathname,
+        ...properties,
+      },
     },
   });
 };

--- a/packages/grafana-runtime/src/services/EchoSrv.ts
+++ b/packages/grafana-runtime/src/services/EchoSrv.ts
@@ -18,6 +18,7 @@ export interface EchoMeta {
   windowSize: SizeMeta;
   userAgent: string;
   url?: string;
+  path?: string;
   /**
    * A unique browser session
    */

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -79,6 +79,7 @@ export class Echo implements EchoSrv {
       userAgent: window.navigator.userAgent,
       ts: new Date().getTime(),
       timeSinceNavigationStart: performance.now(),
+      path: window.location.pathname,
       url: window.location.href,
     };
   };

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -24,6 +24,7 @@ import {
   useTestDataSource,
   useUpdateDatasource,
 } from '../state';
+import { trackDsConfigClicked, trackDsConfigUpdated } from '../tracking';
 import { DataSourceRights } from '../types';
 
 import { BasicSettings } from './BasicSettings';
@@ -119,9 +120,13 @@ export function EditDataSourceView({
 
   const onSubmit = async (e: React.MouseEvent<HTMLButtonElement> | React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    trackDsConfigClicked('save_and_test');
+
     try {
       await onUpdate({ ...dataSource });
+      trackDsConfigUpdated('success');
     } catch (err) {
+      trackDsConfigUpdated('fail');
       return;
     }
 
@@ -129,7 +134,15 @@ export function EditDataSourceView({
   };
 
   if (loadError) {
-    return <DataSourceLoadError dataSourceRights={dataSourceRights} onDelete={onDelete} />;
+    return (
+      <DataSourceLoadError
+        dataSourceRights={dataSourceRights}
+        onDelete={() => {
+          trackDsConfigClicked('delete');
+          onDelete();
+        }}
+      />
+    );
   }
 
   if (loading) {
@@ -181,8 +194,14 @@ export function EditDataSourceView({
 
       <ButtonRow
         onSubmit={onSubmit}
-        onTest={onTest}
-        onDelete={onDelete}
+        onDelete={() => {
+          trackDsConfigClicked('delete');
+          onDelete();
+        }}
+        onTest={() => {
+          trackDsConfigClicked('test');
+          onTest();
+        }}
         canDelete={!readOnly && hasDeleteRights}
         canSave={!readOnly && hasWriteRights}
       />

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -6,7 +6,7 @@ import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
 
 import { useDataSource } from '../state';
-import { trackCreateDashboardClicked, trackExploreClicked } from '../tracking';
+import { trackCreateDashboardClicked, trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 interface Props {
@@ -25,6 +25,7 @@ export function EditDataSourceActions({ uid }: Props) {
           size="sm"
           href={constructDataSourceExploreUrl(dataSource)}
           onClick={() => {
+            trackDsConfigClicked('explore');
             trackExploreClicked({
               grafana_version: config.buildInfo.version,
               datasource_uid: dataSource.uid,
@@ -41,6 +42,7 @@ export function EditDataSourceActions({ uid }: Props) {
         variant="secondary"
         href={`dashboard/new-with-ds/${dataSource.uid}`}
         onClick={() => {
+          trackDsConfigClicked('build_a_dashboard');
           trackCreateDashboardClicked({
             grafana_version: config.buildInfo.version,
             datasource_uid: dataSource.uid,

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -78,3 +78,11 @@ export const trackCreateDashboardClicked = (props: DataSourceGeneralTrackingProp
 export const trackDataSourcesListViewed = (props: { grafana_version?: string; path?: string }) => {
   reportInteraction('grafana_ds_datasources_list_viewed', props);
 };
+
+export const trackDsConfigClicked = (item: string) => {
+  reportInteraction('connections_datasources_settings_clicked', { item });
+};
+
+export const trackDsConfigUpdated = (item: string) => {
+  reportInteraction('connections_datasources_ds_configured', { item });
+};


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/68754

### What changed?
- [ ] ~**`reportInteraction()`**: add the `url` and the `path` as default properties to the function (the props passed in the function should be able to override these)~
- [x] **`reportInteraction()`**: add a `path` property to the event meta (`url` was already present)
- [x] **Datasources Configuration page**: add more _optional_ tracking events to be able have a better picture about the UX of the different user-flows. (These are only tracking anything if the relevant backends are configured by the server admin.)

After this `event.meta.path` (and also `event.meta.url`) should be available on all events.