### PR TITLE
Elasticsearch: Fix infinite loop when using mixed datasources

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -107,10 +107,9 @@ export const createReducer =
     }
 
     if (initQuery.match(action)) {
-      if (state?.length || 0 > 0) {
+      if (state && state.length > 0) {
         return state;
       }
-
       return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
     }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -59,11 +59,11 @@ export const ElasticsearchProvider = ({
   // This initializes the query by dispatching an init action to each reducer.
   // useStatelessReducer will then call `onChange` with the newly generated query
   useEffect(() => {
-    if (shouldRunInit) {
+    if (shouldRunInit && isUninitialized) {
       dispatch(initQuery());
       setShouldRunInit(false);
     }
-  }, [shouldRunInit, dispatch]);
+  }, [shouldRunInit, dispatch, isUninitialized]);
 
   if (isUninitialized) {
     return null;

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
@@ -155,7 +155,7 @@ export const reducer = (state: ElasticsearchQuery['metrics'], action: Action): E
   }
 
   if (initQuery.match(action)) {
-    if (state?.length || 0 > 0) {
+    if (state && state.length > 0) {
       return state;
     }
     return [defaultMetricAgg('1')];


### PR DESCRIPTION
While working with Elasticsearch and mixed data sources I ran into a situation where selecting an Elasticsearch data source from the data source picker would result in an infinite loop, killing the browser.

https://github.com/grafana/grafana/assets/1069378/f41c1fc2-6a56-4b93-9751-f6d3daf638e7

After some investigation I found that re-rendering ElasticsearchContext causes its effect to enter an infinite loop after calling `initQuery()`.

Additionally, I found some hardcoded `0 > 0` which fortunately were harmless but incorrect.

**Special notes for your reviewer:**

Steps to reproduce:
- Use mixed mode in Explore.
- Add a query with any data source (e.g. Loki).
- Add another query row.
- Select Elasticsearch
- = infinite loop.

After changes (color changes means ElasticsearchContext changing):

https://github.com/grafana/grafana/assets/1069378/cc166c0b-53d2-4144-aa2a-7f5d41474399
