### PR TITLE
[Proposal] Loki Query Builder: Highlight query errors while building queries

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
@@ -116,20 +116,29 @@ export const placeHolderScopedVars = {
 
 export function highlightErrorsInQuery(query: string): string {
   const errorBoundaries = validateQuery(query, query, query.split('\n'));
+
   if (!errorBoundaries) {
     return query;
   }
 
   const queryLines = query.split('\n');
   const queryWithErrors = queryLines.map((line, index) => {
-    const errorBoundary = errorBoundaries.find((error) => error.startLineNumber === index + 1);
-    if (!errorBoundary) {
-      return line;
-    }
+    let updatedLine = line;
+    errorBoundaries.forEach((errorBoundary) => {
+      if (errorBoundary.startLineNumber !== index + 1) {
+        return;
+      }
+      const { startColumn, endColumn, error } = errorBoundary;
+      const delta = updatedLine.length - line.length;
 
-    const { startColumn, endColumn, error } = errorBoundary;
-    return `${line.substring(0, startColumn - 1)}%err${error}err%${line.substring(endColumn - 1)}`;
+      updatedLine = `${updatedLine.substring(0, startColumn - 1 + delta)}%err${error}err%${updatedLine.substring(
+        endColumn - 1 + delta
+      )}`;
+    });
+    return updatedLine;
   });
+
+  console.log(queryWithErrors.join('\n'));
 
   return queryWithErrors.join('\n');
 }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
@@ -113,3 +113,23 @@ export const placeHolderScopedVars = {
   __range_s: { text: '1', value: 1 },
   __range: { text: '1s', value: '1s' },
 };
+
+export function highlightErrorsInQuery(query: string): string {
+  const errorBoundaries = validateQuery(query, query, query.split('\n'));
+  if (!errorBoundaries) {
+    return query;
+  }
+
+  const queryLines = query.split('\n');
+  const queryWithErrors = queryLines.map((line, index) => {
+    const errorBoundary = errorBoundaries.find((error) => error.startLineNumber === index + 1);
+    if (!errorBoundary) {
+      return line;
+    }
+
+    const { startColumn, endColumn, error } = errorBoundary;
+    return `${line.substring(0, startColumn - 1)}%err${error}err%${line.substring(endColumn - 1)}`;
+  });
+
+  return queryWithErrors.join('\n');
+}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -66,7 +66,7 @@ export function LokiQueryBuilderContainer(props: Props) {
         showExplain={showExplain}
         data-testid={testIds.editor}
       />
-      {query.expr !== '' && <QueryPreview query={query.expr} />}
+      {query.expr !== '' && <QueryPreview query={query.expr} datasource={datasource} />}
     </>
   );
 }

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { EditorRow, EditorFieldGroup } from '@grafana/experimental';
 
