### PR TITLE
Datasources: Pass down the edit-form errors

### DIFF
--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -130,10 +130,10 @@ export function EditDataSourceView({
 
     try {
       await onUpdate({ ...dataSource });
-      trackDsConfigUpdated('success');
+      trackDsConfigUpdated({ item: 'success' });
       appEvents.publish(new DataSourceUpdatedSuccessfully());
-    } catch (err) {
-      trackDsConfigUpdated('fail');
+    } catch (error) {
+      trackDsConfigUpdated({ item: 'fail', error });
       return;
     }
 

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -83,6 +83,6 @@ export const trackDsConfigClicked = (item: string) => {
   reportInteraction('connections_datasources_settings_clicked', { item });
 };
 
-export const trackDsConfigUpdated = (item: string) => {
-  reportInteraction('connections_datasources_ds_configured', { item });
+export const trackDsConfigUpdated = (props: { item: string; error?: unknown }) => {
+  reportInteraction('connections_datasources_ds_configured', props);
 };


### PR DESCRIPTION
### What changed?

Passing down the errors to the form-update error handler, in case the form submission fails.
(Note: I believe this is different from the test status.)