### PR TITLE
[DOC][Traces] Add second page where include file is called

### DIFF
--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -6,7 +6,7 @@ headless: true
 [//]: # 'This shared file is included in these locations:'
 [//]: # '/grafana/docs/sources/datasources/tempo/query-editor/index.md'
 [//]: # '/website/docs/grfana-cloud/data-configuration/traces/traces-query-editor.md'
-[//]: # ''
+[//]: #
 [//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
 [//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
 

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -5,6 +5,8 @@ headless: true
 [//]: # 'This file documents the Search query type for the Tempo data source. It is available as a public preview.'
 [//]: # 'This shared file is included in these locations:'
 [//]: # '/grafana/docs/sources/datasources/tempo/query-editor/index.md'
+[//]: # '/website/docs/grfana-cloud/data-configuration/traces/traces-query-editor.md'
+[//]: # ''
 [//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
 [//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
 


### PR DESCRIPTION

**What is this feature?**

This updates a shared doc file with an additional location for where the file is used. 

**Who is this feature for?**

Anyone updating the query editor content. 


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
