### PR TITLE
admission: add example for mutation admission plugin

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -170,19 +170,12 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 		rmr(binary, binary+".md5")
 	}
 
-	_, err := ldflags(opts)
+	lf, err := ldflags(opts)
 	if err != nil {
 		return err
 	}
 
-	args := []string{"build"} // , "-ldflags", lf
-
-	gc, err := gcflags(opts)
-	if err != nil {
-		return err
-	}
-
-	args = append(args, "-gcflags", gc)
+	args := []string{"build", "-ldflags", lf}
 
 	if opts.goos == GoOSWindows {
 		// Work around a linking error on Windows: "export ordinal too large"
@@ -218,10 +211,6 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 	return md5File(binary)
 }
 
-func gcflags(opts BuildOpts) (string, error) {
-	return "all=-N -l", nil
-}
-
 func ldflags(opts BuildOpts) (string, error) {
 	buildStamp, err := buildStamp()
 	if err != nil {
@@ -239,7 +228,7 @@ func ldflags(opts BuildOpts) (string, error) {
 	}
 
 	var b bytes.Buffer
-	// b.WriteString("-w")
+	b.WriteString("-w")
 	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", commitSha))
 	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp))

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -170,12 +170,19 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 		rmr(binary, binary+".md5")
 	}
 
-	lf, err := ldflags(opts)
+	_, err := ldflags(opts)
 	if err != nil {
 		return err
 	}
 
-	args := []string{"build", "-ldflags", lf}
+	args := []string{"build"} // , "-ldflags", lf
+
+	gc, err := gcflags(opts)
+	if err != nil {
+		return err
+	}
+
+	args = append(args, "-gcflags", gc)
 
 	if opts.goos == GoOSWindows {
 		// Work around a linking error on Windows: "export ordinal too large"
@@ -211,6 +218,10 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 	return md5File(binary)
 }
 
+func gcflags(opts BuildOpts) (string, error) {
+	return "all=-N -l", nil
+}
+
 func ldflags(opts BuildOpts) (string, error) {
 	buildStamp, err := buildStamp()
 	if err != nil {
@@ -228,7 +239,7 @@ func ldflags(opts BuildOpts) (string, error) {
 	}
 
 	var b bytes.Buffer
-	b.WriteString("-w")
+	// b.WriteString("-w")
 	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", commitSha))
 	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp))

--- a/pkg/services/k8s/apiserver/admission/add_default_fields.go
+++ b/pkg/services/k8s/apiserver/admission/add_default_fields.go
@@ -56,6 +56,9 @@ func (addDefaultFields) Admit(ctx context.Context, a admission.Attributes, o adm
 		}
 		break
 	case admission.Update:
+		// Quick and dirty code with some type assertions that skip error checking
+		// in order to demonstrate how to protect a managed field when it already exists in
+		// an old object and is being attempted to be removed
 		oldObject := a.GetOldObject()
 
 		from, _ := oldObject.(*unstructured.Unstructured)

