### PR TITLE
Library Panels: Fix issue when deleting library panels from folder view

### DIFF
--- a/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.test.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.test.tsx
@@ -40,6 +40,8 @@ jest.mock('debounce-promise', () => {
   return debounce;
 });
 
+jest.spyOn(api, 'getConnectedDashboards').mockResolvedValue([]);
+jest.spyOn(api, 'deleteLibraryPanel').mockResolvedValue({ message: 'success' });
 async function getTestContext(
   propOverrides: Partial<LibraryPanelsSearchProps> = {},
   searchResult: LibraryElementsSearchResult = { elements: [], perPage: 40, page: 1, totalCount: 0 }
@@ -317,6 +319,56 @@ describe('LibraryPanelsSearch', () => {
       expect(within(card()).getByText(/library panel name/i)).toBeInTheDocument();
       expect(within(card()).getByText(/library panel description/i)).toBeInTheDocument();
       expect(within(card()).getByLabelText(/delete button on panel type card/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('when mounted with showSecondaryActions and a specific folder', () => {
+    describe('and user deletes a panel', () => {
+      it('should call api with correct params', async () => {
+        const { getLibraryPanelsSpy } = await getTestContext(
+          { showSecondaryActions: true, currentFolderUID: 'wfTJJL5Wz' },
+          {
+            elements: [
+              {
+                name: 'Library Panel Name',
+                uid: 'uid',
+                description: 'Library Panel Description',
+                folderUid: 'wfTJJL5Wz',
+                model: { type: 'timeseries', title: 'A title' } as Panel,
+                type: 'timeseries',
+                version: 1,
+                meta: {
+                  folderName: 'General',
+                  folderUid: '',
+                  connectedDashboards: 0,
+                  created: '2021-01-01 12:00:00',
+                  createdBy: { id: 1, name: 'Admin', avatarUrl: '' },
+                  updated: '2021-01-01 12:00:00',
+                  updatedBy: { id: 1, name: 'Admin', avatarUrl: '' },
+                },
+              },
+            ],
+            perPage: 40,
+            page: 1,
+            totalCount: 1,
+          }
+        );
+
+        await userEvent.click(screen.getByLabelText(/delete button on panel type card/i));
+        await waitFor(() => expect(screen.getByText('Do you want to delete this panel?')).toBeInTheDocument());
+        await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await waitFor(() => {
+          expect(getLibraryPanelsSpy).toHaveBeenCalledWith({
+            searchString: '',
+            folderFilterUIDs: ['wfTJJL5Wz'],
+            page: 1,
+            typeFilter: [],
+            sortDirection: undefined,
+            perPage: 40,
+          });
+        });
+      });
     });
   });
 });

--- a/public/app/features/library-panels/components/LibraryPanelsView/LibraryPanelsView.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsView/LibraryPanelsView.tsx
@@ -61,7 +61,16 @@ export const LibraryPanelsView = ({
     [searchString, sortDirection, panelFilter, folderFilter, page, asyncDispatch]
   );
   const onDelete = ({ uid }: LibraryElementDTO) =>
-    asyncDispatch(deleteLibraryPanel(uid, { searchString, page, perPage }));
+    asyncDispatch(
+      deleteLibraryPanel(uid, {
+        searchString,
+        sortDirection,
+        panelFilter,
+        folderFilterUIDs: folderFilter,
+        page,
+        perPage,
+      })
+    );
   const onPageChange = (page: number) => asyncDispatch(changePage({ page }));
 
   return (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently after deleting library panels from a specific folder view, the page loads all library panels ignoring the folder you are currently viewing. See https://github.com/grafana/support-escalations/issues/6410 for more information.

**Why do we need this feature?**

So that only the library panels in that folder are visible.

**Who is this feature for?**

Anyone using library panels.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes escalation https://github.com/grafana/support-escalations/issues/6410

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
