### PR TITLE
Prometheus: Fix bug when adding a query in mixed datasource (#69424)

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -106,7 +106,15 @@ function setup(queryOverrides: Partial<PromQuery> = {}, app: CoreApp = CoreApp.P
   const props = {
     app,
     query: {
-      ...getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.PanelEditor),
+      ...getQueryWithDefaults(
+        {
+          refId: 'A',
+          expr: '',
+          range: true,
+          instant: false,
+        } as PromQuery,
+        CoreApp.PanelEditor
+      ),
       ...queryOverrides,
     },
     onRunQuery: jest.fn(),


### PR DESCRIPTION
Back port Prometheus bug fix #69424 
(cherry picked from commit 4fdccef7b33825b636fc8cf340db77e4036e1a95)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
