### PR TITLE
InfluxDB: Interpolate retention policies

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, TypedVariableModel } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { InlineLabel, SegmentSection, useStyles2 } from '@grafana/ui';
 
@@ -42,19 +42,31 @@ type Props = {
   datasource: InfluxDatasource;
 };
 
-function getTemplateVariableOptions() {
+function wrapRegex(v: TypedVariableModel): string {
+  return `/^$${v.name}$/`;
+}
+
+function wrapPure(v: TypedVariableModel): string {
+  return `$${v.name}`;
+}
+
+function getTemplateVariableOptions(wrapper: (v: TypedVariableModel) => string) {
   return (
     getTemplateSrv()
       .getVariables()
       // we make them regex-params, i'm not 100% sure why.
       // probably because this way multi-value variables work ok too.
-      .map((v) => `/^$${v.name}$/`)
+      .map(wrapper)
   );
 }
 
 // helper function to make it easy to call this from the widget-render-code
-function withTemplateVariableOptions(optionsPromise: Promise<string[]>, filter?: string): Promise<string[]> {
-  let templateVariableOptions = getTemplateVariableOptions();
+function withTemplateVariableOptions(
+  optionsPromise: Promise<string[]>,
+  wrapper: (v: TypedVariableModel) => string,
+  filter?: string
+): Promise<string[]> {
+  let templateVariableOptions = getTemplateVariableOptions(wrapper);
   if (filter) {
     templateVariableOptions = templateVariableOptions.filter((tvo) => tvo.indexOf(filter) > -1);
   }
@@ -149,7 +161,12 @@ export const Editor = (props: Props): JSX.Element => {
         <FromSection
           policy={policy ?? retentionPolicies[0]}
           measurement={measurement}
-          getPolicyOptions={() => getAllPolicies(datasource)}
+          getPolicyOptions={() =>
+            withTemplateVariableOptions(
+              allTagKeys.then((keys) => getAllPolicies(datasource)),
+              wrapPure
+            )
+          }
           getMeasurementOptions={(filter) =>
             withTemplateVariableOptions(
               allTagKeys.then((keys) =>
@@ -159,6 +176,7 @@ export const Editor = (props: Props): JSX.Element => {
                   datasource
                 )
               ),
+              wrapRegex,
               filter
             )
           }
@@ -175,7 +193,8 @@ export const Editor = (props: Props): JSX.Element => {
             withTemplateVariableOptions(
               allTagKeys.then((keys) =>
                 getTagValues(key, measurement, policy, filterTags(query.tags ?? [], keys), datasource)
-              )
+              ),
+              wrapRegex
             )
           }
         />

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -199,10 +199,13 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         this.retentionPolicies = allPolicies;
         const policyFixedRequests = {
           ...request,
-          targets: request.targets.map((t) => ({
-            ...t,
-            policy: replaceHardCodedRetentionPolicy(t.policy, this.retentionPolicies),
-          })),
+          targets: request.targets.map((t) => {
+            t.policy = t.policy ? this.templateSrv.replace(t.policy, {}, 'regex') : '';
+            return {
+              ...t,
+              policy: replaceHardCodedRetentionPolicy(t.policy, this.retentionPolicies),
+            };
+          }),
         };
         return this._query(policyFixedRequests);
       })


### PR DESCRIPTION
**What is this feature?**

In the current state of InfluxDB data source, we are not interpolating the retention policies.
This PR is addressing that. 

**Why do we need this feature?**

To be able to use retention policies as variables.

**Who is this feature for?**

InfluxDB users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/67602

### How to test
- Create a dashboard with a variable with the query `SHOW RETENTION POLICIES`
- In the panel select the variable in the retention policy dropdown
- In the network tab observe the query call. See that the selected retention policy is being used.
- Change the retention policy variable. Observe the new retention policy is being used in the query

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
