### PR TITLE
Elasticsearch: Update error message shown when testing the datasource

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
+++ b/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
@@ -75,7 +75,7 @@ export class LegacyQueryRunner {
             const message = err.data.error?.reason ?? err.data.message ?? 'Unknown error';
 
             return throwError({
-              message: 'Elasticsearch error: ' + message,
+              message,
               error: err.data.error,
             });
           }

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -505,7 +505,7 @@ describe('ElasticDatasource', () => {
 
       const errObject = {
         error: 'Bad Request',
-        message: 'Elasticsearch error: Authentication to data source failed',
+        message: 'Authentication to data source failed',
       };
 
       await expect(ds.query(query)).toEmitValuesWith((received) => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -426,7 +426,7 @@ export class ElasticDatasource
               message: 'No date field named ' + this.timeField + ' found',
             });
           }
-          return of({ status: 'success', message: `${versionMessage}Index OK. Time field name OK` });
+          return of({ status: 'success', message: `${versionMessage}Data source successfully connected.` });
         }),
         catchError((err) => {
           const infoInParentheses = err.message ? ` (${err.message})` : '';

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -429,12 +429,9 @@ export class ElasticDatasource
           return of({ status: 'success', message: `${versionMessage}Index OK. Time field name OK` });
         }),
         catchError((err) => {
-          console.error(err);
-          if (err.message) {
-            return of({ status: 'error', message: err.message });
-          } else {
-            return of({ status: 'error', message: err.status });
-          }
+          const infoInParentheses = err.message ? ` (${err.message})` : '';
+          const message = `Unable to connect with Elasticsearch${infoInParentheses}. Please check the server logs for more details.`;
+          return of({ status: 'error', message });
         })
       )
     );


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana/pull/66216, this PR updates the success and error messages shown in the data source configuration page, with the objective of making them easier to understand for users.

![success](https://github.com/grafana/grafana/assets/1069378/f692f275-5664-4319-b559-bd954c19e562)

![error](https://github.com/grafana/grafana/assets/1069378/6d9d2efe-0f60-4a29-8358-c912d97a7404)

The error message replicates the one we use in Loki: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/datasource.ts#L721

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

Go to the Elasticsearch configuration page, change things, save; the messages should be clear and easy to understand.