### PR TITLE
[v9.4.x] What's New: Bump whatsnewurl link

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "betterer:issues": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/generateBettererIssues.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-2/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-4/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "lint-staged": {


### PR DESCRIPTION
**What is this feature?**

Link for `9.4.x` releases is broken. This PR fixes the issue.