### PR TITLE
Demonstrate docs/experimental shortcode

### DIFF
--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -12,12 +12,21 @@ headless: true
 
 # Create TraceQL queries using Search
 
-{{% admonition type="note" %}}
-This new Search query type is available as an experimental feature.
-This feature is under active development and is not production ready.
-To try this feature, enable the `traceqlSearch` feature flag in Grafana (read [documentation](/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/)).
-Grafana Cloud users have this feature.
-{{% /admonition %}}
+{{< docs/experimental.inline product="Search query type" featureFlag="traceqlSearch" >}}
+{{ $product := .Get "product" }}
+{{ $featureFlag := .Get "featureFlag" }}
+
+<div class="admonition admonition-note">
+<blockquote>
+    <p>
+    <strong>Note:</strong> {{ $product }} is available as an experimental feature.
+    This feature is under active development and is not production ready.
+    Enable the <code>{{ $featureFlag }}</code> feature flag in Grafana to use this feature.
+    Contact Grafana Support to enable this feature in Grafana Cloud.
+    </p>
+</blockquote>
+</div>
+{{< /docs/experimental.inline >}}
 
 Using the Search tab in Explore, you can use the query builder’s drop-downs to compose TraceQL queries. The selections you make automatically generate a [TraceQL query](/docs/tempo/latest/traceql).
 


### PR DESCRIPTION
This PR can be used to iterate on the shortcode whilst we understand the uses.

Once the implementation has been approved, the shortcode can be added to the website and documented. 

Reviewers should pay less attention to the patch which contains the shortcode implementation and more about the interface to defining experimental features in a consistent way.

- Would this shortcode suitably replace other adhoc mechanisms for referring to feature flags in your documentation?

You can view the output by running `make docs` and browsing to http://localhost:3002/docs/grafana/latest/datasources/tempo/query-editor/#create-traceql-queries-using-search.

The eventual implementation would mean that a writer could enter something like this:
`{{< experimental product="PRODUCT" featureFlag="FEATURE FLAG" >}}`
where you enter the name of the product and the feature flag.

And that would produce a block of text like this:

> **Note**: PRODUCT is available as an experimental feature. This feature is under active development and is not production ready.
> Enable the FEATURE FLAG in Grafana to use this feature. Contact Grafana Support to enable this feature in Grafana Cloud.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
