### PR TITLE
Codegen: Generate `any` instead of `interface{}`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ require (
 	github.com/grafana/dataplane/sdata v0.0.6
 	github.com/grafana/go-mssqldb v0.9.1
 	github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482
-	github.com/grafana/thema v0.0.0-20230601172625-e3eaca4d36bd
+	github.com/grafana/thema v0.0.0-20230615161902-b6e21996aef8
 	github.com/ory/fosite v0.44.1-0.20230317114349-45a6785cc54f
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/weaveworks/common v0.0.0-20230208133027-16871410fca4

--- a/go.sum
+++ b/go.sum
@@ -1396,6 +1396,8 @@ github.com/grafana/sqlds/v2 v2.3.10 h1:HWKhE0vR6LoEiE+Is8CSZOgaB//D1yqb2ntkass9F
 github.com/grafana/sqlds/v2 v2.3.10/go.mod h1:c6ibxnxRVGxV/0YkEgvy7QpQH/lyifFyV7K/14xvdIs=
 github.com/grafana/thema v0.0.0-20230601172625-e3eaca4d36bd h1:gK5LMNi8AUp8xcrOSNfbvE5g3dT46Qgy+/pCon1Z9jc=
 github.com/grafana/thema v0.0.0-20230601172625-e3eaca4d36bd/go.mod h1:KWAKeFXxQYiJ/kBVbijBLRVq9atxkfkeeFIvmj4clEA=
+github.com/grafana/thema v0.0.0-20230615161902-b6e21996aef8 h1:ESVwKjvGWVucGY65rJq0Hny3a6p8UYqEbClqXhP2qJk=
+github.com/grafana/thema v0.0.0-20230615161902-b6e21996aef8/go.mod h1:KWAKeFXxQYiJ/kBVbijBLRVq9atxkfkeeFIvmj4clEA=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6 h1:I9dh1MXGX0wGyxdV/Sl7+ugnki4Dfsy8lv2s5Yf887o=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6/go.mod h1:ZkJLEYLoVyg7amJK/5r779bHyzs2AU8f8VMiP6BM7uY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/kinds/accesspolicy/accesspolicy_metadata_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/accesspolicy/accesspolicy_status_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/dashboard/dashboard_metadata_gen.go
+++ b/pkg/kinds/dashboard/dashboard_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -293,13 +293,13 @@ type DataTransformerConfig struct {
 
 	// Options to be passed to the transformer
 	// Valid options depend on the transformer id
-	Options interface{} `json:"options"`
+	Options any `json:"options"`
 }
 
 // DynamicConfigValue defines model for DynamicConfigValue.
 type DynamicConfigValue struct {
-	Id    string       `json:"id"`
-	Value *interface{} `json:"value,omitempty"`
+	Id    string `json:"id"`
+	Value *any   `json:"value,omitempty"`
 }
 
 // Map a field to a color.
@@ -363,7 +363,7 @@ type FieldConfig struct {
 
 	// custom is specified by the FieldConfig field
 	// in panel plugin schemas.
-	Custom map[string]interface{} `json:"custom,omitempty"`
+	Custom map[string]any `json:"custom,omitempty"`
 
 	// Specify the number of decimals Grafana includes in the rendered value.
 	// If you leave this field blank, Grafana automatically truncates the number of decimals based on the value.
@@ -385,10 +385,10 @@ type FieldConfig struct {
 	Filterable *bool `json:"filterable,omitempty"`
 
 	// The behavior when clicking on a result
-	Links []interface{} `json:"links,omitempty"`
+	Links []any `json:"links,omitempty"`
 
 	// Convert input values into a display string
-	Mappings []interface{} `json:"mappings,omitempty"`
+	Mappings []any `json:"mappings,omitempty"`
 
 	// The maximum value used in percentage threshold calculations. Leave blank for auto calculation based on all series and fields.
 	Max *float32 `json:"max,omitempty"`
@@ -510,7 +510,7 @@ type MatcherConfig struct {
 	Id string `json:"id"`
 
 	// The matcher options. This is specific to the matcher implementation.
-	Options *interface{} `json:"options,omitempty"`
+	Options *any `json:"options,omitempty"`
 }
 
 // Dashboard panels are the basic visualization building blocks.
@@ -550,7 +550,7 @@ type Panel struct {
 	MaxDataPoints *float32 `json:"maxDataPoints,omitempty"`
 
 	// It depends on the panel plugin. They are specified by the Options field in panel plugin schemas.
-	Options map[string]interface{} `json:"options"`
+	Options map[string]any `json:"options"`
 
 	// The version of the plugin that is used for this panel. This is used to find the plugin to display the panel and to migrate old panel configs.
 	PluginVersion *string `json:"pluginVersion,omitempty"`
@@ -658,7 +658,7 @@ type RowPanel struct {
 	Id int `json:"id"`
 
 	// List of panels in the row
-	Panels []interface{} `json:"panels"`
+	Panels []any `json:"panels"`
 
 	// Name of template variable to repeat for.
 	Repeat *string `json:"repeat,omitempty"`
@@ -751,10 +751,10 @@ type Spec struct {
 	LiveNow *bool `json:"liveNow,omitempty"`
 
 	// List of dashboard panels
-	Panels []interface{} `json:"panels,omitempty"`
+	Panels []any `json:"panels,omitempty"`
 
 	// Refresh rate of dashboard. Represented via interval string, e.g. "5s", "1m", "1h", "1d".
-	Refresh *interface{} `json:"refresh,omitempty"`
+	Refresh *any `json:"refresh,omitempty"`
 
 	// This property should only be used in dashboards defined by plugins.  It is a quick check
 	// to see if the version has changed since the last time.
@@ -856,7 +856,7 @@ type SpecialValueMatch string
 // with types derived from plugins in the Instance variant.
 // When working directly from CUE, importers can extend this
 // type directly to achieve the same effect.
-type Target = map[string]interface{}
+type Target = map[string]any
 
 // User-defined value for a metric that triggers visual changes in a panel when this value is met or exceeded
 // They are used to conditionally style and color visualizations based on query results , and can be applied to most visualizations.
@@ -945,7 +945,7 @@ type VariableModel struct {
 	Options []VariableOption `json:"options,omitempty"`
 
 	// Query used to fetch values for a variable
-	Query *interface{} `json:"query,omitempty"`
+	Query *any `json:"query,omitempty"`
 
 	// Options to config when to refresh a variable
 	// `0`: Never refresh the variable
@@ -974,10 +974,10 @@ type VariableOption struct {
 	Selected *bool `json:"selected,omitempty"`
 
 	// Text to be displayed for the option
-	Text interface{} `json:"text"`
+	Text any `json:"text"`
 
 	// Value of the option
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // Options to config when to refresh a variable

--- a/pkg/kinds/dashboard/dashboard_status_gen.go
+++ b/pkg/kinds/dashboard/dashboard_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/folder/folder_metadata_gen.go
+++ b/pkg/kinds/folder/folder_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/folder/folder_status_gen.go
+++ b/pkg/kinds/folder/folder_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/librarypanel/librarypanel_metadata_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/librarypanel/librarypanel_spec_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_spec_gen.go
@@ -42,7 +42,7 @@ type Spec struct {
 
 	// TODO: should be the same panel schema defined in dashboard
 	// Typescript: Omit<Panel, 'gridPos' | 'id' | 'libraryPanel'>;
-	Model map[string]interface{} `json:"model"`
+	Model map[string]any `json:"model"`
 
 	// Panel name (also saved in the model)
 	Name string `json:"name"`

--- a/pkg/kinds/librarypanel/librarypanel_status_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/playlist/playlist_metadata_gen.go
+++ b/pkg/kinds/playlist/playlist_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/playlist/playlist_status_gen.go
+++ b/pkg/kinds/playlist/playlist_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/preferences/preferences_metadata_gen.go
+++ b/pkg/kinds/preferences/preferences_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/preferences/preferences_status_gen.go
+++ b/pkg/kinds/preferences/preferences_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/publicdashboard/publicdashboard_metadata_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/publicdashboard/publicdashboard_status_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/role/role_metadata_gen.go
+++ b/pkg/kinds/role/role_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/role/role_status_gen.go
+++ b/pkg/kinds/role/role_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/rolebinding/rolebinding_metadata_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/rolebinding/rolebinding_spec_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_spec_gen.go
@@ -67,6 +67,6 @@ type SubjectKind string
 // Spec defines model for Spec.
 type Spec struct {
 	// The role we are discussing
-	Role    interface{} `json:"role"`
-	Subject Subject     `json:"subject"`
+	Role    any     `json:"role"`
+	Subject Subject `json:"subject"`
 }

--- a/pkg/kinds/rolebinding/rolebinding_status_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/kinds/team/team_metadata_gen.go
+++ b/pkg/kinds/team/team_metadata_gen.go
@@ -20,13 +20,13 @@ type Metadata struct {
 	DeletionTimestamp *time.Time `json:"deletionTimestamp,omitempty"`
 
 	// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
-	ExtraFields     map[string]interface{} `json:"extraFields"`
-	Finalizers      []string               `json:"finalizers"`
-	Labels          map[string]string      `json:"labels"`
-	ResourceVersion string                 `json:"resourceVersion"`
-	Uid             string                 `json:"uid"`
-	UpdateTimestamp time.Time              `json:"updateTimestamp"`
-	UpdatedBy       string                 `json:"updatedBy"`
+	ExtraFields     map[string]any    `json:"extraFields"`
+	Finalizers      []string          `json:"finalizers"`
+	Labels          map[string]string `json:"labels"`
+	ResourceVersion string            `json:"resourceVersion"`
+	Uid             string            `json:"uid"`
+	UpdateTimestamp time.Time         `json:"updateTimestamp"`
+	UpdatedBy       string            `json:"updatedBy"`
 }
 
 // _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.

--- a/pkg/kinds/team/team_status_gen.go
+++ b/pkg/kinds/team/team_status_gen.go
@@ -29,7 +29,7 @@ type OperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`
@@ -46,7 +46,7 @@ type OperatorStateState string
 // Status defines model for Status.
 type Status struct {
 	// additionalFields is reserved for future use
-	AdditionalFields map[string]interface{} `json:"additionalFields,omitempty"`
+	AdditionalFields map[string]any `json:"additionalFields,omitempty"`
 
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
@@ -59,7 +59,7 @@ type StatusOperatorState struct {
 	DescriptiveState *string `json:"descriptiveState,omitempty"`
 
 	// details contains any extra information that is operator-specific
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
 
 	// lastEvaluation is the ResourceVersion last evaluated
 	LastEvaluation string `json:"lastEvaluation"`

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -415,7 +415,7 @@ type RoleRegistration struct {
 type Route struct {
 	// For data source plugins. Route headers set the body content and
 	// length to the proxied request.
-	Body map[string]interface{} `json:"body,omitempty"`
+	Body map[string]any `json:"body,omitempty"`
 
 	// For data source plugins. Route headers adds HTTP headers to the
 	// proxied request.

--- a/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/azuremonitor/kinds/dataquery/types_dataquery_gen.go
@@ -207,7 +207,7 @@ type AzureMetricQuery struct {
 }
 
 // AzureMonitorDataQuery defines model for AzureMonitorDataQuery.
-type AzureMonitorDataQuery = map[string]interface{}
+type AzureMonitorDataQuery = map[string]any
 
 // AzureMonitorQuery defines model for AzureMonitorQuery.
 type AzureMonitorQuery struct {
@@ -223,7 +223,7 @@ type AzureMonitorQuery struct {
 
 	// Application Insights Traces sub-query properties
 	AzureTraces               *AzureTracesQuery `json:"azureTraces,omitempty"`
-	GrafanaTemplateVariableFn *interface{}      `json:"grafanaTemplateVariableFn,omitempty"`
+	GrafanaTemplateVariableFn *any              `json:"grafanaTemplateVariableFn,omitempty"`
 	Namespace                 *string           `json:"namespace,omitempty"`
 
 	// Azure Monitor query type.
@@ -306,7 +306,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since

--- a/pkg/tsdb/cloud-monitoring/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/cloud-monitoring/kinds/dataquery/types_dataquery_gen.go
@@ -117,7 +117,7 @@ type CloudMonitoringQuery struct {
 	// GCM query type.
 	// queryType: #QueryType
 	// Time Series List sub-query properties.
-	TimeSeriesList *interface{} `json:"timeSeriesList,omitempty"`
+	TimeSeriesList *any `json:"timeSeriesList,omitempty"`
 
 	// Time Series sub-query properties.
 	TimeSeriesQuery *TimeSeriesQuery `json:"timeSeriesQuery,omitempty"`
@@ -131,7 +131,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -164,7 +164,7 @@ type Filter struct {
 }
 
 // GoogleCloudMonitoringDataQuery defines model for GoogleCloudMonitoringDataQuery.
-type GoogleCloudMonitoringDataQuery = map[string]interface{}
+type GoogleCloudMonitoringDataQuery = map[string]any
 
 // @deprecated Use AnnotationQuery instead. Legacy annotation query properties for migration purposes.
 type LegacyCloudMonitoringAnnotationQuery struct {

--- a/pkg/tsdb/cloudwatch/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/cloudwatch/kinds/dataquery/types_dataquery_gen.go
@@ -132,7 +132,7 @@ type CloudWatchAnnotationQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// A name/value pair that is part of the identity of a metric. For example, you can get statistics for a specific EC2 instance by specifying the InstanceId dimension when you search for metrics.
 	Dimensions *Dimensions `json:"dimensions,omitempty"`
@@ -178,7 +178,7 @@ type CloudWatchAnnotationQuery struct {
 }
 
 // CloudWatchDataQuery defines model for CloudWatchDataQuery.
-type CloudWatchDataQuery = map[string]interface{}
+type CloudWatchDataQuery = map[string]any
 
 // CloudWatchLogsQuery defines model for CloudWatchLogsQuery.
 type CloudWatchLogsQuery struct {
@@ -191,7 +191,7 @@ type CloudWatchLogsQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// The CloudWatch Logs Insights query to execute
 	Expression *string `json:"expression,omitempty"`
@@ -244,7 +244,7 @@ type CloudWatchMetricsQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// A name/value pair that is part of the identity of a metric. For example, you can get statistics for a specific EC2 instance by specifying the InstanceId dimension when you search for metrics.
 	Dimensions *Dimensions `json:"dimensions,omitempty"`
@@ -312,7 +312,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -330,7 +330,7 @@ type DataQuery struct {
 }
 
 // A name/value pair that is part of the identity of a metric. For example, you can get statistics for a specific EC2 instance by specifying the InstanceId dimension when you search for metrics.
-type Dimensions map[string]interface{}
+type Dimensions map[string]any
 
 // LogGroup defines model for LogGroup.
 type LogGroup struct {
@@ -385,7 +385,7 @@ type MetricStat struct {
 
 // QueryEditorArrayExpression defines model for QueryEditorArrayExpression.
 type QueryEditorArrayExpression struct {
-	Expressions []interface{}                  `json:"expressions"`
+	Expressions []any                          `json:"expressions"`
 	Type        QueryEditorArrayExpressionType `json:"type"`
 }
 
@@ -425,8 +425,8 @@ type QueryEditorGroupByExpressionType string
 
 // TS type is QueryEditorOperator<T extends QueryEditorOperatorValueType>, extended in veneer
 type QueryEditorOperator struct {
-	Name  *string      `json:"name,omitempty"`
-	Value *interface{} `json:"value,omitempty"`
+	Name  *string `json:"name,omitempty"`
+	Value *any    `json:"value,omitempty"`
 }
 
 // QueryEditorOperatorExpression defines model for QueryEditorOperatorExpression.
@@ -461,7 +461,7 @@ type QueryEditorPropertyType string
 // SQLExpression defines model for SQLExpression.
 type SQLExpression struct {
 	// FROM part of the SQL expression
-	From    *interface{}                `json:"from,omitempty"`
+	From    *any                        `json:"from,omitempty"`
 	GroupBy *QueryEditorArrayExpression `json:"groupBy,omitempty"`
 
 	// LIMIT part of the SQL expression

--- a/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
@@ -87,8 +87,8 @@ type Average struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Missing *string      `json:"missing,omitempty"`
-		Script  *interface{} `json:"script,omitempty"`
+		Missing *string `json:"missing,omitempty"`
+		Script  *any    `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -96,7 +96,7 @@ type Average struct {
 // BaseBucketAggregation defines model for BaseBucketAggregation.
 type BaseBucketAggregation struct {
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -138,7 +138,7 @@ type BucketScript struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Script *interface{} `json:"script,omitempty"`
+		Script *any `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -170,7 +170,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -191,7 +191,7 @@ type DataQuery struct {
 type DateHistogram struct {
 	BucketAggregationWithField
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -226,10 +226,10 @@ type ElasticsearchDataQuery struct {
 	Alias *string `json:"alias,omitempty"`
 
 	// List of bucket aggregations
-	BucketAggs []interface{} `json:"bucketAggs,omitempty"`
+	BucketAggs []any `json:"bucketAggs,omitempty"`
 
 	// List of metric aggregations
-	Metrics []interface{} `json:"metrics,omitempty"`
+	Metrics []any `json:"metrics,omitempty"`
 
 	// Lucene query
 	Query *string `json:"query,omitempty"`
@@ -251,13 +251,13 @@ type ExtendedStatMetaType string
 type ExtendedStats struct {
 	MetricAggregationWithField
 	MetricAggregationWithInlineScript
-	Hide     *bool                  `json:"hide,omitempty"`
-	Id       string                 `json:"id"`
-	Meta     map[string]interface{} `json:"meta,omitempty"`
+	Hide     *bool          `json:"hide,omitempty"`
+	Id       string         `json:"id"`
+	Meta     map[string]any `json:"meta,omitempty"`
 	Settings *struct {
-		Missing *string      `json:"missing,omitempty"`
-		Script  *interface{} `json:"script,omitempty"`
-		Sigma   *string      `json:"sigma,omitempty"`
+		Missing *string `json:"missing,omitempty"`
+		Script  *any    `json:"script,omitempty"`
+		Sigma   *string `json:"sigma,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -272,7 +272,7 @@ type Filter struct {
 type Filters struct {
 	BaseBucketAggregation
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -285,7 +285,7 @@ type FiltersSettings struct {
 type GeoHashGrid struct {
 	BucketAggregationWithField
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -298,7 +298,7 @@ type GeoHashGridSettings struct {
 type Histogram struct {
 	BucketAggregationWithField
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -326,8 +326,8 @@ type Max struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Missing *string      `json:"missing,omitempty"`
-		Script  *interface{} `json:"script,omitempty"`
+		Missing *string `json:"missing,omitempty"`
+		Script  *any    `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -345,7 +345,7 @@ type MetricAggregationWithField struct {
 type MetricAggregationWithInlineScript struct {
 	BaseMetricAggregation
 	Settings *struct {
-		Script *interface{} `json:"script,omitempty"`
+		Script *any `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 }
 
@@ -364,8 +364,8 @@ type Min struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Missing *string      `json:"missing,omitempty"`
-		Script  *interface{} `json:"script,omitempty"`
+		Missing *string `json:"missing,omitempty"`
+		Script  *any    `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -373,10 +373,10 @@ type Min struct {
 // MovingAverage defines model for MovingAverage.
 type MovingAverage struct {
 	BasePipelineMetricAggregation
-	Hide     *bool                  `json:"hide,omitempty"`
-	Id       string                 `json:"id"`
-	Settings map[string]interface{} `json:"settings,omitempty"`
-	Type     MetricAggregationType  `json:"type"`
+	Hide     *bool                 `json:"hide,omitempty"`
+	Id       string                `json:"id"`
+	Settings map[string]any        `json:"settings,omitempty"`
+	Type     MetricAggregationType `json:"type"`
 }
 
 // MovingAverageEWMAModelSettings defines model for MovingAverageEWMAModelSettings.
@@ -451,9 +451,9 @@ type MovingFunction struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Script *interface{} `json:"script,omitempty"`
-		Shift  *string      `json:"shift,omitempty"`
-		Window *string      `json:"window,omitempty"`
+		Script *any    `json:"script,omitempty"`
+		Shift  *string `json:"shift,omitempty"`
+		Window *string `json:"window,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -462,7 +462,7 @@ type MovingFunction struct {
 type Nested struct {
 	BucketAggregationWithField
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 
@@ -473,9 +473,9 @@ type Percentiles struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Missing  *string      `json:"missing,omitempty"`
-		Percents []string     `json:"percents,omitempty"`
-		Script   *interface{} `json:"script,omitempty"`
+		Missing  *string  `json:"missing,omitempty"`
+		Percents []string `json:"percents,omitempty"`
+		Script   *any     `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -547,8 +547,8 @@ type Sum struct {
 	Hide     *bool  `json:"hide,omitempty"`
 	Id       string `json:"id"`
 	Settings *struct {
-		Missing *string      `json:"missing,omitempty"`
-		Script  *interface{} `json:"script,omitempty"`
+		Missing *string `json:"missing,omitempty"`
+		Script  *any    `json:"script,omitempty"`
 	} `json:"settings,omitempty"`
 	Type MetricAggregationType `json:"type"`
 }
@@ -557,7 +557,7 @@ type Sum struct {
 type Terms struct {
 	BucketAggregationWithField
 	Id       string                `json:"id"`
-	Settings *interface{}          `json:"settings,omitempty"`
+	Settings *any                  `json:"settings,omitempty"`
 	Type     BucketAggregationType `json:"type"`
 }
 

--- a/pkg/tsdb/grafana-pyroscope-datasource/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/kinds/dataquery/types_dataquery_gen.go
@@ -24,7 +24,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -52,7 +52,7 @@ type GrafanaPyroscopeDataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Allows to group the results.
 	GroupBy []string `json:"groupBy"`

--- a/pkg/tsdb/loki/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/loki/kinds/dataquery/types_dataquery_gen.go
@@ -43,7 +43,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -71,7 +71,7 @@ type LokiDataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{}     `json:"datasource,omitempty"`
+	Datasource *any             `json:"datasource,omitempty"`
 	EditorMode *QueryEditorMode `json:"editorMode,omitempty"`
 
 	// The LogQL query.

--- a/pkg/tsdb/parca/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/parca/kinds/dataquery/types_dataquery_gen.go
@@ -24,7 +24,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -52,7 +52,7 @@ type ParcaDataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since

--- a/pkg/tsdb/prometheus/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/prometheus/kinds/dataquery/types_dataquery_gen.go
@@ -30,7 +30,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -61,7 +61,7 @@ type PrometheusDataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{}     `json:"datasource,omitempty"`
+	Datasource *any             `json:"datasource,omitempty"`
 	EditorMode *QueryEditorMode `json:"editorMode,omitempty"`
 
 	// Execute an additional query to identify interesting raw samples relevant for the given expr

--- a/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
@@ -35,7 +35,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -53,7 +53,7 @@ type DataQuery struct {
 }
 
 // TempoDataQuery defines model for TempoDataQuery.
-type TempoDataQuery = map[string]interface{}
+type TempoDataQuery = map[string]any
 
 // TempoQuery defines model for TempoQuery.
 type TempoQuery struct {
@@ -66,7 +66,7 @@ type TempoQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{}    `json:"datasource,omitempty"`
+	Datasource *any            `json:"datasource,omitempty"`
 	Filters    []TraceqlFilter `json:"filters"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
@@ -126,7 +126,7 @@ type TraceqlFilter struct {
 	Tag *string `json:"tag,omitempty"`
 
 	// The value for the search filter
-	Value *interface{} `json:"value,omitempty"`
+	Value *any `json:"value,omitempty"`
 
 	// The type of the value, used for example to check whether we need to wrap the value in quotes when generating the query
 	ValueType *string `json:"valueType,omitempty"`

--- a/pkg/tsdb/testdatasource/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/testdatasource/kinds/dataquery/types_dataquery_gen.go
@@ -79,7 +79,7 @@ type DataQuery struct {
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
 	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource *interface{} `json:"datasource,omitempty"`
+	Datasource *any `json:"datasource,omitempty"`
 
 	// Hide true if query is disabled (ie should not be returned to the dashboard)
 	// Note this does not always imply that the query should not be executed since
@@ -125,7 +125,7 @@ type Scenario struct {
 
 // SimulationQuery defines model for SimulationQuery.
 type SimulationQuery struct {
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
 	Key    struct {
 		Tick float64 `json:"tick"`
 		Type string  `json:"type"`
@@ -164,7 +164,7 @@ type TestDataDataQuery struct {
 	LevelColumn     *bool              `json:"levelColumn,omitempty"`
 	Lines           *int64             `json:"lines,omitempty"`
 	Nodes           *NodesQuery        `json:"nodes,omitempty"`
-	Points          [][]interface{}    `json:"points,omitempty"`
+	Points          [][]any            `json:"points,omitempty"`
 	PulseWave       *PulseWaveQuery    `json:"pulseWave,omitempty"`
 	RawFrameContent *string            `json:"rawFrameContent,omitempty"`
 	ScenarioId      *TestDataQueryType `json:"scenarioId,omitempty"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

A follow-up to https://github.com/grafana/thema/pull/175 that replaces `interface{}` with `any` in all the generated Go code.
This PR updates Thema to the latest version and regenerates the files. 

Fixes https://github.com/grafana/thema/issues/138
