### PR TITLE
PanelChrome: Show pointer when hovering cancel query button

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -140,7 +140,11 @@ export function PanelChrome({
       {loadingState === LoadingState.Loading && onCancelQuery && (
         <DelayRender delay={2000}>
           <Tooltip content="Cancel query">
-            <TitleItem className={dragClassCancel} data-testid="panel-cancel-query" onClick={onCancelQuery}>
+            <TitleItem
+              className={cx(dragClassCancel, styles.pointer)}
+              data-testid="panel-cancel-query"
+              onClick={onCancelQuery}
+            >
               <Icon name="sync-slash" size="md" />
             </TitleItem>
           </Tooltip>
@@ -296,6 +300,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-header',
       display: 'flex',
       alignItems: 'center',
+    }),
+    pointer: css({
+      cursor: 'pointer',
     }),
     streaming: css({
       label: 'panel-streaming',

--- a/packages/grafana-ui/src/utils/DelayRender.tsx
+++ b/packages/grafana-ui/src/utils/DelayRender.tsx
@@ -9,14 +9,11 @@ interface Props {
  * Delay the rendering of the children by N amount of milliseconds
  */
 export function DelayRender({ children, delay }: Props) {
-  const [shouldRender, setRender] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      setRender(true);
+    window.setTimeout(() => {
+      setShouldRender(true);
     }, delay);
-    return () => {
-      clearInterval(intervalId);
-    };
   }, [children, delay]);
 
   return <>{shouldRender ? children : null}</>;


### PR DESCRIPTION
Noticed that hovering over the cancel query button didn't show the usual pointer, so here's a quick PR fixing that.
Also changed `DelayRender` to use `setTimeout` rather than `setInterval`, but let me know if there was a reason for using the latter that I missed @axelavargas 