### PR TITLE
AuthN: Make clientTokenRotation work when Grafana is accessible on a sub url

### DIFF
--- a/devenv/docker/blocks/auth/nginx_proxy_mac/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/nginx_proxy_mac/docker-compose.yaml
@@ -1,11 +1,13 @@
-# This will proxy all requests for http://localhost:10080/grafana/ to
+# This will proxy all requests for http://localhost:8090/grafana/ to
 # http://localhost:3000 (Grafana running locally)
 #
 # Please note that you'll need to change the root_url in the Grafana configuration:
-# root_url = %(protocol)s://%(domain)s:10080/grafana/
+# root_url = %(protocol)s://%(domain)s:8090/grafana/
 
   nginxproxy:
     build: docker/blocks/auth/nginx_proxy_mac
+    volumes:
+      - "./docker/blocks/auth/nginx_proxy_mac/nginx_login_only.conf:/etc/nginx/nginx.conf"
     ports:
-      - "10080:10080"
+      - "8090:8090"
 

--- a/devenv/docker/blocks/auth/nginx_proxy_mac/nginx.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy_mac/nginx.conf
@@ -10,7 +10,7 @@ http {
   proxy_set_header   X-Forwarded-Host $server_name;
 
   server {
-    listen 10080;
+    listen 8090;
 
     location /grafana/ {
       ################################################################

--- a/devenv/docker/blocks/auth/nginx_proxy_mac/nginx_login_only.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy_mac/nginx_login_only.conf
@@ -10,7 +10,7 @@ http {
   proxy_set_header   X-Forwarded-Host $server_name;
 
   server {
-    listen 10080;
+    listen 8090;
 
     location /grafana/ {
       ################################################################
@@ -27,6 +27,8 @@ http {
       # header_name = X-WEBAUTH-USER
       # header_property = username
       ################################################################
+
+      proxy_set_header   Host $host:$server_port;
 
       location /grafana/login {
         auth_basic "Restricted Content";

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -39,6 +39,7 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 			SyncTeams:       true,
 			FetchSyncedUser: true,
 			SyncOrgRoles:    true,
+			SyncPermissions: true,
 			AllowSignUp:     c.cfg.AuthProxyAutoSignUp,
 		},
 	}

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -245,7 +245,7 @@ export class ContextSrv {
 
   private rotateToken() {
     // We directly use fetch here to bypass the request queue from backendSvc
-    return fetch('/api/user/auth-tokens/rotate', { method: 'POST' })
+    return fetch(config.appSubUrl + '/api/user/auth-tokens/rotate', { method: 'POST' })
       .then((res) => {
         if (res.status === 200) {
           this.scheduleTokenRotationJob();


### PR DESCRIPTION
**What is this feature?**t
This PR sets the correct backend url for the rotate-token endpoint on the frontend when Grafana is accessible on a sub url.

Other fixes: 
* Change port to 8090 in the `nginx_proxy_mac` devenv
* Add a missing SyncPermission setting when the user is authenticated by a proxy

**Why do we need this feature?**
ClientTokenRotation should work seamlessly when Grafana is accessible on a sub url.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
