### PR TITLE
Alerting: Support newer http_config struct

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -17,6 +17,7 @@ import { initialAsyncRequestState } from '../../../utils/redux';
 
 import { ChannelSubForm } from './ChannelSubForm';
 import { DeletedSubForm } from './fields/DeletedSubform';
+import { normalizeFormValues } from './util';
 
 interface Props<R extends ChannelValues> {
   config: AlertManagerCortexConfig;
@@ -48,7 +49,10 @@ export function ReceiverForm<R extends ChannelValues>({
   const notifyApp = useAppNotification();
   const styles = useStyles2(getStyles);
 
-  const defaultValues = initialValues || {
+  // normalize deprecated and new config values
+  const normalizedConfig = normalizeFormValues(initialValues);
+
+  const defaultValues = normalizedConfig ?? {
     name: '',
     items: [
       {

--- a/public/app/features/alerting/unified/components/receivers/form/util.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.test.ts
@@ -1,0 +1,58 @@
+import { ChannelValues, ReceiverFormValues } from '../../../types/receiver-form';
+
+import { DeprecatedAuthHTTPConfig, HTTPAuthConfig, normalizeFormValues } from './util';
+
+describe('normalizeFormValues', () => {
+  it('should leave the older config alone', () => {
+    const config = createContactPoint({ bearer_token: 'token' });
+    expect(normalizeFormValues(config)).toEqual(config);
+  });
+
+  it('should leave the older config alone', () => {
+    const config = createContactPoint({ bearer_token_file: 'file' });
+    expect(normalizeFormValues(config)).toEqual(config);
+  });
+
+  it('should normalize newer config', () => {
+    const config = createContactPoint({
+      authorization: {
+        type: 'bearer',
+        credentials: 'token',
+      },
+    });
+
+    expect(normalizeFormValues(config)).toEqual(createContactPoint({ bearer_token: 'token' }));
+  });
+
+  it('should normalize newer config', () => {
+    const config = createContactPoint({
+      authorization: {
+        type: 'bearer',
+        credentials_file: 'file',
+      },
+    });
+
+    expect(normalizeFormValues(config)).toEqual(createContactPoint({ bearer_token_file: 'file' }));
+  });
+});
+
+function createContactPoint(httpConfig: DeprecatedAuthHTTPConfig | HTTPAuthConfig) {
+  const config: ReceiverFormValues<ChannelValues> = {
+    name: 'My Contact Point',
+    items: [
+      {
+        __id: '',
+        type: '',
+        secureSettings: {},
+        secureFields: {},
+        settings: {
+          http_config: {
+            ...httpConfig,
+          },
+        },
+      },
+    ],
+  };
+
+  return config;
+}

--- a/public/app/features/alerting/unified/components/receivers/form/util.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.ts
@@ -2,12 +2,12 @@ import { omit } from 'lodash';
 
 import { ChannelValues, ReceiverFormValues } from '../../../types/receiver-form';
 
-interface DeprecatedAuthHTTPConfig {
+export interface DeprecatedAuthHTTPConfig {
   bearer_token?: string;
   bearer_token_file?: string;
 }
 
-interface HTTPAuthConfig {
+export interface HTTPAuthConfig {
   authorization: {
     type: string;
     credentials?: string;

--- a/public/app/features/alerting/unified/components/receivers/form/util.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.ts
@@ -29,7 +29,7 @@ export function normalizeFormValues(
       ...item,
       settings: {
         ...item.settings,
-        http_config: normalizeHTTPConfig(item.settings.http_config),
+        http_config: item.settings?.http_config ? normalizeHTTPConfig(item.settings?.http_config) : undefined,
       },
     })),
   };

--- a/public/app/features/alerting/unified/components/receivers/form/util.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.ts
@@ -1,0 +1,54 @@
+import { omit } from 'lodash';
+
+import { ChannelValues, ReceiverFormValues } from '../../../types/receiver-form';
+
+interface DeprecatedAuthHTTPConfig {
+  bearer_token?: string;
+  bearer_token_file?: string;
+}
+
+interface HTTPAuthConfig {
+  authorization: {
+    type: string;
+    credentials?: string;
+    credentials_file?: string;
+  };
+}
+
+// convert the newer http_config to the older (deprecated) format
+export function normalizeFormValues(
+  values?: ReceiverFormValues<ChannelValues>
+): ReceiverFormValues<ChannelValues> | undefined {
+  if (!values) {
+    return;
+  }
+
+  return {
+    ...values,
+    items: values.items.map((item) => ({
+      ...item,
+      settings: {
+        ...item.settings,
+        http_config: normalizeHTTPConfig(item.settings.http_config),
+      },
+    })),
+  };
+}
+
+function normalizeHTTPConfig(config: HTTPAuthConfig | DeprecatedAuthHTTPConfig): DeprecatedAuthHTTPConfig {
+  if (isDeprecatedHTTPAuthConfig(config)) {
+    return config;
+  }
+
+  return {
+    ...omit(config, 'authorization'),
+    bearer_token: config.authorization.credentials,
+    bearer_token_file: config.authorization.credentials_file,
+  };
+}
+
+function isDeprecatedHTTPAuthConfig(
+  config: HTTPAuthConfig | DeprecatedAuthHTTPConfig
+): config is DeprecatedAuthHTTPConfig {
+  return ['bearer_token', 'bearer_token_file'].some((prop) => prop in config);
+}


### PR DESCRIPTION
**What is this feature?**

This PR will rewrite the newer `http_config` to the older format so it's compatible with our form values. Essentially using the newer configuration in Mimir will no longer break it when editing and saving that same config in Grafana (see linked issue for more details).

**Which issue(s) does this PR fix?**:

Fixes #68706

**Special notes for your reviewer:**

Ideally we'd rewrite it top the newer config but we can't be sure what version of Alertmanager are floating around. 

The older http config has been deprecated for almost 2 years now and was first introduced in `Alertmanager v0.22.0`