### PR TITLE
Correlations: Show labels fields that have links

### DIFF
--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -1,6 +1,7 @@
 import memoizeOne from 'memoize-one';
 
 import { DataFrame, Field, FieldType, LinkModel, LogRowModel } from '@grafana/data';
+import { safeStringifyValue } from 'app/core/utils/explore';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
 export type FieldDef = {
@@ -69,9 +70,10 @@ export const getDataframeFields = memoizeOne(
       .filter((field, index) => !shouldRemoveField(field, index, row))
       .map((field) => {
         const links = getFieldLinks ? getFieldLinks(field, row.rowIndex, row.dataFrame) : [];
+
         return {
           keys: [field.name],
-          values: [field.values[row.rowIndex].toString()],
+          values: [safeStringifyValue(field.values[row.rowIndex])],
           links: links,
           fieldIndex: field.index,
         };
@@ -82,7 +84,7 @@ export const getDataframeFields = memoizeOne(
 function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   // Remove field if it is:
   // "labels" field that is in Loki used to store all labels
-  if (field.name === 'labels' && field.type === FieldType.other) {
+  if (field.name === 'labels' && field.type === FieldType.other && (field.config.links?.length || 0) === 0) {
     return true;
   }
   // id and tsNs are arbitrary added fields in the backend and should be hidden in the UI

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -70,10 +70,14 @@ export const getDataframeFields = memoizeOne(
       .filter((field, index) => !shouldRemoveField(field, index, row))
       .map((field) => {
         const links = getFieldLinks ? getFieldLinks(field, row.rowIndex, row.dataFrame) : [];
-
+        const fieldVal = field.values[row.rowIndex];
+        const outputVal =
+          typeof fieldVal === 'string' || typeof fieldVal === 'number'
+            ? fieldVal.toString()
+            : safeStringifyValue(fieldVal);
         return {
           keys: [field.name],
-          values: [safeStringifyValue(field.values[row.rowIndex])],
+          values: [outputVal],
           links: links,
           fieldIndex: field.index,
         };

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -270,7 +270,7 @@ describe('logRowsToReadableJson', () => {
   it('should format a df field row', () => {
     const result = logRowsToReadableJson([testRow2]);
 
-    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar', foo2: '"bar2"' } }]);
+    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar', foo2: 'bar2' } }]);
   });
 });
 

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -270,7 +270,7 @@ describe('logRowsToReadableJson', () => {
   it('should format a df field row', () => {
     const result = logRowsToReadableJson([testRow2]);
 
-    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar', foo2: 'bar2' } }]);
+    expect(result).toEqual([{ line: 'test entry', timestamp: '123456789', fields: { foo: 'bar', foo2: '"bar2"' } }]);
   });
 });
 


### PR DESCRIPTION
**What is this feature?**

For correlations, users can extract values from dataframe fields to use in queries to other datasources. When building correlations for logs, this generally means extracting values from the log line. However, interesting values can also be found in the labels for the log, which are not part of the log line itself. For Loki, the field for this is called "labels" and values exist as JSON. Parsing JSON values was already implemented for traces, but logs had a couple other setbacks

- Logs visualizations hide the "labels" field
- The value, which is JSON was parsed using `toString` which would return non helpful information

This feature enables the labels field to show if there is a link attached to it, and parses the value of the labels so it appears as a JSON string instead of `[object Object]`. 

**Why do we need this feature?**

This lets log labels be used as variables. This is for sure not an ideal solution, but it is a workaround for functionality that is almost impossible to workaround right now.

**Who is this feature for?**

People building correlations off log labels.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
An example correlation for this:
Target Datasource: Prometheus
Target query: `web_http_requests{service="${container_name}"}`
Source Datasource: Loki
Results field: labels
Transformations:
- Type: Regular Expression
- Expression: `"container_name":"([^"]*)"`
- Map value: container_name
![Screenshot 2023-05-25 at 5 05 49 PM](https://github.com/grafana/grafana/assets/1533128/c39a1a3a-88d3-4b7d-800f-fd70a9d103dd)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
