### PR TITLE
[v9.4.x] Bug: Fix `build-frontend*` config checks (#70076)

### DIFF
--- a/pkg/build/cmd/buildfrontend.go
+++ b/pkg/build/cmd/buildfrontend.go
@@ -15,9 +15,8 @@ func BuildFrontend(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	version := metadata.GrafanaVersion
 
-	cfg, mode, err := frontend.GetConfig(c, version)
+	cfg, mode, err := frontend.GetConfig(c, metadata)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/cmd/buildfrontendpackages.go
+++ b/pkg/build/cmd/buildfrontendpackages.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"log"
-	"strings"
 
+	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/errutil"
 	"github.com/grafana/grafana/pkg/build/frontend"
 	"github.com/grafana/grafana/pkg/build/syncutil"
@@ -11,16 +11,12 @@ import (
 )
 
 func BuildFrontendPackages(c *cli.Context) error {
-	version := ""
-	if c.NArg() == 1 {
-		// Fixes scenario where an incompatible semver is provided to lerna, which will cause the step to fail.
-		// When there is an invalid semver, a frontend package won't be published anyways.
-		if strings.Count(version, ".") == 2 {
-			version = strings.TrimPrefix(c.Args().Get(0), "v")
-		}
+	metadata, err := config.GenerateMetadata(c)
+	if err != nil {
+		return err
 	}
 
-	cfg, mode, err := frontend.GetConfig(c, version)
+	cfg, mode, err := frontend.GetConfig(c, metadata)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/config/genmetadata.go
+++ b/pkg/build/config/genmetadata.go
@@ -94,7 +94,7 @@ func generateVersionFromBuildID() (string, error) {
 		return "", fmt.Errorf("unable to get DRONE_BUILD_NUMBER environmental variable")
 	}
 	var err error
-	version, err := GetGrafanaVersion(buildID, ".")
+	version, err := GenerateGrafanaVersion(buildID, ".")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/config/version.go
+++ b/pkg/build/config/version.go
@@ -71,8 +71,26 @@ func GetBuildConfig(mode VersionMode) (*BuildConfig, error) {
 	return nil, fmt.Errorf("mode '%s' not found in version list", mode)
 }
 
-// GetGrafanaVersion gets the Grafana version from the package.json
-func GetGrafanaVersion(buildID, grafanaDir string) (string, error) {
+// GenerateGrafanaVersion gets the Grafana version from the package.json
+func GenerateGrafanaVersion(buildID, grafanaDir string) (string, error) {
+	version, err := GetPackageJSONVersion(grafanaDir)
+	if err != nil {
+		return version, err
+	}
+	if buildID != "" {
+		buildID = shortenBuildID(buildID)
+		verComponents := strings.Split(version, "-")
+		version = verComponents[0]
+		if len(verComponents) > 1 {
+			buildID = fmt.Sprintf("%s%s", buildID, verComponents[1])
+		}
+		version = fmt.Sprintf("%s-%s", version, buildID)
+	}
+
+	return version, nil
+}
+
+func GetPackageJSONVersion(grafanaDir string) (string, error) {
 	pkgJSONPath := filepath.Join(grafanaDir, "package.json")
 	//nolint:gosec
 	pkgJSONB, err := os.ReadFile(pkgJSONPath)
@@ -88,16 +106,6 @@ func GetGrafanaVersion(buildID, grafanaDir string) (string, error) {
 	if version == "" {
 		return "", fmt.Errorf("failed to read version from %q", pkgJSONPath)
 	}
-	if buildID != "" {
-		buildID = shortenBuildID(buildID)
-		verComponents := strings.Split(version, "-")
-		version = verComponents[0]
-		if len(verComponents) > 1 {
-			buildID = fmt.Sprintf("%s%s", buildID, verComponents[1])
-		}
-		version = fmt.Sprintf("%s-%s", version, buildID)
-	}
-
 	return version, nil
 }
 

--- a/pkg/build/frontend/config_test.go
+++ b/pkg/build/frontend/config_test.go
@@ -3,9 +3,11 @@ package frontend
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
@@ -13,6 +15,7 @@ import (
 const (
 	jobs        = "jobs"
 	githubToken = "github-token"
+	buildID     = "build-id"
 )
 
 type packageJson struct {
@@ -26,41 +29,47 @@ func TestGetConfig(t *testing.T) {
 		ctx                *cli.Context
 		name               string
 		packageJsonVersion string
-		tagVersion         string
+		metadata           config.Metadata
 		wantErr            bool
 	}{
 		{
-			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, "", flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
 			name:               "package.json matches tag",
 			packageJsonVersion: "10.0.0",
-			tagVersion:         "10.0.0",
+			metadata:           config.Metadata{GrafanaVersion: "10.0.0", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},
 			wantErr:            false,
 		},
 		{
-			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, "", flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
 			name:               "package.json doesn't match tag",
 			packageJsonVersion: "10.1.0",
-			tagVersion:         "10.0.0",
+			metadata:           config.Metadata{GrafanaVersion: "10.0.0", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},
 			wantErr:            true,
 		},
 		{
-			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
-			name:               "non-tag event",
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, "", flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "test tag event, check should be skipped",
 			packageJsonVersion: "10.1.0",
-			tagVersion:         "",
+			metadata:           config.Metadata{GrafanaVersion: "10.1.0-test", ReleaseMode: config.ReleaseMode{Mode: config.TagMode, IsTest: true}},
+			wantErr:            false,
+		},
+		{
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, buildID, flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "non-tag event",
+			packageJsonVersion: "10.1.0-pre",
+			metadata:           config.Metadata{GrafanaVersion: "10.1.0-12345pre", ReleaseMode: config.ReleaseMode{Mode: config.PullRequestMode}},
 			wantErr:            false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var context cli.Context
 			err := createTempPackageJson(t, tt.packageJsonVersion)
 			require.NoError(t, err)
-			defer deleteTempPackageJson(t)
 
-			got, _, err := GetConfig(&context, tt.tagVersion)
+			got, _, err := GetConfig(tt.ctx, tt.metadata)
 			if !tt.wantErr {
-				require.Equal(t, got.PackageVersion, tt.packageJsonVersion)
+				fmt.Println(got.PackageVersion + " : " + tt.metadata.GrafanaVersion)
+				require.Equal(t, got.PackageVersion, tt.metadata.GrafanaVersion)
 			}
 
 			if tt.wantErr {
@@ -71,13 +80,16 @@ func TestGetConfig(t *testing.T) {
 	}
 }
 
-func setFlags(t *testing.T, flag1, flag2 string, flagSet *flag.FlagSet) *flag.FlagSet {
+func setFlags(t *testing.T, flag1, flag2, flag3 string, flagSet *flag.FlagSet) *flag.FlagSet {
 	t.Helper()
 	if flag1 != "" {
 		flagSet.StringVar(&flag1, jobs, "2", "")
 	}
 	if flag2 != "" {
 		flagSet.StringVar(&flag2, githubToken, "token", "")
+	}
+	if flag3 != "" {
+		flagSet.StringVar(&flag3, buildID, "12345", "")
 	}
 	return flagSet
 }
@@ -91,12 +103,9 @@ func createTempPackageJson(t *testing.T, version string) error {
 	err := os.WriteFile("package.json", file, 0644)
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		err := os.RemoveAll("package.json")
+		require.NoError(t, err)
+	})
 	return nil
-}
-
-func deleteTempPackageJson(t *testing.T) {
-	t.Helper()
-
-	err := os.RemoveAll("package.json")
-	require.NoError(t, err)
 }


### PR DESCRIPTION
* Fix frontend config checks

* Exclude test tag events

(cherry picked from commit 5a36fa5f8a345af4564a473cd9d2171afb08f581)

# Conflicts:
#	pkg/build/cmd/buildfrontendpackages.go

Backports: #70076