### PR TITLE
AzureMonitor: Revert timespan change

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -425,12 +425,14 @@ func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) *data.
 }
 
 func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger log.Logger, queryURL string, query *AzureLogAnalyticsQuery) (*http.Request, error) {
-	from := query.TimeRange.From.Format(time.RFC3339)
-	to := query.TimeRange.To.Format(time.RFC3339)
-	timespan := fmt.Sprintf("%s/%s", from, to)
 	body := map[string]interface{}{
-		"query":    query.Query,
-		"timespan": timespan,
+		"query": query.Query,
+	}
+	if query.QueryType == string(dataquery.AzureQueryTypeAzureTraces) {
+		from := query.TimeRange.From.Format(time.RFC3339)
+		to := query.TimeRange.To.Format(time.RFC3339)
+		timespan := fmt.Sprintf("%s/%s", from, to)
+		body["timespan"] = timespan
 	}
 	if len(query.Resources) > 1 && query.QueryType == string(dataquery.AzureQueryTypeAzureLogAnalytics) {
 		body["workspaces"] = query.Resources

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1379,7 +1379,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		if !cmp.Equal(req.Header, expectedHeaders) {
 			t.Errorf("Unexpected HTTP headers: %v", cmp.Diff(req.Header, expectedHeaders))
 		}
-		expectedBody := `{"query":"Perf","timespan":"0001-01-01T00:00:00Z/0001-01-01T00:00:00Z"}`
+		expectedBody := `{"query":"Perf"}`
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {
@@ -1395,29 +1395,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
 		})
 		require.NoError(t, err)
-		expectedBody := `{"query":"Perf","timespan":"0001-01-01T00:00:00Z/0001-01-01T00:00:00Z","workspaces":["r1","r2"]}`
-		body, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-		if !cmp.Equal(string(body), expectedBody) {
-			t.Errorf("Unexpected Body: %v", cmp.Diff(string(body), expectedBody))
-		}
-	})
-
-	t.Run("creates a request with timerange from query", func(t *testing.T) {
-		ds := AzureLogAnalyticsDatasource{}
-		from := time.Now()
-		to := from.Add(3 * time.Hour)
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
-			Resources: []string{"r1", "r2"},
-			Query:     "Perf",
-			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
-			TimeRange: backend.TimeRange{
-				From: from,
-				To:   to,
-			},
-		})
-		require.NoError(t, err)
-		expectedBody := fmt.Sprintf(`{"query":"Perf","timespan":"%s/%s","workspaces":["r1","r2"]}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
+		expectedBody := `{"query":"Perf","workspaces":["r1","r2"]}`
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {


### PR DESCRIPTION
This reverts the change from #67914 to prevent users needing to make a change to existing Logs queries (and so prevents a breaking change right now). It does not affect traces queries.