### PR TITLE
Repeats: Set scoped vars correctly for collapsed panel when toggled

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -768,6 +768,7 @@ export class DashboardModel implements TimeModel {
     for (let optionIndex = 0; optionIndex < selectedOptions.length; optionIndex++) {
       const option = selectedOptions[optionIndex];
       const rowCopy = this.getRowRepeatClone(panel, optionIndex, panelIndex);
+
       setScopedVars(rowCopy, option);
 
       const rowHeight = this.getRowHeight(rowCopy);
@@ -955,6 +956,10 @@ export class DashboardModel implements TimeModel {
     row.collapsed = false;
     const rowPanels = row.panels ?? [];
     const hasRepeat = rowPanels.some((p: PanelModel) => p.repeat);
+
+    // This is set only for the row being repeated.
+    const rowRepeatVariable = row.repeat;
+
     if (rowPanels.length > 0) {
       // Use first panel to figure out if it was moved or pushed
       // If the panel doesn't have gridPos.y, use the row gridPos.y instead.
@@ -969,6 +974,18 @@ export class DashboardModel implements TimeModel {
       let yMax = row.gridPos.y;
 
       for (const panel of rowPanels) {
+        // When expanding original row that's repeated, set scopedVars for repeated row panels.
+        if (rowRepeatVariable) {
+          const variable = this.getPanelRepeatVariable(row);
+          panel.scopedVars ??= {};
+          if (variable) {
+            const selectedOptions = this.getSelectedVariableOptions(variable);
+            panel.scopedVars = {
+              ...panel.scopedVars,
+              [variable.name]: selectedOptions[0],
+            };
+          }
+        }
         // set the y gridPos if it wasn't already set
         panel.gridPos.y ?? (panel.gridPos.y = row.gridPos.y); // (Safari 13.1 lacks ??= support)
         // make sure y is adjusted (in case row moved while collapsed)


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/6252

Repeats are so complex... This is an approach to fixing the issue that makes collapsed row not apply scoped vars correctly when expanding the original row that's being repeated. Not sure this is the best approach. There is so much going on when processing row repeats... 