### PR TITLE
Dashboards: Reuse save code

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -32,7 +32,7 @@ export const useDashboardSave = (dashboard: DashboardModel, isCopy = false) => {
     async (clone: DashboardModel, options: SaveDashboardOptions, dashboard: DashboardModel) => {
       try {
         const result = await saveDashboard(clone, options, dashboard);
-        dashboard.version = result.data.version;
+        dashboard.version = result.version;
         dashboard.clearUnsavedChanges();
 
         // important that these happen before location redirect below

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -32,7 +32,7 @@ export const useDashboardSave = (dashboard: DashboardModel, isCopy = false) => {
     async (clone: DashboardModel, options: SaveDashboardOptions, dashboard: DashboardModel) => {
       try {
         const result = await saveDashboard(clone, options, dashboard);
-        dashboard.version = result.version;
+        dashboard.version = result.data.version;
         dashboard.clearUnsavedChanges();
 
         // important that these happen before location redirect below

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,5 +1,3 @@
-import { lastValueFrom } from 'rxjs';
-
 import { AppEvents } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
@@ -28,15 +26,6 @@ export interface SaveDashboardOptions {
   /** Set the dashboard refresh interval.
    *  If this is lower than the minimum refresh interval, Grafana will ignore it and will enforce the minimum refresh interval. */
   refresh?: string;
-}
-
-interface SaveDashboardResponse {
-  id: number;
-  slug: string;
-  status: string;
-  uid: string;
-  url: string;
-  version: number;
 }
 
 export class DashboardSrv {
@@ -80,16 +69,14 @@ export class DashboardSrv {
     data: SaveDashboardOptions,
     requestOptions?: Pick<BackendSrvRequest, 'showErrorAlert' | 'showSuccessAlert'>
   ) {
-    return lastValueFrom(
-      getBackendSrv().fetch<SaveDashboardResponse>({
-        url: '/api/dashboards/db/',
-        method: 'POST',
-        data: {
-          ...data,
-          dashboard: data.dashboard.getSaveModelClone(),
-        },
-        ...requestOptions,
-      })
+    return saveDashboard(
+      {
+        dashboard: data.dashboard.getSaveModelClone(),
+        folderUid: data.folderUid,
+        message: data.message,
+        overwrite: data.overwrite,
+      },
+      requestOptions
     );
   }
 

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -314,7 +314,7 @@ export async function saveDashboard(
       },
       ...requestOptions,
     })
-  );
+  ).then((r) => r.data);
 }
 
 function deleteFolder(uid: string, showSuccessAlert: boolean) {


### PR DESCRIPTION
While working on a [k8s POC](https://github.com/grafana/grafana/pull/69354), I found that we have two paths to save a dashboard that are almost identical -- would be nicer to have one path :)

This PR combines their options and delegates everything to the manange-dashboards actions