### PR TITLE
Elasticsearch: fix type-related bug within targetContainsTemplate

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1333,6 +1333,17 @@ describe('targetContainsTemplate', () => {
     target.metrics = [{ type: 'extended_stats', id: '1', meta: { something: '$something' } }];
     expect(ds.targetContainsTemplate(target)).toBe(true);
   });
+  it('returns true when there are variables in an array inside an object in metrics', () => {
+    target.metrics = [
+      {
+        field: 'counter',
+        id: '1',
+        settings: { percents: ['20', '40', '$qqq'] },
+        type: 'percentiles',
+      },
+    ];
+    expect(ds.targetContainsTemplate(target)).toBe(true);
+  });
 });
 
 describe('ElasticDatasource using backend', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -829,14 +829,15 @@ export class ElasticDatasource
   }
 
   private objectContainsTemplate(obj: any) {
+    if (typeof obj === 'string') {
+      return this.templateSrv.containsTemplate(obj);
+    }
     if (!obj || typeof obj !== 'object') {
       return false;
     }
 
     for (const key of Object.keys(obj)) {
-      if (typeof obj[key] === 'string' && this.templateSrv.containsTemplate(obj[key])) {
-        return true;
-      } else if (Array.isArray(obj[key])) {
+      if (Array.isArray(obj[key])) {
         for (const item of obj[key]) {
           if (this.objectContainsTemplate(item)) {
             return true;

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -828,37 +828,22 @@ export class ElasticDatasource
     return false;
   }
 
-  private isPrimitive(obj: unknown) {
-    if (obj === null || obj === undefined) {
-      return true;
-    }
-    if (['string', 'number', 'boolean'].some((type) => type === typeof true)) {
-      return true;
-    }
-
-    return false;
-  }
-
   private objectContainsTemplate(obj: any) {
-    if (!obj) {
+    if (!obj || typeof obj !== 'object') {
       return false;
     }
 
     for (const key of Object.keys(obj)) {
-      if (this.isPrimitive(obj[key])) {
-        if (this.templateSrv.containsTemplate(obj[key])) {
-          return true;
-        }
+      if (typeof obj[key] === 'string' && this.templateSrv.containsTemplate(obj[key])) {
+        return true;
       } else if (Array.isArray(obj[key])) {
         for (const item of obj[key]) {
           if (this.objectContainsTemplate(item)) {
             return true;
           }
         }
-      } else {
-        if (this.objectContainsTemplate(obj[key])) {
-          return true;
-        }
+      } else if (this.objectContainsTemplate(obj[key])) {
+        return true;
       }
     }
 


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/pull/69575 I found a bug related with the `isPrimitive` implementation, which didn't correctly check for the object type, but rather it checked `typeof true` which is always `boolean`.

Fixed and added coverage.

**Why do we need this feature?**

It fixes a bug.

**Who is this feature for?**

People who don't enjoy bugs in the code.

**Which issue(s) does this PR fix?**:

Follow up to https://github.com/grafana/grafana/pull/69575

**Special notes for your reviewer:**

The method is used for alerting.