### PR TITLE
ColorPicker: Allow to use in form

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.test.tsx
@@ -17,11 +17,11 @@ describe('ColorPicker', () => {
     render(<ColorPicker color="blue" enableNamedColors onChange={() => {}} />);
     const mainButton = screen.getAllByRole('button');
     expect(mainButton.length).toBe(1);
-    mainButton.forEach((button) => expect(button.type).toBe('button'));
+    mainButton.forEach((button) => expect(button).toHaveAttribute('type', 'button'));
     await userEvent.click(mainButton[0]);
     const buttons = screen.getAllByRole('button');
     expect(buttons.length).toBe(35);
-    buttons.forEach((button) => expect(button.type).toBe('button'));
+    buttons.forEach((button) => expect(button).toHaveAttribute('type', 'button'));
   });
 
   it('renders custom trigger when supplied', () => {

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -9,6 +11,17 @@ describe('ColorPicker', () => {
     expect(
       renderer.create(<ColorPicker color="#EAB839" onChange={() => {}} />).root.findByType(ColorSwatch)
     ).toBeTruthy();
+  });
+
+  it('should not have buttons with default submit type', async () => {
+    render(<ColorPicker color="blue" enableNamedColors onChange={() => {}} />);
+    const mainButton = screen.getAllByRole('button');
+    expect(mainButton.length).toBe(1);
+    mainButton.forEach((button) => expect(button.type).toBe('button'));
+    await userEvent.click(mainButton[0]);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(35);
+    buttons.forEach((button) => expect(button.type).toBe('button'));
   });
 
   it('renders custom trigger when supplied', () => {

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.tsx
@@ -100,7 +100,7 @@ class UnThemedColorPickerPopover<T extends CustomPickersDescriptor> extends Comp
       <>
         {Object.keys(customPickers).map((key) => {
           return (
-            <button className={this.getTabClassName(key)} onClick={this.onTabChange(key)} key={key}>
+            <button className={this.getTabClassName(key)} onClick={this.onTabChange(key)} key={key} type="button">
               {customPickers[key].name}
             </button>
           );
@@ -120,10 +120,10 @@ class UnThemedColorPickerPopover<T extends CustomPickersDescriptor> extends Comp
         */}
         <div tabIndex={-1} className={styles.colorPickerPopover}>
           <div className={styles.colorPickerPopoverTabs}>
-            <button className={this.getTabClassName('palette')} onClick={this.onTabChange('palette')}>
+            <button className={this.getTabClassName('palette')} onClick={this.onTabChange('palette')} type="button">
               Colors
             </button>
-            <button className={this.getTabClassName('spectrum')} onClick={this.onTabChange('spectrum')}>
+            <button className={this.getTabClassName('spectrum')} onClick={this.onTabChange('spectrum')} type="button">
               Custom
             </button>
             {this.renderCustomPickerTabs()}

--- a/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
@@ -34,7 +34,7 @@ export const ColorSwatch = React.forwardRef<HTMLDivElement, Props>(
     return (
       <div ref={ref} className={styles.wrapper} data-testid={selectors.components.ColorSwatch.name} {...otherProps}>
         {hasLabel && <span className={styles.label}>{label}</span>}
-        <button className={styles.swatch} {...focusProps} aria-label={colorLabel} />
+        <button className={styles.swatch} {...focusProps} aria-label={colorLabel} type="button" />
       </div>
     );
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Set button type for all ColorPicker buttons instead of default submit type. 

**Why do we need this feature?**

Allowing ColorPicker to be used in a form.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
