### PR TITLE
Logs: Link anchored logline when opening context in split view

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render } from 'test/redux-rtl';
 
+import { SplitOpenOptions } from '@grafana/data';
+
 import { createLogRow } from '../__mocks__/logRow';
 
 import { LogRowContextModal } from './LogRowContextModal';
@@ -17,10 +19,13 @@ jest.mock('app/types', () => ({
   useDispatch: () => dispatchMock,
 }));
 
-const splitOpen = Symbol('splitOpen');
+const splitOpenSym = Symbol('splitOpen');
+const splitOpen = jest.fn().mockReturnValue(splitOpenSym);
 jest.mock('app/features/explore/state/main', () => ({
   ...jest.requireActual('app/features/explore/state/main'),
-  splitOpen: () => splitOpen,
+  splitOpen: (arg?: SplitOpenOptions) => {
+    return splitOpen(arg);
+  },
 }));
 
 const row = createLogRow({ uid: '1' });
@@ -231,6 +236,42 @@ describe('LogRowContextModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('should create correct splitOpen', async () => {
+    const queryObj = { datasource: { uid: 'test-uid' } };
+    const getRowContextQuery = jest.fn().mockResolvedValue(queryObj);
+    const onClose = jest.fn();
+
+    render(
+      <LogRowContextModal
+        row={row}
+        open={true}
+        onClose={onClose}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+      />
+    );
+
+    const splitViewButton = await screen.findByRole('button', {
+      name: /open in split view/i,
+    });
+
+    await userEvent.click(splitViewButton);
+
+    await waitFor(() =>
+      expect(splitOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queries: [queryObj],
+          panelsState: {
+            logs: {
+              id: row.uid,
+            },
+          },
+        })
+      )
+    );
+  });
+
   it('should dispatch splitOpen', async () => {
     const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
     const onClose = jest.fn();
@@ -252,6 +293,6 @@ describe('LogRowContextModal', () => {
 
     await userEvent.click(splitViewButton);
 
-    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(splitOpen));
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(splitOpenSym));
   });
 });

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -388,11 +388,21 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
           <Button
             variant="secondary"
             onClick={async () => {
+              let rowId = row.uid;
+              if (row.dataFrame.refId) {
+                rowId = row.uid.replace(row.dataFrame.refId, contextQuery.refId);
+              }
+
               dispatch(
                 splitOpen({
                   queries: [contextQuery],
                   range: getFullTimeRange(),
                   datasourceUid: contextQuery.datasource!.uid!,
+                  panelsState: {
+                    logs: {
+                      id: rowId,
+                    },
+                  },
                 })
               );
               onClose();

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -390,6 +390,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
             onClick={async () => {
               let rowId = row.uid;
               if (row.dataFrame.refId) {
+                // the orignal row has the refid from the base query and not the refid from the context query, so we need to replace it.
                 rowId = row.uid.replace(row.dataFrame.refId, contextQuery.refId);
               }
 


### PR DESCRIPTION
**What is this feature?**

With permalinking merged, we can now link anchored loglines from show text when opening this in a split view.

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/8092184/501e4784-d984-47d1-9795-cde520692713

