### PR TITLE
Use reviewdog to provide much more helpful error messages for prettier rewrites

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1063,11 +1063,16 @@ steps:
   image: grafana/build-container:1.7.4
   name: codespell
 - commands:
-  - yarn run prettier:checkDocs
+  - go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
+  - 'prettier --write 2>&1 docs/sources | reviewdog ''--efm=%E[%trror] %f: %m (%l:%c)''
+    --efm=%C[error]%r --efm=%Z[error]%r --efm=%-G%r --fail-on-error  --filter-mode=nofilter
+    --level=info --name=prettier --reporter=local'
   depends_on:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
+    REVIEWDOG_GITHUB_API_TOKEN:
+      from_secret: github_token
   image: grafana/build-container:1.7.4
   name: lint-docs
 - commands:
@@ -1174,11 +1179,16 @@ steps:
   image: grafana/build-container:1.7.4
   name: codespell
 - commands:
-  - yarn run prettier:checkDocs
+  - go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
+  - 'prettier --write 2>&1 docs/sources | reviewdog ''--efm=%E[%trror] %f: %m (%l:%c)''
+    --efm=%C[error]%r --efm=%Z[error]%r --efm=%-G%r --fail-on-error  --filter-mode=nofilter
+    --level=info --name=prettier --reporter=local'
   depends_on:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
+    REVIEWDOG_GITHUB_API_TOKEN:
+      from_secret: github_token
   image: grafana/build-container:1.7.4
   name: lint-docs
 - commands:
@@ -7216,6 +7226,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: d1a589fd39357048aa2b6595181f98d17545e184121774b729553e9165464480
+hmac: d57799d74605b15287d71ea34dc19e002f05dd7cd7132f2ddf22b6dd8217dd87
 
 ...

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -204,6 +204,8 @@ keywords:
 title: Grafana documentation
 ---
 
+
+
 # Grafana documentation
 
 ## Installing Grafana

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -14,6 +14,10 @@ load(
     "scripts/drone/utils/utils.star",
     "pipeline",
 )
+load(
+    "scripts/drone/vault.star",
+    "from_secret",
+)
 
 docs_paths = {
     "include": [
@@ -52,9 +56,11 @@ def lint_docs():
         ],
         "environment": {
             "NODE_OPTIONS": "--max_old_space_size=8192",
+            "REVIEWDOG_GITHUB_API_TOKEN": from_secret("github_token"),
         },
         "commands": [
-            "yarn run prettier:checkDocs",
+            "go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest",
+            "prettier --write 2>&1 docs/sources | reviewdog '--efm=%E[%trror] %f: %m (%l:%c)' --efm=%C[error]%r --efm=%Z[error]%r --efm=%-G%r --fail-on-error  --filter-mode=nofilter --level=info --name=prettier --reporter=local",
         ],
     }
 


### PR DESCRIPTION
Currently drive-by fixes are blocked by needing to go through the following steps:

1. Understand the requirement of the `continuous-integration/drone/pr` check.
1. View the failures of that check in Drone.
1. Get told by `prettier` that you have not run it on specific files.
1. Clone the repository.
1. Install `yarn`.
1. Use `yarn` to install `prettier`.
1. Run `prettier`.
1. Commit the results.

With [`reviewdog`](https://github.com/reviewdog/reviewdog), trivial `prettier` errors are reported as GitHub suggestions. More complicated errors are reported as comments.

This is a translation of the code in https://github.com/EPMatt/reviewdog-action-prettier/blob/main/script.sh.
I need to find a way to test this before it is merged.