### PR TITLE
Nested folders: add analytics tracking for some features

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -104,8 +104,7 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
           {folderDTO && <FolderActionsButton folder={folderDTO} />}
           {(canCreateDashboards || canCreateFolder) && (
             <CreateNewButton
-              parentFolderTitle={folderDTO?.title}
-              parentFolderUid={folderUID}
+              parentFolder={folderDTO}
               canCreateDashboard={canCreateDashboards}
               canCreateFolder={canCreateFolder}
             />

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -155,15 +155,11 @@ const actionMap: Record<actionType, string> = {
 };
 
 function trackAction(action: actionType, selectedDashboards: string[], selectedFolders: string[]) {
-  const itemTypes = [];
-  if (selectedFolders.length > 0) {
-    itemTypes.push('folder');
-  }
-  if (selectedDashboards.length > 0) {
-    itemTypes.push('dashboard');
-  }
   reportInteraction(actionMap[action], {
-    item_type: itemTypes.join(','),
+    item_counts: {
+      folder: selectedFolders.length,
+      dashboard: selectedDashboards.length,
+    },
     source: 'tree_actions',
   });
 }

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -148,9 +148,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-function trackAction(action: 'move' | 'delete', selectedDashboards: string[], selectedFolders: string[]) {
-  const interactionIdentifier =
-    action === 'move' ? 'grafana_manage_dashboards_item_moved' : 'grafana_manage_dashboards_item_deleted';
+type actionType = 'move' | 'delete';
+const actionMap: Record<actionType, string> = {
+  move: 'grafana_manage_dashboards_item_moved',
+  delete: 'grafana_manage_dashboards_item_deleted',
+};
+
+function trackAction(action: actionType, selectedDashboards: string[], selectedFolders: string[]) {
   const itemTypes = [];
   if (selectedFolders.length > 0) {
     itemTypes.push('folder');
@@ -158,7 +162,7 @@ function trackAction(action: 'move' | 'delete', selectedDashboards: string[], se
   if (selectedDashboards.length > 0) {
     itemTypes.push('dashboard');
   }
-  reportInteraction(interactionIdentifier, {
+  reportInteraction(actionMap[action], {
     item_type: itemTypes.join(','),
     source: 'tree_actions',
   });

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
@@ -73,6 +74,7 @@ export function BrowseActions() {
       const dashboard = findItem(rootItems?.items ?? [], childrenByParentUID, dashboardUID);
       parentsToRefresh.add(dashboard?.parentUID);
     }
+    trackAction('delete', selectedDashboards, selectedFolders);
     onActionComplete(parentsToRefresh);
   };
 
@@ -97,6 +99,7 @@ export function BrowseActions() {
       const dashboard = findItem(rootItems?.items ?? [], childrenByParentUID, dashboardUID);
       parentsToRefresh.add(dashboard?.parentUID);
     }
+    trackAction('move', selectedDashboards, selectedFolders);
     onActionComplete(parentsToRefresh);
   };
 
@@ -144,3 +147,19 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: theme.spacing(2),
   }),
 });
+
+function trackAction(action: 'move' | 'delete', selectedDashboards: string[], selectedFolders: string[]) {
+  const interactionIdentifier =
+    action === 'move' ? 'grafana_manage_dashboards_item_moved' : 'grafana_manage_dashboards_item_deleted';
+  const itemTypes = [];
+  if (selectedFolders.length > 0) {
+    itemTypes.push('folder');
+  }
+  if (selectedDashboards.length > 0) {
+    itemTypes.push('dashboard');
+  }
+  reportInteraction(interactionIdentifier, {
+    item_type: itemTypes.join(','),
+    source: 'tree_actions',
+  });
+}

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -3,27 +3,49 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
+import { FolderDTO } from 'app/types';
+
 import CreateNewButton from './CreateNewButton';
+
+const mockParentFolder: FolderDTO = {
+  canAdmin: true,
+  canDelete: true,
+  canEdit: true,
+  canSave: true,
+  created: '',
+  createdBy: '',
+  hasAcl: true,
+  id: 1,
+  title: 'myFolder',
+  uid: '12345',
+  updated: '',
+  updatedBy: '',
+  url: '',
+  version: 1,
+};
 
 function render(...[ui, options]: Parameters<typeof rtlRender>) {
   rtlRender(<TestProvider>{ui}</TestProvider>, options);
 }
 
-async function renderAndOpen(folderUID?: string) {
-  render(<CreateNewButton canCreateDashboard canCreateFolder parentFolderUid={folderUID} />);
+async function renderAndOpen(folder?: FolderDTO) {
+  render(<CreateNewButton canCreateDashboard canCreateFolder parentFolder={folder} />);
   const newButton = screen.getByText('New');
   await userEvent.click(newButton);
 }
 
 describe('NewActionsButton', () => {
-  it('should display the correct urls with a given folderUID', async () => {
-    await renderAndOpen('123');
+  it('should display the correct urls with a given parent folder', async () => {
+    await renderAndOpen(mockParentFolder);
 
-    expect(screen.getByText('New dashboard')).toHaveAttribute('href', '/dashboard/new?folderUid=123');
-    expect(screen.getByText('Import')).toHaveAttribute('href', '/dashboard/import?folderUid=123');
+    expect(screen.getByText('New dashboard')).toHaveAttribute(
+      'href',
+      `/dashboard/new?folderUid=${mockParentFolder.uid}`
+    );
+    expect(screen.getByText('Import')).toHaveAttribute('href', `/dashboard/import?folderUid=${mockParentFolder.uid}`);
   });
 
-  it('should display urls without params when there is no folderUID', async () => {
+  it('should display urls without params when there is no parent folder', async () => {
     await renderAndOpen();
 
     expect(screen.getByText('New dashboard')).toHaveAttribute('href', '/dashboard/new');
@@ -31,8 +53,7 @@ describe('NewActionsButton', () => {
   });
 
   it('clicking the "New folder" button opens the drawer', async () => {
-    const mockParentFolderTitle = 'mockParentFolderTitle';
-    render(<CreateNewButton canCreateDashboard canCreateFolder parentFolderTitle={mockParentFolderTitle} />);
+    render(<CreateNewButton canCreateDashboard canCreateFolder parentFolder={mockParentFolder} />);
 
     const newButton = screen.getByText('New');
     await userEvent.click(newButton);
@@ -41,7 +62,7 @@ describe('NewActionsButton', () => {
     const drawer = screen.getByRole('dialog', { name: 'Drawer title New folder' });
     expect(drawer).toBeInTheDocument();
     expect(within(drawer).getByRole('heading', { name: 'New folder' })).toBeInTheDocument();
-    expect(within(drawer).getByText(`Location: ${mockParentFolderTitle}`)).toBeInTheDocument();
+    expect(within(drawer).getByText(`Location: ${mockParentFolder.title}`)).toBeInTheDocument();
   });
 
   it('should only render dashboard items when folder creation is disabled', async () => {

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -5,24 +5,11 @@ import { TestProvider } from 'test/helpers/TestProvider';
 
 import { FolderDTO } from 'app/types';
 
+import { mockFolderDTO } from '../fixtures/folder.fixture';
+
 import CreateNewButton from './CreateNewButton';
 
-const mockParentFolder: FolderDTO = {
-  canAdmin: true,
-  canDelete: true,
-  canEdit: true,
-  canSave: true,
-  created: '',
-  createdBy: '',
-  hasAcl: true,
-  id: 1,
-  title: 'myFolder',
-  uid: '12345',
-  updated: '',
-  updatedBy: '',
-  url: '',
-  version: 1,
-};
+const mockParentFolder = mockFolderDTO();
 
 function render(...[ui, options]: Parameters<typeof rtlRender>) {
   rtlRender(<TestProvider>{ui}</TestProvider>, options);

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Dropdown, Icon, Menu, MenuItem } from '@grafana/ui';
@@ -30,6 +31,7 @@ type Props = OwnProps & ConnectedProps<typeof connector>;
 
 function CreateNewButton({ parentFolder, canCreateDashboard, canCreateFolder, createNewFolder }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const location = useLocation();
   const [showNewFolderDrawer, setShowNewFolderDrawer] = useState(false);
 
   const onCreateFolder = (folderName: string) => {
@@ -45,11 +47,29 @@ function CreateNewButton({ parentFolder, canCreateDashboard, canCreateFolder, cr
   const newMenu = (
     <Menu>
       {canCreateDashboard && (
-        <MenuItem url={addFolderUidToUrl('/dashboard/new', parentFolder?.uid)} label={getNewDashboardPhrase()} />
+        <MenuItem
+          label={getNewDashboardPhrase()}
+          onClick={() =>
+            reportInteraction('grafana_menu_item_clicked', {
+              url: addFolderUidToUrl('/dashboard/new', parentFolder?.uid),
+              from: location.pathname,
+            })
+          }
+          url={addFolderUidToUrl('/dashboard/new', parentFolder?.uid)}
+        />
       )}
       {canCreateFolder && <MenuItem onClick={() => setShowNewFolderDrawer(true)} label={getNewFolderPhrase()} />}
       {canCreateDashboard && (
-        <MenuItem url={addFolderUidToUrl('/dashboard/import', parentFolder?.uid)} label={getImportPhrase()} />
+        <MenuItem
+          label={getImportPhrase()}
+          onClick={() =>
+            reportInteraction('grafana_menu_item_clicked', {
+              url: addFolderUidToUrl('/dashboard/import', parentFolder?.uid),
+              from: location.pathname,
+            })
+          }
+          url={addFolderUidToUrl('/dashboard/import', parentFolder?.uid)}
+        />
       )}
     </Menu>
   );

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
+import { reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Dropdown, Icon, Menu, MenuItem } from '@grafana/ui';
 import { createNewFolder } from 'app/features/folders/state/actions';
 import {
@@ -9,6 +10,7 @@ import {
   getImportPhrase,
   getNewPhrase,
 } from 'app/features/search/tempI18nPhrases';
+import { FolderDTO } from 'app/types';
 
 import { NewFolderForm } from './NewFolderForm';
 
@@ -19,40 +21,35 @@ const mapDispatchToProps = {
 const connector = connect(null, mapDispatchToProps);
 
 interface OwnProps {
-  parentFolderTitle?: string;
-  /**
-   * Pass a folder UID in which the dashboard or folder will be created
-   */
-  parentFolderUid?: string;
+  parentFolder?: FolderDTO;
   canCreateFolder: boolean;
   canCreateDashboard: boolean;
 }
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-function CreateNewButton({
-  parentFolderTitle,
-  parentFolderUid,
-  canCreateDashboard,
-  canCreateFolder,
-  createNewFolder,
-}: Props) {
+function CreateNewButton({ parentFolder, canCreateDashboard, canCreateFolder, createNewFolder }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [showNewFolderDrawer, setShowNewFolderDrawer] = useState(false);
 
   const onCreateFolder = (folderName: string) => {
-    createNewFolder(folderName, parentFolderUid);
+    createNewFolder(folderName, parentFolder?.uid);
+    const depth = parentFolder?.parents ? parentFolder.parents.length + 1 : 0;
+    reportInteraction('grafana_manage_dashboards_folder_created', {
+      is_subfolder: Boolean(parentFolder?.uid),
+      folder_depth: depth,
+    });
     setShowNewFolderDrawer(false);
   };
 
   const newMenu = (
     <Menu>
       {canCreateDashboard && (
-        <MenuItem url={addFolderUidToUrl('/dashboard/new', parentFolderUid)} label={getNewDashboardPhrase()} />
+        <MenuItem url={addFolderUidToUrl('/dashboard/new', parentFolder?.uid)} label={getNewDashboardPhrase()} />
       )}
       {canCreateFolder && <MenuItem onClick={() => setShowNewFolderDrawer(true)} label={getNewFolderPhrase()} />}
       {canCreateDashboard && (
-        <MenuItem url={addFolderUidToUrl('/dashboard/import', parentFolderUid)} label={getImportPhrase()} />
+        <MenuItem url={addFolderUidToUrl('/dashboard/import', parentFolder?.uid)} label={getImportPhrase()} />
       )}
     </Menu>
   );
@@ -68,7 +65,7 @@ function CreateNewButton({
       {showNewFolderDrawer && (
         <Drawer
           title={getNewFolderPhrase()}
-          subtitle={parentFolderTitle ? `Location: ${parentFolderTitle}` : undefined}
+          subtitle={parentFolder?.title ? `Location: ${parentFolder.title}` : undefined}
           scrollableContent
           onClose={() => setShowNewFolderDrawer(false)}
           size="sm"

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { appEvents, contextSrv } from 'app/core/core';
-import { AccessControlAction, FolderDTO } from 'app/types';
+import { AccessControlAction } from 'app/types';
 import { ShowModalReactEvent } from 'app/types/events';
+
+import { mockFolderDTO } from '../fixtures/folder.fixture';
 
 import { DeleteModal } from './BrowseActions/DeleteModal';
 import { MoveModal } from './BrowseActions/MoveModal';
@@ -21,22 +23,7 @@ jest.mock('app/core/components/AccessControl', () => ({
 }));
 
 describe('browse-dashboards FolderActionsButton', () => {
-  const mockFolder: FolderDTO = {
-    canAdmin: true,
-    canDelete: true,
-    canEdit: true,
-    canSave: true,
-    created: '',
-    createdBy: '',
-    hasAcl: true,
-    id: 1,
-    title: 'myFolder',
-    uid: '12345',
-    updated: '',
-    updatedBy: '',
-    url: '',
-    version: 1,
-  };
+  const mockFolder = mockFolderDTO();
 
   beforeEach(() => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -31,7 +31,10 @@ export function FolderActionsButton({ folder }: Props) {
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID });
     reportInteraction('grafana_manage_dashboards_item_moved', {
-      item_type: 'folder',
+      item_counts: {
+        folder: 1,
+        dashboard: 0,
+      },
       source: 'folder_actions',
     });
     dispatch(refetchChildren({ parentUID: destinationUID, pageSize: destinationUID ? PAGE_SIZE : ROOT_PAGE_SIZE }));
@@ -46,7 +49,10 @@ export function FolderActionsButton({ folder }: Props) {
   const onDelete = async () => {
     await dispatch(deleteFolder(folder.uid));
     reportInteraction('grafana_manage_dashboards_item_deleted', {
-      item_type: 'folder',
+      item_counts: {
+        folder: 1,
+        dashboard: 0,
+      },
       source: 'folder_actions',
     });
     if (folder.parentUid) {

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { locationService } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Dropdown, Icon, Menu, MenuItem } from '@grafana/ui';
 import { Permissions } from 'app/core/components/AccessControl';
 import { appEvents, contextSrv } from 'app/core/core';
@@ -30,6 +30,10 @@ export function FolderActionsButton({ folder }: Props) {
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID });
+    reportInteraction('grafana_manage_dashboards_item_moved', {
+      item_type: 'folder',
+      source: 'folder_actions',
+    });
     dispatch(refetchChildren({ parentUID: destinationUID, pageSize: destinationUID ? PAGE_SIZE : ROOT_PAGE_SIZE }));
 
     if (folder.parentUid) {
@@ -41,6 +45,10 @@ export function FolderActionsButton({ folder }: Props) {
 
   const onDelete = async () => {
     await dispatch(deleteFolder(folder.uid));
+    reportInteraction('grafana_manage_dashboards_item_deleted', {
+      item_type: 'folder',
+      source: 'folder_actions',
+    });
     if (folder.parentUid) {
       dispatch(
         refetchChildren({ parentUID: folder.parentUid, pageSize: folder.parentUid ? PAGE_SIZE : ROOT_PAGE_SIZE })

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -4,9 +4,11 @@ import Skeleton from 'react-loading-skeleton';
 import { CellProps } from 'react-table';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { IconButton, Link, Spinner, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
 import { Span } from '@grafana/ui/src/unstable';
+import { SearchLayout } from 'app/features/search/types';
 
 import { useChildrenByParentUIDState } from '../state';
 import { DashboardsTreeItem } from '../types';
@@ -82,7 +84,20 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
       )}
       <Span variant="body" truncate>
         {item.url ? (
-          <Link href={item.url} className={styles.link}>
+          <Link
+            onClick={() => {
+              reportInteraction('manage_dashboards_result_clicked', {
+                layout: SearchLayout.Folders,
+                starred: false,
+                sortValue: undefined,
+                query: '',
+                tagCount: 0,
+                includePanels: false,
+              });
+            }}
+            href={item.url}
+            className={styles.link}
+          >
             {item.title}
           </Link>
         ) : (

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -8,7 +8,6 @@ import { reportInteraction } from '@grafana/runtime';
 import { IconButton, Link, Spinner, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
 import { Span } from '@grafana/ui/src/unstable';
-import { SearchLayout } from 'app/features/search/types';
 
 import { useChildrenByParentUIDState } from '../state';
 import { DashboardsTreeItem } from '../types';
@@ -86,14 +85,7 @@ export function NameCell({ row: { original: data }, onFolderClick }: NameCellPro
         {item.url ? (
           <Link
             onClick={() => {
-              reportInteraction('manage_dashboards_result_clicked', {
-                layout: SearchLayout.Folders,
-                starred: false,
-                sortValue: undefined,
-                query: '',
-                tagCount: 0,
-                includePanels: false,
-              });
+              reportInteraction('manage_dashboards_result_clicked');
             }}
             href={item.url}
             className={styles.link}

--- a/public/app/features/browse-dashboards/fixtures/folder.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/folder.fixture.ts
@@ -1,0 +1,25 @@
+import { Chance } from 'chance';
+
+import { FolderDTO } from 'app/types';
+
+export function mockFolderDTO(seed = 1, partial?: Partial<FolderDTO>): FolderDTO {
+  const random = Chance(seed);
+  const uid = random.guid();
+  return {
+    canAdmin: true,
+    canDelete: true,
+    canEdit: true,
+    canSave: true,
+    created: new Date(random.timestamp()).toISOString(),
+    createdBy: '',
+    hasAcl: true,
+    id: 1,
+    title: random.sentence({ words: 3 }),
+    uid,
+    updated: new Date(random.timestamp()).toISOString(),
+    updatedBy: '',
+    url: `/dashboards/f/${uid}`,
+    version: 1,
+    ...partial,
+  };
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds feature tracking to the nested folders browse dashboard page
  - changes `CreateNewButton` to accept the full `FolderDTO` (instead of just the uid and title) so it has access to all the properties it needs
  - updates unit tests for `CreateNewButton`
  - adds tracking for move/delete actions
    - differentiates between tree actions/folder actions
    - lists types of items selected
      - this only lists dashboards/folders
      - library panels/alert rules would require some refactoring. it's _possible_, but if we don't absolutely need it i'd rather not make our code more complicated for the sake of tracking 😬 
  - adds tracking for when items are clicked in the tree to match the old folder view behaviour
  
**Why do we need this feature?**

- so we can understand how people are using the new browse dashboards page

**Who is this feature for?**

- grafana devs working on nested folders

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/68707

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
