### PR TITLE
Pyroscope: Fix wrong defaults when importing query from different datasource

### DIFF
--- a/public/app/plugins/datasource/phlare/datasource.ts
+++ b/public/app/plugins/datasource/phlare/datasource.ts
@@ -82,8 +82,7 @@ export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSou
       labelSelector: toPromLikeExpr(labelBasedQuery),
       queryType: 'both',
       profileTypeId: '',
-      maxNodes: 16,
-      groupBy: [''],
+      groupBy: [],
     };
   }
 


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/69292
We have a functionality that can import query from another data source when changing them in explore, so we will preserve label matchers for example when moving between prometheus/loki/pyroscope. There were some odd defaults defined there for pyro.