### PR TITLE
Alerting: Add matchers metrics to Alertmanager

### DIFF
--- a/pkg/services/ngalert/metrics/alertmanager.go
+++ b/pkg/services/ngalert/metrics/alertmanager.go
@@ -18,7 +18,7 @@ func NewAlertmanagerMetrics(r prometheus.Registerer) *Alertmanager {
 	return &Alertmanager{
 		Registerer:                r,
 		Alerts:                    metrics.NewAlerts("grafana", other),
-		AlertmanagerConfigMetrics: NewAlertmanagerConfigMetrics(other),
+		AlertmanagerConfigMetrics: NewAlertmanagerConfigMetrics(r),
 	}
 }
 

--- a/pkg/services/ngalert/metrics/alertmanager.go
+++ b/pkg/services/ngalert/metrics/alertmanager.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+
 	"github.com/prometheus/alertmanager/api/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/services/ngalert/metrics/alertmanager.go
+++ b/pkg/services/ngalert/metrics/alertmanager.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"fmt"
-
 	"github.com/prometheus/alertmanager/api/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -10,12 +9,47 @@ import (
 type Alertmanager struct {
 	Registerer prometheus.Registerer
 	*metrics.Alerts
+	*AlertmanagerConfigMetrics
 }
 
 // NewAlertmanagerMetrics creates a set of metrics for the Alertmanager of each organization.
 func NewAlertmanagerMetrics(r prometheus.Registerer) *Alertmanager {
+	other := prometheus.WrapRegistererWithPrefix(fmt.Sprintf("%s_%s_", Namespace, Subsystem), r)
 	return &Alertmanager{
-		Registerer: r,
-		Alerts:     metrics.NewAlerts("grafana", prometheus.WrapRegistererWithPrefix(fmt.Sprintf("%s_%s_", Namespace, Subsystem), r)),
+		Registerer:                r,
+		Alerts:                    metrics.NewAlerts("grafana", other),
+		AlertmanagerConfigMetrics: NewAlertmanagerConfigMetrics(other),
 	}
+}
+
+type AlertmanagerConfigMetrics struct {
+	Matchers       prometheus.Gauge
+	MatchRE        prometheus.Gauge
+	Match          prometheus.Gauge
+	ObjectMatchers prometheus.Gauge
+}
+
+func NewAlertmanagerConfigMetrics(r prometheus.Registerer) *AlertmanagerConfigMetrics {
+	m := &AlertmanagerConfigMetrics{
+		Matchers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_matchers",
+			Help: "The total number of matchers",
+		}),
+		MatchRE: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_match_re",
+			Help: "The total number of matche_re",
+		}),
+		Match: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_match",
+			Help: "The total number of match",
+		}),
+		ObjectMatchers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_object_matchers",
+			Help: "The total number of object_matchers",
+		}),
+	}
+	if r != nil {
+		r.MustRegister(m.Matchers, m.MatchRE, m.Match, m.ObjectMatchers)
+	}
+	return m
 }

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -325,5 +325,4 @@ func (a *AlertmanagerAggregatedMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfGauges(out, a.matchRE, "alertmanager_config_match_re")
 	data.SendSumOfGauges(out, a.match, "alertmanager_config_match")
 	data.SendSumOfGauges(out, a.objectMatchers, "alertmanager_config_object_matchers")
-
 }

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -18,12 +18,6 @@ type MultiOrgAlertmanager struct {
 	ActiveConfigurations     prometheus.Gauge
 	DiscoveredConfigurations prometheus.Gauge
 
-	//
-	matchers       prometheus.Gauge
-	matchRE        prometheus.Gauge
-	match          prometheus.Gauge
-	objectMatchers prometheus.Gauge
-
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
 
@@ -43,22 +37,6 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Subsystem: Subsystem,
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
-		}),
-		matchers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "alertmanager_config_matchers",
-			Help: "The total number of matchers",
-		}),
-		matchRE: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "alertmanager_config_matchRE",
-			Help: "The total number of match_re",
-		}),
-		match: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "alertmanager_config_match",
-			Help: "The total number of match",
-		}),
-		objectMatchers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "alertmanager_config_object_matchers",
-			Help: "The total number of object matchers",
 		}),
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -18,6 +18,12 @@ type MultiOrgAlertmanager struct {
 	ActiveConfigurations     prometheus.Gauge
 	DiscoveredConfigurations prometheus.Gauge
 
+	//
+	matchers       prometheus.Gauge
+	matchRE        prometheus.Gauge
+	match          prometheus.Gauge
+	objectMatchers prometheus.Gauge
+
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
 
@@ -37,6 +43,22 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Subsystem: Subsystem,
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
+		}),
+		matchers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_matchers",
+			Help: "The total number of matchers",
+		}),
+		matchRE: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_matchRE",
+			Help: "The total number of match_re",
+		}),
+		match: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_match",
+			Help: "The total number of match",
+		}),
+		objectMatchers: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "alertmanager_config_object_matchers",
+			Help: "The total number of object matchers",
 		}),
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -107,6 +107,12 @@ type AlertmanagerAggregatedMetrics struct {
 	// exported metrics, gathered from Alertmanager Dispatcher
 	dispatchAggrGroups         *prometheus.Desc
 	dispatchProcessingDuration *prometheus.Desc
+
+	//
+	matchers       *prometheus.Desc
+	matchRE        *prometheus.Desc
+	match          *prometheus.Desc
+	objectMatchers *prometheus.Desc
 }
 
 func NewAlertmanagerAggregatedMetrics(registries *metrics.TenantRegistries) *AlertmanagerAggregatedMetrics {
@@ -221,6 +227,23 @@ func NewAlertmanagerAggregatedMetrics(registries *metrics.TenantRegistries) *Ale
 			fmt.Sprintf("%s_%s_dispatcher_alert_processing_duration_seconds", Namespace, Subsystem),
 			"Summary of latencies for the processing of alerts.",
 			nil, nil),
