### PR TITLE
loki: rename experimental feature flag

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -75,7 +75,7 @@ Experimental features might be changed or removed without prior notice.
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `live-service-web-worker`          | This will use a webworker thread to processes events rather than the main thread                             |
 | `queryOverLive`                    | Use Grafana Live WebSocket to execute backend queries                                                        |
-| `lokiLive`                         | Support WebSocket streaming for loki (early prototype)                                                       |
+| `lokiExperimentalStreaming`        | Support new streaming approach for loki (prototype, needs special loki build)                                |
 | `storage`                          | Configurable storage for dashboards, datasources, and resources                                              |
 | `newTraceViewHeader`               | Shows the new trace view header                                                                              |
 | `datasourceQueryMultiStatus`       | Introduce HTTP 207 Multi Status for api/ds/query                                                             |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -26,7 +26,7 @@ export interface FeatureToggles {
   prometheusAzureOverrideAudience?: boolean;
   publicDashboards?: boolean;
   publicDashboardsEmailSharing?: boolean;
-  lokiLive?: boolean;
+  lokiExperimentalStreaming?: boolean;
   featureHighlights?: boolean;
   migrationLocking?: boolean;
   storage?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -62,8 +62,8 @@ var (
 			HideFromDocs:    true,
 		},
 		{
-			Name:        "lokiLive",
-			Description: "Support WebSocket streaming for loki (early prototype)",
+			Name:        "lokiExperimentalStreaming",
+			Description: "Support new streaming approach for loki (prototype, needs special loki build)",
 			Stage:       FeatureStageExperimental,
 			Owner:       grafanaObservabilityLogsSquad,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -7,7 +7,7 @@ panelTitleSearch,preview,@grafana/grafana-app-platform-squad,false,false,false,f
 prometheusAzureOverrideAudience,preview,@grafana/observability-metrics,false,false,false,false
 publicDashboards,preview,@grafana/dashboards-squad,false,false,false,false
 publicDashboardsEmailSharing,preview,@grafana/dashboards-squad,false,true,false,false
-lokiLive,experimental,@grafana/observability-logs,false,false,false,false
+lokiExperimentalStreaming,experimental,@grafana/observability-logs,false,false,false,false
 featureHighlights,GA,@grafana/grafana-as-code,false,false,false,false
 migrationLocking,preview,@grafana/backend-platform,false,false,false,false
 storage,experimental,@grafana/grafana-app-platform-squad,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -39,9 +39,9 @@ const (
 	// Enables public dashboard sharing to be restricted to only allowed emails
 	FlagPublicDashboardsEmailSharing = "publicDashboardsEmailSharing"
 
-	// FlagLokiLive
-	// Support WebSocket streaming for loki (early prototype)
-	FlagLokiLive = "lokiLive"
+	// FlagLokiExperimentalStreaming
+	// Support new streaming approach for loki (prototype, needs special loki build)
+	FlagLokiExperimentalStreaming = "lokiExperimentalStreaming"
 
 	// FlagFeatureHighlights
 	// Highlight Grafana Enterprise features

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -28,7 +28,7 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
   },
 ];
 
-if (config.featureToggles.lokiLive) {
+if (config.featureToggles.lokiExperimentalStreaming) {
   queryTypeOptions.push({
     value: LokiQueryType.Stream,
     label: 'Stream',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -263,7 +263,11 @@ export class LokiDatasource
     };
 
     const streamQueries = fixedRequest.targets.filter((q) => q.queryType === LokiQueryType.Stream);
-    if (config.featureToggles.lokiLive && streamQueries.length > 0 && fixedRequest.rangeRaw?.to === 'now') {
+    if (
+      config.featureToggles.lokiExperimentalStreaming &&
+      streamQueries.length > 0 &&
+      fixedRequest.rangeRaw?.to === 'now'
+    ) {
       // this is still an in-development feature,
       // we do not support mixing stream-queries with normal-queries for now.
       const streamRequest = {


### PR DESCRIPTION
the feature-flag `lokiLive` gets renamed to `lokiExperimentalStreaming`, because it's name was confusingly similar to the `[live]` button in explore-mode.

(the flag is in the experimental-stage, so renaming it should not be a problem)

how to test:
1. you need a special build of loki to test this
2. enable the feature-flag `lokiExperimentalStreaming`
3. verify that things in general work normall (you can run a normal loki query for example)
4. go to the dashboards, create a new panel, verify you can choose query-type=stream
5. if you are running with the `devenv-loki` config, run this query:
    - `avg_over_time({age="new",place="moon"}|json wave="wave"| unwrap wave[10s])`
    - choose a shorter time-range,  like last-5-minutes
    - choose query-type=stream
    - verify that the graph is realtime-updated