### PR TITLE
Reword JWT config claim

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -36,7 +36,7 @@ header_name = X-JWT-Assertion
 
 ## Configure login claim
 
-To identify the user, some of the claims needs to be selected as a login info. You could specify a claim that contains either a username or an email of the Grafana user.
+To identify the user, some of the claims needs to be selected as a login info. The subject claim called `"sub"` is mandatory and needs to identify the principal that is the subject of the JWT.
 
 Typically, the subject claim called `"sub"` would be used as a login but it might also be set to some application specific claim.
 


### PR DESCRIPTION
**What is this feature?**

Rewording the JWT config claim.

**Why do we need this feature?**

Contributor @ptz-xyt developed a [PR](https://github.com/grafana/grafana/pull/67996) with these changes from a forked branch. This PR addresses the trailing whitespace needed to pass the CI step.