### PR TITLE
Prometheus: Fix empty query string (expr) breaking dashboard panel

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/QueryPatternsModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/QueryPatternsModal.tsx
@@ -32,7 +32,7 @@ export const QueryPatternsModal = (props: Props) => {
   const styles = useStyles2(getStyles);
   const hasNewQueryOption = !!onAddQuery;
   const hasPreviousQuery = useMemo(() => {
-    const visualQuery = buildVisualQueryFromString(query.expr);
+    const visualQuery = buildVisualQueryFromString(query.expr ?? '');
     // has anything entered in the query, metric, labels, operations, or binary queries
     const hasOperations = visualQuery.query.operations.length > 0,
       hasMetric = visualQuery.query.metric,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
@@ -93,7 +93,7 @@ const stateSlice = createSlice({
     exprChanged: (state, action: PayloadAction<string>) => {
       if (!state.visQuery || state.expr !== action.payload) {
         state.expr = action.payload;
-        const parseResult = buildVisualQueryFromString(action.payload);
+        const parseResult = buildVisualQueryFromString(action.payload ?? '');
 
         state.visQuery = parseResult.query;
       }

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -293,6 +293,22 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('Throws error when undefined', () => {
+    expect(() => buildVisualQueryFromString(undefined as unknown as string)).toThrow(
+      "Cannot read properties of undefined (reading 'replace')"
+    );
+  });
+
+  it('Works with empty string', () => {
+    expect(buildVisualQueryFromString('')).toEqual(
+      noErrors({
+        metric: '',
+        labels: [],
+        operations: [],
+      })
+    );
+  });
+
   it('fails to parse variable for function', () => {
     expect(buildVisualQueryFromString('${func_var}(metric{bar="foo"})')).toEqual({
       errors: [


### PR DESCRIPTION
**What is this feature?**
Fixes bug in which queries that are migrated from other datasources are missing query.expr string which should display an empty panel, instead displays error that breaks panel.

**Why do we need this feature?**
Bug prevents users from editing or making any change to the panel.

**Who is this feature for?**
Prometheus users

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/69935

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
