### PR TITLE
Feat: Match allowed cookies with optional (star) character

### DIFF
--- a/pkg/services/datasources/models_test.go
+++ b/pkg/services/datasources/models_test.go
@@ -1,0 +1,60 @@
+package datasources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+func TestAllowedCookies(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		given map[string]interface{}
+		want  []string
+	}{
+		{
+			desc: "Usual json data with keepCookies",
+			given: map[string]interface{}{
+				"keepCookies": []string{"cookie2"},
+			},
+			want: []string{"cookie2"},
+		},
+		{
+			desc: "Usual json data without kepCookies",
+			given: map[string]interface{}{
+				"something": "somethingelse",
+			},
+			want: []string(nil),
+		},
+		{
+			desc: "Usual json data that has multiple values in keepCookies ",
+			given: map[string]interface{}{
+				"keepCookies": []string{"cookie1", "cookie2", "special*"},
+			},
+			want: []string{"cookie1", "cookie2", "special*"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			jsonDataBytes, err := json.Marshal(&test.given)
+			require.NoError(t, err)
+			jsonData, err := simplejson.NewJson(jsonDataBytes)
+			require.NoError(t, err)
+
+			ds := DataSource{
+				ID:       1235,
+				JsonData: jsonData,
+				UID:      "test",
+			}
+
+			actual := ds.AllowedCookies()
+			assert.Equal(t, test.want, actual)
+			assert.EqualValues(t, test.want, actual)
+		})
+	}
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/contexthandler"

--- a/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/plugins/manager/client/clienttest"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCookiesMiddleware(t *testing.T) {

--- a/pkg/tests/api/influxdb/influxdb_test.go
+++ b/pkg/tests/api/influxdb/influxdb_test.go
@@ -87,7 +87,7 @@ func TestIntegrationInflux(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -93,10 +93,7 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *
 		}
 	}()
 
-	if res.StatusCode/100 != 2 {
-		return getHealthCheckMessage(logger, "", fmt.Errorf("error reading InfluxDB. Status Code: %d", res.StatusCode))
-	}
-	resp := s.responseParser.Parse(res.Body, []Query{{
+	resp := s.responseParser.Parse(res.Body, res.StatusCode, []Query{{
 		RefID:       refID,
 		UseRawQuery: true,
 		RawQuery:    queryString,

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -142,11 +142,8 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			logger.Warn("Failed to close response body", "err", err)
 		}
 	}()
-	if res.StatusCode/100 != 2 {
-		return &backend.QueryDataResponse{}, fmt.Errorf("InfluxDB returned error status: %s", res.Status)
-	}
 
-	resp := s.responseParser.Parse(res.Body, queries)
+	resp := s.responseParser.Parse(res.Body, res.StatusCode, queries)
 
 	return resp, nil
 }

--- a/pkg/tsdb/influxdb/response_parser_bench_test.go
+++ b/pkg/tsdb/influxdb/response_parser_bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkParseJson(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		buf := strings.NewReader(testResponse)
-		result := parser.parse(buf, queries)
+		result := parser.parse(buf, 200, queries)
 		require.NotNil(b, result.Responses["A"].Frames)
 		require.NoError(b, result.Responses["A"].Error)
 	}

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -36,7 +36,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 
 		query := &Query{}
 
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		require.Nil(t, result.Responses["A"].Frames)
 		require.Error(t, result.Responses["A"].Error)
@@ -118,7 +118,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		boolFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
 
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		frame := result.Responses["A"]
 		if diff := cmp.Diff(floatFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -164,7 +164,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			newField,
 		)
 
-		result := parser.Parse(prepare(response), queries)
+		result := parser.Parse(prepare(response), 200, queries)
 
 		frame := result.Responses["metricFindQuery"]
 		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -203,7 +203,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			newField,
 		)
 
-		result := parser.Parse(prepare(response), queries)
+		result := parser.Parse(prepare(response), 200, queries)
 
 		frame := result.Responses["metricFindQuery"]
 		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -232,7 +232,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		queryB := &Query{}
 		queryB.RefID = "B"
 		queries = append(queries, *queryB)
-		result := parser.Parse(prepare(response), queries)
+		result := parser.Parse(prepare(response), 200, queries)
 
 		assert.Len(t, result.Responses, 2)
 		assert.Contains(t, result.Responses, "A")
@@ -265,7 +265,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 
 		query := &Query{}
 		query.RawQuery = "Test raw query"
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		frame := result.Responses["A"]
 		assert.Equal(t, frame.Frames[0].Meta.ExecutedQueryString, "Test raw query")
@@ -311,7 +311,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
 
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		frame := result.Responses["A"]
 		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -359,7 +359,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
 
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		frame := result.Responses["A"]
 		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -410,7 +410,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			newField,
 		)
 		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 		t.Run("should parse aliases", func(t *testing.T) {
 			frame := result.Responses["A"]
 			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -418,7 +418,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $m $measurement", Measurement: "10m"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 			frame = result.Responses["A"]
 			name := "alias 10m 10m"
@@ -429,7 +429,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $col", Measurement: "10m"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias mean"
 			testFrame.Name = name
@@ -449,7 +449,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $tag_datacenter"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias America"
 			testFrame.Name = name
@@ -463,7 +463,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $tag_datacenter/$tag_datacenter"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias America/America"
 			testFrame.Name = name
@@ -477,7 +477,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[col]]", Measurement: "10m"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias mean"
 			testFrame.Name = name
@@ -487,7 +487,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $0 $1 $2 $3 $4"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias cpu upc $2 $3 $4"
 			testFrame.Name = name
@@ -497,7 +497,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $0, $1 - $2 - $3, $4: something"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias cpu, upc - $2 - $3, $4: something"
 			testFrame.Name = name
@@ -507,7 +507,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $1"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias upc"
 			testFrame.Name = name
@@ -517,7 +517,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias $5"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias $5"
 			testFrame.Name = name
@@ -527,7 +527,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "series alias"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "series alias"
 			testFrame.Name = name
@@ -537,7 +537,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[m]] [[measurement]]", Measurement: "10m"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias 10m 10m"
 			testFrame.Name = name
@@ -547,7 +547,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[tag_datacenter]]"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias America"
 			testFrame.Name = name
