### PR TITLE
Insights: Add Grafana version to rudderstack events

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -305,6 +305,7 @@ function initEchoSrv() {
         user: config.bootData.user,
         sdkUrl: config.rudderstackSdkUrl,
         configUrl: config.rudderstackConfigUrl,
+        buildInfo: config.buildInfo,
       })
     );
   }

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -1,6 +1,6 @@
 import type { apiOptions, identify, load, page, track } from 'rudder-sdk-js'; // SDK is loaded dynamically from config, so we only import types from the SDK package
 
-import { CurrentUserDTO } from '@grafana/data';
+import { BuildInfo, CurrentUserDTO } from '@grafana/data';
 import {
   EchoBackend,
   EchoEventType,
@@ -33,6 +33,7 @@ export interface RudderstackBackendOptions {
   user?: CurrentUserDTO;
   sdkUrl?: string;
   configUrl?: string;
+  buildInfo?: BuildInfo;
 }
 
 export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, RudderstackBackendOptions> {
@@ -85,6 +86,8 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
           email: options.user.email,
           orgId: options.user.orgId,
           language: options.user.language,
+          version: options.buildInfo?.version ?? 'unknown',
+          edition: options.buildInfo?.edition ?? 'unknown',
         },
         apiOptions
       );


### PR DESCRIPTION
**What is this feature?**

Currently we are tracking events in Rudderstack without knowing the version of the originating Grafana. This PR adds the version and edition to by added to Rudderstack traits.
