### PR TITLE
Add prometheus querydata instrumentation

### DIFF
--- a/pkg/tsdb/prometheus/instrumentation/instrumentation.go
+++ b/pkg/tsdb/prometheus/instrumentation/instrumentation.go
@@ -1,0 +1,87 @@
+package instrumentation
+
+import (
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	pluginRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "grafana",
+		Name:      "prometheus_plugin_backend_request_count",
+		Help:      "The total amount of prometheus backend plugin requests",
+	}, []string{"endpoint", "status", "errorSource"})
+)
+
+const (
+	StatusOK    = "ok"
+	StatusError = "error"
+
+	EndpointCallResource = "callResource"
+	EndpointQueryData    = "queryData"
+
+	PluginSource   = "plugin"
+	ExternalSource = "external"
+	DatabaseSource = "database"
+	NoneSource     = "none"
+)
+
+func UpdateQueryDataMetrics(err error, resp *backend.QueryDataResponse) {
+	status := StatusOK
+	if err != nil {
+		status = StatusError
+	}
+
+	errorSource := getErrorSource(err, resp)
+
+	pluginRequestCounter.WithLabelValues(EndpointQueryData, status, errorSource).Inc()
+}
+
+func getErrorSource(err error, resp *backend.QueryDataResponse) string {
+	if err != nil {
+		return PluginSource
+	}
+
+	// If there is different errorSource from the list of responses, we want to return the most severe one.
+	// The priority order is: pluginSource > databaseSource > externalSource > noneSource
+	var errorSource = NoneSource
+	for _, res := range resp.Responses {
+		responseErrorSource := getErrorSourceForResponse(res)
+
+		if responseErrorSource == PluginSource {
+			return PluginSource
+		}
+
+		if responseErrorSource == DatabaseSource {
+			errorSource = DatabaseSource
+		}
+
+		if responseErrorSource == ExternalSource && errorSource == NoneSource {
+			errorSource = ExternalSource
+		}
+	}
+
+	return errorSource
+}
+
+func getErrorSourceForResponse(res backend.DataResponse) string {
+	if res.Error != nil {
+		return PluginSource
+	}
+
+	if res.Status >= 500 {
+		return DatabaseSource
+	}
+
+	if res.Status >= 400 {
+		// Those error codes are related to authentication and authorization.
+		if res.Status == 401 || res.Status == 402 || res.Status == 403 || res.Status == 407 {
+			return ExternalSource
+		}
+
+		return PluginSource
+	}
+
+	return NoneSource
+}

--- a/pkg/tsdb/prometheus/instrumentation/instrumentation_test.go
+++ b/pkg/tsdb/prometheus/instrumentation/instrumentation_test.go
@@ -1,0 +1,117 @@
+package instrumentation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func checkErrorSource(t *testing.T, expected, actual string) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("expected errorSource to be %v, but got %v", expected, actual)
+	}
+}
+
+func TestGetErrorSourceForResponse(t *testing.T) {
+	t.Run("A response that return an error should return pluginSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: fmt.Errorf("error")})
+		checkErrorSource(t, PluginSource, errorSource)
+	})
+
+	t.Run("A response with an http satus code > 500 should return databaseSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 500})
+		checkErrorSource(t, DatabaseSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 503})
+		checkErrorSource(t, DatabaseSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 507})
+		checkErrorSource(t, DatabaseSource, errorSource)
+	})
+
+	t.Run("A response with an http satus related to auth (401, 402, 403, 407), should return externalSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 401})
+		checkErrorSource(t, ExternalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 402})
+		checkErrorSource(t, ExternalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 403})
+		checkErrorSource(t, ExternalSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 407})
+		checkErrorSource(t, ExternalSource, errorSource)
+	})
+
+	t.Run("A response with an http satus of 4xx but not related to auth (401, 402, 403, 407), should return pluginSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 400})
+		checkErrorSource(t, PluginSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 404})
+		checkErrorSource(t, PluginSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 405})
+		checkErrorSource(t, PluginSource, errorSource)
+	})
+
+	t.Run("A response without error and with an http status of 2xx, should return noneSource", func(t *testing.T) {
+		errorSource := getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 200})
+		checkErrorSource(t, NoneSource, errorSource)
+
+		errorSource = getErrorSourceForResponse(backend.DataResponse{Error: nil, Status: 201})
+		checkErrorSource(t, NoneSource, errorSource)
+	})
+}
+
+func TestGetErrorSource(t *testing.T) {
+	t.Run("If status of backend.QueryDataResponse is statusError, then errorSource is pluginSource ", func(t *testing.T) {
+		errorSource := getErrorSource(fmt.Errorf("a random error"), nil)
+		checkErrorSource(t, PluginSource, errorSource)
+	})
+
+	t.Run("If status of backend.QueryDataResponse is statusOK, then errorSource is the most severe response's errorSource: pluginSource > databaseSource > externalSource > noneSource", func(t *testing.T) {
+		errorSource := getErrorSource(nil, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"A": {Error: fmt.Errorf("error")},
+				"B": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, PluginSource, errorSource)
+
+		errorSource = getErrorSource(nil, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"A": {Error: nil, Status: 400},
+				"B": {Error: nil, Status: 500},
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, PluginSource, errorSource)
+
+		errorSource = getErrorSource(nil, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"B": {Error: nil, Status: 500},
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, DatabaseSource, errorSource)
+
+		errorSource = getErrorSource(nil, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"C": {Error: nil, Status: 401},
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, ExternalSource, errorSource)
+
+		errorSource = getErrorSource(nil, &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				"D": {Error: nil, Status: 200},
+			},
+		})
+		checkErrorSource(t, NoneSource, errorSource)
+	})
+}


### PR DESCRIPTION
Add a custom prometheus querydata metric with an errorSource label. This is to help us setting SLOs and Alert for plugin requests.

Similar to this:
https://docs.google.com/document/d/1_8KSW3O6R-0hzcVq9VPj9iLoB064NEdJDIEe0uh58Zo/edit

But for plugin request.

Logic:
If plugin request return an error => errorSource = plugin
If there is no error, then it depends on the different http status code returned by the database:
- 500 => errorSource = database
- 401, 402, 403, 407 => errorSource = external (could be config or infra)
- 4xx => errorSource = plugin

If there is multiple responses from the database, with different errorSource, then we return the most sever one.
The priority is: pluginSource > databaseSource > externalSource > noneSource