### PR TITLE
DevEnv: Add Support for SAML SLO in Authentik

### DIFF
--- a/devenv/docker/blocks/auth/authentik/README.md
+++ b/devenv/docker/blocks/auth/authentik/README.md
@@ -44,8 +44,9 @@ active_sync_enabled = true
 
 Grafana expects SLO support to be communicated in the metadata
 
-Single Logout is not supported by authentik.
-https://github.com/goauthentik/authentik/issues/3321 
+Single Logout is now supported by authentik in versions `2023.1` and higher;
+
+Source: <https://goauthentik.io/docs/releases/2023.1#new-features>
 
 **Warning** Client signature validation
 
@@ -65,7 +66,7 @@ assertion_attribute_email = http://schemas.xmlsoap.org/ws/2005/05/identity/claim
 assertion_attribute_groups = http://schemas.xmlsoap.org/claims/Group
 assertion_attribute_org = http://schemas.xmlsoap.org/claims/Group
 allow_sign_up = true
-single_logout = false # not supported by authentik
+single_logout = true # supported by authentik v2023.1 and newer
 signature_algorithm = rsa-sha256
 allow_idp_initiated = true
 org_mapping = admin:1:Admin, editor:1:Editor, viewer:1:Viewer

--- a/devenv/docker/blocks/auth/authentik/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/authentik/docker-compose.yaml
@@ -39,7 +39,7 @@
       - "authentik:authentik"
 
   authentik:
-    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.2.3}
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.5.1}
     restart: unless-stopped
     container_name: authentik
     command: server
@@ -66,7 +66,7 @@
       - "authentikredis:authentikredis"
 
   authentik-worker:
-    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2022.12.1}
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.5.1}
     restart: unless-stopped
     container_name: authentik-worker
     command: worker


### PR DESCRIPTION
**What is this feature?**

Updates the `auth/authentik` block in the Docker DevEnv to add support for SLO (Single Log Out) to the SAML Authentication provider in Authentik

**Why do we need this feature?**

Currently SLO is disabled for SAML, as at the time it was not supported in Authentik, however since January 2023 they have added support for this;

https://goauthentik.io/docs/releases/2023.1

**Who is this feature for?**

Users of the DevEnv (OSS Contributors, Grafana Support, AuthNZ Team and more)

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
