### PR TITLE
Loki: Fix including of template variables in variable query editor

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -88,7 +88,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) 
               aria-label="Label"
               onChange={onLabelChange}
               onBlur={handleBlur}
-              value={label}
+              value={{ label: label, value: label }}
               options={labelOptions}
               width={16}
               allowCustomValue

--- a/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.test.ts
@@ -3,7 +3,7 @@ import { LokiVariableQuery, LokiVariableQueryType } from '../types';
 import { migrateVariableQuery } from './variableQueryMigrations';
 
 describe('Loki migrateVariableQuery()', () => {
-  it('Does not migrate LokiVariableQuery instances', () => {
+  it('does not migrate LokiVariableQuery instances', () => {
     const query: LokiVariableQuery = {
       refId: 'test',
       type: LokiVariableQueryType.LabelValues,
@@ -15,7 +15,7 @@ describe('Loki migrateVariableQuery()', () => {
     expect(migrateVariableQuery(query)).toStrictEqual(query);
   });
 
-  it('Migrates label_names() queries', () => {
+  it('migrates label_names() queries', () => {
     const query = 'label_names()';
 
     expect(migrateVariableQuery(query)).toStrictEqual({
@@ -24,7 +24,7 @@ describe('Loki migrateVariableQuery()', () => {
     });
   });
 
-  it('Migrates label_values(label) queries', () => {
+  it('migrates label_values(label) queries', () => {
     const query = 'label_values(label)';
 
     expect(migrateVariableQuery(query)).toStrictEqual({
@@ -35,7 +35,18 @@ describe('Loki migrateVariableQuery()', () => {
     });
   });
 
-  it('Migrates label_values(log stream selector, label) queries', () => {
+  it('migrates label_values(label) queries with template variable', () => {
+    const query = 'label_values($label)';
+
+    expect(migrateVariableQuery(query)).toStrictEqual({
+      refId: 'LokiVariableQueryEditor-VariableQuery',
+      type: LokiVariableQueryType.LabelValues,
+      label: '$label',
+      stream: undefined,
+    });
+  });
+
+  it('migrates label_values(log stream selector, label) queries', () => {
     const query = 'label_values(log stream selector, label)';
 
     expect(migrateVariableQuery(query)).toStrictEqual({
@@ -43,6 +54,39 @@ describe('Loki migrateVariableQuery()', () => {
       type: LokiVariableQueryType.LabelValues,
       label: 'label',
       stream: 'log stream selector',
+    });
+  });
+
+  it('migrates label_values(log stream selector, label) with template variable as stream', () => {
+    const query = 'label_values($b, label)';
+
+    expect(migrateVariableQuery(query)).toStrictEqual({
+      refId: 'LokiVariableQueryEditor-VariableQuery',
+      type: LokiVariableQueryType.LabelValues,
+      label: 'label',
+      stream: '$b',
+    });
+  });
+
+  it('migrates label_values(log stream selector, label) with template variable in stream', () => {
+    const query = 'label_values({$b="bar"}, label)';
+
+    expect(migrateVariableQuery(query)).toStrictEqual({
+      refId: 'LokiVariableQueryEditor-VariableQuery',
+      type: LokiVariableQueryType.LabelValues,
+      label: 'label',
+      stream: '{$b="bar"}',
+    });
+  });
+
+  it('migrates label_values(log stream selector, label) with template variable in label', () => {
+    const query = 'label_values({$b="bar"}, $label)';
+
+    expect(migrateVariableQuery(query)).toStrictEqual({
+      refId: 'LokiVariableQueryEditor-VariableQuery',
+      type: LokiVariableQueryType.LabelValues,
+      label: '$label',
+      stream: '{$b="bar"}',
     });
   });
 });

--- a/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.ts
@@ -1,7 +1,7 @@
 import { LokiVariableQuery, LokiVariableQueryType } from '../types';
 
 export const labelNamesRegex = /^label_names\(\)\s*$/;
-export const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+export const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_$][a-zA-Z0-9_]*)\)\s*$/;
 
 export function migrateVariableQuery(rawQuery: string | LokiVariableQuery): LokiVariableQuery {
   // If not string, we assume LokiVariableQuery


### PR DESCRIPTION
In this PR we are fixing showing of template variables queries with variables in variable editor. There were 2 issues:

1. The label values regex didn't consider values with template variables used - e.g. `label_values($query1)`,  `label_values($stream1, $query1)`, `label_values({$job="$test"}, $query1)`. 
2. In Variables editor, we were passing label as string and not selectable value and therefore it wasn't showing up.


To test this:
1. Run Loki datasource `make devenv sources=loki`
2. Use this json to import dashboard with created template variables https://gist.github.com/ivanahuckova/6ec7d500bc404a56e2931574f4219d7e
3. Open each variable and make sure that values are correctly displayed (there are other issues with Definition not being displayed but this will be tackled in separate PR)

Fixed (this branch): 

https://github.com/grafana/grafana/assets/30407135/9564f6d6-a847-44c3-b815-e9d1944afa74

Broken (main):

https://github.com/grafana/grafana/assets/30407135/7a53de9e-f3dc-459d-85f7-6e8954001529

