### PR TITLE
Alerting: Show disabled provisioned evaluation group

### DIFF
--- a/packages/grafana-data/src/types/select.ts
+++ b/packages/grafana-data/src/types/select.ts
@@ -13,5 +13,6 @@ export interface SelectableValue<T = any> {
   title?: string;
   // Optional component that will be shown together with other options. Does not get past any props.
   component?: React.ComponentType<any>;
+  isDisabled?: boolean;
   [key: string]: any;
 }

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -357,7 +357,7 @@ export function SelectBase<T>({
             return <DropdownIndicator isOpen={props.selectProps.menuIsOpen} />;
           },
           SingleValue(props: any) {
-            return <SingleValue {...props} disabled={disabled} />;
+            return <SingleValue {...props} isDisabled={disabled} />;
           },
           SelectContainer,
           MultiValueContainer: MultiValueContainer,

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -90,7 +90,7 @@ export interface SelectCommonProps<T> {
   virtualized?: boolean;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number | 'auto';
-  isOptionDisabled?: () => boolean;
+  isOptionDisabled?: (option: SelectableValue<T>) => boolean;
   /** allowCustomValue must be enabled. Determines whether the "create new" option should be displayed based on the current input value, select value and options array. */
   isValidNewOption?: (
     inputValue: string,

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -170,7 +170,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
         invalid={!!errors.group?.message}
       >
         <InputControl
-          render={({ field: { ref, ...field } }) =>
+          render={({ field: { ref, ...field }, fieldState }) =>
             loading ? (
               <LoadingPlaceholder text="Loading..." />
             ) : (
@@ -179,7 +179,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 inputId="group"
                 key={`my_unique_select_key__${selectedGroup?.title ?? ''}`}
                 {...field}
-                invalid={Boolean(folder) && !selectedGroup.title}
+                invalid={Boolean(folder) && !selectedGroup.title && Boolean(fieldState.error)}
                 loadOptions={debouncedSearch}
                 loadingMessage={'Loading groups...'}
                 defaultOptions={groupOptions}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -35,23 +35,23 @@ export const useGetGroupOptionsFromFolder = (folderTitle: string) => {
   const grafanaFolders = useCombinedRuleNamespaces(GRAFANA_RULES_SOURCE_NAME);
   const folderGroups = grafanaFolders.find((f) => f.name === folderTitle)?.groups ?? [];
 
-  // we include provisioned folders, but disable the option to select them
-  const isProvisionedGroup = (group: CombinedRuleGroup) => {
-    return group.rules.some(
-      (rule) => isGrafanaRulerRule(rule.rulerRule) && Boolean(rule.rulerRule.grafana_alert.provenance) === true
-    );
-  };
-
   const groupOptions = folderGroups
     .map<SelectableValue<string>>((group) => ({
       label: group.name,
       value: group.name,
       description: group.interval ?? MINUTE,
+      // we include provisioned folders, but disable the option to select them
       isDisabled: isProvisionedGroup(group),
     }))
     .sort(sortByLabel);
 
   return { groupOptions, loading: groupfoldersForGrafana?.loading };
+};
+
+const isProvisionedGroup = (group: CombinedRuleGroup) => {
+  return group.rules.some(
+    (rule) => isGrafanaRulerRule(rule.rulerRule) && Boolean(rule.rulerRule.grafana_alert.provenance) === true
+  );
 };
 
 const sortByLabel = (a: SelectableValue<string>, b: SelectableValue<string>) => {


### PR DESCRIPTION
**What is this feature?**

This PR adds provisioned evaluation groups to the dropdown list, disabling them and indicating to the user that those have been provisioned and cannot be selected.

Previously provisioned evaluation groups were hidden from the user and was confusing because there was no visual indication for why they were omitted from the list.

<img width="418" alt="image" src="https://github.com/grafana/grafana/assets/868844/fcd4f997-b905-4c63-bd75-8b7b673674bb">


**Which issue(s) does this PR fix?**:

Fixes #69213

**Special notes for your reviewer:**

I've found a bug where the `SingleValue` component destructures `isDisabled` and uses that to determine... if it's disabled but we actually pass a `disabled` prop instead of `isDisabled` in `BaseSelect`.
