### PR TITLE
VariableEditorListRow: Adjust icon styles

### DIFF
--- a/public/app/features/variables/editor/VariableEditorListRow.tsx
+++ b/public/app/features/variables/editor/VariableEditorListRow.tsx
@@ -78,41 +78,32 @@ export function VariableEditorListRow({
           </td>
 
           <td role="gridcell" className={styles.column}>
-            <VariableCheckIndicator passed={passed} />
-          </td>
-
-          <td role="gridcell" className={styles.column}>
-            <VariableUsagesButton id={variable.id} isAdhoc={isAdHoc(variable)} usages={usagesNetwork} />
-          </td>
-
-          <td role="gridcell" className={styles.column}>
-            <IconButton
-              onClick={(event) => {
-                event.preventDefault();
-                reportInteraction('Duplicate variable');
-                propsOnDuplicate(identifier);
-              }}
-              name="copy"
-              tooltip="Duplicate variable"
-              aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowDuplicateButtons(variable.name)}
-            />
-          </td>
-
-          <td role="gridcell" className={styles.column}>
-            <IconButton
-              onClick={(event) => {
-                event.preventDefault();
-                reportInteraction('Delete variable');
-                propsOnDelete(identifier);
-              }}
-              name="trash-alt"
-              tooltip="Remove variable"
-              aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowRemoveButtons(variable.name)}
-            />
-          </td>
-          <td role="gridcell" className={styles.column}>
-            <div {...provided.dragHandleProps} className={styles.dragHandle}>
-              <Icon name="draggabledots" size="lg" />
+            <div className={styles.icons}>
+              <VariableCheckIndicator passed={passed} />
+              <VariableUsagesButton id={variable.id} isAdhoc={isAdHoc(variable)} usages={usagesNetwork} />
+              <IconButton
+                onClick={(event) => {
+                  event.preventDefault();
+                  reportInteraction('Duplicate variable');
+                  propsOnDuplicate(identifier);
+                }}
+                name="copy"
+                tooltip="Duplicate variable"
+                aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowDuplicateButtons(variable.name)}
+              />
+              <IconButton
+                onClick={(event) => {
+                  event.preventDefault();
+                  reportInteraction('Delete variable');
+                  propsOnDelete(identifier);
+                }}
+                name="trash-alt"
+                tooltip="Remove variable"
+                aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowRemoveButtons(variable.name)}
+              />
+              <div {...provided.dragHandleProps} className={styles.dragHandle}>
+                <Icon name="draggabledots" size="lg" />
+              </div>
             </div>
           </td>
         </tr>
@@ -150,6 +141,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     dragHandle: css`
       cursor: grab;
+      margin-left: ${theme.spacing(1)};
     `,
     column: css`
       width: 1%;
@@ -169,9 +161,16 @@ function getStyles(theme: GrafanaTheme2) {
     `,
     iconPassed: css`
       color: ${theme.v1.palette.greenBase};
+      margin-right: ${theme.spacing(2)};
     `,
     iconFailed: css`
       color: ${theme.v1.palette.orange};
+      margin-right: ${theme.spacing(2)};
+    `,
+    icons: css`
+      display: flex;
+      gap: ${theme.spacing(2)};
+      align-items: center;
     `,
   };
 }


### PR DESCRIPTION
Slightly adjusts styles + markup to better align the row action icons.

Before:
<img width="861" alt="image" src="https://github.com/grafana/grafana/assets/45561153/805559ef-c195-4199-acd6-a72c5708217a">


After:
<img width="879" alt="image" src="https://github.com/grafana/grafana/assets/45561153/a3149e37-85aa-4cff-a742-a6f158b48b5b">