### PR TITLE
Docs: Bumping up min spec for Grafana Installations

### DIFF
--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -37,7 +37,7 @@ Installation of Grafana on other operating systems is possible, but is not recom
 
 Grafana requires the minimum system resources:
 
-- Minimum recommended memory: 255 MB
+- Minimum recommended memory: 512 MB
 - Minimum recommended CPU: 1
 
 Some features might require more memory or CPUs, including:
@@ -54,7 +54,7 @@ Grafana supports the following databases:
 
 - [SQLite 3](https://www.sqlite.org/index.html)
 - [MySQL 5.7+](https://www.mysql.com/support/supportedplatforms/database.html)
-- [PostgreSQL 10+](https://www.postgresql.org/support/versioning/)
+- [PostgreSQL 12+](https://www.postgresql.org/support/versioning/)
 
 By default Grafana uses an embedded SQLite database, which is stored in the Grafana installation location.
 


### PR DESCRIPTION
**Why?**
Keeping up to date with supported databases and bumping minimum requirements as those have not been revisited in a while.

