### PR TITLE
Flux: Improve styling of sample query button and use sentence case

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
@@ -199,7 +199,15 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
           >
             Flux language syntax
           </LinkButton>
-          <Segment options={samples} value="Sample Query" onChange={this.onSampleChange} />
+          <Segment
+            options={samples}
+            value="Sample query"
+            onChange={this.onSampleChange}
+            className={css`
+              margin-top: -${theme.spacing(0.5)};
+              margin-left: ${theme.spacing(0.5)};
+            `}
+          />
           <div className="gf-form gf-form--grow">
             <div className="gf-form-label gf-form-label--grow"></div>
           </div>


### PR DESCRIPTION
In this PR I quickly improved styling of `Sample query` button so it looks more styled and I changed casing to `sentence case` as thats what we are supposed to use in product. 

Current main:
<img width="1481" alt="image" src="https://github.com/grafana/grafana/assets/30407135/b29aa105-89f9-4b68-9661-0d93fbfdca4d">

Fixed:
<img width="1480" alt="image" src="https://github.com/grafana/grafana/assets/30407135/7f1dfb77-9491-4966-990f-426142a648a1">
