### PR TITLE
Pass testing status to the data source plugin extension

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -121,6 +121,12 @@ export type PluginExtensionDataSourceConfigContext<JsonData extends DataSourceJs
   // Meta information about the datasource plugin
   dataSourceMeta: DataSourcePluginMeta;
 
+  // Testing status
+  testingStatus?: {
+    message?: string | null;
+    status?: string | null;
+  };
+
   // Can be used to update the `jsonData` field on the datasource
   // (Only updates the form, it still needs to be saved by the user)
   setJsonData: (jsonData: JsonData) => void;

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -359,6 +359,7 @@ describe('<EditDataSource>', () => {
       expect(props.context.dataSource).toBeDefined();
       expect(props.context.dataSourceMeta).toBeDefined();
       expect(props.context.setJsonData).toBeDefined();
+      expect(props.context.testingStatus).toBeDefined();
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -217,6 +217,7 @@ export function EditDataSourceView({
               context={{
                 dataSource: omit(dataSource, ['secureJsonData']),
                 dataSourceMeta: dataSourceMeta,
+                testingStatus,
                 setJsonData: (jsonData) =>
                   onOptionsChange({
                     ...dataSource,


### PR DESCRIPTION
### What changed? 

This PR adds the [TestingStatus](https://github.com/grafana/grafana/blob/fa70fba0e38ef7fb5dcda88767319308d26db915/packages/grafana-runtime/src/utils/queryResponse.ts#L182) info to the PluginExtensionDataSourceConfigContext so that the PDC plugin can react to data source testing errors:
![image](https://github.com/grafana/grafana/assets/561365/c8d9e4a7-a1c7-4b2c-9a0a-8ea5b876c672)

We are still considering options for the plugin UX for the error so this example is just a quick way to demonstrate what we need. 

Another option would be to be able to amend existing error, although not sure whether this would be feasible?  