### PR TITLE
Documentation: Viewer role can arbitrarily query data sources directly

### DIFF
--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -78,7 +78,7 @@ Grafana uses the following roles to control user access:
 
 - **Organization administrator**: Has access to all organization resources, including dashboards, users, and teams.
 - **Editor**: Can view and edit dashboards, folders, and playlists.
-- **Viewer**: Can view dashboards and playlists.
+- **Viewer**: Can view dashboards, playlists, and query data sources.
 - **No Basic Role**: Has no permissions. Permissions will be added with RBAC as needed.
 
 The following table lists permissions for each role.
@@ -94,6 +94,7 @@ The following table lists permissions for each role.
 | View annotations               |            yes             |  yes   |  yes   |               |
 | Add, edit, delete annotations  |            yes             |  yes   |        |               |
 | Access Explore                 |            yes             |  yes   |        |               |
+| Query data sources directly    |            yes             |  yes   |  yes   |               |
 | Add, edit, delete data sources |            yes             |        |        |               |
 | Add and edit users             |            yes             |        |        |               |
 | Add and edit teams             |            yes             |        |        |               |


### PR DESCRIPTION
### What is this feature?

This pull request adds documentation making it clear that `Viewer's can arbitrarily query data sources directly`, depite not being able to edit the dashboard. They can run any arbitrary query against the data source.

### Why do we need this feature?

In the current default configuration & implementation, a Viewer can actually execute arbitrary queries against any data source attached to their organisation.

I don't believe the docs make this clear at all on the roles & permissions index page, and hence is a large oversight in terms of the security model assumptions people are using when configuring Grafana.

Anybody who has assumed a view-only dashboard is a restricted frontend to a data source, like myself, are incorrect. While the dashboard, panels and underlying queries are static and immutable; you can actually use the API to execute any query you like. An authenticated Viewer can execute any query they please, mallicious or not.

### Who is this feature for?

Any Admin or Editor looking at creating dashboard but incorrectly assuming that the queries they create are immutable to Viewers. Viewers can instead query any data source within their organisation directly, bypassing the restricted view-only dashboard.

### Which issue(s) does this PR fix?

This documentation highlights the issues mentioned here:

https://github.com/grafana/grafana/discussions/43487
https://github.com/grafana/grafana/issues/30552
https://github.com/grafana/grafana/issues/26567
https://github.com/grafana/grafana/issues/18157
https://github.com/grafana/grafana/issues/31847