### PR TITLE
Explore: Unified Node Graph panel

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2567,6 +2567,9 @@ exports[`better eslint`] = {
     "public/app/features/explore/Logs/LogsMetaRow.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/features/explore/NodeGraph/NodeGraphContainer.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/explore/QueryRows.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -147,7 +147,7 @@ export const Collapse = ({
   const headerClass = collapsible ? cx([style.header]) : cx([style.headerCollapsed]);
 
   return (
-    <div className={panelClass}>
+    <div className={panelClass} data-testid="collapse-container">
       <button type="button" className={cx(buttonStyles, headerClass)} onClick={onClickToggle}>
         {collapsible && <Icon className={style.icon} name={isOpen ? 'angle-down' : 'angle-right'} />}
         <div className={cx([style.headerLabel])}>{label}</div>

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -104,7 +104,7 @@ export interface Props {
   /** Additional class name for the root element */
   className?: string;
   /** Additional class name for the colapse body */
-  colapseBodyClassName?: string;
+  collapseBodyClassName?: string;
 }
 
 export const ControlledCollapse = ({ isOpen, onToggle, ...otherProps }: React.PropsWithChildren<Props>) => {
@@ -132,7 +132,7 @@ export const Collapse = ({
   onToggle,
   className,
   children,
-  colapseBodyClassName,
+  collapseBodyClassName,
 }: React.PropsWithChildren<Props>) => {
   const buttonStyles = useStyles2(clearButtonStyles);
   const style = useStyles2(getStyles);
@@ -153,7 +153,7 @@ export const Collapse = ({
         <div className={cx([style.headerLabel])}>{label}</div>
       </button>
       {isOpen && (
-        <div className={cx([style.collapseBody, colapseBodyClassName])}>
+        <div className={cx([style.collapseBody, collapseBodyClassName])}>
           <div className={loaderClass} />
           <div className={style.bodyContentWrapper}>{children}</div>
         </div>

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -103,6 +103,8 @@ export interface Props {
   onToggle?: (isOpen: boolean) => void;
   /** Additional class name for the root element */
   className?: string;
+  /** Additional class name for the colapse body */
+  colapseBodyClassName?: string;
 }
 
 export const ControlledCollapse = ({ isOpen, onToggle, ...otherProps }: React.PropsWithChildren<Props>) => {
@@ -130,6 +132,7 @@ export const Collapse = ({
   onToggle,
   className,
   children,
+  colapseBodyClassName,
 }: React.PropsWithChildren<Props>) => {
   const buttonStyles = useStyles2(clearButtonStyles);
   const style = useStyles2(getStyles);
@@ -150,7 +153,7 @@ export const Collapse = ({
         <div className={cx([style.headerLabel])}>{label}</div>
       </button>
       {isOpen && (
-        <div className={cx([style.collapseBody])}>
+        <div className={cx([style.collapseBody, colapseBodyClassName])}>
           <div className={loaderClass} />
           <div className={style.bodyContentWrapper}>{children}</div>
         </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -124,3 +124,9 @@ it('renders streaming indicator in the panel header if loadingState is streaming
 
   expect(screen.getByTestId('panel-streaming')).toBeInTheDocument();
 });
+
+it('renders collapsed component if collapsible is true', () => {
+  setup({ collapsible: true });
+
+  expect(screen.getByTestId('collapse-container')).toBeInTheDocument();
+});

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -126,7 +126,7 @@ export function PanelChrome({
 
   const testid = title ? selectors.components.Panels.Panel.title(title) : 'Panel';
 
-  const [open, toggleOpen] = useToggle(isOpen ? true : false);
+  const [open, toggleOpen] = useToggle(isOpen ?? true);
 
   const toggle = () => {
     toggleOpen();
@@ -134,9 +134,6 @@ export function PanelChrome({
   };
 
   const headerContent = (
-    // TODO: figure out how to render this inline with the Collapse header
-    // We need to figure out where we want to display actions
-    // Some components like Graph have actions in top right corner and it that case we want them to be in line with the title
     <>
       {title && !collapsible && (
         <h6 title={title} className={styles.title}>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -135,7 +135,7 @@ export function PanelChrome({
 
   const headerContent = (
     <>
-      {title && !collapsible && (
+      {title && (
         <h6 title={title} className={styles.title}>
           {title}
         </h6>
@@ -194,7 +194,7 @@ export function PanelChrome({
         </>
       )}
 
-      {hasHeader && (
+      {hasHeader && !collapsible && (
         <div className={cx(styles.headerContainer, dragClass)} style={headerStyles} data-testid="header-container">
           {statusMessage && (
             <div className={dragClassCancel}>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -223,7 +223,7 @@ export function PanelChrome({
   );
 
   return collapsible ? (
-    <Collapse label={title} collapsible isOpen={open} onToggle={() => toggle()} colapseBodyClassName={styles.collapse}>
+    <Collapse label={title} collapsible isOpen={open} onToggle={() => toggle()} collapseBodyClassName={styles.collapse}>
       {chromeContent}
     </Collapse>
   ) : (

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -55,7 +55,7 @@ export interface PanelChromeProps {
   leftItems?: ReactNode[];
   actions?: ReactNode;
   collapsible?: boolean;
-  collapsed?: boolean;
+  isOpen?: boolean;
   displayMode?: 'default' | 'transparent';
   onCancelQuery?: () => void;
   /**
@@ -80,7 +80,7 @@ export function PanelChrome({
   title = '',
   description = '',
   collapsible = false,
-  collapsed = false,
+  isOpen,
   displayMode = collapsible ? 'transparent' : 'default',
   onToggle,
   titleItems,
@@ -126,7 +126,7 @@ export function PanelChrome({
 
   const testid = title ? selectors.components.Panels.Panel.title(title) : 'Panel';
 
-  const [open, toggleOpen] = useToggle(collapsed ? false : true);
+  const [open, toggleOpen] = useToggle(isOpen ? true : false);
 
   const toggle = () => {
     toggleOpen();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -100,7 +100,7 @@ export function PanelChrome({
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
 
-  const hasHeader = !hoverHeader;
+  const hasHeader = !hoverHeader && !collapsible;
 
   // hover menu is only shown on hover when not on touch devices
   const showOnHoverClass = 'show-on-hover';
@@ -194,7 +194,7 @@ export function PanelChrome({
         </>
       )}
 
-      {hasHeader && !collapsible && (
+      {hasHeader && (
         <div className={cx(styles.headerContainer, dragClass)} style={headerStyles} data-testid="header-container">
           {statusMessage && (
             <div className={dragClassCancel}>

--- a/public/app/features/explore/NodeGraph/NodeGraphContainer.test.tsx
+++ b/public/app/features/explore/NodeGraph/NodeGraphContainer.test.tsx
@@ -34,7 +34,7 @@ describe('NodeGraphContainer', () => {
       />
     );
 
-    expect(container.firstChild?.childNodes.length).toBe(2);
+    expect(container.firstChild?.firstChild?.childNodes.length).toBe(3);
     expect(container.querySelector('svg')).toBeInTheDocument();
     await screen.findByLabelText(/Node: tempo-querier/);
   });

--- a/public/app/features/explore/NodeGraph/NodeGraphContainer.test.tsx
+++ b/public/app/features/explore/NodeGraph/NodeGraphContainer.test.tsx
@@ -20,7 +20,7 @@ describe('NodeGraphContainer', () => {
     );
 
     // Make sure we only show header in the collapsible
-    expect(container.firstChild?.childNodes.length).toBe(1);
+    expect(container.firstChild?.firstChild?.childNodes.length).toBe(1);
   });
 
   it('shows the graph if not with trace view', async () => {

--- a/public/app/features/explore/NodeGraph/NodeGraphContainer.tsx
+++ b/public/app/features/explore/NodeGraph/NodeGraphContainer.tsx
@@ -103,6 +103,7 @@ export function UnconnectedNodeGraphContainer(props: Props) {
         title={`Node graph${countWarning}`}
         width={measureWidth}
         height={withTraceView ? 500 : height}
+        padding="none"
         isOpen={withTraceView ? open : true}
         collapsible={withTraceView}
         onToggle={withTraceView ? () => toggled() : undefined}

--- a/public/app/features/explore/NodeGraph/NodeGraphContainer.tsx
+++ b/public/app/features/explore/NodeGraph/NodeGraphContainer.tsx
@@ -56,9 +56,6 @@ export function UnconnectedNodeGraphContainer(props: Props) {
   const { nodes } = useCategorizeFrames(frames);
   const [open, toggleOpen] = useToggle(false);
 
-  console.log('NodeGraph - withTraceView', withTraceView);
-  console.log('NodeGraph - open', open);
-
   const toggled = () => {
     toggleOpen();
     reportInteraction('grafana_traces_node_graph_panel_clicked', {


### PR DESCRIPTION
**What is this feature?**
This feature does the following:

- [x] Makes PanelChrome collapsible
- [x] Makes NodeGraphContainer use PanelChrome so it's unified with other viz components in Explore
- [x] Left-aligns Node Graph's title to match other viz components in Explore

Before:
<img width="1487" alt="Screenshot 2023-06-05 at 7 45 16 AM" src="https://github.com/grafana/grafana/assets/58232930/76b14a4c-bbde-4eab-abe5-e18d8f8e5139">

After:
![5AB33C52-B000-4167-BD36-178E8D20E992](https://github.com/grafana/grafana/assets/58232930/6f901ec9-f449-4ea7-b441-df5d52b0389b)

NodeGraph is collapsible when Trace View is enabled:
![Screenshot 2023-06-06 at 10 37 44 AM](https://github.com/grafana/grafana/assets/58232930/197341eb-91a3-41c9-b4e5-017f3a5c5aa8)

Fixes https://github.com/grafana/grafana/issues/69175

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] Node Graph is collapsible only when Trace View is enabled like [here ](https://ops.grafana-ops.net/explore?orgId=1&left=%7B%22datasource%22:%221KCK2lAnk%22,%22queries%22:%5B%7B%22query%22:%2232618dbc4a2439%22,%22queryType%22:%22traceql%22,%22refId%22:%22A%22,%22limit%22:20%7D%5D,%22range%22:%7B%22from%22:%221685719407113%22,%22to%22:%221685723007113%22%7D%7D)
