### PR TITLE
CI: Remove no-changelog flag from backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
-          labelsToAdd: "backport,no-changelog"
+          labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
This finalizes https://github.com/grafana/grafana-github-actions/pull/148
