### PR TITLE
Logs: Add toggle behavior support for "filter for" and "filter out" label within Logs Details

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1198,7 +1198,19 @@ describe('modifyQuery', () => {
       );
     });
 
+    it('should toggle the filter', () => {
+      query.query = 'foo:"bar"';
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe('');
+    });
+
     it('should add the negative filter', () => {
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
+        '-foo:"bar"'
+      );
+    });
+
+    it('should remove a positive filter to add a negative filter', () => {
+      query.query = 'foo:"bar"';
       expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
         '-foo:"bar"'
       );

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -1,0 +1,35 @@
+import { queryHasFilter, removeFilterFromQuery, addFilterToQuery } from './modifyQuery';
+
+describe('queryHasFilter', () => {
+  it('should return true if the query contains the filter', () => {
+    expect(queryHasFilter('label:"value"', 'label', 'value')).toBe(true);
+    expect(queryHasFilter('label: "value"', 'label', 'value')).toBe(true);
+    expect(queryHasFilter('label : "value"', 'label', 'value')).toBe(true);
+    expect(queryHasFilter('label:value', 'label', 'value')).toBe(true);
+  });
+  it('should return false if the query does not contain the filter', () => {
+    const query = 'label:"value"';
+    expect(queryHasFilter(query, 'label', 'otherValue')).toBe(false);
+  });
+});
+
+describe('removeFilterFromQuery', () => {
+  it('should remove filter from query', () => {
+    const query = 'label:"value"';
+    expect(removeFilterFromQuery(query, 'label', 'value')).toBe('');
+  });
+  it('should remove filter from query with other filters', () => {
+    expect(removeFilterFromQuery('label:"value" AND label2:"value2"', 'label', 'value')).toBe('label2:"value2"');
+    expect(removeFilterFromQuery('label:value AND label2:"value2"', 'label', 'value')).toBe('label2:"value2"');
+    expect(removeFilterFromQuery('label : "value" OR label2:"value2"', 'label', 'value')).toBe('label2:"value2"');
+  });
+});
+
+describe('addFilterToQuery', () => {
+  it('should add filter to query', () => {
+    expect(addFilterToQuery('', 'label', 'value')).toBe('label:"value"');
+  });
+  it('should add filter to query with other filters', () => {
+    expect(addFilterToQuery('label2:"value2"', 'label', 'value')).toBe('label2:"value2" AND label:"value"');
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -7,6 +7,13 @@ describe('queryHasFilter', () => {
     expect(queryHasFilter('label : "value"', 'label', 'value')).toBe(true);
     expect(queryHasFilter('label:value', 'label', 'value')).toBe(true);
     expect(queryHasFilter('this:"that" AND label:value', 'label', 'value')).toBe(true);
+    expect(
+      queryHasFilter(
+        'message:"Jun 20 17:19:47 Xtorm syslogd[348]: ASL Sender Statistics"',
+        'message',
+        'Jun 20 17:19:47 Xtorm syslogd[348]: ASL Sender Statistics'
+      )
+    ).toBe(true);
   });
   it('should return false if the query does not contain the positive filter', () => {
     expect(queryHasFilter('label:"value"', 'label', 'otherValue')).toBe(false);

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -1,0 +1,24 @@
+type ModifierType = '' | '-';
+
+/**
+ * Checks for the presence of a given label:"value" filter in the query.
+ */
+export function queryHasFilter(query: string, key: string, value: string, modifier: ModifierType = ''): boolean {
+  const regex = getFilterRegex(key, value, modifier);
+
+  return regex.test(query);
+}
+
+/**
+ * Removes a label:"value" expression from the query.
+ */
+export function removeFilterFromQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {}
+
+/**
+ * Adds a label:"value" expression to the query.
+ */
+export function addFilterToQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {}
+
+function getFilterRegex(key: string, value: string, modifier: ModifierType = '') {
+  return new RegExp(`${modifier}${key}\\s*:\\s*["']{0,1}${value}["']{0,1}`, 'ig');
+}

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -4,21 +4,52 @@ type ModifierType = '' | '-';
  * Checks for the presence of a given label:"value" filter in the query.
  */
 export function queryHasFilter(query: string, key: string, value: string, modifier: ModifierType = ''): boolean {
-  const regex = getFilterRegex(key, value, modifier);
+  const regex = getFilterRegex(key, value);
+  const matches = query.matchAll(regex);
+  for (const match of matches) {
+    if (modifier === '-' && match[0].startsWith(modifier)) {
+      return true;
+    }
+    if (modifier === '' && !match[0].startsWith('-')) {
+      return true;
+    }
+  }
+  return false;
+}
 
-  return regex.test(query);
+/**
+ * Adds a label:"value" expression to the query.
+ */
+export function addFilterToQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {
+  if (queryHasFilter(query, key, value, modifier)) {
+    return query;
+  }
+
+  const filter = `${modifier}${key}:"${value}"`;
+
+  return query === '' ? filter : `${query} AND ${filter}`;
+}
+
+function getFilterRegex(key: string, value: string) {
+  return new RegExp(`[-]{0,1}\\s*${key}\\s*:\\s*["']{0,1}${value}["']{0,1}`, 'ig');
 }
 
 /**
  * Removes a label:"value" expression from the query.
  */
-export function removeFilterFromQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {}
-
-/**
- * Adds a label:"value" expression to the query.
- */
-export function addFilterToQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {}
-
-function getFilterRegex(key: string, value: string, modifier: ModifierType = '') {
-  return new RegExp(`${modifier}${key}\\s*:\\s*["']{0,1}${value}["']{0,1}`, 'ig');
+export function removeFilterFromQuery(query: string, key: string, value: string, modifier: ModifierType = ''): string {
+  const regex = getFilterRegex(key, value);
+  const matches = query.matchAll(regex);
+  const opRegex = new RegExp(`\\s+(?:AND|OR)\\s*$|^\\s*(?:AND|OR)\\s+`, 'ig');
+  for (const match of matches) {
+    if (modifier === '-' && match[0].startsWith(modifier)) {
+      query = query.replace(regex, '').replace(opRegex, '');
+    }
+    if (modifier === '' && !match[0].startsWith('-')) {
+      query = query.replace(regex, '').replace(opRegex, '');
+    }
+  }
+  query = query.replace(/AND\s+OR/gi, 'OR');
+  query = query.replace(/OR\s+AND/gi, 'AND');
+  return query;
 }

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -1,3 +1,5 @@
+import { escapeRegex } from '@grafana/data';
+
 type ModifierType = '' | '-';
 
 /**
@@ -31,7 +33,7 @@ export function addFilterToQuery(query: string, key: string, value: string, modi
 }
 
 function getFilterRegex(key: string, value: string) {
-  return new RegExp(`[-]{0,1}\\s*${key}\\s*:\\s*["']{0,1}${value}["']{0,1}`, 'ig');
+  return new RegExp(`[-]{0,1}\\s*${key}\\s*:\\s*["']{0,1}${escapeRegex(value)}["']{0,1}`, 'ig');
 }
 
 /**

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -637,23 +637,24 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz", job="grafana"}[5m])');
         });
-        describe('and query has parser', () => {
-          it('then the correct label should be added for logs query', () => {
-            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
-            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
-            const result = ds.modifyQuery(query, action);
+      });
 
-            expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('{bar="baz"} | logfmt | job=`grafana`');
-          });
-          it('then the correct label should be added for metrics query', () => {
-            const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
-            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
-            const result = ds.modifyQuery(query, action);
+      describe('and query has parser', () => {
+        it('then the correct label should be added for logs query', () => {
+          const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
+          const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
+          const result = ds.modifyQuery(query, action);
 
-            expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job=`grafana` [5m])');
-          });
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('{bar="baz"} | logfmt | job=`grafana`');
+        });
+        it('then the correct label should be added for metrics query', () => {
+          const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
+          const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job=`grafana` [5m])');
         });
       });
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -637,6 +637,17 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz", job="grafana"}[5m])');
         });
+
+        describe('and the filter is already present', () => {
+          it('then it should remove the filter', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz", job="grafana"}' };
+            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"}');
+          });
+        });
       });
 
       describe('and query has parser', () => {
@@ -648,6 +659,7 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('{bar="baz"} | logfmt | job=`grafana`');
         });
+
         it('then the correct label should be added for metrics query', () => {
           const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
           const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
@@ -655,6 +667,17 @@ describe('LokiDatasource', () => {
 
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job=`grafana` [5m])');
+        });
+
+        describe('and the filter is already present', () => {
+          it('then it should remove the filter', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt | job="grafana"' };
+            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER' };
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"} | logfmt');
+          });
         });
       });
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -715,6 +715,17 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz", job!="grafana"}[5m])');
         });
+
+        describe('and the filter is already present', () => {
+          it('then it should remove the filter', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz", job!="grafana"}' };
+            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"}');
+          });
+        });
       });
 
       describe('and query has parser', () => {
@@ -731,6 +742,7 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('{bar="baz"} | logfmt | job!=`grafana`');
         });
+
         it('then the correct label should be added for metrics query', () => {
           const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
           const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
@@ -738,6 +750,17 @@ describe('LokiDatasource', () => {
 
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job!=`grafana` [5m])');
+        });
+
+        describe('and the filter is already present', () => {
+          it('then it should remove the filter', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt | job!="grafana"' };
+            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"} | logfmt');
+          });
         });
       });
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -715,28 +715,29 @@ describe('LokiDatasource', () => {
           expect(result.refId).toEqual('A');
           expect(result.expr).toEqual('rate({bar="baz", job!="grafana"}[5m])');
         });
-        describe('and query has parser', () => {
-          let ds: LokiDatasource;
-          beforeEach(() => {
-            ds = createLokiDatasource(templateSrvStub);
-          });
+      });
 
-          it('then the correct label should be added for logs query', () => {
-            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
-            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
-            const result = ds.modifyQuery(query, action);
+      describe('and query has parser', () => {
+        let ds: LokiDatasource;
+        beforeEach(() => {
+          ds = createLokiDatasource(templateSrvStub);
+        });
 
-            expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('{bar="baz"} | logfmt | job!=`grafana`');
-          });
-          it('then the correct label should be added for metrics query', () => {
-            const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
-            const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
-            const result = ds.modifyQuery(query, action);
+        it('then the correct label should be added for logs query', () => {
+          const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
+          const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
+          const result = ds.modifyQuery(query, action);
 
-            expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job!=`grafana` [5m])');
-          });
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('{bar="baz"} | logfmt | job!=`grafana`');
+        });
+        it('then the correct label should be added for metrics query', () => {
+          const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
+          const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('rate({bar="baz"} | logfmt | job!=`grafana` [5m])');
         });
       });
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -647,6 +647,15 @@ describe('LokiDatasource', () => {
             expect(result.refId).toEqual('A');
             expect(result.expr).toEqual('{bar="baz"}');
           });
+
+          it('then it should remove the filter with escaped value', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{place="luna", job="\\"grafana/data\\""}' };
+            const action = { options: { key: 'job', value: '"grafana/data"' }, type: 'ADD_FILTER' };
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{place="luna"}');
+          });
         });
       });
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -725,14 +725,14 @@ describe('LokiDatasource', () => {
           expect(result.expr).toEqual('rate({bar="baz", job!="grafana"}[5m])');
         });
 
-        describe('and the filter is already present', () => {
+        describe('and the opposite filter is present', () => {
           it('then it should remove the filter', () => {
-            const query: LokiQuery = { refId: 'A', expr: '{bar="baz", job!="grafana"}' };
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz", job="grafana"}' };
             const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
             const result = ds.modifyQuery(query, action);
 
             expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('{bar="baz"}');
+            expect(result.expr).toEqual('{bar="baz", job!="grafana"}');
           });
         });
       });
@@ -763,12 +763,12 @@ describe('LokiDatasource', () => {
 
         describe('and the filter is already present', () => {
           it('then it should remove the filter', () => {
-            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt | job!="grafana"' };
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt | job="grafana"' };
             const action = { options: { key: 'job', value: 'grafana' }, type: 'ADD_FILTER_OUT' };
             const result = ds.modifyQuery(query, action);
 
             expect(result.refId).toEqual('A');
-            expect(result.expr).toEqual('{bar="baz"} | logfmt');
+            expect(result.expr).toEqual('{bar="baz"} | logfmt | job!=`grafana`');
           });
         });
       });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -65,6 +65,8 @@ import {
   addLineFilter,
   findLastPosition,
   getLabelFilterPositions,
+  queryHasFilter,
+  removeLabelFromQuery,
 } from './modifyQuery';
 import { getQueryHints } from './queryHints';
 import { runSplitQuery } from './querySplitting';
@@ -614,7 +616,9 @@ export class LokiDatasource
       case 'ADD_FILTER': {
         if (action.options?.key && action.options?.value) {
           const value = escapeLabelValueInSelector(action.options.value);
-          expression = addLabelToQuery(expression, action.options.key, '=', value);
+          expression = queryHasFilter(expression, action.options.key, '=', value)
+            ? removeLabelFromQuery(expression, action.options.key, '=', value)
+            : addLabelToQuery(expression, action.options.key, '=', value);
         }
         break;
       }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -625,7 +625,9 @@ export class LokiDatasource
       case 'ADD_FILTER_OUT': {
         if (action.options?.key && action.options?.value) {
           const value = escapeLabelValueInSelector(action.options.value);
-          expression = addLabelToQuery(expression, action.options.key, '!=', value);
+          expression = queryHasFilter(expression, action.options.key, '!=', value)
+            ? removeLabelFromQuery(expression, action.options.key, '!=', value)
+            : addLabelToQuery(expression, action.options.key, '!=', value);
         }
         break;
       }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -616,6 +616,8 @@ export class LokiDatasource
       case 'ADD_FILTER': {
         if (action.options?.key && action.options?.value) {
           const value = escapeLabelValueInSelector(action.options.value);
+
+          // This gives the user the ability to toggle a filter on and off.
           expression = queryHasFilter(expression, action.options.key, '=', value)
             ? removeLabelFromQuery(expression, action.options.key, '=', value)
             : addLabelToQuery(expression, action.options.key, '=', value);
@@ -625,9 +627,17 @@ export class LokiDatasource
       case 'ADD_FILTER_OUT': {
         if (action.options?.key && action.options?.value) {
           const value = escapeLabelValueInSelector(action.options.value);
-          expression = queryHasFilter(expression, action.options.key, '!=', value)
-            ? removeLabelFromQuery(expression, action.options.key, '!=', value)
-            : addLabelToQuery(expression, action.options.key, '!=', value);
+
+          /**
+           * If there is a filter with the same key and value, remove it.
+           * This prevents the user from seeing no changes in the query when they apply
+           * this filter.
+           */
+          if (queryHasFilter(expression, action.options.key, '=', value)) {
+            expression = removeLabelFromQuery(expression, action.options.key, '=', value);
+          }
+
+          expression = addLabelToQuery(expression, action.options.key, '!=', value);
         }
         break;
       }

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -6,7 +6,9 @@ import {
   addNoPipelineErrorToQuery,
   addParserToQuery,
   NodePosition,
+  queryHasFilter,
   removeCommentsFromQuery,
+  removeLabelFromQuery,
 } from './modifyQuery';
 
 describe('addLabelToQuery()', () => {
@@ -244,5 +246,49 @@ describe('NodePosition', () => {
       expect(result.to).toBe(10);
       expect(result.type).toBe('identifier');
     });
+  });
+});
+
+describe('queryHasFilter', () => {
+  it.each([
+    ['{job="grafana"}', 'grafana'],
+    ['{job="grafana", foo="bar"}', 'grafana'],
+    ['{foo="bar", job="grafana"}', 'grafana'],
+    ['{job="\\"grafana\\""}', '"grafana"'],
+    ['{foo="bar"} | logfmt | job=`grafana`', 'grafana'],
+  ])('should return true if query has a positive filter', (query: string, value: string) => {
+    expect(queryHasFilter(query, 'job', '=', value)).toBe(true);
+  });
+
+  it.each([
+    ['{job!="grafana"}', 'grafana'],
+    ['{job!="grafana", foo="bar"}', 'grafana'],
+    ['{foo="bar", job!="grafana"}', 'grafana'],
+    ['{job!="\\"grafana\\""}', '"grafana"'],
+    ['{foo="bar"} | logfmt | job!=`grafana`', 'grafana'],
+  ])('should return true if query has a negative filter', (query: string, value: string) => {
+    expect(queryHasFilter(query, 'job', '!=', value)).toBe(true);
+  });
+});
+
+describe('removeLabelFromQuery', () => {
+  it.each([
+    ['{job="grafana"}', 'grafana', '{}'],
+    ['{job="grafana", foo="bar"}', 'grafana', '{foo="bar"}'],
+    ['{foo="bar", job="grafana"}', 'grafana', '{foo="bar"}'],
+    ['{job="\\"grafana\\""}', '"grafana"', '{}'],
+    ['{foo="bar"} | logfmt | job=`grafana`', 'grafana', '{foo="bar"} | logfmt'],
+  ])('should remove a positive label matcher from the query', (query: string, value: string, expected: string) => {
+    expect(removeLabelFromQuery(query, 'job', '=', value)).toBe(expected);
+  });
+
+  it.each([
+    ['{job!="grafana"}', 'grafana', '{}'],
+    ['{job!="grafana", foo="bar"}', 'grafana', '{foo="bar"}'],
+    ['{foo="bar", job!="grafana"}', 'grafana', '{foo="bar"}'],
+    ['{job!="\\"grafana\\""}', '"grafana"', '{}'],
+    ['{foo="bar"} | logfmt | job!=`grafana`', 'grafana', '{foo="bar"} | logfmt'],
+  ])('should remove a negative label matcher from the query', (query: string, value: string, expected: string) => {
+    expect(removeLabelFromQuery(query, 'job', '!=', value)).toBe(expected);
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -151,6 +151,10 @@ export function addLabelToQuery(query: string, key: string, operator: string, va
   }
 
   const streamSelectorPositions = getStreamSelectorPositions(query);
+  if (!streamSelectorPositions.length) {
+    return query;
+  }
+
   const hasStreamSelectorMatchers = getMatcherInStreamPositions(query);
   const everyStreamSelectorHasMatcher = streamSelectorPositions.every((streamSelectorPosition) =>
     hasStreamSelectorMatchers.some(
@@ -160,9 +164,6 @@ export function addLabelToQuery(query: string, key: string, operator: string, va
   );
   const parserPositions = getParserPositions(query);
   const labelFilterPositions = getLabelFilterPositions(query);
-  if (!streamSelectorPositions.length) {
-    return query;
-  }
 
   const filter = toLabelFilter(key, value, operator);
   // If we have non-empty stream selector and parser/label filter, we want to add a new label filter after the last one.
@@ -189,6 +190,9 @@ export function addParserToQuery(query: string, parser: string): string {
     return addParser(query, lineFilterPositions, parser);
   } else {
     const streamSelectorPositions = getStreamSelectorPositions(query);
+    if (!streamSelectorPositions.length) {
+      return query;
+    }
     return addParser(query, streamSelectorPositions, parser);
   }
 }
@@ -506,6 +510,9 @@ function addLabelFormat(
 
 export function addLineFilter(query: string): string {
   const streamSelectorPositions = getStreamSelectorPositions(query);
+  if (!streamSelectorPositions.length) {
+    return query;
+  }
   const streamSelectorEnd = streamSelectorPositions[0].to;
 
   const newQueryExpr = query.slice(0, streamSelectorEnd) + ' |= ``' + query.slice(streamSelectorEnd);

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -78,7 +78,10 @@ function removeLabelFilter(query: string, matcher: SyntaxNode): string {
 }
 
 function removeSelector(query: string, matcher: SyntaxNode): string {
-  const selector = matcher.parent?.parent;
+  let selector: SyntaxNode | null = matcher;
+  do {
+    selector = selector.parent;
+  } while (selector && selector.type.id !== Selector);
   const label = matcher.getChild(Identifier);
   if (!selector || !label) {
     return query;

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -2,6 +2,7 @@ import { NodeType, SyntaxNode } from '@lezer/common';
 import { sortBy } from 'lodash';
 
 import {
+  Identifier,
   JsonExpressionParser,
   LabelFilter,
   LabelParser,
@@ -14,13 +15,14 @@ import {
   PipelineExpr,
   Selector,
   UnwrapExpr,
+  String,
 } from '@grafana/lezer-logql';
 
 import { QueryBuilderLabelFilter } from '../prometheus/querybuilder/shared/types';
 
 import { unescapeLabelValue } from './languageUtils';
 import { LokiQueryModeller } from './querybuilder/LokiQueryModeller';
-import { buildVisualQueryFromString } from './querybuilder/parsing';
+import { buildVisualQueryFromString, handleQuotes } from './querybuilder/parsing';
 
 export class NodePosition {
   from: number;
@@ -45,6 +47,87 @@ export class NodePosition {
     return query.substring(this.from, this.to);
   }
 }
+export type Position = { from: number; to: number };
+
+/**
+ * Checks for the presence of a given label=value filter in any Matcher expression in the query.
+ */
+export function queryHasFilter(query: string, key: string, operator: string, value: string): boolean {
+  const matchers = getMatchersWithFilter(query, key, operator, value);
+  return matchers.length > 0;
+}
+
+/**
+ * Removes a label=value Matcher expression from the query.
+ */
+export function removeLabelFromQuery(query: string, key: string, operator: string, value: string): string {
+  const matchers = getMatchersWithFilter(query, key, operator, value);
+  for (const matcher of matchers) {
+    query =
+      matcher.parent?.type.id === LabelFilter ? removeLabelFilter(query, matcher) : removeSelector(query, matcher);
+  }
+  return query;
+}
+
+function removeLabelFilter(query: string, matcher: SyntaxNode): string {
+  const pipelineStage = matcher.parent?.parent;
+  if (!pipelineStage) {
+    return query;
+  }
+  return (query.substring(0, pipelineStage.from) + query.substring(pipelineStage.to)).trim();
+}
+
+function removeSelector(query: string, matcher: SyntaxNode): string {
+  const selector = matcher.parent?.parent;
+  const label = matcher.getChild(Identifier);
+  if (!selector || !label) {
+    return query;
+  }
+  const labelName = query.substring(label.from, label.to);
+  const modeller = new LokiQueryModeller();
+
+  const prefix = query.substring(0, selector.from);
+  const suffix = query.substring(selector.to);
+
+  const matchVisQuery = buildVisualQueryFromString(query.substring(selector.from, selector.to));
+  matchVisQuery.query.labels = matchVisQuery.query.labels.filter((label) => label.label !== labelName);
+
+  return prefix + modeller.renderQuery(matchVisQuery.query) + suffix;
+}
+
+function getMatchersWithFilter(query: string, key: string, operator: string, value: string): SyntaxNode[] {
+  const tree = parser.parse(query);
+  const matchers: SyntaxNode[] = [];
+  tree.iterate({
+    enter: ({ type, node }): void => {
+      if (type.id === Matcher) {
+        matchers.push(node);
+      }
+    },
+  });
+  return matchers.filter((matcher) => {
+    const labelNode = matcher.getChild(Identifier);
+    const opNode = labelNode?.nextSibling;
+    const valueNode = matcher.getChild(String);
+    if (!labelNode || !opNode || !valueNode) {
+      return false;
+    }
+    const labelName = query.substring(labelNode.from, labelNode.to);
+    if (labelName !== key) {
+      return false;
+    }
+    const labelValue = query.substring(valueNode.from, valueNode.to);
+    if (handleQuotes(labelValue) !== value) {
+      return false;
+    }
+    const labelOperator = query.substring(opNode.from, opNode.to);
+    if (labelOperator !== operator) {
+      return false;
+    }
+    return true;
+  });
+}
+
 /**
  * Adds label filter to existing query. Useful for query modification for example for ad hoc filters.
  *
@@ -308,7 +391,6 @@ function addFilterToStreamSelector(
 
   for (let i = 0; i < vectorSelectorPositions.length; i++) {
     // This is basically just doing splice on a string for each matched vector selector.
-
     const match = vectorSelectorPositions[i];
     const isLast = i === vectorSelectorPositions.length - 1;
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -117,7 +117,7 @@ function getMatchersWithFilter(query: string, key: string, operator: string, val
       return false;
     }
     const labelValue = query.substring(valueNode.from, valueNode.to);
-    if (handleQuotes(labelValue) !== value) {
+    if (handleQuotes(labelValue) !== unescapeLabelValue(value)) {
       return false;
     }
     const labelOperator = query.substring(opNode.from, opNode.to);

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -21,7 +21,7 @@ import {
 import { QueryBuilderLabelFilter } from '../prometheus/querybuilder/shared/types';
 
 import { unescapeLabelValue } from './languageUtils';
-import { LokiQueryModeller } from './querybuilder/LokiQueryModeller';
+import { lokiQueryModeller as modeller } from './querybuilder/LokiQueryModeller';
 import { buildVisualQueryFromString, handleQuotes } from './querybuilder/parsing';
 
 export class NodePosition {
@@ -86,7 +86,6 @@ function removeSelector(query: string, matcher: SyntaxNode): string {
     return query;
   }
   const labelName = query.substring(label.from, label.to);
-  const modeller = new LokiQueryModeller();
 
   const prefix = query.substring(0, selector.from);
   const suffix = query.substring(selector.to);
@@ -391,7 +390,6 @@ function addFilterToStreamSelector(
   vectorSelectorPositions: NodePosition[],
   filter: QueryBuilderLabelFilter
 ): string {
-  const modeller = new LokiQueryModeller();
   let newQuery = '';
   let prev = 0;
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -47,7 +47,6 @@ export class NodePosition {
     return query.substring(this.from, this.to);
   }
 }
-export type Position = { from: number; to: number };
 
 /**
  * Checks for the presence of a given label=value filter in any Matcher expression in the query.

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -597,7 +597,7 @@ function isIntervalVariableError(node: SyntaxNode) {
   return node?.parent?.type.id === Range;
 }
 
-function handleQuotes(string: string) {
+export function handleQuotes(string: string) {
   if (string[0] === `"` && string[string.length - 1] === `"`) {
     return string
       .substring(1, string.length - 1)


### PR DESCRIPTION
This is the first part of the changes related with [Easier search and filter](https://github.com/grafana/grafana/issues/61765).

## What changed

Now, the ![imagen](https://github.com/grafana/grafana/assets/1069378/05c852cc-61e6-4461-9344-9f8dfb353766) button has a toggle behavior. That means, if the filter is already present in the current query, it will be removed from it.

**Pending change**: this feature will work best when we display the active status of present filters in the query by changing the icon color ![imagen](https://github.com/grafana/grafana/assets/1069378/b7aa6ae8-5c02-4555-b56d-9b61d950af4a). Will be done in a follow-up PR. 

![Remove applied filter](https://github.com/grafana/grafana/assets/1069378/55351d2c-c64e-4b56-ba28-6f66e4c14417)

![Add and remove label filter](https://github.com/grafana/grafana/assets/1069378/a095cd38-1b22-4b0e-955d-2ddb84728793)

Now the ![imagen](https://github.com/grafana/grafana/assets/1069378/ce17a526-deb7-4d44-9f87-905af11dad0f) is smarter. When some label needs to be excluded from the query, but it previously existed as a positive filter, we remove it and add the new filtered out key, value pair.

![Remove filter and filter out](https://github.com/grafana/grafana/assets/1069378/2fa9ed95-928a-41de-bbc5-ae7002788b8d)

![Add and remove label filter out](https://github.com/grafana/grafana/assets/1069378/fe7739d7-e570-4798-8a4a-b83c2fa7be2d)

## How it used to work

Before these changes, the users would interact with the 🔍  icons with no change in the current query.

![Nothing happens (filter out)](https://github.com/grafana/grafana/assets/1069378/be843cc9-f728-4f4a-82e0-48bb694e2ab4)

![Nothing happens (filter)](https://github.com/grafana/grafana/assets/1069378/46df7277-224b-4746-aa5e-9e282ffb2c5c)

## Support

These changes are currently supported by both Loki and Elasticsearch, with and without using mixed datasources.

## What's next

- Display active state of applied filters.
- Update Elasticsearch's modifyQuery to use a syntax parser.

### Demo in Elasticsearch

https://github.com/grafana/grafana/assets/1069378/5c63e8bd-4d4e-4f6e-8995-73e0f981813c

### Demo with mixed datasources

https://github.com/grafana/grafana/assets/1069378/38870184-fc68-4d04-8e14-1b3c6e7cdeea

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61765

**Special notes for your reviewer:**

Test the changes, see how it feels after them, let me know if anything is broken or could work in a different way. In particular, the query modifiers for Elasticsearch, they need to be battle tested.