### PR TITLE
CI: Make node18 available in update-changelog workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,6 +15,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Run update changelog (manually invoked)
         uses: grafana/grafana-github-actions-go/update-changelog@main
         with:


### PR DESCRIPTION
This is a first step to hopefully get prettier working again in the context of the new update-changelog action.