### PR TITLE
PoC: add 'vector' services to enable semantic search of datasource & Grafana metadata

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1589,3 +1589,14 @@ server_name =
 proxy_address =
 # Determines if the secure socks proxy should be shown on the datasources page, defaults to true if the feature is enabled
 show_ui = true
+
+#################################### LLMs ####################################
+[llms]
+enabled = false
+
+[llms.vector_db]
+# The type of vector database. Currently ignored,
+# 'qdrant' is assumed.
+type = "qdrant"
+# The address of the vector database.
+address = "localhost:6334"

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require k8s.io/apimachinery v0.26.2
 // import that instead of v0.X even though v0.X is newer.
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0
 
+replace github.com/grafana/grafana-plugin-sdk-go => github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609083030-709a50a075f2
+
 require (
 	cloud.google.com/go/storage v1.28.1
 	cuelang.org/go v0.5.0
@@ -62,7 +64,7 @@ require (
 	github.com/grafana/cuetsy v0.1.9
 	github.com/grafana/grafana-aws-sdk v0.15.0
 	github.com/grafana/grafana-azure-sdk-go v1.7.0
-	github.com/grafana/grafana-plugin-sdk-go v0.162.0
+	github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609083030-709a50a075f2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-plugin v1.4.9
@@ -339,6 +341,7 @@ require (
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
+	github.com/qdrant/go-client v1.2.0 // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rueian/rueidis v0.0.100-go1.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ cloud.google.com/go/compute v1.10.0/go.mod h1:ER5CLbMxl90o2jtNbGSbtfOpQKR0t15FOt
 cloud.google.com/go/compute v1.12.0/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x/6PIIOocU=
 cloud.google.com/go/compute v1.12.1/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x/6PIIOocU=
 cloud.google.com/go/compute v1.14.0/go.mod h1:YfLtxrj9sU4Yxv+sXzZkyPjEyPBZfXHUvjxega5vAdo=
+cloud.google.com/go/compute v1.15.1/go.mod h1:bjjoF/NtFUrkD/urWfdHaKuOPDR5nWIs63rR+SXhcpA=
 cloud.google.com/go/compute v1.18.0 h1:FEigFqoDbys2cvFkZ9Fjq4gnHBP55anJ0yQyau2f9oY=
 cloud.google.com/go/compute v1.18.0/go.mod h1:1X7yHxec2Ga+Ss6jPyjxRxpu2uu7PLgsOVXvgU0yacs=
 cloud.google.com/go/compute/metadata v0.1.0/go.mod h1:Z1VN+bulIf6bt4P/C37K4DyZYZEXYonfTBHHFPO/4UU=
@@ -612,6 +613,7 @@ github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac h1:XDAn206aIqKPdF5
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac h1:9yrT5tmn9Zc0ytWPASlaPwQfQMQYnRf0RSDe1XvHw0Q=
+github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
@@ -668,6 +670,7 @@ github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo
 github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
+github.com/getkin/kin-openapi v0.112.0/go.mod h1:QtwUNt0PAAgIIBEvFWYfB7dfngxtAaqCX1zYHMZDeK8=
 github.com/getkin/kin-openapi v0.115.0 h1:c8WHRLVY3G8m9jQTy0/DnIuljgRwTCB5twZytQS4JyU=
 github.com/getkin/kin-openapi v0.115.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
 github.com/getsentry/sentry-go v0.12.0 h1:era7g0re5iY13bHSdN/xMkyV+5zZppjRVQhZrXCaEIk=
@@ -1382,6 +1385,10 @@ github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW3
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/grafana-plugin-sdk-go v0.162.0 h1:ij2ARWohf0IoK9yCVC1Wup4Gp6zwBq2AueVXRYsv/to=
 github.com/grafana/grafana-plugin-sdk-go v0.162.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
+github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609074524-272dff76115e h1:tFW7y+qGKaQuVukgWBtGA6rWkoPdsUaLxF+jUskiO4A=
+github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609074524-272dff76115e/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
+github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609083030-709a50a075f2 h1:t+sJEqvA2NHOey8/vtkPbY5upmBkHMLBrouL9FdwB7s=
+github.com/grafana/grafana-plugin-sdk-go v0.163.1-0.20230609083030-709a50a075f2/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
 github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482 h1:1YNoeIhii4UIIQpCPU+EXidnqf449d0C3ZntAEt4KSo=
 github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482/go.mod h1:GNcfpy5+SY6RVbNGQW264gC0r336Dm+0zgQ5vt6+M8Y=
 github.com/grafana/phlare/api v0.1.4-0.20230426005640-f90edba05413 h1:bBzCezZNRyYlJpXTkyZdY4fpPxHZUdyeyRWzhtw/P6I=
@@ -2153,6 +2160,7 @@ github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+
 github.com/prometheus/common v0.30.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
+github.com/prometheus/common v0.40.0/go.mod h1:L65ZJPSmfn/UBWLQIHV7dBrKFidB/wPlF1y5TlSt9OE=
 github.com/prometheus/common v0.41.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
@@ -2185,6 +2193,8 @@ github.com/prometheus/statsd_exporter v0.21.0/go.mod h1:rbT83sZq2V+p73lHhPZfMc3M
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b h1:zd/2RNzIRkoGGMjE+YIsZ85CnDIz672JK2F3Zl4vux4=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b/go.mod h1:KjY0wibdYKc4DYkerHSbguaf3JeIPGhNJBp2BNiFH78=
+github.com/qdrant/go-client v1.2.0 h1:8vs9OJs6Vh4k3/QvwxkWLawZtqZFTL9xBOJ8dOzxUYs=
+github.com/qdrant/go-client v1.2.0/go.mod h1:680gkxNAsVtre0Z8hAQmtPzJtz1xFAyCu2TUxULtnoE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.0.2 h1:BA426Zqe/7r56kCcvxYLWe1mkaz71LKF77GwgFzSxfE=
@@ -2585,6 +2595,7 @@ go.opentelemetry.io/otel v0.18.0/go.mod h1:PT5zQj4lTsR1YeARt8YNKcFb88/c2IKoSABK9
 go.opentelemetry.io/otel v1.0.0-RC1/go.mod h1:x9tRa9HK4hSSq7jf2TKbqFbtt58/TGk0f9XiEYISI1I=
 go.opentelemetry.io/otel v1.0.0/go.mod h1:AjRVh9A5/5DE7S+mZtTR6t8vpKKryam+0lREnfmS4cg=
 go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
+go.opentelemetry.io/otel v1.11.2/go.mod h1:7p4EUV+AqgdlNV9gL97IgUZiVR3yrFXYo53f9BM3tRI=
 go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
 go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
 go.opentelemetry.io/otel/exporters/jaeger v1.0.0 h1:cLhx8llHw02h5JTqGqaRbYn+QVKHmrzD9vEbKnSPk5U=
@@ -2612,6 +2623,7 @@ go.opentelemetry.io/otel/trace v0.18.0/go.mod h1:FzdUu3BPwZSZebfQ1vl5/tAa8LyMLXS
 go.opentelemetry.io/otel/trace v1.0.0-RC1/go.mod h1:86UHmyHWFEtWjfWPSbu0+d0Pf9Q6e1U+3ViBOc+NXAg=
 go.opentelemetry.io/otel/trace v1.0.0/go.mod h1:PXTWqayeFUlJV1YDNhsJYB184+IvAH814St6o6ajzIs=
 go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
+go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06ObSbKPmxQ/pKA=
 go.opentelemetry.io/otel/trace v1.14.0 h1:wp2Mmvj41tDsyAJXiWDWpfNsOiIyd38fy85pyKcFq/M=
 go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+gozhnZjy/rw9G8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -2884,6 +2896,7 @@ golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
@@ -2920,6 +2933,8 @@ golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri
 golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/oauth2 v0.3.0/go.mod h1:rQrIauxkUhJ6CuwEXwymO2/eh4xz2ZWF1nBkcxS+tGk=
+golang.org/x/oauth2 v0.4.0/go.mod h1:RznEsdpjGAINPTOF0UH/t+xJ75L18YO3Ho6Pyn+uRec=
 golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/oauth2 v0.6.0 h1:Lh8GPgSKBfWSwFvtuWOfeI3aAAnbXTSutYxJiOJFgIw=
 golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
@@ -3108,6 +3123,7 @@ golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
@@ -3119,9 +3135,11 @@ golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
+golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
 golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
+golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -3134,6 +3152,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -178,7 +178,7 @@ export interface DataSourceConstructor<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData
 > {
-  new (instanceSettings: DataSourceInstanceSettings<TOptions>, ...args: any[]): DSType;
+  new(instanceSettings: DataSourceInstanceSettings<TOptions>, ...args: any[]): DSType;
 }
 
 // VariableSupport is hoisted up to its own type to fix the wonky intermittent
@@ -197,7 +197,8 @@ type VariableSupport<TQuery extends DataQuery, TOptions extends DataSourceJsonDa
 abstract class DataSourceApi<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData,
-  TQueryImportConfiguration extends Record<string, object> = {}
+  TQueryImportConfiguration extends Record<string, object> = {},
+  TMetadata extends string | undefined = undefined
 > {
   /**
    *  Set in constructor

--- a/packages/grafana-runtime/src/services/LLMService.ts
+++ b/packages/grafana-runtime/src/services/LLMService.ts
@@ -45,6 +45,16 @@ export type LLMChatCompletionsRequest = LLMRequestCommonOptions & {
   messages: LLMChatCompletionsMessage[];
 };
 
+export interface LLMRelatedMetadataRequest {
+  datasourceType: string;
+  datasourceUid: string;
+  text: string;
+}
+
+export type DataSourceMetadata<T extends string> = {
+  [key in T]?: string[];
+}
+
 /**
  * Used to communicate with LLMs via Grafana.
  *
@@ -57,6 +67,13 @@ export type LLMChatCompletionsRequest = LLMRequestCommonOptions & {
 export interface LLMSrv {
   isEnabled: boolean;
   chatCompletions(request: LLMChatCompletionsRequest): Promise<string>;
+  /**
+   * Fetches related metadata for a given datasource.
+   *
+   * This is only available if Grafana has been configured with a
+   * vector database ([llms.vector_db] in grafana.ini).
+   */
+  relatedMetadata<M extends string>(request: LLMRelatedMetadataRequest): Promise<DataSourceMetadata<M>>;
 }
 
 let singletonInstance: LLMSrv;

--- a/packages/grafana-runtime/src/services/LLMService.ts
+++ b/packages/grafana-runtime/src/services/LLMService.ts
@@ -45,7 +45,11 @@ export type LLMChatCompletionsRequest = LLMRequestCommonOptions & {
   messages: LLMChatCompletionsMessage[];
 };
 
+export type LLMRelatedMetadataRequestTypeDatasource = 'datasource';
+export type LLMRelatedMetadataRequestTypeGrafana = 'grafana';
+
 export interface LLMRelatedMetadataRequest {
+  type: LLMRelatedMetadataRequestTypeDatasource | LLMRelatedMetadataRequestTypeGrafana;
   datasourceType: string;
   datasourceUid: string;
   text: string;

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -113,8 +113,9 @@ export interface HealthCheckResult {
  */
 class DataSourceWithBackend<
   TQuery extends DataQuery = DataQuery,
-  TOptions extends DataSourceJsonData = DataSourceJsonData
-> extends DataSourceApi<TQuery, TOptions> {
+  TOptions extends DataSourceJsonData = DataSourceJsonData,
+  TMetadata extends string | undefined = undefined,
+> extends DataSourceApi<TQuery, TOptions, {}, TMetadata> {
   constructor(instanceSettings: DataSourceInstanceSettings<TOptions>) {
     super(instanceSettings);
   }

--- a/packages/grafana-ui/src/components/LLMQueryEditor/LLMQueryEditor.tsx
+++ b/packages/grafana-ui/src/components/LLMQueryEditor/LLMQueryEditor.tsx
@@ -65,10 +65,12 @@ export function LLMQueryEditor<
   datasource: { uid: datasourceUid, type: datasourceType },
 }: LLMQueryEditorProps<T, M, Q, O, QIC>): JSX.Element {
   const [query, setQuery] = useState('');
+  const [usedSystemPrompt, setUsedSystemPrompt] = useState('');
   const [state, onSubmit] = useAsyncFn(
     async ({ userPrompt }: { userPrompt: string }) => {
       if (createPrompt !== undefined) {
         const metadata = await llmSrv.relatedMetadata<M>({
+          type: 'datasource',
           datasourceUid,
           datasourceType,
           text: userPrompt,
@@ -77,6 +79,7 @@ export function LLMQueryEditor<
         systemPrompt = createPrompt(metadata);
       }
       console.log(systemPrompt);
+      setUsedSystemPrompt(systemPrompt);
       const returnedMessage = await llmSrv.chatCompletions({
         messages: [
           { role: 'system', content: systemPrompt },
@@ -103,12 +106,24 @@ export function LLMQueryEditor<
           );
         }}
       </Form>
+      <br />
       {state.loading ? (
         <Spinner />
       ) : state.error ? (
         <div>Something went wrong! Error: {state.error.message}</div>
       ) : (
-        query !== '' && <div>{query}</div>
+        <>
+          {query !== '' && <div>
+            <h3>Returned query</h3>
+            <pre>{query}</pre>
+          </div>
+          }
+          {usedSystemPrompt !== '' && <div>
+            <h3>System prompt</h3>
+            <pre>{usedSystemPrompt}</pre>
+          </div>
+          }
+        </>
       )}
     </div>
   );

--- a/packages/grafana-ui/src/components/LLMQueryEditor/LLMQueryEditor.tsx
+++ b/packages/grafana-ui/src/components/LLMQueryEditor/LLMQueryEditor.tsx
@@ -1,3 +1,5 @@
+import { DataQuery, DataSourceApi } from '@grafana/data';
+import { DataSourceJsonData } from '@grafana/schema';
 import React, { useState } from 'react';
 
 import { useAsyncFn } from 'react-use';
@@ -18,26 +20,67 @@ interface LLMSrvChatCompletionRequest {
   messages: LLMSrvChatMessage[];
 }
 
+interface LLMRelatedMetadataRequest {
+  datasourceType: string;
+  datasourceUid: string;
+  text: string;
+}
+
+type DataSourceMetadata<T extends string> = {
+  [key in T]?: string[];
+}
+
 // We can't import the real interface from @grafana/runtime, but
 // we can use this subset. Hooray for structural typing!
 interface LLMSrv {
   chatCompletions(request: LLMSrvChatCompletionRequest): Promise<string>;
+  relatedMetadata<M extends string>(request: LLMRelatedMetadataRequest): Promise<DataSourceMetadata<M>>;
 }
 
-export interface LLMQueryEditorProps {
+export interface LLMQueryEditorProps<
+  T extends DataSourceApi<Q, O, QIC, M>,
+  M extends string,
+  Q extends DataQuery = DataQuery,
+  O extends DataSourceJsonData = DataSourceJsonData,
+  QIC extends Record<string, object> = {},
+> {
   systemPrompt: string;
+  createPrompt?: (metadata: DataSourceMetadata<M>) => string;
   onChange: (text: string) => void;
+  datasource: DataSourceApi<Q, O, QIC, M>;
   llmSrv: LLMSrv; // Can't import @grafana/runtime here
 }
 
-export function LLMQueryEditor({ systemPrompt, onChange, llmSrv }: LLMQueryEditorProps): JSX.Element {
+export function LLMQueryEditor<
+  T extends DataSourceApi<Q, O, QIC, M>,
+  M extends string,
+  Q extends DataQuery = DataQuery,
+  O extends DataSourceJsonData = DataSourceJsonData,
+  QIC extends Record<string, object> = {},
+>({
+  systemPrompt,
+  createPrompt,
+  onChange,
+  llmSrv,
+  datasource: { uid: datasourceUid, type: datasourceType },
+}: LLMQueryEditorProps<T, M, Q, O, QIC>): JSX.Element {
   const [query, setQuery] = useState('');
   const [state, onSubmit] = useAsyncFn(
-    async ({ prompt }: { prompt: string }) => {
+    async ({ userPrompt }: { userPrompt: string }) => {
+      if (createPrompt !== undefined) {
+        const metadata = await llmSrv.relatedMetadata<M>({
+          datasourceUid,
+          datasourceType,
+          text: userPrompt,
+        });
+        console.log(metadata);
+        systemPrompt = createPrompt(metadata);
+      }
+      console.log(systemPrompt);
       const returnedMessage = await llmSrv.chatCompletions({
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: prompt },
+          { role: 'user', content: userPrompt },
         ],
       });
       setQuery(returnedMessage);
@@ -53,7 +96,7 @@ export function LLMQueryEditor({ systemPrompt, onChange, llmSrv }: LLMQueryEdito
           return (
             <>
               <Field>
-                <Input {...register('prompt')} />
+                <Input {...register('userPrompt')} />
               </Field>
               <Button type="submit">Translate</Button>
             </>

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -589,7 +589,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// LLMs
 		if hs.Cfg.IsFeatureToggleEnabled("llmAPI") {
-			apiRoute.Any("/llms/*", hs.ProxyLLMRequest)
+			apiRoute.Post("/llms/related-metadata", routing.Wrap(hs.RelatedMetadataRequest))
+			apiRoute.Any("/llms/proxy/*", hs.ProxyLLMRequest)
 		}
 	}, reqSignedIn)
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -59,6 +59,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
+	"github.com/grafana/grafana/pkg/services/llm/vector"
 	"github.com/grafana/grafana/pkg/services/login"
 	loginAttempt "github.com/grafana/grafana/pkg/services/loginattempt"
 	"github.com/grafana/grafana/pkg/services/navtree"
@@ -206,6 +207,7 @@ type HTTPServer struct {
 	statsService         stats.Service
 	authnService         authn.Service
 	starApi              *starApi.API
+	vectorService        *vector.Service
 }
 
 type ServerOptions struct {
@@ -247,7 +249,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	accesscontrolService accesscontrol.Service, navTreeService navtree.Service,
 	annotationRepo annotations.Repository, tagService tag.Service, searchv2HTTPService searchV2.SearchHTTPService, oauthTokenService oauthtoken.OAuthTokenService,
 	statsService stats.Service, authnService authn.Service, pluginsCDNService *pluginscdn.Service,
-	starApi *starApi.API,
+	starApi *starApi.API, vectorService *vector.Service,
 
 ) (*HTTPServer, error) {
 	web.Env = cfg.Env
@@ -351,6 +353,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		authnService:                 authnService,
 		pluginsCDNService:            pluginsCDNService,
 		starApi:                      starApi,
+		vectorService:                vectorService,
 	}
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -17,18 +17,20 @@ type corePlugin struct {
 	backend.CallResourceHandler
 	backend.QueryDataHandler
 	backend.StreamHandler
+	backend.ProvideMetadataHandler
 }
 
 // New returns a new backendplugin.PluginFactoryFunc for creating a core (built-in) backendplugin.Plugin.
 func New(opts backend.ServeOpts) backendplugin.PluginFactoryFunc {
 	return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
 		return &corePlugin{
-			pluginID:            pluginID,
-			logger:              logger,
-			CheckHealthHandler:  opts.CheckHealthHandler,
-			CallResourceHandler: opts.CallResourceHandler,
-			QueryDataHandler:    opts.QueryDataHandler,
-			StreamHandler:       opts.StreamHandler,
+			pluginID:               pluginID,
+			logger:                 logger,
+			CheckHealthHandler:     opts.CheckHealthHandler,
+			CallResourceHandler:    opts.CallResourceHandler,
+			QueryDataHandler:       opts.QueryDataHandler,
+			StreamHandler:          opts.StreamHandler,
+			ProvideMetadataHandler: opts.ProvideMetadataHandler,
 		}, nil
 	}
 }
@@ -116,4 +118,11 @@ func (cp *corePlugin) RunStream(ctx context.Context, req *backend.RunStreamReque
 		return cp.StreamHandler.RunStream(ctx, req, sender)
 	}
 	return backendplugin.ErrMethodNotImplemented
+}
+
+func (cp *corePlugin) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	if cp.ProvideMetadataHandler != nil {
+		return cp.ProvideMetadataHandler.ProvideMetadata(ctx, req)
+	}
+	return nil, backendplugin.ErrMethodNotImplemented
 }

--- a/pkg/plugins/backendplugin/coreplugin/registry.go
+++ b/pkg/plugins/backendplugin/coreplugin/registry.go
@@ -117,6 +117,9 @@ func asBackendPlugin(svc interface{}) backendplugin.PluginFactoryFunc {
 	if healthHandler, ok := svc.(backend.CheckHealthHandler); ok {
 		opts.CheckHealthHandler = healthHandler
 	}
+	if metadataHandler, ok := svc.(backend.ProvideMetadataHandler); ok {
+		opts.ProvideMetadataHandler = metadataHandler
+	}
 
 	if opts.QueryDataHandler != nil || opts.CallResourceHandler != nil ||
 		opts.CheckHealthHandler != nil || opts.StreamHandler != nil {

--- a/pkg/plugins/backendplugin/grpcplugin/client.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client.go
@@ -76,6 +76,7 @@ func getV2PluginSet() goplugin.PluginSet {
 		"resource":       &grpcplugin.ResourceGRPCPlugin{},
 		"data":           &grpcplugin.DataGRPCPlugin{},
 		"stream":         &grpcplugin.StreamGRPCPlugin{},
+		"metadata":       &grpcplugin.MetadataGRPCPlugin{},
 		"renderer":       &pluginextensionv2.RendererGRPCPlugin{},
 		"secretsmanager": &secretsmanagerplugin.SecretsManagerGRPCPlugin{},
 	}

--- a/pkg/plugins/backendplugin/ifaces.go
+++ b/pkg/plugins/backendplugin/ifaces.go
@@ -24,6 +24,7 @@ type Plugin interface {
 	backend.QueryDataHandler
 	backend.CallResourceHandler
 	backend.StreamHandler
+	backend.ProvideMetadataHandler
 }
 
 type Target string

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -100,6 +100,7 @@ type Client interface {
 	backend.StreamHandler
 	backend.CallResourceHandler
 	backend.CollectMetricsHandler
+	backend.ProvideMetadataHandler
 }
 
 // BackendFactoryProvider provides a backend factory for a provided plugin.

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -245,6 +245,19 @@ func (s *Service) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 	return plugin.RunStream(ctx, req, sender)
 }
 
+func (s *Service) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	if req == nil {
+		return nil, errNilRequest
+	}
+
+	plugin, exists := s.plugin(ctx, req.PluginContext.PluginID)
+	if !exists {
+		return nil, backendplugin.ErrPluginNotRegistered
+	}
+
+	return plugin.ProvideMetadata(ctx, req)
+}
+
 // plugin finds a plugin with `pluginID` from the registry that is not decommissioned
 func (s *Service) plugin(ctx context.Context, pluginID string) (*plugins.Plugin, bool) {
 	p, exists := s.pluginRegistry.Plugin(ctx, pluginID)

--- a/pkg/plugins/manager/client/decorator.go
+++ b/pkg/plugins/manager/client/decorator.go
@@ -97,6 +97,15 @@ func (d *Decorator) RunStream(ctx context.Context, req *backend.RunStreamRequest
 	return client.RunStream(ctx, req, sender)
 }
 
+func (d *Decorator) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	if req == nil {
+		return nil, errNilRequest
+	}
+
+	client := clientFromMiddlewares(d.middlewares, d.client)
+	return client.ProvideMetadata(ctx, req)
+}
+
 func clientFromMiddlewares(middlewares []plugins.ClientMiddleware, finalClient plugins.Client) plugins.Client {
 	if len(middlewares) == 0 {
 		return finalClient

--- a/pkg/plugins/manager/process/process.go
+++ b/pkg/plugins/manager/process/process.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -52,6 +53,7 @@ func (m *Manager) Start(ctx context.Context, pluginID string) error {
 	defer m.mu.Unlock()
 
 	if err := startPluginAndRestartKilledProcesses(ctx, p); err != nil {
+		p.Logger().Warn("Failed to start plugin process", "error", fmt.Sprintf("%+v", err))
 		return err
 	}
 

--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -18,6 +18,7 @@ import (
 	ldapapi "github.com/grafana/grafana/pkg/services/ldap/api"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
+	"github.com/grafana/grafana/pkg/services/llm/vectorsync"
 	"github.com/grafana/grafana/pkg/services/login/authinfoservice"
 	"github.com/grafana/grafana/pkg/services/loginattempt/loginattemptimpl"
 	"github.com/grafana/grafana/pkg/services/ngalert"
@@ -52,6 +53,7 @@ func ProvideBackgroundServiceRegistry(
 	bundleService *supportbundlesimpl.Service,
 	publicDashboardsMetric *publicdashboardsmetric.Service,
 	keyRetriever *dynamic.KeyRetriever,
+	vs *vectorsync.Service,
 	// Need to make sure these are initialized, is there a better place to put them?
 	_ dashboardsnapshots.Service, _ *alerting.AlertNotificationService,
 	_ serviceaccounts.Service, _ *guardian.Provider,
@@ -89,6 +91,7 @@ func ProvideBackgroundServiceRegistry(
 		bundleService,
 		publicDashboardsMetric,
 		keyRetriever,
+		vs,
 	)
 }
 

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -73,6 +73,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/librarypanels"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
+	"github.com/grafana/grafana/pkg/services/llm/vector"
+	"github.com/grafana/grafana/pkg/services/llm/vectorsync"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfoservice"
 	authinfodatabase "github.com/grafana/grafana/pkg/services/login/authinfoservice/database"
@@ -362,6 +364,8 @@ var wireBasicSet = wire.NewSet(
 	modules.WireSet,
 	signingkeysimpl.ProvideEmbeddedSigningKeysService,
 	wire.Bind(new(signingkeys.Service), new(*signingkeysimpl.Service)),
+	vector.ProvideService,
+	vectorsync.ProvideService,
 )
 
 var wireSet = wire.NewSet(

--- a/pkg/services/llm/client/client.go
+++ b/pkg/services/llm/client/client.go
@@ -1,0 +1,9 @@
+package client
+
+import (
+	"context"
+)
+
+type LLMClient interface {
+	Embeddings(ctx context.Context, payload string) ([]float32, error)
+}

--- a/pkg/services/llm/client/openai.go
+++ b/pkg/services/llm/client/openai.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type openAILLMClient struct {
+	client *http.Client
+	host   string
+	apiKey string
+	model  string
+}
+
+type openAIEmbeddingsRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+type openAIEmbeddingsResponse struct {
+	Data []openAIEmbeddingData `json:"data"`
+}
+
+type openAIEmbeddingData struct {
+	Embedding []float32 `json:"embedding"`
+}
+
+func (o *openAILLMClient) Embeddings(ctx context.Context, payload string) ([]float32, error) {
+	// TODO: ensure payload is under 8191 tokens, somehow.
+	host := o.host
+	if host == "" {
+		host = "https://api.openai.com"
+	}
+	host = strings.TrimSuffix(host, "/")
+	url := host + "/v1/embeddings"
+	model := o.model
+	if model == "" {
+		model = "text-embedding-ada-002"
+	}
+	reqBody := openAIEmbeddingsRequest{
+		Model: model,
+		Input: payload,
+	}
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("make request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("got non-2xx status from OpenAI: %s", resp.Status)
+	}
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024*2))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	var body openAIEmbeddingsResponse
+	err = json.Unmarshal(respBody, &body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal response body: %w", err)
+	}
+	return body.Data[0].Embedding, nil
+}
+
+// NewOpenAILLMClient creates a new LLMClient using OpenAI's API.
+func NewOpenAILLMClient(cfg setting.LLMSettings) LLMClient {
+	impl := openAILLMClient{
+		client: &http.Client{},
+		apiKey: cfg.OpenAIAPIKey,
+	}
+	return &impl
+}

--- a/pkg/services/llm/vector/client.go
+++ b/pkg/services/llm/vector/client.go
@@ -1,0 +1,157 @@
+package vector
+
+import (
+	"context"
+
+	qdrant "github.com/qdrant/go-client/qdrant"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type VectorClient interface {
+	Collections(ctx context.Context) ([]string, error)
+	CollectionExists(ctx context.Context, collection string) (bool, error)
+	CreateCollection(ctx context.Context, collection string, size uint64) error
+	PointExists(ctx context.Context, collection string, id uint64) (bool, error)
+	UpsertColumnar(ctx context.Context, collection string, ids []uint64, embeddings [][]float32, payloadJSONs []string) error
+	Search(ctx context.Context, collection string, vector []float32, limit uint64) ([]string, error)
+}
+
+type qdrantClient struct {
+	conn              *grpc.ClientConn
+	collectionsClient qdrant.CollectionsClient
+	pointsClient      qdrant.PointsClient
+}
+
+func NewQdrantClient(addr string) (VectorClient, func(), error) {
+	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, err
+	}
+	cancel := func() {
+		defer conn.Close()
+	}
+	return &qdrantClient{
+		conn:              conn,
+		collectionsClient: qdrant.NewCollectionsClient(conn),
+		pointsClient:      qdrant.NewPointsClient(conn),
+	}, cancel, nil
+}
+
+func (q *qdrantClient) Collections(ctx context.Context) ([]string, error) {
+	collections, err := q.collectionsClient.List(ctx, &qdrant.ListCollectionsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(collections.Collections))
+	for _, c := range collections.Collections {
+		names = append(names, c.Name)
+	}
+	return names, nil
+}
+
+func (q *qdrantClient) CollectionExists(ctx context.Context, collection string) (bool, error) {
+	_, err := q.collectionsClient.Get(ctx, &qdrant.GetCollectionInfoRequest{
+		CollectionName: collection,
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		st, ok := status.FromError(err)
+		if !ok {
+			return false, err
+			// Error was not a status error
+		}
+		if st.Code() == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (q *qdrantClient) CreateCollection(ctx context.Context, collection string, size uint64) error {
+	_, err := q.collectionsClient.Create(ctx, &qdrant.CreateCollection{
+		CollectionName: collection,
+		VectorsConfig: &qdrant.VectorsConfig{
+			Config: &qdrant.VectorsConfig_Params{
+				Params: &qdrant.VectorParams{
+					Size: size,
+					// TODO: make this customizable
+					Distance: qdrant.Distance_Cosine,
+				},
+			},
+		},
+	})
+	return err
+}
+
+func (q *qdrantClient) PointExists(ctx context.Context, collection string, id uint64) (bool, error) {
+	point, err := q.pointsClient.Get(ctx, &qdrant.GetPoints{
+		CollectionName: collection,
+		Ids: []*qdrant.PointId{
+			{PointIdOptions: &qdrant.PointId_Num{Num: id}},
+		},
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		st, ok := status.FromError(err)
+		if !ok {
+			return false, err
+			// Error was not a status error
+		}
+		if st.Code() == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	if point.Result == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (q *qdrantClient) UpsertColumnar(ctx context.Context, collection string, ids []uint64, embeddings [][]float32, payloadJSONs []string) error {
+	waitUpsert := false
+	upsertPoints := make([]*qdrant.PointStruct, 0, len(ids))
+	for i, id := range ids {
+		point := &qdrant.PointStruct{
+			Id: &qdrant.PointId{
+				PointIdOptions: &qdrant.PointId_Num{Num: id},
+			},
+			Vectors: &qdrant.Vectors{VectorsOptions: &qdrant.Vectors_Vector{Vector: &qdrant.Vector{Data: embeddings[i]}}},
+			Payload: map[string]*qdrant.Value{
+				"metadata": {
+					Kind: &qdrant.Value_StringValue{StringValue: payloadJSONs[i]},
+				},
+			},
+		}
+		upsertPoints = append(upsertPoints, point)
+	}
+	_, err := q.pointsClient.Upsert(ctx, &qdrant.UpsertPoints{
+		CollectionName: collection,
+		Points:         upsertPoints,
+		Wait:           &waitUpsert,
+	}, grpc.WaitForReady(true))
+	return err
+}
+
+func (q *qdrantClient) Search(ctx context.Context, collection string, vector []float32, limit uint64) ([]string, error) {
+	result, err := q.pointsClient.Search(ctx, &qdrant.SearchPoints{
+		CollectionName: collection,
+		Vector:         vector,
+		Limit:          limit,
+		// Include all payloads in the search result
+		WithVectors: &qdrant.WithVectorsSelector{SelectorOptions: &qdrant.WithVectorsSelector_Enable{Enable: false}},
+		WithPayload: &qdrant.WithPayloadSelector{SelectorOptions: &qdrant.WithPayloadSelector_Enable{Enable: true}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	payloads := make([]string, 0, len(result.GetResult()))
+	for _, v := range result.GetResult() {
+		payload := v.Payload["metadata"]
+		// TODO: handle non-strings, in case they get there
+		payloads = append(payloads, payload.GetStringValue())
+	}
+	return payloads, nil
+}

--- a/pkg/services/llm/vector/vector.go
+++ b/pkg/services/llm/vector/vector.go
@@ -1,0 +1,101 @@
+// package vector provides a service for fetching metadata related to
+// a natural language query.
+//
+// Currently it's not general enough and only supports fetching metadata
+// related to datasources; in future we should support fetching related
+// dashboards, folders, alerts, etc (stuff related to Grafana itself).
+
+package vector
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/llm/client"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var (
+	logger                       = log.New("vector")
+	DataSourceCollectionTemplate = "grafana-datasource-%s-%s-"
+)
+
+// TODO: make this an interface
+type Service struct {
+	llmClient client.LLMClient
+	cfg       *setting.Cfg
+}
+
+func ProvideService(
+	cfg *setting.Cfg,
+) *Service {
+	llmClient := client.NewOpenAILLMClient(cfg.LLM)
+	return &Service{
+		llmClient: llmClient,
+		cfg:       cfg,
+	}
+}
+
+type RelatedMetadataResponse = map[string][]string
+
+// RelatedMetadata returns metadata related to the given text.
+//
+// Each datasource can have multiple vector collections in the vector database,
+// named using the convention "grafana-datasource-{type}-{uid}-{collection}".
+// The datasource's `ProvideMetadata` method should return a map from collection
+// names to slices of text, which will be indexed into the vector database by the
+// vectorsync job.
+//
+// This method will return a map from collection names to the closest `limit` matches
+// in each of the datasources' collections.
+func (s *Service) RelatedMetadata(ctx context.Context, datasourceType, datasourceUID, text string, limit uint64) (RelatedMetadataResponse, error) {
+	embeddings, err := s.llmClient.Embeddings(ctx, text)
+	if err != nil {
+		return nil, fmt.Errorf("get embeddings: %w", err)
+	}
+	qdrantClient, cancel, err := NewQdrantClient(s.cfg.LLM.VectorDB.Host)
+	if err != nil {
+		return nil, fmt.Errorf("create vector store client: %s", err)
+	}
+	defer cancel()
+	collections, err := datasourceCollections(ctx, qdrantClient, datasourceType, datasourceUID)
+	result := make(map[string][]string, len(collections))
+	for _, collection := range collections {
+		best, err := qdrantClient.Search(ctx, collection.vectorDBName, embeddings, limit)
+		if err != nil {
+			logger.Error("error searching vector collection for closest matches", "collection", collection, "error", err)
+			continue
+		}
+		result[collection.name] = best
+	}
+	return result, nil
+}
+
+type collection struct {
+	name         string
+	vectorDBName string
+}
+
+// datasourceCollections fetches the names of all vector collections for the given datasource.
+func datasourceCollections(ctx context.Context, client VectorClient, datasourceType, datasourceUID string) ([]collection, error) {
+	allCollections, err := client.Collections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	prefix := fmt.Sprintf(DataSourceCollectionTemplate, datasourceType, datasourceUID)
+	collections := make([]collection, 0)
+	for _, c := range allCollections {
+		if !strings.HasPrefix(c, prefix) {
+			continue
+		}
+		collection := collection{
+			name:         strings.TrimPrefix(c, prefix),
+			vectorDBName: c,
+		}
+
+		collections = append(collections, collection)
+	}
+	return collections, nil
+}

--- a/pkg/services/llm/vector/vector.go
+++ b/pkg/services/llm/vector/vector.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	logger                       = log.New("vector")
-	DataSourceCollectionTemplate = "grafana-datasource-%s-%s-"
+	logger                             = log.New("vector")
+	DataSourceCollectionPrefixTemplate = "grafana-datasource-%s-%s-"
 )
 
 // TODO: make this an interface
@@ -84,7 +84,7 @@ func datasourceCollections(ctx context.Context, client VectorClient, datasourceT
 	if err != nil {
 		return nil, err
 	}
-	prefix := fmt.Sprintf(DataSourceCollectionTemplate, datasourceType, datasourceUID)
+	prefix := fmt.Sprintf(DataSourceCollectionPrefixTemplate, datasourceType, datasourceUID)
 	collections := make([]collection, 0)
 	for _, c := range allCollections {
 		if !strings.HasPrefix(c, prefix) {

--- a/pkg/services/llm/vector/vector.go
+++ b/pkg/services/llm/vector/vector.go
@@ -55,7 +55,7 @@ func (s *Service) RelatedMetadata(ctx context.Context, datasourceType, datasourc
 	if err != nil {
 		return nil, fmt.Errorf("get embeddings: %w", err)
 	}
-	qdrantClient, cancel, err := NewQdrantClient(s.cfg.LLM.VectorDB.Host)
+	qdrantClient, cancel, err := NewQdrantClient(s.cfg.LLM.VectorDB.Address)
 	if err != nil {
 		return nil, fmt.Errorf("create vector store client: %s", err)
 	}

--- a/pkg/services/llm/vectorsync/vectorsync.go
+++ b/pkg/services/llm/vectorsync/vectorsync.go
@@ -1,0 +1,215 @@
+// package vectorsync provides a background service to sync metadata from
+// Grafana and supported datasources to a configured vector database.
+package vectorsync
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/manager/store"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/llm/client"
+	"github.com/grafana/grafana/pkg/services/llm/vector"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/adapters"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var (
+	logger = log.New("vectorsync")
+)
+
+type Service struct {
+	dataSourceService datasources.DataSourceService
+	pluginService     *store.Service
+	pluginClient      plugins.Client
+
+	llmClient client.LLMClient
+
+	cfg *setting.Cfg
+}
+
+func ProvideService(
+	dataSourceService datasources.DataSourceService,
+	pluginService *store.Service,
+	pluginClient plugins.Client,
+	cfg *setting.Cfg,
+) *Service {
+	llmClient := client.NewOpenAILLMClient(cfg.LLM)
+	return &Service{
+		dataSourceService: dataSourceService,
+		pluginService:     pluginService,
+		pluginClient:      pluginClient,
+		llmClient:         llmClient,
+		cfg:               cfg,
+	}
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	if s.cfg.LLM.VectorDB.Host == "" {
+		logger.Info("no vector db host configured")
+		return nil
+	}
+
+	s.syncVectorStore(ctx)
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			s.syncVectorStore(ctx)
+		}
+	}
+}
+
+// syncVectorStore syncs the vector store with the latest metadata from Grafana
+// and datasources.
+//
+// Currently only supports qdrant as a vector store and only syncs datasource
+// metadata.
+func (s *Service) syncVectorStore(ctx context.Context) error {
+	datasources, err := s.dataSourceService.GetAllDataSources(ctx, &datasources.GetAllDataSourcesQuery{})
+	if err != nil {
+		return fmt.Errorf("get datasources: %w", err)
+	}
+	// TODO: support different types of vector store.
+	client, cancel, err := vector.NewQdrantClient(s.cfg.LLM.VectorDB.Host)
+	if err != nil {
+		return fmt.Errorf("create vector store client: %s", err)
+	}
+	defer cancel()
+	for _, ds := range datasources {
+		plugin, found := s.pluginService.Plugin(ctx, ds.Type)
+		if !found {
+			continue
+		}
+		if plugin.SupportsVectorStore() {
+			if err := s.syncVectorStoreForDatasource(ctx, client, ds); err != nil {
+				logger.Warn("sync vector store for datasource", "datasourceName", ds.Name, "datasourceUid", ds.UID, "err", err)
+			}
+		}
+	}
+	return nil
+}
+
+type VectorMetadataRequest struct {
+	OrgID                      int64
+	PluginID                   string
+	DataSourceInstanceSettings *backend.DataSourceInstanceSettings
+}
+
+// syncVectorStoreForDatasource syncs the vector store with the latest metadata from a datasource.
+//
+// It:
+// - fetches metadata from the datasource
+// - creates a vector store collection for each collection in the datasource, if one doesn't already exist
+// - adds any new metadata to the vector store
+func (s *Service) syncVectorStoreForDatasource(ctx context.Context, client vector.VectorClient, ds *datasources.DataSource) error {
+	instanceSettings, err := adapters.ModelToInstanceSettings(ds, s.decryptSecureJSONDataFn(ctx))
+	if err != nil {
+		return fmt.Errorf("convert datasource to instance settings: %w", err)
+	}
+	metadata, err := s.pluginClient.ProvideMetadata(ctx, &backend.ProvideMetadataRequest{
+		PluginContext: backend.PluginContext{
+			OrgID:                      ds.OrgID,
+			PluginID:                   ds.Type,
+			DataSourceInstanceSettings: instanceSettings,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("get vector metadata: %w", err)
+	}
+	logger.Debug("got vector metadata for datasource", "name", ds.Type, "uid", ds.UID)
+	prefix := fmt.Sprintf(vector.DataSourceCollectionPrefixTemplate, ds.Type, ds.UID)
+	for cName, cMetadata := range metadata.Metadata {
+		collection := fmt.Sprintf("%s%s", prefix, cName)
+		err = s.createCollectionIfNotExists(ctx, client, collection)
+		if err != nil {
+			return fmt.Errorf("create collection: %w", err)
+		}
+		err = s.addNewMetadata(ctx, client, collection, cMetadata)
+		if err != nil {
+			return fmt.Errorf("add metadata to vector DB: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) createCollectionIfNotExists(ctx context.Context, client vector.VectorClient, collection string) error {
+	if exists, err := client.CollectionExists(ctx, collection); err != nil {
+		return fmt.Errorf("check if collection exists: %w", err)
+	} else if exists {
+		logger.Debug("collection already exists", "collection", collection)
+		return nil
+	}
+	logger.Debug("creating collection", "collection", collection)
+	// TODO: make size customizable in config
+	return client.CreateCollection(ctx, collection, 1536)
+}
+
+// addNewMetadata adds any new metadata to the vector store.
+//
+// It takes _all_ metadata as an argument, then checks against the vector store
+// whether each piece of metadata exists. If it doesn't, it adds it by first
+// computing the embedding using the configured LLM service, then inserting it
+// into the vector store.
+//
+// Each piece of metadata is hashed to create a unique ID so we can avoid recomputing
+// embeddings for existing metadata.
+func (s *Service) addNewMetadata(ctx context.Context, client vector.VectorClient, collection string, allMetadata []string) error {
+	// TODO: batch this so we don't try to process every single piece of metadata in memory at once.
+	// IDs are just hashes of the payload
+	logger.Debug("adding metadata", "collection", collection, "count", len(allMetadata))
+	ids := make([]uint64, 0)
+	embeddings := make([][]float32, 0)
+	payloads := make([]string, 0)
+	for _, metadata := range allMetadata {
+		hash := fnv.New64a()
+		hash.Write([]byte(metadata))
+		id := hash.Sum64()
+		// TODO: can we do this call in a batch?
+		// or does it return 404 if _any_ don't exist?
+		// Answer: looks like we can for qdrant at least, the returned array
+		// just returns any found IDs.
+		if exists, err := client.PointExists(ctx, collection, id); err != nil {
+			logger.Warn("check vector exists", "collection", collection, "id", id, "err", err)
+			continue
+		} else if exists {
+			logger.Debug("vector already exists, skipping", "collection", collection, "id", id, "err", err)
+			continue
+		}
+		// If we're here, we have some new metadata to add.
+		logger.Debug("getting embeddings for metadata", "collection", collection, "metadata", metadata)
+		// TODO: we could batch this as well.
+		e, err := s.llmClient.Embeddings(ctx, metadata)
+		if err != nil {
+			logger.Warn("get embeddings", "collection", collection, "err", err)
+			continue
+		}
+		ids = append(ids, id)
+		embeddings = append(embeddings, e)
+		payloads = append(payloads, metadata)
+	}
+	if len(ids) == 0 {
+		logger.Debug("no new embeddings to add")
+		return nil
+	}
+	logger.Debug("adding embeddings to vector DB", "count", len(embeddings))
+	err := client.UpsertColumnar(ctx, collection, ids, embeddings, payloads)
+	if err != nil {
+		return fmt.Errorf("upsert columnar: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) decryptSecureJSONDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
+	return func(ds *datasources.DataSource) (map[string]string, error) {
+		return s.dataSourceService.DecryptedValues(ctx, ds)
+	}
+}

--- a/pkg/services/llm/vectorsync/vectorsync.go
+++ b/pkg/services/llm/vectorsync/vectorsync.go
@@ -50,8 +50,8 @@ func ProvideService(
 }
 
 func (s *Service) Run(ctx context.Context) error {
-	if s.cfg.LLM.VectorDB.Host == "" {
-		logger.Info("no vector db host configured")
+	if s.cfg.LLM.VectorDB.Address == "" {
+		logger.Info("no vector db address configured")
 		return nil
 	}
 

--- a/pkg/services/llm/vectorsync/vectorsync.go
+++ b/pkg/services/llm/vectorsync/vectorsync.go
@@ -98,12 +98,6 @@ func (s *Service) syncVectorStore(ctx context.Context) error {
 	return nil
 }
 
-type VectorMetadataRequest struct {
-	OrgID                      int64
-	PluginID                   string
-	DataSourceInstanceSettings *backend.DataSourceInstanceSettings
-}
-
 // syncVectorStoreForDatasource syncs the vector store with the latest metadata from a datasource.
 //
 // It:

--- a/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
@@ -150,3 +150,7 @@ func (m *CachingMiddleware) PublishStream(ctx context.Context, req *backend.Publ
 func (m *CachingMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *CachingMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
@@ -83,3 +83,7 @@ func (m *ClearAuthHeadersMiddleware) PublishStream(ctx context.Context, req *bac
 func (m *ClearAuthHeadersMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *ClearAuthHeadersMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
@@ -131,3 +131,7 @@ func (m *CookiesMiddleware) PublishStream(ctx context.Context, req *backend.Publ
 func (m *CookiesMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *CookiesMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
@@ -106,3 +106,7 @@ func (m *HTTPClientMiddleware) PublishStream(ctx context.Context, req *backend.P
 func (m *HTTPClientMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *HTTPClientMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/oauthtoken_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/oauthtoken_middleware.go
@@ -141,3 +141,7 @@ func (m *OAuthTokenMiddleware) PublishStream(ctx context.Context, req *backend.P
 func (m *OAuthTokenMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *OAuthTokenMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/resource_response_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/resource_response_middleware.go
@@ -67,3 +67,7 @@ func (m *ResourceResponseMiddleware) PublishStream(ctx context.Context, req *bac
 func (m *ResourceResponseMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *ResourceResponseMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -82,3 +82,7 @@ func (m *TracingHeaderMiddleware) PublishStream(ctx context.Context, req *backen
 func (m *TracingHeaderMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *TracingHeaderMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_middleware.go
@@ -133,3 +133,11 @@ func (m *TracingMiddleware) RunStream(ctx context.Context, req *backend.RunStrea
 	err = m.next.RunStream(ctx, req, sender)
 	return err
 }
+
+func (m *TracingMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	var err error
+	ctx, end := m.traceWrap(ctx, req.PluginContext, "provideMetadata")
+	defer func() { end(err) }()
+	resp, err := m.next.ProvideMetadata(ctx, req)
+	return resp, err
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/user_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/user_header_middleware.go
@@ -81,3 +81,7 @@ func (m *UserHeaderMiddleware) PublishStream(ctx context.Context, req *backend.P
 func (m *UserHeaderMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	return m.next.RunStream(ctx, req, sender)
 }
+
+func (m *UserHeaderMiddleware) ProvideMetadata(ctx context.Context, req *backend.ProvideMetadataRequest) (*backend.ProvideMetadataResponse, error) {
+	return m.next.ProvideMetadata(ctx, req)
+}

--- a/pkg/setting/setting_llm.go
+++ b/pkg/setting/setting_llm.go
@@ -7,12 +7,24 @@ import (
 type LLMSettings struct {
 	Enabled      bool
 	OpenAIAPIKey string
+
+	VectorDB VectorDBSettings
 }
 
 func (cfg *Cfg) readLLMSettings(iniFile *ini.File) {
 	section := cfg.SectionWithEnvOverrides("llms")
+	vectorDBSection := cfg.SectionWithEnvOverrides("llms.vector_db")
 	cfg.LLM = LLMSettings{
 		Enabled:      section.Key("enabled").MustBool(false),
 		OpenAIAPIKey: section.Key("openai_api_key").MustString(""),
+		VectorDB: VectorDBSettings{
+			Type: vectorDBSection.Key("type").MustString(""),
+			Host: vectorDBSection.Key("host").MustString(""),
+		},
 	}
+}
+
+type VectorDBSettings struct {
+	Type string
+	Host string
 }

--- a/pkg/setting/setting_llm.go
+++ b/pkg/setting/setting_llm.go
@@ -18,13 +18,13 @@ func (cfg *Cfg) readLLMSettings(iniFile *ini.File) {
 		Enabled:      section.Key("enabled").MustBool(false),
 		OpenAIAPIKey: section.Key("openai_api_key").MustString(""),
 		VectorDB: VectorDBSettings{
-			Type: vectorDBSection.Key("type").MustString(""),
-			Host: vectorDBSection.Key("host").MustString(""),
+			Type:    vectorDBSection.Key("type").MustString(""),
+			Address: vectorDBSection.Key("address").MustString(""),
 		},
 	}
 }
 
 type VectorDBSettings struct {
-	Type string
-	Host string
+	Type    string
+	Address string
 }

--- a/public/app/core/services/llm_srv.ts
+++ b/public/app/core/services/llm_srv.ts
@@ -1,8 +1,10 @@
 import {
   config,
   getBackendSrv,
+  DataSourceMetadata,
   LLMChatCompletionsMessage,
   LLMChatCompletionsRequest,
+  LLMRelatedMetadataRequest,
   LLMSrv as LLMService,
 } from '@grafana/runtime';
 
@@ -28,13 +30,24 @@ export class LLMSrv implements LLMService {
     this.isEnabled = config.llms?.enabled ?? false;
   }
 
+  async relatedMetadata<M extends string>(request: LLMRelatedMetadataRequest): Promise<DataSourceMetadata<M>> {
+    try {
+      const response = await getBackendSrv().post('/api/llms/related-metadata', request, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      return response;
+    } catch (_) {
+      return {}
+    }
+  }
+
   async chatCompletions(request: LLMChatCompletionsRequest): Promise<string> {
     // TODO: handle non-OpenAI providers.
     const openAIRequest: OpenAIChatCompletionsRequest = {
       model: request.model ?? 'gpt-3.5-turbo',
       messages: request.messages,
     };
-    const response = await getBackendSrv().post('/api/llms/openai/v1/chat/completions', openAIRequest, {
+    const response = await getBackendSrv().post('/api/llms/proxy/openai/v1/chat/completions', openAIRequest, {
       headers: { 'Content-Type': 'application/json' },
     });
     return response.choices[0].message.content;

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -79,8 +79,10 @@ const GET_AND_POST_METADATA_ENDPOINTS = ['api/v1/query', 'api/v1/query_range', '
 
 export const InstantQueryRefIdIndex = '-Instant';
 
+export type PrometheusVectorMetadataTypes = 'metrics' | 'example_queries';
+
 export class PrometheusDatasource
-  extends DataSourceWithBackend<PromQuery, PromOptions>
+  extends DataSourceWithBackend<PromQuery, PromOptions, PrometheusVectorMetadataTypes>
   implements DataSourceWithQueryImportSupport<PromQuery>, DataSourceWithQueryExportSupport<PromQuery>
 {
   type: string;
@@ -183,9 +185,8 @@ export class PrometheusDatasource
    */
   getPrometheusTargetSignature(request: DataQueryRequest<PromQuery>, query: PromQuery) {
     const targExpr = this.interpolateString(query.expr);
-    return `${targExpr}|${query.interval ?? request.interval}|${JSON.stringify(request.rangeRaw ?? '')}|${
-      query.exemplar
-    }`;
+    return `${targExpr}|${query.interval ?? request.interval}|${JSON.stringify(request.rangeRaw ?? '')}|${query.exemplar
+      }`;
   }
 
   hasLabelsMatchAPISupport(): boolean {

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -75,6 +75,7 @@
   "metrics": true,
   "alerting": true,
   "annotations": true,
+  "metadata": true,
   "backend": true,
   "queryOptions": {
     "minInterval": true


### PR DESCRIPTION
Note: this PR builds on #69813 but is even less likely to be merged, there's a lot of probably controversial stuff in here!

**What is this feature?**

This PR adds two new services to the backend and a ton of associated changes.
It builds off of the [`provide-metadata-service`](https://github.com/grafana/grafana-plugin-sdk-go/compare/main...provide-metadata-service) branch of the plugin SDK to add
a 'vector sync' service, which will periodically query for metadata from datasources
and synchronise them to a configured vector DB for semantic search; and a 'vector'
service which provides an API for querying for closely related metadata given a
datasource and some natural language text.

This is then used by the frontend in the LLMQueryEditor component, which now
accepts a callback which will generate a prompt. Before calling the completions
endpoint of the LLM with the system and user prompt, it now requests related metadata
to the user prompt from the backend, and passes this to the callback for the datasource
frontend to use when constructing the prompt. This allows datasources to include related
metadata, such as example metrics or queries, in their system prompt.

A later commit also synchronises and adds core Grafana objects such as datasources and dashboards (later: alert rules, folders, annotations?) to the vector store so that plugins can do semantic search of these objects too, via the same `/api/llms/related-metadata` API.

There are several shortcomings here:
- only qdrant is supported as a vector database
- only OpenAI is supported as an LLM
- it requires a significant commitment to changing the plugin SDK :(

To get this working you'll need to add this to conf/custom.ini:

    [llms]
    enabled = true

    [llms.vector_db]
    type = "qdrant"
    address = "localhost:6334"

Run this before `make run`:

    export GF_LLMS_OPENAI_API_KEY=$OPENAI_API_KEY

And start qdrant in a separate shell:

    docker run -p 6333:6333 -p 6334:6334 --rm \
        -v $(pwd)/qdrant_storage:/qdrant/storage \
        qdrant/qdrant

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