--- a/pkg/services/k8s/apiserver/admission/add_default_fields.go
+++ b/pkg/services/k8s/apiserver/admission/add_default_fields.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -23,6 +24,11 @@ type addDefaultFields struct {
 
 var _ admission.MutationInterface = addDefaultFields{}
 
+const (
+	AddDefaultFieldsKey   = "default_fields_key_1"
+	AddDefaultFieldsValue = "default_fields_value_1"
+)
+
 // NOTE: enable the below assertions for convenient interface additions for a plugin when the plugin
 // needs an external clientset and informer factory
 
@@ -31,30 +37,42 @@ var _ admission.MutationInterface = addDefaultFields{}
 
 // Admit makes an admission decision based on the request attributes.
 func (addDefaultFields) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
-	if a.GetOperation() == admission.Delete {
-		return nil
-	}
-
 	obj := a.GetObject()
 
 	// NOTE: tried using dashboard.K8sResource here, but that doesn't implement runtime.Object
 	// gvk is available as one of the attributes for branching off the logic per kind
-	// a.GetOldObject() is also available for detecting changed fields and disallowing operation if disallowed fields
-	// were modified
 
-	// Interesting behavior: yet to be explained: if you try removing this managed field, it enters a loop
-	// which re-triggers this function, eventually leading to a request timeout on the client side
-
-	// Ideally, we would just disallow such removal of a managed field and return an error
-	target, ok := obj.(*unstructured.Unstructured)
-	if ok {
-		spec, ok := target.Object["spec"].(map[string]interface{})
+	switch a.GetOperation() {
+	case admission.Create:
+		target, ok := obj.(*unstructured.Unstructured)
 		if ok {
-			_, set := spec["default_fields_key_1"].(string)
-			if !set {
-				spec["default_fields_key_1"] = "default_fields_value_1"
+			spec, ok := target.Object["spec"].(map[string]interface{})
+			if ok {
+				_, set := spec[AddDefaultFieldsKey].(string)
+				if !set {
+					spec[AddDefaultFieldsKey] = AddDefaultFieldsValue
+				}
 			}
 		}
+		break
+	case admission.Update:
+		oldObject := a.GetOldObject()
+
+		from, _ := oldObject.(*unstructured.Unstructured)
+		fromSpec, _ := from.Object["spec"].(map[string]interface{})
+		_, ok := fromSpec[AddDefaultFieldsKey].(string)
+
+		to, _ := obj.(*unstructured.Unstructured)
+		toSpec, _ := to.Object["spec"].(map[string]interface{})
+		_, set := toSpec[AddDefaultFieldsKey]
+		if !ok {
+			toSpec[AddDefaultFieldsKey] = AddDefaultFieldsValue
+		} else if !set { // if it was set and user is trying to remove it
+			return admission.NewForbidden(a, fmt.Errorf("error removing managed field from %s", a.GetResource().Resource))
+		}
+		break
+	case admission.Delete:
+		return nil
 	}
 
 	return nil

--- a/pkg/services/k8s/apiserver/admission/add_default_fields.go
+++ b/pkg/services/k8s/apiserver/admission/add_default_fields.go
@@ -1,0 +1,68 @@
+package admission
+
+import (
+	"context"
+	"io"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const PluginNameAddDefaultFields = "AddDefaultFields"
+
+// Register registers a plugin
+func RegisterAddDefaultFields(plugins *admission.Plugins) {
+	plugins.Register(PluginNameAddDefaultFields, func(config io.Reader) (admission.Interface, error) {
+		return NewAddDefaultFields(), nil
+	})
+}
+
+type addDefaultFields struct {
+	*admission.Handler
+}
+
+var _ admission.MutationInterface = addDefaultFields{}
+
+// NOTE: enable the below assertions for convenient interface additions for a plugin when the plugin
+// needs an external clientset and informer factory
+
+// var _ = genericadmissioninitializer.WantsExternalKubeClientSet(&addDefaultFields{})
+// var _ = genericadmissioninitializer.WantsExternalKubeInformerFactory(&addDefaultFields{})
+
+// Admit makes an admission decision based on the request attributes.
+func (addDefaultFields) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
+
+	obj := a.GetObject()
+
+	// NOTE: tried using dashboard.K8sResource here, but that doesn't implement runtime.Object
+	// gvk is available as one of the attributes for branching off the logic per kind
+	// a.GetOldObject() is also available for detecting changed fields and disallowing operation if disallowed fields
+	// were modified
+
+	// Interesting behavior: yet to be explained: if you try removing this managed field, it enters a loop
+	// which re-triggers this function, eventually leading to a request timeout on the client side
+
+	// Ideally, we would just disallow such removal of a managed field and return an error
+	target, ok := obj.(*unstructured.Unstructured)
+	if ok {
+		spec, ok := target.Object["spec"].(map[string]interface{})
+		if ok {
+			_, set := spec["default_fields_key_1"].(string)
+			if !set {
+				spec["default_fields_key_1"] = "default_fields_value_1"
+			}
+		}
+	}
+
+	return nil
+}
+
+// NewAddDefaultFields creates an always deny admission handler
+func NewAddDefaultFields() admission.Interface {
+	return addDefaultFields{
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
+	}
+}

--- a/pkg/services/k8s/apiserver/admission/deny_by_name.go
+++ b/pkg/services/k8s/apiserver/admission/deny_by_name.go
@@ -36,13 +36,7 @@ func RegisterDenyByName(plugins *admission.Plugins) {
 // example of admission plugin that will deny any resource with name "deny"
 type denyByName struct{}
 
-var _ admission.MutationInterface = denyByName{}
 var _ admission.ValidationInterface = denyByName{}
-
-// Admit makes an admission decision based on the request attributes.
-func (denyByName) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
-	return nil
-}
 
 // Validate makes an admission decision based on the request attributes.  It is NOT allowed to mutate.
 func (denyByName) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {

--- a/pkg/services/k8s/apiserver/service.go
+++ b/pkg/services/k8s/apiserver/service.go
@@ -149,9 +149,10 @@ func (s *service) start(ctx context.Context) error {
 	// plugins that depend on the Core V1 APIs and informers.
 	o.RecommendedOptions.Admission.Plugins = admission.NewPlugins()
 	grafanaAdmission.RegisterDenyByName(o.RecommendedOptions.Admission.Plugins)
-	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName}
+	grafanaAdmission.RegisterAddDefaultFields(o.RecommendedOptions.Admission.Plugins)
+	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields}
 	o.RecommendedOptions.Admission.DisablePlugins = append([]string{}, o.RecommendedOptions.Admission.EnablePlugins...)
-	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName}
+	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields}
 
 	// Get the util to get the paths to pre-generated certs
 	certUtil := certgenerator.CertUtil{


### PR DESCRIPTION
* Adds a default field on all update and create operations as needed to demonstrate mutation behavior with an example.
* Also uses the Handler from `admission.Handler` in kubernetes core code to reuse the `Handles` implementation.