### PR TITLE
Docs: Add migration docs for react-router v6 in plugins

### DIFF
--- a/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
+++ b/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
@@ -34,3 +34,54 @@ Most code targeting 9.x will continue to work without any issues. An exception i
 When writing plugins that should run on 9.x, continue to use the Vector interfaces. In this case, when targeting versions 10+, you can now use simple arrays rather than wrapper classes.
 
 To make this transition seamless, we employed the Original JavaScript Sin™. That is, we[extended the native Array prototype](https://github.com/grafana/grafana/blob/v10.0.x/packages/grafana-data/src/types/vector.ts) with several Vector methods. We will atone and undo this in v11, when Vector interfaces and classes are removed.
+
+## Update to React Router v6
+
+Starting from Grafana 10 plugins can start updating to use the v6 version of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
+
+**We strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible, as the v5 version is going to be deprecated in the future.**
+
+[Official React Router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5)
+
+### Update using `@grafana/create-plugin`
+
+Please follow the steps below to start using react router v6 in your plugin.
+
+#### 1. Update the build related configuration:
+
+```
+$ npx @grafana/create-plugin update
+```
+
+#### 2. Use `<Routes>` instead of `<Switch>`
+
+```typescript
+
+Using Routes instead of Switch in react-router v6
+You are using react-router-dom version 6, which replaced Switch with the Routes component
+
+import { Routes } from "react-router-dom";
+
+// ...
+
+return (
+  <Routes>
+    <Route path="/" element={<Home />} />
+  </Routes>
+);
+```
+
+#### 3. Remove the `exact` prop from `<Route>` components
+
+```typescript
+return (
+  <Routes>
+    {/* Until v5 */}
+    <Route exact path="/" element={<Home />} />
+
+    {/* From v6 */}
+    {/* (Routes are "exact" by default, you need to use the "*" to match sub-routes) */}
+    <Route path="/" element={<Home />} />
+  </Routes>
+);
+```

--- a/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
+++ b/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
@@ -57,7 +57,7 @@ $ npx @grafana/create-plugin update
 
 ```typescript
 
-Using Routes instead of Switch in react-router v6
+Using Routes instead of Switch in `react-router` v6
 You are using react-router-dom version 6, which replaced Switch with the Routes component
 
 import { Routes } from "react-router-dom";

--- a/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
+++ b/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
@@ -58,7 +58,7 @@ $ npx @grafana/create-plugin update
 ```typescript
 
 Using Routes instead of Switch in `react-router` v6
-You are using react-router-dom version 6, which replaced Switch with the Routes component
+You are using `react-router-dom` version 6, which replaced Switch with the Routes component
 
 import { Routes } from "react-router-dom";
 

--- a/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
+++ b/docs/sources/developers/plugins/migration-guide/v9.x-v10.x/_index.md
@@ -45,7 +45,7 @@ Starting from Grafana 10 plugins can start updating to use the v6 version of `re
 
 ### Update using `@grafana/create-plugin`
 
-Please follow the steps below to start using react router v6 in your plugin.
+Follow the steps below to start using React router v6 in your plugin.
 
 #### 1. Update the build related configuration:
 


### PR DESCRIPTION
Fixes: #69059 

### What changed?

Added a migration guide for updating react-router `v5` -> `v6` in plugins.

### Prerequisites

In order to have a migration doc backed by our plugin update tool and relevant examples, we have some prerequisites that we should do before updating the migration docs.

- [ ] **1.** Update the `@grafana/create-plugin update` command to be able to update both devDependencies and dependencies https://github.com/grafana/plugin-tools/pull/707
- [x] **2.** Add a feature flag to `@grafana/create-plugin` that allows to use the new react router (can be enabled for existing plugins and automatically received by new scaffolds) https://github.com/grafana/plugin-tools/pull/710
- [ ] **3.** Update the `grafana/grafana-plugin-examples` to use the latest router
- [ ] **4.** Update and release the migration doc