### PR TITLE
AzureMonitor: Correctly build multi-resource queries for Application Insights components

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -47,6 +47,7 @@ type AzureLogAnalyticsQuery struct {
 	Query                   string
 	Resources               []string
 	QueryType               string
+	AppInsightsQuery        bool
 }
 
 func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
@@ -72,10 +73,14 @@ func (e *AzureLogAnalyticsDatasource) ExecuteTimeSeriesQuery(ctx context.Context
 	return result, nil
 }
 
-func getApiURL(resourceOrWorkspace string) string {
+func getApiURL(resourceOrWorkspace string, isAppInsightsQuery bool) string {
 	matchesResourceURI, _ := regexp.MatchString("^/subscriptions/", resourceOrWorkspace)
 
 	if matchesResourceURI {
+		if isAppInsightsQuery {
+			componentName := resourceOrWorkspace[strings.LastIndex(resourceOrWorkspace, "/")+1:]
+			return fmt.Sprintf("v1/apps/%s/query", componentName)
+		}
 		return fmt.Sprintf("v1%s/query", resourceOrWorkspace)
 	} else {
 		return fmt.Sprintf("v1/workspaces/%s/query", resourceOrWorkspace)
@@ -84,12 +89,17 @@ func getApiURL(resourceOrWorkspace string) string {
 
 func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger log.Logger, queries []backend.DataQuery, dsInfo types.DatasourceInfo, tracer tracing.Tracer) ([]*AzureLogAnalyticsQuery, error) {
 	azureLogAnalyticsQueries := []*AzureLogAnalyticsQuery{}
+	appInsightsRegExp, err := regexp.Compile("providers/Microsoft.Insights/components")
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile Application Insights regex")
+	}
 
 	for _, query := range queries {
 		resources := []string{}
 		var resourceOrWorkspace string
 		var queryString string
 		var resultFormat dataquery.ResultFormat
+		appInsightsQuery := false
 		traceExploreQuery := ""
 		traceParentExploreQuery := ""
 		traceLogsExploreQuery := ""
@@ -117,6 +127,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			if len(azureLogAnalyticsTarget.Resources) > 0 {
 				resources = azureLogAnalyticsTarget.Resources
 				resourceOrWorkspace = azureLogAnalyticsTarget.Resources[0]
+				appInsightsQuery = appInsightsRegExp.Match([]byte(resourceOrWorkspace))
 			} else if azureLogAnalyticsTarget.Resource != nil && *azureLogAnalyticsTarget.Resource != "" {
 				resources = []string{*azureLogAnalyticsTarget.Resource}
 				resourceOrWorkspace = *azureLogAnalyticsTarget.Resource
@@ -150,6 +161,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 
 			resources = azureTracesTarget.Resources
 			resourceOrWorkspace = azureTracesTarget.Resources[0]
+			appInsightsQuery = appInsightsRegExp.Match([]byte(resourceOrWorkspace))
 			resourcesMap := make(map[string]bool, 0)
 			if len(resources) > 1 {
 				for _, resource := range resources {
@@ -200,7 +212,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			}
 		}
 
-		apiURL := getApiURL(resourceOrWorkspace)
+		apiURL := getApiURL(resourceOrWorkspace, appInsightsQuery)
 
 		rawQuery, err := macros.KqlInterpolate(logger, query, dsInfo, queryString, "TimeGenerated")
 		if err != nil {
@@ -219,6 +231,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			TraceExploreQuery:       traceExploreQuery,
 			TraceParentExploreQuery: traceParentExploreQuery,
 			TraceLogsExploreQuery:   traceLogsExploreQuery,
+			AppInsightsQuery:        appInsightsQuery,
 		})
 	}
 
@@ -436,8 +449,12 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger 
 		"query":    query.Query,
 		"timespan": timespan,
 	}
-	if len(query.Resources) > 1 && query.QueryType == string(dataquery.AzureQueryTypeAzureLogAnalytics) {
+
+	if len(query.Resources) > 1 && query.QueryType == string(dataquery.AzureQueryTypeAzureLogAnalytics) && !query.AppInsightsQuery {
 		body["workspaces"] = query.Resources
+	}
+	if query.AppInsightsQuery {
+		body["applications"] = query.Resources
 	}
 	jsonValue, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -36,38 +36,38 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 		var correlationRes AzureCorrelationAPIResponse
 		if strings.Contains(r.URL.Path, "test-op-id") {
 			correlationRes = AzureCorrelationAPIResponse{
-				ID:   "/subscriptions/r1",
+				ID:   "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
 				Name: "guid-1",
 				Type: "microsoft.insights/transactions",
 				Properties: AzureCorrelationAPIResponseProperties{
 					Resources: []string{
-						"/subscriptions/r1",
+						"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
 					},
 					NextLink: nil,
 				},
 			}
 		} else if strings.Contains(r.URL.Path, "op-id-multi") {
 			correlationRes = AzureCorrelationAPIResponse{
-				ID:   "/subscriptions/r1",
+				ID:   "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
 				Name: "guid-1",
 				Type: "microsoft.insights/transactions",
 				Properties: AzureCorrelationAPIResponseProperties{
 					Resources: []string{
-						"/subscriptions/r1",
-						"/subscriptions/r2",
+						"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
+						"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2",
 					},
 					NextLink: nil,
 				},
 			}
 		} else if strings.Contains(r.URL.Path, "op-id-non-overlapping") {
 			correlationRes = AzureCorrelationAPIResponse{
-				ID:   "/subscriptions/r1",
+				ID:   "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
 				Name: "guid-1",
 				Type: "microsoft.insights/transactions",
 				Properties: AzureCorrelationAPIResponseProperties{
 					Resources: []string{
-						"/subscriptions/r1",
-						"/subscriptions/r3",
+						"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1",
+						"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r3",
 					},
 					NextLink: nil,
 				},
@@ -130,10 +130,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"resultFormat": "%s"
 						}
 					}`, types.TimeSeries)),
-					Query:     "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
-					Resources: []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
-					TimeRange: timeRange,
-					QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
+					Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
+					TimeRange:        timeRange,
+					QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					AppInsightsQuery: false,
 				},
 			},
 			Err: require.NoError,
@@ -167,9 +168,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"resultFormat": "%s"
 						}
 					}`, types.TimeSeries)),
-					Query:     "Perf",
-					Resources: []string{},
-					QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					Query:            "Perf",
+					Resources:        []string{},
+					QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					AppInsightsQuery: false,
 				},
 			},
 			Err: require.NoError,
