### PR TITLE
Test: Fix windows test for SQL data sources

### DIFF
--- a/pkg/infra/proxy/proxyutil/proxyutil.go
+++ b/pkg/infra/proxy/proxyutil/proxyutil.go
@@ -50,6 +50,9 @@ func SetupTestSecureSocksProxySettings(t *testing.T) *setting.SecureSocksDSProxy
 	})
 	require.NoError(t, err)
 
+	err = caCertFile.Close()
+	require.NoError(t, err)
+
 	// generate test client cert & key
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
@@ -77,6 +80,10 @@ func SetupTestSecureSocksProxySettings(t *testing.T) *setting.SecureSocksDSProxy
 		Bytes: certBytes,
 	})
 	require.NoError(t, err)
+
+	err = certFile.Close()
+	require.NoError(t, err)
+
 	clientKey := filepath.Join(tempDir, "client.key")
 	// nolint:gosec
 	// The gosec G304 warning can be ignored because all values come from the test
@@ -86,6 +93,9 @@ func SetupTestSecureSocksProxySettings(t *testing.T) *setting.SecureSocksDSProxy
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
 	})
+	require.NoError(t, err)
+
+	err = keyFile.Close()
 	require.NoError(t, err)
 
 	return &setting.SecureSocksDSProxySettings{


### PR DESCRIPTION
**What is this feature?**

The error on windows is `The process cannot access the file because it is being used by another process.` which I solved by calling close on the created files.

**Which issue(s) does this PR fix?**:

Fixes #68704
