### PR TITLE
Alerting: Limit alerts regardless of having active filters

### DIFF
--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -67,13 +67,12 @@ const RuleList = withErrorBoundary(
     );
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
-    const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
       }
-    }, [loading, limitAlerts, dispatch]);
+    }, [loading, dispatch]);
 
     useEffect(() => {
       trackRuleListNavigation().catch(() => {});
@@ -81,8 +80,8 @@ const RuleList = withErrorBoundary(
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
-    }, [dispatch, limitAlerts]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
+    }, [dispatch]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -26,7 +26,7 @@ export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfi
 
       // if we're fetching for Grafana managed rules, we should add a limit to the number of alert instances
       // we do this because the response is large otherwise and we don't show all of them in the UI anyway.
-      if (dataSourceName === GRAFANA_RULES_SOURCE_NAME && limitAlerts) {
+      if (dataSourceName === GRAFANA_RULES_SOURCE_NAME) {
         searchParams.set('limit_alerts', String(limitAlerts));
       }
 


### PR DESCRIPTION
**What is this feature?**

Keeps the rules limit even when there are filters applied to the list. 

**Why do we need this feature?**

For some of our largest customers a search on fields that aren't alerts will end up downloading 100MB of JSON instead of just a couple MBs instead using `?limit_alerts=16`.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/70257

**Special notes for your reviewer:**

![2023-06-16 13 52 43](https://github.com/grafana/grafana/assets/6271380/8fe6e9d9-df2e-4c31-9f46-cac245c00619)

