### PR TITLE
Dashboards: Keep save drawer open for unhandled errors

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -9,7 +9,7 @@ import { jsonDiff } from '../VersionHistory/utils';
 
 import DashboardValidation from './DashboardValidation';
 import { SaveDashboardDiff } from './SaveDashboardDiff';
-import { SaveDashboardErrorProxy } from './SaveDashboardErrorProxy';
+import { isHandledError, SaveDashboardErrorProxy } from './SaveDashboardErrorProxy';
 import { SaveDashboardAsForm } from './forms/SaveDashboardAsForm';
 import { SaveDashboardForm } from './forms/SaveDashboardForm';
 import { SaveProvisionedDashboardForm } from './forms/SaveProvisionedDashboardForm';
@@ -73,6 +73,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     }
 
     if (state.loading) {
+      console.log('SaveDashboardDrawer rendering Spinner');
       return (
         <div>
           <Spinner />
@@ -81,6 +82,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     }
 
     if (isNew || isCopy) {
+      console.log('SaveDashboardDrawer rendering SaveDashboardAsForm', dashboard);
       return (
         <SaveDashboardAsForm
           dashboard={dashboard}
@@ -111,7 +113,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
 
   console.log('SaveDashboardDrawer', state);
 
-  if (state.error && isFetchError(state.error) && !state.error.isHandled) {
+  if (state.error && isFetchError(state.error) && !state.error.isHandled && isHandledError(state.error.data.status)) {
     console.log('SaveDashboardDrawer rendering SaveDashboardErrorProxy');
     return (
       <SaveDashboardErrorProxy

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -109,7 +109,10 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     );
   };
 
+  console.log('SaveDashboardDrawer', state);
+
   if (state.error && isFetchError(state.error) && !state.error.isHandled) {
+    console.log('SaveDashboardDrawer rendering SaveDashboardErrorProxy');
     return (
       <SaveDashboardErrorProxy
         error={state.error}

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { config, isFetchError } from '@grafana/runtime';
-import { Drawer, Spinner, Tab, TabsBar } from '@grafana/ui';
+import { Drawer, Tab, TabsBar } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { jsonDiff } from '../VersionHistory/utils';
@@ -72,20 +72,11 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       return <SaveDashboardDiff diff={data.diff} oldValue={previous.value} newValue={data.clone} />;
     }
 
-    // if (state.loading) {
-    //   console.log('SaveDashboardDrawer rendering Spinner');
-    //   return (
-    //     <div>
-    //       <Spinner />
-    //     </div>
-    //   );
-    // }
-
     if (isNew || isCopy) {
-      console.log('SaveDashboardDrawer rendering SaveDashboardAsForm', dashboard);
       return (
         <SaveDashboardAsForm
           dashboard={dashboard}
+          isLoading={state.loading}
           onCancel={onDismiss}
           onSuccess={onSuccess}
           onSubmit={onDashboardSave}
@@ -101,6 +92,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     return (
       <SaveDashboardForm
         dashboard={dashboard}
+        isLoading={state.loading}
         saveModel={data}
         onCancel={onDismiss}
         onSuccess={onSuccess}
@@ -111,10 +103,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     );
   };
 
-  console.log('SaveDashboardDrawer', state);
-
   if (state.error && isFetchError(state.error) && !state.error.isHandled && isHandledError(state.error.data.status)) {
-    console.log('SaveDashboardDrawer rendering SaveDashboardErrorProxy');
     return (
       <SaveDashboardErrorProxy
         error={state.error}

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -72,14 +72,14 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       return <SaveDashboardDiff diff={data.diff} oldValue={previous.value} newValue={data.clone} />;
     }
 
-    if (state.loading) {
-      console.log('SaveDashboardDrawer rendering Spinner');
-      return (
-        <div>
-          <Spinner />
-        </div>
-      );
-    }
+    // if (state.loading) {
+    //   console.log('SaveDashboardDrawer rendering Spinner');
+    //   return (
+    //     <div>
+    //       <Spinner />
+    //     </div>
+    //   );
+    // }
 
     if (isNew || isCopy) {
       console.log('SaveDashboardDrawer rendering SaveDashboardAsForm', dashboard);

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -9,7 +9,7 @@ import { jsonDiff } from '../VersionHistory/utils';
 
 import DashboardValidation from './DashboardValidation';
 import { SaveDashboardDiff } from './SaveDashboardDiff';
-import { isHandledError, SaveDashboardErrorProxy } from './SaveDashboardErrorProxy';
+import { proxyHandlesError, SaveDashboardErrorProxy } from './SaveDashboardErrorProxy';
 import { SaveDashboardAsForm } from './forms/SaveDashboardAsForm';
 import { SaveDashboardForm } from './forms/SaveDashboardForm';
 import { SaveProvisionedDashboardForm } from './forms/SaveProvisionedDashboardForm';
@@ -103,7 +103,12 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
     );
   };
 
-  if (state.error && isFetchError(state.error) && !state.error.isHandled && isHandledError(state.error.data.status)) {
+  if (
+    state.error &&
+    isFetchError(state.error) &&
+    !state.error.isHandled &&
+    proxyHandlesError(state.error.data.status)
+  ) {
     return (
       <SaveDashboardErrorProxy
         error={state.error}

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
@@ -109,7 +109,7 @@ const ConfirmPluginDashboardSaveModal = ({ onDismiss, dashboard }: SaveDashboard
   );
 };
 
-const isHandledError = (errorStatus: string) => {
+export const isHandledError = (errorStatus: string) => {
   switch (errorStatus) {
     case 'version-mismatch':
     case 'name-exists':

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
@@ -28,7 +28,7 @@ export const SaveDashboardErrorProxy = ({
   const { onDashboardSave } = useDashboardSave(dashboard);
 
   useEffect(() => {
-    if (error.data && isHandledError(error.data.status)) {
+    if (error.data && proxyHandlesError(error.data.status)) {
       error.isHandled = true;
     }
   }, [error]);
@@ -109,7 +109,7 @@ const ConfirmPluginDashboardSaveModal = ({ onDismiss, dashboard }: SaveDashboard
   );
 };
 
-export const isHandledError = (errorStatus: string) => {
+export const proxyHandlesError = (errorStatus: string) => {
   switch (errorStatus) {
     case 'version-mismatch':
     case 'name-exists':

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
@@ -37,6 +37,7 @@ const renderAndSubmitForm = async (
 ) => {
   render(
     <SaveDashboardAsForm
+      isLoading={false}
       dashboard={dashboard as DashboardModel}
       onCancel={() => {}}
       onSuccess={() => {}}

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -40,7 +40,7 @@ export interface SaveDashboardAsFormProps extends SaveDashboardFormProps {
   isNew?: boolean;
 }
 
-export const SaveDashboardAsForm = ({ dashboard, isNew, onSubmit, onCancel, onSuccess }: SaveDashboardAsFormProps) => {
+export const SaveDashboardAsForm = ({ dashboard, isLoading, isNew, onSubmit, onCancel, onSuccess }: SaveDashboardAsFormProps) => {
   const defaultValues: SaveDashboardAsFormDTO = {
     title: isNew ? dashboard.title : `${dashboard.title} Copy`,
     $folder: {
@@ -129,8 +129,8 @@ export const SaveDashboardAsForm = ({ dashboard, isNew, onSubmit, onCancel, onSu
             <Button type="button" variant="secondary" onClick={onCancel} fill="outline">
               Cancel
             </Button>
-            <Button type="submit" aria-label="Save dashboard button">
-              Save
+            <Button disabled={isLoading} type="submit" aria-label="Save dashboard button">
+              {isLoading ? 'Saving...' : 'Save'}
             </Button>
           </HorizontalGroup>
         </>

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -40,7 +40,14 @@ export interface SaveDashboardAsFormProps extends SaveDashboardFormProps {
   isNew?: boolean;
 }
 
-export const SaveDashboardAsForm = ({ dashboard, isLoading, isNew, onSubmit, onCancel, onSuccess }: SaveDashboardAsFormProps) => {
+export const SaveDashboardAsForm = ({
+  dashboard,
+  isLoading,
+  isNew,
+  onSubmit,
+  onCancel,
+  onSuccess,
+}: SaveDashboardAsFormProps) => {
   const defaultValues: SaveDashboardAsFormDTO = {
     title: isNew ? dashboard.title : `${dashboard.title} Copy`,
     $folder: {

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
@@ -34,6 +34,7 @@ const prepareDashboardMock = (
 const renderAndSubmitForm = async (dashboard: DashboardModel, submitSpy: jest.Mock) => {
   render(
     <SaveDashboardForm
+      isLoading={false}
       dashboard={dashboard}
       onCancel={() => {}}
       onSuccess={() => {}}
@@ -62,6 +63,7 @@ describe('SaveDashboardAsForm', () => {
     it('renders switches when variables or timerange', () => {
       render(
         <SaveDashboardForm
+          isLoading={false}
           dashboard={prepareDashboardMock(true, true, jest.fn(), jest.fn())}
           onCancel={() => {}}
           onSuccess={() => {}}
@@ -124,6 +126,7 @@ describe('SaveDashboardAsForm', () => {
     it('renders saved message draft if it was filled before', () => {
       render(
         <SaveDashboardForm
+          isLoading={false}
           dashboard={createDashboardModelFixture()}
           onCancel={() => {}}
           onSuccess={() => {}}

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
@@ -13,6 +13,7 @@ interface FormDTO {
 
 export type SaveProps = {
   dashboard: DashboardModel; // original
+  isLoading: boolean;
   saveModel: SaveDashboardData; // already cloned
   onCancel: () => void;
   onSuccess: () => void;
@@ -23,6 +24,7 @@ export type SaveProps = {
 
 export const SaveDashboardForm = ({
   dashboard,
+  isLoading,
   saveModel,
   options,
   onSubmit,
@@ -108,11 +110,11 @@ export const SaveDashboardForm = ({
               </Button>
               <Button
                 type="submit"
-                disabled={!saveModel.hasChanges}
+                disabled={!saveModel.hasChanges || isLoading}
                 icon={saving ? 'fa fa-spinner' : undefined}
                 aria-label={selectors.pages.SaveDashboardModal.save}
               >
-                Save
+                {isLoading ? 'Saving...' : 'Save'}
               </Button>
               {!saveModel.hasChanges && <div>No changes to save</div>}
             </Stack>

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveProvisionedDashboardForm.tsx
@@ -7,7 +7,7 @@ import { Button, ClipboardButton, HorizontalGroup, TextArea } from '@grafana/ui'
 
 import { SaveDashboardFormProps } from '../types';
 
-export const SaveProvisionedDashboardForm = ({ dashboard, onCancel }: SaveDashboardFormProps) => {
+export const SaveProvisionedDashboardForm = ({ dashboard, onCancel }: Omit<SaveDashboardFormProps, 'isLoading'>) => {
   const [dashboardJSON, setDashboardJson] = useState(() => {
     const clone = dashboard.getSaveModelClone();
     delete clone.id;

--- a/public/app/features/dashboard/components/SaveDashboard/types.ts
+++ b/public/app/features/dashboard/components/SaveDashboard/types.ts
@@ -26,6 +26,7 @@ export interface SaveDashboardCommand {
 
 export interface SaveDashboardFormProps {
   dashboard: DashboardModel;
+  isLoading: boolean;
   onCancel: () => void;
   onSuccess: () => void;
   onSubmit?: (clone: DashboardModel, options: SaveDashboardOptions, dashboard: DashboardModel) => Promise<any>;

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -78,8 +78,10 @@ export const useDashboardSave = (dashboard: DashboardModel, isCopy = false) => {
         return result;
       } catch (error) {
         if (error instanceof Error) {
+          console.log('useDashboardSave notifyApp');
           notifyApp.error(error.message ?? 'Error saving dashboard');
         }
+        console.log('useDashboardSave throwing', error);
         throw error;
       }
     },

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -78,10 +78,8 @@ export const useDashboardSave = (dashboard: DashboardModel, isCopy = false) => {
         return result;
       } catch (error) {
         if (error instanceof Error) {
-          console.log('useDashboardSave notifyApp');
           notifyApp.error(error.message ?? 'Error saving dashboard');
         }
-        console.log('useDashboardSave throwing', error);
         throw error;
       }
     },


### PR DESCRIPTION
Currently, if the request to save a dashboard fails with an error code the frontend doesn't handle, the save dialogue will be in a stuck state - it will close, and it's not possible to reopen.

This is because when the server responds with an error, the SaveDashboardDrawer renders this ErrorProxy component instead of the actual drawer:

https://github.com/grafana/grafana/blob/cd8e5dc1407ac09c3b9b25d5092a4c359ea80901/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx#L112-L121

But the ErrorProxy component only handles specific errors. If the server responds with an error the component doesn't handle, nothing is rendered. DashNav still thinks SaveDashboardDrawer is open, but it's essentially rendering null.

https://github.com/grafana/grafana/blob/cd8e5dc1407ac09c3b9b25d5092a4c359ea80901/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx#L36-L77

This PR guards rendering of SaveDashboardErrorProxy so it's only rendered if it handles that error, and otherwise just keeps the drawer open.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
