### PR TITLE
XYChart: Fix formatting of axis ticks (units, decimals)

### DIFF
--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -5,6 +5,7 @@ import {
   DataFrame,
   FieldColorModeId,
   fieldColorModeRegistry,
+  formattedValueToString,
   getDisplayProcessor,
   getFieldColorModeForField,
   getFieldDisplayName,
@@ -620,6 +621,7 @@ const prepConfig = (
       xAxisLabel == null || xAxisLabel === ''
         ? getFieldDisplayName(xField, scatterSeries[0].frame(frames), frames)
         : xAxisLabel,
+    formatValue: (v, decimals) => formattedValueToString(xField.display!(v, decimals)),
   });
 
   scatterSeries.forEach((s, si) => {
@@ -653,7 +655,7 @@ const prepConfig = (
           yAxisLabel == null || yAxisLabel === ''
             ? getFieldDisplayName(field, scatterSeries[si].frame(frames), frames)
             : yAxisLabel,
-        values: (u, splits) => splits.map((s) => field.display!(s).text),
+        formatValue: (v, decimals) => formattedValueToString(field.display!(v, decimals)),
       });
     }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64462
Fixes https://github.com/grafana/grafana/issues/64861

<details><summary>xy-percent-axis.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 717,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "pointSize": {
              "fixed": 10
            },
            "scaleDistribution": {
              "type": "linear"
            },
            "show": "points"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "growth%"
            },
            "properties": [
              {
                "id": "unit",
                "value": "percentunit"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 16,
        "w": 8,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "series": [],
        "seriesMapping": "auto",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "growth%,age\n-0.01,15\n0.04,25",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "xychart"
    }
  ],
  "refresh": "",
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "xy-percent-axis",
  "uid": "a547b69c-b607-4646-88fb-ddd972423c82",
  "version": 2,
  "weekStart": ""
}
```
</details>

before
![image](https://github.com/grafana/grafana/assets/43234/3198b07b-b0e7-470e-bc02-ca9bfbd3e3f1)

after
![image](https://github.com/grafana/grafana/assets/43234/1951a9cb-91dd-4045-bfc7-1e52965dd720)