### PR TITLE
DS Picker: first item is not active when filtering

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -45,6 +45,14 @@ export interface DataSourceListProps {
 export function DataSourceList(props: DataSourceListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const [navigatableProps, selectedItemCssSelector] = useKeyboardNavigatableList({
+    keyboardEvents: props.keyboardEvents,
+    containerRef: containerRef,
+  });
+
+  const theme = useTheme2();
+  const styles = getStyles(theme, selectedItemCssSelector);
+
   const { className, current, onChange, enableKeyboardNavigation, onClickEmptyStateCTA } = props;
   const dataSources = useDatasources({
     alerting: props.alerting,
@@ -61,15 +69,6 @@ export function DataSourceList(props: DataSourceListProps) {
 
   const [recentlyUsedDataSources, pushRecentlyUsedDataSource] = useRecentlyUsedDataSources();
   const filteredDataSources = props.filter ? dataSources.filter(props.filter) : dataSources;
-
-  const [navigatableProps, selectedItemCssSelector] = useKeyboardNavigatableList({
-    keyboardEvents: props.keyboardEvents,
-    containerRef: containerRef,
-    numberOfItems: filteredDataSources.length,
-  });
-
-  const theme = useTheme2();
-  const styles = getStyles(theme, selectedItemCssSelector);
 
   return (
     <div ref={containerRef} className={cx(className, styles.container)}>

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -45,16 +45,7 @@ export interface DataSourceListProps {
 export function DataSourceList(props: DataSourceListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const [navigatableProps, selectedItemCssSelector] = useKeyboardNavigatableList({
-    keyboardEvents: props.keyboardEvents,
-    containerRef: containerRef,
-  });
-
-  const theme = useTheme2();
-  const styles = getStyles(theme, selectedItemCssSelector);
-
   const { className, current, onChange, enableKeyboardNavigation, onClickEmptyStateCTA } = props;
-  // QUESTION: Should we use data from the Redux store as admin DS view does?
   const dataSources = useDatasources({
     alerting: props.alerting,
     annotations: props.annotations,
@@ -70,6 +61,15 @@ export function DataSourceList(props: DataSourceListProps) {
 
   const [recentlyUsedDataSources, pushRecentlyUsedDataSource] = useRecentlyUsedDataSources();
   const filteredDataSources = props.filter ? dataSources.filter(props.filter) : dataSources;
+
+  const [navigatableProps, selectedItemCssSelector] = useKeyboardNavigatableList({
+    keyboardEvents: props.keyboardEvents,
+    containerRef: containerRef,
+    numberOfItems: filteredDataSources.length,
+  });
+
+  const theme = useTheme2();
+  const styles = getStyles(theme, selectedItemCssSelector);
 
   return (
     <div ref={containerRef} className={cx(className, styles.container)}>

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -60,7 +60,6 @@ export function useDatasource(dataSource: string | DataSourceRef | DataSourceIns
 export interface KeybaordNavigatableListProps {
   keyboardEvents?: Observable<React.KeyboardEvent>;
   containerRef: React.RefObject<HTMLElement>;
-  numberOfItems?: number;
 }
 
 /**

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -60,6 +60,7 @@ export function useDatasource(dataSource: string | DataSourceRef | DataSourceIns
 export interface KeybaordNavigatableListProps {
   keyboardEvents?: Observable<React.KeyboardEvent>;
   containerRef: React.RefObject<HTMLElement>;
+  numberOfItems?: number;
 }
 
 /**
@@ -67,7 +68,7 @@ export interface KeybaordNavigatableListProps {
  * @param props
  */
 export function useKeyboardNavigatableList(props: KeybaordNavigatableListProps): [Record<string, string>, string] {
-  const { keyboardEvents, containerRef } = props;
+  const { keyboardEvents, containerRef, numberOfItems } = props;
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
   const attributeName = 'data-role';
@@ -91,7 +92,7 @@ export function useKeyboardNavigatableList(props: KeybaordNavigatableListProps):
       selectedItem.scrollIntoView({ block: 'center' });
       selectedItem.setAttribute(selectedAttributeName, 'true');
     }
-  }, [selectedIndex, containerRef, selectedAttributeName, querySelectorNavigatableElements]);
+  }, [selectedIndex, containerRef, selectedAttributeName, querySelectorNavigatableElements, numberOfItems]);
 
   const clickSelectedElement = () => {
     containerRef?.current


### PR DESCRIPTION
**Problem**
When opening the dropdown, the first item should be always active to use enter. When filtering, since the list of elements changes, it needs to recompute the styles.

**Solution**
Monitor the number of items in the list, and update the HTML attributes for the list items.

|Before|After|
|-|-|
![2023-06-14 15 32 03](https://github.com/grafana/grafana/assets/5699976/6e19696e-a075-4a21-b385-94c4a62c6b55)|![2023-06-14 15 30 56](https://github.com/grafana/grafana/assets/5699976/3718a06d-e166-4a90-9de4-10d3844214eb)

Related to https://github.com/grafana/grafana/issues/66916
