### PR TITLE
LogsPanel: Remove bottom margin

### DIFF
--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -70,7 +70,6 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       font-family: ${theme.typography.fontFamilyMonospace};
       font-size: ${theme.typography.bodySmall.fontSize};
       width: 100%;
-      margin-bottom: ${theme.spacing(2.25)}; /* This is to make sure the last row's LogRowMenu is not cut off. */
     `,
     contextBackground: css`
       background: ${hoverBgColor};


### PR DESCRIPTION
As discovered in https://github.com/grafana/grafana/pull/69847#pullrequestreview-1471884903 the bottom margin does not seem necessary anymore.