### PR TITLE
Reword button to "Add new data source"

### DIFF
--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -30,7 +30,7 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
 
   return (
     <Button variant="primary" onClick={onAddDataSource}>
-      Create a new data source
+      Add new data source
     </Button>
   );
 }

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -30,7 +30,7 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
 
   return (
     <Button variant="primary" onClick={onAddDataSource}>
-      Create a {plugin.name} data source
+      Create a new data source
     </Button>
   );
 }

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -513,7 +513,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() => queryByText('Uninstall'));
-      expect(queryByText(`Create a ${name} data source`)).toBeInTheDocument();
+      expect(queryByText('Add new data source')).toBeInTheDocument();
     });
 
     it('should not display a "Create" button as a post installation step for disabled data source plugins', async () => {
@@ -526,7 +526,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() => queryByText('Uninstall'));
-      expect(queryByText(`Create a ${name} data source`)).toBeNull();
+      expect(queryByText('Add new data source')).toBeNull();
     });
 
     it('should not display post installation step for panel plugins', async () => {
@@ -538,7 +538,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() => queryByText('Uninstall'));
-      expect(queryByText(`Create a ${name} data source`)).toBeNull();
+      expect(queryByText('Add new data source')).toBeNull();
     });
 
     it('should display an enable button for app plugins that are not enabled as a post installation step', async () => {
@@ -787,7 +787,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() => queryByText('Uninstall'));
-      expect(queryByText(`Create a ${name} data source`)).toBeNull();
+      expect(queryByText('Add new data source')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
**What is this feature?**

This PR changes the wording of a button on the data source details page.

The previous wording included the name of the data source, which made it difficult for the doc team to refer to it.
This allows the doc team to refer to this button in an obvious way.

It also makes this button to have a consistent width.

![image](https://github.com/grafana/grafana/assets/13637610/04ad3756-501c-4608-90f2-ab7823574334)



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #68345

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
