### PR TITLE
Log Context: Fix component height to fit revert-button

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -56,6 +56,7 @@ function getStyles(theme: GrafanaTheme2) {
       line-break: anywhere;
       margin-top: -${theme.spacing(0.25)};
       margin-right: ${theme.spacing(4)};
+      min-height: ${theme.spacing(4)};
     `,
     ui: css`
       background-color: ${theme.colors.background.secondary};


### PR DESCRIPTION
**What is this feature?**

The revert button's height was recently changed and it did not fit the component any more.

**Special notes for your reviewer:**

Now:
![image](https://github.com/grafana/grafana/assets/8092184/2127163b-8900-4ed1-9324-e6b1626a2a10)

Before:
![image](https://github.com/grafana/grafana/assets/8092184/e1a0832b-3a17-43d4-b7a6-d0072c93e2b9)
