### PR TITLE
Dashboard: Field Config - Add CFP franc currency (XPF)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -448,6 +448,10 @@
             {
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
+            },
+            {
+              "text": "CFP franc (XPF)",
+              "value": "currencyXPF"
             }
           ],
           "text": "currency"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -448,6 +448,10 @@
             {
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
+            },
+	    {
+              "text": "CFP franc (XPF)",
+              "value": "currencyXPF"
             }
           ],
           "text": "currency"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -143,6 +143,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Vietnamese Dong (VND)', id: 'currencyVND', fn: currency('đ', true) },
       { name: 'Turkish Lira (₺)', id: 'currencyTRY', fn: currency('₺', true) },
       { name: 'Malaysian Ringgit (RM)', id: 'currencyMYR', fn: currency('RM') },
+      { name: 'CFP franc (XPF)', id: 'currencyXPF', fn: currency('XPF') },
     ],
   },
   {


### PR DESCRIPTION
CFP franc has ISO 4217 currency code "XPF":
https://www.six-group.com/en/products-services/financial-information/data-standards.html
