### PR TITLE
Docs: Fix instructions for backend Datasource plugins

### DIFF
--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
@@ -106,7 +106,9 @@ Ensure that Grafana has been started in development mode. If you are running Gra
 app_mode = development
 ```
 
-You can then start Grafana in development mode by running `mage -v && yarn start` in the repository root. If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
+You can then start Grafana in development mode by running `make run & make run-frontend` in the Grafana repository root.
+
+If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
 
 By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
 configure Grafana to [allow unsigned plugins](/docs/grafana/latest/plugins/plugin-signature-verification/#allow-unsigned-plugins).

--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
@@ -100,6 +100,14 @@ You now have a new data source instance of your plugin that is ready to use in a
 
 #### Grafana doesn't load my plugin
 
+Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to include the add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
+
+```ini
+app_mode = development
+```
+
+You can then start Grafana in development mode by running `mage -v && yarn start` in the repository root. If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
+
 By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
 configure Grafana to [allow unsigned plugins](/docs/grafana/latest/plugins/plugin-signature-verification/#allow-unsigned-plugins).
 For more information, refer to [Plugin signature verification](/docs/grafana/latest/plugins/plugin-signature-verification/#backend-plugins).

--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
@@ -100,7 +100,7 @@ You now have a new data source instance of your plugin that is ready to use in a
 
 #### Grafana doesn't load my plugin
 
-Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to include the add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
+Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
 
 ```ini
 app_mode = development

--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
@@ -129,7 +129,7 @@ In the next step we will look at the query endpoint!
 
 ## Implement data queries
 
-We begin by opening the file `/pkg/plugin/plugin.go`. In this file you will see the `SampleDatasource` struct which implements the [backend.QueryDataHandler](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend?tab=doc#QueryDataHandler) interface. The `QueryData` method on this struct is where the data fetching happens for a data source plugin.
+We begin by opening the file `/pkg/plugin/datasource.go`. In this file you will see the `SampleDatasource` struct which implements the [backend.QueryDataHandler](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend?tab=doc#QueryDataHandler) interface. The `QueryData` method on this struct is where the data fetching happens for a data source plugin.
 
 Each request contains multiple queries to reduce traffic between Grafana and plugins. So you need to loop over the slice of queries, process each query, and then return the results of all queries.
 
@@ -147,7 +147,7 @@ When editing a data source in Grafana's UI, you can **Save & Test** to verify th
 
 In this sample data source, there is a 50% chance that the health check will be successful. Make sure to return appropriate error messages to the users, informing them about what is misconfigured in the data source.
 
-Open `/pkg/plugin/plugin.go`. In this file you'll see that the `SampleDatasource` struct also implements the [backend.CheckHealthHandler](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend?tab=doc#CheckHealthHandler) interface. Navigate to the `CheckHealth` method to see how the health check for this sample plugin is implemented.
+Open `/pkg/plugin/datasource.go`. In this file you'll see that the `SampleDatasource` struct also implements the [backend.CheckHealthHandler](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend?tab=doc#CheckHealthHandler) interface. Navigate to the `CheckHealth` method to see how the health check for this sample plugin is implemented.
 
 ## Add authentication
 


### PR DESCRIPTION
This PR fixes some issues with the instructions in the `docs/sources/tutorials/build-a-data-source-backend-plugin/index.md` file for creating a backend Datasource plugin.

- The file contains references to `plugin.go`, which is probably from an old version of the `create-plugin` tool. I changed this to `datasource.go`, which was what was actually created for me when I ran the tool.
- Added a section on starting Grafana in development mode. Not starting Grafana in development mode caused my plugin to not be shown in the datasources list, even though it seemed to be picked up by Grafana in `STDOUT`.