### PR TITLE
PanelTypeCard: Improve contrast for disabled cards

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
@@ -116,7 +116,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       background: ${theme.colors.action.selected};
     `,
     disabled: css`
-      opacity: ${theme.colors.action.disabledOpacity};
+      opacity: 0.6;
       filter: grayscale(1);
       cursor: default;
       pointer-events: none;


### PR DESCRIPTION
Changes opacity for disabled card text so minimum contrast ratio is reached.

Before:
<img width="377" alt="image" src="https://github.com/grafana/grafana/assets/45561153/9cd3ea68-2cab-43b5-9a53-892190adcd92">


After: 
<img width="376" alt="image" src="https://github.com/grafana/grafana/assets/45561153/28876fa0-2826-4a22-8d77-e9002e6ab8d8">
