### PR TITLE
Canvas: Update inline edit to use theme shadow

### DIFF
--- a/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
@@ -111,7 +111,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: column;
     background: ${theme.components.panel.background};
     border: 1px solid ${theme.colors.border.strong};
-    box-shadow: 5px 5px 20px -5px #000000;
+    box-shadow: ${theme.shadows.z3};
     z-index: 1000;
     opacity: 1;
     min-width: 400px;


### PR DESCRIPTION
Update canvas inline editor to use standard theme shadow.

Before
![before](https://github.com/grafana/grafana/assets/22381771/8b571a1e-1857-4b59-bbb1-bb7dfefdb3f5)


After
![after](https://github.com/grafana/grafana/assets/22381771/254dcd9e-a7ee-4e6a-820c-f0c4cd802cf2)
