### PR TITLE
docs: add product labels for reporting page

### DIFF
--- a/docs/sources/dashboards/create-reports/index.md
+++ b/docs/sources/dashboards/create-reports/index.md
@@ -10,6 +10,10 @@ keywords:
   - reporting
   - export
   - pdf
+labels:
+  products:
+    - cloud
+    - enterprise
 menuTitle: Reporting
 title: Create and manage reports
 weight: 85


### PR DESCRIPTION
Adds `cloud` and `enterprise` labels for reporting page