### PR TITLE
Logs: Implement "infinite" scrolling in log context

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -102,7 +102,7 @@ interface State {
   prettifyLogMessage: boolean;
   dedupStrategy: LogsDedupStrategy;
   hiddenLogLevels: LogLevel[];
-  logsSortOrder: LogsSortOrder | null;
+  logsSortOrder: LogsSortOrder;
   isFlipping: boolean;
   displayedFields: string[];
   forceEscape: boolean;

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -84,7 +84,7 @@ interface Props extends Themeable2 {
   onClickFilterOutLabel: (key: string, value: string) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
-  getRowContext?: (row: LogRowModel, options?: LogRowContextOptions) => Promise<any>;
+  getRowContext?: (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions) => Promise<any>;
   getRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions) => Promise<DataQuery | null>;
   getLogRowContextUi?: (row: LogRowModel, runContextQuery?: () => void) => React.ReactNode;
   getFieldLinks: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
@@ -488,7 +488,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
             open={contextOpen}
             row={contextRow}
             onClose={this.onCloseContext}
-            getRowContext={getRowContext}
+            getRowContext={(row, options) => getRowContext(row, contextRow, options)}
             getRowContextQuery={getRowContextQuery}
             getLogRowContextUi={getLogRowContextUi}
             logsSortOrder={logsSortOrder}

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -72,11 +72,15 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
     );
   }
 
