### PR TITLE
Elasticsearch: Fix Typescript errors

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/useDescription.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/useDescription.ts
@@ -49,8 +49,8 @@ export const useDescription = (bucketAgg: BucketAggregation): string => {
     }
 
     case 'histogram': {
-      const interval = bucketAgg.settings?.interval || 1000;
-      const minDocCount = bucketAgg.settings?.min_doc_count || 1;
+      const interval = bucketAgg.settings?.interval || '1000';
+      const minDocCount = parseInt(bucketAgg.settings?.min_doc_count || '1', 10);
 
       return `Interval: ${interval}${minDocCount > 0 ? `, Min Doc Count: ${minDocCount}` : ''}`;
     }
@@ -67,8 +67,8 @@ export const useDescription = (bucketAgg: BucketAggregation): string => {
 
     case 'date_histogram': {
       const interval = bucketAgg.settings?.interval || 'auto';
-      const minDocCount = bucketAgg.settings?.min_doc_count || 0;
-      const trimEdges = bucketAgg.settings?.trimEdges || 0;
+      const minDocCount = parseInt(bucketAgg.settings?.min_doc_count || '0', 10);
+      const trimEdges = parseInt(bucketAgg.settings?.trimEdges || '0', 10);
 
       let description = `Interval: ${interval}`;
 


### PR DESCRIPTION
**What is this PR?**

This PR fixes the errors that comes when we bump Typescript to version 5. This is the https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#forbidden-implicit-coercions-in-relational-operators change.

Part of #69153

