### PR TITLE
CI: Add CI check for `what's new` link

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2297,6 +2297,50 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
+name: release-whatsnew-checker
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.20.4
+  name: compile-build-cmd
+- commands:
+  - ./bin/build whatsnew-checker
+  depends_on:
+  - compile-build-cmd
+  image: golang:1.20.4
+  name: whats-new-checker
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
 name: release-oss-build-e2e-publish
 node:
   type: no-parallel
@@ -7308,6 +7352,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 57a88408eae5719f7ffa85c575c46e5b90ea301627144cb738d2ac8b8396e973
+hmac: c1eaa0e7d7427fd28ec0edba24a89aaa2bcb876391bd7ecde5f5fd55ffc0d0b5
 
 ...

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -83,6 +83,11 @@ func main() {
 			},
 		},
 		{
+			Name:   "whatsnew-checker",
+			Usage:  "Checks whatsNewUrl in package.json for differences between the tag and the docs version",
+			Action: WhatsNewChecker,
+		},
+		{
 			Name:   "build-docker",
 			Usage:  "Build Grafana Docker images",
 			Action: MaxArgCountWrapper(1, BuildDocker),

--- a/pkg/build/cmd/whatsnewchecker.go
+++ b/pkg/build/cmd/whatsnewchecker.go
@@ -32,6 +32,10 @@ func WhatsNewChecker(c *cli.Context) error {
 		return err
 	}
 
+	if metadata.ReleaseMode.IsTest {
+		fmt.Println("test mode, skipping check")
+		return nil
+	}
 	if metadata.ReleaseMode.Mode != config.TagMode {
 		return fmt.Errorf("non-tag pipeline, exiting")
 	}

--- a/pkg/build/cmd/whatsnewchecker.go
+++ b/pkg/build/cmd/whatsnewchecker.go
@@ -19,6 +19,7 @@ var whatsNewRegex = regexp.MustCompile("^.*whats-new-in-(v\\d*-[\\d+]*)")
 
 type PackageJSON struct {
 	Grafana Grafana `json:"grafana"`
+	Version string  `json:"version"`
 }
 
 type Grafana struct {
@@ -32,8 +33,7 @@ func WhatsNewChecker(c *cli.Context) error {
 	}
 
 	if metadata.ReleaseMode.Mode != config.TagMode {
-		fmt.Println("Non-tag pipeline, exiting...")
-		return nil
+		return fmt.Errorf("non-tag pipeline, exiting")
 	}
 
 	tag := fmt.Sprintf("v%s", metadata.GrafanaVersion)
@@ -60,7 +60,7 @@ func WhatsNewChecker(c *cli.Context) error {
 	whatsNewVersion := whatsNewSplit[1]
 
 	if whatsNewVersion != majorMinorDigits {
-		return fmt.Errorf("whatsNewUrl in package.json needs to be updated to %s", strings.Replace(whatsNewSplit[0], whatsNewVersion, majorMinorDigits, 1))
+		return fmt.Errorf("whatsNewUrl in package.json needs to be updated to %s/", strings.Replace(whatsNewSplit[0], whatsNewVersion, majorMinorDigits, 1))
 	}
 
 	return nil

--- a/pkg/build/cmd/whatsnewchecker.go
+++ b/pkg/build/cmd/whatsnewchecker.go
@@ -15,7 +15,6 @@ import (
 
 const GrafanaDir = "."
 
-// nolint:gosimple
 var whatsNewRegex = regexp.MustCompile(`^.*whats-new-in-(v\d*-[\d+]*)`)
 
 type PackageJSON struct {

--- a/pkg/build/cmd/whatsnewchecker.go
+++ b/pkg/build/cmd/whatsnewchecker.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/mod/semver"
+)
+
+const GrafanaDir = "."
+
+var whatsNewRegex = regexp.MustCompile("^.*whats-new-in-(v\\d*-[\\d+]*)")
+
+type PackageJSON struct {
+	Grafana Grafana `json:"grafana"`
+}
+
+type Grafana struct {
+	WhatsNewUrl string `json:"whatsNewUrl"`
+}
+
+func WhatsNewChecker(c *cli.Context) error {
+	metadata, err := config.GenerateMetadata(c)
+	if err != nil {
+		return err
+	}
+
+	if metadata.ReleaseMode.Mode != config.TagMode {
+		fmt.Println("Non-tag pipeline, exiting...")
+		return nil
+	}
+
+	tag := fmt.Sprintf("v%s", metadata.GrafanaVersion)
+
+	if !semver.IsValid(tag) {
+		return fmt.Errorf("non-semver compatible version %s, exiting", tag)
+	}
+
+	majorMinorDigits := strings.Replace(semver.MajorMinor(tag), ".", "-", 1)
+
+	pkgJSONPath := filepath.Join(GrafanaDir, "package.json")
+	//nolint:gosec
+	pkgJSONB, err := os.ReadFile(pkgJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %q: %w", pkgJSONPath, err)
+	}
+
+	var pkgObj PackageJSON
+	if err := json.Unmarshal(pkgJSONB, &pkgObj); err != nil {
+		return fmt.Errorf("failed decoding %q: %w", pkgJSONPath, err)
+	}
+
+	whatsNewSplit := whatsNewRegex.FindStringSubmatch(pkgObj.Grafana.WhatsNewUrl)
+	whatsNewVersion := whatsNewSplit[1]
+
+	if whatsNewVersion != majorMinorDigits {
+		return fmt.Errorf("whatsNewUrl in package.json needs to be updated to %s", strings.Replace(whatsNewSplit[0], whatsNewVersion, majorMinorDigits, 1))
+	}
+
+	return nil
+}

--- a/pkg/build/cmd/whatsnewchecker.go
+++ b/pkg/build/cmd/whatsnewchecker.go
@@ -15,7 +15,8 @@ import (
 
 const GrafanaDir = "."
 
-var whatsNewRegex = regexp.MustCompile("^.*whats-new-in-(v\\d*-[\\d+]*)")
+// nolint:gosimple
+var whatsNewRegex = regexp.MustCompile(`^.*whats-new-in-(v\d*-[\d+]*)`)
 
 type PackageJSON struct {
 	Grafana Grafana `json:"grafana"`

--- a/pkg/build/cmd/whatsnewchecker_test.go
+++ b/pkg/build/cmd/whatsnewchecker_test.go
@@ -40,7 +40,6 @@ func TestWhatsNewChecker(t *testing.T) {
 			setUpEnv(t, tt.envMap)
 			err := createTempPackageJson(t, tt.packageJsonVersion)
 			require.NoError(t, err)
-			defer deleteTempPackageJson(t)
 
 			err = WhatsNewChecker(context)
 			if tt.wantErr {
@@ -74,12 +73,9 @@ func createTempPackageJson(t *testing.T, version string) error {
 	err := os.WriteFile("package.json", file, 0644)
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		err := os.RemoveAll("package.json")
+		require.NoError(t, err)
+	})
 	return nil
-}
-
-func deleteTempPackageJson(t *testing.T) {
-	t.Helper()
-
-	err := os.RemoveAll("package.json")
-	require.NoError(t, err)
 }

--- a/pkg/build/cmd/whatsnewchecker_test.go
+++ b/pkg/build/cmd/whatsnewchecker_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	DroneBuildEvent = "DRONE_BUILD_EVENT"
-	DroneTag        = "DRONE_TAG"
+	DroneBuildEvent       = "DRONE_BUILD_EVENT"
+	DroneTag              = "DRONE_TAG"
+	DroneSemverPrerelease = "DRONE_SEMVER_PRERELEASE"
 )
 
 const whatsNewUrl = "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-"
@@ -29,8 +30,9 @@ func TestWhatsNewChecker(t *testing.T) {
 	}{
 		{envMap: map[string]string{DroneBuildEvent: config.PullRequest}, packageJsonVersion: "", name: "non-tag event", wantErr: true, errMsg: "non-tag pipeline, exiting"},
 		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "abcd123"}, packageJsonVersion: "", name: "non-semver compatible", wantErr: true, errMsg: "non-semver compatible version vabcd123, exiting"},
-		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "10.0.0"}, packageJsonVersion: "v10-0", name: "package.json version matches tag", wantErr: false},
-		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "10.0.0"}, packageJsonVersion: "v9-5", name: "package.json doesn't match tag", wantErr: true, errMsg: "whatsNewUrl in package.json needs to be updated to https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v10-0/"},
+		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "v0.0.0", DroneSemverPrerelease: "test"}, packageJsonVersion: "v10-0", name: "skip check for test tags", wantErr: false},
+		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "v10.0.0"}, packageJsonVersion: "v10-0", name: "package.json version matches tag", wantErr: false},
+		{envMap: map[string]string{DroneBuildEvent: config.Tag, DroneTag: "v10.0.0"}, packageJsonVersion: "v9-5", name: "package.json doesn't match tag", wantErr: true, errMsg: "whatsNewUrl in package.json needs to be updated to https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v10-0/"},
 	}
 	for _, tt := range tests {
 		app := cli.NewApp()

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -219,7 +219,7 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
     # We don't need to run integration tests at release time since they have
     # been run multiple times before:
     if ver_mode in ("release"):
-        pipelines.append(whats_new_checker_pipeline(release_trigger),)
+        pipelines.append(whats_new_checker_pipeline(release_trigger))
         integration_test_steps = []
         volumes = []
 

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -64,6 +64,10 @@ load(
     "scripts/drone/utils/images.star",
     "images",
 )
+load(
+    "scripts/drone/pipelines/whats_new_checker.star",
+    "whats_new_checker_pipeline",
+)
 
 ver_mode = "release"
 release_trigger = {
@@ -210,9 +214,12 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
         memcached_integration_tests_step(),
     ]
 
+    pipelines = []
+
     # We don't need to run integration tests at release time since they have
     # been run multiple times before:
     if ver_mode in ("release"):
+        pipelines.append(whats_new_checker_pipeline(release_trigger),)
         integration_test_steps = []
         volumes = []
 
@@ -220,7 +227,7 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
         "{}-oss-build-e2e-publish".format(ver_mode),
         "{}-oss-test-frontend".format(ver_mode),
     ]
