### PR TITLE
Chore: Skip flakey alerting auth enterpise test

### DIFF
--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -250,6 +250,8 @@ func TestGrafanaRuleConfig(t *testing.T) {
 			t.Skip("Enterprise-only test")
 		}
 
+		t.Skip("flakey tests - skipping") //TODO: Fix tests and remove skip.
+
 		testUserId := createUser(t, env.SQLStore, user.CreateUserCommand{
 			DefaultOrgRole: "DOESNOTEXIST", // Needed so that the SignedInUser has OrgId=1. Otherwise, datasource will not be found.
 			Password:       "test",


### PR DESCRIPTION
`fail if can't query data sources` flakey on drone though I can't reproduce locally, skipping for now.

[Related Drone build](https://drone.grafana.net/grafana/grafana-enterprise/56832/5/8).