### PR TITLE
Authorization using authorizer in apiserver

### DIFF
--- a/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
+++ b/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
@@ -36,6 +36,9 @@ func (auth GrafanaAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 	
 	// We are being called using a Grafana token
 	if orgRole := extra["org-role"]; len(orgRole) > 0 {
+		// NOTE: signedInUser only has one org role which the authenticator is providing through header auth
+		// That is the single role the below logic is based off of
+		// TBD: is a single value enough for our purposes?
 		switch org.RoleType(orgRole[0]) {
 		case org.RoleAdmin:
 			return authorizer.DecisionAllow, "", nil

--- a/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
+++ b/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
@@ -1,0 +1,56 @@
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"github.com/grafana/grafana/pkg/services/org"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type GrafanaAuthorizer struct {
+}
+
+func NewGrafanaAuthorizer() *GrafanaAuthorizer {
+	return &GrafanaAuthorizer{}
+}
+
+func (auth GrafanaAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if userInfo, ok := request.UserFrom(ctx); ok {
+		extra := userInfo.GetExtra()
+		groups := userInfo.GetGroups()
+
+		if orgId := extra["org-id"]; len(orgId) > 0 {
+			// We are being called using a Grafana token
+			if orgRole := extra["org-role"]; len(orgRole) > 0 {
+				switch org.RoleType(orgRole[0]) {
+				case org.RoleAdmin:
+					return authorizer.DecisionAllow, "", nil
+				case org.RoleEditor:
+					switch a.GetVerb() {
+					case "get", "list", "watch", "create", "update", "patch", "delete", "put", "post":
+						return authorizer.DecisionAllow, "", nil
+					}
+				case org.RoleViewer:
+					switch a.GetVerb() {
+					case "get", "list", "watch":
+						return authorizer.DecisionAllow, "", nil
+					}
+				default:
+					return authorizer.DecisionDeny, fmt.Sprintf("Grafana user's org role (%s) didn't allow access on requested resource=%s, path=%s", orgRole[0], a.GetResource(), a.GetPath()), nil
+				}
+			}
+		} else if groups != nil && len(groups) > 0 {
+			for _, gr := range groups {
+				if gr == "system:masters" {
+					// We are being called using LoopbackConfig / internal privileged access
+					return authorizer.DecisionAllow, "", nil
+				}
+			}
+			return authorizer.DecisionDeny, fmt.Sprintf("K8s groups didn't allow access on requested resource=%s, path=%s", a.GetResource(), a.GetPath()), nil
+		} else {
+			fmt.Printf("Didn't match the K8s or Grafana code paths for groups=%v, extra=%v", groups, extra)
+		}
+	}
+	return authorizer.DecisionDeny, fmt.Sprintf("Neither Grafana token rules nor K8s token rules were applicable, denied access on requested resource=%s, path=%s", a.GetResource(), a.GetPath()), nil
+}

--- a/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
+++ b/pkg/services/k8s/apiserver/authorization/grafana_authorizer.go
@@ -24,45 +24,49 @@ func NewGrafanaAuthorizer() *GrafanaAuthorizer {
 }
 
 func (auth GrafanaAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	if userInfo, ok := request.UserFrom(ctx); ok {
-		extra := userInfo.GetExtra()
-		groups := userInfo.GetGroups()
+	userInfo, ok := request.UserFrom(ctx);
+	if !ok {
+		return authorizer.DecisionDeny, fmt.Sprintf("could not determine user info from context, denied %s access on requested resource=%s, path=%s", a.GetVerb(), a.GetResource(), a.GetPath()), nil
+	}
+	extra := userInfo.GetExtra()
+	groups := userInfo.GetGroups()
 
-		if orgId := extra["org-id"]; len(orgId) > 0 {
-			// We are being called using a Grafana token
-			if orgRole := extra["org-role"]; len(orgRole) > 0 {
-				switch org.RoleType(orgRole[0]) {
-				case org.RoleAdmin:
-					return authorizer.DecisionAllow, "", nil
-				case org.RoleEditor:
-					switch a.GetVerb() {
-					case "get", "list", "watch", "create", "update", "patch", "delete", "put", "post":
-						return authorizer.DecisionAllow, "", nil
-					default:
-						return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
-					}
-				case org.RoleViewer:
-					switch a.GetVerb() {
-					case "get", "list", "watch":
-						return authorizer.DecisionAllow, "", nil
-					default:
-						return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
-					}
-				default:
-					return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
-				}
+	// TODO: take orgId into account in relation to namespaced resources
+	// if orgId := extra["org-id"]; len(orgId) > 0 {}
+	
+	// We are being called using a Grafana token
+	if orgRole := extra["org-role"]; len(orgRole) > 0 {
+		switch org.RoleType(orgRole[0]) {
+		case org.RoleAdmin:
+			return authorizer.DecisionAllow, "", nil
+		case org.RoleEditor:
+			switch a.GetVerb() {
+			case "get", "list", "watch", "create", "update", "patch", "delete", "put", "post":
+				return authorizer.DecisionAllow, "", nil
+			default:
+				return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
 			}
-		} else if groups != nil && len(groups) > 0 {
-			for _, gr := range groups {
-				if gr == "system:masters" {
-					// We are being called using LoopbackConfig / internal privileged access
-					return authorizer.DecisionAllow, "", nil
-				}
+		case org.RoleViewer:
+			switch a.GetVerb() {
+			case "get", "list", "watch":
+				return authorizer.DecisionAllow, "", nil
+			default:
+				return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
 			}
-			return authorizer.DecisionDeny, errorMessageForK8sGroup(groups, a), nil
-		} else {
-			fmt.Printf("Didn't match the K8s or Grafana code paths for groups=%v, extra=%v", groups, extra)
+		default:
+			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole[0], a), nil
 		}
 	}
-	return authorizer.DecisionDeny, fmt.Sprintf("could not determine user info from context, denied %s access on requested resource=%s, path=%s", a.GetVerb(), a.GetResource(), a.GetPath()), nil
+
+	if groups != nil && len(groups) > 0 {
+		for _, gr := range groups {
+			if gr == "system:masters" {
+				// We are being called using LoopbackConfig / internal privileged access
+				return authorizer.DecisionAllow, "", nil
+			}
+		}
+		return authorizer.DecisionDeny, errorMessageForK8sGroup(groups, a), nil
+	}
+
+	return authorizer.DecisionDeny, fmt.Sprintf("could not match either of the authorizer's criteria, denied %s access on requested resource=%s, path=%s", a.GetVerb(), a.GetResource(), a.GetPath()), nil
 }


### PR DESCRIPTION
Summary of changes:

1. Adds a Grafana authorizer that builds on previous work of supporting the GLSA token, except this time, the implementation is even more concise than earlier, given the user is on the context after a successful authn with header authentication.
2. This currently supports Admin, Editor and Viewer permissions on all resources.

TODO: evaluate per resource permissions and per org permissions based on the value of namespace that is passed in.