### PR TITLE
Browse: fix spacing on old browse checkboxes

### DIFF
--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -69,6 +69,7 @@ export const SearchItem = ({ item, isSelected, editable, onToggleChecked, onTagS
   return (
     <div className={styles.cardContainer}>
       <SearchCheckbox
+        className={styles.checkbox}
         aria-label="Select dashboard"
         editable={editable}
         checked={isSelected}
@@ -124,6 +125,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: ${theme.spacing(1)} ${theme.spacing(2)};
       margin-bottom: 0;
     `,
+    checkbox: css({
+      marginRight: theme.spacing(1),
+    }),
     metaContainer: css`
       display: flex;
       align-items: center;

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -149,6 +149,7 @@ export const FolderSection = ({
           {selectionToggle && selection && (
             <div onClick={onToggleFolder}>
               <Checkbox
+                className={styles.checkbox}
                 value={selection(section.kind, section.uid)}
                 aria-label={t('search.folder-view.select-folder', 'Select folder')}
               />
@@ -232,5 +233,8 @@ const getSectionHeaderStyles = (theme: GrafanaTheme2, editable: boolean) => {
       place-content: center;
       padding-bottom: 1rem;
     `,
+    checkbox: css({
+      marginRight: theme.spacing(1),
+    }),
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds explicit margin to checkboxes in old browse view
- this margin used to be implicitly set on checkboxes without labels
  - this was a bug that was fixed with https://github.com/grafana/grafana/pull/68885 

**Why do we need this feature?**

- so it doesn't look bad 🤮 

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
