### PR TITLE
Alerting: Refactoring to api_prometheus.go (updated).

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -244,7 +244,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Res
 	}
 
 	dashboardUID := c.Query("dashboard_uid")
-	panelID, err := getPanelIDFromRequest(c.Req)
+	panelID, err := getPanelIDFromQuery(c.Req.URL.Query())
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "invalid panel_id")
 	}


### PR DESCRIPTION
Refactors the code which generates the rule and alert status responses such that the functions can be reused by other parts of the codebase.

This change is similar in nature to https://github.com/grafana/grafana/pull/66726 but supercedes it. The main difference being that we exposed functions take a generic `url.Values`, so that the parsing of said request parameters can be reused.