### PR TITLE
Don't display stackTraces list if passed an empty array

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -289,7 +289,7 @@ export default function SpanDetail(props: SpanDetailProps) {
             onToggle={() => warningsToggle(spanID)}
           />
         )}
-        {stackTraces && stackTraces.length && (
+        {stackTraces?.length ? (
           <AccordianText
             label="Stack trace"
             data={stackTraces}
@@ -316,7 +316,7 @@ export default function SpanDetail(props: SpanDetailProps) {
             }}
             onToggle={() => stackTracesToggle(spanID)}
           />
-        )}
+        ) : null}
         {references && references.length > 0 && (references.length > 1 || references[0].refType !== 'CHILD_OF') && (
           <AccordianReferences
             data={references}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While implementing OpenSearch traces, I noticed that if I pass an empty array for the 'span.stackTraces' field, a "0" is displayed in the UI. This removes it. Probably not relevant in most cases, but I just wanted to get rid of the unexpected result.

Before: 
<img width="600" alt="Screenshot 2023-06-02 at 2 37 40 PM" src="https://github.com/grafana/grafana/assets/16140639/d712477e-c1c8-4d4d-b399-9ffb7d7fc823">

After: 
<img width="600" alt="Screenshot 2023-06-02 at 4 16 26 PM" src="https://github.com/grafana/grafana/assets/16140639/0a8f6bc8-6a4b-48a8-a7f5-5d8df0fc1c10">

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
