### PR TITLE
Query Editor: Ensure dropdown menus position correctly

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -41,6 +41,11 @@ export function LabelFilterItem({
     isLoadingLabelNames?: boolean;
     isLoadingLabelValues?: boolean;
   }>({});
+  // there's a bug in react-select where the menu doesn't recalculate its position when the options are loaded asynchronously
+  // see https://github.com/grafana/grafana/issues/63558
+  // instead, we explicitly control the menu visibility and prevent showing it until the options have fully loaded
+  const [labelNamesMenuOpen, setLabelNamesMenuOpen] = useState(false);
+  const [labelValuesMenuOpen, setLabelValuesMenuOpen] = useState(false);
 
   const isMultiSelect = (operator = item.op) => {
     return operators.find((op) => op.label === operator)?.isMultiValue;
@@ -75,8 +80,13 @@ export function LabelFilterItem({
           onOpenMenu={async () => {
             setState({ isLoadingLabelNames: true });
             const labelNames = await onGetLabelNames(item);
+            setLabelNamesMenuOpen(true);
             setState({ labelNames, isLoadingLabelNames: undefined });
           }}
+          onCloseMenu={() => {
+            setLabelNamesMenuOpen(false);
+          }}
+          isOpen={labelNamesMenuOpen}
           isLoading={state.isLoadingLabelNames ?? false}
           options={state.labelNames}
           onChange={(change) => {
@@ -129,12 +139,17 @@ export function LabelFilterItem({
             if (labelValues.length > PROMETHEUS_QUERY_BUILDER_MAX_RESULTS) {
               labelValues.splice(0, labelValues.length - PROMETHEUS_QUERY_BUILDER_MAX_RESULTS);
             }
+            setLabelValuesMenuOpen(true);
             setState({
               ...state,
               labelValues,
               isLoadingLabelValues: undefined,
             });
           }}
+          onCloseMenu={() => {
+            setLabelValuesMenuOpen(false);
+          }}
+          isOpen={labelValuesMenuOpen}
           defaultOptions={state.labelValues}
           isMulti={isMultiSelect()}
           isLoading={state.isLoadingLabelValues}

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -39,6 +39,11 @@ export function LabelFilterItem({
     isLoadingLabelNames?: boolean;
     isLoadingLabelValues?: boolean;
   }>({});
+  // there's a bug in react-select where the menu doesn't recalculate its position when the options are loaded asynchronously
+  // see https://github.com/grafana/grafana/issues/63558
+  // instead, we explicitly control the menu visibility and prevent showing it until the options have fully loaded
+  const [labelNamesMenuOpen, setLabelNamesMenuOpen] = useState(false);
+  const [labelValuesMenuOpen, setLabelValuesMenuOpen] = useState(false);
   const CONFLICTING_LABEL_FILTER_ERROR_MESSAGE = 'You have conflicting label filters';
 
   const isMultiSelect = (operator = item.op) => {
@@ -79,8 +84,13 @@ export function LabelFilterItem({
             onOpenMenu={async () => {
               setState({ isLoadingLabelNames: true });
               const labelNames = await onGetLabelNames(item);
+              setLabelNamesMenuOpen(true);
               setState({ labelNames, isLoadingLabelNames: undefined });
             }}
+            onCloseMenu={() => {
+              setLabelNamesMenuOpen(false);
+            }}
+            isOpen={labelNamesMenuOpen}
             isLoading={state.isLoadingLabelNames}
             options={state.labelNames}
             onChange={(change) => {
@@ -131,7 +141,12 @@ export function LabelFilterItem({
                 labelValues,
                 isLoadingLabelValues: undefined,
               });
+              setLabelValuesMenuOpen(true);
             }}
+            onCloseMenu={() => {
+              setLabelValuesMenuOpen(false);
+            }}
+            isOpen={labelValuesMenuOpen}
             isMulti={isMultiSelect()}
             isLoading={state.isLoadingLabelValues}
             options={getOptions()}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- there's a bug with `react-select` where it doesn't recalculate the menu position if the list of options changes
- this has been raised a couple of times now:
  - https://github.com/JedWatson/react-select/issues/5642
  - https://github.com/JedWatson/react-select/issues/4936
- as a workaround, we can explicitly control the state of the menu and prevent it from being shown until the options have loaded
  - we've done this previously with influx here: https://github.com/grafana/grafana/pull/60087
- this means the first time the menu is shown it has the full list of options and positions itself correctly 👍 

**Why do we need this feature?**

- better usability

**Who is this feature for?**

- anyone using the prometheus/shared query builders

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/63558
Fixes https://github.com/grafana/support-escalations/issues/5087

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
