### PR TITLE
Canvas: Allow all element types by default

### DIFF
--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -18,7 +18,7 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
 
   builder.addBooleanSwitch({
     path: 'showAdvancedTypes',
-    name: 'Show advanced element types',
+    name: 'Show experimental element types',
     description: 'Display experimental element types',
     defaultValue: true,
   });

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -19,8 +19,8 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
   builder.addBooleanSwitch({
     path: 'showAdvancedTypes',
     name: 'Show advanced element types',
-    description: '',
-    defaultValue: false,
+    description: 'Display experimental element types',
+    defaultValue: true,
   });
 };
 

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -18,8 +18,8 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
 
   builder.addBooleanSwitch({
     path: 'showAdvancedTypes',
-    name: 'Show experimental element types',
-    description: 'Display experimental element types',
+    name: 'Experimental element types',
+    description: 'Enable selection of experimental element types',
     defaultValue: true,
   });
 };


### PR DESCRIPTION
Received [some feedback](https://raintank-corp.slack.com/archives/C04J73AAQ87/p1685020386233309?thread_ts=1685012800.986069&cid=C04J73AAQ87) that the "advanced" element types were not available by default. The panel level setting they are blocked behind is default `false` and is not easy to find.

This PR defaults the `showAdvancedTypes` to `true` so that all element types will be available by default. 

There are a few other ways we can go about this:
1. Remove setting altogether
2. Leave default to `false` and move / improve element types into default (like windmill)