### PR TITLE
DataFrame: Align frame (__series.name) and field naming (__field.name) 

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -1,5 +1,5 @@
 import { toDataFrame } from '../dataframe';
-import { DataFrame, TIME_SERIES_VALUE_FIELD_NAME, FieldType } from '../types';
+import { DataFrame, TIME_SERIES_VALUE_FIELD_NAME, FieldType, TIME_SERIES_TIME_FIELD_NAME } from '../types';
 
 import { getFieldDisplayName, getFrameDisplayName } from './fieldState';
 
@@ -42,7 +42,8 @@ describe('getFrameDisplayName', () => {
     const frame = toDataFrame({
       fields: [{ name: 'value', labels: { server: 'A' } }],
     });
-    expect(getFrameDisplayName(frame)).toBe('{server="A"}');
+
+    expect(getFrameDisplayName(frame)).toBe('value A');
   });
 
   it('Should return field names when labels object exist but has no keys', () => {
@@ -50,6 +51,24 @@ describe('getFrameDisplayName', () => {
       fields: [{ name: 'value', labels: {} }],
     });
     expect(getFrameDisplayName(frame)).toBe('value');
+  });
+
+  it('Should return value field name if single value field', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        {
+          name: TIME_SERIES_VALUE_FIELD_NAME,
+          values: [1, 2, 3],
+          type: FieldType.number,
+          config: {
+            displayName: 'ServerA',
+          },
+        },
+      ],
+    });
+
+    expect(getFrameDisplayName(frame, 1)).toBe('ServerA');
   });
 });
 

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -9,16 +9,23 @@ export function getFrameDisplayName(frame: DataFrame, index?: number) {
     return frame.name;
   }
 
-  // Single field with tags
-  const valuesWithLabels: Field[] = [];
+  const valueFieldNames: string[] = [];
   for (const field of frame.fields) {
-    if (field.labels && Object.keys(field.labels).length > 0) {
-      valuesWithLabels.push(field);
+    if (field.type === FieldType.time) {
+      continue;
     }
+
+    // No point in doing more
+    if (valueFieldNames.length > 1) {
+      break;
+    }
+
+    valueFieldNames.push(getFieldDisplayName(field, frame));
   }
 
-  if (valuesWithLabels.length === 1) {
-    return formatLabels(valuesWithLabels[0].labels!);
+  // If the frame has a single value field then use the name of that field as the frame name
+  if (valueFieldNames.length === 1) {
+    return valueFieldNames[0];
   }
 
   // list all the


### PR DESCRIPTION
There is a big mismatch in how we handle getFrameDisplayName and getFieldDisplayName. The problem is pretty big because we use getFrameDisplayName to evaluate `${__series.name}`  (which is a macro we do show first in data link auto-complete menu). 

The current logic for getFrameDisplayName results in a very different name compared to getFieldDisplayName (Which we use almost everywhere else for the value field of a single time series frame). 

So for time series with 2 fields (time, value) and the value field has say a displayName or displayNameFromDS `${__series.name} ` will currently just result in `Series (<refId>)`  which is pretty far from the display name actually used in all visualizations (which is the getFieldDisplayName for the value field). 

**Changes**

* Update getFrameDisplayName to return the result of the getFieldDisplayName for DataFrames with only a single value field. 

This could be a pretty big breaking change as it changes frame display names. not really sure where we use frame display names where it could cause a breaking change (other than in data links that use `${__series.name}` and are counting on the bad current behavior. 

Escalation where I discovered this 
https://github.com/grafana/support-escalations/issues/6199

# Release notice breaking change

The implementation for template macro `${__series.name}` was not always correct, resulting in an interpolation that was very different from the series name displayed in the visualization. We have now fixed this issue so that it does show the same name. Depending on how `${__series.name}` is used this could result in a minor breaking change.