### PR TITLE
Geomap: Fix tooltip bug

### DIFF
--- a/public/app/plugins/panel/geomap/utils/tootltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tootltip.ts
@@ -19,7 +19,9 @@ export const setTooltipListeners = (panel: GeomapPanel) => {
 };
 
 export const pointerClickListener = (evt: MapBrowserEvent<MouseEvent>, panel: GeomapPanel) => {
+  console.log('pointerClickListener', evt, panel);
   if (pointerMoveListener(evt, panel)) {
+    console.log('SET TTIP OPEN TRUE');
     evt.preventDefault();
     evt.stopPropagation();
     panel.mapDiv!.style.cursor = 'auto';
@@ -32,9 +34,12 @@ export const pointerMoveListener = (evt: MapBrowserEvent<MouseEvent>, panel: Geo
   if (panel.state.measureMenuActive) {
     return true;
   }
-  if (!panel.map || panel.state.ttipOpen) {
+
+  // Eject out of this function if map is not loaded or valid tooltip is already open
+  if (!panel.map || (panel.state.ttipOpen && panel.state?.ttip?.layers?.length)) {
     return false;
   }
+
   const mouse = evt.originalEvent;
   const pixel = panel.map.getEventPixel(mouse);
   const hover = toLonLat(panel.map.getCoordinateFromPixel(pixel));

--- a/public/app/plugins/panel/geomap/utils/tootltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tootltip.ts
@@ -19,9 +19,7 @@ export const setTooltipListeners = (panel: GeomapPanel) => {
 };
 
 export const pointerClickListener = (evt: MapBrowserEvent<MouseEvent>, panel: GeomapPanel) => {
-  console.log('pointerClickListener', evt, panel);
   if (pointerMoveListener(evt, panel)) {
-    console.log('SET TTIP OPEN TRUE');
     evt.preventDefault();
     evt.stopPropagation();
     panel.mapDiv!.style.cursor = 'auto';


### PR DESCRIPTION
Fix issue where Geomap tooltips would "crash" and stop working, requiring a page refresh to fix.

Before

https://github.com/grafana/grafana/assets/22381771/e16de2eb-682f-49af-bcef-b956bf371689


After


https://github.com/grafana/grafana/assets/22381771/fcf9519a-ad8c-4755-805c-240a45c9601c




While addressing this issue I noticed that we are re-rendering the entire geomap panel on every mouse move which doesn't seem super efficient - we may want to address this in a follow-up PR. Also the tooltip UX is a little finicky when clicking around rapidly (i.e. need to wait ~1 second for tooltip to open else it may display another point if you've moved your cursor in the meantime - but at least tooltip functionality doesn't crash / break now). This may be fixed / related [to the rendering optimization task](https://github.com/grafana/grafana/issues/69774).

Fixes https://github.com/grafana/support-escalations/issues/6266