### PR TITLE
Dashboards: Data source template variable options now specify a current value using uid.

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -63,6 +63,7 @@ datasources:
       prometheusVersion: 2.40.0
 
   - name: gdev-slow-prometheus
+    uid: gdev-slow-prometheus-uid
     type: prometheus
     access: proxy
     url: http://localhost:3011

--- a/devenv/dev-dashboards/feature-templating/testdata-test-variable-output.json
+++ b/devenv/dev-dashboards/feature-templating/testdata-test-variable-output.json
@@ -55,6 +55,38 @@
       "pluginVersion": "8.4.0-pre",
       "title": "Panel Title",
       "type": "text"
+    },
+    {
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "mode": "markdown",
+        "content": "VariableUnderTestText: ${VariableUnderTest:text}"
+      },
+      "pluginVersion": "8.4.0-pre",
+      "title": "Panel Title",
+      "type": "text"
+    },
+    {
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 2,
+      "options": {
+        "mode": "markdown",
+        "content": "VariableUnderTestValue: ${VariableUnderTest:value}"
+      },
+      "pluginVersion": "8.4.0-pre",
+      "title": "Panel Title",
+      "type": "text"
     }
   ],
   "schemaVersion": 35,

--- a/devenv/dev-dashboards/feature-templating/testdata-test-variable-output.json
+++ b/devenv/dev-dashboards/feature-templating/testdata-test-variable-output.json
@@ -82,7 +82,7 @@
       "id": 2,
       "options": {
         "mode": "markdown",
-        "content": "VariableUnderTestValue: ${VariableUnderTest:value}"
+        "content": "VariableUnderTestRaw: ${VariableUnderTest:raw}"
       },
       "pluginVersion": "8.4.0-pre",
       "title": "Panel Title",

--- a/e2e/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e/dashboards-suite/new-datasource-variable.spec.ts
@@ -39,5 +39,6 @@ describe('Variables - Datasource', () => {
 
     // Assert it was rendered
     e2e().get('.markdown-html').should('include.text', 'VariableUnderTest: gdev-slow-prometheus-uid');
+    e2e().get('.markdown-html').should('include.text', 'VariableUnderTestText: gdev-slow-prometheus');
   });
 });

--- a/e2e/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e/dashboards-suite/new-datasource-variable.spec.ts
@@ -38,6 +38,6 @@ describe('Variables - Datasource', () => {
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts('gdev-slow-prometheus').click();
 
     // Assert it was rendered
-    e2e().get('.markdown-html').should('include.text', 'VariableUnderTest: gdev-slow-prometheus');
+    e2e().get('.markdown-html').should('include.text', 'VariableUnderTest: gdev-slow-prometheus-uid');
   });
 });

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -254,7 +254,8 @@ export class DatasourceSrv implements DataSourceService {
           // Support for multi-value variables with only one selected datasource
           dsValue = dsValue[0];
         }
