### PR TITLE
Alerting: Add file and rule_group query params in request for filtering the res…

### DIFF
--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -327,6 +327,7 @@ describe('PanelAlertTabContent', () => {
       },
       undefined,
       undefined,
+      undefined,
       undefined
     );
   });

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -2,10 +2,11 @@ import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
-import { RuleNamespace } from 'app/types/unified-alerting';
+import { RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
 import { PromRulesResponse } from 'app/types/unified-alerting-dto';
 
 import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { isCloudRuleIdentifier, isPrometheusRuleIdentifier } from '../utils/rules';
 
 export interface FetchPromRulesFilter {
   dashboardUID: string;
@@ -15,10 +16,11 @@ export interface FetchPromRulesFilter {
 export interface PrometheusDataSourceConfig {
   dataSourceName: string;
   limitAlerts?: number;
+  identifier?: RuleIdentifier;
 }
 
 export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfig) {
-  const { dataSourceName, limitAlerts } = dataSourceConfig;
+  const { dataSourceName, limitAlerts, identifier } = dataSourceConfig;
 
   return {
     rules: (filter?: FetchPromRulesFilter, state?: string[], matcher?: Matcher[]) => {
@@ -28,6 +30,11 @@ export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfi
       // we do this because the response is large otherwise and we don't show all of them in the UI anyway.
       if (dataSourceName === GRAFANA_RULES_SOURCE_NAME && limitAlerts) {
         searchParams.set('limit_alerts', String(limitAlerts));
+      }
+
+      if (identifier && (isPrometheusRuleIdentifier(identifier) || isCloudRuleIdentifier(identifier))) {
+        searchParams.set('file', identifier.namespace);
+        searchParams.set('rule_group', identifier.groupName);
       }
 
       const params = prepareRulesFilterQueryParams(searchParams, filter);
@@ -81,13 +88,18 @@ export async function fetchRules(
   filter?: FetchPromRulesFilter,
   limitAlerts?: number,
   matcher?: Matcher[],
-  state?: string[]
+  state?: string[],
+  identifier?: RuleIdentifier
 ): Promise<RuleNamespace[]> {
   if (filter?.dashboardUID && dataSourceName !== GRAFANA_RULES_SOURCE_NAME) {
     throw new Error('Filtering by dashboard UID is only supported for Grafana Managed rules.');
   }
 
-  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts }).rules(filter, state, matcher);
+  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts, identifier }).rules(
+    filter,
+    state,
+    matcher
+  );
 
   // adding state param here instead of adding it in prometheusUrlBuilder, for being a possible multiple query param
   const response = await lastValueFrom(

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -17,7 +17,7 @@ export function useCombinedRule(
   identifier: RuleIdentifier | undefined,
   ruleSourceName: string | undefined
 ): AsyncRequestState<CombinedRule> {
-  const requestState = useCombinedRulesLoader(ruleSourceName);
+  const requestState = useCombinedRulesLoader(ruleSourceName, identifier);
   const combinedRules = useCombinedRuleNamespaces(ruleSourceName);
 
   const rule = useMemo(() => {
@@ -79,7 +79,10 @@ export function useCombinedRulesMatching(
   };
 }
 
-function useCombinedRulesLoader(rulesSourceName: string | undefined): AsyncRequestState<void> {
+function useCombinedRulesLoader(
+  rulesSourceName: string | undefined,
+  identifier?: RuleIdentifier
+): AsyncRequestState<void> {
   const dispatch = useDispatch();
   const promRuleRequests = useUnifiedAlertingSelector((state) => state.promRules);
   const promRuleRequest = getRequestState(rulesSourceName, promRuleRequests);
@@ -91,7 +94,7 @@ function useCombinedRulesLoader(rulesSourceName: string | undefined): AsyncReque
       return;
     }
 
-    await dispatch(fetchPromAndRulerRulesAction({ rulesSourceName }));
+    await dispatch(fetchPromAndRulerRulesAction({ rulesSourceName, identifier }));
   }, [dispatch, rulesSourceName]);
 
   return {

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -107,12 +107,14 @@ export const fetchPromRulesAction = createAsyncThunk(
       limitAlerts,
       matcher,
       state,
+      identifier,
     }: {
       rulesSourceName: string;
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
       matcher?: Matcher[];
       state?: string[];
+      identifier?: RuleIdentifier;
     },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
@@ -123,7 +125,9 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matcher, state));
+    return await withSerializedError(
+      fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matcher, state, identifier)
+    );
   }
 );
 
@@ -239,12 +243,18 @@ export const fetchRulerRulesAction = createAsyncThunk(
   }
 );
 
-export function fetchPromAndRulerRulesAction({ rulesSourceName }: { rulesSourceName: string }): ThunkResult<void> {
+export function fetchPromAndRulerRulesAction({
+  rulesSourceName,
+  identifier,
+}: {
+  rulesSourceName: string;
+  identifier?: RuleIdentifier;
+}): ThunkResult<void> {
   return async (dispatch, getState) => {
     await dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
     const dsConfig = getDataSourceConfig(getState, rulesSourceName);
 
-    await dispatch(fetchPromRulesAction({ rulesSourceName }));
+    await dispatch(fetchPromRulesAction({ rulesSourceName, identifier }));
     if (dsConfig.rulerConfig) {
       await dispatch(fetchRulerRulesAction({ rulesSourceName }));
     }


### PR DESCRIPTION
**What is this feature?**
This PR introduces some changes to the `RuleViewer` page by adding new query parameters for filtering alert rules based on `file` (namespace) and `rule_group`. These additions effectively reduce the number of rules loaded on the page, resulting in improved loading times.

Initially, the plan was to incorporate the new `rule_name` query parameter introduced in [this PR](https://github.com/prometheus/prometheus/pull/12270). However, to maintain compatibility with existing links to the view and considering the absence of alert names in those links, an alternative approach was necessary.

By introducing the file and rule_group query parameters, we achieve the desired improvements in loading time and enhance the overall performance of the RuleViewer page.

This is only implemented for cloud rules.

**Why do we need this feature?**

We need to prevent the unnecessary loading of all rules when only one rule is being accessed.

**Who is this feature for?**

All users.
**Which issue(s) does this PR fix?**:

This PR fixes partially (FE side) this [issue](https://github.com/grafana/grafana/issues/66701) 

**Special notes for your reviewer:**

https://github.com/grafana/grafana/assets/33540275/de5cec37-09f5-4fe0-861c-1eb96dfce56b


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
