### PR TITLE
Alerting: Fix newlines in text/plain template

### DIFF
--- a/emails/templates/ng_alert_notification.txt
+++ b/emails/templates/ng_alert_notification.txt
@@ -7,7 +7,7 @@ You have [[ len .Alerts.Firing ]] firing alert(s), and [[ len .Alerts.Resolved ]
 [[ template "__default_alerts_summarize" .Alerts.Firing ]]
 [[- end ]]
 
-[[ if .Alerts.Resolved -]]
+[[- if .Alerts.Resolved ]]
 ([[ len .Alerts.Resolved ]]) RESOLVED
 -------------
 [[ template "__default_alerts_summarize" .Alerts.Resolved ]]
@@ -51,12 +51,12 @@ Annotations: [[ template "__default_sorted_pairs" $annotations ]]
 
 [[- define "__default_sorted_pairs" -]]
 [[ range .SortedPairs ]]
-    [[ .Name ]] = [[ .Value ]]
+ - [[ .Name ]] = [[ .Value ]]
 [[- end ]]
 [[- end -]]
 
 [[- if .Message -]]
     [[ .Message ]]
-[[ else -]]
+[[- else -]]
     [[ template "__default_message" . ]]
 [[- end ]]

--- a/public/emails/ng_alert_notification.txt
+++ b/public/emails/ng_alert_notification.txt
@@ -7,7 +7,7 @@ You have {{ len .Alerts.Firing }} firing alert(s), and {{ len .Alerts.Resolved }
 {{ template "__default_alerts_summarize" .Alerts.Firing }}
 {{- end }}
 
-{{ if .Alerts.Resolved -}}
+{{- if .Alerts.Resolved }}
 ({{ len .Alerts.Resolved }}) RESOLVED
 -------------
 {{ template "__default_alerts_summarize" .Alerts.Resolved }}
@@ -51,13 +51,13 @@ Annotations: {{ template "__default_sorted_pairs" $annotations }}
 
 {{- define "__default_sorted_pairs" -}}
 {{ range .SortedPairs }}
-    {{ .Name }} = {{ .Value }}
+ - {{ .Name }} = {{ .Value }}
 {{- end }}
 {{- end -}}
 
 {{- if .Message -}}
     {{ .Message }}
-{{ else -}}
+{{- else -}}
     {{ template "__default_message" . }}
 {{- end }}
 


### PR DESCRIPTION
**What is this feature?**

**Before this change**

```
You have 1 firing alert(s), and 0 resolved alert(s) for grafana_folder=Test Folder

(1) FIRING
-----------

Labels: 
    alertname = Test 1
    bar = baz
    foo = bar
    grafana_folder = Test Folder
Summary: This is a summary
Description: This is a description
Runbook: https://grafana.com/runbooks/test
Annotations: 
    Something else = This is something else



Go to the Alerts page: http://127.0.0.1:3000/alerting/list?alertState=firing&amp;view=state


Sent by Grafana v10.1.0-pre (c) 2023 Grafana Labs
```

**With this change**

```
You have 1 firing alert(s), and 0 resolved alert(s) for grafana_folder=Test Folder

(1) FIRING
-----------

Labels: 
 - alertname = Test 1
 - bar = baz
 - foo = bar
 - grafana_folder = Test Folder
Summary: This is a summary
Description: This is a description
Runbook: https://grafana.com/runbooks/test
Annotations: 
 - Something else = This is something else

Go to the Alerts page: http://127.0.0.1:3000/alerting/list?alertState=firing&amp;view=state


Sent by Grafana v10.1.0-pre (c) 2023 Grafana Labs
```

```
You have 2 firing alert(s), and 0 resolved alert(s) for grafana_folder=Test Folder

(2) FIRING
-----------

Labels: 
 - alertname = Test 1
 - bar = baz
 - foo = bar
 - grafana_folder = Test Folder
Summary: This is a summary
Description: This is a description
Runbook: https://grafana.com/runbooks/test
Annotations: 
 - Something else = This is something else

Labels: 
 - alertname = Test 2
 - bar = baz
 - foo = bar
 - grafana_folder = Test Folder
Annotations: 
 - Something else = This is something else

Go to the Alerts page: http://127.0.0.1:3000/alerting/list?alertState=firing&amp;view=state


Sent by Grafana v10.1.0-pre (c) 2023 Grafana Labs
```

```
You have 1 firing alert(s), and 1 resolved alert(s) for grafana_folder=Test Folder

(1) FIRING
-----------

Labels: 
 - alertname = Test 1
 - bar = baz
 - foo = bar
 - grafana_folder = Test Folder
Summary: This is a summary
Description: This is a description
Runbook: https://grafana.com/runbooks/test
Annotations: 
 - Something else = This is something else

(1) RESOLVED
-------------

Labels: 
 - alertname = Test 2
 - bar = baz
 - foo = bar
 - grafana_folder = Test Folder
Annotations: 
 - Something else = This is something else
 - grafana_state_reason = Updated

Go to the Alerts page: http://127.0.0.1:3000/alerting/list?alertState=firing&amp;view=state


Sent by Grafana v10.1.0-pre (c) 2023 Grafana Labs
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
