### PR TITLE
XYChart: Fix variable interpolation in datalinks/toggletip

### DIFF
--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -187,7 +187,10 @@ export const getFieldLinksForExplore = (options: {
   return [];
 };
 
-function getTitleFromHref(href: string): string {
+/**
+ * @internal
+ */
+export function getTitleFromHref(href: string): string {
   // The URL constructor needs the url to have protocol
   if (href.indexOf('://') < 0) {
     // Doesn't really matter what protocol we use.

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -79,9 +79,7 @@ export const TimeSeriesPanel = ({
       options={options}
     >
       {(config, alignedDataFrame) => {
-        if (
-          alignedDataFrame.fields.filter((f) => f.config.links !== undefined && f.config.links.length > 0).length > 0
-        ) {
+        if (alignedDataFrame.fields.some((f) => Boolean(f.config.links?.length))) {
           alignedDataFrame = regenerateLinksSupplier(alignedDataFrame, frames, replaceVariables, timeZone);
         }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64464

mostly aped from the code below (this is copy-pasted in more than a few places in the codebase already):

https://github.com/grafana/grafana/blob/b963defa44ef264a88e3dd862b9e91d026102e5c/public/app/features/visualization/data-hover/DataHoverView.tsx#L63-L80

i pulled the bit of logic for falling back to domain link text from the explore datalink generator, as it was working before.