### PR TITLE
[v10.0.x] Alerting: Allow selecting the same custom group when swapping folders

### DIFF
--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -55,7 +55,6 @@ const ui = {
     labelValue: (idx: number) => byTestId(`label-value-${idx}`),
   },
   loadingIndicator: byText('Loading the rule'),
-  loadingGroupIndicator: byText('Loading...'),
 };
 
 function getProvidersWrapper() {
@@ -122,7 +121,7 @@ describe('CloneRuleEditor', function () {
       });
 
       await waitForElementToBeRemoved(ui.loadingIndicator.query());
-      await waitForElementToBeRemoved(ui.loadingGroupIndicator.query(), { container: ui.inputs.group.get() });
+      await waitForElementToBeRemoved(within(ui.inputs.group.get()).getByTestId('Spinner'));
 
       await waitFor(() => {
         expect(ui.inputs.name.get()).toHaveValue('First Grafana Rule (copy)');

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -246,7 +246,6 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
                 <>
                   {type === RuleFormType.grafana ? (
                     <GrafanaEvaluationBehavior
-                      initialFolder={defaultValues.folder}
                       evaluateEvery={evaluateEvery}
                       setEvaluateEvery={setEvaluateEvery}
                       existing={Boolean(existing)}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,18 +1,18 @@
 import { css } from '@emotion/css';
-import { debounce } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { debounce, take, uniqueId } from 'lodash';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { AsyncSelect, Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { AsyncSelect, Badge, Field, InputControl, Label, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction, useDispatch } from 'app/types';
 
 import { useCombinedRuleNamespaces } from '../../hooks/useCombinedRuleNamespaces';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
-import { fetchRulerRulesIfNotFetchedYet } from '../../state/actions';
-import { RuleForm, RuleFormValues } from '../../types/rule-form';
+import { fetchRulerRulesAction } from '../../state/actions';
+import { RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { isGrafanaRulerRule } from '../../utils/rules';
 import { InfoIcon } from '../InfoIcon';
@@ -21,13 +21,17 @@ import { MINUTE } from './AlertRuleForm';
 import { Folder, RuleFolderPicker } from './RuleFolderPicker';
 import { checkForPathSeparator } from './util';
 
-export const SLICE_GROUP_RESULTS_TO = 1000;
-
-interface FolderAndGroupProps {
-  initialFolder: RuleForm | null;
-}
+export const MAX_GROUP_RESULTS = 1000;
 
 export const useGetGroupOptionsFromFolder = (folderTitle: string) => {
+  const dispatch = useDispatch();
+
+  // fetch the ruler rules from the database so we can figure out what other "groups" are already defined
+  // for our folders
+  useEffect(() => {
+    dispatch(fetchRulerRulesAction({ rulesSourceName: GRAFANA_RULES_SOURCE_NAME }));
+  }, [dispatch]);
+
   const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
   const groupfoldersForGrafana = rulerRuleRequests[GRAFANA_RULES_SOURCE_NAME];
 
@@ -49,55 +53,33 @@ export const useGetGroupOptionsFromFolder = (folderTitle: string) => {
   return { groupOptions, loading: groupfoldersForGrafana?.loading };
 };
 
-export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
+const findGroupMatchingLabel = (group: SelectableValue<string>, query: string) => {
+  return group.label?.toLowerCase().includes(query.toLowerCase());
+};
+
+export function FolderAndGroup() {
   const {
     formState: { errors },
     watch,
+    setValue,
     control,
   } = useFormContext<RuleFormValues>();
 
   const styles = useStyles2(getStyles);
-  const dispatch = useDispatch();
 
   const folder = watch('folder');
   const group = watch('group');
-  const [selectedGroup, setSelectedGroup] = useState<SelectableValue<string>>({ label: group, title: group });
-  const initialRender = useRef(true);
 
   const { groupOptions, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
 
-  useEffect(() => setSelectedGroup({ label: group, title: group }), [group, setSelectedGroup]);
-
-  useEffect(() => {
-    dispatch(fetchRulerRulesIfNotFetchedYet(GRAFANA_RULES_SOURCE_NAME));
-  }, [dispatch]);
-
   const resetGroup = useCallback(() => {
-    if (group && !initialRender.current && folder?.title) {
-      setSelectedGroup({ label: '', title: '' });
-    }
-    initialRender.current = false;
-  }, [group, folder?.title]);
-
-  const groupIsInGroupOptions = useCallback(
-    (group_: string) => {
-      return groupOptions.includes((groupInList: SelectableValue<string>) => groupInList.label === group_);
-    },
-    [groupOptions]
-  );
-  const sliceResults = (list: Array<SelectableValue<string>>) => list.slice(0, SLICE_GROUP_RESULTS_TO);
+    setValue('group', '');
+  }, [setValue]);
 
   const getOptions = useCallback(
     async (query: string) => {
-      const results = query
-        ? sliceResults(
-            groupOptions.filter((el) => {
-              const label = el.label ?? '';
-              return label.toLowerCase().includes(query.toLowerCase());
-            })
-          )
-        : sliceResults(groupOptions);
-      return results;
+      const results = query ? groupOptions.filter((group) => findGroupMatchingLabel(group, query)) : groupOptions;
+      return take(results, MAX_GROUP_RESULTS);
     },
     [groupOptions]
   );
@@ -105,6 +87,8 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   const debouncedSearch = useMemo(() => {
     return debounce(getOptions, 300, { leading: true });
   }, [getOptions]);
+
+  const defaultGroupValue = group ? { value: group, label: group } : undefined;
 
   return (
     <div className={styles.container}>
@@ -135,9 +119,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               enableReset={true}
               onChange={({ title, uid }) => {
                 field.onChange({ title, uid });
-                if (!groupIsInGroupOptions(selectedGroup.value ?? '')) {
-                  resetGroup();
-                }
+                resetGroup();
               }}
             />
           )}
@@ -160,32 +142,40 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
         invalid={!!errors.group?.message}
       >
         <InputControl
-          render={({ field: { ref, ...field } }) =>
-            loading ? (
-              <LoadingPlaceholder text="Loading..." />
-            ) : (
-              <AsyncSelect
-                disabled={!folder}
-                inputId="group"
-                key={`my_unique_select_key__${selectedGroup?.title ?? ''}`}
-                {...field}
-                invalid={Boolean(folder) && !selectedGroup.title}
-                loadOptions={debouncedSearch}
-                loadingMessage={'Loading groups...'}
-                defaultOptions={groupOptions}
-                defaultValue={selectedGroup}
-                getOptionLabel={(option: SelectableValue<string>) => `${option.label}`}
-                placeholder={'Evaluation group name'}
-                onChange={(value) => {
-                  field.onChange(value.label ?? '');
-                }}
-                value={selectedGroup}
-                allowCustomValue
-                formatCreateLabel={(_) => '+ Add new '}
-                noOptionsMessage="Start typing to create evaluation group"
-              />
-            )
-          }
+          render={({ field: { ref, ...field }, fieldState }) => (
+            <AsyncSelect
+              disabled={!folder || loading}
+              inputId="group"
+              key={uniqueId()}
+              {...field}
+              onChange={(group) => {
+                field.onChange(group.label ?? '');
+              }}
+              isLoading={loading}
+              invalid={Boolean(folder) && !group && Boolean(fieldState.error)}
+              loadOptions={debouncedSearch}
+              cacheOptions
+              loadingMessage={'Loading groups...'}
+              defaultValue={defaultGroupValue}
+              defaultOptions={groupOptions}
+              getOptionLabel={(option: SelectableValue<string>) => (
+                <div>
+                  <span>{option.label}</span>
+                  {/* making the assumption here that it's provisioned when it's disabled, should probably change this */}
+                  {option.isDisabled && (
+                    <>
+                      {' '}
+                      <Badge color="purple" text="Provisioned" />
+                    </>
+                  )}
+                </div>
+              )}
+              placeholder={'Evaluation group name'}
+              allowCustomValue
+              formatCreateLabel={(_) => '+ Add new '}
+              noOptionsMessage="Start typing to create evaluation group"
+            />
+          )}
           name="group"
           control={control}
           rules={{

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -11,7 +11,7 @@ import { CombinedRuleGroup, CombinedRuleNamespace } from '../../../../../types/u
 import { logInfo, LogMessages } from '../../Analytics';
 import { useCombinedRuleNamespaces } from '../../hooks/useCombinedRuleNamespaces';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
-import { RuleForm, RuleFormValues } from '../../types/rule-form';
+import { RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { parsePrometheusDuration } from '../../utils/time';
 import { CollapseToggle } from '../CollapseToggle';
@@ -114,11 +114,9 @@ export const EvaluateEveryNewGroup = ({ rules }: { rules: RulerRulesConfigDTO | 
 };
 
 function FolderGroupAndEvaluationInterval({
-  initialFolder,
   evaluateEvery,
   setEvaluateEvery,
 }: {
-  initialFolder: RuleForm | null;
   evaluateEvery: string;
   setEvaluateEvery: (value: string) => void;
 }) {
@@ -166,7 +164,7 @@ function FolderGroupAndEvaluationInterval({
 
   return (
     <div>
-      <FolderAndGroup initialFolder={initialFolder} />
+      <FolderAndGroup />
       {folderName && isEditingGroup && (
         <EditCloudGroupModal
           namespace={existingNamespace ?? emptyNamespace}
@@ -248,12 +246,10 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
 }
 
 export function GrafanaEvaluationBehavior({
-  initialFolder,
   evaluateEvery,
   setEvaluateEvery,
   existing,
 }: {
-  initialFolder: RuleForm | null;
   evaluateEvery: string;
   setEvaluateEvery: (value: string) => void;
   existing: boolean;
@@ -269,11 +265,7 @@ export function GrafanaEvaluationBehavior({
     // TODO remove "and alert condition" for recording rules
     <RuleEditorSection stepNo={3} title="Alert evaluation behavior">
       <Stack direction="column" justify-content="flex-start" align-items="flex-start">
-        <FolderGroupAndEvaluationInterval
-          initialFolder={initialFolder}
-          setEvaluateEvery={setEvaluateEvery}
-          evaluateEvery={evaluateEvery}
-        />
+        <FolderGroupAndEvaluationInterval setEvaluateEvery={setEvaluateEvery} evaluateEvery={evaluateEvery} />
         <ForInput evaluateEvery={evaluateEvery} />
 
         {existing && (


### PR DESCRIPTION
Backport 87884f4d416299c04c038e60ce68fd0401ea2045 from #70337

Showing provisioned groups in the dropdown wasn't backported so this one had to be manually back-ported.