### PR TITLE
Transformations: Config overrides being lost when config from query transform is applied

### DIFF
--- a/public/app/features/transformers/configFromQuery/configFromQuery.ts
+++ b/public/app/features/transformers/configFromQuery/configFromQuery.ts
@@ -66,6 +66,7 @@ export function extractConfigFromQuery(options: ConfigFromQueryTransformOptions,
     const outputFrame: DataFrame = {
       fields: [],
       length: frame.length,
+      refId: frame.refId,
     };
 
     for (const field of frame.fields) {
@@ -85,7 +86,6 @@ export function extractConfigFromQuery(options: ConfigFromQueryTransformOptions,
 
     output.push(outputFrame);
   }
-
   return output;
 }
 


### PR DESCRIPTION
**What is this feature?**

This fix copies the refId property to the output. The config overides were being lost when the config from query transform is applied due to the refId not being copied over from the original object

**Why do we need this feature?**

To maintain the config overides when the config from query transform is applied


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/grafana/issues/68277

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
