### PR TITLE
Tempo: TraceQL editor - Match type of new values with values in dropdown

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -160,9 +160,9 @@ const SearchField = ({
           value={filter.value}
           onChange={(val) => {
             if (Array.isArray(val)) {
-              updateFilter({ ...filter, value: val.map((v) => v.value), valueType: val[0]?.type });
+              updateFilter({ ...filter, value: val.map((v) => v.value), valueType: val[0]?.type || uniqueOptionType });
             } else {
-              updateFilter({ ...filter, value: val?.value, valueType: val?.type });
+              updateFilter({ ...filter, value: val?.value, valueType: val?.type || uniqueOptionType });
             }
           }}
           placeholder="Select value"


### PR DESCRIPTION
**What is this feature?**

While using the TraceQL UI editor users can create new values for a tag. This PR makes sure that we match the type of those new values with the existing values in the dropdown. These values are retrieved from Tempo and are assigned a type such as string, integer, float, etc. 

**Why do we need this feature?**

Before this PR, for new values, we were generating the query using the exact text that the user wrote. This lead to issues because intuitively the user expected the value to be wrapped in quotes if the value was a string, for example. This PR guarantees that if the existing values in the dropdown are of type `string` that we add new values with type `string` as well.

**Who is this feature for?**

All users of the TraceQL UI editor of the Tempo data source. 


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
