### PR TITLE
Replace prettier for docs linting with reviewdog action

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1063,14 +1063,6 @@ steps:
   image: grafana/build-container:1.7.4
   name: codespell
 - commands:
-  - yarn run prettier:checkDocs
-  depends_on:
-  - yarn-install
-  environment:
-    NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
-  name: lint-docs
-- commands:
   - mkdir -p /hugo/content/docs/grafana/latest
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
@@ -1173,14 +1165,6 @@ steps:
   - rm words_to_ignore.txt
   image: grafana/build-container:1.7.4
   name: codespell
-- commands:
-  - yarn run prettier:checkDocs
-  depends_on:
-  - yarn-install
-  environment:
-    NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
-  name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
@@ -7216,6 +7200,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: d1a589fd39357048aa2b6595181f98d17545e184121774b729553e9165464480
+hmac: 051eb4103df3f8320622e8e6fcc6acfaca3ff0f52f5ca7e1206868db93c0f689
 
 ...

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,17 @@
+name: "pr-docs"
+on:
+  pull_request:
+    paths: ["docs/sources/**"]
+jobs:
+  lint-docs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "EPMatt/reviewdog-action-prettier@v1"
+        with:
+          fail_on_error: true
+          filter_mode: "nofilter"
+          github_token: "${{ secrets.github_token }}"
+          level: "info"
+          prettier_flags: "docs/sources"
+          reporter: "github-pr-review"

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -30,7 +30,6 @@ def docs_pipelines(ver_mode, trigger):
         identify_runner_step(),
         yarn_install_step(),
         codespell_step(),
-        lint_docs(),
         build_docs_website_step(),
     ]
 
@@ -42,21 +41,6 @@ def docs_pipelines(ver_mode, trigger):
         steps = steps,
         environment = environment,
     )
-
-def lint_docs():
-    return {
-        "name": "lint-docs",
-        "image": build_image,
-        "depends_on": [
-            "yarn-install",
-        ],
-        "environment": {
-            "NODE_OPTIONS": "--max_old_space_size=8192",
-        },
-        "commands": [
-            "yarn run prettier:checkDocs",
-        ],
-    }
 
 def trigger_docs_main():
     return {


### PR DESCRIPTION
Currently drive-by fixes are blocked by needing to go through the following steps:

1. Understand the requirement of the `continuous-integration/drone/pr` check.
1. View the failures of that check in Drone.
1. Get told by `prettier` that you have not run it on specific files.
1. Clone the repository.
1. Install `yarn`.
1. Use `yarn` to install `prettier`.
1. Run `prettier`.
1. Commit the results.

With `reviewdog`, trivial `prettier` errors are reported as GitHub suggestions.
More complicated errors are reported as comments.

Replaces https://github.com/grafana/grafana/pull/69458 until I can properly test that solution.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
