### PR TITLE
Dashboards: Allow dashboards with same name in different folders

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2786,11 +2786,6 @@ exports[`better eslint`] = {
     "public/app/features/manage-dashboards/components/ImportDashboardLibraryPanelsList.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/manage-dashboards/services/ValidationSrv.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/features/manage-dashboards/state/actions.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -52,8 +52,9 @@ export const SaveDashboardAsForm = ({ dashboard, isNew, onSubmit, onCancel, onSu
     if (dashboardName && dashboardName === getFormValues().$folder.title?.trim()) {
       return 'Dashboard name cannot be the same as folder name';
     }
+
     try {
-      await validationSrv.validateNewDashboardName(getFormValues().$folder.uid, dashboardName);
+      await validationSrv.validateNewDashboardName(getFormValues().$folder.uid ?? 'general', dashboardName);
       return true;
     } catch (e) {
       return e instanceof Error ? e.message : 'Dashboard name is invalid';

--- a/public/app/features/manage-dashboards/services/ValidationSrv.ts
+++ b/public/app/features/manage-dashboards/services/ValidationSrv.ts
@@ -17,7 +17,11 @@ export class ValidationSrv {
   }
 
   validateNewFolderName(name?: string) {
-    return this.validate(0, name, 'A folder or dashboard in the general folder with the same name already exists');
+    return this.validate(
+      this.rootName,
+      name,
+      'A folder or dashboard in the general folder with the same name already exists'
+    );
   }
 
   private async validate(folderUID: string, name: string | undefined, existingErrorMessage: string) {

--- a/public/app/features/manage-dashboards/services/ValidationSrv.ts
+++ b/public/app/features/manage-dashboards/services/ValidationSrv.ts
@@ -1,9 +1,4 @@
-import { backendSrv } from 'app/core/services/backend_srv';
-
-const hitTypes = {
-  FOLDER: 'dash-folder',
-  DASHBOARD: 'dash-db',
-};
+import { getGrafanaSearcher } from 'app/features/search/service';
 
 class ValidationError extends Error {
   type: string;
@@ -17,15 +12,15 @@ class ValidationError extends Error {
 export class ValidationSrv {
   rootName = 'general';
 
-  validateNewDashboardName(folderUid: any, name: string) {
-    return this.validate(folderUid, name, 'A dashboard or a folder with the same name already exists');
+  validateNewDashboardName(folderUID: string, name: string) {
+    return this.validate(folderUID, name, 'A dashboard or a folder with the same name already exists');
   }
 
   validateNewFolderName(name?: string) {
     return this.validate(0, name, 'A folder or dashboard in the general folder with the same name already exists');
   }
 
-  private async validate(folderId: any, name: string | undefined, existingErrorMessage: string) {
+  private async validate(folderUID: string, name: string | undefined, existingErrorMessage: string) {
     name = (name || '').trim();
     const nameLowerCased = name.toLowerCase();
 
@@ -33,27 +28,20 @@ export class ValidationSrv {
       throw new ValidationError('REQUIRED', 'Name is required');
     }
 
-    if (folderId === 0 && nameLowerCased === this.rootName) {
+    if (nameLowerCased === this.rootName) {
       throw new ValidationError('EXISTING', 'This is a reserved name and cannot be used for a folder.');
     }
 
-    const promises = [];
-    promises.push(backendSrv.search({ type: hitTypes.FOLDER, folderIds: [folderId], query: name }));
-    promises.push(backendSrv.search({ type: hitTypes.DASHBOARD, folderIds: [folderId], query: name }));
+    const searcher = getGrafanaSearcher();
 
-    const res = await Promise.all(promises);
-    let hits: any[] = [];
+    const dashboardResults = await searcher.search({
+      kind: ['dashboard'],
+      query: name,
+      location: folderUID || 'general',
+    });
 
-    if (res.length > 0 && res[0].length > 0) {
-      hits = res[0];
-    }
-
-    if (res.length > 1 && res[1].length > 0) {
-      hits = hits.concat(res[1]);
-    }
-
-    for (const hit of hits) {
-      if (nameLowerCased === hit.title.toLowerCase()) {
+    for (const result of dashboardResults.view) {
+      if (nameLowerCased === result.name.toLowerCase()) {
         throw new ValidationError('EXISTING', existingErrorMessage);
       }
     }


### PR DESCRIPTION
 - Grafana previously used to validate that your dashboard name is unique _in the folder you're saving to_
 - https://github.com/grafana/grafana/pull/58393 regressed this behaviour to instead validate the name globally
    - it started passing in folderUID (string) instead of folderID (number) to the search API which only supports ID
    - this remained hidden because the parameters were typed to `any` :(
  - **This PR** changes ValidationSrv to use getGrafanaSearcher which handles converting folder ID to UID for search (it also uses search v2 if configured) to search the correct folder

Requires https://github.com/grafana/grafana/pull/70376 to work with SQLSearcher/Search v1

Fixes https://github.com/grafana/grafana/issues/69611