### PR TITLE
CloudMonitoring: Remove excess logs

### DIFF
--- a/pkg/tsdb/cloud-monitoring/utils.go
+++ b/pkg/tsdb/cloud-monitoring/utils.go
@@ -88,8 +88,9 @@ func doRequestPage(ctx context.Context, logger log.Logger, r *http.Request, dsIn
 	}
 
 	defer func() {
-		err := res.Body.Close()
-		logger.Warn("failed to close response body", "error", err)
+		if err = res.Body.Close(); err != nil {
+			logger.Warn("failed to close response body", "error", err)
+		}
 	}()
 
 	dnext, err := unmarshalResponse(logger, res)


### PR DESCRIPTION
This PR removes excess logs. The referenced log should only occur if the error value from `res.Body.Close()` is not nil.

Fixes grafana/grafana#68659