### PR TITLE
Alerting: Add two missing tests which cover missing URLs for Loki state history

### DIFF
--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -58,6 +58,20 @@ func TestLokiConfig(t *testing.T) {
 				expWrite: "http://url.com",
 			},
 			{
+				name: "missing read",
+				in: setting.UnifiedAlertingStateHistorySettings{
+					LokiWriteURL: "http://url.com",
+				},
+				expErr: "either read path URL or remote",
+			},
+			{
+				name: "missing write",
+				in: setting.UnifiedAlertingStateHistorySettings{
+					LokiReadURL: "http://url.com",
+				},
+				expErr: "either write path URL or remote",
+			},
+			{
 				name: "invalid",
 				in: setting.UnifiedAlertingStateHistorySettings{
 					LokiRemoteURL: "://://",


### PR DESCRIPTION
**What is this feature?**

Tiny PR that adds two tests for URL parsing.

Added these while verifying the URL config code for a different change elsewhere. Figured I'd commit them - no reason not to.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
