### PR TITLE
Tracing: Use new DataSourceDescription component

### DIFF
--- a/public/app/plugins/datasource/jaeger/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/jaeger/components/ConfigEditor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
-import { ConfigSection } from '@grafana/experimental';
+import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { DataSourceHttpSettings, useStyles2 } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
@@ -18,6 +18,14 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
 
   return (
     <div className={styles.container}>
+      <DataSourceDescription
+        dataSourceName="Jaeger"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/jaeger"
+        hasRequiredFields={false}
+      />
+
+      <Divider />
+
       <DataSourceHttpSettings
         defaultUrl="http://localhost:16686"
         dataSourceConfig={options}
@@ -55,6 +63,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
     label: container;
     margin-bottom: ${theme.spacing(2)};
-    max-width: '578px';
+    max-width: 900px;
   `,
 });

--- a/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
-import { ConfigSection, ConfigSubSection } from '@grafana/experimental';
+import { ConfigSection, ConfigSubSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { DataSourceHttpSettings, useStyles2 } from '@grafana/ui';
 import { ConfigDescriptionLink } from 'app/core/components/ConfigDescriptionLink';
@@ -25,6 +25,14 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
 
   return (
     <div className={styles.container}>
+      <DataSourceDescription
+        dataSourceName="Tempo"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/tempo"
+        hasRequiredFields={false}
+      />
+
+      <Divider />
+
       <DataSourceHttpSettings
         defaultUrl="http://tempo"
         dataSourceConfig={options}
@@ -129,6 +137,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
     label: container;
     margin-bottom: ${theme.spacing(2)};
-    max-width: '578px';
+    max-width: 900px;
   `,
 });

--- a/public/app/plugins/datasource/zipkin/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/zipkin/ConfigEditor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
-import { ConfigSection } from '@grafana/experimental';
+import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { DataSourceHttpSettings, useStyles2 } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
@@ -18,6 +18,14 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
 
   return (
     <div className={styles.container}>
+      <DataSourceDescription
+        dataSourceName="Zipkin"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/zipkin"
+        hasRequiredFields={false}
+      />
+
+      <Divider />
+
       <DataSourceHttpSettings
         defaultUrl="http://localhost:9411"
         dataSourceConfig={options}
@@ -55,6 +63,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
     label: container;
     margin-bottom: ${theme.spacing(2)};
-    max-width: '578px';
+    max-width: 900px;
   `,
 });


### PR DESCRIPTION
**What is this feature?**

Updates Tempo/Jaeger/Zipkin to use new DataSourceDescription component.

**Why do we need this feature?**

As part of an initiative to update our data source configs and have a common design.

**Who is this feature for?**

Tempo/Jaeger/Zipkin users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
