### PR TITLE
DSPicker: Respect datasource & mixed props

### DIFF
--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -18,10 +18,12 @@ interface BuiltInDataSourceListProps {
   className?: string;
   current: DataSourceRef | string | null | undefined;
   onChange: (ds: DataSourceInstanceSettings) => void;
+  dashboard?: boolean;
+  mixed?: boolean;
 }
 
-export function BuiltInDataSourceList({ className, current, onChange }: BuiltInDataSourceListProps) {
-  const grafanaDataSources = useDatasources({ mixed: true, dashboard: true, filter: (ds) => !!ds.meta.builtIn });
+export function BuiltInDataSourceList({ className, current, onChange, dashboard, mixed }: BuiltInDataSourceListProps) {
+  const grafanaDataSources = useDatasources({ mixed, dashboard, filter: (ds) => !!ds.meta.builtIn });
 
   return (
     <div className={className}>

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -240,6 +240,8 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
                   enableFileUpload: props.enableFileUpload,
                   fileUploadOptions: props.fileUploadOptions,
                   reportedInteractionFrom: 'ds_picker',
+                  dashboard: props.dashboard,
+                  mixed: props.mixed,
                   current,
                   onDismiss: hideModal,
                   onChange: (ds) => {

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -37,12 +37,16 @@ interface DataSourceModalProps {
   onDismiss: () => void;
   recentlyUsed?: string[];
   enableFileUpload?: boolean;
+  dashboard?: boolean;
+  mixed?: boolean;
   fileUploadOptions?: DropzoneOptions;
   reportedInteractionFrom?: string;
 }
 
 export function DataSourceModal({
   enableFileUpload,
+  dashboard,
+  mixed,
   fileUploadOptions,
   onChange,
   current,
@@ -113,6 +117,8 @@ export function DataSourceModal({
             }
           />
           <BuiltInDataSourceList
+            dashboard={dashboard}
+            mixed={mixed}
             className={styles.appendBuiltInDataSourcesList}
             onChange={onChangeDataSource}
             current={current}
@@ -122,7 +128,12 @@ export function DataSourceModal({
       <div className={styles.rightColumn}>
         <div className={styles.builtInDataSources}>
           <CustomScrollbar className={styles.builtInDataSourcesList}>
-            <BuiltInDataSourceList onChange={onChangeDataSource} current={current} />
+            <BuiltInDataSourceList
+              onChange={onChangeDataSource}
+              current={current}
+              dashboard={dashboard}
+              mixed={mixed}
+            />
           </CustomScrollbar>
           {enableFileUpload && (
             <FileDropzone

--- a/public/app/features/datasources/components/picker/types.ts
+++ b/public/app/features/datasources/components/picker/types.ts
@@ -13,6 +13,8 @@ export interface DataSourceDropdownProps {
   onClickAddCSV?: () => void;
   recentlyUsed?: string[];
   hideTextValue?: boolean;
+  dashboard?: boolean;
+  mixed?: boolean;
   width?: number;
 }
 
@@ -20,6 +22,8 @@ export interface PickerContentProps extends DataSourceDropdownProps {
   keyboardEvents: Observable<React.KeyboardEvent>;
   style: React.CSSProperties;
   filterTerm?: string;
+  dashboard?: boolean;
+  mixed?: boolean;
   onClose: () => void;
   onDismiss: () => void;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The new DS picker, unlike the old one, ignores the Dashboard prop when deciding which datasources to show and ignores the `mixed` props when displaying the advanced picker.

To be exactly consistent with the old picker i slighlty changed the logic of the new DS picker to match the previous one.

Due to the high number of permutations in configuration options it's quite hard to compile a list, the best way to test this is toggle between `advancedDataSourcePicker = false` and `advancedDataSourcePicker = true` and check **BOTH** the root datasource picker i dashboard edit, the inner ones when selecting mixed and in both cases the advanced picker (modal). Then repeat the tests in Explore with `exploreMixedDatasource = false` and `exploreMixedDatasource = true`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70375 

**Special notes for your reviewer:**

I didn't find any unit test for this behavior, probably some should be added. cc. @ivanortegaalba 


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
