### PR TITLE
Log Row: Fix menu styling and dimensions

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -100,16 +100,15 @@ export class LogRowMessage extends PureComponent<Props> {
           </div>
         </td>
         <td className={cx('log-row-menu-cell', styles.logRowMenuCell)}>
-          <span
-            className={cx('log-row-menu', styles.rowMenu, {
-              [styles.rowMenuWithContextButton]: shouldShowContextToggle,
-            })}
-            onClick={this.onLogRowClick}
-          >
+          <span className={cx('log-row-menu', styles.rowMenu)} onClick={this.onLogRowClick}>
             {shouldShowContextToggle && (
-              <Tooltip placement="top" content={'Show context'}>
-                <IconButton size="md" name="gf-show-context" onClick={this.onShowContextClick} />
-              </Tooltip>
+              <IconButton
+                tooltip="Show context"
+                tooltipPlacement="top"
+                size="md"
+                name="gf-show-context"
+                onClick={this.onShowContextClick}
+              />
             )}
             <ClipboardButton
               className={styles.copyLogButton}

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -3,8 +3,8 @@ import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 import Highlighter from 'react-highlight-words';
 
-import { LogRowModel, findHighlightChunksInText, CoreApp } from '@grafana/data';
-import { ClipboardButton, IconButton, Tooltip } from '@grafana/ui';
+import { CoreApp, findHighlightChunksInText, LogRowModel } from '@grafana/data';
+import { ClipboardButton, IconButton } from '@grafana/ui';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowStyles } from './getLogRowStyles';

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -241,16 +241,12 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       position: absolute;
       top: 0;
       bottom: auto;
-      height: ${theme.spacing(4.5)};
       background: ${theme.colors.background.primary};
       box-shadow: ${theme.shadows.z3};
-      padding: ${theme.spacing(0, 0, 0, 0.5)};
+      padding: ${theme.spacing(0.5, 0.5, 0.5, 1)};
       z-index: 100;
       visibility: hidden;
-      width: ${theme.spacing(5)};
-    `,
-    rowMenuWithContextButton: css`
-      width: ${theme.spacing(10)};
+      gap: ${theme.spacing(0.5)};
     `,
     logRowMenuCell: css`
       position: sticky;


### PR DESCRIPTION
**What is this feature?**

The Log Row menu's styling was a bit off and dimensions were wrong.

**Special notes for your reviewer:**

Now: 
<img width="87" alt="image" src="https://github.com/grafana/grafana/assets/8092184/3bd75cd9-b354-42b1-b563-e8cdd51a8a32">

Before:
<img width="121" alt="image" src="https://github.com/grafana/grafana/assets/8092184/442048aa-795c-4803-a08e-5cdf3944cf93">

