### PR TITLE
Loki: Exclude queries using DISTINCT from query splitting

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -223,8 +223,8 @@ describe('runSplitQuery()', () => {
         range,
       });
       await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
-        // 3 days, 3 chunks, 3x Logs + 3x Metric + 1x Instant + 1x Distinct, 8 requests.
-        expect(datasource.runQuery).toHaveBeenCalledTimes(8);
+        // 3 days, 3 chunks, 3x Logs + 3x Metric + (1x Instant | Distinct), 7 requests.
+        expect(datasource.runQuery).toHaveBeenCalledTimes(7);
       });
     });
   });

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -182,6 +182,19 @@ describe('runSplitQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(1);
       });
     });
+    test('Groups queries using distinct', async () => {
+      const request = getQueryOptions<LokiQuery>({
+        targets: [
+          { expr: '{a="b"} | distinct field', refId: 'A' },
+          { expr: 'count_over_time({c="d"} | distinct something [1m])', refId: 'B' },
+        ],
+        range,
+      });
+      await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
+        // Queries using distinct are omitted from splitting
+        expect(datasource.runQuery).toHaveBeenCalledTimes(1);
+      });
+    });
     test('Respects maxLines of logs queries', async () => {
       const { logFrameA } = getMockFrames();
       const request = getQueryOptions<LokiQuery>({
@@ -199,18 +212,19 @@ describe('runSplitQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(4);
       });
     });
-    test('Groups multiple queries into logs, queries, and instant', async () => {
+    test('Groups multiple queries into logs, queries, instant, and distinct', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [
           { expr: 'count_over_time({a="b"}[1m])', refId: 'A', queryType: LokiQueryType.Instant },
           { expr: '{c="d"}', refId: 'B' },
           { expr: 'count_over_time({c="d"}[1m])', refId: 'C' },
+          { expr: 'count_over_time({c="d"} | distinct id [1m])', refId: 'D' },
         ],
         range,
       });
       await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
-        // 3 days, 3 chunks, 3x Logs + 3x Metric + 1x Instant, 7 requests.
-        expect(datasource.runQuery).toHaveBeenCalledTimes(7);
+        // 3 days, 3 chunks, 3x Logs + 3x Metric + 1x Instant + 1x Distinct, 8 requests.
+        expect(datasource.runQuery).toHaveBeenCalledTimes(8);
       });
     });
   });

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -9,6 +9,7 @@ import {
   getParserFromQuery,
   obfuscate,
   requestSupportsSplitting,
+  isQueryWithDistinct,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -278,6 +279,18 @@ describe('isQueryWithLabelFormat', () => {
 
   it('returns false if metrics query without label format', () => {
     expect(isQueryWithLabelFormat('rate({job="grafana"} [5m])')).toBe(false);
+  });
+});
+
+describe('isQueryWithDistinct', () => {
+  it('identifies queries using distinct', () => {
+    expect(isQueryWithDistinct('{job="grafana"} | distinct id')).toBe(true);
+    expect(isQueryWithDistinct('count_over_time({job="grafana"} | distinct id [1m])')).toBe(true);
+  });
+
+  it('does not return false positives', () => {
+    expect(isQueryWithDistinct('{label="distinct"} | logfmt')).toBe(false);
+    expect(isQueryWithDistinct('count_over_time({job="distinct"} | json [1m])')).toBe(false);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -17,6 +17,7 @@ import {
   MetricExpr,
   Matcher,
   Identifier,
+  Distinct,
 } from '@grafana/lezer-logql';
 import { DataQuery } from '@grafana/schema';
 
@@ -285,6 +286,20 @@ export function isQueryWithLineFilter(query: string): boolean {
   });
 
   return queryWithLineFilter;
+}
+
+export function isQueryWithDistinct(query: string): boolean {
+  let hasDistinct = false;
+  const tree = parser.parse(query);
+  tree.iterate({
+    enter: ({ type }): false | void => {
+      if (type.id === Distinct) {
+        hasDistinct = true;
+        return false;
+      }
+    },
+  });
+  return hasDistinct;
 }
 
 export function getStreamSelectorsFromQuery(query: string): string[] {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -219,6 +219,7 @@ export function isQueryWithLabelFormat(query: string): boolean {
     enter: ({ type }): false | void => {
       if (type.id === LabelFormatExpr) {
         queryWithLabelFormat = true;
+        return false;
       }
     },
   });
@@ -261,10 +262,10 @@ export function isQueryWithLabelFilter(query: string): boolean {
   let hasLabelFilter = false;
 
   tree.iterate({
-    enter: ({ type, node }): false | void => {
+    enter: ({ type }): false | void => {
       if (type.id === LabelFilter) {
         hasLabelFilter = true;
-        return;
+        return false;
       }
     },
   });
@@ -280,7 +281,7 @@ export function isQueryWithLineFilter(query: string): boolean {
     enter: ({ type }): false | void => {
       if (type.id === LineFilter) {
         queryWithLineFilter = true;
-        return;
+        return false;
       }
     },
   });


### PR DESCRIPTION
We identified that splitting queries using distinct could produce unexpected and erroneous results, so with this PR we are excluding them from splitting, allowing them to run over the original range in a separate group.

**Special notes for your reviewer:**

Query splitting should remain working as usual for other types of queries.