@@ -203,9 +205,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"resultFormat": "%s"
 						}
 					}`, types.TimeSeries)),
-					Query:     "Perf",
-					Resources: []string{},
-					QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					Query:            "Perf",
+					Resources:        []string{},
+					QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					AppInsightsQuery: false,
 				},
 			},
 			Err: require.NoError,
@@ -239,9 +242,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"resultFormat": "%s"
 						}
 					}`, types.TimeSeries)),
-					Query:     "Perf",
-					Resources: []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
-					QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					Query:            "Perf",
+					Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace"},
+					QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					AppInsightsQuery: false,
 				},
 			},
 			Err: require.NoError,
@@ -253,7 +257,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
-							"resources":     ["/subscriptions/r1","/subscriptions/r2"],
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
@@ -267,19 +271,20 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: types.TimeSeries,
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
 					JSON: []byte(fmt.Sprintf(`{
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": {
-							"resources":     ["/subscriptions/r1","/subscriptions/r2"],
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",  "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"],
 							"query":        "Perf",
 							"resultFormat": "%s"
 						}
 					}`, types.TimeSeries)),
-					Query:     "Perf",
-					Resources: []string{"/subscriptions/r1", "/subscriptions/r2"},
-					TimeRange: timeRange,
-					QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					Query:            "Perf",
+					Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace", "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace2"},
+					TimeRange:        timeRange,
+					QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+					AppInsightsQuery: false,
 				},
 			},
 			Err: require.NoError,
@@ -292,7 +297,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
@@ -307,11 +312,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
@@ -329,7 +334,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true trace` +
@@ -359,6 +364,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -370,7 +376,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
 							}
@@ -384,11 +390,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"traceTypes":	["trace"],
 								"operationId":	"test-op-id"
 							}
@@ -405,7 +411,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true trace` +
@@ -435,6 +441,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -446,7 +453,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTable)),
@@ -459,11 +466,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTable)),
@@ -478,7 +485,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
@@ -508,6 +515,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"${__data.fields.traceID}\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -519,7 +527,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"operationId":	"test-op-id"
 							}
