### PR TITLE
Fix: Fixed a typo in reference.md

### DIFF
--- a/docs/sources/alerting/manage-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/reference.md
@@ -41,7 +41,7 @@ weight: 400
 | Resolved alerts   | `[]Alert` | List of all resolved alerts in this notification                                                     | `There are {{ len .Alerts.Resolved }} resolved alerts` |
 | GroupLabels       | `KV`      | The labels that group these alerts in this                                                           | `{{ .GroupLabels }}`                                   |
 | CommonLabels      | `KV`      | The labels common to all alerts in this notification                                                 | `{{ .CommonLabels }}`                                  |
-| CommonAnnotations | `KV`      | The annotations common to all alerts i this notification                                             | `{{ .CommonAnnotations }}`                             |
+| CommonAnnotations | `KV`      | The annotations common to all alerts in this notification                                             | `{{ .CommonAnnotations }}`                             |
 | ExternalURL       | `string`  | A link to Grafana, or the Alertmanager that sent this notification if using an external Alertmanager | `{{ .ExternalURL }}`                                   |
 
 ### KV

--- a/docs/sources/alerting/manage-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/reference.md
@@ -41,7 +41,7 @@ weight: 400
 | Resolved alerts   | `[]Alert` | List of all resolved alerts in this notification                                                     | `There are {{ len .Alerts.Resolved }} resolved alerts` |
 | GroupLabels       | `KV`      | The labels that group these alerts in this                                                           | `{{ .GroupLabels }}`                                   |
 | CommonLabels      | `KV`      | The labels common to all alerts in this notification                                                 | `{{ .CommonLabels }}`                                  |
-| CommonAnnotations | `KV`      | The annotations common to all alerts in this notification                                             | `{{ .CommonAnnotations }}`                             |
+| CommonAnnotations | `KV`      | The annotations common to all alerts in this notification                                            | `{{ .CommonAnnotations }}`                             |
 | ExternalURL       | `string`  | A link to Grafana, or the Alertmanager that sent this notification if using an external Alertmanager | `{{ .ExternalURL }}`                                   |
 
 ### KV


### PR DESCRIPTION
Fixed typo: : `i` to `in`
Old: `The annotations common to all alerts i this notification`
New: `The annotations common to all alerts in this notification`

**What is this feature?**

Fixed a typo in the documentation.

**Why do we need this feature?**

To improve documentation.