### PR TITLE
Fix: Fix dashboards not showing in folders with search v2 enabled

### DIFF
--- a/public/app/features/browse-dashboards/api/services.test.ts
+++ b/public/app/features/browse-dashboards/api/services.test.ts
@@ -1,0 +1,49 @@
+import { DataFrame, DataFrameView, FieldType } from '@grafana/data';
+import { DashboardQueryResult, getGrafanaSearcher, QueryResponse } from 'app/features/search/service';
+
+import { listDashboards } from './services';
+
+describe('browse-dashboards services', () => {
+  describe('listDashboards', () => {
+    const searchData: DataFrame = {
+      fields: [
+        { name: 'kind', type: FieldType.string, config: {}, values: [] },
+        { name: 'name', type: FieldType.string, config: {}, values: [] },
+        { name: 'uid', type: FieldType.string, config: {}, values: [] },
+        { name: 'url', type: FieldType.string, config: {}, values: [] },
+        { name: 'tags', type: FieldType.other, config: {}, values: [] },
+        { name: 'location', type: FieldType.string, config: {}, values: [] },
+      ],
+      length: 0,
+    };
+
+    const mockSearchResult: QueryResponse = {
+      isItemLoaded: jest.fn(),
+      loadMoreItems: jest.fn(),
+      totalRows: searchData.length,
+      view: new DataFrameView<DashboardQueryResult>(searchData),
+    };
+
+    const searchMock = jest.spyOn(getGrafanaSearcher(), 'search');
+    searchMock.mockResolvedValue(mockSearchResult);
+
+    const PAGE_SIZE = 50;
+
+    it.each([
+      { page: undefined, expectedFrom: 0 },
+      { page: 1, expectedFrom: 0 },
+      { page: 2, expectedFrom: 50 },
+      { page: 4, expectedFrom: 150 },
+    ])('skips first $expectedFrom when listing page $page', async ({ page, expectedFrom }) => {
+      await listDashboards('abc-123', page, PAGE_SIZE);
+
+      expect(searchMock).toHaveBeenCalledWith({
+        kind: ['dashboard'],
+        query: '*',
+        location: 'abc-123',
+        from: expectedFrom,
+        limit: PAGE_SIZE,
+      });
+    });
+  });
+});

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -38,7 +38,7 @@ export async function listDashboards(parentUID?: string, page = 1, pageSize = PA
     kind: ['dashboard'],
     query: '*',
     location: parentUID || 'general',
-    from: (page - 1) * pageSize,
+    from: (page - 1) * pageSize, // our pages are 1-indexed, so we need to -1 to convert that to correct value to skip
     limit: pageSize,
   });
 

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -38,7 +38,7 @@ export async function listDashboards(parentUID?: string, page = 1, pageSize = PA
     kind: ['dashboard'],
     query: '*',
     location: parentUID || 'general',
-    from: page * pageSize,
+    from: (page - 1) * pageSize,
     limit: pageSize,
   });
 

--- a/public/app/features/search/service/sql.test.ts
+++ b/public/app/features/search/service/sql.test.ts
@@ -118,4 +118,31 @@ describe('SQLSearcher', () => {
       starred: true,
     });
   });
+
+  describe('pagination', () => {
+    it.each([
+      { from: undefined, expectedPage: undefined },
+      { from: 0, expectedPage: 1 },
+      { from: 50, expectedPage: 2 },
+      { from: 150, expectedPage: 4 },
+    ])('should search page $expectedPage when skipping $from results', async ({ from, expectedPage }) => {
+      searchMock.mockResolvedValue([]);
+      const sqlSearcher = new SQLSearcher();
+
+      await sqlSearcher.search({
+        query: '*',
+        kind: ['dashboard'],
+        from,
+        limit: 50,
+      });
+
+      expect(searchMock).toHaveBeenLastCalledWith('/api/search', {
+        limit: 50,
+        page: expectedPage,
+        sort: undefined,
+        tag: undefined,
+        type: 'dash-db',
+      });
+    });
+  });
 });

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -83,7 +83,8 @@ export class SQLSearcher implements GrafanaSearcher {
     const limit = query.limit ?? (query.from !== undefined ? 1 : DEFAULT_MAX_VALUES);
     const page =
       query.from !== undefined
-        ? query.from / limit + 1 // pages are 1-indexed
+        ? // prettier-ignore
+          (query.from / limit) + 1 // pages are 1-indexed, so need to +1 to get there
         : undefined;
 
     const q = await this.composeQuery(

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -81,7 +81,10 @@ export class SQLSearcher implements GrafanaSearcher {
     }
 
     const limit = query.limit ?? (query.from !== undefined ? 1 : DEFAULT_MAX_VALUES);
-    const page = query.from !== undefined ? query.from / limit : undefined;
+    const page =
+      query.from !== undefined
+        ? query.from / limit + 1 // pages are 1-indexed
+        : undefined;
 
     const q = await this.composeQuery(
       {


### PR DESCRIPTION
Fixes regression introduced in https://github.com/grafana/grafana/pull/68617 where dashboards would not show for folders when Search v2 was enabled.

The issue here was converting `page` based pagination paraemter to `from`, 

 - Folders API and Search v1 uses 1-indexed pages for pagination - the first page is `?page=1`
 - Search v2 uses `from` parameter to indicate how many results to skip. First page is `?from=0&limit=50`, second page is `?from=50&limit=50
 - The frontend abstraction over both search methods uses `from`-based pagination.
 - `listDashboards` accepts a `page`, and converts that to `limit` for the searcher, but it did this incorrectly - it simply did `from = page * pageSize` which will attempt to load the first page by skipping the first 50 results~
 - The SearchV1/SQLSearcher frontend also contains an incorrect conversion of limit to page which _undoes_ the previous bug, so it was never noticed with search v1
    - Note: this is doubly on me - I briefly noticed that this conversion seemed wrong, but everything worked as expected so I carried on


Note - I will add tests to this before merging.