### PR TITLE
Prometheus: variable query editor interpolate variables in label values

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -29,6 +29,23 @@ describe('PromVariableQueryEditor', () => {
     expect(migration).toEqual(expected);
   });
 
+  test('Allows for use of variables to interpolate label names in the label values query type.', () => {
+    const query: StandardPromVariableQuery = {
+      query: 'label_values($label_name)',
+      refId: 'StandardVariableQuery',
+    };
+
+    const migration: PromVariableQuery = variableMigration(query);
+
+    const expected: PromVariableQuery = {
+      qryType: PromVariableQueryType.LabelValues,
+      label: '$label_name',
+      refId: 'PrometheusDatasource-VariableQuery',
+    };
+
+    expect(migration).toEqual(expected);
+  });
+
   test('Migrates from jsonnet grafana as code variable to custom variable query', () => {
     const query = 'label_names()';
 

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -1,7 +1,7 @@
 import { PromVariableQuery, PromVariableQueryType as QueryType } from '../types';
 
 const labelNamesRegex = /^label_names\(\)\s*$/;
-const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_$][a-zA-Z0-9_]*)\)\s*$/;
 const metricNamesRegex = /^metrics\((.+)\)\s*$/;
 const queryResultRegex = /^query_result\((.+)\)\s*$/;
 


### PR DESCRIPTION
**What is this feature?**
Similar to this issue, https://github.com/grafana/grafana/pull/69698, the Prom variable query editor was not supporting variable use in the `label_values` query type.

This fixes that and allows a user to create a variable of the query type `label_names` and use that variable in the `label_values` query type.

**Why do we need this feature?**
This is needed to support variable interpolation.

**Who is this feature for?**
Prometheus users who are creating variables of the query type.

**Special notes for your reviewer:**
1. Create a variable of the label_names query type.
2. Use this variable in the label_values query type.
3. See that it is interpolated and the label_values variable returns values.
![Screenshot 2023-06-07 at 10 45 07 AM](https://github.com/grafana/grafana/assets/25674746/0a4c761b-161e-4050-a76b-175066b5ebd8)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
