### PR TITLE
Prometheus: Metrics explorer add docs and image

### DIFF
--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -130,7 +130,7 @@ You can also enter text into the selector when the dropdown is open to search an
 
 {{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 
-If you would like to explore your metrics further, you can open the **Metrics Explorer** by clicking the first option in the metric select.
+If you would like to explore your metrics further, you can open the **Metrics Explorer** by clicking the first option in the metric select component of the query builder.
 
 {{< figure src="/static/img/docs/prometheus/metrics-explorer-option.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -126,7 +126,7 @@ When you are ready to create a query, you can choose the specific metric name fr
 The data source requests the list of available metrics from the Prometheus server based on the selected time rage.
 You can also enter text into the selector when the dropdown is open to search and filter the list.
 
-#### Metrics Explorer
+#### Metrics explorer
 
 {{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -126,6 +126,24 @@ When you are ready to create a query, you can choose the specific metric name fr
 The data source requests the list of available metrics from the Prometheus server based on the selected time rage.
 You can also enter text into the selector when the dropdown is open to search and filter the list.
 
+#### Metrics Explorer
+
+{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
+
+If you would like to explore your metrics further, you can open the **Metrics Explorer** by clicking the first option in the metric select.
+
+{{< figure src="/static/img/docs/prometheus/metrics-explorer-option.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
+
+The metrics explorer displays all metrics in a paginated table list. The list shows the total number of metrics, as well as the name, type and description for each metric. You can enter text into the search input to filter results.
+You can also filter by type.
+
+There are also additional settings for the following items:
+
+- Include description in search. Search by name **and** description
+- Include results with no metadata. Many prometheus metrics have no metadata. This allows users to include metrics with undefined type and descrition.
+- Disable text wrap.
+- Enable regex search. This uses the prometheus API to enable regex search for the metric name.
+
 ### Label filters
 
 Select desired labels and their values from the dropdown list.

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -128,7 +128,7 @@ You can also enter text into the selector when the dropdown is open to search an
 
 #### Metrics Explorer
 
-{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
+{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 
 If you would like to explore your metrics further, you can open the **Metrics Explorer** by clicking the first option in the metric select.
 
@@ -140,7 +140,7 @@ You can also filter by type.
 There are also additional settings for the following items:
 
 - Include description in search. Search by name **and** description
-- Include results with no metadata. Many prometheus metrics have no metadata. This allows users to include metrics with undefined type and descrition.
+- Include results with no metadata. Many prometheus metrics have no metadata. This allows users to include metrics with undefined type and description.
 - Disable text wrap.
 - Enable regex search. This uses the prometheus API to enable regex search for the metric name.
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -130,9 +130,11 @@ You can also enter text into the selector when the dropdown is open to search an
 
 {{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 
-If you would like to explore your metrics further, you can open the **Metrics Explorer** by clicking the first option in the metric select component of the query builder.
+If you would like to explore your metrics in the query builder further, you can open the **Metrics Explorer** by clicking the first option in the metric select component of the query builder.
 
 {{< figure src="/static/img/docs/prometheus/metrics-explorer-option.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
+
+The metrics explorer is different than the metrics browser. The metrics explorer is only found in the query builder selection. The metrics browser is only found in the code editor. The metrics explorer does not have the ability to browse labels yet, but the metrics browser can display all labels on a metric name.
 
 The metrics explorer displays all metrics in a paginated table list. The list shows the total number of metrics, as well as the name, type and description for each metric. You can enter text into the search input to filter results.
 You can also filter by type.
@@ -202,7 +204,7 @@ The autocompletion dropdown includes documentation for the suggested items where
 ### Metrics browser
 
 The metrics browser locates metrics and selects relevant labels to help you build basic queries.
-When you click **Metrics browser**, it displays all available metrics and labels.
+When you click **Metrics browser** in code mode, it displays all available metrics and labels.
 If supported by your Prometheus instance, each metric also displays its `HELP` and `TYPE` as a tooltip.
 
 {{< figure src="/static/img/docs/prometheus/metric-browser.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics browser" >}}

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -132,8 +132,6 @@ You can also enter text into the selector when the dropdown is open to search an
 
 If you would like to explore your metrics in the query builder further, you can open the **Metrics Explorer** by clicking the first option in the metric select component of the query builder.
 
-{{< figure src="/static/img/docs/prometheus/metrics-explorer-option.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
-
 The metrics explorer is different than the metrics browser. The metrics explorer is only found in the query builder section. The metrics browser is only found in the code editor. The metrics explorer does not have the ability to browse labels yet, but the metrics browser can display all labels on a metric name.
 
 The metrics explorer displays all metrics in a paginated table list. The list shows the total number of metrics, as well as the name, type and description for each metric. You can enter text into the search input to filter results.

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -134,7 +134,7 @@ If you would like to explore your metrics in the query builder further, you can 
 
 {{< figure src="/static/img/docs/prometheus/metrics-explorer-option.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
 
-The metrics explorer is different than the metrics browser. The metrics explorer is only found in the query builder selection. The metrics browser is only found in the code editor. The metrics explorer does not have the ability to browse labels yet, but the metrics browser can display all labels on a metric name.
+The metrics explorer is different than the metrics browser. The metrics explorer is only found in the query builder section. The metrics browser is only found in the code editor. The metrics explorer does not have the ability to browse labels yet, but the metrics browser can display all labels on a metric name.
 
 The metrics explorer displays all metrics in a paginated table list. The list shows the total number of metrics, as well as the name, type and description for each metric. You can enter text into the search input to filter results.
 You can also filter by type.

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -142,7 +142,7 @@ You can also filter by type.
 There are also additional settings for the following items:
 
 - Include description in search. Search by name **and** description
-- Include results with no metadata. Many prometheus metrics have no metadata. This allows users to include metrics with undefined type and description.
+- Include results with no metadata. Many Prometheus metrics have no metadata. This allows users to include metrics with undefined type and description.
 - Disable text wrap.
 - Enable regex search. This uses the prometheus API to enable regex search for the metric name.
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -204,7 +204,7 @@ The autocompletion dropdown includes documentation for the suggested items where
 ### Metrics browser
 
 The metrics browser locates metrics and selects relevant labels to help you build basic queries.
-When you click **Metrics browser** in code mode, it displays all available metrics and labels.
+When you click **Metrics browser** in `Code` mode, it displays all available metrics and labels.
 If supported by your Prometheus instance, each metric also displays its `HELP` and `TYPE` as a tooltip.
 
 {{< figure src="/static/img/docs/prometheus/metric-browser.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics browser" >}}

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -142,7 +142,7 @@ There are also additional settings for the following items:
 - Include description in search. Search by name **and** description
 - Include results with no metadata. Many Prometheus metrics have no metadata. This allows users to include metrics with undefined type and description.
 - Disable text wrap.
-- Enable regex search. This uses the prometheus API to enable regex search for the metric name.
+- Enable regex search. This uses the Prometheus API to enable regex search for the metric name.
 
 ### Label filters
 


### PR DESCRIPTION
**What is this?**
This is a pr to add documentation for the metrics explorer in the query builder docs.

**Why do we need this feature?**
The metrics explorer is being turned on by default in v10.1 and part of the roll out is to add documentation about the feature.

**Who is this feature for?**
The metrics explorer is for prometheus users with beginning and intermediate experience who want to explore their metrics.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
