### PR TITLE
Fix plugin metric

### DIFF
--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -39,7 +39,7 @@ var (
 		}, []string{"source", "plugin_id", "endpoint", "target"},
 	)
 
-	PluginRequestDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	PluginRequestDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "grafana",
 		Name:      "plugin_request_duration_seconds",
 		Help:      "Plugin request duration in seconds",


### PR DESCRIPTION
**What is this feature?**

Fix the plugin metric registration

**Why do we need this feature?**

There was a mistake when creating this metric, and it is not registered, so it doesn't work

**Who is this feature for?**

Everyone monitoring Grafana instances
