### PR TITLE
CloudWatch Logs: add monaco editor feature flag and types

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -113,6 +113,7 @@ Experimental features might be changed or removed without prior notice.
 | `extraThemes`                      | Enables extra themes                                                                                         |
 | `lokiPredefinedOperations`         | Adds predefined query operations to Loki query editor                                                        |
 | `pluginsFrontendSandbox`           | Enables the plugins frontend sandbox                                                                         |
+| `cloudWatchLogsMonacoEditor`       | Enables the Monaco editor for CloudWatch Logs queries                                                        |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -100,4 +100,5 @@ export interface FeatureToggles {
   lokiPredefinedOperations?: boolean;
   pluginsFrontendSandbox?: boolean;
   sqlDatasourceDatabaseSelection?: boolean;
+  cloudWatchLogsMonacoEditor?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -557,5 +557,12 @@ var (
 			Stage:        FeatureStagePublicPreview,
 			Owner:        grafanaBiSquad,
 		},
+		{
+			Name:         "cloudWatchLogsMonacoEditor",
+			Description:  "Enables the Monaco editor for CloudWatch Logs queries",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        awsPluginsSquad,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -81,3 +81,4 @@ extraThemes,experimental,@grafana/grafana-frontend-platform,false,false,false,tr
 lokiPredefinedOperations,experimental,@grafana/observability-logs,false,false,false,true
 pluginsFrontendSandbox,experimental,@grafana/plugins-platform-backend,false,false,false,true
 sqlDatasourceDatabaseSelection,preview,@grafana/grafana-bi-squad,false,false,false,true
+cloudWatchLogsMonacoEditor,experimental,@grafana/aws-plugins,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -334,4 +334,8 @@ const (
 	// FlagSqlDatasourceDatabaseSelection
 	// Enables previous SQL data source dataset dropdown behavior
 	FlagSqlDatasourceDatabaseSelection = "sqlDatasourceDatabaseSelection"
+
+	// FlagCloudWatchLogsMonacoEditor
+	// Enables the Monaco editor for CloudWatch Logs queries
+	FlagCloudWatchLogsMonacoEditor = "cloudWatchLogsMonacoEditor"
 )

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
@@ -1,0 +1,15 @@
+import { TokenTypes } from '../../monarch/types';
+
+export const LogsTokenTypes: TokenTypes = {
+  Parenthesis: 'delimiter.parenthesis.cloudwatch-logs',
+  Whitespace: 'white.cloudwatch-logs',
+  Keyword: 'keyword.cloudwatch-logs',
+  Delimiter: 'delimiter.cloudwatch-logs',
+  Operator: 'operator.cloudwatch-logs',
+  Identifier: 'identifier.cloudwatch-logs',
+  Type: 'type.cloudwatch-logs',
+  Function: 'predefined.cloudwatch-logs',
+  Number: 'number.cloudwatch-logs',
+  String: 'string.cloudwatch-logs',
+  Variable: 'variable.cloudwatch-logs',
+};


### PR DESCRIPTION
Sets up the feature flag for the CloudWatch Logs Monaco editor and the types for the auto-completion

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #69342

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
