### PR TITLE
Explore: fix new URL parsing to handle legacy edge cases

### DIFF
--- a/public/app/features/explore/ExplorePage.test.tsx
+++ b/public/app/features/explore/ExplorePage.test.tsx
@@ -90,14 +90,15 @@ describe('ExplorePage', () => {
       const urlParams = {
         left: serializeStateToUrlParam({
           datasource: 'loki-uid',
-          queries: [{ refId: 'A', expr: '{ label="value"}' }],
+          queries: [{ refId: 'A', expr: '{ label="value"}', datasource: { type: 'logs', uid: 'loki-uid' } }],
           range: { from: 'now-1h', to: 'now' },
         }),
         right: serializeStateToUrlParam({
           datasource: 'elastic-uid',
-          queries: [{ refId: 'A', expr: 'error' }],
+          queries: [{ refId: 'A', expr: 'error', datasource: { type: 'logs', uid: 'elastic-uid' } }],
           range: { from: 'now-1h', to: 'now' },
         }),
+        orgId: '1',
       };
 
       const { datasources, location } = setupExplore({ urlParams });
@@ -322,7 +323,7 @@ describe('ExplorePage', () => {
             urlParams: {
               left: '{"datasource":"elastic-uid","queries":[{"refId":"A"}],"range":{"from":"now-1h","to":"now"}}',
             },
-            prevUsedDatasource: { orgId: 1, datasource: 'elastic' },
+            prevUsedDatasource: { orgId: 1, datasource: 'loki-uid' },
             mixedEnabled: true,
           });
           await waitForExplore();
@@ -330,7 +331,7 @@ describe('ExplorePage', () => {
           await waitFor(() => {
             const urlParams = decodeURIComponent(location.getSearch().toString());
             expect(urlParams).toBe(
-              'left={"datasource":"elastic-uid","queries":[{"refId":"A"}],"range":{"from":"now-1h","to":"now"}}&orgId=1'
+              'left={"datasource":"elastic-uid","queries":[{"refId":"A","datasource":{"type":"logs","uid":"elastic-uid"}}],"range":{"from":"now-1h","to":"now"}}&orgId=1'
             );
           });
 

--- a/public/app/features/explore/hooks/useStateSync.ts
+++ b/public/app/features/explore/hooks/useStateSync.ts
@@ -183,6 +183,7 @@ export function useStateSync(params: ExploreQueryParams) {
                       withUniqueRefIds(queries)
                         // but filter out the ones that are not compatible with the pane datasource
                         .filter(getQueryFilter(paneDatasource))
+                        .map((query) => ({ ...query, datasource: paneDatasource.getRef() }))
                     : getDatasourceSrv()
                         // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
                         .get(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef())
@@ -261,10 +262,18 @@ function getQueryFilter(datasource?: DataSourceApi) {
       }
       // Due to legacy URLs, `datasource` in queries may be a string. This logic should probably be in the migration
       if (typeof q.datasource === 'string') {
-        return q.datasource === datasource?.uid;
+        return (
+          q.datasource === datasource?.uid ||
+          // Also for legacy reasons, the datasource name may be used instead of the uid
+          q.datasource === datasource?.name
+        );
       }
 
-      return q.datasource.uid === datasource?.uid;
+      return (
+        q.datasource.uid === datasource?.uid ||
+        // For legacy reasons, the datasource name may be used instead of the uid
+        q.datasource.uid === datasource?.name
+      );
     };
   }
 }

--- a/public/app/features/explore/hooks/useStateSync.ts
+++ b/public/app/features/explore/hooks/useStateSync.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isEqual, isObject, mapValues, omitBy } from 'lodash';
+import { identity, isEmpty, isEqual, isObject, mapValues, omitBy } from 'lodash';
 import { useEffect, useRef } from 'react';
 
 import {
@@ -183,7 +183,11 @@ export function useStateSync(params: ExploreQueryParams) {
                       withUniqueRefIds(queries)
                         // but filter out the ones that are not compatible with the pane datasource
                         .filter(getQueryFilter(paneDatasource))
-                        .map((query) => ({ ...query, datasource: paneDatasource.getRef() }))
+                        .map(
+                          isMixedDatasource(paneDatasource)
+                            ? identity<DataQuery>
+                            : (query) => ({ ...query, datasource: paneDatasource.getRef() })
+                        )
                     : getDatasourceSrv()
                         // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
                         .get(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef())

--- a/public/app/features/explore/spec/query.test.tsx
+++ b/public/app/features/explore/spec/query.test.tsx
@@ -30,7 +30,7 @@ describe('Explore: handle running/not running query', () => {
     const urlParams = {
       left: serializeStateToUrlParam({
         datasource: 'loki-uid',
-        queries: [{ refId: 'A', expr: '{ label="value"}' }],
+        queries: [{ refId: 'A', expr: '{ label="value"}', datasource: { type: 'logs', uid: 'loki-uid' } }],
         range: { from: 'now-1h', to: 'now' },
       }),
     };


### PR DESCRIPTION
**What is this feature?**

Fixes new Explore URL parsing logic to handle some legacy behaviour where queries in the URL were considered valid and not filtered out when the `queries[x].datasource.uid` property was set to be the datasource name and not the UID.
While it was not the intended behavior there are at least a few instances where we know Explore URLs were generated with such links, so in order to avoid breaking changes we are forced to keep that behaviour.

[Slack thread for reference](https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1686766054589569)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70260

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
