### PR TITLE
Elasticsearch: Enable logs samples for metric queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -92,7 +92,6 @@ const QueryEditorForm = ({ value }: Props) => {
   const nextId = useNextId();
   const styles = useStyles2(getStyles);
 
-  // To be considered a time series query, the last bucked aggregation must be a Date Histogram
   const isTimeSeries = isTimeSeriesQuery(value);
 
   const showBucketAggregationsEditor = value.metrics?.every(

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -9,7 +9,7 @@ import { ElasticDatasource } from '../../datasource';
 import { useNextId } from '../../hooks/useNextId';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 import { ElasticsearchOptions, ElasticsearchQuery } from '../../types';
-import { isSupportedVersion, unsupportedVersionMessage } from '../../utils';
+import { isSupportedVersion, isTimeSeriesQuery, unsupportedVersionMessage } from '../../utils';
 
 import { BucketAggregationsEditor } from './BucketAggregationsEditor';
 import { ElasticsearchProvider } from './ElasticsearchQueryContext';
@@ -93,7 +93,7 @@ const QueryEditorForm = ({ value }: Props) => {
   const styles = useStyles2(getStyles);
 
   // To be considered a time series query, the last bucked aggregation must be a Date Histogram
-  const isTimeSeriesQuery = value?.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
+  const isTimeSeries = isTimeSeriesQuery(value);
 
   const showBucketAggregationsEditor = value.metrics?.every(
     (metric) => metricAggregationConfig[metric.type].impliedQueryType === 'metrics'
@@ -111,7 +111,7 @@ const QueryEditorForm = ({ value }: Props) => {
         <InlineLabel width={17}>Lucene Query</InlineLabel>
         <ElasticSearchQueryField onChange={(query) => dispatch(changeQuery(query))} value={value?.query} />
 
-        {isTimeSeriesQuery && (
+        {isTimeSeries && (
           <InlineField
             label="Alias"
             labelWidth={15}

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1029,7 +1029,7 @@ describe('ElasticDatasource', () => {
       expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
     });
 
-    it('does create a logs sample provider for date_histogram query', () => {
+    it('does create a logs sample provider for time series query', () => {
       const options = getQueryOptions<ElasticsearchQuery>({
         targets: [
           {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -979,7 +979,7 @@ describe('ElasticDatasource', () => {
       });
     });
 
-    it('does not return logs samples for non date_histogram queries', () => {
+    it('does not return logs samples for non time series queries', () => {
       expect(
         ds.getSupplementaryQuery(
           { type: SupplementaryQueryType.LogsSample, limit: 100 },

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1049,7 +1049,7 @@ describe('ElasticDatasource', () => {
       ds = getTestContext().ds;
     });
 
-    it("doesn't return a logs sample provider given a log query", () => {
+    it("doesn't return a logs sample provider given a non time series query", () => {
       const request = getQueryOptions<ElasticsearchQuery>({
         targets: [
           {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1016,7 +1016,7 @@ describe('ElasticDatasource', () => {
       ds = getTestContext().ds;
     });
 
-    it('does not create a logs sample provider for logs query', () => {
+    it('does not create a logs sample provider for non time series query', () => {
       const options = getQueryOptions<ElasticsearchQuery>({
         targets: [
           {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1062,7 +1062,7 @@ describe('ElasticDatasource', () => {
       expect(ds.getLogsSampleDataProvider(request)).not.toBeDefined();
     });
 
-    it('returns a logs sample provider given a date_histogram query', () => {
+    it('returns a logs sample provider given a time series query', () => {
       const request = getQueryOptions<ElasticsearchQuery>({
         targets: [
           {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -992,7 +992,7 @@ describe('ElasticDatasource', () => {
       ).toEqual(undefined);
     });
 
-    it('returns logs samples for data_histogram queries', () => {
+    it('returns logs samples for time series queries', () => {
       expect(
         ds.getSupplementaryQuery(
           { type: SupplementaryQueryType.LogsSample, limit: 100 },

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1,5 +1,6 @@
 import { map } from 'lodash';
 import { Observable, of, throwError } from 'rxjs';
+import { getQueryOptions } from 'test/helpers/getQueryOptions';
 
 import {
   CoreApp,
@@ -1006,6 +1007,72 @@ describe('ElasticDatasource', () => {
         query: '',
         metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
       });
+    });
+  });
+
+  describe('getDataProvider', () => {
+    let ds: ElasticDatasource;
+    beforeEach(() => {
+      ds = getTestContext().ds;
+    });
+
+    it('does not create a logs sample provider for logs query', () => {
+      const options = getQueryOptions<ElasticsearchQuery>({
+        targets: [
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
+          },
+        ],
+      });
+
+      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
+    });
+
+    it('does create a logs sample provider for date_histogram query', () => {
+      const options = getQueryOptions<ElasticsearchQuery>({
+        targets: [
+          {
+            refId: 'A',
+            bucketAggs: [{ type: 'date_histogram', id: '1' }],
+          },
+        ],
+      });
+
+      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
+    });
+  });
+
+  describe('getLogsSampleDataProvider', () => {
+    let ds: ElasticDatasource;
+    beforeEach(() => {
+      ds = getTestContext().ds;
+    });
+
+    it("doesn't return a logs sample provider given a log query", () => {
+      const request = getQueryOptions<ElasticsearchQuery>({
+        targets: [
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
+          },
+        ],
+      });
+
+      expect(ds.getLogsSampleDataProvider(request)).not.toBeDefined();
+    });
+
+    it('returns a logs sample provider given a date_histogram query', () => {
+      const request = getQueryOptions<ElasticsearchQuery>({
+        targets: [
+          {
+            refId: 'A',
+            bucketAggs: [{ type: 'date_histogram', id: '1' }],
+          },
+        ],
+      });
+
+      expect(ds.getLogsSampleDataProvider(request)).toBeDefined();
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -978,27 +978,27 @@ describe('ElasticDatasource', () => {
       });
     });
 
-    it('does not return logs samples for log query', () => {
+    it('does not return logs samples for non date_histogram queries', () => {
       expect(
         ds.getSupplementaryQuery(
           { type: SupplementaryQueryType.LogsSample },
           {
             refId: 'A',
-            metrics: [{ type: 'logs', id: '1' }],
+            bucketAggs: [{ type: 'filters', id: '1' }],
             query: '',
           }
         )
       ).toEqual(undefined);
     });
 
-    it('returns logs samples for metric queries', () => {
+    it('returns logs samples for data_histogram queries', () => {
       expect(
         ds.getSupplementaryQuery(
           { type: SupplementaryQueryType.LogsSample },
           {
             refId: 'A',
-            metrics: [{ type: 'count', id: '1' }],
             query: '',
+            bucketAggs: [{ type: 'date_histogram', id: '1' }],
           }
         )
       ).toEqual({

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -981,7 +981,7 @@ describe('ElasticDatasource', () => {
     it('does not return logs samples for non date_histogram queries', () => {
       expect(
         ds.getSupplementaryQuery(
-          { type: SupplementaryQueryType.LogsSample },
+          { type: SupplementaryQueryType.LogsSample, limit: 100 },
           {
             refId: 'A',
             bucketAggs: [{ type: 'filters', id: '1' }],
@@ -994,7 +994,7 @@ describe('ElasticDatasource', () => {
     it('returns logs samples for data_histogram queries', () => {
       expect(
         ds.getSupplementaryQuery(
-          { type: SupplementaryQueryType.LogsSample },
+          { type: SupplementaryQueryType.LogsSample, limit: 100 },
           {
             refId: 'A',
             query: '',
@@ -1004,7 +1004,7 @@ describe('ElasticDatasource', () => {
       ).toEqual({
         refId: `log-sample-A`,
         query: '',
-        metrics: [{ type: 'logs', id: '1' }],
+        metrics: [{ type: 'logs', id: '1', settings: { limit: '100' } }],
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -977,6 +977,36 @@ describe('ElasticDatasource', () => {
         timeField: '',
       });
     });
+
+    it('does not return logs samples for log query', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsSample },
+          {
+            refId: 'A',
+            metrics: [{ type: 'logs', id: '1' }],
+            query: '',
+          }
+        )
+      ).toEqual(undefined);
+    });
+
+    it('returns logs samples for metric queries', () => {
+      expect(
+        ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsSample },
+          {
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            query: '',
+          }
+        )
+      ).toEqual({
+        refId: `log-sample-A`,
+        query: '',
+        metrics: [{ type: 'logs', id: '1' }],
+      });
+    });
   });
 });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -599,10 +599,7 @@ export class ElasticDatasource
 
       case SupplementaryQueryType.LogsSample:
         isQuerySuitable = !!(
-          query.metrics?.length === 1 &&
-          query.metrics[0].type !== 'logs' &&
-          query.metrics[0].type !== 'raw_data' &&
-          query.metrics[0].type !== 'raw_document'
+          query.bucketAggs?.length === 1 && query.bucketAggs.some((bucket) => bucket.type === 'date_histogram')
         );
 
         if (!isQuerySuitable) {

--- a/public/app/plugins/datasource/elasticsearch/utils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.test.ts
@@ -1,4 +1,5 @@
-import { removeEmpty } from './utils';
+import { ElasticsearchQuery } from './types';
+import { isTimeSeriesQuery, removeEmpty } from './utils';
 
 describe('removeEmpty', () => {
   it('Should remove all empty', () => {
@@ -32,5 +33,49 @@ describe('removeEmpty', () => {
     };
 
     expect(removeEmpty(original)).toStrictEqual(expectedResult);
+  });
+});
+
+describe('isTimeSeriesQuery', () => {
+  it('should return false when given a log query', () => {
+    const logsQuery: ElasticsearchQuery = {
+      refId: `A`,
+      metrics: [{ type: 'logs', id: '1' }],
+    };
+
+    expect(isTimeSeriesQuery(logsQuery)).toBe(false);
+  });
+
+  it('should return false when bucket aggs are empty', () => {
+    const query: ElasticsearchQuery = {
+      refId: `A`,
+      bucketAggs: [],
+    };
+
+    expect(isTimeSeriesQuery(query)).toBe(false);
+  });
+
+  it('returns false when empty date_histogram is not last', () => {
+    const query: ElasticsearchQuery = {
+      refId: `A`,
+      bucketAggs: [
+        { id: '1', type: 'date_histogram' },
+        { id: '2', type: 'terms' },
+      ],
+    };
+
+    expect(isTimeSeriesQuery(query)).toBe(false);
+  });
+
+  it('returns true when empty date_histogram is last', () => {
+    const query: ElasticsearchQuery = {
+      refId: `A`,
+      bucketAggs: [
+        { id: '1', type: 'terms' },
+        { id: '2', type: 'date_histogram' },
+      ],
+    };
+
+    expect(isTimeSeriesQuery(query)).toBe(true);
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -102,6 +102,7 @@ export const isSupportedVersion = (version: SemVer): boolean => {
 export const unsupportedVersionMessage =
   'Support for Elasticsearch versions after their end-of-life (currently versions < 7.16) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results.';
 
+// To be considered a time series query, the last bucked aggregation must be a Date Histogram
 export const isTimeSeriesQuery = (query: ElasticsearchQuery): boolean => {
   return query?.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
 };

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -2,7 +2,7 @@ import { gte, SemVer } from 'semver';
 
 import { isMetricAggregationWithField } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
-import { MetricAggregation, MetricAggregationWithInlineScript } from './types';
+import { ElasticsearchQuery, MetricAggregation, MetricAggregationWithInlineScript } from './types';
 
 export const describeMetric = (metric: MetricAggregation) => {
   if (!isMetricAggregationWithField(metric)) {
@@ -101,3 +101,7 @@ export const isSupportedVersion = (version: SemVer): boolean => {
 
 export const unsupportedVersionMessage =
   'Support for Elasticsearch versions after their end-of-life (currently versions < 7.16) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results.';
+
+export const isTimeSeriesQuery = (query: ElasticsearchQuery): boolean => {
+  return query?.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
+};


### PR DESCRIPTION
**What is this feature?**

this enables log samples for elasticsearch metric queries

**Which issue(s) does this PR fix?**:

Fixes #62212

**Special notes for your reviewer:**

https://github.com/grafana/grafana/assets/34524710/27f15647-b2b5-42e8-8009-0d1ceb525b04

