### PR TITLE
logs: handle dataplane-compatible logs-frames

### DIFF
--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -356,7 +356,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
         };
 
         allSeries.push(info);
-        if (frameLabels != null && frameLabels.length > 0) {
+        if (frameLabels && frameLabels.length > 0) {
           allLabels.push(frameLabels);
         }
       }

--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -348,7 +348,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
       const logsFrame = parseLogsFrame(series);
       if (logsFrame != null) {
         // for now we ignore the nested-ness of attributes, and just stringify-them
-        const frameLabels = logsFrame.getAttributesAsLabels();
+        const frameLabels = logsFrame.getAttributesAsLabels() ?? undefined;
         const info = {
           rawFrame: series,
           logsFrame: logsFrame,

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -1,0 +1,53 @@
+import { DataFrame, FieldCache, FieldType, Field, Labels } from '@grafana/data';
+
+import type { LogsFrame } from './logsFrame';
+
+function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Labels[] | undefined {
+  const useLabelsField = frame.meta?.custom?.frameType === 'LabeledTimeValues';
+
+  if (!useLabelsField) {
+    const lineLabels = lineField.labels;
+    if (lineLabels != null) {
+      const result = new Array(frame.length);
+      result.fill(lineLabels);
+      return result;
+    } else {
+      return undefined;
+    }
+  }
+
+  const labelsField = cache.getFieldByName('labels');
+
+  if (labelsField == null) {
+    return undefined;
+  }
+
+  return labelsField.values;
+}
+
+export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
+  const cache = new FieldCache(frame);
+  const timeField = cache.getFields(FieldType.time)[0];
+  const bodyField = cache.getFields(FieldType.string)[0];
+
+  // these two are mandatory
+  if (timeField === undefined || bodyField === undefined) {
+    return null;
+  }
+
+  const timeNanosecondField = cache.getFieldByName('tsNs');
+  const severityField = cache.getFieldByName('level');
+  const idField = cache.getFieldByName('id');
+
+  const labels = getLabels(frame, cache, bodyField);
+
+  return {
+    timeField,
+    bodyField,
+    timeNanosecondField,
+    severityField,
+    idField,
+    attributes: labels,
+    getAttributesAsLabels: () => labels,
+  };
+}

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -18,7 +18,7 @@ function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Label
 
   const labelsField = cache.getFieldByName('labels');
 
-  if (labelsField == null) {
+  if (labelsField === undefined) {
     return undefined;
   }
 

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -2,7 +2,7 @@ import { DataFrame, FieldCache, FieldType, Field, Labels } from '@grafana/data';
 
 import type { LogsFrame } from './logsFrame';
 
-function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Labels[] | undefined {
+function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Labels[] | null {
   const useLabelsField = frame.meta?.custom?.frameType === 'LabeledTimeValues';
 
   if (!useLabelsField) {
@@ -12,14 +12,14 @@ function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Label
       result.fill(lineLabels);
       return result;
     } else {
-      return undefined;
+      return null;
     }
   }
 
   const labelsField = cache.getFieldByName('labels');
 
   if (labelsField === undefined) {
-    return undefined;
+    return null;
   }
 
   return labelsField.values;
@@ -35,9 +35,9 @@ export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
     return null;
   }
 
-  const timeNanosecondField = cache.getFieldByName('tsNs');
-  const severityField = cache.getFieldByName('level');
-  const idField = cache.getFieldByName('id');
+  const timeNanosecondField = cache.getFieldByName('tsNs') ?? null;
+  const severityField = cache.getFieldByName('level') ?? null;
+  const idField = cache.getFieldByName('id') ?? null;
 
   const labels = getLabels(frame, cache, bodyField);
 

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -7,7 +7,7 @@ function getLabels(frame: DataFrame, cache: FieldCache, lineField: Field): Label
 
   if (!useLabelsField) {
     const lineLabels = lineField.labels;
-    if (lineLabels != null) {
+    if (lineLabels !== undefined) {
       const result = new Array(frame.length);
       result.fill(lineLabels);
       return result;

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -1,0 +1,206 @@
+import { FieldType, DataFrameType, Field, Labels } from '@grafana/data';
+
+import { parseLogsFrame, attributesToLabels } from './logsFrame';
+
+function makeString(name: string, values: string[], labels?: Labels): Field {
+  return {
+    name,
+    type: FieldType.string,
+    config: {},
+    values,
+    labels,
+  };
+}
+
+function makeTime(name: string, values: number[], nanos?: number[]): Field {
+  return {
+    name,
+    type: FieldType.time,
+    config: {},
+    values,
+  };
+}
+
+function makeObject(name: string, values: Object[]): Field {
+  return {
+    name,
+    type: FieldType.other,
+    config: {},
+    values,
+  };
+}
+
+describe('parseLogsFrame should parse different logs-dataframe formats', () => {
+  it('should parse a dataplane-complaint logs frame', () => {
+    const time = makeTime('timestamp', [1687185711795, 1687185711995]);
+    const body = makeString('body', ['line1', 'line2']);
+    const severity = makeString('severity', ['info', 'debug']);
+    const id = makeString('id', ['id1', 'id2']);
+    const attributes = makeObject('attributes', [
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+
+    const result = parseLogsFrame({
+      meta: {
+        type: DataFrameType.LogLines,
+      },
+      fields: [id, body, attributes, severity, time],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+    if (result == null) {
+      // to make typescript happy
+      throw new Error('should never happen');
+    }
+
+    expect(result.timeField.values[0]).toBe(time.values[0]);
+    expect(result.bodyField.values[0]).toBe(body.values[0]);
+    expect(result.idField?.values[0]).toBe(id.values[0]);
+    expect(result.timeNanosecondField).toBeUndefined();
+    expect(result.severityField?.values[0]).toBe(severity.values[0]);
+    expect(result.attributes).toStrictEqual([
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+  });
+
+  it('should parse old Loki-style (grafana8.x) frames ( multi-frame, but here we only parse a single frame )', () => {
+    const time = makeTime('ts', [1687185711795, 1687185711995]);
+    const line = makeString('line', ['line1', 'line2'], { counter: '34543', lable: 'val3', level: 'info' });
+    const id = makeString('id', ['id1', 'id2']);
+    const ns = makeString('tsNs', ['1687185711795123456', '1687185711995987654']);
+
+    const result = parseLogsFrame({
+      fields: [time, line, ns, id],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+    if (result == null) {
+      // to make typescript happy
+      throw new Error('should never happen');
+    }
+
+    expect(result.timeField.values[0]).toBe(time.values[0]);
+    expect(result.bodyField.values[0]).toBe(line.values[0]);
+    expect(result.idField?.values[0]).toBe(id.values[0]);
+    expect(result.timeNanosecondField?.values[0]).toBe(ns.values[0]);
+    expect(result.severityField).toBeUndefined();
+    expect(result.attributes).toStrictEqual([
+      { counter: '34543', lable: 'val3', level: 'info' },
+      { counter: '34543', lable: 'val3', level: 'info' },
+    ]);
+  });
+
+  it('should parse a Loki-style frame (single-frame, labels-in-json)', () => {
+    const time = makeTime('Time', [1687185711795, 1687185711995]);
+    const line = makeString('Line', ['line1', 'line2']);
+    const id = makeString('id', ['id1', 'id2']);
+    const ns = makeString('tsNs', ['1687185711795123456', '1687185711995987654']);
+    const labels = makeObject('labels', [
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+
+    const result = parseLogsFrame({
+      meta: {
+        custom: {
+          frameType: 'LabeledTimeValues',
+        },
+      },
+      fields: [labels, time, line, ns, id],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+    if (result == null) {
+      // to make typescript happy
+      throw new Error('should never happen');
+    }
+
+    expect(result.timeField.values[0]).toBe(time.values[0]);
+    expect(result.bodyField.values[0]).toBe(line.values[0]);
+    expect(result.idField?.values[0]).toBe(id.values[0]);
+    expect(result.timeNanosecondField?.values[0]).toBe(ns.values[0]);
+    expect(result.severityField).toBeUndefined();
+    expect(result.attributes).toStrictEqual([
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+  });
+
+  it('should parse elastic-style frame (has level-field, no labels parsed, extra fields ignored)', () => {
+    const time = makeTime('Time', [1687185711795, 1687185711995]);
+    const line = makeString('Line', ['line1', 'line2']);
+    const source = makeObject('_source', [
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+    const host = makeString('hostname', ['h1', 'h2']);
+    const level = makeString('level', ['info', 'error']);
+
+    const result = parseLogsFrame({
+      meta: {
+        custom: {
+          frameType: 'LabeledTimeValues',
+        },
+      },
+      fields: [time, line, source, level, host],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+    if (result == null) {
+      // to make typescript happy
+      throw new Error('should never happen');
+    }
+
+    expect(result.timeField.values[0]).toBe(time.values[0]);
+    expect(result.bodyField.values[0]).toBe(line.values[0]);
+    expect(result.severityField?.values[0]).toBe(level.values[0]);
+    expect(result.idField).toBeUndefined();
+    expect(result.timeNanosecondField).toBeUndefined();
+    expect(result.attributes).toBeUndefined();
+  });
+});
+
+describe('attributesToLabels', () => {
+  it('should convert nested structures correctly', () => {
+    expect(
+      attributesToLabels({
+        key1: 'val1',
+        key2: ['k2v1', 'k2v2', 'k2v3'],
+        key3: {
+          k3k1: 'v1',
+          k3k2: 'v2',
+          k3k3: [
+            'k3k3v1',
+            {
+              k3k3k1: 'one',
+              k3k3k2: 'two',
+            },
+          ],
+        },
+      })
+    ).toStrictEqual({
+      key1: 'val1',
+      key2: '["k2v1","k2v2","k2v3"]',
+      key3: '{"k3k1":"v1","k3k2":"v2","k3k3":["k3k3v1",{"k3k3k1":"one","k3k3k2":"two"}]}',
+    });
+  });
+
+  it('should convert not-nested structures correctly', () => {
+    expect(
+      attributesToLabels({
+        key1: 'val1',
+        key2: 'val2',
+      })
+    ).toStrictEqual({
+      key1: 'val1',
+      key2: 'val2',
+    });
+    // FIXME
+  });
+});

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -50,17 +50,13 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     });
 
     expect(result).not.toBeNull();
-    if (result == null) {
-      // to make typescript happy
-      throw new Error('should never happen');
-    }
 
-    expect(result.timeField.values[0]).toBe(time.values[0]);
-    expect(result.bodyField.values[0]).toBe(body.values[0]);
-    expect(result.idField?.values[0]).toBe(id.values[0]);
-    expect(result.timeNanosecondField).toBeUndefined();
-    expect(result.severityField?.values[0]).toBe(severity.values[0]);
-    expect(result.attributes).toStrictEqual([
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(body.values[0]);
+    expect(result!.idField?.values[0]).toBe(id.values[0]);
+    expect(result!.timeNanosecondField).toBeUndefined();
+    expect(result!.severityField?.values[0]).toBe(severity.values[0]);
+    expect(result!.attributes).toStrictEqual([
       { counter: '38141', label: 'val2', level: 'warning' },
       { counter: '38143', label: 'val2', level: 'info' },
     ]);
@@ -78,17 +74,13 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     });
 
     expect(result).not.toBeNull();
-    if (result == null) {
-      // to make typescript happy
-      throw new Error('should never happen');
-    }
 
-    expect(result.timeField.values[0]).toBe(time.values[0]);
-    expect(result.bodyField.values[0]).toBe(line.values[0]);
-    expect(result.idField?.values[0]).toBe(id.values[0]);
-    expect(result.timeNanosecondField?.values[0]).toBe(ns.values[0]);
-    expect(result.severityField).toBeUndefined();
-    expect(result.attributes).toStrictEqual([
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.idField?.values[0]).toBe(id.values[0]);
+    expect(result!.timeNanosecondField?.values[0]).toBe(ns.values[0]);
+    expect(result!.severityField).toBeUndefined();
+    expect(result!.attributes).toStrictEqual([
       { counter: '34543', lable: 'val3', level: 'info' },
       { counter: '34543', lable: 'val3', level: 'info' },
     ]);
@@ -115,17 +107,13 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     });
 
     expect(result).not.toBeNull();
-    if (result == null) {
-      // to make typescript happy
-      throw new Error('should never happen');
-    }
 
-    expect(result.timeField.values[0]).toBe(time.values[0]);
-    expect(result.bodyField.values[0]).toBe(line.values[0]);
-    expect(result.idField?.values[0]).toBe(id.values[0]);
-    expect(result.timeNanosecondField?.values[0]).toBe(ns.values[0]);
-    expect(result.severityField).toBeUndefined();
-    expect(result.attributes).toStrictEqual([
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.idField?.values[0]).toBe(id.values[0]);
+    expect(result!.timeNanosecondField?.values[0]).toBe(ns.values[0]);
+    expect(result!.severityField).toBeUndefined();
+    expect(result!.attributes).toStrictEqual([
       { counter: '38141', label: 'val2', level: 'warning' },
       { counter: '38143', label: 'val2', level: 'info' },
     ]);
@@ -152,17 +140,13 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     });
 
     expect(result).not.toBeNull();
-    if (result == null) {
-      // to make typescript happy
-      throw new Error('should never happen');
-    }
 
-    expect(result.timeField.values[0]).toBe(time.values[0]);
-    expect(result.bodyField.values[0]).toBe(line.values[0]);
-    expect(result.severityField?.values[0]).toBe(level.values[0]);
-    expect(result.idField).toBeUndefined();
-    expect(result.timeNanosecondField).toBeUndefined();
-    expect(result.attributes).toBeUndefined();
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.severityField?.values[0]).toBe(level.values[0]);
+    expect(result!.idField).toBeUndefined();
+    expect(result!.timeNanosecondField).toBeUndefined();
+    expect(result!.attributes).toBeUndefined();
   });
 });
 

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -54,7 +54,7 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.timeField.values[0]).toBe(time.values[0]);
     expect(result!.bodyField.values[0]).toBe(body.values[0]);
     expect(result!.idField?.values[0]).toBe(id.values[0]);
-    expect(result!.timeNanosecondField).toBeUndefined();
+    expect(result!.timeNanosecondField).toBeNull();
     expect(result!.severityField?.values[0]).toBe(severity.values[0]);
     expect(result!.attributes).toStrictEqual([
       { counter: '38141', label: 'val2', level: 'warning' },
@@ -79,7 +79,7 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.bodyField.values[0]).toBe(line.values[0]);
     expect(result!.idField?.values[0]).toBe(id.values[0]);
     expect(result!.timeNanosecondField?.values[0]).toBe(ns.values[0]);
-    expect(result!.severityField).toBeUndefined();
+    expect(result!.severityField).toBeNull();
     expect(result!.attributes).toStrictEqual([
       { counter: '34543', lable: 'val3', level: 'info' },
       { counter: '34543', lable: 'val3', level: 'info' },
@@ -112,7 +112,7 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.bodyField.values[0]).toBe(line.values[0]);
     expect(result!.idField?.values[0]).toBe(id.values[0]);
     expect(result!.timeNanosecondField?.values[0]).toBe(ns.values[0]);
-    expect(result!.severityField).toBeUndefined();
+    expect(result!.severityField).toBeNull();
     expect(result!.attributes).toStrictEqual([
       { counter: '38141', label: 'val2', level: 'warning' },
       { counter: '38143', label: 'val2', level: 'info' },
@@ -144,9 +144,9 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.timeField.values[0]).toBe(time.values[0]);
     expect(result!.bodyField.values[0]).toBe(line.values[0]);
     expect(result!.severityField?.values[0]).toBe(level.values[0]);
-    expect(result!.idField).toBeUndefined();
-    expect(result!.timeNanosecondField).toBeUndefined();
-    expect(result!.attributes).toBeUndefined();
+    expect(result!.idField).toBeNull();
+    expect(result!.timeNanosecondField).toBeNull();
+    expect(result!.attributes).toBeNull();
   });
 });
 

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -148,6 +148,25 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.timeNanosecondField).toBeNull();
     expect(result!.attributes).toBeNull();
   });
+
+  it('should parse a minimal old-style frame (only two fields, time and line)', () => {
+    const time = makeTime('Time', [1687185711795, 1687185711995]);
+    const line = makeString('Line', ['line1', 'line2']);
+
+    const result = parseLogsFrame({
+      fields: [time, line],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.severityField).toBeNull();
+    expect(result!.idField).toBeNull();
+    expect(result!.timeNanosecondField).toBeNull();
+    expect(result!.attributes).toBeNull();
+  });
 });
 
 describe('attributesToLabels', () => {

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -1,0 +1,80 @@
+import { DataFrame, FieldCache, FieldType, FieldWithIndex, DataFrameType, Labels } from '@grafana/data';
+
+import { parseLegacyLogsFrame } from './legacyLogsFrame';
+
+// these are like Labels, but their values can be
+// arbitrary structures, not just strings
+export type Attributes = Record<string, unknown>;
+
+// the attributes-access is a little awkward, but it's necessary
+// because there are multiple,very different dataframe-represenations.
+export type LogsFrame = {
+  timeField: FieldWithIndex;
+  bodyField: FieldWithIndex;
+  timeNanosecondField?: FieldWithIndex;
+  severityField?: FieldWithIndex;
+  idField?: FieldWithIndex;
+  attributes?: Attributes[];
+  getAttributesAsLabels: () => Labels[] | undefined; // temporarily exists to make the labels=>attributes migration simpler
+};
+
+function getField(cache: FieldCache, name: string, fieldType: FieldType): FieldWithIndex | undefined {
+  const field = cache.getFieldByName(name);
+  if (field == null) {
+    return undefined;
+  }
+
+  return field.type === fieldType ? field : undefined;
+}
+
+const DATAPLANE_TIMESTAMP_NAME = 'timestamp';
+const DATAPLANE_BODY_NAME = 'body';
+const DATAPLANE_SEVERITY_NAME = 'severity';
+const DATAPLANE_ID_NAME = 'id';
+const DATAPLANE_ATTRIBUTES_NAME = 'attributes';
+
+export function attributesToLabels(attributes: Attributes): Labels {
+  const result: Labels = {};
+
+  Object.entries(attributes).forEach(([k, v]) => {
+    result[k] = typeof v === 'string' ? v : JSON.stringify(v);
+  });
+
+  return result;
+}
+
+function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
+  const cache = new FieldCache(frame);
+
+  const timestampField = getField(cache, DATAPLANE_TIMESTAMP_NAME, FieldType.time);
+  const bodyField = getField(cache, DATAPLANE_BODY_NAME, FieldType.string);
+
+  // these two are mandatory
+  if (timestampField == null || bodyField == null) {
+    return null;
+  }
+
+  const severityField = getField(cache, DATAPLANE_SEVERITY_NAME, FieldType.string);
+  const idField = getField(cache, DATAPLANE_ID_NAME, FieldType.string);
+  const attributesField = getField(cache, DATAPLANE_ATTRIBUTES_NAME, FieldType.other);
+
+  const attributes = attributesField == null ? undefined : attributesField.values;
+
+  return {
+    timeField: timestampField,
+    bodyField,
+    severityField,
+    idField,
+    attributes,
+    getAttributesAsLabels: () => (attributes != null ? attributes.map(attributesToLabels) : undefined),
+  };
+  return null;
+}
+
+export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
+  if (frame.meta?.type === DataFrameType.LogLines) {
+    return parseDataplaneLogsFrame(frame);
+  } else {
+    return parseLegacyLogsFrame(frame);
+  }
+}

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -11,11 +11,11 @@ export type Attributes = Record<string, unknown>;
 export type LogsFrame = {
   timeField: FieldWithIndex;
   bodyField: FieldWithIndex;
-  timeNanosecondField?: FieldWithIndex;
-  severityField?: FieldWithIndex;
-  idField?: FieldWithIndex;
-  attributes?: Attributes[];
-  getAttributesAsLabels: () => Labels[] | undefined; // temporarily exists to make the labels=>attributes migration simpler
+  timeNanosecondField: FieldWithIndex | null;
+  severityField: FieldWithIndex | null;
+  idField: FieldWithIndex | null;
+  attributes: Attributes[] | null;
+  getAttributesAsLabels: () => Labels[] | null; // temporarily exists to make the labels=>attributes migration simpler
 };
 
 function getField(cache: FieldCache, name: string, fieldType: FieldType): FieldWithIndex | undefined {
@@ -25,6 +25,12 @@ function getField(cache: FieldCache, name: string, fieldType: FieldType): FieldW
   }
 
   return field.type === fieldType ? field : undefined;
+}
+
+const z: undefined | number = undefined;
+
+if (z ?? 0 > 0) {
+  console.log('yo');
 }
 
 const DATAPLANE_TIMESTAMP_NAME = 'timestamp';
@@ -54,11 +60,11 @@ function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
     return null;
   }
 
-  const severityField = getField(cache, DATAPLANE_SEVERITY_NAME, FieldType.string);
-  const idField = getField(cache, DATAPLANE_ID_NAME, FieldType.string);
-  const attributesField = getField(cache, DATAPLANE_ATTRIBUTES_NAME, FieldType.other);
+  const severityField = getField(cache, DATAPLANE_SEVERITY_NAME, FieldType.string) ?? null;
+  const idField = getField(cache, DATAPLANE_ID_NAME, FieldType.string) ?? null;
+  const attributesField = getField(cache, DATAPLANE_ATTRIBUTES_NAME, FieldType.other) ?? null;
 
-  const attributes = attributesField == null ? undefined : attributesField.values;
+  const attributes = attributesField == null ? null : attributesField.values;
 
   return {
     timeField: timestampField,
@@ -66,7 +72,8 @@ function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
     severityField,
     idField,
     attributes,
-    getAttributesAsLabels: () => (attributes != null ? attributes.map(attributesToLabels) : undefined),
+    timeNanosecondField: null,
+    getAttributesAsLabels: () => (attributes !== null ? attributes.map(attributesToLabels) : null),
   };
   return null;
 }

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -27,12 +27,6 @@ function getField(cache: FieldCache, name: string, fieldType: FieldType): FieldW
   return field.type === fieldType ? field : undefined;
 }
 
-const z: undefined | number = undefined;
-
-if (z ?? 0 > 0) {
-  console.log('yo');
-}
-
 const DATAPLANE_TIMESTAMP_NAME = 'timestamp';
 const DATAPLANE_BODY_NAME = 'body';
 const DATAPLANE_SEVERITY_NAME = 'severity';

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -56,7 +56,7 @@ function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
   const bodyField = getField(cache, DATAPLANE_BODY_NAME, FieldType.string);
 
   // these two are mandatory
-  if (timestampField == null || bodyField == null) {
+  if (timestampField === undefined || bodyField === undefined) {
     return null;
   }
 
@@ -64,7 +64,7 @@ function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
   const idField = getField(cache, DATAPLANE_ID_NAME, FieldType.string) ?? null;
   const attributesField = getField(cache, DATAPLANE_ATTRIBUTES_NAME, FieldType.other) ?? null;
 
-  const attributes = attributesField == null ? null : attributesField.values;
+  const attributes = attributesField === null ? null : attributesField.values;
 
   return {
     timeField: timestampField,

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -20,7 +20,7 @@ export type LogsFrame = {
 
 function getField(cache: FieldCache, name: string, fieldType: FieldType): FieldWithIndex | undefined {
   const field = cache.getFieldByName(name);
-  if (field == null) {
+  if (field === undefined) {
     return undefined;
   }
 


### PR DESCRIPTION
we update the logs-visualization code to be able to read dataframes that are created based on the dataplane spec : https://grafana.github.io/dataplane/logs
(we will adjust Loki to optionally output this kind of data in a future PR)

how to test:
1. make sure normal things still work (for example, run some Loki logql queries etc)
2. use the test-datasource (`gdev-testdata`), choose the `raw frames` mode, and paste in the following JSON:
```json
[
  {
    "schema": {
      "refId": "A",
      "meta": {
        "type": "log-lines",
        "preferredVisualisationType": "logs"
      },
      "fields": [
        { "name": "timestamp", "type": "time" },
        { "name": "body", "type": "string" },
        { "name": "severity", "type": "string" },
        { "name": "attributes", "type": "other" },
        { "name": "id", "type": "string" }
      ]
    },
    "data": {
      "values": [
        [1686648201526, 1686648200232, 1686648200714, 1686648200008, 1686648199345, 1686648198480, 1686648198873],
        ["line1", "line2", "line3", "line4", "line5", "line6", "line7"],
        ["info", "warning", "error", "error", "warning", "error", "info"],
        [
          { "source": "client", "place": "luna1", "nested": ["one", "two", "three"] },
          { "source": "server", "place": "luna2" },
          { "source": "server", "place": "luna1" },
          { "source": "client", "place": "luna2" },
          { "source": "client", "place": "luna1" },
          { "source": "server", "place": "luna2" },
          { "source": "client", "place": "luna1" }
        ],
        ["id1", "id2", "id3", "id4", "id5", "id6", "id7"]
      ],
      "nanos": [[52946, 0, 531000, 531000, 955000, 0, 0], null, null, null, null]
    }
  }
]
```

make sure you see logs, they have the correct log-level-color etc.

some features are still missing, will be added in later PR to keep the diffs small:
1. the dataplane-contract uses the timefield's native nanosecond support to handle nanosecond-precision timestamps (opposed to how the loki-style dataframes have a `tsNs` string-field with timestamps-as-strings). the support for this will come in a separate PR.
2. in logs-details currently we hide certain attributes, like timestamp&id.. we also hide`labels`. now we have `attributes`, so we should hide that one when it is correct to hide it  (probably switch based on the dataframe-type?)
3. the dataplane-contract uses `attributes`, not `labels`. these are basically labels, but the values can be any structures, not just `string`..they can be "nested". for now, we just `.toString()` them in `logsFrame.ts`, in the future we should have full support for them. (this may be a long-term plan)

( part of https://github.com/grafana/grafana/issues/67657 )