### PR TITLE
DS Picker: Built-in datasources are not marked as selected

### DIFF
--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -6,6 +6,7 @@ import { DataSourceRef } from '@grafana/schema';
 import { useDatasources } from '../../hooks';
 
 import { DataSourceCard } from './DataSourceCard';
+import { isDataSourceMatch } from './utils';
 
 const CUSTOM_DESCRIPTIONS_BY_UID: Record<string, string> = {
   grafana: 'Discover visualizations using mock data',
@@ -30,7 +31,7 @@ export function BuiltInDataSourceList({ className, current, onChange }: BuiltInD
             key={ds.id}
             ds={ds}
             description={CUSTOM_DESCRIPTIONS_BY_UID[ds.uid]}
-            selected={current === ds.id}
+            selected={isDataSourceMatch(ds, current)}
             onClick={() => onChange(ds)}
           />
         );

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -86,7 +86,7 @@ export function DataSourceList(props: DataSourceListProps) {
               pushRecentlyUsedDataSource(ds);
               onChange(ds);
             }}
-            selected={!!isDataSourceMatch(ds, current)}
+            selected={isDataSourceMatch(ds, current)}
             {...(enableKeyboardNavigation ? navigatableProps : {})}
           />
         ))}

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -3,7 +3,7 @@ import { DataSourceInstanceSettings, DataSourceJsonData, DataSourceRef } from '@
 export function isDataSourceMatch(
   ds: DataSourceInstanceSettings | undefined,
   current: string | DataSourceInstanceSettings | DataSourceRef | null | undefined
-): boolean | undefined {
+): boolean {
   if (!ds) {
     return false;
   }


### PR DESCRIPTION
**Problem**
DS was not marked as selected because the id was used to compare the current DS. 

**Solution**
Use the comparison utility to detect if a DS is selected


|Before|After|
|-|-|
![2023-06-13 18 04 45](https://github.com/grafana/grafana/assets/5699976/b9a616d5-c470-4ace-8ac6-488fa540e84f)|![2023-06-13 18 03 33](https://github.com/grafana/grafana/assets/5699976/c6559771-49d5-4689-9027-1feaec3f9010)

