### PR TITLE
Nested folders: Improve loading states

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -94,6 +94,7 @@
     "react-hook-form": "7.5.3",
     "react-i18next": "^12.0.0",
     "react-inlinesvg": "3.0.2",
+    "react-loading-skeleton": "^3.3.1",
     "react-popper": "2.3.0",
     "react-popper-tooltip": "4.4.2",
     "react-router-dom": "5.3.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -94,7 +94,7 @@
     "react-hook-form": "7.5.3",
     "react-i18next": "^12.0.0",
     "react-inlinesvg": "3.0.2",
-    "react-loading-skeleton": "^3.3.1",
+    "react-loading-skeleton": "3.3.1",
     "react-popper": "2.3.0",
     "react-popper-tooltip": "4.4.2",
     "react-router-dom": "5.3.3",

--- a/packages/grafana-ui/src/components/Tags/Tag.tsx
+++ b/packages/grafana-ui/src/components/Tags/Tag.tsx
@@ -1,9 +1,10 @@
 import { cx, css } from '@emotion/css';
 import React, { forwardRef, HTMLAttributes } from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { useTheme2 } from '../../themes';
+import { useStyles2, useTheme2 } from '../../themes';
 import { IconName } from '../../types/icon';
 import { getTagColor, getTagColorsFromName } from '../../utils';
 import { Icon } from '../Icon/Icon';
@@ -22,7 +23,7 @@ export interface Props extends Omit<HTMLAttributes<HTMLElement>, 'onClick'> {
   onClick?: OnTagClick;
 }
 
