### PR TITLE
Secure socks proxy: allow for UI to be disabled

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1575,12 +1575,12 @@ index_update_interval = 10s
 
 #################################### Secure Socks5 Datasource Proxy #####################################
 [secure_socks_datasource_proxy]
-enabled = true
-root_ca_cert = ca.crt
-client_key = client.key
-client_cert = client.crt
-server_name = localhost:6005
+enabled = false
+root_ca_cert =
+client_key =
+client_cert =
+server_name =
 # The address of the socks5 proxy datasources should connect to
-proxy_address = localhost:6005
+proxy_address =
 # Determines if the secure socks proxy should be shown on the datasources page, defaults to true if the feature is enabled
 show_ui = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1575,10 +1575,12 @@ index_update_interval = 10s
 
 #################################### Secure Socks5 Datasource Proxy #####################################
 [secure_socks_datasource_proxy]
-enabled = false
-root_ca_cert =
-client_key =
-client_cert =
-server_name =
+enabled = true
+root_ca_cert = ca.crt
+client_key = client.key
+client_cert = client.crt
+server_name = localhost:6005
 # The address of the socks5 proxy datasources should connect to
-proxy_address =
+proxy_address = localhost:6005
+# Determines if the secure socks proxy should be shown on the datasources page, defaults to true if the feature is enabled
+show_ui = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1486,3 +1486,4 @@
 ; server_name =
 # The address of the socks5 proxy datasources should connect to
 ; proxy_address =
+; show_ui = true

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -148,7 +148,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		TrustedTypesDefaultPolicyEnabled:    trustedTypesDefaultPolicyEnabled,
 		CSPReportOnlyEnabled:                hs.Cfg.CSPReportOnlyEnabled,
 		DateFormats:                         hs.Cfg.DateFormats,
-		SecureSocksDSProxyEnabled:           hs.Cfg.SecureSocksDSProxy.Enabled,
+		SecureSocksDSProxyEnabled:           hs.Cfg.SecureSocksDSProxy.Enabled && hs.Cfg.SecureSocksDSProxy.ShowUI,
 
 		Auth: dtos.FrontendSettingsAuthDTO{
 			OAuthSkipOrgRoleUpdateSync:  hs.Cfg.OAuthSkipOrgRoleUpdateSync,

--- a/pkg/setting/setting_secure_socks_proxy.go
+++ b/pkg/setting/setting_secure_socks_proxy.go
@@ -8,6 +8,7 @@ import (
 
 type SecureSocksDSProxySettings struct {
 	Enabled      bool
+	ShowUI       bool
 	ClientCert   string
 	ClientKey    string
 	RootCA       string
@@ -24,6 +25,7 @@ func readSecureSocksDSProxySettings(iniFile *ini.File) (SecureSocksDSProxySettin
 	s.RootCA = secureSocksProxySection.Key("root_ca_cert").MustString("")
 	s.ProxyAddress = secureSocksProxySection.Key("proxy_address").MustString("")
 	s.ServerName = secureSocksProxySection.Key("server_name").MustString("")
+	s.ShowUI = secureSocksProxySection.Key("show_ui").MustBool(true)
 
 	if !s.Enabled {
 		return s, nil


### PR DESCRIPTION
**What is this feature?**

This PR allows for disabling of the secure socks proxy UI when the feature is enabled. Currently, the UI already doesn't show unless the feature is enabled, but this allows for the UI to be hidden even when the feature is enabled. 

**Why do we need this feature?**

There will be a specific cloud UI that we want to show for [private datasource connect](https://grafana.com/docs/grafana-cloud/data-configuration/configure-private-datasource-connect), rather than the on-premise version for the [secure socks proxy](https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/proxy/).

**Screenshots**
The default, if the feature is enabled:
![Screenshot 2023-05-31 at 10 14 35 PM](https://github.com/grafana/grafana/assets/14365078/298fecaf-3f5b-4191-9d9a-425ab19beb0b)

The view, if the feature is disabled OR the feature is enabled and hides the UI.
![Screenshot 2023-05-31 at 10 15 18 PM](https://github.com/grafana/grafana/assets/14365078/0671f0a9-ca3c-49dc-9a3e-4cdc4e66294f)
