### PR TITLE
Logs: Add new scroll behaviour to logs samples panel

### DIFF
--- a/public/app/features/explore/Logs/LogsSamplePanel.tsx
+++ b/public/app/features/explore/Logs/LogsSamplePanel.tsx
@@ -11,7 +11,7 @@ import {
   SplitOpen,
   SupplementaryQueryType,
 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
 import { Button, Collapse, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { dataFrameToLogsModel } from 'app/core/logsModel';
@@ -107,6 +107,7 @@ export function LogsSamplePanel(props: Props) {
 
   return queryResponse?.state !== LoadingState.NotStarted ? (
     <Collapse
+      className={styles.logsSamplePanel}
       label={
         <div>
           Logs sample
@@ -124,16 +125,25 @@ export function LogsSamplePanel(props: Props) {
   ) : null;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  logSamplesButton: css`
-    position: absolute;
-    top: ${theme.spacing(1)};
-    right: ${theme.spacing(1)};
-  `,
-  logContainer: css`
-    overflow-x: scroll;
-  `,
-  infoTooltip: css`
-    margin-left: ${theme.spacing(1)};
-  `,
-});
+const getStyles = (theme: GrafanaTheme2) => {
+  const scrollableLogsContainer = config.featureToggles.exploreScrollableLogsContainer;
+
+  return {
+    logsSamplePanel: css`
+      ${scrollableLogsContainer && 'max-height: calc(100vh - 115px);'}
+    `,
+    logSamplesButton: css`
+      position: absolute;
+      top: ${theme.spacing(1)};
+      right: ${theme.spacing(1)};
+    `,
+    logContainer: css`
+      ${scrollableLogsContainer && 'position: relative;'}
+      ${scrollableLogsContainer && 'height: 100%;'}
+      overflow: scroll;
+    `,
+    infoTooltip: css`
+      margin-left: ${theme.spacing(1)};
+    `,
+  };
+};


### PR DESCRIPTION
**What is this feature?**

this makes logs samples use the new scrolling behaviour with `exploreScrollableLogsContainer` feature-flag.

**Special notes for your reviewer:**
video before & after:
- https://raintank-corp.slack.com/archives/C03PMJLVC67/p1687176719671679