### PR TITLE
Loki: Fix error when empty template variables response

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1148,6 +1148,15 @@ describe('LokiDatasource', () => {
       expect(spy).toHaveBeenCalled();
     });
   });
+
+  describe('statsMetadataRequest', () => {
+    it('throws error if url starts with /', () => {
+      const ds = createLokiDatasource();
+      expect(async () => {
+        await ds.statsMetadataRequest('/index');
+      }).rejects.toThrow('invalid metadata request url: /index');
+    });
+  });
 });
 
 describe('applyTemplateVariables', () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -32,7 +32,7 @@ import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { createLokiDatasource, createMetadataRequest } from './mocks';
 import { runSplitQuery } from './querySplitting';
 import { parseToNodeNamesArray } from './queryUtils';
-import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';
+import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, QueryStats, SupportingQueryType } from './types';
 import { LokiVariableSupport } from './variables';
 
 jest.mock('@grafana/runtime', () => {
@@ -1137,6 +1137,15 @@ describe('LokiDatasource', () => {
       await expect(ds.query(query)).toEmitValuesWith(() => {
         expect(runSplitQuery).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('getQueryStats', () => {
+    it('uses statsMetadataRequest', async () => {
+      const ds = createLokiDatasource(templateSrvStub);
+      const spy = jest.spyOn(ds, 'statsMetadataRequest').mockResolvedValue({} as QueryStats);
+      ds.getQueryStats('{foo="bar"}');
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -420,7 +420,7 @@ export class LokiDatasource
     }
 
     const res = await this.getResource(url, params, options);
-    return res.data ?? [];
+    return res.data || [];
   }
 
   // We need a specific metadata method for stats endpoint as it does not return res.data,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -420,7 +420,21 @@ export class LokiDatasource
     }
 
     const res = await this.getResource(url, params, options);
-    return res.data ?? (res || []);
+    return res.data ?? [];
+  }
+
+  // We need a specific metadata method for stats endpoint as it does not return res.data,
+  // but it returns stats directly in res object.
+  async statsMetadataRequest(
+    url: string,
+    params?: Record<string, string | number>,
+    options?: Partial<BackendSrvRequest>
+  ): Promise<QueryStats> {
+    if (url.startsWith('/')) {
+      throw new Error(`invalid metadata request url: ${url}`);
+    }
+
+    return await this.getResource(url, params, options);
   }
 
   async getQueryStats(query: string): Promise<QueryStats | undefined> {
@@ -436,7 +450,7 @@ export class LokiDatasource
 
     for (const labelMatcher of labelMatchers) {
       try {
-        const data = await this.metadataRequest(
+        const data = await this.statsMetadataRequest(
           'index/stats',
           { query: labelMatcher, start, end },
           { showErrorAlert: false }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/69331

This PR fixes a bug introduced in https://github.com/grafana/grafana/pull/62109 where we changed `metadataRequest`
 to return `return res.data ?? (res || [])` instead of  `return res.data || [];`. This caused an error in cases, where responses didn't have any data and instead of returning `[]`, we returned `res` which caused issues, as we expected an array.

This was a reason why in https://github.com/grafana/grafana/issues/69331 we received an error, because we reseived response `{"status": "success"}` and we passed to it to processing of values in `labelValuesQuery`.

Therefore I have created specific method for `statsMetadataRequest`

Fixed: 

https://github.com/grafana/grafana/assets/30407135/94db5221-1c6c-4086-a814-c78a1767f19b

Broken:

https://github.com/grafana/grafana/assets/30407135/f5c26a88-8052-4f4b-942d-861709d0872d


