### PR TITLE
Barchart: Fix tooltip for normal/percentage stacking(2)

### DIFF
--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -493,7 +493,12 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
         let heightReduce = 0;
         let widthReduce = 0;
 
-        const rect = hRect && findRect(qt, hRect.sidx - 1, hRect.didx);
+        let rect = undefined;
+
+        if (isStacked) {
+          rect = hRect && findRect(qt, hRect.sidx - 1, hRect.didx);
+        }
+
         // get height of bar rect at same index of the series below the hovered one
         if (isStacked && isHovered && hRect!.sidx > 1 && rect) {
           if (isXHorizontal) {

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -493,18 +493,15 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
         let heightReduce = 0;
         let widthReduce = 0;
 
-        let rect = undefined;
-
-        if (isStacked) {
-          rect = hRect && findRect(qt, hRect.sidx - 1, hRect.didx);
-        }
-
         // get height of bar rect at same index of the series below the hovered one
-        if (isStacked && isHovered && hRect!.sidx > 1 && rect) {
-          if (isXHorizontal) {
-            heightReduce = rect.h;
-          } else {
-            widthReduce = rect.w;
+        if (isStacked && isHovered) {
+          const rect = hRect && findRect(qt, hRect.sidx - 1, hRect.didx);
+          if (hRect!.sidx > 1 && rect) {
+            if (isXHorizontal) {
+              heightReduce = rect.h;
+            } else {
+              widthReduce = rect.w;
+            }
           }
         }
 

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -495,8 +495,8 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
 
         // get height of bar rect at same index of the series below the hovered one
         if (isStacked && isHovered) {
-          const rect = hRect && findRect(qt, hRect.sidx - 1, hRect.didx);
-          if (hRect!.sidx > 1 && rect) {
+          const rect = hRect && hRect.sidx > 1 && findRect(qt, hRect.sidx - 1, hRect.didx);
+          if (rect) {
             if (isXHorizontal) {
               heightReduce = rect.h;
             } else {


### PR DESCRIPTION
Missing condition in https://github.com/grafana/grafana/pull/69931 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
