### PR TITLE
Prometheus: fix icons that are only visible on hover

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
@@ -110,15 +110,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: theme.spacing(0.5, 0.5, 0.5, 1),
       display: 'flex',
       alignItems: 'center',
-      '&:hover .operation-header-show-on-hover': css({
-        opacity: 1,
-      }),
     }),
     operationHeaderButtons: css({
-      opacity: 0,
-      transition: theme.transitions.create(['opacity'], {
-        duration: theme.transitions.duration.short,
-      }),
+      opacity: 1,
     }),
     selectWrapper: css({
       paddingRight: theme.spacing(2),


### PR DESCRIPTION
always make icons visible instead of only showing on hover to allow users to see outline when interacting with icons via keyboard navigation

**What is this feature?**
When selecting the aggregation icons via the keyboard, the icons are not made visible, making it difficult to know what you are interacting with. The fix proposed here is to simply always show these icons for all users, and drop the show on hover functionality.

**Why do we need this feature?**
Accessibility

**Who is this feature for?**
Users navigating the website via the keyboard, and for users on devices without "hover" functionality (touch screens).

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/69388

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
