### PR TITLE
NPM packages: Fail `build-frontend-packages` step if `package.json` and input tag differ

### DIFF
--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -30,7 +30,7 @@ func GetConfig(c *cli.Context, version string) (config.Config, config.Edition, e
 		}
 	} else {
 		if version != packageVersion {
-			return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s", packageVersion, version), 1)
+			return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json!", packageVersion, version), 1)
 		}
 	}
 

--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -9,11 +9,11 @@ import (
 
 const GrafanaDir = "."
 
-func GetConfig(c *cli.Context, version string) (config.Config, config.Edition, error) {
+func GetConfig(c *cli.Context, inputTagVersion string) (config.Config, config.Edition, error) {
 	cfg := config.Config{
 		NumWorkers:     c.Int("jobs"),
 		GitHubToken:    c.String("github-token"),
-		PackageVersion: version,
+		PackageVersion: inputTagVersion,
 	}
 
 	mode := config.Edition(c.String("edition"))
@@ -23,16 +23,17 @@ func GetConfig(c *cli.Context, version string) (config.Config, config.Edition, e
 		return config.Config{}, "", cli.Exit(err.Error(), 1)
 	}
 
-	if version == "" {
+	if inputTagVersion == "" {
 		cfg.PackageVersion = packageVersion
 		if err != nil {
 			return config.Config{}, config.EditionOSS, cli.Exit(err.Error(), 1)
 		}
-	} else {
-		if version != packageVersion {
-			return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json!", packageVersion, version), 1)
-		}
+		return cfg, mode, err
+	}
+	if inputTagVersion != packageVersion {
+		return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json!", packageVersion, inputTagVersion), 1)
 	}
 
+	cfg.PackageVersion = inputTagVersion
 	return cfg, mode, nil
 }

--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -31,7 +31,7 @@ func GetConfig(c *cli.Context, inputTagVersion string) (config.Config, config.Ed
 		return cfg, mode, err
 	}
 	if inputTagVersion != packageVersion {
-		return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json!", packageVersion, inputTagVersion), 1)
+		return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json", packageVersion, inputTagVersion), 1)
 	}
 
 	cfg.PackageVersion = inputTagVersion

--- a/pkg/build/frontend/config_test.go
+++ b/pkg/build/frontend/config_test.go
@@ -1,0 +1,101 @@
+package frontend
+
+import (
+	"encoding/json"
+	"flag"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"os"
+	"testing"
+)
+
+const (
+	jobs        = "jobs"
+	githubToken = "github-token"
+)
+
+type packageJson struct {
+	Version string `json:"version"`
+}
+
+var app = cli.NewApp()
+
+func TestGetConfig(t *testing.T) {
+	tests := []struct {
+		ctx                *cli.Context
+		name               string
+		packageJsonVersion string
+		tagVersion         string
+		wantErr            bool
+	}{
+		{
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "package.json matches tag",
+			packageJsonVersion: "10.0.0",
+			tagVersion:         "10.0.0",
+			wantErr:            false,
+		},
+		{
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "package.json doesn't match tag",
+			packageJsonVersion: "10.1.0",
+			tagVersion:         "10.0.0",
+			wantErr:            true,
+		},
+		{
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "non-tag event",
+			packageJsonVersion: "10.1.0",
+			tagVersion:         "",
+			wantErr:            false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var context cli.Context
+			err := createTempPackageJson(t, tt.packageJsonVersion)
+			require.NoError(t, err)
+			defer deleteTempPackageJson(t)
+
+			got, _, err := GetConfig(&context, tt.tagVersion)
+			if !tt.wantErr {
+				require.Equal(t, got.PackageVersion, tt.packageJsonVersion)
+			}
+
+			if tt.wantErr {
+				require.Equal(t, got.PackageVersion, "")
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func setFlags(t *testing.T, flag1, flag2 string, flagSet *flag.FlagSet) *flag.FlagSet {
+	t.Helper()
+	if flag1 != "" {
+		flagSet.StringVar(&flag1, jobs, "2", "")
+	}
+	if flag2 != "" {
+		flagSet.StringVar(&flag2, githubToken, "token", "")
+	}
+	return flagSet
+}
+
+func createTempPackageJson(t *testing.T, version string) error {
+	t.Helper()
+
+	data := packageJson{Version: version}
+	file, _ := json.MarshalIndent(data, "", " ")
+
+	err := os.WriteFile("package.json", file, 0644)
+	require.NoError(t, err)
+
+	return nil
+}
+
+func deleteTempPackageJson(t *testing.T) {
+	t.Helper()
+
+	err := os.RemoveAll("package.json")
+	require.NoError(t, err)
+}

--- a/pkg/build/frontend/config_test.go
+++ b/pkg/build/frontend/config_test.go
@@ -3,10 +3,11 @@ package frontend
 import (
 	"encoding/json"
 	"flag"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 const (


### PR DESCRIPTION
**What is this feature?**

Fails `build-frontend-packages` step if `package.json` and input tag differ.

During Grafana 10 release we bumped on an issue where we package.json was different than the release tag and thus the npm packages were named as `*@10.0.0` but actually were built on `10.0.0-preview`. This PR fixes that by checking the tag and the version in `package.json` and fails if they differ.