### PR TITLE
Tempo/ServiceGraph: Specify explicit field types (#69759)

### DIFF
--- a/public/app/plugins/datasource/tempo/graphTransform.test.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.test.ts
@@ -1,4 +1,4 @@
-import { DataFrameView, dateTime, MutableDataFrame } from '@grafana/data';
+import { DataFrameView, dateTime, MutableDataFrame, createDataFrame, FieldType } from '@grafana/data';
 
 import { createGraphFrames, mapPromMetricsToServiceMap } from './graphTransform';
 import { bigResponse } from './testResponse';
@@ -57,6 +57,26 @@ describe('createGraphFrames', () => {
     expect(frames[0].length).toBe(2);
     expect(frames[1].length).toBe(0);
   });
+});
+
+it('assigns correct field type even if values are numbers', async () => {
+  const range = {
+    from: dateTime('2000-01-01T00:00:00'),
+    to: dateTime('2000-01-01T00:01:00'),
+  };
+  const { nodes } = mapPromMetricsToServiceMap([{ data: [serverIsANumber, serverIsANumber] }], {
+    ...range,
+    raw: range,
+  });
+
+  expect(nodes.fields).toMatchObject([
+    { name: 'id', values: ['0', '1'], type: FieldType.string },
+    { name: 'title', values: ['0', '1'], type: FieldType.string },
+    { name: 'mainstat', values: [NaN, NaN], type: FieldType.number },
+    { name: 'secondarystat', values: [10, 20], type: FieldType.number },
+    { name: 'arc__success', values: [1, 1], type: FieldType.number },
+    { name: 'arc__failed', values: [0, 0], type: FieldType.number },
+  ]);
 });
 
 describe('mapPromMetricsToServiceMap', () => {
@@ -189,5 +209,18 @@ const invalidFailedPromMetric = new MutableDataFrame({
     { name: 'server', values: ['db', 'app'] },
     { name: 'tempo_config', values: ['default', 'default'] },
     { name: 'Value #traces_service_graph_request_failed_total', values: [20, 40] },
+  ],
+});
+
+const serverIsANumber = createDataFrame({
+  refId: 'traces_service_graph_request_total',
+  fields: [
+    { name: 'Time', values: [1628169788000, 1628169788000] },
+    { name: 'client', values: ['0', '1'] },
+    { name: 'instance', values: ['127.0.0.1:12345', '127.0.0.1:12345'] },
+    { name: 'job', values: ['local_scrape', 'local_scrape'] },
+    { name: 'server', values: ['0', '1'] },
+    { name: 'tempo_config', values: ['default', 'default'] },
+    { name: 'Value #traces_service_graph_request_total', values: [10, 20] },
   ],
 });

--- a/public/app/plugins/datasource/tempo/graphTransform.test.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.test.ts
@@ -1,4 +1,4 @@
-import { DataFrameView, dateTime, MutableDataFrame, createDataFrame, FieldType } from '@grafana/data';
+import { DataFrameView, dateTime, MutableDataFrame, FieldType } from '@grafana/data';
 
 import { createGraphFrames, mapPromMetricsToServiceMap } from './graphTransform';
 import { bigResponse } from './testResponse';
@@ -212,7 +212,7 @@ const invalidFailedPromMetric = new MutableDataFrame({
   ],
 });
 
-const serverIsANumber = createDataFrame({
+const serverIsANumber = new MutableDataFrame({
   refId: 'traces_service_graph_request_total',
   fields: [
     { name: 'Time', values: [1628169788000, 1628169788000] },

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -7,6 +7,7 @@ import {
   MutableDataFrame,
   NodeGraphDataFrameFieldNames as Fields,
   TimeRange,
+  FieldType,
 } from '@grafana/data';
 
 import { getNonOverlappingDuration, getStats, makeFrames, makeSpanMap } from '../../../core/utils/tracing';
@@ -188,28 +189,35 @@ function createServiceMapDataFrames() {
   }
 
   const nodes = createDF('Nodes', [
-    { name: Fields.id },
-    { name: Fields.title, config: { displayName: 'Service name' } },
-    { name: Fields.mainStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
+    { name: Fields.id, type: FieldType.string },
+    { name: Fields.title, type: FieldType.string, config: { displayName: 'Service name' } },
+    { name: Fields.mainStat, type: FieldType.number, config: { unit: 'ms/r', displayName: 'Average response time' } },
     {
       name: Fields.secondaryStat,
+      type: FieldType.number,
       config: { unit: 'r/sec', displayName: 'Requests per second' },
     },
     {
       name: Fields.arc + 'success',
+      type: FieldType.number,
       config: { displayName: 'Success', color: { fixedColor: 'green', mode: FieldColorModeId.Fixed } },
     },
     {
       name: Fields.arc + 'failed',
+      type: FieldType.number,
       config: { displayName: 'Failed', color: { fixedColor: 'red', mode: FieldColorModeId.Fixed } },
     },
   ]);
   const edges = createDF('Edges', [
-    { name: Fields.id },
-    { name: Fields.source },
-    { name: Fields.target },
-    { name: Fields.mainStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
-    { name: Fields.secondaryStat, config: { unit: 'r/sec', displayName: 'Requests per second' } },
+    { name: Fields.id, type: FieldType.string },
+    { name: Fields.source, type: FieldType.string },
+    { name: Fields.target, type: FieldType.string },
+    { name: Fields.mainStat, type: FieldType.number, config: { unit: 'ms/r', displayName: 'Average response time' } },
+    {
+      name: Fields.secondaryStat,
+      type: FieldType.number,
+      config: { unit: 'r/sec', displayName: 'Requests per second' },
+    },
   ]);
 
   return [nodes, edges];


### PR DESCRIPTION
Assign field types to service graph fields. Backport of https://github.com/grafana/grafana/pull/69759

(cherry picked from commit 1696bc201eeac25f28184bfa47bb0960c1c90b73)

