### PR TITLE
JoinDataFrames: Keep field name if possible

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
@@ -275,10 +275,16 @@ describe('align frames', () => {
         { name: 'Value', type: FieldType.number, values: [1, 100] },
       ],
     });
-    expect(getFieldNames([series1])).toMatchInlineSnapshot(`
+    expect(getFieldDisplayNames([series1])).toMatchInlineSnapshot(`
       [
         "Time",
         "Muta",
+      ]
+    `);
+    expect(getFieldNames([series1])).toMatchInlineSnapshot(`
+      [
+        "Time",
+        "Value",
       ]
     `);
 
@@ -289,19 +295,32 @@ describe('align frames', () => {
         { name: 'Value', type: FieldType.number, values: [150] },
       ],
     });
-    expect(getFieldNames([series2])).toMatchInlineSnapshot(`
+    expect(getFieldDisplayNames([series2])).toMatchInlineSnapshot(`
       [
         "Time",
         "Muta",
       ]
     `);
+    expect(getFieldNames([series2])).toMatchInlineSnapshot(`
+      [
+        "Time",
+        "Value",
+      ]
+    `);
 
     const out = joinDataFrames({ frames: [series1, series2] })!;
-    expect(getFieldNames([out])).toMatchInlineSnapshot(`
+    expect(getFieldDisplayNames([out])).toMatchInlineSnapshot(`
       [
         "Time",
         "Muta 1",
         "Muta 2",
+      ]
+    `);
+    expect(getFieldNames([out])).toMatchInlineSnapshot(`
+      [
+        "Time",
+        "Muta",
+        "Muta",
       ]
     `);
   });
@@ -398,6 +417,10 @@ describe('align frames', () => {
   });
 });
 
-function getFieldNames(data: DataFrame[]): string[] {
+function getFieldDisplayNames(data: DataFrame[]): string[] {
   return data.flatMap((frame) => frame.fields.map((f) => getFieldDisplayName(f, frame, data)));
+}
+
+function getFieldNames(data: DataFrame[]): string[] {
+  return data.flatMap((frame) => frame.fields.map((f) => f.name));
 }

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -203,6 +203,7 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
         };
       }
     }
+
     if (!join) {
       continue; // skip the frame
     }

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -1,7 +1,7 @@
 import intersect from 'fast_array_intersect';
 
 import { getTimeField, sortDataFrame } from '../../dataframe';
-import { DataFrame, Field, FieldMatcher, FieldType } from '../../types';
+import { DataFrame, Field, FieldMatcher, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types';
 import { fieldMatchers } from '../matchers';
 import { FieldMatcherID } from '../matchers/ids';
 
@@ -180,12 +180,18 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
         nullModesFrame.push(spanNulls === true ? NULL_REMOVE : spanNulls === -1 ? NULL_RETAIN : NULL_EXPAND);
 
         let labels = field.labels ?? {};
+        let name = field.name;
         if (frame.name) {
-          labels = { ...labels, name: frame.name };
+          if (field.name === TIME_SERIES_VALUE_FIELD_NAME) {
+            name = frame.name;
+          } else {
+            labels = { ...labels, name: frame.name };
+          }
         }
 
         fields.push({
           ...field,
+          name,
           labels, // add the name label from frame
         });
       }
@@ -197,7 +203,6 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
         };
       }
     }
-
     if (!join) {
       continue; // skip the frame
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/69207 (though there may be additional issues)

When joining data using the legacy "Time/Value" fields where the name exists on the series, this PR updates the logic so that the series name is moved to the field name rather than sending it into labels.

This will make the names consistent between the first and second renders (why there are two renders is still another question!)



