### PR TITLE
Prometheus: Expr undefined at runtime

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.ts
@@ -47,6 +47,7 @@ export function getQueryWithDefaults(
   }
 
   // default query expr is now empty string, set in getDefaultQuery
+  // While expr is required in the types, it is not always defined at runtime, so we need to check for undefined and default to an empty string to prevent runtime errors
   if (!query.expr) {
     result = { ...result, expr: '', legendFormat: LegendFormatMode.Auto };
   }

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.ts
@@ -36,7 +36,7 @@ function getDefaultEditorMode(expr: string, defaultEditor: QueryEditorMode = Que
  * Returns query with defaults, and boolean true/false depending on change was required
  */
 export function getQueryWithDefaults(
-  query: PromQuery,
+  query: PromQuery & { expr?: string },
   app: CoreApp | undefined,
   defaultEditor?: QueryEditorMode
 ): PromQuery {
@@ -47,7 +47,7 @@ export function getQueryWithDefaults(
   }
 
   // default query expr is now empty string, set in getDefaultQuery
-  if (query.expr === '') {
+  if (!query.expr) {
     result = { ...result, expr: '', legendFormat: LegendFormatMode.Auto };
   }
 


### PR DESCRIPTION
**What is this feature?**
Attempting to change prometheus query string `expr` to default to empty string when undefined.

**Why do we need this feature?**
There are edge cases which can cause the query object to be invalid at runtime, we want consumers of datasource types to be aware and plan for these cases.

**Who is this feature for?**

Prometheus datasource plugin developers.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/69945

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
