### PR TITLE
Loki: Remove unused datasource prop from LokiQueryBuilderOptions

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -203,7 +203,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           onRunQuery={onRunQuery}
           app={app}
           maxLines={datasource.maxLines}
-          datasource={datasource}
           queryStats={queryStats}
         />
       </EditorRows>

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { createLokiDatasource } from '../../mocks';
 import { LokiQuery, LokiQueryType } from '../../types';
 
 import { LokiQueryBuilderOptions } from './LokiQueryBuilderOptions';
@@ -48,7 +47,6 @@ function setup(queryOverrides: Partial<LokiQuery> = {}) {
     onRunQuery: jest.fn(),
     onChange: jest.fn(),
     maxLines: 20,
-    datasource: createLokiDatasource(),
     queryStats: { streams: 0, chunks: 0, bytes: 0, entries: 0 },
   };
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -7,7 +7,6 @@ import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 import { QueryOptionGroup } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryOptionGroup';
 
 import { preprocessMaxLines, queryTypeOptions, RESOLUTION_OPTIONS } from '../../components/LokiOptionFields';
-import { LokiDatasource } from '../../datasource';
 import { isLogsQuery } from '../../queryUtils';
 import { LokiQuery, LokiQueryType, QueryStats } from '../../types';
 
@@ -17,13 +16,12 @@ export interface Props {
   onRunQuery: () => void;
   maxLines: number;
   app?: CoreApp;
-  datasource: LokiDatasource;
   queryStats: QueryStats | null;
 }
 
 export const LokiQueryBuilderOptions = React.memo<Props>(
-  ({ app, query, onChange, onRunQuery, maxLines, datasource, queryStats }) => {
-    const [splitDurationValid, setsplitDurationValid] = useState(true);
+  ({ app, query, onChange, onRunQuery, maxLines, queryStats }) => {
+    const [splitDurationValid, setSplitDurationValid] = useState(true);
 
     const onQueryTypeChange = (value: LokiQueryType) => {
       onChange({ ...query, queryType: value });
@@ -42,10 +40,10 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
     const onChunkRangeChange = (evt: React.FormEvent<HTMLInputElement>) => {
       const value = evt.currentTarget.value;
       if (!isValidDuration(value)) {
-        setsplitDurationValid(false);
+        setSplitDurationValid(false);
         return;
       }
-      setsplitDurationValid(true);
+      setSplitDurationValid(true);
       onChange({ ...query, splitDuration: value });
       onRunQuery();
     };


### PR DESCRIPTION
In this PR, we are removing unused `datasource` prop from `LokiQueryBuilderOptions` as it is not used anymore. I have also fixed spelling/casing in `setsplitDurationValid` -> `setSplitDurationValid`. 