### PR TITLE
Query Splitting: Display progress of sub-requests using an annotation frame

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -45,7 +45,10 @@ describe('runSplitQuery()', () => {
       .spyOn(datasource, 'runQuery')
       .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
     await expect(runSplitQuery(datasource, request)).toEmitValuesWith((values) => {
-      expect(values).toEqual([{ error: { refId: 'A', message: 'Error' }, data: [], state: LoadingState.Streaming }]);
+      expect(values).toHaveLength(1);
+      expect(values[0]).toEqual(
+        expect.objectContaining({ error: { refId: 'A', message: 'Error' }, state: LoadingState.Streaming })
+      );
     });
   });
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -3,8 +3,10 @@ import { Observable, Subscriber, Subscription, tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
+  arrayToDataFrame,
   DataQueryRequest,
   DataQueryResponse,
+  DataTopic,
   dateTime,
   durationToMilliseconds,
   parseDuration,
@@ -171,7 +173,7 @@ function updateLoadingFrame(
     return response;
   }
 
-  const loadingFrame = new ArrayDataFrame([
+  const loadingFrame = arrayToDataFrame([
     {
       time: partition[0].from.valueOf(),
       timeEnd: partition[requestN - 2].to.valueOf(),


### PR DESCRIPTION
Alternative implementation to https://github.com/grafana/grafana/pull/65905, where instead of finding a place to display the progress of split requests, we add a loading frame that is updated as we receive data.

https://user-images.githubusercontent.com/1069378/233137075-b30f8eff-1f5a-49f1-8255-41ea63dea1f5.mov

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65104

**Special notes for your reviewer:**

Updated implementation using annotations:

![2023-04-19 18 05 20](https://user-images.githubusercontent.com/1069378/233136329-89c89d7f-eb04-45ee-8c33-c88e9705cab9.gif)

![2023-04-19 18 05 55](https://user-images.githubusercontent.com/1069378/233136337-a8183838-f4cd-4aa6-af62-52f30abf4330.gif)

Note when testing: these changes currently trigger some errors which are going to resolved after https://github.com/grafana/grafana/pull/66877 is merged.