-    pipelines = [
+    pipelines.extend([
         pipeline(
             name = "{}-oss-build-e2e-publish".format(ver_mode),
             edition = "oss",
@@ -232,7 +239,7 @@ def oss_pipelines(ver_mode = ver_mode, trigger = release_trigger):
         ),
         test_frontend(trigger, ver_mode),
         test_backend(trigger, ver_mode),
-    ]
+    ])
 
     if ver_mode not in ("release"):
         pipelines.append(pipeline(

--- a/scripts/drone/pipelines/whats_new_checker.star
+++ b/scripts/drone/pipelines/whats_new_checker.star
@@ -1,0 +1,39 @@
+load(
+    "scripts/drone/utils/images.star",
+    "images",
+)
+load(
+    "scripts/drone/steps/lib.star",
+    "compile_build_cmd",
+)
+load(
+    "scripts/drone/utils/utils.star",
+    "pipeline",
+)
+
+def whats_new_checker_step():
+    return {
+        "name": "whats-new-checker",
+        "image": images["go_image"],
+        "depends_on": [
+            "compile-build-cmd",
+        ],
+        "commands": [
+            "./bin/build whatsnew-checker",
+        ],
+    }
+
+def whats_new_checker_pipeline(trigger):
+    environment = {"EDITION": "oss"}
+    steps = [
+        compile_build_cmd(),
+        whats_new_checker_step(),
+    ]
+    return pipeline(
+        name = "release-whatsnew-checker",
+        edition = "oss",
+        trigger = trigger,
+        services = [],
+        steps = steps,
+        environment = environment,
+    )

--- a/scripts/drone/pipelines/whats_new_checker.star
+++ b/scripts/drone/pipelines/whats_new_checker.star
@@ -1,3 +1,7 @@
+"""
+This module contains logic for checking if the package.json whats new url matches with the in-flight tag.
+"""
+
 load(
     "scripts/drone/utils/images.star",
     "images",


### PR DESCRIPTION
**What is this feature?**

Adds a new feature which will check for differences between the What's New link in `package.json` and the build tag.

**Why do we need this feature?**

During G10 release, for a little while our docs in the Grafana 10 downloads page were pointing to the `9.2` changes. This happened because the what's new link in the `package.json` was outdated and there wasn't any check to tell us so.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-delivery/issues/174

**Special notes for your reviewer:**

Example:

If we are during a `10.1.0` minor release and we start a build without having updated the what's new link in `package.json`, the pipeline should fail with the following message:

```
whatsNewUrl in package.json needs to be updated to https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v10-1/
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