@@ -533,11 +541,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"operationId":	"test-op-id"
 							}
@@ -554,7 +562,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
@@ -584,6 +592,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -595,7 +604,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "eq"}]
@@ -610,11 +619,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "eq"}]
@@ -633,7 +642,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
@@ -665,6 +674,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -676,7 +686,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"}]
@@ -691,11 +701,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"}]
@@ -714,7 +724,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
@@ -746,6 +756,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -757,7 +768,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"},{"filters": ["test-client-id"], "property": "clientId", "operation": "eq"}]
@@ -772,11 +783,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTable),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 								"queryType": "Azure Traces",
 								"azureTraces": {
-									"resources":     ["/subscriptions/r1"],
+									"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 									"resultFormat": "%s",
 									"operationId":	"test-op-id",
 									"filters":		[{"filters": ["test-app-id"], "property": "appId", "operation": "ne"},{"filters": ["test-client-id"], "property": "clientId", "operation": "eq"}]
@@ -795,7 +806,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,traces` +
@@ -827,6 +838,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -838,7 +850,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -851,11 +863,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":     ["/subscriptions/r1"],
+								"resources":     ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -870,7 +882,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests` +
@@ -900,6 +912,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"${__data.fields.traceID}\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -912,7 +925,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -925,12 +938,12 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -946,7 +959,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests` +
@@ -976,6 +989,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -988,7 +1002,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"traceTypes":		["traces"]
 							}
@@ -1002,24 +1016,25 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"test-op-id",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s",
 								"traceTypes":		["traces"]
 							}
 						}`, dataquery.ResultFormatTrace)),
 					Query:                   "",
-					Resources:               []string{"/subscriptions/r1"},
+					Resources:               []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange:               timeRange,
 					QueryType:               string(dataquery.AzureQueryTypeAzureTraces),
 					TraceExploreQuery:       "",
 					TraceParentExploreQuery: "",
 					TraceLogsExploreQuery: "union availabilityResults,\n" + "customEvents,\n" + "dependencies,\n" + "exceptions,\n" + "pageViews,\n" + "requests,\n" + "traces\n" +
 						"| where operation_Id == \"test-op-id\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -1032,7 +1047,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -1045,16 +1060,16 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
-								"resources":    ["/subscriptions/r1"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
-					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1065,10 +1080,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
-					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1079,7 +1094,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| where (operation_ParentId != '' and operation_ParentId == '${__data.fields.parentSpanID}')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1092,14 +1107,15 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union *,\n" +
-						"app('/subscriptions/r2').availabilityResults,\n" +
-						"app('/subscriptions/r2').customEvents,\n" +
-						"app('/subscriptions/r2').dependencies,\n" +
-						"app('/subscriptions/r2').exceptions,\n" +
-						"app('/subscriptions/r2').pageViews,\n" +
-						"app('/subscriptions/r2').requests,\n" +
-						"app('/subscriptions/r2').traces\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').traces\n" +
 						"| where operation_Id == \"op-id-multi\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -1111,7 +1127,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -1124,15 +1140,15 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
-					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
 						`| extend operationName = iff(isempty(column_ifexists("name", "")), column_ifexists("problemId", ""), column_ifexists("name", ""))` +
@@ -1142,10 +1158,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1", "/subscriptions/r2"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
-					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == '${__data.fields.traceID}') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == '${__data.fields.traceID}')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1156,7 +1172,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == '${__data.fields.traceID}') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == '${__data.fields.traceID}')` +
 						`| where (operation_ParentId != '' and operation_ParentId == '${__data.fields.parentSpanID}')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1169,14 +1185,15 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union *,\n" +
-						"app('/subscriptions/r2').availabilityResults,\n" +
-						"app('/subscriptions/r2').customEvents,\n" +
-						"app('/subscriptions/r2').dependencies,\n" +
-						"app('/subscriptions/r2').exceptions,\n" +
-						"app('/subscriptions/r2').pageViews,\n" +
-						"app('/subscriptions/r2').requests,\n" +
-						"app('/subscriptions/r2').traces\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').traces\n" +
 						"| where operation_Id == \"${__data.fields.traceID}\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -1189,7 +1206,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -1202,16 +1219,16 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-multi",
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
-					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1222,10 +1239,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1", "/subscriptions/r2"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
-					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1236,7 +1253,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests` +
+					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-multi') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-multi')` +
 						`| where (operation_ParentId != '' and operation_ParentId == '${__data.fields.parentSpanID}')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1249,14 +1266,15 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union *,\n" +
