### PR TITLE
Prometheus: Bug fix to check default expr is empty string to set legend format as auto

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -1265,12 +1265,7 @@ export class PrometheusDatasource
   }
 
   getDefaultQuery(app: CoreApp): PromQuery {
-    const defaults = {
-      refId: 'A',
-      expr: '',
-      range: true,
-      instant: false,
-    };
+    const defaults = promDefaultBaseQuery();
 
     if (app === CoreApp.UnifiedAlerting) {
       return {
@@ -1339,4 +1334,13 @@ export function prometheusRegularEscape(value: any) {
 
 export function prometheusSpecialRegexEscape(value: any) {
   return typeof value === 'string' ? value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&') : value;
+}
+
+export function promDefaultBaseQuery(): PromQuery {
+  return {
+    refId: 'A',
+    expr: '',
+    range: true,
+    instant: false,
+  };
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -106,7 +106,7 @@ function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.P
   const props = {
     app,
     query: {
-      ...getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.PanelEditor),
+      ...getQueryWithDefaults({ refId: 'A', expr: '' } as PromQuery, CoreApp.PanelEditor),
       ...queryOverrides,
     },
     onRunQuery: jest.fn(),

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -5,6 +5,7 @@ import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
 import { CoreApp } from '@grafana/data';
 
+import { promDefaultBaseQuery } from '../../datasource';
 import { PromQuery } from '../../types';
 import { getQueryWithDefaults } from '../state';
 
@@ -106,7 +107,7 @@ function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.P
   const props = {
     app,
     query: {
-      ...getQueryWithDefaults({ refId: 'A', expr: '' } as PromQuery, CoreApp.PanelEditor),
+      ...getQueryWithDefaults(promDefaultBaseQuery(), CoreApp.PanelEditor),
       ...queryOverrides,
     },
     onRunQuery: jest.fn(),

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
@@ -7,7 +7,7 @@ import { changeEditorMode, getQueryWithDefaults } from './state';
 
 describe('getQueryWithDefaults(', () => {
   it('should set defaults', () => {
-    expect(getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.Dashboard)).toEqual({
+    expect(getQueryWithDefaults({ expr: '', refId: 'A' } as PromQuery, CoreApp.Dashboard)).toEqual({
       editorMode: 'builder',
       expr: '',
       legendFormat: '__auto',
@@ -17,7 +17,7 @@ describe('getQueryWithDefaults(', () => {
   });
 
   it('should set both range and instant to true when in Explore', () => {
-    expect(getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.Explore)).toEqual({
+    expect(getQueryWithDefaults({ expr: '', refId: 'A' } as PromQuery, CoreApp.Explore)).toEqual({
       editorMode: 'builder',
       expr: '',
       legendFormat: '__auto',
@@ -29,7 +29,7 @@ describe('getQueryWithDefaults(', () => {
 
   it('should not set both instant and range for Prometheus queries in Alert Creation', () => {
     expect(
-      getQueryWithDefaults({ refId: 'A', range: true, instant: true } as PromQuery, CoreApp.UnifiedAlerting)
+      getQueryWithDefaults({ expr: '', refId: 'A', range: true, instant: true } as PromQuery, CoreApp.UnifiedAlerting)
     ).toEqual({
       editorMode: 'builder',
       expr: '',
@@ -45,13 +45,15 @@ describe('getQueryWithDefaults(', () => {
       expect(query.editorMode).toBe(QueryEditorMode.Code);
     });
 
-    expect(getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.Dashboard).editorMode).toEqual(
+    expect(getQueryWithDefaults({ expr: '', refId: 'A' } as PromQuery, CoreApp.Dashboard).editorMode).toEqual(
       QueryEditorMode.Code
     );
   });
 
   it('should return default editor mode when it is provided', () => {
-    expect(getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.Dashboard, QueryEditorMode.Code)).toEqual({
+    expect(
+      getQueryWithDefaults({ expr: '', refId: 'A' } as PromQuery, CoreApp.Dashboard, QueryEditorMode.Code)
+    ).toEqual({
       editorMode: 'code',
       expr: '',
       legendFormat: '__auto',

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.ts
@@ -46,7 +46,8 @@ export function getQueryWithDefaults(
     result = { ...query, editorMode: getDefaultEditorMode(query.expr, defaultEditor) };
   }
 
-  if (query.expr == null) {
+  // default query expr is now empty string, set in getDefaultQuery
+  if (query.expr === '') {
     result = { ...result, expr: '', legendFormat: LegendFormatMode.Auto };
   }
 


### PR DESCRIPTION
What is this?
This is a bug fix to correctly set the default query legend format to auto. There was a change to set a default query for Prometheus and here the expr is set as ''. When we check for the default query we previously checked it by null to set the legend format to auto. That check failed and the legend format was set incorrectly. This fixes that so a default query sets the legend to auto.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

To test this, open the Prometheus Explore page and check that the options legend format is set to auto.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
