### PR TITLE
[DOC] Update for query editor live in Cloud

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/index.md
+++ b/docs/sources/datasources/tempo/query-editor/index.md
@@ -67,11 +67,12 @@ To query a particular trace:
 
 Inspired by PromQL and LogQL, TraceQL is a query language designed for selecting traces.
 The default traces search reviews the whole trace.
-TraceQL provides a method for formulating precise queries so you can zoom in to the data you need. Query results are returned faster because the queries limit what is searched
+TraceQL provides a method for formulating precise queries so you can zoom in to the data you need.
+Query results are returned faster because the queries limit what is searched.
 
 To learn more about how to query by TraceQL, refer to the [TraceQL documentation](/docs/tempo/latest/traceql).
 
-You can create TraceQL queries using the Query editor or using Search query tab (preview feature).
+You can create TraceQL queries using the Query editor or using Search query tab.
 
 [//]: # 'Include content for preview of Search tab featuring TraceQL query builder'
 

--- a/docs/sources/datasources/tempo/query-editor/index.md
+++ b/docs/sources/datasources/tempo/query-editor/index.md
@@ -72,7 +72,7 @@ Query results are returned faster because the queries limit what is searched.
 
 To learn more about how to query by TraceQL, refer to the [TraceQL documentation](/docs/tempo/latest/traceql).
 
-You can create TraceQL queries using the Query editor or using Search query tab.
+You can create TraceQL queries using the Query editor or using **Search** query type.
 
 [//]: # 'Include content for preview of Search tab featuring TraceQL query builder'
 

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -2,10 +2,10 @@
 headless: true
 ---
 
-[//]: # 'This file documents the Search query type for the Tempo data source. It is available as a public preview.'
+[//]: # 'This file documents the Search query type for the Tempo data source.'
 [//]: # 'This shared file is included in these locations:'
 [//]: # '/grafana/docs/sources/datasources/tempo/query-editor/index.md'
-[//]: # '/website/docs/grfana-cloud/data-configuration/traces/traces-query-editor.md'
+[//]: # '/website/docs/grafana-cloud/data-configuration/traces/traces-query-editor.md'
 [//]: #
 [//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
 [//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
@@ -13,7 +13,10 @@ headless: true
 # Create TraceQL queries using Search
 
 {{% admonition type="note" %}}
-This new Search query type is available as an experimental feature. This feature is under active development and is not production ready. To try this feature, enable the `traceqlSearch` feature flag in Grafana (read [documentation](/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/)). Grafana Cloud users should contact Grafana Support to enable this feature.
+This new Search query type is available as an experimental feature.
+This feature is under active development and is not production ready.
+To try this feature, enable the `traceqlSearch` feature flag in Grafana (read [documentation](/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/)).
+Grafana Cloud users have this feature.
 {{% /admonition %}}
 
 Using the Search tab in Explore, you can use the query builder’s drop-downs to compose TraceQL queries. The selections you make automatically generate a [TraceQL query](/docs/tempo/latest/traceql).


### PR DESCRIPTION
**What is this feature?**

This PR removes the warning message that Cloud users have to contact support to enable the query editor for Traces. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
