### PR TITLE
Revert "Prometheus: Fix series to rows frame name issue for custom name from legend option"

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
@@ -124,7 +124,7 @@ describe('Series to rows', () => {
     });
   });
 
-  it('combine two time series, where first series fields has displayName, into one and displayNameFromDS overrides frame.name', async () => {
+  it('combine two time series, where first serie fields has displayName, into one', async () => {
     const cfg: DataTransformerConfig<SeriesToRowsTransformerOptions> = {
       id: DataTransformerID.seriesToRows,
       options: {},
@@ -156,7 +156,7 @@ describe('Series to rows', () => {
 
       const expected: Field[] = [
         createField('Time', FieldType.time, [200, 150, 126, 125, 100, 100]),
-        createField('Metric', FieldType.string, ['dsName', 'dsName', 'B', 'B', 'dsName', 'B']),
+        createField('Metric', FieldType.string, ['A', 'A', 'B', 'B', 'A', 'B']),
         createField('Value', FieldType.number, [5, 4, 3, 2, 1, -1]),
       ];
 

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -70,25 +70,13 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
         for (let frameIndex = 0; frameIndex < data.length; frameIndex++) {
           const frame = data[frameIndex];
 
-          const firstNonTimeField = frame.fields[1];
-
-          // To support consistent naming for dataplane and prometheus
-          // displayNameFromDS > frameDisplayName
-          // This supports new naming and custom names (from the prom legend option)
-          // and supports the older pattern of getting the frame name.
-          // if neither of those return a name we use getFieldDisplayName which is good.
-          const displayNameFromDS = firstNonTimeField.config.displayNameFromDS;
-          const frameDisplayName = getFrameDisplayName(frame);
-
-          const displayName = displayNameFromDS ?? frameDisplayName;
-
           for (let valueIndex = 0; valueIndex < frame.length; valueIndex++) {
             const timeFieldIndex = timeFieldByIndex[frameIndex];
             const valueFieldIndex = timeFieldIndex === 0 ? 1 : 0;
 
             dataFrame.add({
               [TIME_SERIES_TIME_FIELD_NAME]: frame.fields[timeFieldIndex].values[valueIndex],
-              [TIME_SERIES_METRIC_FIELD_NAME]: displayName,
+              [TIME_SERIES_METRIC_FIELD_NAME]: getFrameDisplayName(frame),
               [TIME_SERIES_VALUE_FIELD_NAME]: frame.fields[valueFieldIndex].values[valueIndex],
             });
           }


### PR DESCRIPTION
Reverts grafana/grafana#69343 in favor of https://github.com/grafana/grafana/pull/69621 because the reverted PR is not correct.