### PR TITLE
Search: Always send specified kind in sql searcher

### DIFF
--- a/public/app/features/search/service/sql.test.ts
+++ b/public/app/features/search/service/sql.test.ts
@@ -10,9 +10,10 @@ jest.spyOn(backendSrv, 'fetch');
 describe('SQLSearcher', () => {
   beforeEach(() => {
     searchMock.mockReset();
-  });
-  it('should call search api with correct query for general folder', async () => {
     searchMock.mockResolvedValue([]);
+  });
+
+  it('should call search api with correct query for general folder', async () => {
     const sqlSearcher = new SQLSearcher();
     const query = {
       query: '*',
@@ -31,9 +32,7 @@ describe('SQLSearcher', () => {
     });
   });
 
-  it('should call search api with correct query based on its kinds', async () => {
-    searchMock.mockResolvedValue([]);
-
+  it('should call search api with correct folder kind when searching for *', async () => {
     const sqlSearcher = new SQLSearcher();
 
     const query = {
@@ -52,29 +51,34 @@ describe('SQLSearcher', () => {
       type: DashboardSearchItemType.DashFolder,
       folderIds: [0],
     });
+  });
 
-    searchMock.mockClear();
+  it('should call search api with correct folder kind when searching for a specific term', async () => {
+    const sqlSearcher = new SQLSearcher();
 
-    const query2 = {
+    const query = {
       query: 'test',
       kind: ['folder'],
       location: 'any',
       sort: 'name_sort',
     };
 
-    await sqlSearcher.search(query2);
+    await sqlSearcher.search(query);
 
     expect(searchMock).toHaveBeenLastCalledWith('/api/search', {
       limit: 1000,
-      sort: query2.sort,
-      query: query2.query,
+      sort: query.sort,
+      query: query.query,
       tag: undefined,
+      type: DashboardSearchItemType.DashFolder,
       folderIds: [0],
     });
+  });
 
-    searchMock.mockClear();
+  it('should call search api with correct folder kind when searching with a specific uid', async () => {
+    const sqlSearcher = new SQLSearcher();
 
-    const query3 = {
+    const query = {
       query: 'test',
       kind: ['folder'],
       location: 'any',
@@ -82,25 +86,23 @@ describe('SQLSearcher', () => {
       uid: ['T202C0Tnk'],
     };
 
-    await sqlSearcher.search(query3);
+    await sqlSearcher.search(query);
 
     expect(searchMock).toHaveBeenLastCalledWith('/api/search', {
       limit: 1000,
-      sort: query3.sort,
-      query: query3.query,
+      sort: query.sort,
+      query: query.query,
       tag: undefined,
-      dashboardUID: query3.uid,
+      dashboardUID: query.uid,
+      type: DashboardSearchItemType.DashFolder,
     });
   });
 
   it('starred should call search api with correct query', async () => {
-    searchMock.mockResolvedValue([]);
-
     const sqlSearcher = new SQLSearcher();
 
     const query = {
       query: 'test',
-      kind: ['folder'],
       location: 'any',
       sort: 'name_sort',
       uid: ['T202C0Tnk'],
@@ -126,7 +128,6 @@ describe('SQLSearcher', () => {
       { from: 50, expectedPage: 2 },
       { from: 150, expectedPage: 4 },
     ])('should search page $expectedPage when skipping $from results', async ({ from, expectedPage }) => {
-      searchMock.mockResolvedValue([]);
       const sqlSearcher = new SQLSearcher();
 
       await sqlSearcher.search({

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -42,12 +42,13 @@ export class SQLSearcher implements GrafanaSearcher {
   private async composeQuery(apiQuery: APIQuery, searchOptions: SearchQuery): Promise<APIQuery> {
     const query = await replaceCurrentFolderQuery(searchOptions);
 
-    if (query.query === '*') {
-      if (query.kind?.length === 1 && TYPE_KIND_MAP[query.kind[0]]) {
-        apiQuery.type = TYPE_KIND_MAP[query.kind[0]];
-      }
-    } else if (query.query?.length) {
+    if (query.query?.length && query.query !== '*') {
       apiQuery.query = query.query;
+    }
+
+    // search v1 supports only one kind
+    if (query.kind?.length === 1 && TYPE_KIND_MAP[query.kind[0]]) {
+      apiQuery.type = TYPE_KIND_MAP[query.kind[0]];
     }
 
     if (query.uid) {


### PR DESCRIPTION
The SQL searcher (search v1) did not send through the kind to the search API as expected. The previous behaviour was unclear to me, and the tests didn't really explain this behaviour (though it did assert it). I've done a bunch of testing and everything still appears to work fine.

Part of https://github.com/grafana/grafana/issues/69611