### PR TITLE
SSE: Add functions that determine NodeType by UID and construct a data source struct from NodeType 

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -166,13 +166,13 @@ func (s *Service) buildGraph(req *Request) (*simple.DirectedGraph, error) {
 		}
 
 		var node Node
-		switch QueryKindByDatasourceUID(query.DataSource.UID) {
+		switch NodeTypeFromDatasourceUID(query.DataSource.UID) {
 		case TypeDatasourceNode:
 			node, err = buildCMDNode(dp, rn)
 		case TypeCMDNode:
 			node, err = s.buildDSNode(dp, rn, req)
 		default:
-			err = fmt.Errorf("unsupported node type '%s'", QueryKindByDatasourceUID(query.DataSource.UID))
+			err = fmt.Errorf("unsupported node type '%s'", NodeTypeFromDatasourceUID(query.DataSource.UID))
 		}
 
 		if err != nil {

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -166,11 +166,13 @@ func (s *Service) buildGraph(req *Request) (*simple.DirectedGraph, error) {
 		}
 
 		var node Node
-
-		if IsDataSource(rn.DataSource.UID) {
+		switch QueryKindByDatasourceUID(query.DataSource.UID) {
+		case TypeDatasourceNode:
 			node, err = buildCMDNode(dp, rn)
-		} else {
+		case TypeCMDNode:
 			node, err = s.buildDSNode(dp, rn, req)
+		default:
+			err = fmt.Errorf("unsupported node type '%s'", QueryKindByDatasourceUID(query.DataSource.UID))
 		}
 
 		if err != nil {

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -168,9 +168,9 @@ func (s *Service) buildGraph(req *Request) (*simple.DirectedGraph, error) {
 		var node Node
 		switch NodeTypeFromDatasourceUID(query.DataSource.UID) {
 		case TypeDatasourceNode:
-			node, err = buildCMDNode(dp, rn)
-		case TypeCMDNode:
 			node, err = s.buildDSNode(dp, rn, req)
+		case TypeCMDNode:
+			node, err = buildCMDNode(dp, rn)
 		default:
 			err = fmt.Errorf("unsupported node type '%s'", NodeTypeFromDatasourceUID(query.DataSource.UID))
 		}

--- a/pkg/expr/graph_test.go
+++ b/pkg/expr/graph_test.go
@@ -22,7 +22,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"expression": "B",
 							"reducer": "mean",
@@ -46,7 +46,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 								"expression": "$B",
 								"type": "math"
@@ -54,7 +54,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 					},
 					{
 						RefID:      "B",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 								"expression": "$A",
 								"type": "math"
@@ -70,7 +70,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 								"expression": "$A",
 								"type": "math"
@@ -86,7 +86,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 								"expression": "$B",
 								"type": "math"
@@ -102,7 +102,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"type": "classic_conditions",
 							"conditions": [
@@ -133,7 +133,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 					},
 					{
 						RefID:      "B",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"expression": "C",
 							"reducer": "mean",
@@ -157,7 +157,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"type": "classic_conditions",
 							"conditions": [
@@ -188,7 +188,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 					},
 					{
 						RefID:      "B",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"expression": "A",
 							"reducer": "mean",
@@ -212,7 +212,7 @@ func TestServicebuildPipeLine(t *testing.T) {
 				Queries: []Query{
 					{
 						RefID:      "A",
-						DataSource: DataSourceModel(),
+						DataSource: dataSourceModel(),
 						JSON: json.RawMessage(`{
 							"expression": "B",
 							"reducer": "mean",

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -2,6 +2,8 @@ package expr
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -95,13 +97,21 @@ func (s *Service) ExecutePipeline(ctx context.Context, now time.Time, pipeline D
 	return res, nil
 }
 
-func DataSourceModel() *datasources.DataSource {
-	return &datasources.DataSource{
-		ID:             DatasourceID,
-		UID:            DatasourceUID,
-		Name:           DatasourceUID,
-		Type:           DatasourceType,
-		JsonData:       simplejson.New(),
-		SecureJsonData: make(map[string][]byte),
+// Create a datasources.DataSource struct from NodeType. Returns error if kind is TypeDatasourceNode or unknown one.
+func DataSourceModel(kind NodeType) (*datasources.DataSource, error) {
+	switch kind {
+	case TypeCMDNode:
+		return &datasources.DataSource{
+			ID:             DatasourceID,
+			UID:            DatasourceUID,
+			Name:           DatasourceUID,
+			Type:           DatasourceType,
+			JsonData:       simplejson.New(),
+			SecureJsonData: make(map[string][]byte),
+		}, nil
+	case TypeDatasourceNode:
+		return nil, errors.New("cannot create expression data source for data source kind")
+	default:
+		return nil, fmt.Errorf("cannot create expression data source for '%s' kind", kind)
 	}
 }

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -57,6 +57,8 @@ type Service struct {
 	pCtxProvider *plugincontext.Provider
 	features     featuremgmt.FeatureToggles
 
+	pluginsClient backend.CallResourceHandler
+
 	tracer  tracing.Tracer
 	metrics *metrics
 }
@@ -64,12 +66,13 @@ type Service struct {
 func ProvideService(cfg *setting.Cfg, pluginClient plugins.Client, pCtxProvider *plugincontext.Provider,
 	features featuremgmt.FeatureToggles, registerer prometheus.Registerer, tracer tracing.Tracer) *Service {
 	return &Service{
-		cfg:          cfg,
-		dataService:  pluginClient,
-		pCtxProvider: pCtxProvider,
-		features:     features,
-		tracer:       tracer,
-		metrics:      newMetrics(registerer),
+		cfg:           cfg,
+		dataService:   pluginClient,
+		pCtxProvider:  pCtxProvider,
+		features:      features,
+		tracer:        tracer,
+		metrics:       newMetrics(registerer),
+		pluginsClient: pluginClient,
 	}
 }
 
@@ -103,7 +106,7 @@ func (s *Service) ExecutePipeline(ctx context.Context, now time.Time, pipeline D
 }
 
 // Create a datasources.DataSource struct from NodeType. Returns error if kind is TypeDatasourceNode or unknown one.
-func DataSourceModel(kind NodeType) (*datasources.DataSource, error) {
+func DataSourceModelFromNodeType(kind NodeType) (*datasources.DataSource, error) {
 	switch kind {
 	case TypeCMDNode:
 		return &datasources.DataSource{
@@ -119,4 +122,10 @@ func DataSourceModel(kind NodeType) (*datasources.DataSource, error) {
 	default:
 		return nil, fmt.Errorf("cannot create expression data source for '%s' kind", kind)
 	}
+}
+
+// Deprecated. Use DataSourceModelFromNodeType instead
+func DataSourceModel() *datasources.DataSource {
+	d, _ := DataSourceModelFromNodeType(TypeCMDNode)
+	return d
 }

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -34,9 +34,13 @@ const DatasourceID = -100
 // should be used instead and should be set to "__expr__".
 const OldDatasourceUID = "-100"
 
-// IsDataSource checks if the uid points to an expression query
-func IsDataSource(uid string) bool {
-	return uid == DatasourceUID || uid == OldDatasourceUID
+// QueryKindByDatasourceUID returns NodeType depending on the UID of the data source: TypeCMDNode if UID is DatasourceUID
+// or OldDatasourceUID, and TypeDatasourceNode otherwise.
+func QueryKindByDatasourceUID(uid string) NodeType {
+	if uid == DatasourceUID || uid == OldDatasourceUID {
+		return TypeCMDNode
+	}
+	return TypeDatasourceNode
 }
 
 // Service is service representation for expression handling.

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -36,10 +36,15 @@ const DatasourceID = -100
 // should be used instead and should be set to "__expr__".
 const OldDatasourceUID = "-100"
 
-// QueryKindByDatasourceUID returns NodeType depending on the UID of the data source: TypeCMDNode if UID is DatasourceUID
+// IsDataSource checks if the uid points to an expression query
+func IsDataSource(uid string) bool {
+	return uid == DatasourceUID || uid == OldDatasourceUID
+}
+
+// NodeTypeFromDatasourceUID returns NodeType depending on the UID of the data source: TypeCMDNode if UID is DatasourceUID
 // or OldDatasourceUID, and TypeDatasourceNode otherwise.
-func QueryKindByDatasourceUID(uid string) NodeType {
-	if uid == DatasourceUID || uid == OldDatasourceUID {
+func NodeTypeFromDatasourceUID(uid string) NodeType {
+	if IsDataSource(uid) {
 		return TypeCMDNode
 	}
 	return TypeDatasourceNode

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -126,6 +126,6 @@ func (me *mockEndpoint) QueryData(ctx context.Context, req *backend.QueryDataReq
 }
 
 func dataSourceModel() *datasources.DataSource {
-	d, _ := DataSourceModel(TypeCMDNode)
+	d, _ := DataSourceModelFromNodeType(TypeCMDNode)
 	return d
 }

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -62,7 +62,7 @@ func TestService(t *testing.T) {
 		},
 		{
 			RefID:      "B",
-			DataSource: DataSourceModel(),
+			DataSource: dataSourceModel(),
 			JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "$A * 2" }`),
 		},
 	}
@@ -123,4 +123,9 @@ func (me *mockEndpoint) QueryData(ctx context.Context, req *backend.QueryDataReq
 		Frames: me.Frames,
 	}
 	return resp, nil
+}
+
+func dataSourceModel() *datasources.DataSource {
+	d, _ := DataSourceModel(TypeCMDNode)
+	return d
 }

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -269,7 +269,7 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 
 		ds, ok := datasources[q.DatasourceUID]
 		if !ok {
-			switch kind := expr.QueryKindByDatasourceUID(q.DatasourceUID); kind {
+			switch kind := expr.NodeTypeFromDatasourceUID(q.DatasourceUID); kind {
 			case expr.TypeCMDNode:
 				ds, err = expr.DataSourceModel(kind)
 			case expr.TypeDatasourceNode:
@@ -622,7 +622,7 @@ func (e *evaluatorImpl) Validate(ctx EvaluationContext, condition models.Conditi
 		return err
 	}
 	for _, query := range req.Queries {
-		if query.DataSource == nil || expr.QueryKindByDatasourceUID(query.DataSource.UID) != expr.TypeDatasourceNode {
+		if query.DataSource == nil || expr.NodeTypeFromDatasourceUID(query.DataSource.UID) != expr.TypeDatasourceNode {
 			continue
 		}
 		p, found := e.pluginsStore.Plugin(ctx.Ctx, query.DataSource.Type)

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -269,14 +269,14 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 
 		ds, ok := datasources[q.DatasourceUID]
 		if !ok {
-			switch expr.QueryKindByDatasourceUID(q.DatasourceUID) {
+			switch kind := expr.QueryKindByDatasourceUID(q.DatasourceUID); kind {
 			case expr.TypeCMDNode:
-				ds = expr.DataSourceModel()
+				ds, err = expr.DataSourceModel(kind)
 			case expr.TypeDatasourceNode:
 				ds, err = dsCacheService.GetDatasourceByUID(ctx.Ctx, q.DatasourceUID, ctx.User, false /*skipCache*/)
-				if err != nil {
-					return nil, fmt.Errorf("failed to build query '%s': %w", q.RefID, err)
-				}
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to build query '%s': %w", q.RefID, err)
 			}
 			datasources[q.DatasourceUID] = ds
 		}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -269,9 +269,9 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 
 		ds, ok := datasources[q.DatasourceUID]
 		if !ok {
-			switch kind := expr.NodeTypeFromDatasourceUID(q.DatasourceUID); kind {
+			switch nodeType := expr.NodeTypeFromDatasourceUID(q.DatasourceUID); nodeType {
 			case expr.TypeCMDNode:
-				ds, err = expr.DataSourceModel(kind)
+				ds, err = expr.DataSourceModelFromNodeType(nodeType)
 			case expr.TypeDatasourceNode:
 				ds, err = dsCacheService.GetDatasourceByUID(ctx.Ctx, q.DatasourceUID, ctx.User, false /*skipCache*/)
 			}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -269,9 +269,10 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 
 		ds, ok := datasources[q.DatasourceUID]
 		if !ok {
-			if expr.IsDataSource(q.DatasourceUID) {
+			switch expr.QueryKindByDatasourceUID(q.DatasourceUID) {
+			case expr.TypeCMDNode:
 				ds = expr.DataSourceModel()
-			} else {
+			case expr.TypeDatasourceNode:
 				ds, err = dsCacheService.GetDatasourceByUID(ctx.Ctx, q.DatasourceUID, ctx.User, false /*skipCache*/)
 				if err != nil {
 					return nil, fmt.Errorf("failed to build query '%s': %w", q.RefID, err)
@@ -621,7 +622,7 @@ func (e *evaluatorImpl) Validate(ctx EvaluationContext, condition models.Conditi
 		return err
 	}
 	for _, query := range req.Queries {
-		if query.DataSource == nil || expr.IsDataSource(query.DataSource.UID) {
+		if query.DataSource == nil || expr.QueryKindByDatasourceUID(query.DataSource.UID) != expr.TypeDatasourceNode {
 			continue
 		}
 		p, found := e.pluginsStore.Plugin(ctx.Ctx, query.DataSource.Type)

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -113,7 +113,7 @@ func (aq *AlertQuery) setModelProps() error {
 
 // IsExpression returns true if the alert query is an expression.
 func (aq *AlertQuery) IsExpression() (bool, error) {
-	return expr.QueryKindByDatasourceUID(aq.DatasourceUID) == expr.TypeCMDNode, nil
+	return expr.NodeTypeFromDatasourceUID(aq.DatasourceUID) == expr.TypeCMDNode, nil
 }
 
 // setMaxDatapoints sets the model maxDataPoints if it's missing or invalid

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -113,7 +113,7 @@ func (aq *AlertQuery) setModelProps() error {
 
 // IsExpression returns true if the alert query is an expression.
 func (aq *AlertQuery) IsExpression() (bool, error) {
-	return expr.IsDataSource(aq.DatasourceUID), nil
+	return expr.QueryKindByDatasourceUID(aq.DatasourceUID) == expr.TypeCMDNode, nil
 }
 
 // setMaxDatapoints sets the model maxDataPoints if it's missing or invalid

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -321,8 +321,8 @@ func (s *ServiceImpl) getDataSourceFromQuery(ctx context.Context, user *user.Sig
 		return ds, nil
 	}
 
-	if expr.QueryKindByDatasourceUID(uid) != expr.TypeDatasourceNode {
-		return expr.DataSourceModel(), nil
+	if kind := expr.QueryKindByDatasourceUID(uid); kind != expr.TypeDatasourceNode {
+		return expr.DataSourceModel(kind)
 	}
 
 	if uid == grafanads.DatasourceUID {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -269,7 +269,7 @@ func (s *ServiceImpl) parseMetricRequest(ctx context.Context, user *user.SignedI
 		}
 
 		datasourcesByUid[ds.UID] = ds
-		if expr.QueryKindByDatasourceUID(ds.UID) != expr.TypeDatasourceNode {
+		if expr.NodeTypeFromDatasourceUID(ds.UID) != expr.TypeDatasourceNode {
 			req.hasExpression = true
 		} else {
 			req.dsTypes[ds.Type] = true
@@ -321,7 +321,7 @@ func (s *ServiceImpl) getDataSourceFromQuery(ctx context.Context, user *user.Sig
 		return ds, nil
 	}
 
-	if kind := expr.QueryKindByDatasourceUID(uid); kind != expr.TypeDatasourceNode {
+	if kind := expr.NodeTypeFromDatasourceUID(uid); kind != expr.TypeDatasourceNode {
 		return expr.DataSourceModel(kind)
 	}
 

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -269,7 +269,7 @@ func (s *ServiceImpl) parseMetricRequest(ctx context.Context, user *user.SignedI
 		}
 
 		datasourcesByUid[ds.UID] = ds
-		if expr.IsDataSource(ds.UID) {
+		if expr.QueryKindByDatasourceUID(ds.UID) != expr.TypeDatasourceNode {
 			req.hasExpression = true
 		} else {
 			req.dsTypes[ds.Type] = true
@@ -321,7 +321,7 @@ func (s *ServiceImpl) getDataSourceFromQuery(ctx context.Context, user *user.Sig
 		return ds, nil
 	}
 
-	if expr.IsDataSource(uid) {
+	if expr.QueryKindByDatasourceUID(uid) != expr.TypeDatasourceNode {
 		return expr.DataSourceModel(), nil
 	}
 

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -322,7 +322,7 @@ func (s *ServiceImpl) getDataSourceFromQuery(ctx context.Context, user *user.Sig
 	}
 
 	if kind := expr.NodeTypeFromDatasourceUID(uid); kind != expr.TypeDatasourceNode {
-		return expr.DataSourceModel(kind)
+		return expr.DataSourceModelFromNodeType(kind)
 	}
 
 	if uid == grafanads.DatasourceUID {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR
- introduces `NodeTypeFromDatasourceUID(uid) NodeType` that will replace expr.IsDataSource(uid).
- adds `expr.DataSourceModelFromNodeType()` that returns a fake data source for struct for CMD command (and later for ML command). 
- marks function expr.IsDataSource as deprecated.

The usages of functions expr.IsDataSource and expr.DataSourceModel() are replaced with new functions.

**Why do we need this feature?**
This PR prepares `expr` package for the introduction of a new query type (NodeType). See https://github.com/grafana/grafana/pull/69963. This will make the introduction of new types in the future more straightforward and error-proof. 

**Who is this feature for?**
Developers

**Special notes for your reviewer:**
PR can be reviewed by commit

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
