### PR TITLE
MSSQL: Change encrypt default value to false 

### DIFF
--- a/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
@@ -186,7 +186,7 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
         >
           <Select
             options={encryptOptions}
-            value={jsonData.encrypt || MSSQLEncryptOptions.disable}
+            value={jsonData.encrypt || MSSQLEncryptOptions.false}
             inputId="encrypt"
             onChange={onEncryptChanged}
           ></Select>


### PR DESCRIPTION
fixes #67492 
issue description- In the MSSQL data source config page, the default value for the encrypted field is set to false now.

