### PR TITLE
K8s: set summary metadata in k8s metadata

### DIFF
--- a/pkg/kinds/general.go
+++ b/pkg/kinds/general.go
@@ -1,7 +1,6 @@
 package kinds
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -151,35 +150,25 @@ func (m *GrafanaResourceMetadata) SetDescription(v string) {
 }
 
 func (m *GrafanaResourceMetadata) GetTags() []string {
-	var tags []string
 	v, ok := m.Annotations[annoKeyTags]
 	if ok {
-		err := json.Unmarshal([]byte(v), &tags)
-		if err != nil && len(v) > 0 {
-			return strings.Split(v, ",")
+		tags := strings.Split(v, ",")
+		for i := range tags {
+			tags[i] = strings.TrimSpace(tags[i])
 		}
+		return tags
 	}
-	return tags
+	return []string{}
 }
 
+// SetTags will set the tags annotation.  NOTE: any commas in the tags will get replaced with a dash
 func (m *GrafanaResourceMetadata) SetTags(tags []string) {
 	str := ""
 	if len(tags) > 0 {
-		hasComma := false
-		for _, t := range tags {
-			if strings.Contains(t, ",") {
-				hasComma = true
-				break
-			}
+		for i := range tags {
+			tags[i] = strings.ReplaceAll(strings.TrimSpace(tags[i]), ",", "-")
 		}
-		if hasComma {
-			out, err := json.Marshal(tags)
-			if err == nil {
-				str = string(out)
-			}
-		} else {
-			str = strings.Join(tags, ",")
-		}
+		str = strings.Join(tags, ",")
 	}
 	m.set(annoKeyTags, str)
 }

--- a/pkg/kinds/general.go
+++ b/pkg/kinds/general.go
@@ -66,10 +66,10 @@ const annoKeyFolder = "grafana.com/folder"
 const annoKeySlug = "grafana.com/slug"
 
 // Identify where values came from
-const annoKeyOriginName = "grafana.com/origin/name"
-const annoKeyOriginPath = "grafana.com/origin/path"
-const annoKeyOriginKey = "grafana.com/origin/key"
-const annoKeyOriginTime = "grafana.com/origin/time"
+const annoKeyOriginName = "grafana.com/origin.name"
+const annoKeyOriginPath = "grafana.com/origin.path"
+const annoKeyOriginKey = "grafana.com/origin.key"
+const annoKeyOriginTime = "grafana.com/origin.time"
 
 func (m *GrafanaResourceMetadata) set(key string, val string) {
 	if val == "" {

--- a/pkg/kinds/general_test.go
+++ b/pkg/kinds/general_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTagMetadata(t *testing.T) {
-	tags := []string{"a", "b", "c"}
+	tags := []string{"a", "b", "c,d"}
 	m := GrafanaResourceMetadata{Name: "hello"}
 	m.SetTags(tags)
 	m.SetTitle("A title here")
@@ -17,12 +17,12 @@ func TestTagMetadata(t *testing.T) {
 		"name": "hello",
 		"creationTimestamp": null,
 		"annotations": {
-		  "grafana.com/tags": "a,b,c",
+		  "grafana.com/tags": "a,b,c-d",
 		  "grafana.com/title": "A title here"
 		}
 	  }`)
 
-	require.Equal(t, tags, m.GetTags())
+	require.Equal(t, []string{"a", "b", "c-d"}, m.GetTags())
 	m.SetTitle("") // remove the property
 	m.SetTags([]string{})
 
@@ -30,6 +30,16 @@ func TestTagMetadata(t *testing.T) {
 		"name": "hello",
 		"creationTimestamp": null
 	  }`)
+
+	m.Annotations[annoKeyTags] = "hello, world"
+	requireJSON(t, m, `{
+		"name": "hello",
+		"creationTimestamp": null,
+		"annotations": {
+		  "grafana.com/tags": "hello, world"
+		}
+	  }`)
+	require.Equal(t, []string{"hello", "world"}, m.GetTags())
 }
 
 func requireJSON(t *testing.T, obj interface{}, val string) {

--- a/pkg/kinds/general_test.go
+++ b/pkg/kinds/general_test.go
@@ -1,0 +1,40 @@
+package kinds
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagMetadata(t *testing.T) {
+	tags := []string{"a", "b", "c"}
+	m := GrafanaResourceMetadata{Name: "hello"}
+	m.SetTags(tags)
+	m.SetTitle("A title here")
+
+	requireJSON(t, m, `{
+		"name": "hello",
+		"creationTimestamp": null,
+		"annotations": {
+		  "grafana.com/tags": "a,b,c",
+		  "grafana.com/title": "A title here"
+		}
+	  }`)
+
+	require.Equal(t, tags, m.GetTags())
+	m.SetTitle("") // remove the property
+	m.SetTags([]string{})
+
+	requireJSON(t, m, `{
+		"name": "hello",
+		"creationTimestamp": null
+	  }`)
+}
+
+func requireJSON(t *testing.T, obj interface{}, val string) {
+	out, err := json.MarshalIndent(obj, "", "  ")
+	require.NoError(t, err)
+	//fmt.Printf("OUT: %s", string(out))
+	require.JSONEq(t, val, string(out))
+}


### PR DESCRIPTION
Rather than have basic metadata like: title, description, and tags modeled by EntitySummary -- we can just shove that in the standard k8s metadata.

Tags are a bit weird since it is an array that needs to be modeled as a string