+
+		matchers: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_alertmanager_config_matchers", Namespace, Subsystem),
+			"The total number of matchers",
+			nil, nil),
+		matchRE: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_alertmanager_config_match_re", Namespace, Subsystem),
+			"The total number of matchRE",
+			nil, nil),
+		match: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_alertmanager_config_match", Namespace, Subsystem),
+			"The total number of match",
+			nil, nil),
+		objectMatchers: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_alertmanager_config_object_matchers", Namespace, Subsystem),
+			"The total number of object_matchers",
+			nil, nil),
 	}
 
 	return aggregatedMetrics
@@ -257,6 +280,11 @@ func (a *AlertmanagerAggregatedMetrics) Describe(out chan<- *prometheus.Desc) {
 
 	out <- a.dispatchAggrGroups
 	out <- a.dispatchProcessingDuration
+
+	out <- a.matchers
+	out <- a.matchRE
+	out <- a.match
+	out <- a.objectMatchers
 }
 
 func (a *AlertmanagerAggregatedMetrics) Collect(out chan<- prometheus.Metric) {
@@ -292,4 +320,10 @@ func (a *AlertmanagerAggregatedMetrics) Collect(out chan<- prometheus.Metric) {
 
 	data.SendSumOfGauges(out, a.dispatchAggrGroups, "alertmanager_dispatcher_aggregation_groups")
 	data.SendSumOfSummaries(out, a.dispatchProcessingDuration, "alertmanager_dispatcher_alert_processing_duration_seconds")
+
+	data.SendSumOfGauges(out, a.matchers, "alertmanager_config_matchers")
+	data.SendSumOfGauges(out, a.matchRE, "alertmanager_config_match_re")
+	data.SendSumOfGauges(out, a.match, "alertmanager_config_match")
+	data.SendSumOfGauges(out, a.objectMatchers, "alertmanager_config_object_matchers")
+
 }

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -108,7 +108,8 @@ type AlertmanagerAggregatedMetrics struct {
 	dispatchAggrGroups         *prometheus.Desc
 	dispatchProcessingDuration *prometheus.Desc
 
-	//
+	// added to measure usage of matchers, match_re, match and
+	// object_matchers
 	matchers       *prometheus.Desc
 	matchRE        *prometheus.Desc
 	match          *prometheus.Desc

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -257,7 +257,7 @@ func (am *Alertmanager) updateConfigMetrics(cfg *apimodels.PostableUserConfig) {
 
 func (am *Alertmanager) aggregateMatchers(r *apimodels.Route, amu *AggregateMatchersUsage) {
 	amu.Matchers += len(r.Matchers)
-	amu.MatchRE += len(r.Matchers)
+	amu.MatchRE += len(r.MatchRE)
 	amu.Match += len(r.Match)
 	amu.ObjectMatchers += len(r.ObjectMatchers)
 	for _, next := range r.Routes {

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -47,6 +47,7 @@ type Alertmanager struct {
 	Base   *alertingNotify.GrafanaAlertmanager
 	logger log.Logger
 
+	ConfigMetrics       *metrics.AlertmanagerConfigMetrics
 	Settings            *setting.Cfg
 	Store               AlertingStore
 	fileStore           *FileStore
@@ -133,6 +134,7 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store A
 
 	am := &Alertmanager{
 		Base:                gam,
+		ConfigMetrics:       m.AlertmanagerConfigMetrics,
 		Settings:            cfg,
 		Store:               store,
 		NotificationService: ns,
@@ -237,6 +239,32 @@ func (am *Alertmanager) ApplyConfig(ctx context.Context, dbCfg *ngmodels.AlertCo
 	return outerErr
 }
 
+type AggregateMatchersUsage struct {
+	Matchers       int
+	MatchRE        int
+	Match          int
+	ObjectMatchers int
+}
+
+func (am *Alertmanager) updateConfigMetrics(cfg *apimodels.PostableUserConfig) {
+	var amu AggregateMatchersUsage
+	am.aggregateMatchers(cfg.AlertmanagerConfig.Route, &amu)
+	am.ConfigMetrics.Matchers.Set(float64(amu.Matchers))
+	am.ConfigMetrics.MatchRE.Set(float64(amu.MatchRE))
+	am.ConfigMetrics.Match.Set(float64(amu.Match))
+	am.ConfigMetrics.ObjectMatchers.Set(float64(amu.ObjectMatchers))
+}
+
+func (am *Alertmanager) aggregateMatchers(r *apimodels.Route, amu *AggregateMatchersUsage) {
+	amu.Matchers += len(r.Matchers)
+	amu.MatchRE += len(r.Matchers)
+	amu.Match += len(r.Match)
+	amu.ObjectMatchers += len(r.ObjectMatchers)
+	for _, next := range r.Routes {
+		am.aggregateMatchers(next, amu)
+	}
+}
+
 // applyConfig applies a new configuration by re-initializing all components using the configuration provided.
 // It returns a boolean indicating whether the user config was changed and an error.
 // It is not safe to call concurrently.
@@ -273,6 +301,8 @@ func (am *Alertmanager) applyConfig(cfg *apimodels.PostableUserConfig, rawConfig
 		am.logger.Debug("Neither config nor template have changed, skipping configuration sync.")
 		return false, nil
 	}
+
+	am.updateConfigMetrics(cfg)
 
 	err = am.Base.ApplyConfig(AlertingConfiguration{
 		rawAlertmanagerConfig:    rawConfig,

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/alertmanager/config"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -13,6 +12,7 @@ import (
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers"
 	alertingTemplates "github.com/grafana/alerting/templates"
+	"github.com/prometheus/alertmanager/config"
 
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 


### PR DESCRIPTION
**What is this feature?**

This pull request tracks the usage of `matchers`, `match`, `match_re` and `object_matchers` in Grafana to understand the possible impact of https://github.com/grafana/alerting-squad/issues/520.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
