### PR TITLE
Prometheus: Incremental query - cache frames post transformV2

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -496,13 +496,16 @@ export class PrometheusDatasource
       const startTime = new Date();
       return super.query({ ...fullOrPartialRequest, targets: targets.flat() }).pipe(
         map((response) => {
-          const amendedResponse = {
-            ...response,
-            data: this.cache.procFrames(request, requestInfo, response.data),
-          };
-          return transformV2(amendedResponse, request, {
+          const transformed = transformV2(response, request, {
             exemplarTraceIdDestinations: this.exemplarTraceIdDestinations,
           });
+
+          const amendedResponse = {
+            ...transformed,
+            data: this.cache.procFrames(request, requestInfo, transformed.data),
+          };
+
+          return amendedResponse;
         }),
         tap((response: DataQueryResponse) => {
           trackQuery(response, request, startTime);

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -496,7 +496,7 @@ export class PrometheusDatasource
       const startTime = new Date();
       return super.query({ ...fullOrPartialRequest, targets: targets.flat() }).pipe(
         map((response) => {
-          const transformed = transformV2(response, request, {
+          const transformed = transformV2(response, fullOrPartialRequest, {
             exemplarTraceIdDestinations: this.exemplarTraceIdDestinations,
           });
 

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -343,8 +343,7 @@ export class QueryCache<T extends SupportedQueryTypes> {
             return;
           }
 
-          // frames are identified by their second (non-time) field's name + labels
-          // TODO: maybe also frame.meta.type?
+          // frames are identified by their second (non-time) field's name + labels, also frame.meta.type?
           let respFrameIdent = getFieldIdent(respFrame.fields[1]);
 
           let cachedFrame = cachedFrames.find(

--- a/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
+++ b/public/app/plugins/datasource/prometheus/querycache/QueryCache.ts
@@ -347,7 +347,10 @@ export class QueryCache<T extends SupportedQueryTypes> {
           // TODO: maybe also frame.meta.type?
           let respFrameIdent = getFieldIdent(respFrame.fields[1]);
 
-          let cachedFrame = cachedFrames.find((cached) => getFieldIdent(cached.fields[1]) === respFrameIdent);
+          let cachedFrame = cachedFrames.find(
+            (cached) =>
+              getFieldIdent(cached.fields[1]) === respFrameIdent && respFrame.fields[1].type === cached.fields[1].type
+          );
 
           if (!cachedFrame) {
             // append new unknown frames


### PR DESCRIPTION
**What is this feature?**

Instead of caching raw values and transforming the entire merged dataframe, let's modify incremental querying to cache values after transforming them with transformV2, this should allow for an easier upgrade path when migrating this to the backend.

**Why do we need this feature?**

In order to prepare for the migration of [transformV2 to the backend](https://github.com/grafana/grafana/issues/69018), incremental query needs to cache post-transform values.

This should also reduce the amount of computation we run on each incremental query.

**Who is this feature for?**
Prometheus users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/69807

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