-						"app('/subscriptions/r2').availabilityResults,\n" +
-						"app('/subscriptions/r2').customEvents,\n" +
-						"app('/subscriptions/r2').dependencies,\n" +
-						"app('/subscriptions/r2').exceptions,\n" +
-						"app('/subscriptions/r2').pageViews,\n" +
-						"app('/subscriptions/r2').requests,\n" +
-						"app('/subscriptions/r2').traces\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').traces\n" +
 						"| where operation_Id == \"op-id-multi\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -1269,7 +1287,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
@@ -1282,16 +1300,16 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				{
 					RefID:        "A",
 					ResultFormat: string(dataquery.ResultFormatTrace),
-					URL:          "v1/subscriptions/r1/query",
+					URL:          "v1/apps/r1/query",
 					JSON: []byte(fmt.Sprintf(`{
 							"queryType": "Azure Traces",
 							"azureTraces": {
 								"operationId": 	"op-id-non-overlapping",
-								"resources":    ["/subscriptions/r1", "/subscriptions/r2"],
+								"resources":    ["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],
 								"resultFormat": "%s"
 							}
 						}`, dataquery.ResultFormatTrace)),
-					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests,app('/subscriptions/r3').availabilityResults,app('/subscriptions/r3').customEvents,app('/subscriptions/r3').dependencies,app('/subscriptions/r3').exceptions,app('/subscriptions/r3').pageViews,app('/subscriptions/r3').requests` +
+					Query: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-non-overlapping') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-non-overlapping')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1302,10 +1320,10 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					Resources: []string{"/subscriptions/r1", "/subscriptions/r2"},
+					Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"},
 					TimeRange: timeRange,
 					QueryType: string(dataquery.AzureQueryTypeAzureTraces),
-					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests,app('/subscriptions/r3').availabilityResults,app('/subscriptions/r3').customEvents,app('/subscriptions/r3').dependencies,app('/subscriptions/r3').exceptions,app('/subscriptions/r3').pageViews,app('/subscriptions/r3').requests` +
+					TraceExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-non-overlapping') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-non-overlapping')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
 						`| extend spanID = iff(itemType == "pageView" or isempty(column_ifexists("id", "")), tostring(new_guid()), column_ifexists("id", ""))` +
@@ -1316,7 +1334,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project-rename traceID = operation_Id, parentSpanID = operation_ParentId, startTime = timestamp` +
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
-					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/r2').availabilityResults,app('/subscriptions/r2').customEvents,app('/subscriptions/r2').dependencies,app('/subscriptions/r2').exceptions,app('/subscriptions/r2').pageViews,app('/subscriptions/r2').requests,app('/subscriptions/r3').availabilityResults,app('/subscriptions/r3').customEvents,app('/subscriptions/r3').dependencies,app('/subscriptions/r3').exceptions,app('/subscriptions/r3').pageViews,app('/subscriptions/r3').requests` +
+					TraceParentExploreQuery: `set truncationmaxrecords=10000; set truncationmaxsize=67108864; union isfuzzy=true availabilityResults,customEvents,dependencies,exceptions,pageViews,requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').availabilityResults,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').customEvents,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').dependencies,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').exceptions,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').pageViews,app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').requests` +
 						`| where (operation_Id != '' and operation_Id == 'op-id-non-overlapping') or (customDimensions.ai_legacyRootId != '' and customDimensions.ai_legacyRootId == 'op-id-non-overlapping')` +
 						`| where (operation_ParentId != '' and operation_ParentId == '${__data.fields.parentSpanID}')` +
 						`| extend duration = iff(isnull(column_ifexists("duration", real(null))), toreal(0), column_ifexists("duration", real(null)))` +
@@ -1329,21 +1347,22 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						`| project startTime, itemType, serviceName, duration, traceID, spanID, parentSpanID, operationName, serviceTags, tags, itemId` +
 						`| order by startTime asc`,
 					TraceLogsExploreQuery: "union *,\n" +
