### PR TITLE
Prometheus: Fix bug when adding a query in mixed datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -1265,7 +1265,12 @@ export class PrometheusDatasource
   }
 
   getDefaultQuery(app: CoreApp): PromQuery {
-    const defaults = promDefaultBaseQuery();
+    const defaults = {
+      refId: 'A',
+      expr: '',
+      range: true,
+      instant: false,
+    };
 
     if (app === CoreApp.UnifiedAlerting) {
       return {
@@ -1334,13 +1339,4 @@ export function prometheusRegularEscape(value: any) {
 
 export function prometheusSpecialRegexEscape(value: any) {
   return typeof value === 'string' ? value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&') : value;
-}
-
-export function promDefaultBaseQuery(): PromQuery {
-  return {
-    refId: 'A',
-    expr: '',
-    range: true,
-    instant: false,
-  };
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -5,7 +5,6 @@ import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
 import { CoreApp } from '@grafana/data';
 
-import { promDefaultBaseQuery } from '../../datasource';
 import { PromQuery } from '../../types';
 import { getQueryWithDefaults } from '../state';
 
@@ -107,7 +106,15 @@ function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.P
   const props = {
     app,
     query: {
-      ...getQueryWithDefaults(promDefaultBaseQuery(), CoreApp.PanelEditor),
+      ...getQueryWithDefaults(
+        {
+          refId: 'A',
+          expr: '',
+          range: true,
+          instant: false,
+        } as PromQuery,
+        CoreApp.PanelEditor
+      ),
       ...queryOverrides,
     },
     onRunQuery: jest.fn(),


### PR DESCRIPTION
**What is this?**
This fixes a regression caused by https://github.com/grafana/grafana/pull/69255 when adding a new prometheus query in a query row in the mixed data source. The first PR wrapped the default base query in a function which was not available to the ds. This caused a bug that was exposed when adding a new query in the mixed data source. The original PR caused the `expr` to be undefined, this broke prometheus where `buildVisualQueryFromString` was used which uses a replace function which breaks when `expr` is undefined.

<img width="428" alt="Screenshot 2023-06-01 at 7 37 31 PM" src="https://github.com/grafana/grafana/assets/25674746/326737ec-5ac8-4301-a19f-cad9cd98bd75">

![Screenshot 2023-06-01 at 7 32 55 PM](https://github.com/grafana/grafana/assets/25674746/06a8c2e2-5afe-4e25-b0ea-982416ca3152)

**Why do we need this?**
So people can add a new prom query row query in the mixed data source.


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
