### PR TITLE
Util: Fix panic when generating UIDs concurrently

### DIFF
--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,6 +15,25 @@ func TestAllowedCharMatchesUidPattern(t *testing.T) {
 			t.Fatalf("charset for creating new shortids contains chars not present in uid pattern")
 		}
 	}
+}
+
+// Run with "go test -race -run ^TestThreadSafe$ github.com/grafana/grafana/pkg/util"
+func TestThreadSafe(t *testing.T) {
+	// This test was used to showcase the bug, unfortunately there is
+	// no way to enable the -race flag programmatically.
+	t.Skip()
+	// Use 1000 go routines to create 100 UIDs each at roughly the same time.
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		go func() {
+			for ii := 0; ii < 100; ii++ {
+				_ = GenerateShortUID()
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
 }
 
 func TestRandomUIDs(t *testing.T) {


### PR DESCRIPTION
This pr fixes the flaky test reported in https://github.com/grafana/grafana/issues/69444.

The gist is that `math/rand` is not concurrency safe if one does not use the top-level functions of the package. I wrote a test to reproduce the issue using the `-race` flag that golang provides. The bug was fixed by using a mutex for the UID generation. This should have minimal performance implications for our use case.

```
go test -race -run ^TestThreadSafe$ github.com/grafana/grafana/pkg/util
==================
WARNING: DATA RACE
Read at 0x00c0001cd500 by goroutine 9:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:239 +0x2c
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Previous write at 0x00c0001cd500 by goroutine 14:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:239 +0x3c
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Goroutine 9 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40

Goroutine 14 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0001cd508 by goroutine 10:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:244 +0x94
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Previous write at 0x00c0001cd508 by goroutine 14:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:244 +0xa8
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Goroutine 10 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40

Goroutine 14 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0001cdaf8 by goroutine 14:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:249 +0x128
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Previous write at 0x00c0001cdaf8 by goroutine 10:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:250 +0x1b0
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Goroutine 14 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40

Goroutine 10 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40
==================
==================
WARNING: DATA RACE
Write at 0x00c0001cd900 by goroutine 14:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:250 +0x1b0
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Previous write at 0x00c0001cd900 by goroutine 18:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:250 +0x1b0
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Goroutine 14 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40

Goroutine 18 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0001cdf78 by goroutine 10:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:249 +0x164
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Previous write at 0x00c0001cdf78 by goroutine 14:
  math/rand.(*rngSource).Uint64()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:250 +0x1b0
  math/rand.(*rngSource).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1c4
  math/rand.(*Rand).Int63()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95 +0x60
  math/rand.(*Rand).Int31()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109 +0x88
  math/rand.(*Rand).Int31n()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x48
  math/rand.(*Rand).Intn()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x44
  github.com/grafana/grafana/pkg/util.GenerateShortUID()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xec
  github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x34

Goroutine 10 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40

Goroutine 14 (running) created at:
  github.com/grafana/grafana/pkg/util.TestThreadSafe()
      /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x4c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x40
==================
panic: runtime error: index out of range [-1]

goroutine 115 [running]:
math/rand.(*rngSource).Uint64(...)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:249
math/rand.(*rngSource).Int63(0xc0001cd500)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rng.go:234 +0x1ec
math/rand.(*Rand).Int63(...)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:95
math/rand.(*Rand).Int31(...)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:109
math/rand.(*Rand).Int31n(0xc000125b00, 0x6)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:144 +0x64
math/rand.(*Rand).Intn(0x0?, 0x6)
        /opt/homebrew/Cellar/go/1.20.2/libexec/src/math/rand/rand.go:182 +0x48
github.com/grafana/grafana/pkg/util.GenerateShortUID()
        /Users/jpq/projects/grafana/pkg/util/shortid_generator.go:49 +0xf0
github.com/grafana/grafana/pkg/util.TestThreadSafe.func1()
        /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:26 +0x38
created by github.com/grafana/grafana/pkg/util.TestThreadSafe
        /Users/jpq/projects/grafana/pkg/util/shortid_generator_test.go:24 +0x50
FAIL    github.com/grafana/grafana/pkg/util     0.200s
FAIL
```