### PR TITLE
Alerting: Add NamespaceUID and DatasourceUIDs fields to RuleResponse.

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -304,7 +304,8 @@ func (srv PrometheusSrv) toRuleGroup(groupKey ngmodels.AlertRuleGroupKey, folder
 	newGroup := &apimodels.RuleGroup{
 		Name: groupKey.RuleGroup,
 		// file is what Prometheus uses for provisioning, we replace it with namespace which is the folder in Grafana.
-		File: folder.Title,
+		File:         folder.Title,
+		NamespaceUID: folder.UID,
 	}
 
 	rulesTotals := make(map[string]int64, len(rules))
@@ -312,11 +313,12 @@ func (srv PrometheusSrv) toRuleGroup(groupKey ngmodels.AlertRuleGroupKey, folder
 	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
 		alertingRule := apimodels.AlertingRule{
-			State:       "inactive",
-			Name:        rule.Title,
-			Query:       ruleToQuery(srv.log, rule),
-			Duration:    rule.For.Seconds(),
-			Annotations: rule.Annotations,
+			State:          "inactive",
+			Name:           rule.Title,
+			Query:          ruleToQuery(srv.log, rule),
+			DatasourceUIDs: requiredDatasourceAccessForRule(rule),
+			Duration:       rule.For.Seconds(),
+			Annotations:    rule.Annotations,
 		}
 
 		newRule := apimodels.Rule{

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -320,10 +320,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
+			"namespace_uid": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1)",
+				"datasource_uids": ["AUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus"
@@ -362,7 +364,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		}
 	}
 }
-`, folder.Title), string(r.Body()))
+`, folder.Title, folder.UID), string(r.Body()))
 	})
 
 	t.Run("with the inclusion of internal Labels", func(t *testing.T) {
@@ -383,10 +385,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
+			"namespace_uid": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1)",
+				"datasource_uids": ["AUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus",
@@ -428,7 +432,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		}
 	}
 }
-`, folder.Title), string(r.Body()))
+`, folder.Title, folder.UID), string(r.Body()))
 	})
 
 	t.Run("with a rule that has multiple queries", func(t *testing.T) {
@@ -445,10 +449,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
+			"namespace_uid": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1) | vector(1)",
+				"datasource_uids": ["AUID", "BUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus"
@@ -487,7 +493,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		}
 	}
 }
-`, folder.Title), string(r.Body()))
+`, folder.Title, folder.UID), string(r.Body()))
 	})
 
 	t.Run("with many rules in a group", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -320,12 +320,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
-			"namespace_uid": "%s",
+			"namespaceUID": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1)",
-				"datasource_uids": ["AUID"],
+				"datasourceUIDs": ["AUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus"
@@ -385,12 +385,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
-			"namespace_uid": "%s",
+			"namespaceUID": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1)",
-				"datasource_uids": ["AUID"],
+				"datasourceUIDs": ["AUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus",
@@ -449,12 +449,12 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		"groups": [{
 			"name": "rule-group",
 			"file": "%s",
-			"namespace_uid": "%s",
+			"namespaceUID": "%s",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "vector(1) | vector(1)",
-				"datasource_uids": ["AUID", "BUID"],
+				"datasourceUIDs": ["AUID", "BUID"],
 				"alerts": [{
 					"labels": {
 						"job": "prometheus"

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -85,7 +85,7 @@ type RuleGroup struct {
 	Name string `json:"name"`
 	// required: true
 	File         string `json:"file"`
-	NamespaceUID string `json:"namespace_uid"`
+	NamespaceUID string `json:"namespaceUID"`
 	// In order to preserve rule ordering, while exposing type (alerting or recording)
 	// specific properties, both alerting and recording rules are exposed in the
 	// same array.
@@ -133,7 +133,7 @@ type AlertingRule struct {
 	Query    string  `json:"query,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
 	// UIDs of the datasources used in the rule query.
-	DatasourceUIDs []string `json:"datasource_uids"`
+	DatasourceUIDs []string `json:"datasourceUIDs"`
 	// required: true
 	Annotations overrideLabels `json:"annotations,omitempty"`
 	// required: true

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -133,7 +133,7 @@ type AlertingRule struct {
 	Query    string  `json:"query,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
 	// UIDs of the datasources used in the rule query.
-	DatasourceUIDs []string `json:"datasource_uids,omitempty"`
+	DatasourceUIDs []string `json:"datasource_uids"`
 	// required: true
 	Annotations overrideLabels `json:"annotations,omitempty"`
 	// required: true

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -84,7 +84,8 @@ type RuleGroup struct {
 	// required: true
 	Name string `json:"name"`
 	// required: true
-	File string `json:"file"`
+	File         string `json:"file"`
+	NamespaceUID string `json:"namespace_uid"`
 	// In order to preserve rule ordering, while exposing type (alerting or recording)
 	// specific properties, both alerting and recording rules are exposed in the
 	// same array.
@@ -131,6 +132,8 @@ type AlertingRule struct {
 	// required: true
 	Query    string  `json:"query,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
+	// UIDs of the datasources used in the rule query.
+	DatasourceUIDs []string `json:"datasource_uids,omitempty"`
 	// required: true
 	Annotations overrideLabels `json:"annotations,omitempty"`
 	// required: true

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -235,10 +235,12 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 		"groups": [{
 			"name": "arulegroup",
 			"file": "default",
+			"namespaceUID": "default",
 			"rules": [{
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"duration": 10,
 				"annotations": {
 					"annotation1": "val1"
@@ -254,6 +256,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiringButSilenced",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"health": "ok",
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
@@ -297,6 +300,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"duration": 10,
 				"annotations": {
 					"annotation1": "val1"
@@ -312,6 +316,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiringButSilenced",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"health": "ok",
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
@@ -448,6 +453,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"duration": 10,
 				"annotations": {
 					"__dashboardUid__": "%s",
@@ -461,6 +467,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiringButSilenced",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"health": "ok",
 				"type": "alerting",
 				"lastEvaluation": "0001-01-01T00:00:00Z",
@@ -489,6 +496,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 				"state": "inactive",
 				"name": "AlwaysFiring",
 				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"__expr__\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"datasourceUIDs": [],
 				"duration": 10,
 				"annotations": {
 					"__dashboardUid__": "%s",


### PR DESCRIPTION
Given that the rule status API has already diverged from Prometheus, it would
be very useful for upstream consumers to have access to these fields, and they
are already easily accessible in the code.

Note: I have run the unit tests without the `Skip()` and checked they pass.
