### PR TITLE
GoogleAPI: Add retries functionallity to GoogleAPI calls

### DIFF
--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -61,6 +61,7 @@ func New() (*Client, error) {
 	return client, nil
 }
 
+// SetRetryer adds a retry strategy for the googleapi client calls that fail.
 func (client *Client) SetRetryer() {
 	client.SetRetry([]storage.RetryOption{
 		storage.WithPolicy(storage.RetryAlways),

--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -48,14 +48,24 @@ type File struct {
 
 // New creates a new Client by checking for the Google Cloud SDK auth key and/or environment variable.
 func New() (*Client, error) {
-	client, err := newClient()
+	storageClient, err := newClient()
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{
-		Client: *client,
-	}, nil
+	client := &Client{
+		Client: *storageClient,
+	}
+	client.SetRetryer()
+
+	return client, nil
+}
+
+func (client *Client) SetRetryer() {
+	client.SetRetry([]storage.RetryOption{
+		storage.WithPolicy(storage.RetryAlways),
+		storage.WithErrorFunc(storage.ShouldRetry),
+	}...)
 }
 
 // newClient initializes the google-cloud-storage (GCS) client.
@@ -147,8 +157,6 @@ func (client *Client) Copy(ctx context.Context, file File, bucket *storage.Bucke
 	if _, err = io.Copy(wc, localFile); err != nil {
 		return fmt.Errorf("failed to copy to Cloud Storage: %w", err)
 	}
-
-	log.Printf("Successfully uploaded tarball to Google Cloud Storage, path: %s/%s\n", remote, file.FullPath)
 
 	return nil
 }
@@ -258,7 +266,6 @@ func (client *Client) Delete(ctx context.Context, bucket *storage.BucketHandle, 
 	if err := object.Delete(ctx); err != nil {
 		return fmt.Errorf("cannot delete %s, err: %w", path, err)
 	}
-	log.Printf("Successfully deleted tarball to Google Cloud Storage, path: %s", path)
 	return nil
 }
 


### PR DESCRIPTION
**What is this feature?**

Running our flaky test analysis, we have identified an intermittent error which has to do with GoogleAPI returning errors. 
In this PR we add a retry functionality so idempotent and non-idempotent operations are going to be retried when they fail.
 
**Why do we need this feature?**

To prevent GoogleAPI errors for blocking our releases.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-delivery/issues/142

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
