### PR TITLE
Chore: Update codeowners for api-keys frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -357,7 +357,7 @@ lerna.json @grafana/frontend-ops
 /public/app/features/admin/ @grafana/grafana-authnz-team
 /public/app/features/auth-config/ @grafana/grafana-authnz-team
 /public/app/features/annotations/ @grafana/grafana-frontend-platform
-/public/app/features/api-keys/ @grafana/grafana-frontend-platform
+/public/app/features/api-keys/ @grafana/grafana-authnz-team
 /public/app/features/canvas/ @grafana/dataviz-squad
 /public/app/features/geo/ @grafana/dataviz-squad
 /public/app/features/visualization/data-hover/ @grafana/dataviz-squad


### PR DESCRIPTION
Update codeowners for api-keys frontend to @grafana/grafana-authnz-team 