### PR TITLE
G10: Update GitHub actions for to replace `preview` with `beta`

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-preview<number> format. example: 7.4.3 or 7.4.3-preview'
+        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. example: 7.4.3, 7.4.3-preview or 7.4.3-preview1'
         required: true
 env:
     YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -28,15 +28,15 @@ jobs:
         if: ${{ steps.regex-match.outputs.match == '' && github.event.inputs.version != '' }}
         run: |
           echo "The input version format is not correct, please respect:\
-          major.minor.patch or major.minor.patch-preview.number format. \
-          example: 7.4.3 or 7.4.3-preview1"
+          major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. \
+          example: 7.4.3, 7.4.3-preview or 7.4.3-preview1"
           exit 1
       - name: Validate input version call
         if: ${{ inputs.version_call != '' && steps.regex-match-version-call.outputs.match == '' }}
         run: |
           echo "The input version format is not correct, please respect:\
-          major.minor.patch or major.minor.patch-preview<number> format. \
-          example: 7.4.3 or 7.4.3-preview1"
+          major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. \
+          example: 7.4.3, 7.4.3-preview or 7.4.3-preview1"
           exit 1
 
       - uses: actions/checkout@v3

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
+        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-preview<number> format. example: 7.4.3 or 7.4.3-preview1'
         required: true
 env:
     YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -17,26 +17,26 @@ jobs:
         id: regex-match
         with:
           text: ${{ github.event.inputs.version }}
-          regex: '^(\d+.\d+).\d+(?:-(?:(beta\d+)|(pre)))?$'
+          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d+)|(pre)))?$'
       - uses: actions-ecosystem/action-regex-match@v2.0.2
         if: ${{ inputs.version_call != '' }}
         id: regex-match-version-call
         with:
           text: ${{ inputs.version_call }}
-          regex: '^(\d+.\d+).\d+(?:-(?:(beta\d+)|(pre)))?$'
+          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d+)|(pre)))?$'
       - name: Validate input version
         if: ${{ steps.regex-match.outputs.match == '' && github.event.inputs.version != '' }}
         run: |
           echo "The input version format is not correct, please respect:\
-          major.minor.patch or major.minor.patch-beta.number format. \
-          example: 7.4.3 or 7.4.3-beta1"
+          major.minor.patch or major.minor.patch-preview.number format. \
+          example: 7.4.3 or 7.4.3-preview1"
           exit 1
       - name: Validate input version call
         if: ${{ inputs.version_call != '' && steps.regex-match-version-call.outputs.match == '' }}
         run: |
           echo "The input version format is not correct, please respect:\
-          major.minor.patch or major.minor.patch-beta<number> format. \
-          example: 7.4.3 or 7.4.3-beta1"
+          major.minor.patch or major.minor.patch-preview<number> format. \
+          example: 7.4.3 or 7.4.3-preview1"
           exit 1
 
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
           node-version: '16'
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Run bump version (manually invoked)        
+      - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-preview<number> format. example: 7.4.3 or 7.4.3-preview1'
+        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-preview<number> format. example: 7.4.3 or 7.4.3-preview'
         required: true
 env:
     YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -17,13 +17,13 @@ jobs:
         id: regex-match
         with:
           text: ${{ github.event.inputs.version }}
-          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d+)|(pre)))?$'
+          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d?)|(pre)))?$'
       - uses: actions-ecosystem/action-regex-match@v2.0.2
         if: ${{ inputs.version_call != '' }}
         id: regex-match-version-call
         with:
           text: ${{ inputs.version_call }}
-          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d+)|(pre)))?$'
+          regex: '^(\d+.\d+).\d+(?:-(?:(preview\d?)|(pre)))?$'
       - name: Validate input version
         if: ${{ steps.regex-match.outputs.match == '' && github.event.inputs.version != '' }}
         run: |

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version_input:
-        description: 'The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
+        description: 'The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-preview1'
         required: true
 jobs:
   call-remove-milestone:

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version_input:
-        description: 'The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-preview1'
+        description: 'The version to be released please respect: major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. example: 7.4.3, 7.4.3-preview or 7.4.3-preview1'
         required: true
 jobs:
   call-remove-milestone:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         required: true
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-preview1'
+        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. example: 7.4.3, 7.4.3-preview or 7.4.3-preview1'
       skip_pr:
         required: false
         default: "0"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         required: true
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
+        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-preview1'
       skip_pr:
         required: false
         default: "0"


### PR DESCRIPTION
**What is this feature?**

Updates GitHub actions for to replace `preview` with `beta`

**Which issue(s) does this PR fix?**:

Fixes #68346

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
