### PR TITLE
TextPanel: Fix <summary> styling missing the disclosure triangle

### DIFF
--- a/public/sass/base/_normalize.scss
+++ b/public/sass/base/_normalize.scss
@@ -40,8 +40,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 


### PR DESCRIPTION
Fixes styling of summary/details HTML tags where the the 'disclosure triangle' on the clickable summary was missing.

`<summary>` should be by default `display: list-item` (TIL!), where it will get that chevron. The (very old) normalize stylesheet was resetting it's display to block to support old browsers. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#customizing_the_disclosure_widget 

Fixes https://github.com/grafana/grafana/issues/69661