### PR TITLE
CloudMonitoring: Improve parsing of GCM labels

### DIFF
--- a/pkg/tsdb/cloud-monitoring/test-data/7-series-response-mql.json
+++ b/pkg/tsdb/cloud-monitoring/test-data/7-series-response-mql.json
@@ -13,6 +13,9 @@
       {
         "key": "metric.response_code_class",
         "valueType": "INT64"
+      },
+      {
+        "key": "metadata.app"
       }
     ],
     "pointDescriptors": [
@@ -37,6 +40,9 @@
         },
         {
           "int64Value": "200"
+        },
+        {
+          "stringValue": "test-app"
         }
       ],
       "pointData": [

--- a/pkg/tsdb/cloud-monitoring/time_series_query_test.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_query_test.go
@@ -110,6 +110,7 @@ func TestTimeSeriesQuery(t *testing.T) {
 		labels, ok := custom["labels"].(gdata.Labels)
 		require.True(t, ok)
 		assert.Equal(t, "6724404429462225363", labels["resource.label.instance_id"])
+		assert.Equal(t, "test-app", labels["metadata.label.app"])
 	})
 
 	t.Run("includes time interval", func(t *testing.T) {

--- a/pkg/tsdb/cloud-monitoring/types.go
+++ b/pkg/tsdb/cloud-monitoring/types.go
@@ -208,7 +208,7 @@ func (ts timeSeriesData) getLabels(labelDescriptors []LabelDescriptor) (data.Lab
 			seriesLabels[key] = labelValue.StringValue
 		}
 
-		if strings.Contains(key, "metric.label") || strings.Contains(key, "resource.label") {
+		if strings.Contains(key, "metric.label") || strings.Contains(key, "resource.label") || strings.Contains(key, "metadata.label") {
 			defaultMetricName += seriesLabels[key] + " "
 		}
 	}


### PR DESCRIPTION
This improves the parsing of labels returned from MQL queries to also include `metadata` prefixed labels. This accounts for when users may use group by queries with the default `metadata` labels (and potentially custom labels).

Fixes #68634