### PR TITLE
GitHub Apps: Replace `grafanabot` token with `grafana-delivery-bot` GitHub App

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,10 +17,16 @@ jobs:
           ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+          id: generate_token
+          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+          with:
+            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run backport
         uses: ./actions/backport
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{ steps.generate_token.outputs.token }}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -68,8 +68,14 @@ jobs:
           node-version: '16'
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-          metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
+          metricsWriteAPIKey: "grafana-delivery-bot:${{ steps.generate_token.outputs.token }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -66,11 +66,6 @@ jobs:
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-      - name: Check if token exists
-        id: check-if-token-exists
-        if: ${{ steps.generate_token.outputs.token != '' }}
-        run: |
-          echo "token present"
       - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -6,12 +6,12 @@ on:
         description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. example: 7.4.3, 7.4.3-preview or 7.4.3-preview1'
         required: true
 env:
-    YARN_ENABLE_IMMUTABLE_INSTALLS: false
+  YARN_ENABLE_IMMUTABLE_INSTALLS: false
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    # This is a basic workflow to help you get started with Actions
+      # This is a basic workflow to help you get started with Actions
       - uses: actions-ecosystem/action-regex-match@v2.0.2
         if: ${{ github.event.inputs.version != '' }}
         id: regex-match
@@ -66,6 +66,11 @@ jobs:
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: Check if token exists
+        id: check-if-token-exists
+        if: ${{ steps.generate_token.outputs.token != '' }}
+        run: |
+          echo "token present"
       - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -69,5 +69,5 @@ jobs:
       - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:
-          token: "grafana-delivery-bot:${{ steps.generate_token.outputs.token }}"
+          token: ${{ steps.generate_token.outputs.token }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -49,14 +49,6 @@ jobs:
           echo "branch_name=v${{steps.regex-match.outputs.group1}}" >> $GITHUB_OUTPUT
           echo "branch_exist=$(git ls-remote --heads https://github.com/grafana/grafana.git v${{ steps.regex-match.outputs.group1 }}.x | wc -l)" >> $GITHUB_OUTPUT
 
-      - name: Check input version is aligned with branch(main)
-        if: ${{ github.event.inputs.version != '' && steps.intermedia.outputs.branch_exist == '0' && !contains(github.event.inputs.version, 'pre') && !contains(steps.intermedia.outputs.short_ref, 'main') }}
-        run: |
-          echo "When you want to deliver a new new minor version, you might want to create a new branch first \
-          with naming convention v[major].[minor].x, and just run the workflow on that branch. \
-          Run the workflow on main only when needed"
-          exit 1
-
       - name: Checkout Actions
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -77,5 +77,5 @@ jobs:
       - name: Run bump version (manually invoked)
         uses: ./actions/bump-version
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-          metricsWriteAPIKey: "grafana-delivery-bot:${{ steps.generate_token.outputs.token }}"
+          token: "grafana-delivery-bot:${{ steps.generate_token.outputs.token }}"
+          metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}

--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -26,11 +26,17 @@ jobs:
           ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+          id: generate_token
+          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+          with:
+            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Close milestone (manually invoked)
         if: ${{ github.event.inputs.version != '' }}
         uses: ./actions/close-milestone
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Close milestone (workflow invoked)
         if: ${{ inputs.version_call != '' }}
         uses: ./actions/close-milestone

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        required: true        
+        required: true
         description: Needs to match, exactly, the name of a milestone (NO v prefix)
 jobs:
   main:
@@ -14,11 +14,17 @@ jobs:
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions
-          ref: main    
+          ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+          id: generate_token
+          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+          with:
+            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run github release action
         uses: ./actions/github-release
         with:
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{ steps.generate_token.outputs.token }}
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -7,15 +7,27 @@ on:
         required: true
 jobs:
   call-remove-milestone:
-    uses: grafana/grafana/.github/workflows/remove-milestone.yml@main
-    with:
-      version_call: ${{ github.event.inputs.version_input }}
-    secrets:
-      token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+    - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+    - uses: grafana/grafana/.github/workflows/remove-milestone.yml@main
+      with:
+        version_call: ${{ github.event.inputs.version_input }}
+      secrets:
+        token: ${{ steps.generate_token.outputs.token }}
   call-close-milestone:
-    uses: grafana/grafana/.github/workflows/close-milestone.yml@main
-    with:
-      version_call: ${{ github.event.inputs.version_input }}
-    secrets:
-      token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-    needs: call-remove-milestone
+    - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+    - uses: grafana/grafana/.github/workflows/close-milestone.yml@main
+      with:
+        version_call: ${{ github.event.inputs.version_input }}
+      secrets:
+        token: ${{ steps.generate_token.outputs.token }}
+      needs: call-remove-milestone

--- a/.github/workflows/remove-milestone.yml
+++ b/.github/workflows/remove-milestone.yml
@@ -26,11 +26,17 @@ jobs:
           ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+          id: generate_token
+          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+          with:
+            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Remove milestone from open issues (manually invoked)
         if: ${{ github.event.inputs.version != '' }}
         uses: ./actions/remove-milestone
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Remove milestone from open issues (workflow invoked)
         if: ${{ inputs.version_call != '' }}
         uses: ./actions/remove-milestone

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,10 +15,16 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run update changelog (manually invoked)
         uses: grafana/grafana-github-actions-go/update-changelog@main
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           version: ${{ inputs.version }}
           metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
           community_api_key: ${{ secrets.GRAFANABOT_FORUM_KEY }}


### PR DESCRIPTION
**What is this feature?**

Replacing `grafnabot` token with `grafana-delivery-bot` GitHub App, for delivery related GitHub Actions.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-delivery/issues/180