@@ -557,7 +557,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[tag_dc.region.name]]"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Northeast"
 			testFrame.Name = name
@@ -567,7 +567,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[tag_cluster-name]]"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Cluster"
 			testFrame.Name = name
@@ -577,7 +577,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[tag_/cluster/name/]]"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Cluster/"
 			testFrame.Name = name
@@ -587,7 +587,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias [[tag_@cluster@name@]]"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Cluster@"
 			testFrame.Name = name
@@ -598,7 +598,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		})
 		t.Run("shouldn't parse aliases", func(t *testing.T) {
 			query = &Query{Alias: "alias words with no brackets"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame := result.Responses["A"]
 			name := "alias words with no brackets"
 			testFrame.Name = name
@@ -608,7 +608,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias Test 1.5"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Test 1.5"
 			testFrame.Name = name
@@ -618,7 +618,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			}
 
 			query = &Query{Alias: "alias Test -1"}
-			result = parser.Parse(prepare(response), addQueryToQueries(*query))
+			result = parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 			frame = result.Responses["A"]
 			name = "alias Test -1"
 			testFrame.Name = name
@@ -677,7 +677,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			newField,
 		)
 		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
-		result := parser.Parse(prepare(response), queries)
+		result := parser.Parse(prepare(response), 200, queries)
 
 		frame := result.Responses["A"]
 		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -698,7 +698,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 
 		query := &Query{}
 
-		result := parser.Parse(prepare(response), addQueryToQueries(*query))
+		result := parser.Parse(prepare(response), 200, addQueryToQueries(*query))
 
 		require.Nil(t, result.Responses["A"].Frames)
 
@@ -797,7 +797,7 @@ func TestResponseParser_Parse_RetentionPolicy(t *testing.T) {
 			}),
 		)
 
