### PR TITLE
Alerting: Add info to enable alert forwarding when using an external …

### DIFF
--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
 import { DataSourceHttpSettings, InlineField, InlineFormLabel, InlineSwitch, Select } from '@grafana/ui';
+import { Span } from '@grafana/ui/src/unstable';
 import { config } from 'app/core/config';
 
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from './types';
@@ -75,9 +76,9 @@ export const ConfigEditor = (props: Props) => {
           </InlineField>
         </div>
         {options.jsonData.handleGrafanaManagedAlerts && (
-          <span>
-            Make sure to enable the alert forwarding on the <Link to="/alerting/admin">admin page.</Link>
-          </span>
+          <Span variant="bodySmall" color="secondary">
+            Make sure to enable the alert forwarding on the <Link to="/alerting/admin">admin page</Link>.
+          </Span>
         )}
       </div>
       <DataSourceHttpSettings

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -73,6 +73,11 @@ export const ConfigEditor = (props: Props) => {
             />
           </InlineField>
         </div>
+        {options.jsonData.handleGrafanaManagedAlerts && (
+          <span>
+            Make sure to enable the alert forwarding on the <a href="/alerting/admin">admin page.</a>
+          </span>
+        )}
       </div>
       <DataSourceHttpSettings
         defaultUrl={''}

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -1,5 +1,6 @@
 import produce from 'immer';
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
@@ -75,7 +76,7 @@ export const ConfigEditor = (props: Props) => {
         </div>
         {options.jsonData.handleGrafanaManagedAlerts && (
           <span>
-            Make sure to enable the alert forwarding on the <a href="/alerting/admin">admin page.</a>
+            Make sure to enable the alert forwarding on the <Link to="/alerting/admin">admin page.</Link>
           </span>
         )}
       </div>


### PR DESCRIPTION
This PR adds an info text when enabling an Alertmanager datasource to receive external alerts, so that the user knows they also need to activate it on the admin page.

![Screenshot 2023-05-26 at 15 16 43](https://github.com/grafana/grafana/assets/3528218/0b3efff6-3ba2-45ea-9973-b4e5c8fcc432)

