### PR TITLE
Tempo: Use pipe in TraceQL by default for multi-value variables

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4705,9 +4705,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "14"]
     ],
     "public/app/plugins/datasource/tempo/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -1,5 +1,6 @@
 import { lastValueFrom, Observable, of } from 'rxjs';
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
+import { initTemplateSrv } from 'test/helpers/initTemplateSrv';
 
 import {
   DataFrame,
@@ -74,26 +75,39 @@ describe('Tempo data source', () => {
           refId: 'linked',
           expr: '{instance="$interpolationVar"}',
         },
-        query: '$interpolationVar',
+        query: '$interpolationVarWithPipe',
+        spanName: '$interpolationVar',
+        serviceName: '$interpolationVar',
         search: '$interpolationVar',
         minDuration: '$interpolationVar',
         maxDuration: '$interpolationVar',
         filters: [],
       };
     }
+    let templateSrv: TemplateSrv;
+    const text = 'interpolationText';
+    const textWithPipe = 'interpolationTextOne|interpolationTextTwo';
+
+    beforeEach(() => {
+      templateSrv = initTemplateSrv('key', [
+        {
+          type: 'custom',
+          name: 'interpolationVar',
+          current: { value: [text] },
+        },
+        {
+          type: 'custom',
+          name: 'interpolationVarWithPipe',
+          current: { value: [textWithPipe] },
+        },
+      ]);
+    });
 
     it('when traceId query for dashboard->explore', async () => {
-      const templateSrv: any = { replace: jest.fn() };
       const ds = new TempoDatasource(defaultSettings, templateSrv);
-      const text = 'interpolationText';
-      templateSrv.replace.mockReturnValue(text);
-
-      const queries = ds.interpolateVariablesInQueries([getQuery()], {
-        interpolationVar: { text: text, value: text },
-      });
-      expect(templateSrv.replace).toBeCalledTimes(7);
-      expect(queries[0].linkedQuery?.expr).toBe(text);
-      expect(queries[0].query).toBe(text);
+      const queries = ds.interpolateVariablesInQueries([getQuery()], {});
+      expect(queries[0].linkedQuery?.expr).toBe(`{instance=\"${text}\"}`);
+      expect(queries[0].query).toBe(textWithPipe);
       expect(queries[0].serviceName).toBe(text);
       expect(queries[0].spanName).toBe(text);
       expect(queries[0].search).toBe(text);
@@ -102,22 +116,18 @@ describe('Tempo data source', () => {
     });
 
     it('when traceId query for template variable', async () => {
-      const templateSrv: any = { replace: jest.fn() };
+      const scopedText = 'scopedInterpolationText';
       const ds = new TempoDatasource(defaultSettings, templateSrv);
-      const text = 'interpolationText';
-      templateSrv.replace.mockReturnValue(text);
-
       const resp = ds.applyTemplateVariables(getQuery(), {
-        interpolationVar: { text: text, value: text },
+        interpolationVar: { text: scopedText, value: scopedText },
       });
-      expect(templateSrv.replace).toBeCalledTimes(7);
-      expect(resp.linkedQuery?.expr).toBe(text);
-      expect(resp.query).toBe(text);
-      expect(resp.serviceName).toBe(text);
-      expect(resp.spanName).toBe(text);
-      expect(resp.search).toBe(text);
-      expect(resp.minDuration).toBe(text);
-      expect(resp.maxDuration).toBe(text);
+      expect(resp.linkedQuery?.expr).toBe(`{instance=\"${scopedText}\"}`);
+      expect(resp.query).toBe(textWithPipe);
+      expect(resp.serviceName).toBe(scopedText);
+      expect(resp.spanName).toBe(scopedText);
+      expect(resp.search).toBe(scopedText);
+      expect(resp.minDuration).toBe(scopedText);
+      expect(resp.maxDuration).toBe(scopedText);
     });
   });
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -353,7 +353,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
     return {
       ...expandedQuery,
-      query: this.templateSrv.replace(query.query ?? '', scopedVars),
+      query: this.templateSrv.replace(query.query ?? '', scopedVars, 'pipe'),
       serviceName: this.templateSrv.replace(query.serviceName ?? '', scopedVars),
       spanName: this.templateSrv.replace(query.spanName ?? '', scopedVars),
       search: this.templateSrv.replace(query.search ?? '', scopedVars),

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -26,7 +26,7 @@ import {
   TemplateSrv,
   getTemplateSrv,
 } from '@grafana/runtime';
-import { BarGaugeDisplayMode, TableCellDisplayMode } from '@grafana/schema';
+import { BarGaugeDisplayMode, TableCellDisplayMode, VariableFormatID } from '@grafana/schema';
 import { NodeGraphOptions } from 'app/core/components/NodeGraphSettings';
 import { TraceToLogsOptions } from 'app/core/components/TraceToLogs/TraceToLogsSettings';
 import { serializeParams } from 'app/core/utils/fetch';
@@ -353,7 +353,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
     return {
       ...expandedQuery,
-      query: this.templateSrv.replace(query.query ?? '', scopedVars, 'pipe'),
+      query: this.templateSrv.replace(query.query ?? '', scopedVars, VariableFormatID.Pipe),
       serviceName: this.templateSrv.replace(query.serviceName ?? '', scopedVars),
       spanName: this.templateSrv.replace(query.spanName ?? '', scopedVars),
       search: this.templateSrv.replace(query.search ?? '', scopedVars),


### PR DESCRIPTION
**What is this feature?**

Updates Tempo TraceQL queries to use pipe by default for multi-value variables.

**Why do we need this feature?**

Fixes issue where TraceQL queries with multi-value variables were not being replaced correctly for the TraceQL query.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/69841

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
