### PR TITLE
Prometheus: Fix numeric values in raw prometheus view which are being formatted as text

### DIFF
--- a/public/app/features/explore/PrometheusListView/RawListItem.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.tsx
@@ -108,19 +108,17 @@ const RawListItem = ({ listItemData, listKey, totalNumberOfValues, valueLabels, 
    * Transform the symbols in the dataFrame to uniform strings
    */
   const transformCopyValue = (value: string): string => {
-    if (value === '∞') {
+    if (value === '∞' || value === 'Infinity') {
       return '+Inf';
     }
     return value;
   };
 
   // Convert the object back into a string
-  const stringRep = `${__name__}{${attributeValues
-    .filter((value) => value.key !== 'le')
-    .map((value) => {
-      // For histograms the string representation currently in this object is not directly queryable in all situations, leading to broken copied queries. Omitting the attribute from the copied result gives a query which returns all le values, which I assume to be a more common use case.
-      return `${value.key}="${transformCopyValue(value.value)}"`;
-    })}}`;
+  const stringRep = `${__name__}{${attributeValues.map((value) => {
+    // For histograms the string representation currently in this object is not directly queryable in all situations, leading to broken copied queries. Omitting the attribute from the copied result gives a query which returns all le values, which I assume to be a more common use case.
+    return `${value.key}="${transformCopyValue(value.value)}"`;
+  })}}`;
 
   const hideFieldsWithoutValues = Boolean(valueLabels && valueLabels?.length);
 

--- a/public/app/features/explore/PrometheusListView/RawListItem.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.tsx
@@ -115,10 +115,12 @@ const RawListItem = ({ listItemData, listKey, totalNumberOfValues, valueLabels, 
   };
 
   // Convert the object back into a string
-  const stringRep = `${__name__}{${attributeValues.map((value) => {
-    // For histograms the string representation currently in this object is not directly queryable in all situations, leading to broken copied queries. Omitting the attribute from the copied result gives a query which returns all le values, which I assume to be a more common use case.
-    return value.key !== 'le' ? `${value.key}="${transformCopyValue(value.value)}"` : '';
-  })}}`;
+  const stringRep = `${__name__}{${attributeValues
+    .filter((value) => value.key !== 'le')
+    .map((value) => {
+      // For histograms the string representation currently in this object is not directly queryable in all situations, leading to broken copied queries. Omitting the attribute from the copied result gives a query which returns all le values, which I assume to be a more common use case.
+      return `${value.key}="${transformCopyValue(value.value)}"`;
+    })}}`;
 
   const hideFieldsWithoutValues = Boolean(valueLabels && valueLabels?.length);
 

--- a/public/app/features/explore/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -38,11 +38,17 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
       if (label !== 'Time') {
         // Initialize the objects
         if (typeof field?.display === 'function') {
-          const stringValue = formattedValueToString(field?.display(field.values[i]));
-          if (stringValue) {
-            formattedMetric[label] = stringValue;
-          } else if (label.includes('Value #')) {
-            formattedMetric[label] = RawPrometheusListItemEmptyValue;
+          const value = field?.display(field.values[i]);
+          if (value.numeric) {
+            formattedMetric[label] = value.numeric.toString(10);
+          } else {
+            const stringValue = formattedValueToString(value);
+
+            if (stringValue) {
+              formattedMetric[label] = stringValue;
+            } else if (label.includes('Value #')) {
+              formattedMetric[label] = RawPrometheusListItemEmptyValue;
+            }
           }
         } else {
           console.warn('Field display method is missing!');

--- a/public/app/features/explore/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -39,7 +39,7 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
         // Initialize the objects
         if (typeof field?.display === 'function') {
           const value = field?.display(field.values[i]);
-          if (value.numeric) {
+          if (!isNaN(value.numeric)) {
             formattedMetric[label] = value.numeric.toString(10);
           } else {
             const stringValue = formattedValueToString(value);


### PR DESCRIPTION
**What is this feature?**
Fixes bug formatting label values in prometheus raw instant view in explore.

**Why do we need this feature?**
Raw prometheus view should always output valid queries, so whatever values we get from prometheus we need to display in the frontend.

**Who is this feature for?**
Prometheus users in Explore UI.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/69660

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
