### PR TITLE
Alerting: Add debug logs for EndsAt timestamp

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -190,6 +190,7 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 	if state.State == eval.Normal {
 		logger.Debug("Keeping state", "state", state.State)
 	} else {
+		nextEndsAt := result.EvaluatedAt
 		logger.Debug("Changing state",
 			"previous_state",
 			state.State,
@@ -198,9 +199,9 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 			"previous_ends_at",
 			state.EndsAt,
 			"next_ends_at",
-			result.EvaluatedAt)
+			nextEndsAt)
 		// Normal states have the same start and end timestamps
-		state.SetNormal("", result.EvaluatedAt, result.EvaluatedAt)
+		state.SetNormal("", nextEndsAt, nextEndsAt)
 	}
 }
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -138,10 +138,8 @@ func (a *State) Resolve(reason string, endsAt time.Time) {
 }
 
 // Maintain updates the end time using the most recent evaluation.
-func (a *State) Maintain(interval int64, evaluatedAt time.Time) time.Time {
-	prevEndsAt := a.EndsAt
+func (a *State) Maintain(interval int64, evaluatedAt time.Time) {
 	a.EndsAt = nextEndsTime(interval, evaluatedAt)
-	return prevEndsAt
 }
 
 // IsNormalStateWithNoReason returns true if the state is Normal and reason is empty
@@ -209,7 +207,8 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
 	switch state.State {
 	case eval.Alerting:
-		prevEndsAt := state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
+		prevEndsAt := state.EndsAt
+		state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
 		logger.Debug("Keeping state",
 			"state",
 			state.State,
@@ -270,7 +269,8 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 		state.StateReason = "error"
 	case models.ErrorErrState:
 		if state.State == eval.Error {
-			prevEndsAt := state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
+			prevEndsAt := state.EndsAt
+			state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
 			logger.Debug("Keeping state",
 				"state",
 				state.State,
@@ -326,7 +326,8 @@ func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logg
 		state.StateReason = models.NoData.String()
 	case models.NoData:
 		if state.State == eval.NoData {
-			prevEndsAt := state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
+			prevEndsAt := state.EndsAt
+			state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
 			logger.Debug("Keeping state",
 				"state",
 				state.State,

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -252,16 +252,14 @@ func TestMaintain(t *testing.T) {
 
 	// the interval is less than the resend interval of 30 seconds
 	s := State{State: eval.Alerting, StartsAt: now, EndsAt: now.Add(time.Second)}
-	prevEndsAt := s.Maintain(10, now.Add(10*time.Second))
+	s.Maintain(10, now.Add(10*time.Second))
 	// 10 seconds + 3 x 30 seconds is 100 seconds
-	assert.Equal(t, now.Add(time.Second), prevEndsAt)
 	assert.Equal(t, now.Add(100*time.Second), s.EndsAt)
 
 	// the interval is above the resend interval of 30 seconds
 	s = State{State: eval.Alerting, StartsAt: now, EndsAt: now.Add(time.Second)}
-	prevEndsAt = s.Maintain(60, now.Add(10*time.Second))
+	s.Maintain(60, now.Add(10*time.Second))
 	// 10 seconds + 3 x 60 seconds is 190 seconds
-	assert.Equal(t, now.Add(time.Second), prevEndsAt)
 	assert.Equal(t, now.Add(190*time.Second), s.EndsAt)
 }
 

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -252,14 +252,16 @@ func TestMaintain(t *testing.T) {
 
 	// the interval is less than the resend interval of 30 seconds
 	s := State{State: eval.Alerting, StartsAt: now, EndsAt: now.Add(time.Second)}
-	s.Maintain(10, now.Add(10*time.Second))
+	prevEndsAt := s.Maintain(10, now.Add(10*time.Second))
 	// 10 seconds + 3 x 30 seconds is 100 seconds
+	assert.Equal(t, now.Add(time.Second), prevEndsAt)
 	assert.Equal(t, now.Add(100*time.Second), s.EndsAt)
 
 	// the interval is above the resend interval of 30 seconds
 	s = State{State: eval.Alerting, StartsAt: now, EndsAt: now.Add(time.Second)}
-	s.Maintain(60, now.Add(10*time.Second))
+	prevEndsAt = s.Maintain(60, now.Add(10*time.Second))
 	// 10 seconds + 3 x 60 seconds is 190 seconds
+	assert.Equal(t, now.Add(time.Second), prevEndsAt)
 	assert.Equal(t, now.Add(190*time.Second), s.EndsAt)
 }
 


### PR DESCRIPTION
**What is this feature?**

This commit adds debug logs for previous_ends_at and next_ends_at to state.go to help us debug issues where alerts are resolved in Alertmanager due to expiration. This change is in response to a support escalation where this information was needed but unavailable.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
