### PR TITLE
Auth: Show invite button if disable login form is set to false

### DIFF
--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -65,9 +65,38 @@ describe('Render', () => {
     expect(screen.getByRole('link', { name: 'someUrl' })).toHaveAttribute('href', 'some/url');
   });
 
-  it('should not show invite button when externalUserMngInfo is set', () => {
+  it('should not show invite button when externalUserMngInfo is set and disableLoginForm is true', () => {
     const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
+    config.disableLoginForm = true;
+
+    setup({
+      canInvite: true,
+    });
+
+    expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
+    // Reset the disableLoginForm mock to its original value
+    config.externalUserMngInfo = originalExternalUserMngInfo;
+  });
+
+  it('should show invite button when externalUserMngInfo is not set and disableLoginForm is true', () => {
+    const originalExternalUserMngInfo = config.externalUserMngInfo;
+    config.externalUserMngInfo = '';
+    config.disableLoginForm = true;
+
+    setup({
+      canInvite: true,
+    });
+
+    expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
+    // Reset the disableLoginForm mock to its original value
+    config.externalUserMngInfo = originalExternalUserMngInfo;
+  });
+
+  it('should show invite button when externalUserMngInfo is set and disableLoginForm is false', () => {
+    const originalExternalUserMngInfo = config.externalUserMngInfo;
+    config.externalUserMngInfo = 'truthy';
+    config.disableLoginForm = false;
 
     setup({
       canInvite: true,

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -80,7 +80,6 @@ describe('Render', () => {
   });
 
   it('should show invite button when externalUserMngInfo is not set and disableLoginForm is true', () => {
-    const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = '';
     config.disableLoginForm = true;
 
@@ -88,21 +87,20 @@ describe('Render', () => {
       canInvite: true,
     });
 
-    expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value
-    config.externalUserMngInfo = originalExternalUserMngInfo;
+    config.disableLoginForm = false;
   });
 
   it('should show invite button when externalUserMngInfo is set and disableLoginForm is false', () => {
     const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
-    config.disableLoginForm = false;
 
     setup({
       canInvite: true,
     });
 
-    expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value
     config.externalUserMngInfo = originalExternalUserMngInfo;
   });

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -49,8 +49,10 @@ export const UsersActionBarUnconnected = ({
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
   const canAddToOrg: boolean = contextSrv.hasAccess(AccessControlAction.OrgUsersAdd, canInvite);
-  // Hide Invite button in case users are managed externally
-  const showInviteButton: boolean = canAddToOrg && !config.externalUserMngInfo;
+  // Show invite button in the following cases:
+  // 1) the instance is not a hosted Grafana instance (!config.externalUserMngInfo)
+  // 2) new basic auth users can be created for this instance (!config.disableLoginForm).
+  const showInviteButton: boolean = canAddToOrg && (!config.disableLoginForm || !config.externalUserMngInfo);
 
   return (
     <div className="page-action-bar" data-testid="users-action-bar">

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -52,7 +52,7 @@ export const UsersActionBarUnconnected = ({
   // Show invite button in the following cases:
   // 1) the instance is not a hosted Grafana instance (!config.externalUserMngInfo)
   // 2) new basic auth users can be created for this instance (!config.disableLoginForm).
-  const showInviteButton: boolean = canAddToOrg && (!config.disableLoginForm || !config.externalUserMngInfo);
+  const showInviteButton: boolean = canAddToOrg && !(config.disableLoginForm && config.externalUserMngInfo);
 
   return (
     <div className="page-action-bar" data-testid="users-action-bar">


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/pull/67031 and https://github.com/grafana/grafana/pull/68991 change the logic of when the `invite` button is shown, which lead the button from being hidden from cloud instances where it was actually used. This PR extends the logic again to show the `invite` button if:
1) the instance is not a cloud instance;
2) the instance has `disable_login_form` set to false (so new basic auth users can be added).

**Why do we need this feature?**

To reenable the `invite` button for cloud instances where it was being used.

**Who is this feature for?**

Cloud users.

**Which issue(s) does this PR fix?**:

Fixes #69878

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
