### PR TITLE
Docs: removes references to YUM

### DIFF
--- a/docs/sources/setup-grafana/installation/suse-opensuse/index.md
+++ b/docs/sources/setup-grafana/installation/suse-opensuse/index.md
@@ -9,13 +9,13 @@ weight: 300
 
 This topic explains how to install Grafana dependencies, install Grafana on SUSE or openSUSE and start the Grafana server on your system.
 
-You can install Grafana using a YUM repository, using RPM, or by downloading a binary `.tar.gz` file.
+You can install Grafana using the RPM repository, or by downloading a binary `.tar.gz` file.
 
 If you install via RPM or the `.tar.gz` file, then you must manually update Grafana for each new version.
 
-## Install Grafana from the YUM repository
+## Install Grafana from the RPM repository
 
-If you install from the YUM repository, then Grafana is automatically updated every time you run `sudo zypper update`.
+If you install from the RPM repository, then Grafana is automatically updated every time you run `sudo zypper update`.
 
 | Grafana Version    | Package            | Repository                |
 | ------------------ | ------------------ | ------------------------- |
@@ -26,7 +26,7 @@ If you install from the YUM repository, then Grafana is automatically updated ev
 Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
 {{% /admonition %}}
 
-To install Grafana using a YUM repository, complete the following steps:
+To install Grafana using the RPM repository, complete the following steps:
 
 1. Use zypper to add the grafana repo.
 
@@ -48,7 +48,7 @@ To install Grafana using a YUM repository, complete the following steps:
 
 ## Install the Grafana RPM package manually
 
-If you install Grafana manually using YUM or RPM, then you must manually update Grafana for each new version. This method varies according to which Linux OS you are running.
+If you install Grafana manually using RPM, then you must manually update Grafana for each new version. This method varies according to which Linux OS you are running.
 
 **Note:** The RPM files are signed. You can verify the signature with this [public GPG key](https://rpm.grafana.com/gpg.key).
 


### PR DESCRIPTION
This PR updates the Grafana installation docs by removing references to YUM in the SUSE/openSUSE topic.