### PR TITLE
EchoBackend: Make EchoSrvTransport batched

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
@@ -3,12 +3,17 @@ import { getEchoSrv, EchoEventType, config } from '@grafana/runtime';
 export class EchoSrvTransport extends BaseTransport {
   readonly name: string = 'EchoSrvTransport';
   readonly version: string = config.buildInfo.version;
-  send(event: TransportItem) {
+  send(items: TransportItem[]) {
     getEchoSrv().addEvent({
       type: EchoEventType.GrafanaJavascriptAgent,
-      payload: event,
+      payload: items,
     });
   }
+
+  isBatched() {
+    return true;
+  }
+
   getIgnoreUrls() {
     return [];
   }


### PR DESCRIPTION
**What is this feature?**

With the update of faro web sdk to 1.1.0, batching was introduced, in which several telemetry signals can be grouped together in a fixed interval or buffer length. The current setup in which the EchoSrvTransport was proxying signals through the Echo Backend was yielding the following issue.

The updated Fetch transport is batched but the way it was being used by the `GrafanaJavascriptAgentBackend` was pushing single items.

**Why do we need this feature?**

The current state of the repository is not sending any telemetry signals to Faro.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
