### PR TITLE
TempoQueryEDitor: Respect onRunQuery updates

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -28,6 +28,10 @@ export function TraceQLEditor(props: Props) {
   const setupAutocompleteFn = useAutocomplete(props.datasource);
   const theme = useTheme2();
   const styles = getStyles(theme, placeholder);
+  // work around the problem that `onEditorDidMount` is called once
+  // and wouldn't get new version of onRunQuery
+  const onRunQueryRef = useRef(onRunQuery);
+  onRunQueryRef.current = onRunQuery;
 
   return (
     <CodeEditor
@@ -56,7 +60,7 @@ export function TraceQLEditor(props: Props) {
       onEditorDidMount={(editor, monaco) => {
         if (!props.readOnly) {
           setupAutocompleteFn(editor, monaco, setupRegisterInteractionCommand(editor));
-          setupActions(editor, monaco, onRunQuery);
+          setupActions(editor, monaco, () => onRunQueryRef.current());
           setupPlaceholder(editor, monaco, styles);
         }
         setupAutoSize(editor);


### PR DESCRIPTION
:wave: 

Tempo query editor uses the first version of `onRunQuery` it receives, ignoring updates. However a common react pattern involves using query variable in closure, which ends up not working. This PR works around the issue using `useRef`


Example of the problem:
```jsx

export function Foo(props: Props): JSX.Element {
  const [query, setQuery] = useState<TempoQuery | undefined>(props.query);

  const onChange = (newQuery: TempoQuery) => {
    setQuery(newQUery);
  };

  const onRunQuery = () => {
    // always has initial version of query because underlying monaco editor is passed `onRunQuery` only once,
   // with initial version of query var in closure
    props.run(query);
  };

 return <Editor datasource={props.dataSource} query={query} onChange={onChange} onRunQuery={onRunQuery} />;
}
```