### PR TITLE
Grafana UI: Fix plugin unit test errors

### DIFF
--- a/packages/grafana-ui/.eslintrc
+++ b/packages/grafana-ui/.eslintrc
@@ -3,7 +3,7 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui", "@grafana/e2e"],
+        "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui", "@grafana/e2e", "@grafana/e2e-selectors/*"],
         "paths": [
           {
             "name": "react-i18next",

--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { ReactElement, useCallback, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
+import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../themes';
 import { Icon } from '../Icon/Icon';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

#66685 introduced an `@grafana/e2e-selectors/src` import in `@grafana/ui`. This works fine in the core codebase but once the packages are bundled and published plugins unit tests will fail with the following:

```
 FAIL  src/components/AppConfig/AppConfig.test.tsx
  ● Test suite failed to run

    Cannot find module '@grafana/e2e-selectors/src' from 'node_modules/@grafana/ui/dist/index.js'

    Require stack:
      node_modules/@grafana/ui/dist/index.js
      src/components/AppConfig/AppConfig.tsx
      src/components/AppConfig/AppConfig.test.tsx

      18 |       <div>
      19 |         {/* Enable the plugin */}
    > 20 |         <Legend>Enable / Disable</Legend>
         |             ^
      21 |         {!enabled && (
      22 |           <>
      23 |             <div className={s.colorWeak}>The plugin is currently not enabled.</div>

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
      at Object.<anonymous> (node_modules/@grafana/ui/dist/index.js:58:11)
      at Object.<anonymous> (src/components/AppConfig/AppConfig.tsx:20:13)
      at Object.<anonymous> (src/components/AppConfig/AppConfig.test.tsx:8:20)
```

This PR removes `src` from the path and updates the eslintrc for grafana/ui to prevent this from occurring in the future.

**Why do we need this feature?**

To prevent errors in plugin unit tests

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
