### PR TITLE
[v9.5.x] What's New: Bump whatsnewurl link

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "betterer:issues": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/generateBettererIssues.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-2/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-5/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "lint-staged": {


### PR DESCRIPTION
**What is this feature?**

Link for `9.5.x` releases is broken. This PR fixes the issue.