-import { RawQuery } from '../../../prometheus/querybuilder/shared/RawQuery';
-import { lokiGrammar } from '../../syntax';
+import { RawQuery } from './RawQuery';
 
 export interface Props {
   query: string;
@@ -13,7 +12,7 @@ export function QueryPreview({ query }: Props) {
   return (
     <EditorRow>
       <EditorFieldGroup>
-        <RawQuery query={query} lang={{ grammar: lokiGrammar, name: 'lokiql' }} />
+        <RawQuery query={query} />
       </EditorFieldGroup>
     </EditorRow>
   );

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 
 import { EditorRow, EditorFieldGroup } from '@grafana/experimental';
 
+import { LokiDatasource } from '../../datasource';
+
 import { RawQuery } from './RawQuery';
 
 export interface Props {
   query: string;
+  datasource: LokiDatasource;
 }
 
-export function QueryPreview({ query }: Props) {
+export function QueryPreview(props: Props) {
   return (
     <EditorRow>
       <EditorFieldGroup>
-        <RawQuery query={query} />
+        <RawQuery {...props} />
       </EditorFieldGroup>
     </EditorRow>
   );

--- a/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
@@ -1,14 +1,15 @@
 import { css, cx } from '@emotion/css';
 import Prism from 'prismjs';
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data/src';
-import { useTheme2 } from '@grafana/ui/src';
+import { Alert, Tooltip, useTheme2 } from '@grafana/ui/src';
 
 import {
   highlightErrorsInQuery,
   placeHolderScopedVars,
   processErrorTokens,
+  validateQuery,
 } from '../../components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiDatasource } from '../../datasource';
 import { lokiGrammar } from '../../syntax';
@@ -22,35 +23,43 @@ export interface Props {
 export function RawQuery({ query, className, datasource }: Props) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const highlighted = Prism.highlight(
-    highlightErrorsInQuery(datasource.interpolateString(query, placeHolderScopedVars)),
-    lokiGrammar,
-    'lokiql'
+  const interpolatedQuery = useMemo(
+    () => datasource.interpolateString(query, placeHolderScopedVars),
+    [datasource, query]
   );
+  const highlighted = Prism.highlight(highlightErrorsInQuery(query, interpolatedQuery), lokiGrammar, 'lokiql');
+  const hasErrors = useMemo(() => validateQuery(query, interpolatedQuery, [query]), [query, interpolatedQuery]);
 
-  Prism.hooks.add('after-tokenize', function (env) {
-    if (env.language !== 'lokiql') {
-      return;
-    }
+  useEffect(() => {
+    Prism.hooks.add('after-tokenize', function (env) {
+      if (env.language !== 'lokiql') {
+        return;
+      }
 
-    env.tokens = processErrorTokens(env.tokens);
-    console.log(env.tokens);
-  });
-  Prism.hooks.add('wrap', (env) => {
-    if (env.language !== 'lokiql') {
-      return;
-    }
-    if (env.type === 'error') {
-      env.classes.push(styles.queryError);
-    }
-  });
+      env.tokens = processErrorTokens(env.tokens);
+    });
+    Prism.hooks.add('wrap', (env) => {
+      if (env.language !== 'lokiql') {
+        return;
+      }
+      if (env.type === 'error') {
+        env.classes.push(styles.queryError);
+      }
+    });
+  }, [styles.queryError]);
 
   return (
-    <div
-      className={cx(styles.editorField, 'prism-syntax-highlight', className)}
-      aria-label="selector"
-      dangerouslySetInnerHTML={{ __html: highlighted }}
-    />
+    <>
+      <Tooltip
+        content={hasErrors ? 'The query appears to be incorrect and could fail to be executed' : 'The query is valid'}
+      >
+        <div
+          className={cx(styles.editorField, 'prism-syntax-highlight', className)}
+          aria-label="selector"
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+        />
+      </Tooltip>
+    </>
   );
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import Prism, { Token } from 'prismjs';
+import Prism from 'prismjs';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data/src';
@@ -8,6 +8,7 @@ import { useTheme2 } from '@grafana/ui/src';
 import {
   highlightErrorsInQuery,
   placeHolderScopedVars,
+  processErrorTokens,
 } from '../../components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiDatasource } from '../../datasource';
 import { lokiGrammar } from '../../syntax';
@@ -32,23 +33,8 @@ export function RawQuery({ query, className, datasource }: Props) {
       return;
     }
 
-    let errorZone = false;
-    env.tokens = env.tokens.map((token: string | Token) => {
-      if (typeof token !== 'string') {
-        return errorZone ? new Prism.Token('error', token.content) : token;
-      }
-      if (token.includes('%err')) {
-        errorZone = true;
-        return new Prism.Token('error', token.replace('%err', ''));
-      }
-
-      if (token.includes('err%')) {
-        errorZone = false;
-        return new Prism.Token('error', token.replace('err%', ''));
-      }
-
-      return token;
-    });
+    env.tokens = processErrorTokens(env.tokens);
+    console.log(env.tokens);
   });
   Prism.hooks.add('wrap', (env) => {
     if (env.language !== 'lokiql') {
@@ -75,7 +61,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       font-size: ${theme.typography.bodySmall.fontSize};
     `,
     queryError: css`
-      color: ${theme.colors.error.main};
+      color: ${theme.colors.error.main} !important;
       text-decoration: underline wavy;
     `,
   };

--- a/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
@@ -5,18 +5,27 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data/src';
 import { useTheme2 } from '@grafana/ui/src';
 
-import { highlightErrorsInQuery } from '../../components/monaco-query-field/monaco-completion-provider/validation';
+import {
+  highlightErrorsInQuery,
+  placeHolderScopedVars,
+} from '../../components/monaco-query-field/monaco-completion-provider/validation';
+import { LokiDatasource } from '../../datasource';
 import { lokiGrammar } from '../../syntax';
 
 export interface Props {
   query: string;
   className?: string;
+  datasource: LokiDatasource;
 }
 
-export function RawQuery({ query, className }: Props) {
+export function RawQuery({ query, className, datasource }: Props) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const highlighted = Prism.highlight(highlightErrorsInQuery(query), lokiGrammar, 'lokiql');
+  const highlighted = Prism.highlight(
+    highlightErrorsInQuery(datasource.interpolateString(query, placeHolderScopedVars)),
+    lokiGrammar,
+    'lokiql'
+  );
 
   Prism.hooks.add('after-tokenize', function (env) {
     if (env.language !== 'lokiql') {

--- a/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
@@ -70,7 +70,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       font-size: ${theme.typography.bodySmall.fontSize};
     `,
     queryError: css`
-      color: ${theme.colors.error.main} !important;
+      color: ${theme.colors.error.text} !important;
       text-decoration: underline wavy;
     `,
   };

--- a/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/RawQuery.tsx
@@ -1,0 +1,73 @@
+import { css, cx } from '@emotion/css';
+import Prism, { Token } from 'prismjs';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data/src';
+import { useTheme2 } from '@grafana/ui/src';
+
+import { highlightErrorsInQuery } from '../../components/monaco-query-field/monaco-completion-provider/validation';
+import { lokiGrammar } from '../../syntax';
+
+export interface Props {
+  query: string;
+  className?: string;
+}
+
+export function RawQuery({ query, className }: Props) {
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+  const highlighted = Prism.highlight(highlightErrorsInQuery(query), lokiGrammar, 'lokiql');
+
+  Prism.hooks.add('after-tokenize', function (env) {
+    if (env.language !== 'lokiql') {
+      return;
+    }
+
+    let errorZone = false;
+    env.tokens = env.tokens.map((token: string | Token) => {
+      if (typeof token !== 'string') {
+        return errorZone ? new Prism.Token('error', token.content) : token;
+      }
+      if (token.includes('%err')) {
+        errorZone = true;
+        return new Prism.Token('error', token.replace('%err', ''));
+      }
+
+      if (token.includes('err%')) {
+        errorZone = false;
+        return new Prism.Token('error', token.replace('err%', ''));
+      }
+
+      return token;
+    });
+  });
+  Prism.hooks.add('wrap', (env) => {
+    if (env.language !== 'lokiql') {
+      return;
+    }
+    if (env.type === 'error') {
+      env.classes.push(styles.queryError);
+    }
+  });
+
+  return (
+    <div
+      className={cx(styles.editorField, 'prism-syntax-highlight', className)}
+      aria-label="selector"
+      dangerouslySetInnerHTML={{ __html: highlighted }}
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    editorField: css`
+      font-family: ${theme.typography.fontFamilyMonospace};
+      font-size: ${theme.typography.bodySmall.fontSize};
+    `,
+    queryError: css`
+      color: ${theme.colors.error.main};
+      text-decoration: underline wavy;
+    `,
+  };
+};


### PR DESCRIPTION
This PR is to propose a solution to adding query validation for queries built using the Query Builder.

The reasons for supporting query validation with the Query Builder are:
- We validate queries in the Code editor but not in Query Builder.
- The Query Builder is one of our getting started options to reduce the friction when writing LogQL.
- With the Query Builder users can select any operation in any order with no feedback on what combination creates a valid query until it's executed.

The approach chosen for this version of the implementation was to leverage Prism to highlight parts of the query that we know are not valid.

Note: most of the code required to highlight errors was limited and determined by Prism, which (AFAIK) doesn't have great support for highligting errors in the code. In any case, the implementation can be changed to other alternatives, but what I wanted to validate with this PR was the way to visually show invalid queries in the UI.

Some examples:

![imagen](https://github.com/grafana/grafana/assets/1069378/f35a9a48-68b6-4d48-925b-12a02e3dccfb)

![imagen](https://github.com/grafana/grafana/assets/1069378/9a3816f3-fbdd-4b65-a5f0-8094c5c6788c)

![imagen](https://github.com/grafana/grafana/assets/1069378/e7494dc7-9caa-4f15-938b-4bd68d36136e)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65376

**Special notes for your reviewer:**

Play with the implementation, try to find limitations or edge cases, and see how it feels and if you think this way of showing visual feedback could be useful.

This is still work in progress, so it's not ready to be merged.