### PR TITLE
docs: table panel: modified support section regarding alerts

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -29,7 +29,7 @@ The table panel visualization is very flexible, supporting multiple modes for ti
 
 ## Annotation and alert support
 
-Annotations and alerts are not currently supported in the new table panel. 
+Annotations and alerts are not currently supported in the new table panel.
 
 ## Sort column
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -27,7 +27,7 @@ The table panel visualization is very flexible, supporting multiple modes for ti
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-## Annotation and Alert support
+## Annotation and alert support
 
 Annotations and alerts are not currently supported in the new table panel. However, annotations might be added back in a future release.
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -29,7 +29,7 @@ The table panel visualization is very flexible, supporting multiple modes for ti
 
 ## Annotation and alert support
 
-Annotations and alerts are not currently supported in the new table panel. However, annotations might be added back in a future release.
+Annotations and alerts are not currently supported in the new table panel. 
 
 ## Sort column
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -27,9 +27,9 @@ The table panel visualization is very flexible, supporting multiple modes for ti
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-## Annotation support
+## Annotation and Alert support
 
-Annotations are not currently supported in the new table panel. This might be added back in a future release.
+Annotations and alerts are not currently supported in the new table panel. However, annotations might be added back in a future release.
 
 ## Sort column
 


### PR DESCRIPTION
**What is this feature?**

updating the [docs](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/) with the fact that alerts are not supported in the table panel visualization

Brought up by the community: 

https://community.grafana.com/t/visualizations-table-set-up-alerting/89842

