### PR TITLE
Core: Upgrade @grafana/tsconfig to `1.3.0-rc1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@grafana/eslint-config": "5.1.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/toolkit": "workspace:*",
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@react-types/button": "3.7.1",
     "@react-types/menu": "3.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,6 +3921,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/tsconfig@npm:^1.3.0-rc1":
+  version: 1.3.0-rc1
+  resolution: "@grafana/tsconfig@npm:1.3.0-rc1"
+  checksum: 3ed039967ae9e0c6ab70387b6aee648086aed00bf0c831ca4d82088cd829e15dac953387413e18941cc75958eec89e58c53ed1a6dedc02a34bbb794fa9658ea0
+  languageName: node
+  linkType: hard
+
 "@grafana/ui@10.1.0-pre, @grafana/ui@workspace:*, @grafana/ui@workspace:packages/grafana-ui":
   version: 0.0.0-use.local
   resolution: "@grafana/ui@workspace:packages/grafana-ui"
@@ -18594,7 +18601,7 @@ __metadata:
     "@grafana/scenes": ^0.15.0
     "@grafana/schema": "workspace:*"
     "@grafana/toolkit": "workspace:*"
-    "@grafana/tsconfig": ^1.2.0-rc1
+    "@grafana/tsconfig": ^1.3.0-rc1
     "@grafana/ui": "workspace:*"
     "@kusto/monaco-kusto": ^7.4.0
     "@leeoniya/ufuzzy": 1.0.6


### PR DESCRIPTION
**What is this feature?**

As described in https://github.com/grafana/tsconfig-grafana/pull/6 we need to include `es2022` in ts libs.