### PR TITLE
SQLStore: Align SQLite IsUniqueConstraintViolation() with other backend implementations

### DIFF
--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -148,7 +148,7 @@ func (db *SQLite3) ErrorMessage(err error) string {
 }
 
 func (db *SQLite3) IsUniqueConstraintViolation(err error) bool {
-	return db.isThisError(err, int(sqlite3.ErrConstraintUnique))
+	return db.isThisError(err, int(sqlite3.ErrConstraintUnique)) || db.isThisError(err, int(sqlite3.ErrConstraintPrimaryKey))
 }
 
 func (db *SQLite3) IsDeadlock(err error) bool {

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,12 +1,16 @@
 package sqlstore
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -96,6 +100,64 @@ func TestIntegrationSQLConnectionString(t *testing.T) {
 				require.Contains(t, connStr, connSubStr)
 			}
 		})
+	}
+}
+
+func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
+	store := InitTestDB(t)
+
+	testCases := []struct {
+		desc string
+		f    func(*testing.T, *DBSession) error
+	}{
+		{
+			desc: "successfully detect primary key violations",
+			f: func(t *testing.T, sess *DBSession) error {
+				// Attempt to insert org with provided ID (primary key) twice
+				now := time.Now()
+				org := org.Org{Name: "test org primary key violation", Created: now, Updated: now, ID: 42}
+				err := sess.InsertId(&org, store.Dialect)
+				require.NoError(t, err)
+
+				// Provide a different name to avoid unique constraint violation
+				org.Name = "test org 2"
+				return sess.InsertId(&org, store.Dialect)
+			},
+		},
+		{
+			desc: "successfully detect unique constrain violations",
+			f: func(t *testing.T, sess *DBSession) error {
+				// Attempt to insert org with reserved name
+				now := time.Now()
+				org := org.Org{Name: "test org unique constrain violation", Created: now, Updated: now, ID: 43}
+				err := sess.InsertId(&org, store.Dialect)
+				require.NoError(t, err)
+
+				// Provide a different ID to avoid primary key violation
+				org.ID = 44
+				return sess.InsertId(&org, store.Dialect)
+			},
+		},
+	}
+
+	failures := 0
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := store.WithDbSession(context.Background(), func(sess *DBSession) error {
+				return tc.f(t, sess)
+			})
+
+			if err == nil {
+				return
+			}
+
+			failures++
+			assert.True(t, store.Dialect.IsUniqueConstraintViolation(err))
+		})
+
+		if failures == 0 {
+			t.Log("no failures detected")
+		}
 	}
 }
 

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -140,24 +140,14 @@ func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
 		},
 	}
 
-	failures := 0
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := store.WithDbSession(context.Background(), func(sess *DBSession) error {
 				return tc.f(t, sess)
 			})
-
-			if err == nil {
-				return
-			}
-
-			failures++
+			require.Error(t, err)
 			assert.True(t, store.Dialect.IsUniqueConstraintViolation(err))
 		})
-
-		if failures == 0 {
-			t.Log("no failures detected")
-		}
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

`IsUniqueConstraintViolation()` for MysQL and Postgres return true both in case of primary key and unique constraint violations. However, the respective `SQLite` implementation used to return true only for unique constraint violations.
(go-sqlite returns different errors - [ErrConstraintPrimaryKey](https://github.com/mattn/go-sqlite3/blob/master/error.go#L142) for primary constraint violation and [ErrConstraintUnique](https://github.com/mattn/go-sqlite3/blob/d366d8de4e44f5c6c37b6b7169a276ee94d0d55b/error.go#L144) for unique constraint violations.

This fix changes the SQLite `IsUniqueConstraintViolation()` implementation to return `true` also in case of primary key constraint violations (checks also for  [ErrConstraintPrimaryKey](https://github.com/mattn/go-sqlite3/blob/master/error.go#L142) extension code)

It introduces also an integration test for ensuring the same behaviour for all the backends.

**Why do we need this feature?**

In #68644 we tried to fix flaky test failures by ignoring unique constraint failures when creating the main organisation. However, [this condition](https://github.com/grafana/grafana/blob/adaebb29bb0e7c8ed4d2d3399344727f4ee02d87/pkg/services/sqlstore/user.go#L174) was `false` for SQLite because the specific is primary key violation.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
The following table summarises all the `IsUniqueConstraintViolation()` [references](https://github.com/search?q=repo%3Agrafana/grafana%20IsUniqueConstraintViolation&type=code).

| Service | Actions | Primary key present | behaviour on SQLite primary key failure (before the fix) |
|--------|--------| --------| --------|
| Alerting | [insert](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/ngalert/store/alert_rule.go#L162) alert rule | No | not affected |
| Alerting | [update](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/ngalert/store/alert_rule.go#L197) alert rule | Yes | different error message than the expected (`ngmodels.ErrAlertRuleUniqueConstraintViolation` )
| Data source | [add](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/services/datasources/service/store.go#L273) | No | not affected |
| Legacy alerting | [insert notification state](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/alerting/store_notification.go#L564) | No | not affected |
| Library Elements | [create](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/libraryelements/database.go#L148) | No | not affected |
| Library Elements | [patch](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/libraryelements/database.go#L148) | Yes | different error message than the expected: (`model.ErrLibraryElementAlreadyExists`)
| Query history | [star](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/services/queryhistory/database.go#L203) | No  |not affected |
| Remote cache | [set cache key](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/infra/remotecache/database_storage.go#L101) | Yes (both [primary key and unique index on `cache_key` column](https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/migrations/cache_data_mig.go)) | no effect; the optimistic lock introduced in #17485 will be still executed because of the unique constraint |
| Star | insert [SQLx](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/services/star/starimpl/sqlx_store.go#L36) impl | No | not affected |
| Star | insert [XORM](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/services/star/starimpl/xorm_store.go#L38) impl. | No | not affected |
| Tag | [ensure tag existence](https://github.com/grafana/grafana/blob/cb8386163025ebd51af41559b922bb6c92461ac1/pkg/services/tag/tagimpl/xorm_store.go#L24) | called for several case, I think we never set the primary key | not affected |
| User | [main org creation](https://github.com/grafana/grafana/blob/fc858d982c95acb50412c3973acd7a55c3957319/pkg/services/sqlstore/user.go#L174) | Yes | failure to ignore the error

According to the above table only the user service failure to catch this error has an actual effect (the rest case should not be affected)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
