### PR TITLE
Drag&Drop: Dynamically load sheets module

### DIFF
--- a/public/app/features/dataframe-import/utils.ts
+++ b/public/app/features/dataframe-import/utils.ts
@@ -2,7 +2,6 @@ import { Accept } from 'react-dropzone';
 import { Observable } from 'rxjs';
 
 import { toDataFrame } from '@grafana/data';
-import { readSpreadsheet } from 'app/core/utils/sheet';
 
 import { FileImportResult } from './types';
 
@@ -27,24 +26,30 @@ export function formatFileTypes(acceptedFiles: Accept) {
 export function filesToDataframes(files: File[]): Observable<FileImportResult> {
   return new Observable<FileImportResult>((subscriber) => {
     let completedFiles = 0;
-    files.forEach((file) => {
-      const reader = new FileReader();
-      reader.readAsArrayBuffer(file);
-      reader.onload = () => {
-        const result = reader.result;
-        if (result && result instanceof ArrayBuffer) {
-          if (file.type === 'application/json') {
-            const decoder = new TextDecoder('utf-8');
-            const json = JSON.parse(decoder.decode(result));
-            subscriber.next({ dataFrames: [toDataFrame(json)], file: file });
-          } else {
-            subscriber.next({ dataFrames: readSpreadsheet(result), file: file });
-          }
-          if (++completedFiles >= files.length) {
-            subscriber.complete();
-          }
-        }
-      };
-    });
+    import('app/core/utils/sheet')
+      .then((sheet) => {
+        files.forEach((file) => {
+          const reader = new FileReader();
+          reader.readAsArrayBuffer(file);
+          reader.onload = () => {
+            const result = reader.result;
+            if (result && result instanceof ArrayBuffer) {
+              if (file.type === 'application/json') {
+                const decoder = new TextDecoder('utf-8');
+                const json = JSON.parse(decoder.decode(result));
+                subscriber.next({ dataFrames: [toDataFrame(json)], file: file });
+              } else {
+                subscriber.next({ dataFrames: sheet.readSpreadsheet(result), file: file });
+              }
+              if (++completedFiles >= files.length) {
+                subscriber.complete();
+              }
+            }
+          };
+        });
+      })
+      .catch(() => {
+        throw 'Failed to load sheets module';
+      });
   });
 }


### PR DESCRIPTION
**What is this feature?**

This dynamically loads the sheets module to avoid loading the quite heavy xlsx library up front.

**Why do we need this feature?**

Makes the initial load of Grafana faster.

**Which issue(s) does this PR fix?**:

Fixes #69463

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
