### PR TITLE
PanelPlugin: Allow hiding standard field config from defaults

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -226,7 +226,8 @@ exports[`better eslint`] = {
     "packages/grafana-data/src/panel/registryFactories.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"]
     ],
     "packages/grafana-data/src/text/text.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -23,6 +23,7 @@ import { createFieldConfigRegistry } from './registryFactories';
 export type StandardOptionConfig = {
   defaultValue?: any;
   settings?: any;
+  hideFromDefaults?: boolean;
 };
 
 /** @beta */

--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -50,8 +50,18 @@ export function createFieldConfigRegistry<TFieldConfigOptions>(
       }
     }
     if (config.standardOptions) {
+      const customHideFromDefaults =
+        config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.hideFromDefaults;
       const customDefault = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.defaultValue;
       const customSettings = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.settings;
+
+      if (customHideFromDefaults) {
+        fieldConfigProp = {
+          ...fieldConfigProp,
+          hideFromDefaults: customHideFromDefaults,
+        };
+      }
+
       if (customDefault) {
         fieldConfigProp = {
           ...fieldConfigProp,


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/pull/70202

This PR allows standard field config configuration for the panel plugin to only be available as an override. It builds on top of standard options configuration API by extending it with `hideFromDefaults` property that's equivalent to the custom field config configuration [1]

Usage:

```tsx
new PanelPlugin<Options>(SomePanel)
  .useFieldConfig({
    standardOptions: {
      [FieldConfigProperty.Min]: {
        hideFromDefaults: true,
      },
      [FieldConfigProperty.Max]: {
        hideFromDefaults: true,
      },
    },
  })
```

@leeoniya let me know if this will be sufficient for your needs.


[1]. Custom field config existing API, example in the wild: https://github.com/grafana/grafana/blob/field-config-hide-from-defaults/public/app/plugins/panel/heatmap/module.tsx#L38

```tsx
useCustomConfig: (builder) => {
  builder.addCustomEditor<void, ScaleDistributionConfig>({
    ...,
    hideFromDefaults: true,
  })
}
```


