### PR TITLE
QueryField: Set default value for onBlur prop

### DIFF
--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -241,6 +241,12 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
 
 export const QueryField = withTheme2(UnThemedQueryField);
 
+// By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
+// And slate will claim the focus, making it impossible to leave the field.
+QueryField.defaultProps = {
+  onBlur: () => {},
+};
+
 const getStyles = (theme: GrafanaTheme2) => {
   const focusStyles = getFocusStyles(theme);
   return {

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -102,9 +102,6 @@ export const CloudWatchLogsQueryField = (props: CloudWatchLogsQueryFieldProps) =
             cleanText={cleanText}
             placeholder="Enter a CloudWatch Logs Insights query (run with Shift+Enter)"
             portalOrigin="cloudwatch"
-            // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
-            // And slate will claim the focus, making it impossible to leave the field.
-            onBlur={() => {}}
           />
         </div>
         {ExtraFieldElement}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
@@ -59,7 +59,6 @@ export const FiltersSettingsEditor = ({ bucketAgg }: Props) => {
                 <QueryField
                   placeholder="Lucene Query"
                   portalOrigin="elasticsearch"
-                  onBlur={() => {}}
                   onChange={(query) => dispatch(changeFilter({ index, filter: { ...filter, query } }))}
                   query={filter.query}
                 />

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -82,15 +82,7 @@ export const ElasticSearchQueryField = ({ value, onChange }: { value?: string; o
 
   return (
     <div className={styles.queryItem}>
-      <QueryField
-        query={value}
-        // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
-        // And slate will claim the focus, making it impossible to leave the field.
-        onBlur={() => {}}
-        onChange={onChange}
-        placeholder="Enter a lucene query"
-        portalOrigin="elasticsearch"
-      />
+      <QueryField query={value} onChange={onChange} placeholder="Enter a lucene query" portalOrigin="elasticsearch" />
     </div>
   );
 };

--- a/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
@@ -43,7 +43,6 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
                 query={query.query}
                 onChange={onChangeQuery}
                 onRunQuery={onRunQuery}
-                onBlur={() => {}}
                 placeholder={'Enter a Trace ID (run with Shift+Enter)'}
                 portalOrigin="jaeger"
               />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

If onBlur isn't defined for QueryField component, clicking out of the field is impossible and the user needs to refresh the page.

![221133867-23aa2a34-5df9-4e8f-9bf4-6e4db4de1751](https://github.com/grafana/grafana/assets/16140639/7c9e41a4-0c05-4f37-b88a-1d2004a59d13)
(documented in [this ticket](https://github.com/grafana/grafana/issues/63702))

I think we determined the cause was somewhere in _slate-react_ component. I didn't want to debug that, so I just define a default function for onBlur. This should prevent the same thing from happening other plugins that might use this field. 
I also moved the comment about this to the QueryField component and removed all instances where onBlur was (now unnecessarily) passed an empty function. 
Haven't tested other datasources apart from Cloudwatch cause I don't have them set up, but I really don't expect it to change anything. I would appreciate a quick test for ElasticSearch and Jaeger! 🙏🏻

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/63702
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
