### PR TITLE
Prometheus: Fix series to rows frame name issue for custom name from legend option

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
@@ -124,7 +124,7 @@ describe('Series to rows', () => {
     });
   });
 
-  it('combine two time series, where first serie fields has displayName, into one', async () => {
+  it('combine two time series, where first series fields has displayName, into one and displayNameFromDS overrides frame.name', async () => {
     const cfg: DataTransformerConfig<SeriesToRowsTransformerOptions> = {
       id: DataTransformerID.seriesToRows,
       options: {},
@@ -156,7 +156,7 @@ describe('Series to rows', () => {
 
       const expected: Field[] = [
         createField('Time', FieldType.time, [200, 150, 126, 125, 100, 100]),
-        createField('Metric', FieldType.string, ['A', 'A', 'B', 'B', 'A', 'B']),
+        createField('Metric', FieldType.string, ['dsName', 'dsName', 'B', 'B', 'dsName', 'B']),
         createField('Value', FieldType.number, [5, 4, 3, 2, 1, -1]),
       ];
 

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 
 import { MutableDataFrame, sortDataFrame } from '../../dataframe';
 import { isTimeSeriesFrames } from '../../dataframe/utils';
-import { getFrameDisplayName } from '../../field/fieldState';
+import { getFieldDisplayName, getFrameDisplayName } from '../../field/fieldState';
 import {
   Field,
   FieldType,
@@ -70,13 +70,29 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
         for (let frameIndex = 0; frameIndex < data.length; frameIndex++) {
           const frame = data[frameIndex];
 
+          const firstNonTimeField = frame.fields[1];
+
+          // To support consistent naming for dataplane and prometheus
+          // we implement the following hierarchy:
+
+          // displayNameFromDS > frameDisplayName > fieldDisplayName
+
+          // This supports new naming and custom names (from the prom legend option)
+          // and supports the older pattern of getting the frame name.
+          // if neither of those return a name we use getFieldDisplayName which is good.
+          const displayNameFromDS = firstNonTimeField.config.displayNameFromDS;
+          const frameDisplayName = displayNameFromDS ?? getFrameDisplayName(frame);
+          const fieldDisplayName = getFieldDisplayName(firstNonTimeField, frame);
+
+          const displayName = displayNameFromDS ?? frameDisplayName ?? fieldDisplayName;
+
           for (let valueIndex = 0; valueIndex < frame.length; valueIndex++) {
             const timeFieldIndex = timeFieldByIndex[frameIndex];
             const valueFieldIndex = timeFieldIndex === 0 ? 1 : 0;
 
             dataFrame.add({
               [TIME_SERIES_TIME_FIELD_NAME]: frame.fields[timeFieldIndex].values[valueIndex],
-              [TIME_SERIES_METRIC_FIELD_NAME]: getFrameDisplayName(frame),
+              [TIME_SERIES_METRIC_FIELD_NAME]: displayName,
               [TIME_SERIES_VALUE_FIELD_NAME]: frame.fields[valueFieldIndex].values[valueIndex],
             });
           }

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -73,8 +73,7 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
           const firstNonTimeField = frame.fields[1];
 
           // To support consistent naming for dataplane and prometheus
-          // displayNameFromDS > frameDisplayName 
-
+          // displayNameFromDS > frameDisplayName
           // This supports new naming and custom names (from the prom legend option)
           // and supports the older pattern of getting the frame name.
           // if neither of those return a name we use getFieldDisplayName which is good.

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 
 import { MutableDataFrame, sortDataFrame } from '../../dataframe';
 import { isTimeSeriesFrames } from '../../dataframe/utils';
-import { getFieldDisplayName, getFrameDisplayName } from '../../field/fieldState';
+import { getFrameDisplayName } from '../../field/fieldState';
 import {
   Field,
   FieldType,
@@ -73,18 +73,15 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
           const firstNonTimeField = frame.fields[1];
 
           // To support consistent naming for dataplane and prometheus
-          // we implement the following hierarchy:
-
-          // displayNameFromDS > frameDisplayName > fieldDisplayName
+          // displayNameFromDS > frameDisplayName 
 
           // This supports new naming and custom names (from the prom legend option)
           // and supports the older pattern of getting the frame name.
           // if neither of those return a name we use getFieldDisplayName which is good.
           const displayNameFromDS = firstNonTimeField.config.displayNameFromDS;
-          const frameDisplayName = displayNameFromDS ?? getFrameDisplayName(frame);
-          const fieldDisplayName = getFieldDisplayName(firstNonTimeField, frame);
+          const frameDisplayName = getFrameDisplayName(frame);
 
-          const displayName = displayNameFromDS ?? frameDisplayName ?? fieldDisplayName;
+          const displayName = displayNameFromDS ?? frameDisplayName;
 
           for (let valueIndex = 0; valueIndex < frame.length; valueIndex++) {
             const timeFieldIndex = timeFieldByIndex[frameIndex];

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -123,7 +123,7 @@ func addMetadataToMultiFrame(q *models.Query, frame *data.Frame, enableDataplane
 		frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
 	}
 
-	if enableDataplane && customName == "" {
+	if enableDataplane {
 		valueField := frame.Fields[1]
 		if n, ok := valueField.Labels["__name__"]; ok {
 			valueField.Name = n

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -123,7 +123,7 @@ func addMetadataToMultiFrame(q *models.Query, frame *data.Frame, enableDataplane
 		frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
 	}
 
-	if enableDataplane {
+	if enableDataplane && customName == "" {
 		valueField := frame.Fields[1]
 		if n, ok := valueField.Labels["__name__"]; ok {
 			valueField.Name = n


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/6161

**What is this**
Use displayNameFromDS over getFrameDisplayName in Series to Rows transformation so that when choosing a custom legend format in Prometheus, the legend is shown in the transformation.

**Why do we need this?**
To support dataplane format there was a change [here](https://github.com/grafana/grafana/pull/65993) where the custom name from the legendFormat option is dropped in favor of the naming pattern for dataplane and loki. Certain transformations require this frame name set from the legend, like Series to rows. The legend format now is updated in displayNameFromDS and this is prioritized in the transformation.

**Who uses this?**
Anyone who used the legendFormat option in the prometheus datasource query editor.

How to test this:
1. Make a prometheus query
2. Choose a custom legend format
3. enter {{< label name >}} or even "test"
4. Select a transformation.
5. Choose the series to rows transformation.
6. select "view as table"
7. See that the names are similar to the legend format expectation.

Expected names by legend format
<img width="665" alt="Screenshot 2023-05-31 at 5 04 07 PM" src="https://github.com/grafana/grafana/assets/25674746/f81af18f-aab0-4b12-8e98-5959efe36b30">

Names in transformation by regression
<img width="705" alt="Screenshot 2023-05-31 at 5 01 28 PM" src="https://github.com/grafana/grafana/assets/25674746/d8e39a10-4cc3-4f0a-b681-277aa9fcea8e">

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
