### PR TITLE
DS Picker: Support width and hide label

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -31,7 +31,7 @@ const INTERACTION_ITEM = {
 };
 
 export function DataSourceDropdown(props: DataSourceDropdownProps) {
-  const { current, onChange, ...restProps } = props;
+  const { current, onChange, hideTextValue, width, ...restProps } = props;
 
   const [isOpen, setOpen] = useState(false);
   const [inputHasFocus, setInputHasFocus] = useState(false);
@@ -107,7 +107,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
   const styles = useStyles2(getStylesDropdown);
 
   return (
-    <div className={styles.container} data-testid={selectors.components.DataSourcePicker.container}>
+    <div className={styles.container} data-testid={selectors.components.DataSourcePicker.container} style={{ width }}>
       {/* This clickable div is just extending the clickable area on the input element to include the prefix and suffix. */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div className={styles.trigger} onClick={openDropdown}>
@@ -122,7 +122,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
             )
           }
           suffix={<Icon name={isOpen ? 'search' : 'angle-down'} />}
-          placeholder={dataSourceLabel(currentDataSourceInstanceSettings)}
+          placeholder={hideTextValue ? '' : dataSourceLabel(currentDataSourceInstanceSettings)}
           onClick={openDropdown}
           onFocus={() => {
             setInputHasFocus(true);

--- a/public/app/features/datasources/components/picker/types.ts
+++ b/public/app/features/datasources/components/picker/types.ts
@@ -12,6 +12,8 @@ export interface DataSourceDropdownProps {
   fileUploadOptions?: DropzoneOptions;
   onClickAddCSV?: () => void;
   recentlyUsed?: string[];
+  hideTextValue?: boolean;
+  width?: number;
 }
 
 export interface PickerContentProps extends DataSourceDropdownProps {


### PR DESCRIPTION
- [x] Add `hideTextValue`to be able to hide the label text for dropdown (support Explore use case)
- [x] Add `width` to support to set a width (support Explore use case)

Related to https://github.com/grafana/grafana/issues/66916