### PR TITLE
Explore: Use new DS picker

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -4,11 +4,12 @@ import React, { lazy, RefObject, Suspense, useMemo } from 'react';
 import { shallowEqual } from 'react-redux';
 
 import { DataSourceInstanceSettings, RawTimeRange } from '@grafana/data';
-import { config, DataSourcePicker, reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { defaultIntervals, PageToolbar, RefreshPicker, SetInterval, ToolbarButton, ButtonGroup } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { contextSrv } from 'app/core/core';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
+import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { AccessControlAction } from 'app/types';
 import { ExploreId } from 'app/types/explore';
 import { StoreState, useDispatch, useSelector } from 'app/types/store';


### PR DESCRIPTION
Depends on:
* This PR which fixes the E2E https://github.com/grafana/grafana/pull/70071
* This PR which adds the props that Explore needs https://github.com/grafana/grafana/pull/70074

||Before|After|
|-|-|-|
|Global picker closed|![Captura de pantalla 2023-06-14 a las 12 09 59](https://github.com/grafana/grafana/assets/5699976/c4c13eb3-9f09-4207-979d-a779b3e59b36)|![Captura de pantalla 2023-06-14 a las 12 09 52](https://github.com/grafana/grafana/assets/5699976/f096bc80-bce4-4438-82ec-8ba55e9ced3e)|
|Global picker open|![Captura de pantalla 2023-06-14 a las 12 10 24](https://github.com/grafana/grafana/assets/5699976/0c66f471-3f56-4049-9c50-6e2d96e3fdd4)|![Captura de pantalla 2023-06-14 a las 12 10 15](https://github.com/grafana/grafana/assets/5699976/b1d79b3a-9759-49b2-99ef-722233098d4c)|
|Split view|![Captura de pantalla 2023-06-14 a las 12 09 27](https://github.com/grafana/grafana/assets/5699976/394dc0f0-c618-4f2a-be44-fcb3d1f1eec7)|![Captura de pantalla 2023-06-14 a las 12 09 19](https://github.com/grafana/grafana/assets/5699976/fd8c5aff-c36a-4da3-987c-2b47b1724866)|

**What is this feature?**

The new DS picker was only used when editing a panel. Explore can benefit from it.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

The new DS picker has discoverability and UX improvements that Explore can benefit from.

**Which issue(s) does this PR fix?**: 
Relates to #66916 

**Special notes for your reviewer:**
I added support for `hideTextValue` and `width`, to make it work in split mode.

**IMPORTANT:** This probably involves changes in Explore documentation to update the screenshots (cc/ @imatwawana).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
