### PR TITLE
Canvas: Tweak inline editor border styling

### DIFF
--- a/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
@@ -110,7 +110,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: column;
     background: ${theme.components.panel.background};
-    border: 1px solid ${theme.colors.border.strong};
+    border: 1px solid ${theme.colors.border.weak};
     box-shadow: ${theme.shadows.z3};
     z-index: 1000;
     opacity: 1;
@@ -125,7 +125,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     align-items: center;
     justify-content: center;
     background: ${theme.colors.background.canvas};
-    border: 1px solid ${theme.colors.border.weak};
+    border-bottom: 1px solid ${theme.colors.border.weak};
     height: 40px;
     cursor: move;
   `,


### PR DESCRIPTION
Tweak inline editor border styling to use weak instead of strong border to improve consistency with other modals in Grafana.

Before
<img width="432" alt="before" src="https://github.com/grafana/grafana/assets/22381771/6cda62c7-ed1c-46fc-9d18-518da6719210">


After

<img width="433" alt="after" src="https://github.com/grafana/grafana/assets/22381771/6819bccd-0326-4f14-8e50-c7d3f5756e0c">
