### PR TITLE
PublicDashboards: Add support for recorded queries used in Mixed ds

### DIFF
--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -222,9 +222,9 @@ func getUniqueDashboardDatasourceUids(dashboard *simplejson.Json) []string {
 
 		// if uid is for a mixed datasource, get the datasource uids from the targets
 		if uid == "-- Mixed --" {
-			for _, target := range panel.Get("targets").MustArray() {
-				target := simplejson.NewFromAny(target)
-				datasourceUid := target.Get("datasource").Get("uid").MustString()
+			for _, targetObj := range panel.Get("targets").MustArray() {
+				target := simplejson.NewFromAny(targetObj)
+				datasourceUid := getDataSourceUidFromJson(target)
 				if _, ok := exists[datasourceUid]; !ok {
 					datasourceUids = append(datasourceUids, datasourceUid)
 					exists[datasourceUid] = true

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -133,6 +133,15 @@ const (
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "datasource": "6SOeCRrVk",
+          "exemplar": true,
+          "expr": "test{id=\"f0dd9b69-ad04-4342-8e79-ced8c245683b\", name=\"test\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
         }
       ],
       "title": "Panel Title",
@@ -1153,9 +1162,10 @@ func TestGetUniqueDashboardDatasourceUids(t *testing.T) {
 		require.NoError(t, err)
 
 		uids := getUniqueDashboardDatasourceUids(json)
-		require.Len(t, uids, 2)
+		require.Len(t, uids, 3)
 		require.Equal(t, "abc123", uids[0])
-		require.Equal(t, "_yxMP8Ynk", uids[1])
+		require.Equal(t, "6SOeCRrVk", uids[1])
+		require.Equal(t, "_yxMP8Ynk", uids[2])
 	})
 
 	t.Run("can get no datasource uids from empty dashboard", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Add support for displaying panels in public dashboards that use recording queries
Recorded queries data source on the dashboard JSON has a different structure. This PR leverages an existent function to return the data source uid in these exceptional cases.

Fixes https://github.com/grafana/grafana-enterprise/issues/5279

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
