### PR TITLE
XYChart: Prevent crash on point hover

### DIFF
--- a/public/app/plugins/panel/xychart/TooltipView.tsx
+++ b/public/app/plugins/panel/xychart/TooltipView.tsx
@@ -82,8 +82,8 @@ export const TooltipView = ({
   let yValue: YValue | null = null;
   let extraFacets: ExtraFacets | null = null;
   if (seriesMapping === SeriesMapping.Manual && manualSeriesConfigs) {
-    const colorFacetFieldName = manualSeriesConfigs[hoveredPointIndex].pointColor?.field ?? '';
-    const sizeFacetFieldName = manualSeriesConfigs[hoveredPointIndex].pointSize?.field ?? '';
+    const colorFacetFieldName = manualSeriesConfigs[hoveredPointIndex]?.pointColor?.field ?? '';
+    const sizeFacetFieldName = manualSeriesConfigs[hoveredPointIndex]?.pointSize?.field ?? '';
 
     const colorFacet = colorFacetFieldName ? findField(frame, colorFacetFieldName) : undefined;
     const sizeFacet = sizeFacetFieldName ? findField(frame, sizeFacetFieldName) : undefined;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/70223

Simply check to see if the manualSeriesConfigs has an object at the hoveredPointIndex fixes the issue.