### PR TITLE
Loki: Fix showing of correct line limit in options

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import { LokiOptionFieldsProps, LokiOptionFields } from './LokiOptionFields';
+import { LokiOptionFieldsProps, LokiOptionFields, preprocessMaxLines } from './LokiOptionFields';
 
 const setup = () => {
   const lineLimitValue = '1';
@@ -87,5 +87,17 @@ describe('Resolution Field', () => {
     const props = setup();
     render(<LokiOptionFields {...props} resolution={5} />);
     expect(await screen.findByText('1/5')).toBeInTheDocument();
+  });
+});
+
+describe('preprocessMaxLines', () => {
+  test.each([
+    { inputValue: '', expected: undefined },
+    { inputValue: 'abc', expected: undefined },
+    { inputValue: '-1', expected: undefined },
+    { inputValue: '1', expected: 1 },
+    { inputValue: '100', expected: 100 },
+  ])('should return correct max lines value', ({ inputValue, expected }) => {
+    expect(preprocessMaxLines(inputValue)).toBe(expected);
   });
 });

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -154,16 +154,11 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
 
 export default memo(LokiOptionFields);
 
-export function preprocessMaxLines(value: string): number {
-  if (value.length === 0) {
-    // empty input - falls back to dataSource.maxLines limit
-    return NaN;
-  } else if (value.length > 0 && (isNaN(+value) || +value < 0)) {
-    // input with at least 1 character and that is either incorrect (value in the input field is not a number) or negative
-    // falls back to the limit of 0 lines
-    return 0;
-  } else {
-    // default case - correct input
-    return +value;
+export function preprocessMaxLines(value: string): number | undefined {
+  const maxLines = parseInt(value, 10);
+  if (isNaN(maxLines) || maxLines < 0) {
+    return undefined;
   }
+
+  return maxLines;
 }

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -7,7 +7,7 @@ import { LokiQuery, LokiQueryType } from '../../types';
 import { LokiQueryBuilderOptions } from './LokiQueryBuilderOptions';
 
 describe('LokiQueryBuilderOptions', () => {
-  it('Can change query type', async () => {
+  it('can change query type', async () => {
     const { props } = setup();
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
@@ -21,7 +21,7 @@ describe('LokiQueryBuilderOptions', () => {
     });
   });
 
-  it('Can change legend format', async () => {
+  it('can change legend format', async () => {
     const { props } = setup();
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
@@ -33,6 +33,58 @@ describe('LokiQueryBuilderOptions', () => {
     expect(props.onChange).toHaveBeenCalledWith({
       ...props.query,
       legendFormat: 'asd',
+    });
+  });
+
+  it('can change line limit to valid value', async () => {
+    const { props } = setup();
+    props.query.expr = '{foo="bar"}';
+
+    await userEvent.click(screen.getByTitle('Click to edit options'));
+
+    const element = screen.getByLabelText('Line limit');
+    await userEvent.type(element, '10');
+    await userEvent.keyboard('{enter}');
+
+    expect(props.onChange).toHaveBeenCalledWith({
+      ...props.query,
+      maxLines: 10,
+    });
+  });
+
+  it('does not change line limit to invalid numeric value', async () => {
+    const { props } = setup();
+    // We need to start with some value to be able to change it
+    props.query.maxLines = 10;
+    props.query.expr = '{foo="bar"}';
+
+    await userEvent.click(screen.getByTitle('Click to edit options'));
+
+    const element = screen.getByLabelText('Line limit');
+    await userEvent.type(element, '-10');
+    await userEvent.keyboard('{enter}');
+
+    expect(props.onChange).toHaveBeenCalledWith({
+      ...props.query,
+      maxLines: undefined,
+    });
+  });
+
+  it('does not change line limit to invalid text value', async () => {
+    const { props } = setup();
+    // We need to start with some value to be able to change it
+    props.query.maxLines = 10;
+    props.query.expr = '{foo="bar"}';
+
+    await userEvent.click(screen.getByTitle('Click to edit options'));
+
+    const element = screen.getByLabelText('Line limit');
+    await userEvent.type(element, 'asd');
+    await userEvent.keyboard('{enter}');
+
+    expect(props.onChange).toHaveBeenCalledWith({
+      ...props.query,
+      maxLines: undefined,
     });
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -26,7 +26,8 @@ describe('LokiQueryBuilderOptions', () => {
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
 
-    const element = screen.getByLabelText('Legend');
+    // First autosize input is a Legend
+    const element = screen.getAllByTestId('autosize-input')[0];
     await userEvent.type(element, 'asd');
     await userEvent.keyboard('{enter}');
 
@@ -41,8 +42,8 @@ describe('LokiQueryBuilderOptions', () => {
     props.query.expr = '{foo="bar"}';
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
-
-    const element = screen.getByLabelText('Line limit');
+    // Second autosize input is a Line limit
+    const element = screen.getAllByTestId('autosize-input')[1];
     await userEvent.type(element, '10');
     await userEvent.keyboard('{enter}');
 
@@ -59,8 +60,8 @@ describe('LokiQueryBuilderOptions', () => {
     props.query.expr = '{foo="bar"}';
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
-
-    const element = screen.getByLabelText('Line limit');
+    // Second autosize input is a Line limit
+    const element = screen.getAllByTestId('autosize-input')[1];
     await userEvent.type(element, '-10');
     await userEvent.keyboard('{enter}');
 
@@ -77,8 +78,8 @@ describe('LokiQueryBuilderOptions', () => {
     props.query.expr = '{foo="bar"}';
 
     await userEvent.click(screen.getByTitle('Click to edit options'));
-
-    const element = screen.getByLabelText('Line limit');
+    // Second autosize input is a Line limit
+    const element = screen.getAllByTestId('autosize-input')[1];
     await userEvent.type(element, 'asd');
     await userEvent.keyboard('{enter}');
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -77,7 +77,6 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           >
             <AutoSizeInput
               placeholder="{{label}}"
-              id="loki-query-editor-legend-format"
               type="string"
               minWidth={14}
               defaultValue={query.legendFormat}
@@ -90,7 +89,6 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           {showMaxLines && (
             <EditorField label="Line limit" tooltip="Upper limit for number of log lines returned by query.">
               <AutoSizeInput
-                id="loki-query-editor-line-limit"
                 className="width-4"
                 placeholder={maxLines.toString()}
                 type="number"

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -90,6 +90,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           {showMaxLines && (
             <EditorField label="Line limit" tooltip="Upper limit for number of log lines returned by query.">
               <AutoSizeInput
+                id="loki-query-editor-line-limit"
                 className="width-4"
                 placeholder={maxLines.toString()}
                 type="number"


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/69555

In this PR we simplifying the logic of `preprocessMaxLines` and we are returning:
- `undefined` if value is:
  - empty string
  - non-numeric string (e.g. `e`)
  - negative number
- actual number if it is valid number

This also fixes showing of correct log lines in the Query options as we have there `query.maxLines ?? maxLines`, which is correct, but it wasn't correctly working with `NaN`.

How to test:
1. make sure your loki datasource has a configured line limit
2. go to explore, run a query
3. adjust the line-limit in the query editor, run the query
4. now clear the value of the line-limit field in the query editor, run the query
5. you should see correctly displayed configured log line limit from


https://github.com/grafana/grafana/assets/30407135/a8dbdf92-a633-4712-b6db-5dd8ba41a9b0



