### PR TITLE
Alerting: Fix broken UI because of query being optional for some ExpressionQuer…

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -396,16 +396,6 @@ function createThresholdExample(thresholdType: string): AlertQuery[] {
             params: [0, 10],
             type: thresholdType ?? 'gt',
           },
-          operator: {
-            type: 'and',
-          },
-          query: {
-            params: ['B'],
-          },
-          reducer: {
-            params: [],
-            type: 'last',
-          },
         },
       ],
       expression: 'B',

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -152,7 +152,7 @@ export function getThresholdsForQueries(queries: AlertQuery[]) {
       const threshold = condition.evaluator.params;
 
       // "classic_conditions" use `condition.query.params[]` and "threshold" uses `query.model.expression`
-      const refId = condition.query.params[0] ?? query.model.expression;
+      const refId = condition.query?.params[0] ?? query.model.expression;
 
       // if an expression hasn't been linked to a data query yet, it won't have a refId
       if (!refId) {


### PR DESCRIPTION
**What is this feature?**

This PR fixes UI been broken because of assuming expressions contain a conditions prop that actually is optional.


**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/6186
**Special notes for your reviewer:**

We are going to have a follow up PR for refactoring ExpressionQuery type and make it more clear which fields are optional/required for each ExpressionQuery case.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
