### PR TITLE
Loki: Fix parsing of escaped quotes in LogQL

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -76,6 +76,21 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses query with line filters and escaped characters', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} |= "\\"line"')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.LineContains, params: ['\\"line'] }],
+      })
+    );
+  });
+
   it('returns error for query with ip matching line filter', () => {
     const context = buildVisualQueryFromString('{app="frontend"} |= ip("192.168.4.5/16") | logfmt');
     expect(context).toEqual(
@@ -320,7 +335,7 @@ describe('buildVisualQueryFromString', () => {
   });
 
   it('parses query with with decolorize and other operations', () => {
-    expect(buildVisualQueryFromString('{app="frontend"} | logfmt | decolorize | __error__="')).toEqual(
+    expect(buildVisualQueryFromString('{app="frontend"} | logfmt | decolorize | __error__=""')).toEqual(
       noErrors({
         labels: [
           {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -76,7 +76,7 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
-  it('parses query with line filters and escaped characters', () => {
+  it('parses query with line filter and escaped quote', () => {
     expect(buildVisualQueryFromString('{app="frontend"} |= "\\"line"')).toEqual(
       noErrors({
         labels: [
@@ -86,7 +86,22 @@ describe('buildVisualQueryFromString', () => {
             label: 'app',
           },
         ],
-        operations: [{ id: LokiOperationId.LineContains, params: ['\\"line'] }],
+        operations: [{ id: LokiOperationId.LineContains, params: ['"line'] }],
+      })
+    );
+  });
+
+  it('parses query with label filter and escaped quote', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | bar="\\"baz"')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.LabelFilter, params: ['bar', '=', '"baz'] }],
       })
     );
   });

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -599,7 +599,7 @@ function isIntervalVariableError(node: SyntaxNode) {
 
 function handleQuotes(string: string) {
   if (string[0] === `"` && string[string.length - 1] === `"`) {
-    return string.replace(/"/g, '').replace(/\\\\/g, '\\');
+    return string.substring(1, string.length - 1).replace(/\\\\/g, '\\');
   }
   return string.replace(/`/g, '');
 }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -599,7 +599,10 @@ function isIntervalVariableError(node: SyntaxNode) {
 
 function handleQuotes(string: string) {
   if (string[0] === `"` && string[string.length - 1] === `"`) {
-    return string.substring(1, string.length - 1).replace(/\\\\/g, '\\');
+    return string
+      .substring(1, string.length - 1)
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, '\\');
   }
   return string.replace(/`/g, '');
 }


### PR DESCRIPTION
**What is this feature?**

Parsing a visual representation of a query containing escaped quotes caused a bug. This PR fixes parsing of escaped quotes.

**Special notes for your reviewer:**

1. Open a Loki in code editor with the query:
```
{app="frontend"} |= "\"line"
```
2. Change to query builder. 
3. Notice that the `"line` value in the visualrepresentation is now correct - previously it was not.
4. Add any operation.
5. Notice that the resulting query will be something like 
```
{app="frontend"} |= `"line`
```