### PR TITLE
Logs: Change permalink icon back to `link`

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -128,7 +128,7 @@ export class LogRowMessage extends PureComponent<Props> {
                 aria-label="Copy shortlink"
                 tooltipPlacement="top"
                 size="md"
-                name="share-alt"
+                name="link"
                 onClick={() => onPermalinkClick(row)}
               />
             )}


### PR DESCRIPTION
**What is this feature?**
As discussed with @niat22 we should use the link icon.