### PR TITLE
PanelChrome: Fix tabbing to panel menu button

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -261,14 +261,12 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
 
       '.show-on-hover': {
-        visibility: 'hidden',
         opacity: '0',
       },
 
       '&:focus-visible, &:hover': {
         // only show menu icon on hover or focused panel
         '.show-on-hover': {
-          visibility: 'visible',
           opacity: '1',
         },
       },


### PR DESCRIPTION
Removes `visibility` property from hover class CSS as it was preventing tabbing to the button while hidden.

Closes #66256