### PR TITLE
Bug: Fix `yaml` identation for github action yamls

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: "Generate token"
-          id: generate_token
-          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-          with:
-            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run backport
         uses: ./actions/backport
         with:

--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: "Generate token"
-          id: generate_token
-          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-          with:
-            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Close milestone (manually invoked)
         if: ${{ github.event.inputs.version != '' }}
         uses: ./actions/close-milestone

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: "Generate token"
-          id: generate_token
-          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-          with:
-            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Run github release action
         uses: ./actions/github-release
         with:

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   call-remove-milestone:
     - name: "Generate token"
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      id: generate_token
+      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+      with:
+        app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+        private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
     - uses: grafana/grafana/.github/workflows/remove-milestone.yml@main
       with:
         version_call: ${{ github.event.inputs.version_input }}
@@ -20,11 +20,11 @@ jobs:
         token: ${{ steps.generate_token.outputs.token }}
   call-close-milestone:
     - name: "Generate token"
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      id: generate_token
+      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+      with:
+        app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+        private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
     - uses: grafana/grafana/.github/workflows/close-milestone.yml@main
       with:
         version_call: ${{ github.event.inputs.version_input }}

--- a/.github/workflows/remove-milestone.yml
+++ b/.github/workflows/remove-milestone.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: "Generate token"
-          id: generate_token
-          uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-          with:
-            app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-            private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Remove milestone from open issues (manually invoked)
         if: ${{ github.event.inputs.version != '' }}
         uses: ./actions/remove-milestone


### PR DESCRIPTION
**What is this feature?**

Fixes github actions yaml identation after https://github.com/grafana/grafana/pull/70242 broke it 😅 

Need to add a yaml validator for gh actions to run on CI.
