### PR TITLE
Loki: Add feature tracking to reduce repetition

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { AlertingSettings, DataSourceHttpSettings } from '@grafana/ui';
 
 import { LokiOptions } from '../types';
@@ -30,6 +30,14 @@ const setDerivedFields = makeJsonUpdater('derivedFields');
 export const ConfigEditor = (props: Props) => {
   const { options, onOptionsChange } = props;
 
+  const updatePredefinedOperations = useCallback(
+    (value: string) => {
+      reportInteraction('grafana_loki_predefined_operations_changed', { value });
+      onOptionsChange(setPredefinedOperations(options, value));
+    },
+    [options, onOptionsChange]
+  );
+
   return (
     <>
       <DataSourceHttpSettings
@@ -46,7 +54,7 @@ export const ConfigEditor = (props: Props) => {
         maxLines={options.jsonData.maxLines || ''}
         onMaxLinedChange={(value) => onOptionsChange(setMaxLines(options, value))}
         predefinedOperations={options.jsonData.predefinedOperations || ''}
-        onPredefinedOperationsChange={(value) => onOptionsChange(setPredefinedOperations(options, value))}
+        onPredefinedOperationsChange={updatePredefinedOperations}
       />
 
       <DerivedFields

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -290,7 +290,11 @@ export class LokiDatasource
     }
 
     const startTime = new Date();
-    return this.runQuery(fixedRequest).pipe(tap((response) => trackQuery(response, fixedRequest, startTime)));
+    return this.runQuery(fixedRequest).pipe(
+      tap((response) =>
+        trackQuery(response, fixedRequest, startTime, { predefinedOperations: this.predefinedOperations })
+      )
+    );
   }
 
   runQuery(fixedRequest: DataQueryRequest<LokiQuery>) {

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -91,7 +91,8 @@ describe('runSplitQuery()', () => {
             },
           ],
           request,
-          new Date()
+          new Date(),
+          { predefinedOperations: '' }
         );
       });
     });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -281,7 +281,9 @@ export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequ
   return runSplitGroupedQueries(datasource, requests).pipe(
     tap((response) => {
       if (response.state === LoadingState.Done) {
-        trackGroupedQueries(response, requests, request, startTime);
+        trackGroupedQueries(response, requests, request, startTime, {
+          predefinedOperations: datasource.predefinedOperations,
+        });
       }
     })
   );

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -92,6 +92,35 @@ test('Tracks queries', () => {
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
+    predefined_operations_applied: 'n/a',
+  });
+});
+
+test('Tracks predefined operations', () => {
+  trackQuery({ data: [] }, originalRequest, new Date(), { predefinedOperations: 'count_over_time' });
+
+  expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
+    app: 'explore',
+    bytes_processed: 0,
+    editor_mode: 'builder',
+    grafana_version: '1.0',
+    has_data: false,
+    has_error: false,
+    is_split: false,
+    legend: undefined,
+    line_limit: undefined,
+    obfuscated_query: 'count_over_time({Identifier=String}[1m])',
+    parsed_query:
+      'LogQL,Expr,MetricExpr,RangeAggregationExpr,RangeOp,CountOverTime,LogRangeExpr,Selector,Matchers,Matcher,Identifier,Eq,String,Range,Duration',
+    query_type: 'metric',
+    query_vector_type: undefined,
+    resolution: 1,
+    simultaneously_executed_query_count: 2,
+    simultaneously_hidden_query_count: 1,
+    time_range_from: '2023-02-08T05:00:00.000Z',
+    time_range_to: '2023-02-10T06:00:00.000Z',
+    time_taken: 0,
+    predefined_operations_applied: true,
   });
 });
 
@@ -123,6 +152,7 @@ test('Tracks grouped queries', () => {
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
+    predefined_operations_applied: 'n/a',
   });
 
   expect(reportInteraction).toHaveBeenCalledWith('grafana_loki_query_executed', {
@@ -149,5 +179,6 @@ test('Tracks grouped queries', () => {
     time_range_from: '2023-02-08T05:00:00.000Z',
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
+    predefined_operations_applied: 'n/a',
   });
 });


### PR DESCRIPTION
This PR adds feature tracking to the new reduce repetition feature of Loki.

It tracks when a predefined operation is configured, and it adds a property to query tracking. That property will be `n/a` for every query without predefined operations being configured, and will be a boolean value for datasources with configured operations. It will be true if the query contained the operations and false if it did not.

Fixes #67661