### PR TITLE
devenv: add healthcheck to loki block

### DIFF
--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -5,6 +5,11 @@
       - ./docker/blocks/loki/loki-config.yaml:/etc/loki/loki-config.yaml
     ports:
       - "3100:3100"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   loki-data:
     build: docker/blocks/loki/data


### PR DESCRIPTION
This prevents `loki-data` from failing and restarting while the ingester is getting ready