### PR TITLE
Drawer: Fixes closeOnMaskClick false issue

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -73,7 +73,8 @@ export function Drawer({
 
   // Adds body class while open so the toolbar nav can hide some actions while drawer is open
   useBodyClassWhileOpen();
-  useClickAway(overlayRef, onClose);
+  // Close when we click outside mask (topnav) but only if closeOnMaskClick is true
+  useClickAway(overlayRef, closeOnMaskClick ? onClose : doNothing);
 
   // Apply size styles (unless deprecated width prop is used)
   const rootClass = cx(styles.drawer, !width && styles.sizes[size]);
@@ -141,6 +142,8 @@ export function Drawer({
     </RcDrawer>
   );
 }
+
+function doNothing() {}
 
 function useBodyClassWhileOpen() {
   useEffect(() => {

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -132,7 +132,6 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       title={title}
       onClose={onDismiss}
       subtitle={dashboard.title}
-      closeOnMaskClick={false}
       tabs={
         <TabsBar>
           <Tab label={'Details'} active={!showDiff} onChangeTab={() => setShowDiff(false)} />

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -132,6 +132,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       title={title}
       onClose={onDismiss}
       subtitle={dashboard.title}
+      closeOnMaskClick={false}
       tabs={
         <TabsBar>
           <Tab label={'Details'} active={!showDiff} onChangeTab={() => setShowDiff(false)} />


### PR DESCRIPTION
After the move of the drawer under topnav we added a "clickaway" handler to make the drawer close when you click the topnav area. But this should be disabled if `closeOnMaskClick` is set to false (defaults to true). 

We do not have any drawers that have closeOnMaskClick set to false in core so we missed this 