### PR TITLE
Alerting: Fix flaky TestIntegrationUpdateAlertRules

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -29,16 +29,17 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	cfg := setting.NewCfg()
-	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{BaseInterval: time.Duration(rand.Int63n(100)) * time.Second}
+	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{BaseInterval: time.Duration(rand.Int63n(100)+1) * time.Second}
 	sqlStore := db.InitTestDB(t)
 	store := &DBstore{
 		SQLStore:      sqlStore,
 		Cfg:           cfg.UnifiedAlerting,
 		FolderService: setupFolderService(t, sqlStore, cfg),
 	}
+	generator := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval), models.WithUniqueID())
 
 	t.Run("should increase version", func(t *testing.T) {
-		rule := createRule(t, store, nil)
+		rule := createRule(t, store, generator)
 		newRule := models.CopyRule(rule)
 		newRule.Title = util.GenerateShortUID()
 		err := store.UpdateAlertRules(context.Background(), []models.UpdateRule{{
@@ -60,7 +61,7 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 	})
 
 	t.Run("should fail due to optimistic locking if version does not match", func(t *testing.T) {
-		rule := createRule(t, store, nil)
+		rule := createRule(t, store, generator)
 		rule.Version-- // simulate version discrepancy
 
 		newRule := models.CopyRule(rule)
@@ -168,7 +169,7 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 
 func withIntervalMatching(baseInterval time.Duration) func(*models.AlertRule) {
 	return func(rule *models.AlertRule) {
-		rule.IntervalSeconds = int64(baseInterval.Seconds()) * rand.Int63n(10)
+		rule.IntervalSeconds = int64(baseInterval.Seconds()) * (rand.Int63n(10) + 1)
 		rule.For = time.Duration(rule.IntervalSeconds*rand.Int63n(9)+1) * time.Second
 	}
 }


### PR DESCRIPTION
Fixes the flakiness in integration test TestIntegrationUpdateAlertRules by preventing duplicate alert rule ids and 0 values for BaseInterval and IntervalSeconds.