-  getLogRowContext = async (row: LogRowModel, options?: LogRowContextOptions): Promise<DataQueryResponse | []> => {
+  getLogRowContext = async (
+    row: LogRowModel,
+    origRow: LogRowModel,
+    options: LogRowContextOptions
+  ): Promise<DataQueryResponse | []> => {
     const { datasourceInstance, logsQueries } = this.props;
 
     if (hasLogsContextSupport(datasourceInstance)) {
-      const query = this.getQuery(logsQueries, row, datasourceInstance);
+      const query = this.getQuery(logsQueries, origRow, datasourceInstance);
       return datasourceInstance.getLogRowContext(row, options, query);
     }
 

--- a/public/app/features/logs/components/log-context/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/log-context/LoadingIndicator.tsx
@@ -5,8 +5,8 @@ import { Spinner } from '@grafana/ui';
 
 // ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
 // one has a large margin-bottom.
-export const LoadingIndicator = ({ place }: { place: 'top' | 'bottom' }) => {
-  const text = place === 'top' ? 'Loading newer logs...' : 'Loading older logs...';
+export const LoadingIndicator = ({ place }: { place: 'above' | 'below' }) => {
+  const text = place === 'above' ? 'Loading newer logs...' : 'Loading older logs...';
   return (
     <div className={loadingIndicatorStyles}>
       <div>

--- a/public/app/features/logs/components/log-context/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/log-context/LoadingIndicator.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { Spinner } from '@grafana/ui';
+
+// ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
+// one has a large margin-bottom.
+export const LoadingIndicator = ({ place }: { place: 'top' | 'bottom' }) => {
+  const text = place === 'top' ? 'Loading newer logs...' : 'Loading older logs...';
+  return (
+    <div className={loadingIndicatorStyles}>
+      <div>
+        {text} <Spinner inline />
+      </div>
+    </div>
+  );
+};
+
+const loadingIndicatorStyles = css`
+  display: flex;
+  justify-content: center;
+`;

--- a/public/app/features/logs/components/log-context/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/log-context/LoadingIndicator.tsx
@@ -3,9 +3,16 @@ import React from 'react';
 
 import { Spinner } from '@grafana/ui';
 
+import { Place } from './types';
+
 // ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
 // one has a large margin-bottom.
-export const LoadingIndicator = ({ place }: { place: 'above' | 'below' }) => {
+
+type Props = {
+  place: Place;
+};
+
+export const LoadingIndicator = ({ place }: Props) => {
   const text = place === 'above' ? 'Loading newer logs...' : 'Loading older logs...';
   return (
     <div className={loadingIndicatorStyles}>

--- a/public/app/features/logs/components/log-context/LogContextButtons.test.tsx
+++ b/public/app/features/logs/components/log-context/LogContextButtons.test.tsx
@@ -2,46 +2,28 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { SelectableValue } from '@grafana/data';
-
-import { LogContextButtons, LoadMoreOptions } from './LogContextButtons';
+import { LogContextButtons } from './LogContextButtons';
 
 describe('LogContextButtons', () => {
-  const onChangeOption = jest.fn();
-  const option: SelectableValue<number> = { label: '10 lines', value: 10 };
-  const position: 'top' | 'bottom' = 'bottom';
-
-  beforeEach(() => {
-    render(<LogContextButtons option={option} onChangeOption={onChangeOption} position={position} />);
+  it('should call onChangeWrapLines when the checkbox is used, case 1', async () => {
+    const onChangeWrapLines = jest.fn();
+    render(<LogContextButtons onChangeWrapLines={onChangeWrapLines} />);
+    const wrapLinesBox = screen.getByRole('checkbox', {
+      name: 'Wrap lines',
+    });
+    await userEvent.click(wrapLinesBox);
+    expect(onChangeWrapLines).toHaveBeenCalledTimes(1);
+    expect(onChangeWrapLines).toHaveBeenCalledWith(true);
   });
 
-  it('should render a ButtonGroup with one button', () => {
-    const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toBe(1);
-  });
-
-  it('should render a ButtonSelect with LoadMoreOptions', async () => {
-    const tenLinesButton = screen.getByRole('button', {
-      name: /10 lines/i,
+  it('should call onChangeWrapLines when the checkbox is used, case 2', async () => {
+    const onChangeWrapLines = jest.fn();
+    render(<LogContextButtons onChangeWrapLines={onChangeWrapLines} wrapLines />);
+    const wrapLinesBox = screen.getByRole('checkbox', {
+      name: 'Wrap lines',
     });
-    await userEvent.click(tenLinesButton);
-    const options = screen.getAllByRole('menuitemradio');
-    expect(options.length).toBe(LoadMoreOptions.length);
-    options.forEach((optionEl, index) => {
-      expect(optionEl).toHaveTextContent(LoadMoreOptions[index].label!);
-    });
-  });
-
-  it('should call onChangeOption when an option is selected', async () => {
-    const tenLinesButton = screen.getByRole('button', {
-      name: /10 lines/i,
-    });
-    await userEvent.click(tenLinesButton);
-    const twentyLinesButton = screen.getByRole('menuitemradio', {
-      name: /20 lines/i,
-    });
-    await userEvent.click(twentyLinesButton);
-    const newOption = { label: '20 lines', value: 20 };
-    expect(onChangeOption).toHaveBeenCalledWith(newOption);
+    await userEvent.click(wrapLinesBox);
+    expect(onChangeWrapLines).toHaveBeenCalledTimes(1);
+    expect(onChangeWrapLines).toHaveBeenCalledWith(false);
   });
 });

--- a/public/app/features/logs/components/log-context/LogContextButtons.tsx
+++ b/public/app/features/logs/components/log-context/LogContextButtons.tsx
@@ -1,16 +1,7 @@
-import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
 
 import { reportInteraction } from '@grafana/runtime';
-import { ButtonGroup, InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
-
-const getStyles = () => {
-  return {
-    buttonGroup: css`
-      display: inline-flex;
-    `,
-  };
-};
+import { InlineSwitch } from '@grafana/ui';
 
 export type Props = {
   wrapLines?: boolean;
@@ -29,15 +20,6 @@ export const LogContextButtons = (props: Props) => {
     },
     [onChangeWrapLines]
   );
-  const styles = useStyles2(getStyles);
 
-  return (
-    <ButtonGroup className={styles.buttonGroup}>
-      <InlineFieldRow>
-        <InlineField label="Wrap lines">
-          <InlineSwitch value={wrapLines} onChange={internalOnChangeWrapLines} />
-        </InlineField>
-      </InlineFieldRow>
-    </ButtonGroup>
-  );
+  return <InlineSwitch showLabel value={wrapLines} onChange={internalOnChangeWrapLines} label="Wrap lines" />;
 };

--- a/public/app/features/logs/components/log-context/LogContextButtons.tsx
+++ b/public/app/features/logs/components/log-context/LogContextButtons.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
 
-import { SelectableValue } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { ButtonGroup, ButtonSelect, InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
+import { ButtonGroup, InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
 
 const getStyles = () => {
   return {
@@ -13,34 +12,20 @@ const getStyles = () => {
   };
 };
 
-export const LoadMoreOptions: Array<SelectableValue<number>> = [
-  { label: '10 lines', value: 10 },
-  { label: '20 lines', value: 20 },
-  { label: '50 lines', value: 50 },
-  { label: '100 lines', value: 100 },
-  { label: '200 lines', value: 200 },
-];
-
 export type Props = {
-  option: SelectableValue<number>;
-  onChangeOption: (item: SelectableValue<number>) => void;
-  position?: 'top' | 'bottom';
-
   wrapLines?: boolean;
-  onChangeWrapLines?: (wrapLines: boolean) => void;
+  onChangeWrapLines: (wrapLines: boolean) => void;
 };
 
 export const LogContextButtons = (props: Props) => {
-  const { option, onChangeOption, wrapLines, onChangeWrapLines, position } = props;
+  const { wrapLines, onChangeWrapLines } = props;
   const internalOnChangeWrapLines = useCallback(
     (event: React.FormEvent<HTMLInputElement>) => {
-      if (onChangeWrapLines) {
-        const state = event.currentTarget.checked;
-        reportInteraction('grafana_explore_logs_log_context_toggle_lines_clicked', {
-          state,
-        });
-        onChangeWrapLines(state);
-      }
+      const state = event.currentTarget.checked;
+      reportInteraction('grafana_explore_logs_log_context_toggle_lines_clicked', {
+        state,
+      });
+      onChangeWrapLines(state);
     },
     [onChangeWrapLines]
   );
@@ -48,14 +33,11 @@ export const LogContextButtons = (props: Props) => {
 
   return (
     <ButtonGroup className={styles.buttonGroup}>
-      {position === 'top' && onChangeWrapLines && (
-        <InlineFieldRow>
-          <InlineField label="Wrap lines">
-            <InlineSwitch value={wrapLines} onChange={internalOnChangeWrapLines} />
-          </InlineField>
-        </InlineFieldRow>
-      )}
-      <ButtonSelect variant="canvas" value={option} options={LoadMoreOptions} onChange={onChangeOption} />
+      <InlineFieldRow>
+        <InlineField label="Wrap lines">
+          <InlineSwitch value={wrapLines} onChange={internalOnChangeWrapLines} />
+        </InlineField>
+      </InlineFieldRow>
     </ButtonGroup>
   );
 };

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -99,7 +99,14 @@ describe('LogRowContextModal', () => {
 
   it('should not render modal when it is closed', async () => {
     render(
-      <LogRowContextModal row={row} open={false} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={false}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
 
     await waitFor(() => expect(screen.queryByText('Log context')).not.toBeInTheDocument());
@@ -107,7 +114,14 @@ describe('LogRowContextModal', () => {
 
   it('should render modal when it is open', async () => {
     render(
-      <LogRowContextModal row={row} open={true} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
 
     await waitFor(() => expect(screen.queryByText('Log context')).toBeInTheDocument());
@@ -115,7 +129,14 @@ describe('LogRowContextModal', () => {
 
   it('should call getRowContext on open and change of row', async () => {
     render(
-      <LogRowContextModal row={row} open={false} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={false}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
 
     await waitFor(() => expect(getRowContext).not.toHaveBeenCalled());
@@ -123,7 +144,14 @@ describe('LogRowContextModal', () => {
 
   it('should call getRowContext on open', async () => {
     render(
-      <LogRowContextModal row={row} open={true} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
     await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
   });
@@ -145,7 +173,14 @@ describe('LogRowContextModal', () => {
 
   it('should call getRowContext when limit changes', async () => {
     render(
-      <LogRowContextModal row={row} open={true} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
     await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
 
@@ -170,6 +205,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 
@@ -201,6 +237,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 
@@ -215,7 +252,14 @@ describe('LogRowContextModal', () => {
 
   it('should not show a split view button', async () => {
     render(
-      <LogRowContextModal row={row} open={true} onClose={() => {}} getRowContext={getRowContext} timeZone={timeZone} />
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
+      />
     );
 
     await waitFor(() => {
@@ -237,6 +281,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 
@@ -254,6 +299,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 
@@ -279,6 +325,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 
@@ -314,6 +361,7 @@ describe('LogRowContextModal', () => {
         getRowContext={getRowContext}
         getRowContextQuery={getRowContextQuery}
         timeZone={timeZone}
+        logsSortOrder={LogsSortOrder.Descending}
       />
     );
 

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { render } from 'test/redux-rtl';
 
 import {
@@ -64,8 +63,6 @@ const getRowContext = jest.fn().mockImplementation(async (_, options) => {
     return { data: [dfAfter] };
   }
 });
-const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
-
 const dispatchMock = jest.fn();
 jest.mock('app/types', () => ({
   ...jest.requireActual('app/types'),

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -171,61 +171,6 @@ describe('LogRowContextModal', () => {
     await waitFor(() => expect(screen.getAllByText('foo123').length).toBe(3));
   });
 
-  it('should call getRowContext when limit changes', async () => {
-    render(
-      <LogRowContextModal
-        row={row}
-        open={true}
-        onClose={() => {}}
-        getRowContext={getRowContext}
-        timeZone={timeZone}
-        logsSortOrder={LogsSortOrder.Descending}
-      />
-    );
-    await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
-
-    const fiftyLinesButton = screen.getByRole('button', {
-      name: /50 lines/i,
-    });
-    await userEvent.click(fiftyLinesButton);
-    const twentyLinesButton = screen.getByRole('menuitemradio', {
-      name: /20 lines/i,
-    });
-    await userEvent.click(twentyLinesButton);
-
-    await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(4));
-  });
-
-  it('should call getRowContextQuery when limit changes', async () => {
-    render(
-      <LogRowContextModal
-        row={row}
-        open={true}
-        onClose={() => {}}
-        getRowContext={getRowContext}
-        getRowContextQuery={getRowContextQuery}
-        timeZone={timeZone}
-        logsSortOrder={LogsSortOrder.Descending}
-      />
-    );
-
-    // this will call it initially and in the first fetchResults
-    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(2));
-
-    const tenLinesButton = screen.getByRole('button', {
-      name: /50 lines/i,
-    });
-    await userEvent.click(tenLinesButton);
-    const twentyLinesButton = screen.getByRole('menuitemradio', {
-      name: /20 lines/i,
-    });
-    act(() => {
-      userEvent.click(twentyLinesButton);
-    });
-
-    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(3));
-  });
-
   it('should show a split view button', async () => {
     const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
 

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -56,11 +56,30 @@ const dfAfter = createDataFrame({
     },
   ],
 });
+
+let uniqueRefIdCounter = 1;
+
 const getRowContext = jest.fn().mockImplementation(async (_, options) => {
+  uniqueRefIdCounter += 1;
+  const refId = `refid_${uniqueRefIdCounter}`;
   if (options.direction === LogRowContextQueryDirection.Forward) {
-    return { data: [dfBefore] };
+    return {
+      data: [
+        {
+          refId,
+          ...dfBefore,
+        },
+      ],
+    };
   } else {
-    return { data: [dfAfter] };
+    return {
+      data: [
+        {
+          refId,
+          ...dfAfter,
+        },
+      ],
+    };
   }
 });
 const dispatchMock = jest.fn();

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -299,8 +299,8 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       return;
     }
 
-    setSection(place, (s) => ({
-      ...s,
+    setSection(place, (section) => ({
+      ...section,
       loadingState: LoadingState.Loading,
     }));
 
@@ -308,14 +308,14 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     try {
       const newRows = await loadMore(place);
       if (currentGen === generationRef.current) {
-        setSection(place, (s) => ({
-          rows: place === 'above' ? [...newRows, ...s.rows] : [...s.rows, ...newRows],
+        setSection(place, (section) => ({
+          rows: place === 'above' ? [...newRows, ...section.rows] : [...section.rows, ...newRows],
           loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
         }));
       }
     } catch {
-      setSection(place, (s) => ({
-        rows: s.rows,
+      setSection(place, (section) => ({
+        rows: section.rows,
         loadingState: LoadingState.Error,
       }));
     }

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -312,8 +312,6 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
           rows: place === 'above' ? [...newRows, ...s.rows] : [...s.rows, ...newRows],
           loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
         }));
-      } else {
-        // do nothing, we were told to ignore the result of this fetch
       }
     } catch {
       setSection(place, (s) => ({

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -28,6 +28,7 @@ import { LogRows } from '../LogRows';
 
 import { LoadingIndicator } from './LoadingIndicator';
 import { LogContextButtons } from './LogContextButtons';
+import { Place } from './types';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -125,8 +126,6 @@ interface LogRowContextModalProps {
   runContextQuery?: () => void;
   getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
 }
-
-type Place = 'above' | 'below';
 
 type Section = {
   loadingState: LoadingState;

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -150,6 +150,8 @@ const getLoadMoreDirection = (place: Place, sortOrder: LogsSortOrder): LogRowCon
   return LogRowContextQueryDirection.Backward;
 };
 
+const PAGE_SIZE = 50;
+
 export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps> = ({
   row,
   open,
@@ -252,7 +254,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
 
     const direction = getLoadMoreDirection(place, logsSortOrder);
 
-    const result = await getRowContext(refRow, { limit: 10, direction });
+    const result = await getRowContext(refRow, { limit: PAGE_SIZE, direction });
     const newRows = dataFrameToLogsModel(result.data).rows;
 
     if (logsSortOrder === LogsSortOrder.Ascending) {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useAsync, useAsyncFn } from 'react-use';
+import { useAsync } from 'react-use';
 
 import {
   DataQueryResponse,
@@ -16,7 +16,7 @@ import {
 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery, LoadingState, TimeZone } from '@grafana/schema';
-import { Icon, Button, LoadingBar, Modal, useTheme2 } from '@grafana/ui';
+import { Icon, Button, Modal, useTheme2 } from '@grafana/ui';
 import { dataFrameToLogsModel } from 'app/core/logsModel';
 import store from 'app/core/store';
 import { SETTINGS_KEYS } from 'app/features/explore/Logs/utils/logs';
@@ -113,11 +113,6 @@ const getStyles = (theme: GrafanaTheme2) => {
   };
 };
 
-export enum LogGroupPosition {
-  Bottom = 'bottom',
-  Top = 'top',
-}
-
 interface LogRowContextModalProps {
   row: LogRowModel;
   open: boolean;
@@ -126,14 +121,34 @@ interface LogRowContextModalProps {
   getRowContext: (row: LogRowModel, options: LogRowContextOptions) => Promise<DataQueryResponse>;
 
   getRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions) => Promise<DataQuery | null>;
-  logsSortOrder?: LogsSortOrder | null;
+  logsSortOrder: LogsSortOrder;
   runContextQuery?: () => void;
   getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
 }
 
-type Source = 'none' | 'top' | 'bottom' | 'center';
+type Place = 'above' | 'below';
 
-const INITIAL_LOAD_LIMIT = 100;
+type Section = {
+  loadingState: LoadingState;
+  rows: LogRowModel[];
+};
+type Context = Record<Place, Section>;
+
+const makeEmptyContext = (): Context => ({
+  above: { loadingState: LoadingState.NotStarted, rows: [] },
+  below: { loadingState: LoadingState.NotStarted, rows: [] },
+});
+
+const getLoadMoreDirection = (place: Place, sortOrder: LogsSortOrder): LogRowContextQueryDirection => {
+  if (place === 'above' && sortOrder === LogsSortOrder.Descending) {
+    return LogRowContextQueryDirection.Forward;
+  }
+  if (place === 'below' && sortOrder === LogsSortOrder.Ascending) {
+    return LogRowContextQueryDirection.Forward;
+  }
+
+  return LogRowContextQueryDirection.Backward;
+};
 
 export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps> = ({
   row,
@@ -152,38 +167,47 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   // first.
   const preEntryElement = useRef<HTMLTableRowElement | null>(null);
 
-  const prevHeightRef = useRef<number | null>(null);
+  const prevScrollHeightRef = useRef<number | null>(null);
+  const prevClientHeightRef = useRef<number | null>(null);
 
-  const topElement = useRef<HTMLDivElement | null>(null);
-  const bottomElement = useRef<HTMLDivElement | null>(null);
+  const aboveLoadingElement = useRef<HTMLDivElement | null>(null);
+  const belowLoadingElement = useRef<HTMLDivElement | null>(null);
 
   const dispatch = useDispatch();
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const [context, setContext] = useState<{
-    after: LogRowModel[];
-    before: LogRowModel[];
-    source: Source;
-    hasTop: boolean;
-    hasBottom: boolean;
-  }>({
-    after: [],
-    before: [],
-    source: 'none',
-    hasTop: true,
-    hasBottom: true,
-  });
-  const [loadingStateTop, setLoadingStateTop] = useState(LoadingState.NotStarted);
-  const [loadingStateBottom, setLoadingStateBottom] = useState(LoadingState.NotStarted);
 
-  const [loadingWidth, setLoadingWidth] = useState(0);
+  // we need to keep both the "above" and "below" rows
+  // in the same react-state, to be able to atomically change both
+  // at the same time.
+  // we create the `setSection` convenience function to adjust any
+  // part of it easily.
+  const [context, setContext] = useState<Context>(makeEmptyContext());
+  const setSection = (place: Place, fun: (s: Section) => Section) => {
+    setContext((c) => {
+      const newContext = { ...c };
+      newContext[place] = fun(c[place]);
+      return newContext;
+    });
+  };
+
+  // this is used to "cancel" the ongoing load-more requests.
+  // whenever we want to cancel them, we increment this number.
+  // and when those requests return, we check if the number
+  // is still the same as when we started. and if it is not the same,
+  // we ignore the results.
+  //
+  // best would be to literally cancel those requests,
+  // but right now there's no way with the current logs-context API.
+  const generationRef = useRef(1);
+
   const [contextQuery, setContextQuery] = useState<DataQuery | null>(null);
   const [wrapLines, setWrapLines] = useState(
     store.getBool(SETTINGS_KEYS.logContextWrapLogMessage, store.getBool(SETTINGS_KEYS.wrapLogMessage, true))
   );
   const getFullTimeRange = useCallback(() => {
-    const { before, after } = context;
-    const allRows = sortLogRows([...before, row, ...after], LogsSortOrder.Ascending);
+    const { below, above } = context;
+    const allRows = sortLogRows([...below.rows, row, ...above.rows], LogsSortOrder.Ascending);
     const fromMs = allRows[0].timeEpochMs;
     let toMs = allRows[allRows.length - 1].timeEpochMs;
     // In case we have a lot of logs and from and to have same millisecond
@@ -205,104 +229,48 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     return range;
   }, [context, row]);
 
-  const updateContextQuery = async () => {
+  const updateContextQuery = useCallback(async () => {
     const contextQuery = getRowContextQuery ? await getRowContextQuery(row) : null;
     setContextQuery(contextQuery);
+  }, [row, getRowContextQuery]);
+
+  const updateResults = async () => {
+    await updateContextQuery();
+    setContext(makeEmptyContext());
+    generationRef.current += 1; // results from currently running loadMore calls will be ignored
   };
 
-  const [{ loading }, fetchResults] = useAsyncFn(async () => {
-    const limit = INITIAL_LOAD_LIMIT;
-    if (open && row) {
-      await updateContextQuery();
-      const rawResults = await Promise.all([
-        getRowContext(row, {
-          limit: logsSortOrder === LogsSortOrder.Descending ? limit + 1 : limit,
-          direction:
-            logsSortOrder === LogsSortOrder.Descending
-              ? LogRowContextQueryDirection.Forward
-              : LogRowContextQueryDirection.Backward,
-        }),
-        getRowContext(row, {
-          limit: logsSortOrder === LogsSortOrder.Ascending ? limit + 1 : limit,
-          direction:
-            logsSortOrder === LogsSortOrder.Ascending
-              ? LogRowContextQueryDirection.Forward
-              : LogRowContextQueryDirection.Backward,
-        }),
-      ]);
-
-      const logsModels = rawResults.map((result) => {
-        return dataFrameToLogsModel(result.data);
-      });
-
-      const afterRows = logsSortOrder === LogsSortOrder.Ascending ? logsModels[0].rows.reverse() : logsModels[0].rows;
-      const beforeRows = logsSortOrder === LogsSortOrder.Ascending ? logsModels[1].rows.reverse() : logsModels[1].rows;
-
-      setContext({
-        after: afterRows.filter((r) => {
-          return r.timeEpochNs !== row.timeEpochNs || r.entry !== row.entry;
-        }),
-        before: beforeRows.filter((r) => {
-          return r.timeEpochNs !== row.timeEpochNs || r.entry !== row.entry;
-        }),
-        source: 'center',
-        hasTop: true,
-        hasBottom: true,
-      });
-    } else {
-      setContext({ after: [], before: [], source: 'none', hasTop: true, hasBottom: true });
-    }
-  }, [row, open]);
-
-  const loadMore = async (location: 'top' | 'bottom') => {
-    const { before, after } = context;
-    const refRow = location === 'top' ? after.at(0) : before.at(-1);
+  const loadMore = async (place: Place): Promise<LogRowModel[]> => {
+    const { below, above } = context;
+    // we consider all the currently existing rows, even the original row,
+    // this way this array of rows will never be empty
+    const allRows = [...above.rows, row, ...below.rows];
+    const refRow = allRows.at(place === 'above' ? 0 : -1);
     if (refRow == null) {
-      return;
+      throw new Error('should never happen. the array always contains at least 1 item (the middle row)');
     }
 
-    const direction = location === 'top' ? LogRowContextQueryDirection.Forward : LogRowContextQueryDirection.Backward;
+    const direction = getLoadMoreDirection(place, logsSortOrder);
 
-    const result = await getRowContext(refRow, { limit: 50, direction });
+    const result = await getRowContext(refRow, { limit: 10, direction });
     const newRows = dataFrameToLogsModel(result.data).rows;
 
     if (logsSortOrder === LogsSortOrder.Ascending) {
       newRows.reverse();
     }
 
-    if (location === 'top') {
-      const uniqueNewRows = newRows.filter((r) => {
-        return r.timeEpochNs !== refRow.timeEpochNs && r.entry !== refRow.entry;
-      });
+    const out = newRows.filter((r) => {
+      return r.timeEpochNs !== refRow.timeEpochNs || r.entry !== refRow.entry;
+    });
 
-      setContext((c) => ({
-        after: [...uniqueNewRows, ...c.after],
-        before: c.before,
-        source: 'top',
-        hasTop: uniqueNewRows.length > 0,
-        hasBottom: c.hasBottom,
-      }));
-    } else {
-      const uniqueNewRows = newRows.filter((r) => {
-        return r.timeEpochNs !== refRow.timeEpochNs && r.entry !== refRow.entry;
-      });
-      setContext((c) => ({
-        after: c.after,
-        before: [...c.before, ...uniqueNewRows],
-        source: 'bottom',
-        hasTop: c.hasTop,
-        hasBottom: uniqueNewRows.length > 0,
-      }));
-    }
-
-    return newRows;
+    return out;
   };
 
   useEffect(() => {
     if (open) {
-      fetchResults();
+      updateContextQuery();
     }
-  }, [fetchResults, open]);
+  }, [updateContextQuery, open]);
 
   const [displayedFields, setDisplayedFields] = useState<string[]>([]);
 
@@ -323,6 +291,36 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     }
   };
 
+  const maybeLoadMore = async (place: Place) => {
+    const section = context[place];
+    if (section.loadingState === LoadingState.Loading) {
+      return;
+    }
+
+    setSection(place, (s) => ({
+      ...s,
+      loadingState: LoadingState.Loading,
+    }));
+
+    const currentGen = generationRef.current;
+    try {
+      const newRows = await loadMore(place);
+      if (currentGen === generationRef.current) {
+        setSection(place, (s) => ({
+          rows: place === 'above' ? [...newRows, ...s.rows] : [...s.rows, ...newRows],
+          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+        }));
+      } else {
+        // do nothing, we were told to ignore the result of this fetch
+      }
+    } catch {
+      setSection(place, (s) => ({
+        rows: s.rows,
+        loadingState: LoadingState.Error,
+      }));
+    }
+  };
+
   const onScrollHit = async (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
     for (const entry of entries) {
       // If the element is not intersecting, skip to the next one
@@ -331,54 +329,33 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       }
 
       const targetElement = entry.target;
-      let loadingState;
-      let setLoadingState;
 
-      if (targetElement === topElement.current) {
-        loadingState = loadingStateTop;
-        setLoadingState = setLoadingStateTop;
-      } else if (targetElement === bottomElement.current) {
-        loadingState = loadingStateBottom;
-        setLoadingState = setLoadingStateBottom;
-      } else {
-        continue; // Skip processing for unknown elements
-      }
-
-      if (loadingState !== LoadingState.Loading) {
-        try {
-          setLoadingState(LoadingState.Loading);
-          const rows = await loadMore(targetElement === topElement.current ? 'top' : 'bottom');
-          if (!rows || rows.length > 0) {
-            setLoadingState(LoadingState.NotStarted);
-          } else if (rows.length === 0) {
-            setLoadingState(LoadingState.Done);
-          }
-        } catch (_) {
-          setLoadingState(LoadingState.Error);
-        }
+      if (targetElement === aboveLoadingElement.current) {
+        maybeLoadMore('above');
+      } else if (targetElement === belowLoadingElement.current) {
+        maybeLoadMore('below');
       }
     }
   };
 
   useEffect(() => {
     const scroll = scrollElement.current;
-    const top = topElement.current;
-    const bottom = bottomElement.current;
+    const aboveElem = aboveLoadingElement.current;
+    const belowElem = belowLoadingElement.current;
 
     if (scroll == null) {
-      //bottom FIXME: ugly
       // should not happen, but need to make typescript happy
       return;
     }
 
     const observer = new IntersectionObserver(onScrollHit, { root: scroll });
 
-    if (top != null) {
-      observer.observe(top);
+    if (aboveElem != null) {
+      observer.observe(aboveElem);
     }
 
-    if (bottom != null) {
-      observer.observe(bottom);
+    if (belowElem != null) {
+      observer.observe(belowElem);
     }
 
     return () => {
@@ -387,43 +364,34 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   }); // on every render, why not
 
   useLayoutEffect(() => {
-    const { source } = context;
-    switch (source) {
-      case 'center':
-        preEntryElement.current?.scrollIntoView({ block: 'center' });
-        entryElement.current?.scrollIntoView({ block: 'center' });
-        break;
-      case 'top':
-        const prevHeight = prevHeightRef.current;
-        const scrollE = scrollElement.current;
-        if (scrollE != null) {
-          const currentHeight = scrollE.scrollHeight;
-          prevHeightRef.current = currentHeight;
-          if (prevHeight != null) {
-            const newScrollTop = scrollE.scrollTop + (currentHeight - prevHeight);
-            scrollE.scrollTop = newScrollTop;
-          }
-        }
-        break;
-      case 'bottom':
-        // nothing to do
-        break;
-      case 'none':
-        // nothing to do
-        break;
-      default:
-        throw new Error(`invalid source: ${source}`);
+    const scrollE = scrollElement.current;
+    if (scrollE == null) {
+      return;
     }
-  }, [context]);
 
-  useLayoutEffect(() => {
-    const width = scrollElement?.current?.parentElement?.clientWidth;
-    if (width && width > 0) {
-      setLoadingWidth(width);
+    const prevClientHeight = prevClientHeightRef.current;
+    const currentClientHeight = scrollE.clientHeight;
+    prevClientHeightRef.current = currentClientHeight;
+    if (prevClientHeight !== currentClientHeight) {
+      // height has changed, we scroll to the center
+      preEntryElement.current?.scrollIntoView({ block: 'center' });
+      entryElement.current?.scrollIntoView({ block: 'center' });
+      return;
     }
-  }, []);
+
+    const prevScrollHeight = prevScrollHeightRef.current;
+    const currentHeight = scrollE.scrollHeight;
+    prevScrollHeightRef.current = currentHeight;
+    if (prevScrollHeight != null) {
+      const newScrollTop = scrollE.scrollTop + (currentHeight - prevScrollHeight);
+      scrollE.scrollTop = newScrollTop;
+    }
+  }, [context.above.rows]);
 
   useAsync(updateContextQuery, [getRowContextQuery, row]);
+
+  const loadingStateAbove = context.above.loadingState;
+  const loadingStateBelow = context.below.loadingState;
 
   return (
     <Modal
@@ -434,34 +402,31 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       onDismiss={onClose}
     >
       {config.featureToggles.logsContextDatasourceUi && getLogRowContextUi && (
-        <div className={styles.datasourceUi}>{getLogRowContextUi(row, fetchResults)}</div>
+        <div className={styles.datasourceUi}>{getLogRowContextUi(row, updateResults)}</div>
       )}
       <div className={cx(styles.flexRow, styles.paddingBottom)}>
         <div>
           <LogContextButtons wrapLines={wrapLines} onChangeWrapLines={setWrapLines} />
         </div>
       </div>
-      <div className={loading ? '' : styles.hidden}>
-        <LoadingBar width={loadingWidth} />
-      </div>
       <div ref={scrollElement} className={styles.logRowGroups}>
         <table>
           <tbody>
             <tr>
               <td className={styles.loadingCell}>
-                {loadingStateTop !== LoadingState.Done && loadingStateTop !== LoadingState.Error && (
-                  <div ref={topElement}>
-                    <LoadingIndicator place="top" />
+                {loadingStateAbove !== LoadingState.Done && loadingStateAbove !== LoadingState.Error && (
+                  <div ref={aboveLoadingElement}>
+                    <LoadingIndicator place="above" />
                   </div>
                 )}
-                {loadingStateTop === LoadingState.Error && <div>Error loading log more logs.</div>}
-                {loadingStateTop === LoadingState.Done && <div>No more logs available.</div>}
+                {loadingStateAbove === LoadingState.Error && <div>Error loading log more logs.</div>}
+                {loadingStateAbove === LoadingState.Done && <div>No more logs available.</div>}
               </td>
             </tr>
             <tr>
               <td className={styles.noMarginBottom}>
                 <LogRows
-                  logRows={context.after}
+                  logRows={context.above.rows}
                   dedupStrategy={LogsDedupStrategy.none}
                   showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
                   showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
@@ -497,7 +462,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
               <td>
                 <>
                   <LogRows
-                    logRows={context.before}
+                    logRows={context.below.rows}
                     dedupStrategy={LogsDedupStrategy.none}
                     showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
                     showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
@@ -514,13 +479,13 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
             </tr>
             <tr>
               <td className={styles.loadingCell}>
-                {loadingStateBottom !== LoadingState.Done && loadingStateBottom !== LoadingState.Error && (
-                  <div ref={bottomElement}>
-                    <LoadingIndicator place="bottom" />
+                {loadingStateBelow !== LoadingState.Done && loadingStateBelow !== LoadingState.Error && (
+                  <div ref={belowLoadingElement}>
+                    <LoadingIndicator place="below" />
                   </div>
                 )}
-                {loadingStateBottom === LoadingState.Error && <div>Error loading log more logs.</div>}
-                {loadingStateBottom === LoadingState.Done && <div>No more logs available.</div>}
+                {loadingStateBelow === LoadingState.Error && <div>Error loading log more logs.</div>}
+                {loadingStateBelow === LoadingState.Done && <div>No more logs available.</div>}
               </td>
             </tr>
           </tbody>

--- a/public/app/features/logs/components/log-context/types.ts
+++ b/public/app/features/logs/components/log-context/types.ts
@@ -1,0 +1,1 @@
+export type Place = 'above' | 'below';

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -127,7 +127,11 @@ export class LogContextProvider {
     const query: LokiQuery = {
       expr,
       queryType: LokiQueryType.Range,
-      refId: REF_ID_STARTER_LOG_ROW_CONTEXT,
+      // refId has to be:
+      // - always different (temporarily, will be fixed later)
+      // - not increase in size
+      // because it may be called many times from logs-context
+      refId: `${REF_ID_STARTER_LOG_ROW_CONTEXT}_${Math.random().toString()}`,
       maxLines: limit,
       direction: queryDirection,
       datasource: { uid: this.datasource.uid, type: this.datasource.type },

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -127,7 +127,7 @@ export class LogContextProvider {
     const query: LokiQuery = {
       expr,
       queryType: LokiQueryType.Range,
-      refId: `${REF_ID_STARTER_LOG_ROW_CONTEXT}${row.dataFrame.refId || ''}`,
+      refId: REF_ID_STARTER_LOG_ROW_CONTEXT,
       maxLines: limit,
       direction: queryDirection,
       datasource: { uid: this.datasource.uid, type: this.datasource.type },


### PR DESCRIPTION
in the logs-context section, we allow the user to scroll to the top&bottom of the list of log lines, and trigger loading more.

how to test:
test the following scenarios, make sure it behaves correctly:
1. when there are no more logs at the top
2. when there are no more logs at the bottom
3. when there are enough logs at both the top and the bottom
4. when you adjust the loki query 