### PR TITLE
Revert "Variables: Show description instead of definition in table"

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -114,8 +114,7 @@ export const Pages = {
           newButton: 'Variable editor New variable button',
           table: 'Variable editor Table',
           tableRowNameFields: (variableName: string) => `Variable editor Table Name field ${variableName}`,
-          tableRowDescriptionFields: (variableName: string) =>
-            `Variable editor Table Description field ${variableName}`,
+          tableRowDefinitionFields: (variableName: string) => `Variable editor Table Definition field ${variableName}`,
           tableRowArrowUpButtons: (variableName: string) => `Variable editor Table ArrowUp button ${variableName}`,
           tableRowArrowDownButtons: (variableName: string) => `Variable editor Table ArrowDown button ${variableName}`,
           tableRowDuplicateButtons: (variableName: string) => `Variable editor Table Duplicate button ${variableName}`,

--- a/public/app/features/variables/editor/VariableEditorList.tsx
+++ b/public/app/features/variables/editor/VariableEditorList.tsx
@@ -59,7 +59,7 @@ export function VariableEditorList({
               <thead>
                 <tr>
                   <th>Variable</th>
-                  <th>Description</th>
+                  <th>Definition</th>
                   <th colSpan={5} />
                 </tr>
               </thead>


### PR DESCRIPTION
Reverts grafana/grafana#69786

This change might have missed some key details. After taking a closer look, it seems it didn't quite consider variable types like custom. Also from some datasources like Prometheus, this change might cause more confusion.  (Slack [thread](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1686571201033249) with more context)

![image_720](https://github.com/grafana/grafana/assets/239999/1958948b-a3c7-4438-98ab-91f2c0896919)
