### PR TITLE
Alerting: Display error if repeat interval is lower than group interval

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.test.tsx
@@ -78,6 +78,34 @@ describe('EditDefaultPolicyForm', function () {
     });
   });
 
+  it('should show an error if repeat interval is lower than group interval', async function () {
+    const user = userEvent.setup();
+
+    const onSubmit = jest.fn();
+    renderRouteForm(
+      {
+        id: '0',
+        receiver: 'default',
+      },
+      [{ value: 'default', label: 'Default' }],
+      onSubmit
+    );
+
+    await user.click(ui.timingOptionsBtn.get());
+
+    await user.type(ui.groupWaitInput.get(), '5m25s');
+    await user.type(ui.groupIntervalInput.get(), '35m40s');
+    await user.type(ui.repeatIntervalInput.get(), '30m');
+
+    await user.click(ui.submitBtn.get());
+
+    expect(ui.error.getAll()).toHaveLength(1);
+    expect(ui.error.get().textContent).toBe(
+      'Invalid value. Repeat interval should be higher or equal to Group interval'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('should allow resetting existing timing options', async function () {
     const user = userEvent.setup();
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.test.tsx
@@ -100,9 +100,7 @@ describe('EditDefaultPolicyForm', function () {
     await user.click(ui.submitBtn.get());
 
     expect(ui.error.getAll()).toHaveLength(1);
-    expect(ui.error.get().textContent).toBe(
-      'Invalid value. Repeat interval should be higher or equal to Group interval'
-    );
+    expect(ui.error.get().textContent).toBe('Repeat interval should be higher or equal to Group interval');
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -10,6 +10,7 @@ import {
   mapMultiSelectValueToStrings,
   mapSelectValueToString,
   promDurationValidator,
+  repeatIntervalValidator,
   stringsToSelectableValues,
   stringToSelectableValue,
 } from '../../utils/amroutes';
@@ -43,7 +44,7 @@ export const AmRootRouteForm = ({
 
   return (
     <Form defaultValues={{ ...defaultValues, overrideTimings: true, overrideGrouping: true }} onSubmit={onSubmit}>
-      {({ register, control, errors, setValue }) => (
+      {({ register, control, errors, setValue, getValues }) => (
         <>
           <Field label="Default contact point" invalid={!!errors.receiver} error={errors.receiver?.message}>
             <>
@@ -143,7 +144,12 @@ export const AmRootRouteForm = ({
                 data-testid="am-repeat-interval"
               >
                 <PromDurationInput
-                  {...register('repeatIntervalValue', { validate: promDurationValidator })}
+                  {...register('repeatIntervalValue', {
+                    validate: (value: string) => {
+                      const groupInterval = getValues('groupIntervalValue');
+                      return repeatIntervalValidator(value, groupInterval);
+                    },
+                  })}
                   placeholder={TIMING_OPTIONS_DEFAULTS.repeat_interval}
                   className={styles.promDurationInput}
                   aria-label="Repeat interval"

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.test.tsx
@@ -98,9 +98,7 @@ describe('EditNotificationPolicyForm', function () {
     await user.click(ui.submitBtn.get());
 
     expect(ui.error.getAll()).toHaveLength(1);
-    expect(ui.error.get().textContent).toBe(
-      'Invalid value. Repeat interval should be higher or equal to Group interval'
-    );
+    expect(ui.error.get().textContent).toBe('Repeat interval should be higher or equal to Group interval');
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.test.tsx
@@ -76,6 +76,34 @@ describe('EditNotificationPolicyForm', function () {
     });
   });
 
+  it('should show an error if repeat interval is lower than group interval', async function () {
+    const user = userEvent.setup();
+
+    const onSubmit = jest.fn();
+    renderRouteForm(
+      {
+        id: '1',
+        receiver: 'default',
+      },
+      [{ value: 'default', label: 'Default' }],
+      onSubmit
+    );
+
+    await user.click(ui.overrideTimingsCheckbox.get());
+
+    await user.type(ui.groupWaitInput.get(), '5m25s');
+    await user.type(ui.groupIntervalInput.get(), '35m40s');
+    await user.type(ui.repeatIntervalInput.get(), '30m');
+
+    await user.click(ui.submitBtn.get());
+
+    expect(ui.error.getAll()).toHaveLength(1);
+    expect(ui.error.get().textContent).toBe(
+      'Invalid value. Repeat interval should be higher or equal to Group interval'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('should allow resetting existing timing options', async function () {
     const user = userEvent.setup();
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
@@ -32,6 +32,7 @@ import {
   commonGroupByOptions,
   amRouteToFormAmRoute,
   promDurationValidator,
+  repeatIntervalValidator,
 } from '../../utils/amroutes';
 import { AmRouteReceiver } from '../receivers/grafanaAppReceivers/types';
 
@@ -74,7 +75,7 @@ export const AmRoutesExpandedForm = ({
 
   return (
     <Form defaultValues={defaultValues} onSubmit={onSubmit} maxWidth="none">
-      {({ control, register, errors, setValue, watch }) => (
+      {({ control, register, errors, setValue, watch, getValues }) => (
         <>
           <input type="hidden" {...register('id')} />
           {/* @ts-ignore-check: react-hook-form made me do this */}
@@ -247,7 +248,12 @@ export const AmRoutesExpandedForm = ({
                 error={errors.repeatIntervalValue?.message}
               >
                 <PromDurationInput
-                  {...register('repeatIntervalValue', { validate: promDurationValidator })}
+                  {...register('repeatIntervalValue', {
+                    validate: (value: string) => {
+                      const groupInterval = getValues('groupIntervalValue');
+                      return repeatIntervalValidator(value, groupInterval);
+                    },
+                  })}
                   aria-label="Repeat interval value"
                   className={formStyles.promDurationInput}
                 />

--- a/public/app/features/alerting/unified/utils/amroutes.ts
+++ b/public/app/features/alerting/unified/utils/amroutes.ts
@@ -248,7 +248,5 @@ export const repeatIntervalValidator = (repeatInterval: string, groupInterval: s
 
   const isRepeatLowerThanGroupDuration = groupDuration !== 0 && repeatDuration < groupDuration;
 
-  return (
-    !isRepeatLowerThanGroupDuration || `Invalid value. Repeat interval should be higher or equal to Group interval`
-  );
+  return isRepeatLowerThanGroupDuration ? 'Repeat interval should be higher or equal to Group interval' : true;
 };


### PR DESCRIPTION
**What is this feature?**

Adds a form error when the repeat interval of a notification policy is lower than the group interval.

**Why do we need this feature?**

This does not work in Alertmanager. If `repeat_interval` is less than `group_interval` it is silently ignored, and notifications are repeated once per `group_interval` instead.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Reported in Slack.

![image](https://github.com/grafana/grafana/assets/6271380/001e791d-c831-4bf7-b716-6c8c3983c0c9)
