### PR TITLE
Templating: Fix updating of definition to empty string

### DIFF
--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -137,7 +137,7 @@ export const changeQueryVariableQuery =
       )
     );
 
-    if (definition) {
+    if (definition !== undefined) {
       dispatch(
         toKeyedAction(
           rootStateKey,


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/6236

Context:

In Loki in https://github.com/grafana/grafana/pull/54102 we have changed Loki variables editor and also query model. Previously, it was string. Now it is object with properties. However, now when users change something in Loki variable query, the old `definition` is being displayed. This is a bug, because we want to overwrite `definition` to empty string, but this wasn't happening.

This PR fixes it by allowing definition to be updated to empty string.

Here is the demo/debug video:

https://github.com/grafana/grafana/assets/30407135/1394f238-43b3-4881-a167-829022fa1aed