-        const dsSettings = !Array.isArray(dsValue) && this.settingsMapByName[dsValue];
+        const dsSettings =
+          !Array.isArray(dsValue) && (this.settingsMapByName[dsValue] || this.settingsMapByUid[dsValue]);
 
         if (dsSettings) {
           const key = `$\{${variable.name}\}`;

--- a/public/app/features/plugins/tests/datasource_srv.test.ts
+++ b/public/app/features/plugins/tests/datasource_srv.test.ts
@@ -20,6 +20,13 @@ const templateSrv: any = {
     },
     {
       type: 'datasource',
+      name: 'datasourceByUid',
+      current: {
+        value: 'uid-code-DDDD',
+      },
+    },
+    {
+      type: 'datasource',
       name: 'datasourceDefault',
       current: {
         value: 'default',
@@ -32,6 +39,7 @@ const templateSrv: any = {
     }
 
     let result = v.replace('${datasource}', 'BBB');
+    result = result.replace('${datasourceByUid}', 'DDDD');
     result = result.replace('${datasourceDefault}', 'default');
     return result;
   },
@@ -103,6 +111,12 @@ describe('datasource_srv', () => {
       meta: { metrics: true },
       isDefault: true,
     },
+    DDDD: {
+      type: 'test-db',
+      name: 'DDDD',
+      uid: 'uid-code-DDDD',
+      meta: { metrics: true },
+    },
     Jaeger: {
       type: 'jaeger-db',
       name: 'Jaeger',
@@ -165,7 +179,7 @@ describe('datasource_srv', () => {
         expect(dataSourceSrv.getInstanceSettings({ uid: 'uid-code-mmm' })).toBe(ds);
       });
 
-      it('should work with variable', () => {
+      it('should work with variable by ds name', () => {
         const ds = dataSourceSrv.getInstanceSettings('${datasource}');
         expect(ds?.name).toBe('${datasource}');
         expect(ds?.uid).toBe('${datasource}');
@@ -173,6 +187,18 @@ describe('datasource_srv', () => {
           {
             "type": "test-db",
             "uid": "uid-code-BBB",
+          }
+        `);
+      });
+
+      it('should work with variable by ds value (uid)', () => {
+        const ds = dataSourceSrv.getInstanceSettings('${datasourceByUid}');
+        expect(ds?.name).toBe('${datasourceByUid}');
+        expect(ds?.uid).toBe('${datasourceByUid}');
+        expect(ds?.rawRef).toMatchInlineSnapshot(`
+          {
+            "type": "test-db",
+            "uid": "uid-code-DDDD",
           }
         `);
       });
@@ -247,7 +273,7 @@ describe('datasource_srv', () => {
     describe('when getting external metric sources', () => {
       it('should return list of explore sources', () => {
         const externalSources = dataSourceSrv.getExternal();
-        expect(externalSources.length).toBe(6);
+        expect(externalSources.length).toBe(7);
       });
     });
 
@@ -260,8 +286,9 @@ describe('datasource_srv', () => {
 
     it('Can get list of data sources with variables: true', () => {
       const list = dataSourceSrv.getList({ metrics: true, variables: true });
-      expect(list[0].name).toBe('${datasourceDefault}');
-      expect(list[1].name).toBe('${datasource}');
+      expect(list[0].name).toBe('${datasourceByUid}');
+      expect(list[1].name).toBe('${datasourceDefault}');
+      expect(list[2].name).toBe('${datasource}');
     });
 
     it('Can get list of data sources with tracing: true', () => {
@@ -299,6 +326,14 @@ describe('datasource_srv', () => {
             "name": "BBB",
             "type": "test-db",
             "uid": "uid-code-BBB",
+          },
+          {
+            "meta": {
+              "metrics": true,
+            },
+            "name": "DDDD",
+            "type": "test-db",
+            "uid": "uid-code-DDDD",
           },
           {
             "meta": {

--- a/public/app/features/variables/datasource/reducer.ts
+++ b/public/app/features/variables/datasource/reducer.ts
@@ -42,7 +42,7 @@ export const dataSourceVariableSlice = createSlice({
         }
 
         if (isValid(source, regex)) {
-          options.push({ text: source.name, value: source.name, selected: false });
+          options.push({ text: source.name, value: source.uid, selected: false });
         }
 
         if (isDefault(source, regex)) {

--- a/public/app/features/variables/shared/testing/helpers.ts
+++ b/public/app/features/variables/shared/testing/helpers.ts
@@ -3,7 +3,7 @@ import { DataSourceInstanceSettings, DataSourceJsonData, DataSourcePluginMeta } 
 export function getDataSourceInstanceSetting(name: string, meta: DataSourcePluginMeta): DataSourceInstanceSettings {
   return {
     id: 1,
-    uid: '',
+    uid: name,
     type: '',
     name,
     meta,

--- a/public/app/features/variables/shared/testing/optionsVariableBuilder.ts
+++ b/public/app/features/variables/shared/testing/optionsVariableBuilder.ts
@@ -3,14 +3,20 @@ import { VariableOption, VariableWithOptions } from 'app/features/variables/type
 import { VariableBuilder } from './variableBuilder';
 
 export class OptionsVariableBuilder<T extends VariableWithOptions> extends VariableBuilder<T> {
-  withOptions(...texts: string[]) {
+  withOptions(...options: Array<string | { text: string; value: string }>) {
     this.variable.options = [];
-    for (let index = 0; index < texts.length; index++) {
-      this.variable.options.push({
-        text: texts[index],
-        value: texts[index],
-        selected: false,
-      });
+    for (let index = 0; index < options.length; index++) {
+      const option = options[index];
+
+      if (typeof option === 'string') {
+        this.variable.options.push({
+          text: option,
+          value: option,
+          selected: false,
+        });
+      } else {
+        this.variable.options.push({ ...option, selected: false });
+      }
     }
     return this;
   }

--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -381,6 +381,74 @@ describe('shared actions', () => {
       });
     });
 
+    describe('and not multivalue, but with currentValue specified', () => {
+      const A = { text: 'A', value: 'a-uid' };
+      const B = { text: 'B', value: 'b-uid' };
+      const C = { text: 'C', value: 'c-uid' };
+
+      it.each`
+        withOptions  | currentText  | currentValue | defaultValue | expected
+        ${[A, B, C]} | ${undefined} | ${undefined} | ${undefined} | ${A}
+        ${[A, B, C]} | ${'B'}       | ${'b-uid'}   | ${undefined} | ${B}
+        ${[A, B, C]} | ${'B'}       | ${undefined} | ${undefined} | ${B}
+        ${[A, B, C]} | ${undefined} | ${'b-uid'}   | ${undefined} | ${B}
+        ${[A, B, C]} | ${'Old B'}   | ${'b-uid'}   | ${undefined} | ${B}
+        ${[A, B, C]} | ${undefined} | ${'x-uid'}   | ${'b-uid'}   | ${B}
+        ${[A, B, C]} | ${undefined} | ${'b-uid'}   | ${'c-uid'}   | ${B}
+        ${[A, B, C]} | ${undefined} | ${'x-uid'}   | ${undefined} | ${A}
+        ${undefined} | ${undefined} | ${'b-uid'}   | ${undefined} | ${'should not dispatch setCurrentVariableValue'}
+      `(
+        'then correct actions are dispatched',
+        async ({ withOptions, currentText, currentValue, defaultValue, expected }) => {
+          let custom;
+          const key = 'key';
+          if (!withOptions) {
+            custom = customBuilder()
+              .withId('0')
+              .withRootStateKey(key)
+              .withCurrent(currentText, currentValue)
+              .withoutOptions()
+              .build();
+          } else {
+            custom = customBuilder()
+              .withId('0')
+              .withRootStateKey(key)
+              .withOptions(...withOptions)
+              .withCurrent(currentText, currentValue)
+              .build();
+          }
+
+          const tester = await reduxTester<TemplatingReducerType>()
+            .givenRootReducer(getTemplatingRootReducer())
+            .whenActionIsDispatched(
+              toKeyedAction(key, addVariable(toVariablePayload(custom, { global: false, index: 0, model: custom })))
+            )
+            .whenAsyncActionIsDispatched(
+              validateVariableSelectionState(toKeyedVariableIdentifier(custom), defaultValue),
+              true
+            );
+
+          await tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
+            const expectedActions: AnyAction[] = withOptions
+              ? [
+                  toKeyedAction(
+                    key,
+                    setCurrentVariableValue(
+                      toVariablePayload(
+                        { type: 'custom', id: '0' },
+                        { option: { text: expected.text, value: expected.value, selected: false } }
+                      )
+                    )
+                  ),
+                ]
+              : [];
+            expect(dispatchedActions).toEqual(expectedActions);
+            return true;
+          });
+        }
+      );
+    });
+
     describe('and multivalue', () => {
       it.each`
         withOptions        | withCurrent   | defaultValue | expectedText  | expectedSelected

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -532,7 +532,7 @@ export const validateVariableSelectionState = (
 
     // 2. find the default value
     if (defaultValue) {
-      option = variableInState.options?.find((v) => v.text === defaultValue);
+      option = variableInState.options?.find((v) => v.text === defaultValue || v.value === defaultValue);
       if (option) {
         return setValue(variableInState, option);
       }

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -532,9 +532,7 @@ export const validateVariableSelectionState = (
 
     // 2. find the default value
     if (defaultValue) {
-      option = variableInState.options?.find(
-        (v: VariableOption) => v.text === defaultValue || v.value === defaultValue
-      );
+      option = variableInState.options?.find((v) => v.text === defaultValue);
       if (option) {
         return setValue(variableInState, option);
       }

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -60,6 +60,7 @@ import {
   ensureStringValues,
   ExtendedUrlQueryMap,
   getCurrentText,
+  getCurrentValue,
   getVariableRefresh,
   hasOngoingTransaction,
   toKeyedVariableIdentifier,
@@ -522,14 +523,18 @@ export const validateVariableSelectionState = (
 
     // 1. find the current value
     const text = getCurrentText(variableInState);
-    option = variableInState.options?.find((v) => v.text === text);
+    const value = getCurrentValue(variableInState);
+
+    option = variableInState.options?.find((v: VariableOption) => v.text === text || v.value === value);
     if (option) {
       return setValue(variableInState, option);
     }
 
     // 2. find the default value
     if (defaultValue) {
-      option = variableInState.options?.find((v) => v.text === defaultValue);
+      option = variableInState.options?.find(
+        (v: VariableOption) => v.text === defaultValue || v.value === defaultValue
+      );
       if (option) {
         return setValue(variableInState, option);
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The goal was to make it possible for a dashboard to specify a provisioned data source as the "current" option for a template variable. The only way to currently achieve this is to use the name of the datasource, but for our use case this would vary between grafana cloud instances. 

The solution makes use of the `value` part of the `{text, value}` structure under a template variable's `options.current`. The `value` field was being completely ignored and was a duplicate of `text`: the name of data source. This PR now takes the `value` into consideration when resolving the initial template variable value, and for data source template variables, the `value` now corresponds to the uid. It will be reflected in new dashboard JSON accordingly. Old dashboard JSON which uses the data source name will still function as before.

**Why do we need this feature?**

When provisioning dashboards and datasources with specific uids, we might want a dashboard to initially select that specific datasource first, instead of defaulting to alphabetical order and choosing the first on the list. This should also make it possible to set a selected value for query-based template variables as well.

**Who is this feature for?**

Specifically, cloud customers accessing the Cardinality management dashboards with multiple metrics datasources defined. We want the dashboards to choose the provisioned `grafanacloud-prom` to be selected first by default when opening the dashboard, instead of the datasource with the earliest name in alphabetical sort. Since the `grafanacloud-prom` datasource has a inconstant name: `grafanacloud-${instanceName}-prom`, it cannot be specified by setting the `current` value in dashboard JSON. This PR allows specifying that uid through the variable's `current.value` field.

**Special notes for your reviewer:**

- There didn't seem to be any place where the documentation needed to know about the specifics of this issue.
- Previously, when a user changes their variable, the `current` fields of `text`, and `value` would both be set to the data source name. Now `text` gets the name, and `value` gets the uid. This will be reflected in the JSON. Old dashboards which use the name for both will still be compatible.
 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


# Release notice breaking change

The data source template variable type has changed the way it represents its options. The `text` field still represents the data source name, but the `value` has been changed to the `uid` of the data source. This allows dashboards to declare the currently selected option by `uid`, however it changes how a datasource template variable value will be rendered by default. If the name of the data source is expected, the variable syntax will have to be changed to specify the [text format](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#text).

For example, given a data source variable (datasourceVariable), the following string:

```
${datasourceVariable}<br/>
Name: ${datasourceVariable:text}<br/>
UID: ${datasourceVariable:raw}
```
was previously interpolated as:
```
grafanacloud-k8smonitoring-prom
Name: grafanacloud-k8smonitoring-prom
UID: grafanacloud-k8smonitoring-prom
```
After these changes, it's interpolated as:
```
d7bbe725-9e48-4af8-a0cb-6cb255d873a3
Name: grafanacloud-k8smonitoring-prom
UID: d7bbe725-9e48-4af8-a0cb-6cb255d873a3
```
Any dashboards that are relying on the data source name being returned by `${datasourceVariable}` will have to update all their usages to `${datasourceVariable:text}` in order to get the previous behavior.

Affected use cases:
- Using `${datasourceVariable}` to display the data source name in text panel or in the panel title.
- Using `${datasourceVariable}` to use the data source name as part of the query content.

Unaffected use cases:
- Using the `${datasourceVariable}` to choose which data source to use for a query (through its data source picker) will not be affected since it can use both the name and the uid