### PR TITLE
CODEOWNERS: Switching `pkg/service/apikey` to authnz squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,7 +94,7 @@
 /pkg/models/ @grafana/backend-platform
 /pkg/server/ @grafana/backend-platform
 /pkg/services/annotations/ @grafana/backend-platform
-/pkg/services/apikey/ @grafana/backend-platform
+/pkg/services/apikey/ @grafana/grafana-authnz-team
 /pkg/services/cleanup/ @grafana/backend-platform
 /pkg/services/contexthandler/ @grafana/backend-platform
 /pkg/services/correlations/ @grafana/backend-platform


### PR DESCRIPTION
Changinge codeowners file to reflect ownership properly.


For:
`/pkg/services/apikey/` from backend platform to `@grafana/grafana-authnz-team`.
