### PR TITLE
Docs: Bring back the alias for external group sync HTTP API page

### DIFF
--- a/docs/sources/developers/http_api/team_sync.md
+++ b/docs/sources/developers/http_api/team_sync.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../../http_api/external_group_sync/
-  - ../../http_api/team_sync/
+  - ./external_group_sync/
 canonical: /docs/grafana/latest/developers/http_api/team_sync/
 description: Grafana Team Sync HTTP API
 keywords:

--- a/docs/sources/developers/http_api/team_sync.md
+++ b/docs/sources/developers/http_api/team_sync.md
@@ -1,5 +1,6 @@
 ---
 aliases:
+  - ../../http_api/external_group_sync/
   - ../../http_api/team_sync/
 canonical: /docs/grafana/latest/developers/http_api/team_sync/
 description: Grafana Team Sync HTTP API


### PR DESCRIPTION
A follow up PR based on the conversation here https://github.com/grafana/grafana/pull/69395/files#r1213357295