-						"app('/subscriptions/r2').availabilityResults,\n" +
-						"app('/subscriptions/r2').customEvents,\n" +
-						"app('/subscriptions/r2').dependencies,\n" +
-						"app('/subscriptions/r2').exceptions,\n" +
-						"app('/subscriptions/r2').pageViews,\n" +
-						"app('/subscriptions/r2').requests,\n" +
-						"app('/subscriptions/r2').traces,\n" +
-						"app('/subscriptions/r3').availabilityResults,\n" +
-						"app('/subscriptions/r3').customEvents,\n" +
-						"app('/subscriptions/r3').dependencies,\n" +
-						"app('/subscriptions/r3').exceptions,\n" +
-						"app('/subscriptions/r3').pageViews,\n" +
-						"app('/subscriptions/r3').requests,\n" +
-						"app('/subscriptions/r3').traces\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').availabilityResults,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').customEvents,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').dependencies,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').exceptions,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').pageViews,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').requests,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r2').traces,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').availabilityResults,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').customEvents,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').dependencies,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').exceptions,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').pageViews,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').requests,\n" +
+						"app('/subscriptions/test-sub/resourcegroups/test-rg/providers/microsoft.insights/components/r3').traces\n" +
 						"| where operation_Id == \"op-id-non-overlapping\"",
+					AppInsightsQuery: true,
 				},
 			},
 			Err: require.NoError,
@@ -1368,8 +1387,9 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 	t.Run("creates a request", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
-			Resources: []string{"r"},
-			Query:     "Perf",
+			Resources:        []string{"r"},
+			Query:            "Perf",
+			AppInsightsQuery: false,
 		})
 		require.NoError(t, err)
 		if req.URL.String() != url {
@@ -1390,12 +1410,13 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 	t.Run("creates a request with multiple resources", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
-			Resources: []string{"r1", "r2"},
-			Query:     "Perf",
-			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+			Resources:        []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"},
+			Query:            "Perf",
+			QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
+			AppInsightsQuery: false,
 		})
 		require.NoError(t, err)
-		expectedBody := `{"query":"Perf","timespan":"0001-01-01T00:00:00Z/0001-01-01T00:00:00Z","workspaces":["r1","r2"]}`
+		expectedBody := `{"query":"Perf","timespan":"0001-01-01T00:00:00Z/0001-01-01T00:00:00Z","workspaces":["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1","/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"]}`
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {
@@ -1408,16 +1429,17 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		from := time.Now()
 		to := from.Add(3 * time.Hour)
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
-			Resources: []string{"r1", "r2"},
+			Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"},
 			Query:     "Perf",
 			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
 			TimeRange: backend.TimeRange{
 				From: from,
 				To:   to,
 			},
+			AppInsightsQuery: false,
 		})
 		require.NoError(t, err)
-		expectedBody := fmt.Sprintf(`{"query":"Perf","timespan":"%s/%s","workspaces":["r1","r2"]}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
+		expectedBody := fmt.Sprintf(`{"query":"Perf","timespan":"%s/%s","workspaces":["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1","/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"]}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {
@@ -1425,20 +1447,21 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("does not pass multiple resources for traces queries", func(t *testing.T) {
+	t.Run("correctly passes multiple resources for traces queries", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		from := time.Now()
 		to := from.Add(3 * time.Hour)
 		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
-			Resources: []string{"r1", "r2"},
+			Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"},
 			QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 			TimeRange: backend.TimeRange{
 				From: from,
 				To:   to,
 			},
+			AppInsightsQuery: true,
 		})
 		require.NoError(t, err)
-		expectedBody := fmt.Sprintf(`{"query":"","timespan":"%s/%s"}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
+		expectedBody := fmt.Sprintf(`{"applications":["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1","/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],"query":"","timespan":"%s/%s"}`, from.Format(time.RFC3339), to.Format(time.RFC3339))
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {


### PR DESCRIPTION
Update the backend Log Analytics datasource to appropriately construct the request for multi-resource queries where the resource type is `Microsoft.Insights/components` (Application Insights).

- Add additional query property to distinguish queries containing AI resources
- Add logic to validate resource URI matches correct namespace
- Set `applications` request property if needed
- Update tests

Fixes #69821 