### PR TITLE
Traces: Remove noop functions

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -122,7 +122,6 @@ export function TraceView(props: Props) {
       childrenHiddenIDs,
       detailStates,
       hoverIndentGuideIds,
-      shouldScrollToFirstUiFindMatch: false,
       spanNameColumnWidth,
       traceID: props.traceProp?.traceID,
     }),
@@ -192,7 +191,6 @@ export function TraceView(props: Props) {
           )}
           <TraceTimelineViewer
             registerAccessors={noop}
-            scrollToFirstVisibleSpan={noop}
             findMatchesIDs={config.featureToggles.newTraceViewHeader ? spanFilterMatches : spanFindMatches}
             trace={traceProp}
             datasourceType={datasourceType}
@@ -208,7 +206,6 @@ export function TraceView(props: Props) {
             expandAll={expandAll}
             expandOne={expandOne}
             childrenToggle={childrenToggle}
-            clearShouldScrollToFirstUiFindMatch={noop}
             detailLogItemToggle={detailLogItemToggle}
             detailLogsToggle={detailLogsToggle}
             detailWarningsToggle={detailWarningsToggle}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
@@ -29,7 +29,6 @@ const topOfExploreViewRef = jest.fn();
 let props = {
   childrenHiddenIDs: new Set(),
   childrenToggle: jest.fn(),
-  clearShouldScrollToFirstUiFindMatch: jest.fn(),
   currentViewRangeTime: [0.25, 0.75],
   detailLogItemToggle: jest.fn(),
   detailLogsToggle: jest.fn(),
@@ -39,10 +38,8 @@ let props = {
   detailToggle: jest.fn(),
   findMatchesIDs: null,
   registerAccessors: jest.fn(),
-  scrollToFirstVisibleSpan: jest.fn(),
   setSpanNameColumnWidth: jest.fn(),
   setTrace: jest.fn(),
-  shouldScrollToFirstUiFindMatch: false,
   spanNameColumnWidth: 0.5,
   trace,
   uiFind: 'uiFind',

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -87,13 +87,11 @@ type TVirtualizedTraceViewOwnProps = {
   currentViewRangeTime: [number, number];
   timeZone: TimeZone;
   findMatchesIDs: Set<string> | TNil;
-  scrollToFirstVisibleSpan: () => void;
   registerAccessors: (accesors: Accessors) => void;
   trace: Trace;
   spanBarOptions: SpanBarOptions | undefined;
   linksGetter: (span: TraceSpan, items: TraceKeyValuePair[], itemIndex: number) => TraceLink[];
   childrenToggle: (spanID: string) => void;
-  clearShouldScrollToFirstUiFindMatch: () => void;
   detailLogItemToggle: (spanID: string, log: TraceLog) => void;
   detailLogsToggle: (spanID: string) => void;
   detailWarningsToggle: (spanID: string) => void;
@@ -224,14 +222,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
     let key: keyof VirtualizedTraceViewProps;
     for (key in nextProps) {
       if (nextProps[key] !== this.props[key]) {
-        // Unless the only change was props.shouldScrollToFirstUiFindMatch changing to false.
-        if (key === 'shouldScrollToFirstUiFindMatch') {
-          if (nextProps[key]) {
-            return true;
-          }
-        } else {
-          return true;
-        }
+        return true;
       }
     }
     return false;
@@ -240,9 +231,6 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
   componentDidUpdate(prevProps: Readonly<VirtualizedTraceViewProps>) {
     const { registerAccessors, trace, headerHeight } = prevProps;
     const {
-      shouldScrollToFirstUiFindMatch,
-      clearShouldScrollToFirstUiFindMatch,
-      scrollToFirstVisibleSpan,
       registerAccessors: nextRegisterAccessors,
       setTrace,
       trace: nextTrace,
@@ -257,11 +245,6 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
 
     if (this.listView && registerAccessors !== nextRegisterAccessors) {
       nextRegisterAccessors(this.getAccessors());
-    }
-
-    if (shouldScrollToFirstUiFindMatch) {
-      scrollToFirstVisibleSpan();
-      clearShouldScrollToFirstUiFindMatch();
     }
 
     if (focusedSpanId !== prevProps.focusedSpanId) {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -74,7 +74,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
 export type TProps = TExtractUiFindFromStateReturn & {
   registerAccessors: (accessors: Accessors) => void;
   findMatchesIDs: Set<string> | TNil;
-  scrollToFirstVisibleSpan: () => void;
   traceTimeline: TTraceTimeline;
   trace: Trace;
   datasourceType: string;
@@ -91,7 +90,6 @@ export type TProps = TExtractUiFindFromStateReturn & {
   expandOne: (spans: TraceSpan[]) => void;
 
   childrenToggle: (spanID: string) => void;
-  clearShouldScrollToFirstUiFindMatch: () => void;
   detailLogItemToggle: (spanID: string, log: TraceLog) => void;
   detailLogsToggle: (spanID: string) => void;
   detailWarningsToggle: (spanID: string) => void;

--- a/public/app/features/explore/TraceView/components/types/TTraceTimeline.tsx
+++ b/public/app/features/explore/TraceView/components/types/TTraceTimeline.tsx
@@ -20,7 +20,6 @@ type TTraceTimeline = {
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;
   hoverIndentGuideIds: Set<string>;
-  shouldScrollToFirstUiFindMatch: boolean;
   spanNameColumnWidth: number;
   traceID: string | TNil;
 };


### PR DESCRIPTION
**What is this feature?**

Removes noop functions.

**Why do we need this feature?**

noop functions are unused and lead to code bloat.

**Who is this feature for?**

Devs.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