-		result := parser.Parse(prepare(response), queries)
+		result := parser.Parse(prepare(response), 200, queries)
 
 		frame := result.Responses["metricFindQuery"]
 		if diff := cmp.Diff(policyFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -870,7 +870,7 @@ func TestResponseParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &ResponseParser{}
-			got := parser.Parse(prepare(tt.input), addQueryToQueries(Query{}))
+			got := parser.Parse(prepare(tt.input), 200, addQueryToQueries(Query{}))
 			require.NotNil(t, got)
 			if tt.f != nil {
 				tt.f(t, got)

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -46,8 +46,22 @@ func ClearCookieHeader(req *http.Request, keepCookiesNames []string, skipCookies
 	keepCookies := map[string]*http.Cookie{}
 	for _, c := range req.Cookies() {
 		for _, v := range keepCookiesNames {
-			if c.Name == v {
+			// match all
+			if v == "*" {
 				keepCookies[c.Name] = c
+				continue
+			}
+
+			l := len(v) - 1
+			if v[l] == '*' {
+				if len(c.Name) >= l && c.Name[:l] == v[:l] {
+					keepCookies[c.Name] = c
+				}
+			} else {
+				// look for exact match
+				if c.Name == v {
+					keepCookies[c.Name] = c
+				}
 			}
 		}
 	}

--- a/pkg/util/proxyutil/proxyutil_test.go
+++ b/pkg/util/proxyutil/proxyutil_test.go
@@ -110,6 +110,62 @@ func TestClearCookieHeader(t *testing.T) {
 		require.Contains(t, req.Header, "Cookie")
 		require.Equal(t, "cookie1=", req.Header.Get("Cookie"))
 	})
+
+	t.Run("Clear cookie header with cookies to keep should clear Cookie header and keep cookies with optional matching", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "cookie1"})
+		req.AddCookie(&http.Cookie{Name: "cookie3"})
+
+		ClearCookieHeader(req, []string{"cookie*"}, nil)
+		require.Contains(t, req.Header, "Cookie")
+		require.Equal(t, "cookie1=; cookie3=", req.Header.Get("Cookie"))
+	})
+
+	t.Run("Clear cookie header with cookies to keep should clear Cookie header and keep cookies with matching pattern but with empty matching option", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "cookie1"})
+		req.AddCookie(&http.Cookie{Name: "cookie2"})
+		req.AddCookie(&http.Cookie{Name: "cookie3"})
+
+		ClearCookieHeader(req, []string{"cookie*"}, []string{"cookie2"})
+		require.Contains(t, req.Header, "Cookie")
+		require.Equal(t, "cookie1=; cookie3=", req.Header.Get("Cookie"))
+	})
+
+	t.Run("Clear cookie header with cookie match pattern to keep and skip should clear Cookie header and keep cookies", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "cook1"})
+		req.AddCookie(&http.Cookie{Name: "special23"})
+		req.AddCookie(&http.Cookie{Name: "special_1asd987dsf9a"})
+		req.AddCookie(&http.Cookie{Name: "c00k1e"})
+
+		ClearCookieHeader(req, []string{"special_*"}, nil)
+		require.Contains(t, req.Header, "Cookie")
+		require.Equal(t, "special_1asd987dsf9a=", req.Header.Get("Cookie"))
+	})
+
+	t.Run("Clear cookie header with cookie should not match BAD pattern and return no cookies", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "cookie1"})
+		req.AddCookie(&http.Cookie{Name: "special23"})
+
+		ClearCookieHeader(req, []string{"*cookie"}, nil)
+		require.NotContains(t, req.Header, "Cookie")
+	})
+
+	t.Run("Clear cookie header with cookie should match all cookies when keepCookies is *", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "cookie1"})
+		req.AddCookie(&http.Cookie{Name: "special23"})
+
+		ClearCookieHeader(req, []string{"*"}, nil)
+		require.Equal(t, "cookie1=; special23=", req.Header.Get("Cookie"))
+	})
 }
 
 func TestApplyUserHeader(t *testing.T) {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -311,9 +311,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
     if (query.tags) {
       expandedQuery.tags = query.tags.map((tag) => {
+        let val = tag.value;
+        val = this.templateSrv.replace(val, scopedVars);
+        if (tag.operator !== '>' && tag.operator !== '<') {
+          val = val.replace(/\\/g, '\\\\').replace(/\'/g, "\\'");
+        }
+
         return {
           ...tag,
-          value: this.templateSrv.replace(tag.value, scopedVars, 'regex'),
+          value: val,
         };
       });
     }


### PR DESCRIPTION
**What is this feature?**

This adds a new option for "Allowed Cookies". Allowed cookies can be determined via their name or an optional part. 
This optional part will be matched with `*`. If the last character of the allowed cookie name ends with `*` we match all cookies that start with the given string.

Example:
Allowed Cookie: `cookie*`
Matched Cookies: `cookie1, cookie2, cookie__special, cookieeeeee`

More details are here: https://github.com/grafana/observability-metrics-squad/issues/124

**Why do we need this feature?**

To have an easier matcher for allowed cookies.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/observability-metrics-squad/issues/124
Fixes https://github.com/grafana/observability-metrics-squad/issues/102

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
