### PR TITLE
Datasource Service: Add `getSync` method to get datasource instances in a sync way

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2992,7 +2992,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/features/plugins/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -17,6 +17,13 @@ export interface DataSourceSrv {
   get(ref?: DataSourceRef | string | null, scopedVars?: ScopedVars): Promise<DataSourceApi>;
 
   /**
+   * Returns the requested dataSource in a sync way if it was loaded already. If it cannot be found it returns null.
+   * @param ref - The datasource identifier, typically an object with UID and type,
+   * @param scopedVars - variables used to interpolate a templated passed as name.
+   */
+  getSync(ref?: DataSourceRef | string | null, scopedVars?: ScopedVars): DataSourceApi | null;
+
+  /**
    * Get a list of data sources
    */
   getList(filters?: GetDataSourceListFilters): DataSourceInstanceSettings[];

--- a/public/app/features/alerting/getAlertingValidationMessage.test.ts
+++ b/public/app/features/alerting/getAlertingValidationMessage.test.ts
@@ -32,6 +32,9 @@ describe('getAlertingValidationMessage', () => {
         get: (ref: DataSourceRef) => {
           return getMock(ref.uid);
         },
+        getSync: (ref: DataSourceRef) => {
+          return getMock(ref.uid);
+        },
         getList(): DataSourceInstanceSettings[] {
           return [];
         },
@@ -75,6 +78,13 @@ describe('getAlertingValidationMessage', () => {
 
           return Promise.resolve(alertingDatasource);
         },
+        getSync: (name: string) => {
+          if (name === datasource.name) {
+            return datasource;
+          }
+
+          return alertingDatasource;
+        },
         getInstanceSettings: jest.fn(),
         getList(): DataSourceInstanceSettings[] {
           return [];
@@ -105,6 +115,9 @@ describe('getAlertingValidationMessage', () => {
       const getMock = jest.fn().mockResolvedValue(datasource);
       const datasourceSrv: DataSourceSrv = {
         get: (ref: DataSourceRef) => {
+          return getMock(ref.uid);
+        },
+        getSync: (ref: DataSourceRef) => {
           return getMock(ref.uid);
         },
         getInstanceSettings: jest.fn(),
@@ -142,6 +155,9 @@ describe('getAlertingValidationMessage', () => {
         get: (ref: DataSourceRef) => {
           return getMock(ref.uid);
         },
+        getSync: (ref: DataSourceRef) => {
+          return getMock(ref.uid);
+        },
         getInstanceSettings: jest.fn(),
         getList(): DataSourceInstanceSettings[] {
           return [];
@@ -174,6 +190,9 @@ describe('getAlertingValidationMessage', () => {
       const getMock = jest.fn().mockResolvedValue(datasource);
       const datasourceSrv: DataSourceSrv = {
         get: (ref: DataSourceRef) => {
+          return getMock(ref.uid);
+        },
+        getSync: (ref: DataSourceRef) => {
           return getMock(ref.uid);
         },
         getInstanceSettings: jest.fn(),

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -343,6 +343,11 @@ export class MockDataSourceSrv implements DataSourceSrv {
     //return Promise.reject(new Error('not implemented'));
   }
 
+  getSync(name?: string | null | DataSourceRef, scopedVars?: ScopedVars): DataSourceApi | null {
+    return DatasourceSrv.prototype.getSync.call(this, name, scopedVars);
+    //return Promise.reject(new Error('not implemented'));
+  }
+
   /**
    * Get a list of data sources
    */

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -232,6 +232,7 @@ describe('DashboardPage', () => {
     beforeEach(() => {
       setDataSourceSrv({
         get: jest.fn().mockResolvedValue({ getRef: jest.fn(), query: jest.fn().mockResolvedValue([]) }),
+        getSync: jest.fn().mockReturnValue({ getRef: jest.fn(), query: jest.fn().mockResolvedValue([]) }),
         getInstanceSettings: jest.fn().mockReturnValue({ meta: {} }),
         getList: jest.fn(),
         reload: jest.fn(),

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -102,6 +102,24 @@ export function setupExplore(options?: SetupOptions): {
 
       return Promise.reject();
     },
+    getSync(datasource?: string | DataSourceRef | null): DataSourceApi | null {
+      let ds: DataSourceApi | undefined;
+      if (!datasource) {
+        ds = dsSettings[0]?.api;
+      } else {
+        ds = dsSettings.find((ds) =>
+          typeof datasource === 'string'
+            ? ds.api.name === datasource || ds.api.uid === datasource
+            : ds.api.uid === datasource?.uid
+        )?.api;
+      }
+
+      if (ds) {
+        return ds;
+      }
+
+      return null;
+    },
     reload() {},
   });
 

--- a/public/app/features/variables/state/initVariableTransaction.test.ts
+++ b/public/app/features/variables/state/initVariableTransaction.test.ts
@@ -50,6 +50,7 @@ function getTestContext(variables?: VariableModel[]) {
   const getInstanceSettingsMock = jest.fn().mockReturnValue(undefined);
   setDataSourceSrv({
     get: jest.fn().mockResolvedValue({}),
+    getSync: jest.fn().mockReturnValue({}),
     getList: jest.fn().mockReturnValue([]),
     getInstanceSettings: getInstanceSettingsMock,
     reload: jest.fn(),

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
@@ -73,6 +73,28 @@ export function setupForLogs() {
 
       return ds;
     },
+    getSync() {
+      const ds: DataSourceApi = {
+        name: 'Xray',
+        id: 0,
+        type: '',
+        uid: '',
+        query: function (
+          request: DataQueryRequest<DataQuery>
+        ): Observable<DataQueryResponse> | Promise<DataQueryResponse> {
+          throw new Error('Function not implemented.');
+        },
+        testDatasource: function (): Promise<TestDataSourceResponse> {
+          throw new Error('Function not implemented.');
+        },
+        meta: meta,
+        getRef: function (): DataSourceRef {
+          throw new Error('Function not implemented.');
+        },
+      };
+
+      return ds;
+    },
     getList: function (
       filters?: GetDataSourceListFilters | undefined
     ): Array<DataSourceInstanceSettings<DataSourceJsonData>> {

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
@@ -15,6 +15,7 @@ describe('DerivedField', () => {
   beforeEach(() => {
     setDataSourceSrv({
       get: jest.fn(),
+      getSync: jest.fn(),
       reload: jest.fn(),
       getInstanceSettings: jest.fn(),
       getList: mockList.mockImplementation(() => [

--- a/public/test/mocks/datasource_srv.ts
+++ b/public/test/mocks/datasource_srv.ts
@@ -27,6 +27,18 @@ export class DatasourceSrvMock {
     }
     return Promise.reject(`Unknown Datasource: ${JSON.stringify(ref)}`);
   }
+
+  getSync(ref?: DataSourceRef | string): DataSourceApi | null {
+    if (!ref) {
+      return this.defaultDS;
+    }
+    const uid = getDataSourceUID(ref) ?? '';
+    const ds = this.datasources[uid];
+    if (ds) {
+      return ds;
+    }
+    return null;
+  }
 }
 
 export class MockDataSourceApi extends DataSourceApi {


### PR DESCRIPTION
**What is this feature?**

This PR adds a `getSync(ref?: DataSourceRef | string | null, scopedVars?: ScopedVars): DataSourceApi | null;`  method that would not return a datasource instance wrapped in a Promise but in a sync way. If the datasource is not found, it returns null. This can be discussed if throwing an error would be better.

**Why do we need this feature?**

I recently came across this when trying to make certain Logs Panel features (e.g. show context) work with mixed datasources: https://github.com/grafana/grafana/pull/70220. With mixed datasources you need to get the datasource instance for each log line. With the current API that requires to await each of the calls.
Resolving datasourceRefs into an instance from the logs panel in Explore should not really be async as the datasource should be loaded already. Thus I think it would make sense to have a sync way of resolving `DatasourceRef` into their instances.

