### PR TITLE
[auth-docs] - Add Grafana Cloud Limitations

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -124,7 +124,10 @@ Hide the Grafana login form using the below configuration settings.
 disable_login_form = true
 ```
 
-> Please Note: For Grafana Cloud users, this option can only be configured under specific circumstances, e.g. when enabling LDAP Authentication, please contact Grafana Support for further assistance.
+{{% admonition type="note" %}}
+For Grafana Cloud users, this option can only be configured under specific circumstances, such as enabling LDAP authentication. Please contact Grafana Support for further assistance.
+{{% /admonition %}}
+
 
 ### Automatic OAuth login
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -33,7 +33,7 @@ The following table shows all supported authentication providers and the feature
 
 ## Grafana Auth
 
-Grafana OSS and Grafana Enterprise, of course has a built in user authentication system with password authentication enabled 
+Grafana OSS and Grafana Enterprise, has a built-in user authentication system with password authentication enabled 
 by default. For Grafana Cloud, the default authentication system uses your `grafana.com` account for authentication.  
 
 You can disable authentication by enabling anonymous access (not available on Grafana Cloud). 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -116,7 +116,10 @@ To disable basic auth:
 enabled = false
 ```
 
-> Please Note: Basic authentication (or Local Grafana Authentication) is not supported in Grafana Cloud.
+{{% admonition type="note" %}}
+Basic authentication (or local Grafana authentication) is not supported in Grafana Cloud.
+{{% /admonition %}}
+
 
 ### Disable login form
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -99,7 +99,10 @@ org_role = Viewer
 
 If you change your organization name in the Grafana UI, this setting needs to be updated to match the new name.
 
-> Please Note: Anonymous authentication is not supported in Grafana Cloud.
+{{% admonition type="note" %}}
+Anonymous authentication is not supported in Grafana Cloud.
+{{% /admonition %}}
+
 
 ### Basic authentication
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -33,9 +33,13 @@ The following table shows all supported authentication providers and the feature
 
 ## Grafana Auth
 
-Grafana of course has a built in user authentication system with password authentication enabled by default. You can
-disable authentication by enabling anonymous access. You can also hide the login form and only allow login through an auth
-provider (listed above). There are also options for allowing self sign up.
+Grafana OSS and Grafana Enterprise, of course has a built in user authentication system with password authentication enabled 
+by default. For Grafana Cloud, the default authentication system uses your `grafana.com` account for authentication.  
+
+You can disable authentication by enabling anonymous access (not available on Grafana Cloud). 
+
+You can also hide the login form and only allow login through an auth provider (listed above). 
+There are also options for allowing self sign up (not available on Grafana Cloud).
 
 ### Login and short-lived tokens
 
@@ -95,6 +99,8 @@ org_role = Viewer
 
 If you change your organization name in the Grafana UI, this setting needs to be updated to match the new name.
 
+> Please Note: Anonymous authentication is not supported in Grafana Cloud.
+
 ### Basic authentication
 
 Basic auth is enabled by default and works with the built-in Grafana user-password authentication system and LDAP
@@ -107,6 +113,8 @@ To disable basic auth:
 enabled = false
 ```
 
+> Please Note: Basic authentication (or Local Grafana Authentication) is not supported in Grafana Cloud.
+
 ### Disable login form
 
 Hide the Grafana login form using the below configuration settings.
@@ -115,6 +123,8 @@ Hide the Grafana login form using the below configuration settings.
 [auth]
 disable_login_form = true
 ```
+
+> Please Note: For Grafana Cloud users, this option can only be configured under specific circumstances, e.g. when enabling LDAP Authentication, please contact Grafana Support for further assistance.
 
 ### Automatic OAuth login
 


### PR DESCRIPTION
Add additional comments to specify what is not available on Grafana Cloud.

**What is this feature?**

Update to Docs, to make clearer what auth methods can't be enabled on Grafana Cloud.

**Why do we need this feature?**

To make it clearer for customer what methods and features are available in OSS/Enterprise (On-Prem) vs Grafana Cloud.

Internal additional context can also be provided if needed

**Who is this feature for?**

Readers of our Documentation, Grafana Cloud Users, Grafana Support.

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
