### PR TITLE
AuthN: Use EqualFold for skipping introspection endpoint

### DIFF
--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -44,7 +44,7 @@ func (c *Basic) Test(ctx context.Context, r *authn.Request) bool {
 		return false
 	}
 	// The OAuth2 introspection endpoint uses basic auth but is handled by the oauthserver package.
-	if strings.HasPrefix(r.HTTPRequest.RequestURI, "/oauth2/introspect") {
+	if strings.EqualFold(r.HTTPRequest.RequestURI, "/oauth2/introspect") {
 		return false
 	}
 	return looksLikeBasicAuthRequest(r)

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -85,6 +85,12 @@ func TestBasic_Test(t *testing.T) {
 				HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {"something"}}},
 			},
 		},
+		{
+			desc: "should fail when the URL ends with /oauth2/introspect",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {encodeBasicAuth("user", "password")}}, RequestURI: "/oauth2/introspect"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What is this feature?**
Use `EqualFold` (exact check) instead of `HasPrefix` when testing the RequestURI if it targets the introspection endpoint.

**Why do we need this feature?**


**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
