### PR TITLE
[v10.0.x] Loki: Fix parsing of escaped quotes in LogQL (#69584)

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -76,6 +76,36 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses query with line filter and escaped quote', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} |= "\\"line"')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.LineContains, params: ['"line'] }],
+      })
+    );
+  });
+
+  it('parses query with label filter and escaped quote', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | bar="\\"baz"')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.LabelFilter, params: ['bar', '=', '"baz'] }],
+      })
+    );
+  });
+
   it('returns error for query with ip matching line filter', () => {
     const context = buildVisualQueryFromString('{app="frontend"} |= ip("192.168.4.5/16") | logfmt');
     expect(context).toEqual(

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -576,7 +576,10 @@ function isIntervalVariableError(node: SyntaxNode) {
 
 function handleQuotes(string: string) {
   if (string[0] === `"` && string[string.length - 1] === `"`) {
-    return string.replace(/"/g, '').replace(/\\\\/g, '\\');
+    return string
+      .substring(1, string.length - 1)
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, '\\');
   }
   return string.replace(/`/g, '');
 }


### PR DESCRIPTION
manual backport of #69584