### PR TITLE
grafana-data: Add frame type for logs dataframes

### DIFF
--- a/packages/grafana-data/src/types/dataFrameTypes.ts
+++ b/packages/grafana-data/src/types/dataFrameTypes.ts
@@ -18,6 +18,9 @@ export enum DataFrameType {
   NumericMulti = 'numeric-multi',
   NumericLong = 'numeric-long',
 
+  /** Logs types: https://grafana.github.io/dataplane/logs */
+  LogLines = 'log-lines',
+
   /** Directory listing */
   DirectoryListing = 'directory-listing',
 


### PR DESCRIPTION
the grafana-backend `go` part already has a frame-type for logs, at: https://github.com/grafana/grafana-plugin-sdk-go/blob/e8cf32a09e61a0f62e2a08f8e6da622fe7ebb3b7/data/frame_type.go#L76
this PR adds the same frame-type in javascript.

(handling of such dataframes in the logs-visualization will come later, in a separate PR)