### PR TITLE
`package.json`: Fix `what's new` URL in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "betterer:issues": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/generateBettererIssues.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-2/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v10-0/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "lint-staged": {


### PR DESCRIPTION
**What is this feature?**

Fixes `whatsNewUrl` in `package.json` to point to G10.