### PR TITLE
Loki: Add step input field validation

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -100,6 +100,13 @@ describe('LokiQueryBuilderOptions', () => {
     expect(screen.getByText('Step: 1m')).toBeInTheDocument();
   });
 
+  it('shows correct options for metric query with invalid step', async () => {
+    setup({ expr: 'rate({foo="bar"}[5m]', step: 'abc' });
+    expect(screen.queryByText('Line limit: 20')).not.toBeInTheDocument();
+    expect(screen.getByText('Type: Range')).toBeInTheDocument();
+    expect(screen.getByText('Step: Invalid step')).toBeInTheDocument();
+  });
+
   it('shows error when invalid value in step', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]', step: 'a' });
     await userEvent.click(screen.getByTitle('Click to edit options'));

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -99,6 +99,18 @@ describe('LokiQueryBuilderOptions', () => {
     expect(screen.getByText('Type: Range')).toBeInTheDocument();
     expect(screen.getByText('Step: 1m')).toBeInTheDocument();
   });
+
+  it('shows error when invalid value in step', async () => {
+    setup({ expr: 'rate({foo="bar"}[5m]', step: 'a' });
+    await userEvent.click(screen.getByTitle('Click to edit options'));
+    expect(screen.getByText(/Invalid step/)).toBeInTheDocument();
+  });
+
+  it('does not shows error when valid value in step', async () => {
+    setup({ expr: 'rate({foo="bar"}[5m]', step: '1m' });
+    await userEvent.click(screen.getByTitle('Click to edit options'));
+    expect(screen.queryByText(/Invalid step/)).not.toBeInTheDocument();
+  });
 });
 
 function setup(queryOverrides: Partial<LokiQuery> = {}) {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -104,7 +104,7 @@ describe('LokiQueryBuilderOptions', () => {
     setup({ expr: 'rate({foo="bar"}[5m]', step: 'abc' });
     expect(screen.queryByText('Line limit: 20')).not.toBeInTheDocument();
     expect(screen.getByText('Type: Range')).toBeInTheDocument();
-    expect(screen.getByText('Step: Invalid step')).toBeInTheDocument();
+    expect(screen.getByText('Step: Invalid value')).toBeInTheDocument();
   });
 
   it('shows error when invalid value in step', async () => {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -190,7 +190,7 @@ function getCollapsedInfo(
 
   if (!isLogQuery) {
     if (query.step) {
-      items.push(`Step: ${isValidStep ? query.step : 'Invalid step'}`);
+      items.push(`Step: ${isValidStep ? query.step : 'Invalid value'}`);
     }
 
     if (query.resolution) {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -1,5 +1,5 @@
 import { trim } from 'lodash';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { CoreApp, isValidDuration, SelectableValue } from '@grafana/data';
 import { EditorField, EditorRow } from '@grafana/experimental';
@@ -70,6 +70,13 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
     const queryType = query.queryType ?? (query.instant ? LokiQueryType.Instant : LokiQueryType.Range);
     const isLogQuery = isLogsQuery(query.expr);
 
+    const isValidStep = useMemo(() => {
+      if (!query.step || isValidDuration(query.step) || !isNaN(Number(query.step))) {
+        return true;
+      }
+      return false;
+    }, [query.step]);
+
     return (
       <EditorRow>
         <QueryOptionGroup
@@ -109,6 +116,8 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
               <EditorField
                 label="Step"
                 tooltip="Use the step parameter when making metric queries to Loki. If not filled, Grafana's calculated interval will be used. Example valid values: 1s, 5m, 10h, 1d."
+                invalid={!isValidStep}
+                error={'Invalid step. Example valid values: 1s, 5m, 10h, 1d.'}
               >
                 <AutoSizeInput
                   className="width-6"

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -81,7 +81,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
       <EditorRow>
         <QueryOptionGroup
           title="Options"
-          collapsedInfo={getCollapsedInfo(query, queryType, maxLines, isLogQuery)}
+          collapsedInfo={getCollapsedInfo(query, queryType, maxLines, isLogQuery, isValidStep)}
           queryStats={queryStats}
         >
           <EditorField
@@ -162,7 +162,13 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
   }
 );
 
-function getCollapsedInfo(query: LokiQuery, queryType: LokiQueryType, maxLines: number, isLogQuery: boolean): string[] {
+function getCollapsedInfo(
+  query: LokiQuery,
+  queryType: LokiQueryType,
+  maxLines: number,
+  isLogQuery: boolean,
+  isValidStep: boolean
+): string[] {
   const queryTypeLabel = queryTypeOptions.find((x) => x.value === queryType);
   const resolutionLabel = RESOLUTION_OPTIONS.find((x) => x.value === (query.resolution ?? 1));
 
@@ -184,7 +190,7 @@ function getCollapsedInfo(query: LokiQuery, queryType: LokiQueryType, maxLines: 
 
   if (!isLogQuery) {
     if (query.step) {
-      items.push(`Step: ${query.step}`);
+      items.push(`Step: ${isValidStep ? query.step : 'Invalid step'}`);
     }
 
     if (query.resolution) {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/58337

This PR adds a simple query step validation to make it:

- Clear when user inputs invalid step that the step is invalid
- Provide guidance on what are examples of valid step

<img width="975" alt="image" src="https://github.com/grafana/grafana/assets/30407135/52c2c735-978f-41dc-bf9a-d471491d3b8a">
<img width="913" alt="image" src="https://github.com/grafana/grafana/assets/30407135/643a5190-6993-4e93-8f0b-51c14be2056b">
<img width="824" alt="image" src="https://github.com/grafana/grafana/assets/30407135/99ce6d15-abef-41fb-8f2a-67fa01914177">
<img width="918" alt="image" src="https://github.com/grafana/grafana/assets/30407135/4c083dcd-3f18-437b-b59b-ca26aca5f4a2">

Part of https://github.com/grafana/grafana/issues/58337
