### PR TITLE
Loki: Make stream selector input in variables editor larger

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import React, { FormEvent, useState, useEffect } from 'react';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
@@ -70,33 +71,45 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) 
   };
 
   return (
-    <InlineFieldRow>
-      <InlineField label="Query type" labelWidth={20}>
-        <Select
-          aria-label="Query type"
-          onChange={onQueryTypeChange}
-          onBlur={handleBlur}
-          value={type}
-          options={variableOptions}
-          width={16}
-        />
-      </InlineField>
+    <>
+      <InlineFieldRow>
+        <InlineField label="Query type" labelWidth={20}>
+          <Select
+            aria-label="Query type"
+            onChange={onQueryTypeChange}
+            onBlur={handleBlur}
+            value={type}
+            options={variableOptions}
+            width={16}
+          />
+        </InlineField>
+        {type === QueryType.LabelValues && (
+          <>
+            <InlineField label="Label" labelWidth={20}>
+              <Select
+                aria-label="Label"
+                onChange={onLabelChange}
+                onBlur={handleBlur}
+                value={{ label: label, value: label }}
+                options={labelOptions}
+                width={16}
+                allowCustomValue
+              />
+            </InlineField>
+          </>
+        )}
+      </InlineFieldRow>
       {type === QueryType.LabelValues && (
-        <>
-          <InlineField label="Label" labelWidth={20}>
-            <Select
-              aria-label="Label"
-              onChange={onLabelChange}
-              onBlur={handleBlur}
-              value={{ label: label, value: label }}
-              options={labelOptions}
-              width={16}
-              allowCustomValue
-            />
-          </InlineField>
+        <InlineFieldRow
+          // We want stream selector input to have a space for long stream selectors
+          className={css`
+            width: 75%;
+          `}
+        >
           <InlineField
             label="Stream selector"
             labelWidth={20}
+            grow={true}
             tooltip={
               <div>
                 {
@@ -112,11 +125,10 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) 
               value={stream}
               onChange={onStreamChange}
               onBlur={handleBlur}
-              width={22}
             />
           </InlineField>
-        </>
+        </InlineFieldRow>
       )}
-    </InlineFieldRow>
+    </>
   );
 };

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import React, { FormEvent, useState, useEffect } from 'react';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
@@ -100,12 +99,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) 
         )}
       </InlineFieldRow>
       {type === QueryType.LabelValues && (
-        <InlineFieldRow
-          // We want stream selector input to have a space for long stream selectors
-          className={css`
-            width: 75%;
-          `}
-        >
+        <InlineFieldRow>
           <InlineField
             label="Stream selector"
             labelWidth={20}


### PR DESCRIPTION
Loki stream selectors can (and usually are) quite long and there is no reason to keep the input short, as then it is hard to read the stream selector and edit it. In this PR, we are making it longer, as we have enough space in the variable editor. 

New:

<img width="1500" alt="image" src="https://github.com/grafana/grafana/assets/30407135/406d92ce-60a7-494f-8b5c-7cfb5c30bce3">

Before:

<img width="1493" alt="image" src="https://github.com/grafana/grafana/assets/30407135/3511f53b-4cb4-4b01-8149-348b213d144b">


