### PR TITLE
DS Picker: Fix React key issue for built-in data source list

### DIFF
--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -27,7 +27,7 @@ export function BuiltInDataSourceList({ className, current, onChange }: BuiltInD
       {grafanaDataSources.map((ds) => {
         return (
           <DataSourceCard
-            key={ds.id}
+            key={ds.uid}
             ds={ds}
             description={CUSTOM_DESCRIPTIONS_BY_UID[ds.uid]}
             selected={current === ds.id}


### PR DESCRIPTION
React duplicate key error:

![image (1)](https://github.com/grafana/grafana/assets/5699976/cc1320fb-9fec-4e7b-9cfe-906d0b8f9a5b)

**How to reproduce**
1. Create a new dashboard
2. Click “Add visualization” button
3. After modal opens check the console and see the error.

**Solution**
I think it is happening because `BuiltInDataSourceList` uses `ds.id` as key, but it is `undefined` for these data sources. Using `uid` fixes the error.


