### PR TITLE
Prometheus: Make config header tags consistent

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/AlertingSettingsOverhaul.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AlertingSettingsOverhaul.tsx
@@ -21,7 +21,7 @@ export function AlertingSettingsOverhaul<T extends AlertingConfig>({
 
   return (
     <>
-      <h6 className="page-heading">Alerting</h6>
+      <h3 className="page-heading">Alerting</h3>
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form">

--- a/public/app/plugins/datasource/prometheus/configuration/ExemplarsSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ExemplarsSettings.tsx
@@ -20,7 +20,7 @@ export function ExemplarsSettings({ options, onChange, disabled }: Props) {
   const styles = overhaulStyles(theme);
   return (
     <div className={styles.sectionBottomPadding}>
-      <h6 className="page-heading">Exemplars</h6>
+      <h3 className="page-heading">Exemplars</h3>
 
       {options &&
         options.map((option, index) => {

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -172,7 +172,7 @@ export const PromSettings = (props: Props) => {
 
   return (
     <>
-      <h6 className="page-heading">Interval behaviour</h6>
+      <h3 className="page-heading">Interval behaviour</h3>
       <div className="gf-form-group">
         {/* Scrape interval */}
         <div className="gf-form-inline">
@@ -231,7 +231,7 @@ export const PromSettings = (props: Props) => {
         </div>
       </div>
 
-      <h6 className="page-heading">Query editor</h6>
+      <h3 className="page-heading">Query editor</h3>
       <div className="gf-form-group">
         <div className="gf-form">
           <InlineField
@@ -275,7 +275,7 @@ export const PromSettings = (props: Props) => {
         </div>
       </div>
 
-      <h6 className="page-heading">Performance</h6>
+      <h3 className="page-heading">Performance</h3>
       {!options.jsonData.prometheusType && !options.jsonData.prometheusVersion && options.readOnly && (
         <div className={styles.versionMargin}>
           For more information on configuring prometheus type and version in data sources, see the{' '}
@@ -442,7 +442,7 @@ export const PromSettings = (props: Props) => {
         </div>
       </div>
 
-      <h6 className="page-heading">Other</h6>
+      <h3 className="page-heading">Other</h3>
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form max-width-30">


### PR DESCRIPTION
What is this?
This is important to get the styling correct for G10 as part of the config overhaul. This changes Prometheus config header tags in the "Additional settings" subsection to h3 to make them consistent with other elements of the config page.

See the headings in "Additional Settings"

Image left is how it looks with h3 tags; image right is how it looks with h6 tags
<div>
<img width="277" alt="Screenshot 2023-05-30 at 2 30 54 PM" src="https://github.com/grafana/grafana/assets/25674746/944d535e-a0ad-4d55-b429-5794c2fd861f">|<img width="295" alt="Screenshot 2023-05-30 at 2 32 11 PM" src="https://github.com/grafana/grafana/assets/25674746/917cc95e-9239-4afc-94df-811c6840a2d2">
</div>

Why? This is for the config overhaul project. It is important to have consistent styling for Grafana v10

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
