### PR TITLE
Chore: Skip Explore flaky test

### DIFF
--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -137,7 +137,8 @@ describe('Explore: Query History', () => {
     await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}']);
   });
 
-  it('updates the state in both Explore panes', async () => {
+  // FIXME: flaky test
+  it.skip('updates the state in both Explore panes', async () => {
     const urlParams = {
       left: serializeStateToUrlParam({
         datasource: 'loki',


### PR DESCRIPTION
the test in the diff seems to be flaky. i suspect this is because we expect queries in history to appear in a specific order but that may be nondeterministic.

i couldn't find a quick solution so i'm skipping the test for now until we find a proper one.