### PR TITLE
Command Palette: Links opened in a new tab now route correctly when Grafana is served under a subpath

### DIFF
--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -1,7 +1,6 @@
 import debounce from 'debounce-promise';
 import { useEffect, useRef, useState } from 'react';
 
-import { locationUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -43,7 +42,7 @@ export async function getRecentDashboardActions(): Promise<CommandPaletteAction[
       name: `${name}`,
       section: t('command-palette.section.recent-dashboards', 'Recent dashboards'),
       priority: RECENT_DASHBOARDS_PRORITY,
-      url: locationUtil.stripBaseFromUrl(url),
+      url,
     };
   });
 
@@ -72,7 +71,7 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
           ? t('command-palette.section.dashboard-search-results', 'Dashboards')
           : t('command-palette.section.folder-search-results', 'Folders'),
       priority: SEARCH_RESULTS_PRORITY,
-      url: locationUtil.stripBaseFromUrl(url),
+      url,
       subtitle: data.view.dataFrame.meta?.custom?.locationInfo[location]?.name,
     };
   });

--- a/public/app/features/commandPalette/actions/staticActions.ts
+++ b/public/app/features/commandPalette/actions/staticActions.ts
@@ -1,4 +1,4 @@
-import { locationUtil, NavModelItem } from '@grafana/data';
+import { NavModelItem } from '@grafana/data';
 import { t } from 'app/core/internationalization';
 import { changeTheme } from 'app/core/services/theme';
 
@@ -32,7 +32,7 @@ function navTreeToActions(navTree: NavModelItem[], parents: NavModelItem[] = [])
       id: idForNavItem(navItem),
       name: text,
       section: section,
-      url: url && locationUtil.stripBaseFromUrl(url),
+      url,
       target,
       parent: parents.length > 0 && !isCreateAction ? idForNavItem(parents[parents.length - 1]) : undefined,
       priority: priority,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- stop using the `stripBaseFromUrl` function to modify the command palette links
- this used to be necessary when the links weren't actual links but buttons with `onClick`
  - in that case, we used to directly push the link onto the `locationService` (which already knew about the base path)
  - when serving under a subPath, without stripping we'd end up with a url of `/<subPath>/<subPath>/<route>`
  - now that they're actual proper fully fledged links, this stripping of the base path actually breaks them and leaves the links as just `/route`

**Why do we need this feature?**

- so people can ctrl/cmd-click links in the command palette when grafana is served under a subpath

**Who is this feature for?**

- anyone serving grafana under a subpath

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #67698

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
