### PR TITLE
Log Context: Fix split view button using the wrong query

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -129,18 +129,16 @@ describe('LogRowContextModal', () => {
   });
 
   it('should call getRowContextQuery when limit changes', async () => {
-    act(() => {
-      render(
-        <LogRowContextModal
-          row={row}
-          open={true}
-          onClose={() => {}}
-          getRowContext={getRowContext}
-          getRowContextQuery={getRowContextQuery}
-          timeZone={timeZone}
-        />
-      );
-    });
+    render(
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+      />
+    );
 
     // this will call it initially and in the first fetchResults
     await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(2));

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -9,6 +9,7 @@ import { createLogRow } from '../__mocks__/logRow';
 import { LogRowContextModal } from './LogRowContextModal';
 
 const getRowContext = jest.fn().mockResolvedValue({ data: { fields: [], rows: [] } });
+const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
 
 const dispatchMock = jest.fn();
 jest.mock('app/types', () => ({
@@ -127,6 +128,37 @@ describe('LogRowContextModal', () => {
     await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(4));
   });
 
+  it('should call getRowContextQuery when limit changes', async () => {
+    act(() => {
+      render(
+        <LogRowContextModal
+          row={row}
+          open={true}
+          onClose={() => {}}
+          getRowContext={getRowContext}
+          getRowContextQuery={getRowContextQuery}
+          timeZone={timeZone}
+        />
+      );
+    });
+
+    // this will call it initially and in the first fetchResults
+    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(2));
+
+    const tenLinesButton = screen.getByRole('button', {
+      name: /50 lines/i,
+    });
+    await userEvent.click(tenLinesButton);
+    const twentyLinesButton = screen.getByRole('menuitemradio', {
+      name: /20 lines/i,
+    });
+    act(() => {
+      userEvent.click(twentyLinesButton);
+    });
+
+    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(3));
+  });
+
   it('should show a split view button', async () => {
     const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
 
@@ -175,7 +207,7 @@ describe('LogRowContextModal', () => {
       />
     );
 
-    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(2));
   });
 
   it('should close modal', async () => {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -190,12 +190,14 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     }
   };
 
+  const updateContextQuery = async () => {
+    const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
+    setContextQuery(contextQuery);
+  };
+
   const [{ loading }, fetchResults] = useAsyncFn(async () => {
     if (open && row && limit) {
-      // also update context query when we fetch new results
-      const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
-      setContextQuery(contextQuery);
-
+      await updateContextQuery();
       const rawResults = await Promise.all([
         getRowContext(row, {
           limit: logsSortOrder === LogsSortOrder.Descending ? limit + 1 : limit,
@@ -272,11 +274,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     }
   }, [scrollElement]);
 
-  useAsync(async () => {
-    // initially update context query
-    const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
-    setContextQuery(contextQuery);
-  }, [getRowContextQuery, row]);
+  useAsync(updateContextQuery, [getRowContextQuery, row]);
 
   return (
     <Modal

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -192,6 +192,10 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
 
   const [{ loading }, fetchResults] = useAsyncFn(async () => {
     if (open && row && limit) {
+      // also update context query when we fetch new results
+      const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
+      setContextQuery(contextQuery);
+
       const rawResults = await Promise.all([
         getRowContext(row, {
           limit: logsSortOrder === LogsSortOrder.Descending ? limit + 1 : limit,
@@ -269,6 +273,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   }, [scrollElement]);
 
   useAsync(async () => {
+    // initially update context query
     const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
     setContextQuery(contextQuery);
   }, [getRowContextQuery, row]);


### PR DESCRIPTION

**What is this feature?**
Log Context has an `Open in Split view` button which uses a DataQuery object and runs that in a second Explore pane. This PR fixes a missing update of the `contextQuery`, which lead to a non-updated query being used.

**Special notes for your reviewer:**

1. Run a Loki query
2. Open LogContext
3. Remove some labels from the context query
4. Open in Split view
5. Now the updated query should be used, previously it was always the initial query