-export const Tag = forwardRef<HTMLElement, Props>(({ name, onClick, icon, className, colorIndex, ...rest }, ref) => {
+const TagComponent = forwardRef<HTMLElement, Props>(({ name, onClick, icon, className, colorIndex, ...rest }, ref) => {
   const theme = useTheme2();
   const styles = getTagStyles(theme, name, colorIndex);
 
@@ -47,8 +48,26 @@ export const Tag = forwardRef<HTMLElement, Props>(({ name, onClick, icon, classN
     </span>
   );
 });
+TagComponent.displayName = 'Tag';
 
-Tag.displayName = 'Tag';
+const TagSkeleton = () => {
+  const styles = useStyles2(getSkeletonStyles);
+  return <Skeleton width={60} height={22} containerClassName={styles.container} />;
+};
+
+interface TagWithSkeleton extends React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLElement>> {
+  Skeleton: typeof TagSkeleton;
+}
+
+export const Tag: TagWithSkeleton = Object.assign(TagComponent, {
+  Skeleton: TagSkeleton,
+});
+
+const getSkeletonStyles = () => ({
+  container: css({
+    lineHeight: 1,
+  }),
+});
 
 const getTagStyles = (theme: GrafanaTheme2, name: string, colorIndex?: number) => {
   let colors;

--- a/packages/grafana-ui/src/components/Tags/TagList.tsx
+++ b/packages/grafana-ui/src/components/Tags/TagList.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, memo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { useTheme2 } from '../../themes';
+import { useStyles2, useTheme2 } from '../../themes';
 import { IconName } from '../../types/icon';
 
 import { OnTagClick, Tag } from './Tag';
@@ -23,7 +23,7 @@ export interface Props {
   icon?: IconName;
 }
 
-export const TagList = memo(
+const TagListComponent = memo(
   forwardRef<HTMLUListElement, Props>(({ displayMax, tags, icon, onClick, className, getAriaLabel }, ref) => {
     const theme = useTheme2();
     const styles = getStyles(theme, Boolean(displayMax && displayMax > 0));
@@ -43,8 +43,32 @@ export const TagList = memo(
     );
   })
 );
+TagListComponent.displayName = 'TagList';
 
-TagList.displayName = 'TagList';
+const TagListSkeleton = () => {
+  const styles = useStyles2(getSkeletonStyles);
+  return (
+    <div className={styles.container}>
+      <Tag.Skeleton />
+      <Tag.Skeleton />
+    </div>
+  );
+};
+
+interface TagListWithSkeleton extends React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLUListElement>> {
+  Skeleton: typeof TagListSkeleton;
+}
+
+export const TagList: TagListWithSkeleton = Object.assign(TagListComponent, {
+  Skeleton: TagListSkeleton,
+});
+
+const getSkeletonStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+  }),
+});
 
 const getStyles = (theme: GrafanaTheme2, isTruncated: boolean) => {
   return {

--- a/public/app/core/components/Page/EditableTitle.tsx
+++ b/public/app/core/components/Page/EditableTitle.tsx
@@ -13,7 +13,7 @@ export interface Props {
 
 export const EditableTitle = ({ value, onEdit }: Props) => {
   const styles = useStyles2(getStyles);
-  const [localValue, setLocalValue] = useState<string>();
+  const [localValue, setLocalValue] = useState(value);
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
-import { Spinner } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { DashboardViewItem } from 'app/features/search/types';
 import { useDispatch } from 'app/types';
@@ -44,10 +43,6 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
     },
     [dispatch]
   );
-
-  useEffect(() => {
-    dispatch(fetchNextChildrenPage({ parentUID: folderUID, pageSize: ROOT_PAGE_SIZE }));
-  }, [handleFolderClick, dispatch, folderUID]);
 
   const handleItemSelectionChange = useCallback(
     (item: DashboardViewItem, isSelected: boolean) => {
@@ -115,10 +110,6 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
   );
 
   const handleLoadMore = useLoadNextChildrenPage(folderUID);
-
-  if (status === 'pending') {
-    return <Spinner />;
-  }
 
   if (status === 'fulfilled' && flatTree.length === 0) {
     return (

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -1,7 +1,9 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Checkbox } from '@grafana/ui';
+import { Checkbox, useStyles2 } from '@grafana/ui';
 
 import { DashboardsTreeCellProps, SelectionState } from '../types';
 
@@ -10,10 +12,19 @@ export default function CheckboxCell({
   isSelected,
   onItemSelectionChange,
 }: DashboardsTreeCellProps) {
+  const styles = useStyles2(getStyles);
   const item = row.item;
 
-  if (item.kind === 'ui' || !isSelected) {
-    return null;
+  if (!isSelected) {
+    return <span className={styles.checkboxSpacer} />;
+  }
+
+  if (item.kind === 'ui') {
+    if (item.uiKind === 'pagination-placeholder') {
+      return <Checkbox disabled />;
+    } else {
+      return <span className={styles.checkboxSpacer} />;
+    }
   }
 
   const state = isSelected(item);
@@ -27,3 +38,10 @@ export default function CheckboxCell({
     />
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  // Should be the same size as the <IconButton /> so Dashboard name is aligned to Folder name siblings
+  checkboxSpacer: css({
+    paddingLeft: theme.spacing(2),
+  }),
+});

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -21,7 +21,7 @@ export default function CheckboxCell({
 
   if (item.kind === 'ui') {
     if (item.uiKind === 'pagination-placeholder') {
-      return <Checkbox disabled />;
+      return <Checkbox disabled value={false} />;
     } else {
       return <span className={styles.checkboxSpacer} />;
     }

--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -103,10 +103,10 @@ describe('browse-dashboards DashboardsTree', () => {
         requestLoadMore={requestLoadMore}
       />
     );
-    const folderButton = screen.getByLabelText('Collapse folder');
+    const folderButton = screen.getByLabelText('Expand folder');
     await userEvent.click(folderButton);
 
-    expect(handler).toHaveBeenCalledWith(folder.item.uid, false);
+    expect(handler).toHaveBeenCalledWith(folder.item.uid, true);
   });
 
   it('renders empty folder indicators', () => {

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -76,7 +76,7 @@ export function DashboardsTree({
     const nameColumn: DashboardsTreeColumn = {
       id: 'name',
       width: 3,
-      Header: <span style={{ paddingLeft: 20 }}>Name</span>,
+      Header: <span style={{ paddingLeft: 24 }}>Name</span>,
       Cell: (props: DashboardsTreeCellProps) => <NameCell {...props} onFolderClick={onFolderClick} />,
     };
 

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -67,7 +67,9 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
               className={styles.chevron}
               ref={chevronRef}
               onClick={() => {
-                setShouldRestoreFocus(true);
+                if (isOpen && !childrenByParentUID[item.uid]) {
+                  setShouldRestoreFocus(true);
+                }
                 onFolderClick(item.uid, !isOpen);
               }}
               name={isOpen ? 'angle-down' : 'angle-right'}

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -73,7 +73,7 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
                 onFolderClick(item.uid, !isOpen);
               }}
               name={isOpen ? 'angle-down' : 'angle-right'}
-              tooltip={isOpen ? 'Collapse folder' : 'Expand folder'}
+              ariaLabel={isOpen ? 'Collapse folder' : 'Expand folder'}
             />
           )}
         </>

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -44,11 +44,19 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
 
   // we change the icon to a spinner here instead of actually using the <Spinner /> component
   // conditionally rendering <Spinner /> here would lose focus on the button and break keyboard a11y
-  const getChevronIcon = () => {
+  const getIcon = () => {
     if (isOpen) {
       return !childrenByParentUID[item.uid] ? 'fa fa-spinner' : 'angle-down';
     } else {
       return 'angle-right';
+    }
+  };
+
+  const getTooltip = () => {
+    if (isOpen) {
+      return !childrenByParentUID[item.uid] ? 'Fetching folder contents...' : 'Collapse folder';
+    } else {
+      return 'Expand folder';
     }
   };
 
@@ -61,8 +69,8 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
           size={CHEVRON_SIZE}
           className={styles.button}
           onClick={isOpen && !childrenByParentUID[item.uid] ? undefined : () => onFolderClick(item.uid, !isOpen)}
-          name={getChevronIcon()}
-          ariaLabel={isOpen ? 'Collapse folder' : 'Expand folder'}
+          name={getIcon()}
+          tooltip={getTooltip()}
         />
       ) : (
         <span className={styles.folderButtonSpacer} />

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -56,19 +56,17 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
     <>
       <Indent level={level} />
 
-      <div className={styles.buttonContainer}>
-        {item.kind === 'folder' ? (
-          <IconButton
-            size={CHEVRON_SIZE}
-            className={styles.button}
-            onClick={isOpen && !childrenByParentUID[item.uid] ? undefined : () => onFolderClick(item.uid, !isOpen)}
-            name={getChevronIcon()}
-            ariaLabel={isOpen ? 'Collapse folder' : 'Expand folder'}
-          />
-        ) : (
-          <span className={styles.folderButtonSpacer} />
-        )}
-      </div>
+      {item.kind === 'folder' ? (
+        <IconButton
+          size={CHEVRON_SIZE}
+          className={styles.button}
+          onClick={isOpen && !childrenByParentUID[item.uid] ? undefined : () => onFolderClick(item.uid, !isOpen)}
+          name={getChevronIcon()}
+          ariaLabel={isOpen ? 'Collapse folder' : 'Expand folder'}
+        />
+      ) : (
+        <span className={styles.folderButtonSpacer} />
+      )}
       <Span variant="body" truncate>
         {item.url ? (
           <Link href={item.url} className={styles.link}>
@@ -86,14 +84,8 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     button: css({
       height: getSvgSize(CHEVRON_SIZE),
+      marginRight: theme.spacing(1),
       width: getSvgSize(CHEVRON_SIZE),
-    }),
-    buttonContainer: css({
-      alignItems: 'center',
-      display: 'flex',
-      justifyContent: 'center',
-      height: getSvgSize(CHEVRON_SIZE),
-      marginRight: theme.spacing(0.5),
     }),
     emptyText: css({
       // needed for text to truncate correctly
@@ -101,7 +93,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     // Should be the same size as the <IconButton /> so Dashboard name is aligned to Folder name siblings
     folderButtonSpacer: css({
-      paddingLeft: `calc(${getSvgSize(CHEVRON_SIZE)}px + ${theme.spacing(0.5)})`,
+      paddingLeft: `calc(${getSvgSize(CHEVRON_SIZE)}px + ${theme.spacing(1)})`,
     }),
     link: css({
       '&:hover': {

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -67,7 +67,7 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
               className={styles.chevron}
               ref={chevronRef}
               onClick={() => {
-                if (isOpen && !childrenByParentUID[item.uid]) {
+                if (!isOpen && !childrenByParentUID[item.uid]) {
                   setShouldRestoreFocus(true);
                 }
                 onFolderClick(item.uid, !isOpen);

--- a/public/app/features/browse-dashboards/components/TagsCell.tsx
+++ b/public/app/features/browse-dashboards/components/TagsCell.tsx
@@ -10,7 +10,16 @@ import { DashboardsTreeItem } from '../types';
 export function TagsCell({ row: { original: data } }: CellProps<DashboardsTreeItem, unknown>) {
   const styles = useStyles2(getStyles);
   const item = data.item;
-  if (item.kind === 'ui' || !item.tags) {
+
+  if (item.kind === 'ui') {
+    if (item.uiKind === 'pagination-placeholder') {
+      return <TagList.Skeleton />;
+    } else {
+      return null;
+    }
+  }
+
+  if (!item.tags) {
     return null;
   }
 
@@ -22,6 +31,7 @@ function getStyles(theme: GrafanaTheme2) {
     // TagList is annoying and has weird default alignment
     tagList: css({
       justifyContent: 'flex-start',
+      flexWrap: 'nowrap',
     }),
   };
 }

--- a/public/app/features/browse-dashboards/components/TypeCell.tsx
+++ b/public/app/features/browse-dashboards/components/TypeCell.tsx
@@ -1,35 +1,61 @@
+import { css } from '@emotion/css';
 import React from 'react';
+import Skeleton from 'react-loading-skeleton';
 import { CellProps } from 'react-table';
 
-import { Icon } from '@grafana/ui';
-import { TextModifier } from '@grafana/ui/src/unstable';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { Span } from '@grafana/ui/src/unstable';
 import { getIconForKind } from 'app/features/search/service/utils';
 
 import { DashboardsTreeItem } from '../types';
 
 export function TypeCell({ row: { original: data } }: CellProps<DashboardsTreeItem, unknown>) {
   const iconName = getIconForKind(data.item.kind);
+  const styles = useStyles2(getStyles);
 
   switch (data.item.kind) {
     case 'dashboard':
       return (
-        <TextModifier color="secondary">
-          <Icon name={iconName} /> Dashboard
-        </TextModifier>
+        <div className={styles.container}>
+          <Icon name={iconName} />
+          <Span variant="body" color="secondary" truncate>
+            Dashboard
+          </Span>
+        </div>
       );
     case 'folder':
       return (
-        <TextModifier color="secondary">
-          <Icon name={iconName} /> Folder
-        </TextModifier>
+        <div className={styles.container}>
+          <Icon name={iconName} />
+          <Span variant="body" color="secondary" truncate>
+            Folder
+          </Span>
+        </div>
       );
     case 'panel':
       return (
-        <TextModifier color="secondary">
-          <Icon name={iconName} /> Panel
-        </TextModifier>
+        <div className={styles.container}>
+          <Icon name={iconName} />
+          <Span variant="body" color="secondary" truncate>
+            Panel
+          </Span>
+        </div>
       );
+    case 'ui':
+      return data.item.uiKind === 'empty-folder' ? null : <Skeleton width={100} />;
     default:
       return null;
   }
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    alignItems: 'center',
+    display: 'flex',
+    flexWrap: 'nowrap',
+    gap: theme.spacing(0.5),
+    // needed for text to truncate correctly
+    overflow: 'hidden',
+  }),
+});

--- a/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
@@ -60,7 +60,7 @@ export function wellFormedFolder(
       ...itemPartial,
     },
     level: 0,
-    isOpen: true,
+    isOpen: false,
     ...partial,
   };
 }

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -143,7 +143,7 @@ function createFlatTree(
 
   let children = (items || []).flatMap((item) => mapItem(item, folderUID, level));
 
-  if (level === 0 && collection && !collection.isFullyLoaded) {
+  if (level === 0 && (!collection || !collection.isFullyLoaded)) {
     children = children.concat(getPaginationPlaceholders(ROOT_PAGE_SIZE, folderUID, level));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3714,6 +3714,7 @@ __metadata:
     react-hook-form: 7.5.3
     react-i18next: ^12.0.0
     react-inlinesvg: 3.0.2
+    react-loading-skeleton: ^3.3.1
     react-popper: 2.3.0
     react-popper-tooltip: 4.4.2
     react-router-dom: 5.3.3
@@ -26566,7 +26567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-loading-skeleton@npm:3.3.1":
+"react-loading-skeleton@npm:3.3.1, react-loading-skeleton@npm:^3.3.1":
   version: 3.3.1
   resolution: "react-loading-skeleton@npm:3.3.1"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3714,7 +3714,7 @@ __metadata:
     react-hook-form: 7.5.3
     react-i18next: ^12.0.0
     react-inlinesvg: 3.0.2
-    react-loading-skeleton: ^3.3.1
+    react-loading-skeleton: 3.3.1
     react-popper: 2.3.0
     react-popper-tooltip: 4.4.2
     react-router-dom: 5.3.3
@@ -26567,7 +26567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-loading-skeleton@npm:3.3.1, react-loading-skeleton@npm:^3.3.1":
+"react-loading-skeleton@npm:3.3.1":
   version: 3.3.1
   resolution: "react-loading-skeleton@npm:3.3.1"
   peerDependencies:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds skeleton versions of `Tag` and `TagList`
  - not sure the best structure for this 🤔 
  - currently they're added to the component namespace, e.g. `<Tag.Skeleton />`
  - this works nicely most of the time, but requires a bit of extra typescript when using `forwardRef` 🤮 
- adds a skeleton loading state on initial page load + further page loads when scrolling
- adds a spinner loading state when expanding a folder 
- fixes some css so the `type`/`tags` columns never wrap (as they did on mobile)

skeleton loading state: 
![image](https://github.com/grafana/grafana/assets/20999846/eac773f3-4186-493b-a420-49b91dd6835c)

spinner loading state when expanding:
![image](https://github.com/grafana/grafana/assets/20999846/10e8a3c8-c67d-461f-9d3c-c5303f37cc67)


**Why do we need this feature?**

- so it's clear what's happening when loading is taking place

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #69136 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
