### PR TITLE
Docs: update Legacy alerting deprecation to pass doc-validator

### DIFF
--- a/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
@@ -29,11 +29,11 @@ The new system is based on Prometheus Alertmanager, which offers a more comprehe
 
 Overall, the new alerting system in Grafana is a major improvement over the legacy alerting feature, providing users with a more powerful and flexible alerting experience.
 
-Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../developers/angular_deprecation" >}}) in Grafana 11.
+Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../..developers/angular_deprecation" >}}) in Grafana 11.
 
 ## When will we remove legacy alerting completely?
 
-Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation]({{< relref "../developers/angular_deprecation" >}}).
+Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation]({{< relref "../../developers/angular_deprecation" >}}).
 
 ## How do I migrate to the new Grafana alerting?
 
@@ -43,4 +43,4 @@ Refer to our [migration instructions]({{< relref "./opt-in" >}}).
 
 - [Upgrade Alerting]({{< relref "./_index.md" >}})
 - [Legacy alerting differences and limitations]({{< relref "./_index.md" >}})
-- [Angular support deprecation]({{< relref "../developers/angular_deprecation/" >}})
+- [Angular support deprecation]({{< relref "../../developers/angular_deprecation/" >}})

--- a/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
@@ -29,7 +29,7 @@ The new system is based on Prometheus Alertmanager, which offers a more comprehe
 
 Overall, the new alerting system in Grafana is a major improvement over the legacy alerting feature, providing users with a more powerful and flexible alerting experience.
 
-Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../..developers/angular_deprecation" >}}) in Grafana 11.
+Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../../developers/angular_deprecation" >}}) in Grafana 11.
 
 ## When will we remove legacy alerting completely?
 

--- a/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
@@ -43,4 +43,4 @@ Refer to our [migration instructions]({{< relref "./opt-in" >}}).
 
 - [Upgrade Alerting]({{< relref "./_index.md" >}})
 - [Legacy alerting differences and limitations]({{< relref "./_index.md" >}})
-- [Angular support deprecation]({{< relref "../../developers/angular_deprecation/" >}})
+- [Angular support deprecation]({{< relref "../../developers/angular_deprecation" >}})

--- a/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/migrating-alerts/legacy-alerting-deprecation.md
@@ -29,11 +29,11 @@ The new system is based on Prometheus Alertmanager, which offers a more comprehe
 
 Overall, the new alerting system in Grafana is a major improvement over the legacy alerting feature, providing users with a more powerful and flexible alerting experience.
 
-Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref ".../developers/angular_deprecation" >}}) in Grafana 11.
+Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../developers/angular_deprecation" >}}) in Grafana 11.
 
 ## When will we remove legacy alerting completely?
 
-Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation]({{< relref ".../developers/angular_deprecation" >}}).
+Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation]({{< relref "../developers/angular_deprecation" >}}).
 
 ## How do I migrate to the new Grafana alerting?
 
@@ -43,4 +43,4 @@ Refer to our [migration instructions]({{< relref "./opt-in" >}}).
 
 - [Upgrade Alerting]({{< relref "./_index.md" >}})
 - [Legacy alerting differences and limitations]({{< relref "./_index.md" >}})
-- [Angular support deprecation]({{< relref ".../developers/angular_deprecation/" >}})
+- [Angular support deprecation]({{< relref "../developers/angular_deprecation/" >}})


### PR DESCRIPTION
**What is this feature?**

Updates Legacy alerting deprecation to pass doc-validator

**Why do we need this feature?**

So the app can pass the doc validator

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
