### PR TITLE
ZoomPlugin: Remove the `timeRange` prop

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/ZoomPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/ZoomPlugin.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-
-import { TimeRange } from '@grafana/data';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 import { PlotSelection } from '../types';
@@ -9,7 +7,6 @@ import { pluginLog } from '../utils';
 interface ZoomPluginProps {
   onZoom: (range: { from: number; to: number }) => void;
   config: UPlotConfigBuilder;
-  timeRange?: TimeRange;
 }
 
 // min px width that triggers zoom
@@ -18,13 +15,8 @@ const MIN_ZOOM_DIST = 5;
 /**
  * @alpha
  */
-export const ZoomPlugin = ({ onZoom, config, timeRange }: ZoomPluginProps) => {
+export const ZoomPlugin = ({ onZoom, config }: ZoomPluginProps) => {
   const [selection, setSelection] = useState<PlotSelection | null>(null);
-
-  const refTimeRange = useRef<TimeRange | undefined>(timeRange);
-  useEffect(() => {
-    refTimeRange.current = timeRange;
-  }, [timeRange]);
 
   useEffect(() => {
     if (selection) {
@@ -59,14 +51,14 @@ export const ZoomPlugin = ({ onZoom, config, timeRange }: ZoomPluginProps) => {
 
     config.setCursor({
       bind: {
-        dblclick: () => () => {
-          if (refTimeRange.current) {
-            const frTs = refTimeRange.current.from.valueOf();
-            const toTs = refTimeRange.current.to.valueOf();
-            const pad = (toTs - frTs) / 2;
+        dblclick: (u) => () => {
+          let xScale = u.scales.x;
 
-            onZoom({ from: frTs - pad, to: toTs + pad });
-          }
+          const frTs = xScale.min!;
+          const toTs = xScale.max!;
+          const pad = (toTs - frTs) / 2;
+
+          onZoom({ from: frTs - pad, to: toTs + pad });
 
           return null;
         },

--- a/packages/grafana-ui/src/components/uPlot/plugins/ZoomPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/ZoomPlugin.tsx
@@ -9,7 +9,7 @@ import { pluginLog } from '../utils';
 interface ZoomPluginProps {
   onZoom: (range: { from: number; to: number }) => void;
   config: UPlotConfigBuilder;
-  timeRange: TimeRange;
+  timeRange?: TimeRange;
 }
 
 // min px width that triggers zoom
@@ -21,7 +21,7 @@ const MIN_ZOOM_DIST = 5;
 export const ZoomPlugin = ({ onZoom, config, timeRange }: ZoomPluginProps) => {
   const [selection, setSelection] = useState<PlotSelection | null>(null);
 
-  const refTimeRange = useRef<TimeRange>(timeRange);
+  const refTimeRange = useRef<TimeRange | undefined>(timeRange);
   useEffect(() => {
     refTimeRange.current = timeRange;
   }, [timeRange]);
@@ -60,11 +60,13 @@ export const ZoomPlugin = ({ onZoom, config, timeRange }: ZoomPluginProps) => {
     config.setCursor({
       bind: {
         dblclick: () => () => {
-          const frTs = refTimeRange.current.from.valueOf();
-          const toTs = refTimeRange.current.to.valueOf();
-          const pad = (toTs - frTs) / 2;
+          if (refTimeRange.current) {
+            const frTs = refTimeRange.current.from.valueOf();
+            const toTs = refTimeRange.current.to.valueOf();
+            const pad = (toTs - frTs) / 2;
 
-          onZoom({ from: frTs - pad, to: toTs + pad });
+            onZoom({ from: frTs - pad, to: toTs + pad });
+          }
 
           return null;
         },

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -260,7 +260,7 @@ export const CandlestickPanel = ({
 
         return (
           <>
-            <ZoomPlugin config={config} onZoom={onChangeTimeRange} timeRange={timeRange} />
+            <ZoomPlugin config={config} onZoom={onChangeTimeRange} />
             <TooltipPlugin
               data={alignedDataFrame}
               config={config}

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -191,7 +191,7 @@ export const StateTimelinePanel = ({
 
         return (
           <>
-            <ZoomPlugin config={config} onZoom={onChangeTimeRange} timeRange={timeRange} />
+            <ZoomPlugin config={config} onZoom={onChangeTimeRange} />
 
             <OutsideRangePlugin config={config} onChangeTimeRange={onChangeTimeRange} />
 

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -215,7 +215,7 @@ export const StatusHistoryPanel = ({
 
         return (
           <>
-            <ZoomPlugin config={config} onZoom={onChangeTimeRange} timeRange={timeRange} />
+            <ZoomPlugin config={config} onZoom={onChangeTimeRange} />
             {renderTooltip(alignedFrame)}
             <OutsideRangePlugin config={config} onChangeTimeRange={onChangeTimeRange} />
           </>

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -88,7 +88,7 @@ export const TimeSeriesPanel = ({
         return (
           <>
             <KeyboardPlugin config={config} />
-            <ZoomPlugin config={config} onZoom={onChangeTimeRange} timeRange={timeRange} />
+            <ZoomPlugin config={config} onZoom={onChangeTimeRange} />
             {options.tooltip.mode === TooltipDisplayMode.None || (
               <TooltipPlugin
                 frames={frames}


### PR DESCRIPTION
### What changed?
[We realised today](https://raintank-corp.slack.com/archives/C024NL6AEJH/p1685099772746369) that [adding a new `timeRange` prop to the `ZoomPlugin`](https://github.com/grafana/grafana/pull/68936) actually can be a breaking change for plugins that are depending on it. This PR turns that prop into an optional one, so it also works plugins which don't specify this new prop.