### PR TITLE
Log Context: Add visual changes to infinite scrolling

### DIFF
--- a/public/app/features/logs/components/log-context/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/log-context/LoadingIndicator.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { Spinner } from '@grafana/ui';
+
+// ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
+// one has a large margin-bottom.
+export const LoadingIndicator = ({ place }: { place: 'top' | 'bottom' }) => {
+  const text = place === 'top' ? 'Loading newer logs...' : 'Loading older logs...';
+  return (
+    <div className={loadingIndicatorStyles}>
+      <div>
+        {text} <Spinner inline />
+      </div>
+    </div>
+  );
+};
+
+const loadingIndicatorStyles = css`
+  display: flex;
+  justify-content: center;
+`;

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
-import { Icon, Button, LoadingBar, Modal, useTheme2, Spinner } from '@grafana/ui';
+import { Icon, Button, LoadingBar, Modal, useTheme2 } from '@grafana/ui';
 import { dataFrameToLogsModel } from 'app/core/logsModel';
 import store from 'app/core/store';
 import { SETTINGS_KEYS } from 'app/features/explore/Logs/utils/logs';

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -26,6 +26,7 @@ import { useDispatch } from 'app/types';
 import { sortLogRows } from '../../utils';
 import { LogRows } from '../LogRows';
 
+import { LoadingIndicator } from './LoadingIndicator';
 import { LogContextButtons } from './LogContextButtons';
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -63,6 +64,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       max-height: 75%;
       align-self: stretch;
       display: inline-block;
+      border: 1px solid ${theme.colors.border.weak};
+      border-radius: ${theme.shape.radius.default};
       & > table {
         min-width: 100%;
       }
@@ -100,6 +103,12 @@ const getStyles = (theme: GrafanaTheme2) => {
       :hover {
         color: ${theme.colors.text.link};
       }
+    `,
+    loadingCell: css`
+      position: sticky;
+      left: 50%;
+      display: inline-block;
+      transform: translateX(-50%);
     `,
   };
 };
@@ -411,25 +420,27 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
         <table>
           <tbody>
             <tr>
+              <td className={styles.loadingCell}>
+                <div ref={topElement}>
+                  <LoadingIndicator place="top" />
+                </div>
+              </td>
+            </tr>
+            <tr>
               <td className={styles.noMarginBottom}>
-                <>
-                  <div ref={topElement}>
-                    <LoadingIndicator place="top" />
-                  </div>
-                  <LogRows
-                    logRows={context.after}
-                    dedupStrategy={LogsDedupStrategy.none}
-                    showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
-                    showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
-                    wrapLogMessage={wrapLines}
-                    prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
-                    enableLogDetails={true}
-                    timeZone={timeZone}
-                    displayedFields={displayedFields}
-                    onClickShowField={showField}
-                    onClickHideField={hideField}
-                  />
-                </>
+                <LogRows
+                  logRows={context.after}
+                  dedupStrategy={LogsDedupStrategy.none}
+                  showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
+                  showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
+                  wrapLogMessage={wrapLines}
+                  prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
+                  enableLogDetails={true}
+                  timeZone={timeZone}
+                  displayedFields={displayedFields}
+                  onClickShowField={showField}
+                  onClickHideField={hideField}
+                />
               </td>
             </tr>
             <tr ref={preEntryElement}></tr>
@@ -466,10 +477,14 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
                     onClickShowField={showField}
                     onClickHideField={hideField}
                   />
-                  <div ref={bottomElement}>
-                    <LoadingIndicator place="bottom" />
-                  </div>
                 </>
+              </td>
+            </tr>
+            <tr>
+              <td className={styles.loadingCell}>
+                <div ref={bottomElement}>
+                  <LoadingIndicator place="bottom" />
+                </div>
               </td>
             </tr>
           </tbody>
@@ -515,23 +530,5 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
         )}
       </Modal.ButtonRow>
     </Modal>
-  );
-};
-
-const loadingIndicatorStyles = css`
-  display: flex;
-  justify-content: center;
-`;
-
-// ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
-// one has a large margin-bottom.
-const LoadingIndicator = ({ place }: { place: 'top' | 'bottom' }) => {
-  const text = place === 'top' ? 'Loading newer logs...' : 'Loading older logs...';
-  return (
-    <div className={loadingIndicatorStyles}>
-      <div>
-        {text} <Spinner inline />
-      </div>
-    </div>
   );
 };

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -124,7 +124,7 @@ interface LogRowContextModalProps {
 
 type Source = 'none' | 'top' | 'bottom' | 'center';
 
-const INITIAL_LOAD_LIMIT = 20;
+const INITIAL_LOAD_LIMIT = 100;
 
 export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps> = ({
   row,
@@ -400,9 +400,6 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
         <div className={styles.datasourceUi}>{getLogRowContextUi(row, fetchResults)}</div>
       )}
       <div className={cx(styles.flexRow, styles.paddingBottom)}>
-        <div className={loading ? styles.hidden : ''}>
-          Showing {context.after.length} lines {logsSortOrder === LogsSortOrder.Ascending ? 'after' : 'before'} match.
-        </div>
         <div>
           <LogContextButtons wrapLines={wrapLines} onChangeWrapLines={setWrapLines} />
         </div>
@@ -477,11 +474,6 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
             </tr>
           </tbody>
         </table>
-      </div>
-      <div>
-        <div className={cx(styles.paddingTop, loading ? styles.hidden : '')}>
-          Showing {context.before.length} lines {logsSortOrder === LogsSortOrder.Descending ? 'after' : 'before'} match.
-        </div>
       </div>
 
       <Modal.ButtonRow>


### PR DESCRIPTION
- Remove the you-have-this-many-log-lines message
- Loading-indicator, make it “hanging in” from the non-scrolling parent element
- Handle the case where we are at the end (detect it by: i loaded more data and i got an empty-array), show message. Probably just change the loading-indicator message
- Add a frame around the log-lines, the same way as we have one around the query-part at the top
