### PR TITLE
[v10.0.x] Alerting: Fix provisioned templates being ignored by alertmanager

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -260,13 +260,13 @@ func (am *Alertmanager) applyConfig(cfg *apimodels.PostableUserConfig, rawConfig
 		cfg.TemplateFiles = map[string]string{}
 	}
 	cfg.TemplateFiles["__default__.tmpl"] = alertingTemplates.DefaultTemplateString
-	cfg.AlertmanagerConfig.Templates = append(cfg.AlertmanagerConfig.Templates, "__default__.tmpl")
 
 	// next, we need to make sure we persist the templates to disk.
-	_, templatesChanged, err := PersistTemplates(cfg, am.Base.WorkingDirectory())
+	paths, templatesChanged, err := PersistTemplates(cfg, am.Base.WorkingDirectory())
 	if err != nil {
 		return false, err
 	}
+	cfg.AlertmanagerConfig.Templates = paths
 
 	// If neither the configuration nor templates have changed, we've got nothing to do.
 	if !amConfigChanged && !templatesChanged {

--- a/pkg/services/ngalert/notifier/config.go
+++ b/pkg/services/ngalert/notifier/config.go
@@ -34,7 +34,7 @@ func PersistTemplates(cfg *api.PostableUserConfig, path string) ([]string, bool,
 		}
 
 		file := filepath.Join(path, name)
-		pathSet[file] = struct{}{}
+		pathSet[name] = struct{}{}
 
 		// Check if the template file already exists and if it has changed
 		// We can safely ignore gosec here as we've previously checked the filename is clean
@@ -62,7 +62,7 @@ func PersistTemplates(cfg *api.PostableUserConfig, path string) ([]string, bool,
 	}
 	for _, existingFile := range existingFiles {
 		p := filepath.Join(path, existingFile.Name())
-		_, ok := pathSet[p]
+		_, ok := pathSet[existingFile.Name()]
 		if !ok {
 			templatesChanged = true
 			err := os.Remove(p)

--- a/pkg/services/ngalert/notifier/config_test.go
+++ b/pkg/services/ngalert/notifier/config_test.go
@@ -94,11 +94,6 @@ func TestPersistTemplates(t *testing.T) {
 				files[f.Name()] = string(content)
 			}
 
-			// Given we use a temporary directory in tests, we need to prepend the expected paths with it.
-			for i, p := range tt.expectedPaths {
-				tt.expectedPaths[i] = filepath.Join(dir, p)
-			}
-
 			require.Equal(t, tt.expectedError, persistErr)
 			require.ElementsMatch(t, tt.expectedPaths, paths)
 			require.Equal(t, tt.expectedChange, changed)

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -53,6 +53,11 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 		revision.cfg.TemplateFiles = map[string]string{}
 	}
 	revision.cfg.TemplateFiles[tmpl.Name] = tmpl.Template
+	tmpls := make([]string, 0, len(revision.cfg.TemplateFiles))
+	for name := range revision.cfg.TemplateFiles {
+		tmpls = append(tmpls, name)
+	}
+	revision.cfg.AlertmanagerConfig.Templates = tmpls
 
 	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
 	if err != nil {


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/c16f1f5e99def9e0136170605368ab33e31e80a1 from https://github.com/grafana/grafana/pull/69485

Manual backport, caused by innocuous merge conflict.