### PR TITLE
Alerting: Change how we display annotations in the rule form

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -170,8 +170,7 @@ describe('RuleEditor grafana managed rules', () => {
     // expect(within(folderInput).queryByText("Folders with '/' character are not allowed.")).not.toBeInTheDocument();
 
     // add an annotation
-    await clickSelectOptionMatch(ui.inputs.annotationKey(2).get(), /Add new/);
-    await userEvent.type(byRole('textbox').get(ui.inputs.annotationKey(2).get()), 'custom');
+    await userEvent.type(ui.inputs.annotationKey(2).get(), 'custom');
     await userEvent.type(ui.inputs.annotationValue(2).get(), 'value');
 
     //add a label

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -168,8 +168,8 @@ describe('RuleEditor grafana managed rules', () => {
     // expect(within(folderInput).queryByText("Folders with '/' character are not allowed.")).not.toBeInTheDocument();
 
     // add an annotation
-    await userEvent.type(ui.inputs.annotationKey(2).get(), 'custom');
-    await userEvent.type(ui.inputs.annotationValue(2).get(), 'value');
+    await userEvent.type(screen.getByPlaceholderText('Enter custom annotation name...'), 'custom');
+    await userEvent.type(screen.getByPlaceholderText('Enter custom annotation content...'), 'value');
 
     //add a label
     await userEvent.type(getLabelInput(ui.inputs.labelKey(2).get()), 'custom{enter}');

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -4,8 +4,6 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { ui } from 'test/helpers/alertingRuleEditor';
-import { clickSelectOptionMatch } from 'test/helpers/selectOptionInTest';
-import { byRole } from 'testing-library-selector';
 
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
 import { ADD_NEW_FOLER_OPTION } from 'app/core/components/Select/FolderPicker';

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -151,8 +151,8 @@ describe('RuleEditor grafana managed rules', () => {
     expect(nameInput).toHaveValue('my great new rule');
     //check that folder is in the list
     expect(ui.inputs.folder.get()).toHaveTextContent(new RegExp(folder.title));
-    expect(ui.inputs.annotationValue(0).get()).toHaveValue('some description');
-    expect(ui.inputs.annotationValue(1).get()).toHaveValue('some summary');
+    expect(ui.inputs.annotationValue(0).get()).toHaveValue('some summary');
+    expect(ui.inputs.annotationValue(1).get()).toHaveValue('some description');
 
     //check that slashed folders are not in the list
     expect(ui.inputs.folder.get()).toHaveTextContent(new RegExp(folder.title));

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -168,6 +168,7 @@ describe('RuleEditor grafana managed rules', () => {
     // expect(within(folderInput).queryByText("Folders with '/' character are not allowed.")).not.toBeInTheDocument();
 
     // add an annotation
+    await userEvent.click(screen.getByText('Add custom annotation'));
     await userEvent.type(screen.getByPlaceholderText('Enter custom annotation name...'), 'custom');
     await userEvent.type(screen.getByPlaceholderText('Enter custom annotation content...'), 'value');
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
@@ -260,8 +260,7 @@ describe('Receivers', () => {
     await waitFor(() => expect(ui.contactPointAnnotationSelect(0).get()).toBeInTheDocument());
 
     // enter custom annotations and labels
-    await userEvent.type(screen.getByPlaceholderText('Enter custom annotation name...'), 'description');
-    await userEvent.type(ui.contactPointAnnotationValue(0).get(), 'Test contact point');
+    await userEvent.type(screen.getByPlaceholderText('Enter a description...'), 'Test contact point');
     await userEvent.type(ui.contactPointLabelKey(0).get(), 'foo');
     await userEvent.type(ui.contactPointLabelValue(0).get(), 'bar');
     await userEvent.click(ui.testContactPoint.get());

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
@@ -260,7 +260,7 @@ describe('Receivers', () => {
     await waitFor(() => expect(ui.contactPointAnnotationSelect(0).get()).toBeInTheDocument());
 
     // enter custom annotations and labels
-    await clickSelectOption(ui.contactPointAnnotationSelect(0).get(), 'Description');
+    await userEvent.type(screen.getByPlaceholderText('Enter custom annotation name...'), 'description');
     await userEvent.type(ui.contactPointAnnotationValue(0).get(), 'Test contact point');
     await userEvent.type(ui.contactPointLabelKey(0).get(), 'foo');
     await userEvent.type(ui.contactPointLabelValue(0).get(), 'bar');

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
@@ -257,7 +257,6 @@ describe('Receivers', () => {
 
     await waitFor(() => expect(ui.testContactPointModal.get()).toBeInTheDocument(), { timeout: 1000 });
     await userEvent.click(ui.customContactPointOption.get());
-    await waitFor(() => expect(ui.contactPointAnnotationSelect(0).get()).toBeInTheDocument());
 
     // enter custom annotations and labels
     await userEvent.type(screen.getByPlaceholderText('Enter a description...'), 'Test contact point');

--- a/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
@@ -7,6 +7,7 @@ import { Modal, Button, Label, useStyles2, RadioButtonGroup } from '@grafana/ui'
 import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
 import { Annotations, Labels } from 'app/types/unified-alerting-dto';
 
+import { defaultAnnotations } from '../../../utils/constants';
 import AnnotationsField from '../../rule-editor/AnnotationsField';
 import LabelsField from '../../rule-editor/LabelsField';
 
@@ -34,7 +35,7 @@ enum NotificationType {
 const notificationOptions = Object.values(NotificationType).map((value) => ({ label: value, value: value }));
 
 const defaultValues: FormFields = {
-  annotations: [{ key: '', value: '' }],
+  annotations: [...defaultAnnotations],
   labels: [{ key: '', value: '' }],
 };
 

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
@@ -1,0 +1,78 @@
+import { css } from '@emotion/css';
+import React from 'react';
+import { FieldArrayWithId, useFormContext } from 'react-hook-form';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { InputControl, useStyles2 } from '@grafana/ui';
+
+import { RuleFormValues } from '../../types/rule-form';
+import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';
+
+import CustomAnnotationField from './CustomAnnotationField';
+
+const AnnotationHeaderField = ({
+  annotationField,
+  annotations,
+  annotation,
+  index,
+}: {
+  annotationField: FieldArrayWithId<RuleFormValues, 'annotations', 'id'>;
+  annotations: Array<{ key: string; value: string }>;
+  annotation: Annotation;
+  index: number;
+}) => {
+  const styles = useStyles2(getStyles);
+  const { control } = useFormContext<RuleFormValues>();
+  return (
+    <div>
+      <label className={styles.annotationContainer}>
+        {
+          <InputControl
+            name={`annotations.${index}.key`}
+            defaultValue={annotationField.key}
+            render={({ field: { ref, ...field } }) => {
+              switch (annotationField.key) {
+                case Annotation.dashboardUID:
+                  return <div>Dashboard and panel</div>;
+                case Annotation.panelID:
+                  return <span></span>;
+                default:
+                  return (
+                    <div>
+                      {annotationLabels[annotation] && (
+                        <span className={styles.annotationTitle} data-testid={`annotation-key-${index}`}>
+                          {annotationLabels[annotation]}
+                          {' (optional)'}
+                        </span>
+                      )}
+                      {!annotationLabels[annotation] && <CustomAnnotationField field={field} />}
+                    </div>
+                  );
+              }
+            }}
+            control={control}
+            rules={{ required: { value: !!annotations[index]?.value, message: 'Required.' } }}
+          />
+        }
+      </label>
+      <div className={styles.annotationDescription}>{annotationDescriptions[annotation]}</div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  annotationTitle: css`
+    color: ${theme.colors.text.primary};
+    margin-bottom: 3px;
+  `,
+
+  annotationContainer: css`
+    margin-top: 5px;
+  `,
+
+  annotationDescription: css`
+    color: ${theme.colors.text.secondary};
+  `,
+});
+
+export default AnnotationHeaderField;

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
@@ -8,7 +8,7 @@ import { InputControl, useStyles2 } from '@grafana/ui';
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';
 
-import CustomAnnotationField from './CustomAnnotationField';
+import CustomAnnotationHeaderField from './CustomAnnotationHeaderField';
 
 const AnnotationHeaderField = ({
   annotationField,
@@ -45,7 +45,7 @@ const AnnotationHeaderField = ({
                           {' (optional)'}
                         </span>
                       )}
-                      {!annotationLabels[annotation] && <CustomAnnotationField field={field} />}
+                      {!annotationLabels[annotation] && <CustomAnnotationHeaderField field={field} />}
                     </div>
                   );
               }

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -33,7 +33,7 @@ jest.mock(
 );
 
 const ui = {
-  setDashboardButton: byRole('button', { name: 'Set dashboard and panel' }),
+  setDashboardButton: byRole('button', { name: 'Link dashboard and panel' }),
   annotationKeys: byTestId('annotation-key-', { exact: false }),
   annotationValues: byTestId('annotation-value-', { exact: false }),
   dashboardPicker: {
@@ -158,9 +158,10 @@ describe('AnnotationsField', function () {
 
       expect(ui.dashboardPicker.dialog.query()).not.toBeInTheDocument();
 
-      expect(annotationValueElements).toHaveLength(2);
-      expect(annotationValueElements[0]).toHaveTextContent('dash-test-uid');
-      expect(annotationValueElements[1]).toHaveTextContent('2');
+      expect(annotationValueElements).toHaveLength(5); //first 3 correspond to the default values (summary, description, runbook url)
+
+      expect(annotationValueElements[3]).toHaveTextContent('dash-test-uid');
+      expect(annotationValueElements[4]).toHaveTextContent('2');
     });
 
     // this test _should_ work in theory but something is stopping the 'onClick' function on the dashboard item

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -154,18 +154,12 @@ describe('AnnotationsField', function () {
 
       await user.click(ui.dashboardPicker.confirmButton.get());
 
-      const annotationKeyElements = ui.annotationKeys.getAll();
       const annotationValueElements = ui.annotationValues.getAll();
 
       expect(ui.dashboardPicker.dialog.query()).not.toBeInTheDocument();
 
-      expect(annotationKeyElements).toHaveLength(2);
       expect(annotationValueElements).toHaveLength(2);
-
-      expect(annotationKeyElements[0]).toHaveTextContent('Dashboard UID');
       expect(annotationValueElements[0]).toHaveTextContent('dash-test-uid');
-
-      expect(annotationKeyElements[1]).toHaveTextContent('Panel ID');
       expect(annotationValueElements[1]).toHaveTextContent('2');
     });
 

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -158,10 +158,9 @@ describe('AnnotationsField', function () {
 
       expect(ui.dashboardPicker.dialog.query()).not.toBeInTheDocument();
 
-      expect(annotationValueElements).toHaveLength(5); //first 3 correspond to the default values (summary, description, runbook url)
-
-      expect(annotationValueElements[3]).toHaveTextContent('dash-test-uid');
-      expect(annotationValueElements[4]).toHaveTextContent('2');
+      expect(annotationValueElements).toHaveLength(2);
+      expect(annotationValueElements[0]).toHaveTextContent('dash-test-uid');
+      expect(annotationValueElements[1]).toHaveTextContent('2');
     });
 
     // this test _should_ work in theory but something is stopping the 'onClick' function on the dashboard item

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -13,6 +13,7 @@ import { dashboardApi } from '../../api/dashboardApi';
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';
 
+import CustomAnnotationField from './CustomAnnotationField';
 import DashboardAnnotationField from './DashboardAnnotationField';
 import { DashboardPicker, PanelDTO } from './DashboardPicker';
 
@@ -119,15 +120,7 @@ const AnnotationsField = () => {
                               {annotationLabels[annotation] ? (
                                 <span className={styles.annotationTitle}>(optional)</span>
                               ) : (
-                                <div>
-                                  <span className={styles.annotationTitle}>Custom annotation name and content</span>
-                                  <Input
-                                    placeholder="Enter custom annotation name..."
-                                    width={18}
-                                    {...field}
-                                    className={styles.customAnnotationInput}
-                                  />
-                                </div>
+                                <CustomAnnotationField field={field} />
                               )}
                             </div>
                           )
@@ -188,18 +181,18 @@ const AnnotationsField = () => {
         <Stack direction="row" gap={1}>
           <div className={styles.addAnnotationsButtonContainer}>
             <Button
-              icon="plus-circle"
+              icon="plus"
               type="button"
               variant="secondary"
               onClick={() => {
                 append({ key: '', value: '' });
               }}
             >
-              Add annotation
+              Add custom annotation
             </Button>
             {!selectedDashboard && (
               <Button type="button" variant="secondary" icon="dashboard" onClick={() => setShowPanelSelector(true)}>
-                Set dashboard and panel
+                Link dashboard and panel
               </Button>
             )}
           </div>
@@ -262,11 +255,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
   annotationDescription: css`
     color: ${theme.colors.text.secondary};
-  `,
-
-  customAnnotationInput: css`
-    margin-top: 5px;
-    width: 100%;
   `,
 
   annotationValueContainer: css`

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
 import produce from 'immer';
-import { defaultOrder } from 'ol/renderer/vector';
 import React, { useEffect, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useToggle } from 'react-use';

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -13,6 +13,7 @@ import { dashboardApi } from '../../api/dashboardApi';
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationDescriptions, annotationLabels, defaultAnnotations } from '../../utils/constants';
 
+import AnnotationHeaderField from './AnnotationHeaderField';
 import CustomAnnotationField from './CustomAnnotationField';
 import DashboardAnnotationField from './DashboardAnnotationField';
 import { DashboardPicker, PanelDTO } from './DashboardPicker';
@@ -113,39 +114,12 @@ const AnnotationsField = () => {
           return (
             <div key={annotationField.id} className={styles.flexRow}>
               <div>
-                <div>
-                  <label className={styles.annotationContainer}>
-                    {
-                      <InputControl
-                        name={`annotations.${index}.key`}
-                        defaultValue={annotationField.key}
-                        render={({ field: { ref, ...field } }) => {
-                          switch (annotationField.key) {
-                            case Annotation.dashboardUID:
-                              return <div>Dashboard and panel</div>;
-                            case Annotation.panelID:
-                              return <span></span>;
-                            default:
-                              return (
-                                <div>
-                                  {annotationLabels[annotation] && (
-                                    <span className={styles.annotationTitle} data-testid={`annotation-key-${index}`}>
-                                      {annotationLabels[annotation]}
-                                      {' (optional)'}
-                                    </span>
-                                  )}
-                                  {!annotationLabels[annotation] && <CustomAnnotationField field={field} />}
-                                </div>
-                              );
-                          }
-                        }}
-                        control={control}
-                        rules={{ required: { value: !!annotations[index]?.value, message: 'Required.' } }}
-                      />
-                    }
-                  </label>
-                  <div className={styles.annotationDescription}>{annotationDescriptions[annotation]}</div>
-                </div>
+                <AnnotationHeaderField
+                  annotationField={annotationField}
+                  annotations={annotations}
+                  annotation={annotation}
+                  index={index}
+                />
                 {selectedDashboard && annotationField.key === Annotation.dashboardUID && (
                   <DashboardAnnotationField
                     dashboard={selectedDashboard}

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -89,6 +89,8 @@ const AnnotationsField = () => {
       }
     });
     setValue('annotations', updatedAnnotations);
+    setSelectedDashboard(undefined);
+    setSelectedPanel(undefined);
   };
 
   const handleEditDashboardAnnotation = () => {
@@ -107,7 +109,7 @@ const AnnotationsField = () => {
             <div key={annotationField.id} className={styles.flexRow}>
               <div>
                 <div>
-                  <label>
+                  <label className={styles.annotationContainer}>
                     {
                       <InputControl
                         name={`annotations.${index}.key`}
@@ -119,13 +121,18 @@ const AnnotationsField = () => {
                             <span></span>
                           ) : (
                             <div>
-                              {annotationLabels[annotation]}{' '}
+                              <span className={styles.annotationTitle}>{annotationLabels[annotation]} </span>
                               {annotationLabels[annotation] ? (
-                                '(optional)'
+                                <span className={styles.annotationTitle}>(optional)</span>
                               ) : (
                                 <div>
-                                  <div>Custom annotation name and content</div>
-                                  <Input placeholder="Enter custom annotation name..." width={18} {...field} />
+                                  <span className={styles.annotationTitle}>Custom annotation name and content</span>
+                                  <Input
+                                    placeholder="Enter custom annotation name..."
+                                    width={18}
+                                    {...field}
+                                    className={styles.customAnnotationInput}
+                                  />
                                 </div>
                               )}
                             </div>
@@ -136,7 +143,7 @@ const AnnotationsField = () => {
                       />
                     }
                   </label>
-                  <div>{annotationDescriptions[annotation]}</div>
+                  <div className={styles.annotationDescription}>{annotationDescriptions[annotation]}</div>
                 </div>
                 {selectedDashboard && annotationField.key === Annotation.dashboardUID && (
                   <DashboardAnnotationField
@@ -149,29 +156,36 @@ const AnnotationsField = () => {
 
                 {(!selectedDashboard ||
                   (annotationField.key !== Annotation.dashboardUID && annotationField.key !== Annotation.panelID)) && (
-                  <Field
-                    className={cx(styles.flexRowItemMargin, styles.field)}
-                    invalid={!!errors.annotations?.[index]?.value?.message}
-                    error={errors.annotations?.[index]?.value?.message}
-                  >
-                    <ValueInputComponent
-                      data-testid={`annotation-value-${index}`}
-                      className={cx(styles.annotationValueInput, { [styles.textarea]: !isUrl })}
-                      {...register(`annotations.${index}.value`)}
-                      placeholder={isUrl ? 'https://' : `Text`}
-                      defaultValue={annotationField.value}
-                    />
-                  </Field>
-                )}
-                {!annotationLabels[annotation] && (
-                  <Button
-                    type="button"
-                    className={styles.deleteAnnotationButton}
-                    aria-label="delete annotation"
-                    icon="trash-alt"
-                    variant="secondary"
-                    onClick={() => remove(index)}
-                  />
+                  <div className={styles.annotationValueContainer}>
+                    <Field
+                      className={cx(styles.flexRowItemMargin, styles.field)}
+                      invalid={!!errors.annotations?.[index]?.value?.message}
+                      error={errors.annotations?.[index]?.value?.message}
+                    >
+                      <ValueInputComponent
+                        data-testid={`annotation-value-${index}`}
+                        className={cx(styles.annotationValueInput, { [styles.textarea]: !isUrl })}
+                        {...register(`annotations.${index}.value`)}
+                        placeholder={
+                          isUrl
+                            ? 'https://'
+                            : (annotationField.key && `Enter a ${annotationField.key}...`) ||
+                              'Enter custom annotation content...'
+                        }
+                        defaultValue={annotationField.value}
+                      />
+                    </Field>
+                    {!annotationLabels[annotation] && (
+                      <Button
+                        type="button"
+                        className={styles.deleteAnnotationButton}
+                        aria-label="delete annotation"
+                        icon="trash-alt"
+                        variant="secondary"
+                        onClick={() => remove(index)}
+                      />
+                    )}
+                  </div>
                 )}
               </div>
             </div>
@@ -239,6 +253,30 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   deleteAnnotationButton: css`
     display: inline-block;
+    margin-top: 10px;
+    margin-left: 10px;
+  `,
+
+  annotationTitle: css`
+    color: ${theme.colors.text.primary};
+    margin-bottom: 3px;
+  `,
+
+  annotationContainer: css`
+    margin-top: 5px;
+  `,
+
+  annotationDescription: css`
+    color: ${theme.colors.text.secondary};
+  `,
+
+  customAnnotationInput: css`
+    margin-top: 5px;
+    width: 100%;
+  `,
+
+  annotationValueContainer: css`
+    display: flex;
   `,
 });
 

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -113,7 +113,9 @@ const AnnotationsField = () => {
                             <span></span>
                           ) : (
                             <div>
-                              <span className={styles.annotationTitle}>{annotationLabels[annotation]} </span>
+                              <span className={styles.annotationTitle} data-testid={`annotation-key-${index}`}>
+                                {annotationLabels[annotation]}{' '}
+                              </span>
                               {annotationLabels[annotation] ? (
                                 <span className={styles.annotationTitle}>(optional)</span>
                               ) : (

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -119,24 +119,26 @@ const AnnotationsField = () => {
                       <InputControl
                         name={`annotations.${index}.key`}
                         defaultValue={annotationField.key}
-                        render={({ field: { ref, ...field } }) =>
-                          annotationField.key === Annotation.dashboardUID ? (
-                            <div>Dashboard and panel</div>
-                          ) : annotationField.key === Annotation.panelID ? (
-                            <span></span>
-                          ) : (
-                            <div>
-                              <span className={styles.annotationTitle} data-testid={`annotation-key-${index}`}>
-                                {annotationLabels[annotation]}{' '}
-                              </span>
-                              {annotationLabels[annotation] ? (
-                                <span className={styles.annotationTitle}>(optional)</span>
-                              ) : (
-                                <CustomAnnotationField field={field} />
-                              )}
-                            </div>
-                          )
-                        }
+                        render={({ field: { ref, ...field } }) => {
+                          switch (annotationField.key) {
+                            case Annotation.dashboardUID:
+                              return <div>Dashboard and panel</div>;
+                            case Annotation.panelID:
+                              return <span></span>;
+                            default:
+                              return (
+                                <div>
+                                  {annotationLabels[annotation] && (
+                                    <span className={styles.annotationTitle} data-testid={`annotation-key-${index}`}>
+                                      {annotationLabels[annotation]}
+                                      {' (optional)'}
+                                    </span>
+                                  )}
+                                  {!annotationLabels[annotation] && <CustomAnnotationField field={field} />}
+                                </div>
+                              );
+                          }
+                        }}
                         control={control}
                         rules={{ required: { value: !!annotations[index]?.value, message: 'Required.' } }}
                       />

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import produce from 'immer';
+import { defaultOrder } from 'ol/renderer/vector';
 import React, { useEffect, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useToggle } from 'react-use';
@@ -11,7 +12,7 @@ import { DashboardDataDTO } from 'app/types';
 
 import { dashboardApi } from '../../api/dashboardApi';
 import { RuleFormValues } from '../../types/rule-form';
-import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';
+import { Annotation, annotationDescriptions, annotationLabels, defaultAnnotations } from '../../utils/constants';
 
 import CustomAnnotationField from './CustomAnnotationField';
 import DashboardAnnotationField from './DashboardAnnotationField';
@@ -31,6 +32,18 @@ const AnnotationsField = () => {
   const annotations = watch('annotations');
 
   const { fields, append, remove } = useFieldArray({ control, name: 'annotations' });
+
+  //make sure default annotations are always shown even if empty
+  useEffect(() => {
+    const defaultAnnotationKeys = defaultAnnotations.map((annotation) => annotation.key);
+
+    defaultAnnotationKeys.forEach((defaultAnnotationKey, defaultOrderIndex: number) => {
+      const fieldIndex = fields.findIndex((field) => field.key === defaultAnnotationKey);
+      if (fieldIndex === -1) {
+        append({ key: defaultAnnotationKey, value: '' });
+      }
+    });
+  }, [append, fields]);
 
   const selectedDashboardUid = annotations.find((annotation) => annotation.key === Annotation.dashboardUID)?.value;
   const selectedPanelId = annotations.find((annotation) => annotation.key === Annotation.panelID)?.value;

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -6,7 +6,7 @@ import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Field, Input, TextArea, useStyles2 } from '@grafana/ui';
+import { Button, Field, Input, InputControl, TextArea, useStyles2 } from '@grafana/ui';
 
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';
@@ -67,7 +67,27 @@ const AnnotationsField = () => {
               <div>
                 <div>
                   <label>
-                    {annotationLabels[annotation]} {annotationLabels[annotation] ? '(optional)' : ''}
+                    {
+                      <InputControl
+                        name={`annotations.${index}.key`}
+                        defaultValue={annotationField.key}
+                        render={({ field: { ref, ...field } }) => (
+                          <div>
+                            {annotationLabels[annotation]}{' '}
+                            {annotationLabels[annotation] ? (
+                              '(optional)'
+                            ) : (
+                              <div>
+                                <div>Custom annotation name and content</div>
+                                <Input placeholder="Enter custom annotation name..." width={18} {...field} />
+                              </div>
+                            )}
+                          </div>
+                        )}
+                        control={control}
+                        rules={{ required: { value: !!annotations[index]?.value, message: 'Required.' } }}
+                      />
+                    }
                   </label>
                   <div>{annotationDescriptions[annotation]}</div>
                 </div>

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -77,17 +77,9 @@ const AnnotationsField = () => {
   };
 
   const handleDeleteDashboardAnnotation = () => {
-    const updatedAnnotations = produce(annotations, (draft) => {
-      const dashboardAnnotation = draft.find((a) => a.key === Annotation.dashboardUID);
-      const panelAnnotation = draft.find((a) => a.key === Annotation.panelID);
-
-      if (dashboardAnnotation) {
-        dashboardAnnotation.value = '';
-      }
-      if (panelAnnotation) {
-        panelAnnotation.value = '';
-      }
-    });
+    const updatedAnnotations = annotations.filter(
+      (a) => a.key !== Annotation.dashboardUID && a.key !== Annotation.panelID
+    );
     setValue('annotations', updatedAnnotations);
     setSelectedDashboard(undefined);
     setSelectedPanel(undefined);

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -6,15 +6,14 @@ import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Field, Input, InputControl, TextArea, useStyles2 } from '@grafana/ui';
+import { Button, Field, Input, TextArea, useStyles2 } from '@grafana/ui';
 import { DashboardDataDTO } from 'app/types';
 
 import { dashboardApi } from '../../api/dashboardApi';
 import { RuleFormValues } from '../../types/rule-form';
-import { Annotation, annotationDescriptions, annotationLabels, defaultAnnotations } from '../../utils/constants';
+import { Annotation, annotationLabels, defaultAnnotations } from '../../utils/constants';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
-import CustomAnnotationField from './CustomAnnotationField';
 import DashboardAnnotationField from './DashboardAnnotationField';
 import { DashboardPicker, PanelDTO } from './DashboardPicker';
 

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -11,7 +11,7 @@ import { DashboardDataDTO } from 'app/types';
 
 import { dashboardApi } from '../../api/dashboardApi';
 import { RuleFormValues } from '../../types/rule-form';
-import { Annotation, annotationLabels, defaultAnnotations } from '../../utils/constants';
+import { Annotation, annotationLabels } from '../../utils/constants';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
 import DashboardAnnotationField from './DashboardAnnotationField';
@@ -31,18 +31,6 @@ const AnnotationsField = () => {
   const annotations = watch('annotations');
 
   const { fields, append, remove } = useFieldArray({ control, name: 'annotations' });
-
-  //make sure default annotations are always shown even if empty
-  useEffect(() => {
-    const defaultAnnotationKeys = defaultAnnotations.map((annotation) => annotation.key);
-
-    defaultAnnotationKeys.forEach((defaultAnnotationKey, defaultOrderIndex: number) => {
-      const fieldIndex = fields.findIndex((field) => field.key === defaultAnnotationKey);
-      if (fieldIndex === -1) {
-        append({ key: defaultAnnotationKey, value: '' });
-      }
-    });
-  }, [append, fields]);
 
   const selectedDashboardUid = annotations.find((annotation) => annotation.key === Annotation.dashboardUID)?.value;
   const selectedPanelId = annotations.find((annotation) => annotation.key === Annotation.panelID)?.value;

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -107,19 +107,23 @@ const AnnotationsField = () => {
                   annotation={annotation}
                   index={index}
                 />
-                {selectedDashboard && annotationField.key === Annotation.dashboardUID && (
+                {selectedDashboardUid && selectedPanelId && annotationField.key === Annotation.dashboardUID && (
                   <DashboardAnnotationField
                     dashboard={selectedDashboard}
                     panel={selectedPanel}
+                    dashboardUid={selectedDashboardUid.toString()}
+                    panelId={selectedPanelId.toString()}
                     onEditClick={handleEditDashboardAnnotation}
                     onDeleteClick={handleDeleteDashboardAnnotation}
                   />
                 )}
 
-                {(!selectedDashboard ||
-                  (annotationField.key !== Annotation.dashboardUID && annotationField.key !== Annotation.panelID)) && (
+                {
                   <div className={styles.annotationValueContainer}>
                     <Field
+                      hidden={
+                        annotationField.key === Annotation.dashboardUID || annotationField.key === Annotation.panelID
+                      }
                       className={cx(styles.flexRowItemMargin, styles.field)}
                       invalid={!!errors.annotations?.[index]?.value?.message}
                       error={errors.annotations?.[index]?.value?.message}
@@ -148,7 +152,7 @@ const AnnotationsField = () => {
                       />
                     )}
                   </div>
-                )}
+                }
               </div>
             </div>
           );

--- a/public/app/features/alerting/unified/components/rule-editor/CustomAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CustomAnnotationField.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Input, useStyles2 } from '@grafana/ui';
+
+interface CustomAnnotationFieldProps {
+  field: { onChange: () => void; onBlur: () => void; value: string; name: string };
+}
+
+const CustomAnnotationField = ({ field }: CustomAnnotationFieldProps) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div>
+      <span className={styles.annotationTitle}>Custom annotation name and content</span>
+      <Input
+        placeholder="Enter custom annotation name..."
+        width={18}
+        {...field}
+        className={styles.customAnnotationInput}
+      />
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  annotationTitle: css`
+    color: ${theme.colors.text.primary};
+    margin-bottom: 3px;
+  `,
+
+  customAnnotationInput: css`
+    margin-top: 5px;
+    width: 100%;
+  `,
+});
+
+export default CustomAnnotationField;

--- a/public/app/features/alerting/unified/components/rule-editor/CustomAnnotationHeaderField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CustomAnnotationHeaderField.tsx
@@ -4,11 +4,11 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Input, useStyles2 } from '@grafana/ui';
 
-interface CustomAnnotationFieldProps {
+interface CustomAnnotationHeaderFieldProps {
   field: { onChange: () => void; onBlur: () => void; value: string; name: string };
 }
 
-const CustomAnnotationField = ({ field }: CustomAnnotationFieldProps) => {
+const CustomAnnotationHeaderField = ({ field }: CustomAnnotationHeaderFieldProps) => {
   const styles = useStyles2(getStyles);
 
   return (
@@ -36,4 +36,4 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-export default CustomAnnotationField;
+export default CustomAnnotationHeaderField;

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -26,10 +26,16 @@ const DashboardAnnotationField = ({
   const panelLink = makePanelLink(dashboard.uid, panel?.id.toString() || '');
   return (
     <>
-      <a href={dashboardLink} className={styles.link} target="_blank" rel="noreferrer">
+      <a
+        href={dashboardLink}
+        className={styles.link}
+        target="_blank"
+        rel="noreferrer"
+        data-testid="dashboard-annotation"
+      >
         {dashboard.title} <Icon name={'external-link-alt'} />
       </a>
-      <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer">
+      <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer" data-testid="panel-annotation">
         {panel?.title || '<No title>'} <Icon name={'external-link-alt'} />
       </a>
 

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -1,0 +1,54 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { DashboardDataDTO } from 'app/types';
+
+import { makeDashboardLink, makePanelLink } from '../../utils/misc';
+
+import { PanelDTO } from './DashboardPicker';
+
+const DashboardAnnotationField = ({
+  dashboard,
+  panel,
+  onEditClick,
+  onDeleteClick,
+}: {
+  dashboard: DashboardDataDTO;
+  panel?: PanelDTO;
+  onEditClick: () => void;
+  onDeleteClick: () => void;
+}) => {
+  const styles = useStyles2(getStyles);
+
+  const dashboardLink = makeDashboardLink(dashboard.uid);
+  const panelLink = makePanelLink(dashboard.uid, panel?.id.toString() || '');
+  return (
+    <>
+      <a href={dashboardLink} className={styles.link} target="_blank" rel="noreferrer">
+        {dashboard.title} <Icon name={'external-link-alt'} />
+      </a>
+      <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer">
+        {panel?.title} <Icon name={'external-link-alt'} />
+      </a>
+
+      <Icon name={'pen'} onClick={onEditClick} className={styles.icon} />
+      <Icon name={'trash-alt'} onClick={onDeleteClick} className={styles.icon} />
+    </>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  link: css`
+    color: ${theme.colors.text.link};
+    margin-right: ${theme.spacing(1.5)};
+  `,
+
+  icon: css`
+    margin-right: ${theme.spacing(1)};
+    cursor: pointer;
+  `,
+});
+
+export default DashboardAnnotationField;

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -30,7 +30,7 @@ const DashboardAnnotationField = ({
         {dashboard.title} <Icon name={'external-link-alt'} />
       </a>
       <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer">
-        {panel?.title} <Icon name={'external-link-alt'} />
+        {panel?.title || '<No title>'} <Icon name={'external-link-alt'} />
       </a>
 
       <Icon name={'pen'} onClick={onEditClick} className={styles.icon} />

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -12,40 +12,64 @@ import { PanelDTO } from './DashboardPicker';
 const DashboardAnnotationField = ({
   dashboard,
   panel,
+  dashboardUid,
+  panelId,
   onEditClick,
   onDeleteClick,
 }: {
-  dashboard: DashboardDataDTO;
+  dashboard?: DashboardDataDTO;
   panel?: PanelDTO;
+  dashboardUid: string; //fallback
+  panelId: string; //fallback
   onEditClick: () => void;
   onDeleteClick: () => void;
 }) => {
   const styles = useStyles2(getStyles);
 
-  const dashboardLink = makeDashboardLink(dashboard.uid);
-  const panelLink = makePanelLink(dashboard.uid, panel?.id.toString() || '');
+  const dashboardLink = makeDashboardLink(dashboard?.uid || dashboardUid);
+  const panelLink = makePanelLink(dashboard?.uid || dashboardUid, panel?.id.toString() || panelId);
   return (
-    <>
-      <a
-        href={dashboardLink}
-        className={styles.link}
-        target="_blank"
-        rel="noreferrer"
-        data-testid="dashboard-annotation"
-      >
-        {dashboard.title} <Icon name={'external-link-alt'} />
-      </a>
-      <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer" data-testid="panel-annotation">
-        {panel?.title || '<No title>'} <Icon name={'external-link-alt'} />
-      </a>
+    <div className={styles.container}>
+      {dashboard && (
+        <a
+          href={dashboardLink}
+          className={styles.link}
+          target="_blank"
+          rel="noreferrer"
+          data-testid="dashboard-annotation"
+        >
+          {dashboard.title} <Icon name={'external-link-alt'} />
+        </a>
+      )}
 
-      <Icon name={'pen'} onClick={onEditClick} className={styles.icon} />
-      <Icon name={'trash-alt'} onClick={onDeleteClick} className={styles.icon} />
-    </>
+      {!dashboard && <span className={styles.noLink}>Dashboard {dashboardUid} </span>}
+
+      {panel && (
+        <a href={panelLink} className={styles.link} target="_blank" rel="noreferrer" data-testid="panel-annotation">
+          {panel.title || '<No title>'} <Icon name={'external-link-alt'} />
+        </a>
+      )}
+
+      {!panel && <span className={styles.noLink}> - Panel {panelId}</span>}
+
+      {(dashboard || panel) && (
+        <>
+          <Icon name={'pen'} onClick={onEditClick} className={styles.icon} />
+          <Icon name={'trash-alt'} onClick={onDeleteClick} className={styles.icon} />
+        </>
+      )}
+    </div>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    margin-top: 5px;
+  `,
+
+  noLink: css`
+    color: ${theme.colors.text.secondary};
+  `,
   link: css`
     color: ${theme.colors.text.link};
     margin-right: ${theme.spacing(1.5)};

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -1,7 +1,9 @@
+import { css } from '@emotion/css';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { Icon } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
 
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { HoverCard } from '../HoverCard';
@@ -10,7 +12,7 @@ import AnnotationsField from './AnnotationsField';
 import { GroupAndNamespaceFields } from './GroupAndNamespaceFields';
 import { RuleEditorSection } from './RuleEditorSection';
 
-function getDescription(ruleType: RuleFormType | undefined) {
+function getDescription(ruleType: RuleFormType | undefined, styles: { [key: string]: string }) {
   const annotationsText = 'Add annotations to provide more context in your alert notifications.';
 
   if (ruleType === RuleFormType.cloudRecording) {
@@ -20,26 +22,26 @@ function getDescription(ruleType: RuleFormType | undefined) {
     'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation';
 
   const HelpContent = () => (
-    <div>
-      <h6>
+    <div className={styles.needHelpTooltip}>
+      <div className={styles.tooltipHeader}>
         <Icon name="question-circle" /> Annotations
-      </h6>
+      </div>
       <div>
         Annotations add metadata to provide more information on the alert in your alert notifications. For example, add
         a Summary annotation to tell you which value caused the alert to fire or which server it happened on.
       </div>
       <div>Annotations can contain a combination of text and template code.</div>
       <div>
-        <a href={docsLink} target="_blank" rel="noreferrer">
-          Read about annotations
+        <a href={docsLink} target="_blank" rel="noreferrer" className={styles.tooltipLink}>
+          Read about annotations <Icon name="external-link-alt" size="sm" tabIndex={0} />
         </a>
       </div>
     </div>
   );
   const LinkToDocs = () => (
     <HoverCard content={<HelpContent />} placement={'bottom-start'}>
-      <span>
-        <Icon name="info-circle" size="sm" tabIndex={0} /> Need help?
+      <span className={styles.needHelpText}>
+        <Icon name="info-circle" size="sm" tabIndex={0} /> <span className={styles.underline}>Need help?</span>
       </span>
     </HoverCard>
   );
@@ -64,6 +66,8 @@ function getDescription(ruleType: RuleFormType | undefined) {
 export function DetailsStep() {
   const { watch } = useFormContext<RuleFormValues & { location?: string }>();
 
+  const styles = useStyles2(getStyles);
+
   const ruleFormType = watch('type');
   const dataSourceName = watch('dataSourceName');
   const type = watch('type');
@@ -72,7 +76,7 @@ export function DetailsStep() {
     <RuleEditorSection
       stepNo={type === RuleFormType.cloudRecording ? 3 : 4}
       title={type === RuleFormType.cloudRecording ? 'Folder and group' : 'Add annotations'}
-      description={getDescription(type)}
+      description={getDescription(type, styles)}
     >
       {(ruleFormType === RuleFormType.cloudRecording || ruleFormType === RuleFormType.cloudAlerting) &&
         dataSourceName && <GroupAndNamespaceFields rulesSourceName={dataSourceName} />}
@@ -81,3 +85,42 @@ export function DetailsStep() {
     </RuleEditorSection>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  needHelpText: css`
+    color: ${theme.colors.text.primary};
+    font-size: ${theme.typography.size.sm};
+    margin-bottom: ${theme.spacing(0.5)};
+    cursor: pointer;
+    text-underline-position: under;
+  `,
+
+  needHelpTooltip: css`
+    max-width: 300px;
+    font-size: ${theme.typography.size.sm};
+    margin-left: 5px;
+
+    div {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+  `,
+
+  tooltipHeader: css`
+    color: ${theme.colors.text.primary};
+    font-weight: bold;
+  `,
+
+  tooltipLink: css`
+    color: ${theme.colors.text.link};
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  `,
+
+  underline: css`
+    text-decoration: underline;
+  `,
+});

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -1,40 +1,60 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { Icon } from '@grafana/ui';
+
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
+import { HoverCard } from '../HoverCard';
 
 import AnnotationsField from './AnnotationsField';
 import { GroupAndNamespaceFields } from './GroupAndNamespaceFields';
 import { RuleEditorSection } from './RuleEditorSection';
 
 function getDescription(ruleType: RuleFormType | undefined) {
+  const annotationsText = 'Add annotations to provide more context in your alert notifications.';
+
   if (ruleType === RuleFormType.cloudRecording) {
     return 'Select the Namespace and Group for your recording rule.';
   }
   const docsLink =
     'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation';
+
+  const HelpContent = () => (
+    <div>
+      <h6>
+        <Icon name="question-circle" /> Annotations
+      </h6>
+      <div>
+        Annotations add metadata to provide more information on the alert in your alert notifications. For example, add
+        a Summary annotation to tell you which value caused the alert to fire or which server it happened on.
+      </div>
+      <div>Annotations can contain a combination of text and template code.</div>
+      <div>
+        <a href={docsLink} target="_blank" rel="noreferrer">
+          Read about annotations
+        </a>
+      </div>
+    </div>
+  );
   const LinkToDocs = () => (
-    <span>
-      Click{' '}
-      <a href={docsLink} target="_blank" rel="noreferrer">
-        here{' '}
-      </a>
-      for documentation on how to template annotations and labels.
-    </span>
+    <HoverCard content={<HelpContent />} placement={'bottom-start'}>
+      <span>
+        <Icon name="info-circle" size="sm" tabIndex={0} /> Need help?
+      </span>
+    </HoverCard>
   );
   if (ruleType === RuleFormType.grafana) {
     return (
       <span>
-        {' '}
-        Write a summary to help you better manage your alerts. <LinkToDocs />
+        {` ${annotationsText} `}
+        <LinkToDocs />
       </span>
     );
   }
   if (ruleType === RuleFormType.cloudAlerting) {
     return (
       <span>
-        {' '}
-        Select the Namespace and evaluation group for your alert. Write a summary to help you better manage your alerts.{' '}
+        {`Select the Namespace and evaluation group for your alert. ${annotationsText} `} <LinkToDocs />
       </span>
     );
   }
@@ -51,7 +71,7 @@ export function DetailsStep() {
   return (
     <RuleEditorSection
       stepNo={type === RuleFormType.cloudRecording ? 3 : 4}
-      title={type === RuleFormType.cloudRecording ? 'Folder and group' : 'Add details for your alert rule'}
+      title={type === RuleFormType.cloudRecording ? 'Folder and group' : 'Add annotations'}
       description={getDescription(type)}
     >
       {(ruleFormType === RuleFormType.cloudRecording || ruleFormType === RuleFormType.cloudAlerting) &&

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -25,7 +25,7 @@ export const RuleEditorSection = ({
       </div>
       <div className={styles.content}>
         <FieldSet label={title} className={styles.fieldset}>
-          {description && <p className={styles.description}>{description}</p>}
+          {description && <div className={styles.description}>{description}</div>}
           {children}
         </FieldSet>
       </div>

--- a/public/app/features/alerting/unified/utils/constants.ts
+++ b/public/app/features/alerting/unified/utils/constants.ts
@@ -38,3 +38,9 @@ export const annotationDescriptions: Record<Annotation, string> = {
   [Annotation.panelID]: '',
   [Annotation.alertId]: '',
 };
+
+export const defaultAnnotations = [
+  { key: Annotation.summary, value: '' },
+  { key: Annotation.description, value: '' },
+  { key: Annotation.runbookURL, value: '' },
+];

--- a/public/app/features/alerting/unified/utils/constants.ts
+++ b/public/app/features/alerting/unified/utils/constants.ts
@@ -29,3 +29,12 @@ export const annotationLabels: Record<Annotation, string> = {
   [Annotation.panelID]: 'Panel ID',
   [Annotation.alertId]: 'Alert ID',
 };
+
+export const annotationDescriptions: Record<Annotation, string> = {
+  [Annotation.description]: 'Description of what the alert rule does',
+  [Annotation.summary]: 'Short summary of what happened and why',
+  [Annotation.runbookURL]: 'Webpage where you keep your runbook for the alert',
+  [Annotation.dashboardUID]: '',
+  [Annotation.panelID]: '',
+  [Annotation.alertId]: '',
+};

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -94,8 +94,15 @@ export function formValuesToRulerRuleDTO(values: RuleFormValues): RulerRuleDTO {
   throw new Error(`unexpected rule type: ${type}`);
 }
 
-function listifyLabelsOrAnnotations(item: Labels | Annotations | undefined): Array<{ key: string; value: string }> {
-  return [...recordToArray(item || {}), { key: '', value: '' }];
+function listifyLabelsOrAnnotations(
+  item: Labels | Annotations | undefined,
+  addEmpty: boolean
+): Array<{ key: string; value: string }> {
+  const list = [...recordToArray(item || {})];
+  if (addEmpty) {
+    list.push({ key: '', value: '' });
+  }
+  return list;
 }
 
 //make sure default annotations are always shown in order even if empty
@@ -159,9 +166,9 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         execErrState: ga.exec_err_state,
         queries: ga.data,
         condition: ga.condition,
-        annotations: normalizeDefaultAnnotations(listifyLabelsOrAnnotations(rule.annotations)),
-        labels: listifyLabelsOrAnnotations(rule.labels),
-        folder: { title: namespace, uid: ga.namespace_uid },
+        annotations: normalizeDefaultAnnotations(listifyLabelsOrAnnotations(rule.annotations, false)),
+        labels: listifyLabelsOrAnnotations(rule.labels, true),
+        folder: { title: namespace, id: ga.namespace_id },
         isPaused: ga.is_paused,
       };
     } else {
@@ -210,8 +217,8 @@ export function alertingRulerRuleToRuleForm(
     expression: rule.expr,
     forTime,
     forTimeUnit,
-    annotations: listifyLabelsOrAnnotations(rule.annotations),
-    labels: listifyLabelsOrAnnotations(rule.labels),
+    annotations: listifyLabelsOrAnnotations(rule.annotations, false),
+    labels: listifyLabelsOrAnnotations(rule.labels, true),
   };
 }
 
@@ -221,7 +228,7 @@ export function recordingRulerRuleToRuleForm(
   return {
     name: rule.record,
     expression: rule.expr,
-    labels: listifyLabelsOrAnnotations(rule.labels),
+    labels: listifyLabelsOrAnnotations(rule.labels, true),
   };
 }
 

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -168,7 +168,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         condition: ga.condition,
         annotations: normalizeDefaultAnnotations(listifyLabelsOrAnnotations(rule.annotations, false)),
         labels: listifyLabelsOrAnnotations(rule.labels, true),
-        folder: { title: namespace, id: ga.namespace_id },
+        folder: { title: namespace, uid: ga.namespace_uid },
         isPaused: ga.is_paused,
       };
     } else {

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -34,7 +34,7 @@ import { EvalFunction } from '../../state/alertDef';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
 
 import { getRulesAccess } from './access-control';
-import { Annotation } from './constants';
+import { Annotation, defaultAnnotations } from './constants';
 import { getDefaultOrFirstCompatibleDataSource, isGrafanaRulesSource } from './datasource';
 import { arrayToRecord, recordToArray } from './misc';
 import { isAlertingRulerRule, isGrafanaRulerRule, isRecordingRulerRule } from './rules';
@@ -51,11 +51,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     name: '',
     uid: '',
     labels: [{ key: '', value: '' }],
-    annotations: [
-      { key: Annotation.summary, value: '' },
-      { key: Annotation.description, value: '' },
-      { key: Annotation.runbookURL, value: '' },
-    ],
+    annotations: defaultAnnotations,
     dataSourceName: null,
     type: canCreateGrafanaRules ? RuleFormType.grafana : canCreateCloudRules ? RuleFormType.cloudAlerting : undefined, // viewers can't create prom alerts
     group: '',


### PR DESCRIPTION
**What is this feature?**

Changes how we display the section to add annotations when creating a rule. From now on Summary, Description and Runbook URL are always present as optional fields. Besides that, now we display de Dashboard name and Panel name when linked instead of just the id.

**Why do we need this feature?**

To make it simpler to use.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/68200

![image](https://github.com/grafana/grafana/assets/6271380/7fbdbd56-b08d-4fce-99e8-44a2a0e469f6)

![image](https://github.com/grafana/grafana/assets/6271380/4d886d4d-2fe4-4760-88e2-9c24eea574ac)



