### PR TITLE
Loki: Preserve pipeline stages in context query

### DIFF
--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -461,4 +461,38 @@ describe('LogContextProvider', () => {
       });
     });
   });
+
+  describe('queryContainsValidPipelineStages', () => {
+    it('should return true if query contains a line_format stage', () => {
+      expect(
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | line_format "foo"' } as LokiQuery)
+      ).toBe(true);
+    });
+
+    it('should return true if query contains a label_format stage', () => {
+      expect(
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | label_format a="foo"' } as LokiQuery)
+      ).toBe(true);
+    });
+
+    it('should return false if query contains a parser', () => {
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | json' } as LokiQuery)).toBe(
+        false
+      );
+    });
+
+    it('should return false if query contains a line filter', () => {
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} |= "test"' } as LokiQuery)).toBe(
+        false
+      );
+    });
+
+    it('should return true if query contains a line filter and a label_format', () => {
+      expect(
+        logContextProvider.queryContainsValidPipelineStages({
+          expr: '{foo="bar"} |= "test" | label_format a="foo"',
+        } as LokiQuery)
+      ).toBe(true);
+    });
+  });
 });

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -3,14 +3,26 @@ import { of } from 'rxjs';
 import { DataQueryResponse, FieldType, LogRowContextQueryDirection, LogRowModel, createDataFrame } from '@grafana/data';
 
 import LokiLanguageProvider from './LanguageProvider';
-import { LogContextProvider, LOKI_LOG_CONTEXT_PRESERVED_LABELS } from './LogContextProvider';
+import {
+  LogContextProvider,
+  LOKI_LOG_CONTEXT_PRESERVED_LABELS,
+  SHOULD_INCLUDE_PIPELINE_OPERATIONS,
+} from './LogContextProvider';
 import { createLokiDatasource } from './mocks';
 import { LokiQuery } from './types';
 
 jest.mock('app/core/store', () => {
   return {
-    get() {
-      return window.localStorage.getItem(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
+    get(item: string) {
+      return window.localStorage.getItem(item);
+    },
+    getBool(key: string, defaultValue?: boolean) {
+      const item = window.localStorage.getItem(key);
+      if (item === null) {
+        return defaultValue;
+      } else {
+        return item === 'true';
+      }
     },
   };
 });
@@ -200,6 +212,143 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | json',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"}`);
+    });
+
+    it('should not apply line_format if flag is not set by default', async () => {
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt`);
+    });
+
+    it('should not apply line_format if flag is not set', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'false');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt  | line_format = "foo"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt`);
+    });
+
+    it('should apply line_format if flag is set', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+    });
+
+    it('should not apply line filters if flag is set', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      let contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo" |= "bar"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+
+      contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo" |~ "bar"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+
+      contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo" !~ "bar"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+
+      contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format = "foo" != "bar"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+    });
+
+    it('should not apply line filters if nested between two operations', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format "foo" |= "bar" | label_format a="baz"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo" | label_format a="baz"`);
+    });
+
+    it('should not apply label filters', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format "foo" | bar > 1 | label_format a="baz"',
+        } as unknown as LokiQuery
+      );
+
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo" | label_format a="baz"`);
+    });
+
+    it('should not apply additional parsers', async () => {
+      window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
+      logContextProvider.appliedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
+        defaultLogRow,
+        10,
+        LogRowContextQueryDirection.Backward,
+        {
+          expr: '{bar="baz"} | logfmt | line_format "foo" | json | label_format a="baz"',
         } as unknown as LokiQuery
       );
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -117,7 +117,7 @@ export class LogContextProvider {
     direction: LogRowContextQueryDirection,
     origQuery?: LokiQuery
   ): Promise<{ query: LokiQuery; range: TimeRange }> {
-    let expr = this.prepareExpression(
+    const expr = this.prepareExpression(
       this.appliedContextFilters,
       origQuery,
       store.getBool(SHOULD_INCLUDE_PIPELINE_OPERATIONS, false)

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -35,7 +35,7 @@ import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
 import { ContextFilter, LokiQuery, LokiQueryDirection, LokiQueryType } from './types';
 
 export const LOKI_LOG_CONTEXT_PRESERVED_LABELS = 'lokiLogContextPreservedLabels';
-export const SHOULD_INCLUDE_PIPELINE_OPERATIONS = 'shouldIncludePipelineOperations';
+export const SHOULD_INCLUDE_PIPELINE_OPERATIONS = 'lokiLogContextShouldIncludePipelineOperations';
 
 export type PreservedLabels = {
   removedLabels: string[];

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -117,11 +117,7 @@ export class LogContextProvider {
     direction: LogRowContextQueryDirection,
     origQuery?: LokiQuery
   ): Promise<{ query: LokiQuery; range: TimeRange }> {
-    const expr = this.prepareExpression(
-      this.appliedContextFilters,
-      origQuery,
-      store.getBool(SHOULD_INCLUDE_PIPELINE_OPERATIONS, false)
-    );
+    const expr = this.prepareExpression(this.appliedContextFilters, origQuery);
 
     const contextTimeBuffer = 2 * 60 * 60 * 1000; // 2h buffer
 
@@ -197,13 +193,9 @@ export class LogContextProvider {
     });
   }
 
-  prepareExpression(
-    contextFilters: ContextFilter[],
-    query: LokiQuery | undefined,
-    includePipelineOperations: boolean
-  ): string {
+  prepareExpression(contextFilters: ContextFilter[], query: LokiQuery | undefined): string {
     let preparedExpression = this.processContextFiltersToExpr(contextFilters, query);
-    if (includePipelineOperations) {
+    if (store.getBool(SHOULD_INCLUDE_PIPELINE_OPERATIONS, false)) {
       preparedExpression = this.processPipelineStagesToExpr(preparedExpression, query);
     }
     return preparedExpression;

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -36,6 +36,8 @@ import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
 import { ContextFilter, LokiQuery, LokiQueryDirection, LokiQueryType } from './types';
 
 export const LOKI_LOG_CONTEXT_PRESERVED_LABELS = 'lokiLogContextPreservedLabels';
+export const SHOULD_INCLUDE_PIPELINE_OPERATIONS = 'shouldIncludePipelineOperations';
+
 export type PreservedLabels = {
   removedLabels: string[];
   selectedExtractedLabels: string[];
@@ -117,7 +119,9 @@ export class LogContextProvider {
     origQuery?: LokiQuery
   ): Promise<{ query: LokiQuery; range: TimeRange }> {
     let expr = this.processContextFiltersToExpr(row, this.appliedContextFilters, origQuery);
-    expr = this.processPipelineStagesToExpr(expr, origQuery);
+    if (store.getBool(SHOULD_INCLUDE_PIPELINE_OPERATIONS, false)) {
+      expr = this.processPipelineStagesToExpr(expr, origQuery);
+    }
 
     const contextTimeBuffer = 2 * 60 * 60 * 1000; // 2h buffer
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -193,6 +193,7 @@ export class LogContextProvider {
       updateFilter,
       onClose: this.onContextClose,
       logContextProvider: this,
+      runContextQuery,
     });
   }
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -258,6 +258,22 @@ export class LogContextProvider {
     return newExpr;
   };
 
+  queryContainsValidPipelineStages = (query: LokiQuery | undefined): boolean => {
+    const origExpr = query?.expr ?? '';
+    const allNodePositions = getNodePositionsFromQuery(origExpr, [
+      PipelineStage,
+      LabelParser,
+      LineFilters,
+      LabelFilter,
+    ]);
+    const pipelineStagePositions = allNodePositions.filter((position) => position.type?.id === PipelineStage);
+    const otherNodePositions = allNodePositions.filter((position) => position.type?.id !== PipelineStage);
+
+    return pipelineStagePositions.some((pipelineStagePosition) =>
+      otherNodePositions.every((position) => pipelineStagePosition.contains(position) === false)
+    );
+  };
+
   getInitContextFilters = async (labels: Labels, query?: LokiQuery) => {
     if (!query || isEmpty(labels)) {
       return [];

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -47,6 +47,7 @@ const setupProps = (): LokiContextUiProps => {
       expr: '{label1="value1"} | logfmt',
       refId: 'A',
     },
+    runContextQuery: jest.fn(),
   };
 
   return defaults;
@@ -60,7 +61,7 @@ const mockLogContextProvider = {
     ])
   ),
   processContextFiltersToExpr: jest.fn().mockImplementation(
-    (row: LogRowModel, contextFilters: ContextFilter[], query: LokiQuery | undefined) =>
+    (contextFilters: ContextFilter[], query: LokiQuery | undefined) =>
       `{${contextFilters
         .filter((filter) => filter.enabled)
         .map((filter) => `${filter.label}="${filter.value}"`)
@@ -71,6 +72,13 @@ const mockLogContextProvider = {
     .mockImplementation((currentExpr: string, query: LokiQuery | undefined) => `${currentExpr} | newOperation`),
   getLogRowContext: jest.fn(),
   queryContainsValidPipelineStages: jest.fn().mockReturnValue(true),
+  prepareExpression: jest.fn().mockImplementation(
+    (contextFilters: ContextFilter[], query: LokiQuery | undefined) =>
+      `{${contextFilters
+        .filter((filter) => filter.enabled)
+        .map((filter) => `${filter.label}="${filter.value}"`)
+        .join('` ')}}`
+  ),
 };
 
 describe('LokiContextUi', () => {

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -5,11 +5,7 @@ import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
 import { LogRowModel } from '@grafana/data';
 
-import {
-  LogContextProvider,
-  LOKI_LOG_CONTEXT_PRESERVED_LABELS,
-  SHOULD_INCLUDE_PIPELINE_OPERATIONS,
-} from '../LogContextProvider';
+import { LogContextProvider, SHOULD_INCLUDE_PIPELINE_OPERATIONS } from '../LogContextProvider';
 import { ContextFilter, LokiQuery } from '../types';
 
 import { IS_LOKI_LOG_CONTEXT_UI_OPEN, LokiContextUi, LokiContextUiProps } from './LokiContextUi';

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -124,14 +124,19 @@ export function LokiContextUi(props: LokiContextUiProps) {
   const previousInitialized = React.useRef<boolean>(false);
   const previousContextFilters = React.useRef<ContextFilter[]>([]);
 
-  const isInitialQuery = useMemo(() => {
+  const isInitialState = useMemo(() => {
     // Initial query has all regular labels enabled and all parsed labels disabled
     if (initialized && contextFilters.some((filter) => filter.fromParser === filter.enabled)) {
       return false;
     }
 
+    // if we include pipeline operations, we also want to enable the revert button
+    if (includePipelineOperations && logContextProvider.queryContainsValidPipelineStages(origQuery)) {
+      return false;
+    }
+
     return true;
-  }, [contextFilters, initialized]);
+  }, [contextFilters, includePipelineOperations, initialized, logContextProvider, origQuery]);
 
   useEffect(() => {
     if (!initialized) {
@@ -244,7 +249,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
             data-testid="revert-button"
             icon="history-alt"
             variant="secondary"
-            disabled={isInitialQuery}
+            disabled={isInitialState}
             onClick={(e) => {
               reportInteraction('grafana_explore_logs_loki_log_context_reverted', {
                 logRowUid: row.uid,

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -377,34 +377,36 @@ export function LokiContextUi(props: LokiContextUiProps) {
               />
             </>
           )}
-          <InlineFieldRow className={styles.operationsToggle}>
-            <InlineField
-              label="Include LogQL pipeline operations"
-              tooltip={
-                <RenderUserContentAsHTML
-                  content={renderMarkdown(
-                    "This will include LogQL operations such as `line_format` or `label_format`. It won't include line or label filter operations."
-                  )}
+          {logContextProvider.queryContainsValidPipelineStages(origQuery) && (
+            <InlineFieldRow className={styles.operationsToggle}>
+              <InlineField
+                label="Include LogQL pipeline operations"
+                tooltip={
+                  <RenderUserContentAsHTML
+                    content={renderMarkdown(
+                      "This will include LogQL operations such as `line_format` or `label_format`. It won't include line or label filter operations."
+                    )}
+                  />
+                }
+              >
+                <InlineSwitch
+                  value={includePipelineOperations}
+                  showLabel={true}
+                  transparent={true}
+                  onChange={(e) => {
+                    reportInteraction('grafana_explore_logs_loki_log_context_pipeline_toggled', {
+                      logRowUid: row.uid,
+                      action: e.currentTarget.checked ? 'enable' : 'disable',
+                    });
+                    store.set(SHOULD_INCLUDE_PIPELINE_OPERATIONS, e.currentTarget.checked);
+                    setIncludePipelineOperations(e.currentTarget.checked);
+                    // need to retrigger a query to run by calling `updateFilter`
+                    updateFilter(contextFilters.filter(({ enabled }) => enabled));
+                  }}
                 />
-              }
-            >
-              <InlineSwitch
-                value={includePipelineOperations}
-                showLabel={true}
-                transparent={true}
-                onChange={(e) => {
-                  reportInteraction('grafana_explore_logs_loki_log_context_pipeline_toggled', {
-                    logRowUid: row.uid,
-                    action: e.currentTarget.checked ? 'enable' : 'disable',
-                  });
-                  store.set(SHOULD_INCLUDE_PIPELINE_OPERATIONS, e.currentTarget.checked);
-                  setIncludePipelineOperations(e.currentTarget.checked);
-                  // need to retrigger a query to run by calling `updateFilter`
-                  updateFilter(contextFilters.filter(({ enabled }) => enabled));
-                }}
-              />
-            </InlineField>
-          </InlineFieldRow>
+              </InlineField>
+            </InlineFieldRow>
+          )}
         </div>
       </Collapse>
     </div>

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -238,8 +238,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
 
   let queryExpr = logContextProvider.prepareExpression(
     contextFilters.filter(({ enabled }) => enabled),
-    origQuery,
-    includePipelineOperations
+    origQuery
   );
   return (
     <div className={styles.wrapper}>

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -262,6 +262,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
               // We are removing the preserved labels from local storage so we can preselect the labels in the UI
               store.delete(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
               store.delete(SHOULD_INCLUDE_PIPELINE_OPERATIONS);
+              setIncludePipelineOperations(false);
             }}
           />
         </div>

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -200,6 +200,13 @@ export function LokiContextUi(props: LokiContextUiProps) {
   // Currently we support adding of parser and showing parsed labels only if there is 1 parser
   const showParsedLabels = origQuery && isQueryWithParser(origQuery.expr).parserCount === 1 && parsedLabels.length > 0;
 
+  let queryExpr = logContextProvider.processContextFiltersToExpr(
+    row,
+    contextFilters.filter(({ enabled }) => enabled),
+    origQuery
+  );
+  queryExpr = logContextProvider.processPipelineStagesToExpr(queryExpr, origQuery);
+
   return (
     <div className={styles.wrapper}>
       <Tooltip content={'Revert to initial log context query.'}>
@@ -242,15 +249,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
           <div className={styles.rawQueryContainer}>
             {initialized ? (
               <>
-                <RawQuery
-                  lang={{ grammar: lokiGrammar, name: 'loki' }}
-                  query={logContextProvider.processContextFiltersToExpr(
-                    row,
-                    contextFilters.filter(({ enabled }) => enabled),
-                    origQuery
-                  )}
-                  className={styles.rawQuery}
-                />
+                <RawQuery lang={{ grammar: lokiGrammar, name: 'loki' }} query={queryExpr} className={styles.rawQuery} />
                 <Tooltip content="The initial log context query is created from all labels defining the stream for the selected log line. Use the editor below to customize the log context query.">
                   <Icon name="info-circle" size="sm" className={styles.queryDescription} />
                 </Tooltip>

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -104,7 +104,7 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-const IS_LOKI_LOG_CONTEXT_UI_OPEN = 'isLogContextQueryUiOpen';
+export const IS_LOKI_LOG_CONTEXT_UI_OPEN = 'isLogContextQueryUiOpen';
 
 export function LokiContextUi(props: LokiContextUiProps) {
   const { row, logContextProvider, updateFilter, onClose, origQuery } = props;

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -38,6 +38,7 @@ export interface LokiContextUiProps {
   updateFilter: (value: ContextFilter[]) => void;
   onClose: () => void;
   origQuery?: LokiQuery;
+  runContextQuery?: () => void;
 }
 
 function getStyles(theme: GrafanaTheme2) {
@@ -107,7 +108,7 @@ function getStyles(theme: GrafanaTheme2) {
 export const IS_LOKI_LOG_CONTEXT_UI_OPEN = 'isLogContextQueryUiOpen';
 
 export function LokiContextUi(props: LokiContextUiProps) {
-  const { row, logContextProvider, updateFilter, onClose, origQuery } = props;
+  const { row, logContextProvider, updateFilter, onClose, origQuery, runContextQuery } = props;
   const styles = useStyles2(getStyles);
 
   const [contextFilters, setContextFilters] = useState<ContextFilter[]>([]);
@@ -397,8 +398,9 @@ export function LokiContextUi(props: LokiContextUiProps) {
                     });
                     store.set(SHOULD_INCLUDE_PIPELINE_OPERATIONS, e.currentTarget.checked);
                     setIncludePipelineOperations(e.currentTarget.checked);
-                    // need to retrigger a query to run by calling `updateFilter`
-                    updateFilter(contextFilters.filter(({ enabled }) => enabled));
+                    if (runContextQuery) {
+                      runContextQuery();
+                    }
                   }}
                 />
               </InlineField>

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -230,15 +230,11 @@ export function LokiContextUi(props: LokiContextUiProps) {
   // Currently we support adding of parser and showing parsed labels only if there is 1 parser
   const showParsedLabels = origQuery && isQueryWithParser(origQuery.expr).parserCount === 1 && parsedLabels.length > 0;
 
-  let queryExpr = logContextProvider.processContextFiltersToExpr(
-    row,
+  let queryExpr = logContextProvider.prepareExpression(
     contextFilters.filter(({ enabled }) => enabled),
-    origQuery
+    origQuery,
+    includePipelineOperations
   );
-  if (includePipelineOperations) {
-    queryExpr = logContextProvider.processPipelineStagesToExpr(queryExpr, origQuery);
-  }
-
   return (
     <div className={styles.wrapper}>
       <Tooltip content={'Revert to initial log context query.'}>

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -1,8 +1,11 @@
+import { SyntaxNode } from '@lezer/common';
+
 import {
   addLabelFormatToQuery,
   addLabelToQuery,
   addNoPipelineErrorToQuery,
   addParserToQuery,
+  NodePosition,
   removeCommentsFromQuery,
 } from './modifyQuery';
 
@@ -185,5 +188,61 @@ describe('removeCommentsFromQuery', () => {
     ${'rate({job="grafana"} | logfmt | foo="bar" [10m])'}     | ${'rate({job="grafana"} | logfmt | foo="bar" [10m])'}
   `('returns original query if no comments in metrics query:  {$query}', ({ query, expectedResult }) => {
     expect(removeCommentsFromQuery(query)).toBe(expectedResult);
+  });
+});
+
+describe('NodePosition', () => {
+  describe('contains', () => {
+    it('should return true if the position is contained within the current position', () => {
+      const position = new NodePosition(5, 10);
+      const containedPosition = new NodePosition(6, 9);
+      const result = position.contains(containedPosition);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the position is not contained within the current position', () => {
+      const position = new NodePosition(5, 10);
+      const outsidePosition = new NodePosition(11, 15);
+      const result = position.contains(outsidePosition);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if the position is the same as the current position', () => {
+      const position = new NodePosition(5, 10);
+      const samePosition = new NodePosition(5, 10);
+      const result = position.contains(samePosition);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getExpression', () => {
+    it('should return the substring of the query within the given position', () => {
+      const position = new NodePosition(7, 12);
+      const query = 'Hello, world!';
+      const result = position.getExpression(query);
+      expect(result).toBe('world');
+    });
+
+    it('should return an empty string if the position is out of range', () => {
+      const position = new NodePosition(15, 20);
+      const query = 'Hello, world!';
+      const result = position.getExpression(query);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('fromNode', () => {
+    it('should create a new NodePosition instance from a SyntaxNode', () => {
+      const syntaxNode = {
+        from: 5,
+        to: 10,
+        type: 'identifier',
+      } as unknown as SyntaxNode;
+      const result = NodePosition.fromNode(syntaxNode);
+      expect(result).toBeInstanceOf(NodePosition);
+      expect(result.from).toBe(5);
+      expect(result.to).toBe(10);
+      expect(result.type).toBe('identifier');
+    });
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from '@lezer/common';
+import { NodeType, SyntaxNode } from '@lezer/common';
 import { sortBy } from 'lodash';
 
 import {
@@ -12,6 +12,7 @@ import {
   Matcher,
   parser,
   PipelineExpr,
+  PipelineStage,
   Selector,
   UnwrapExpr,
 } from '@grafana/lezer-logql';
@@ -22,7 +23,7 @@ import { unescapeLabelValue } from './languageUtils';
 import { LokiQueryModeller } from './querybuilder/LokiQueryModeller';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 
-export type Position = { from: number; to: number };
+export type Position = { from: number; to: number; type?: NodeType };
 /**
  * Adds label filter to existing query. Useful for query modification for example for ad hoc filters.
  *

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -1,3 +1,5 @@
+import { String } from '@grafana/lezer-logql';
+
 import {
   getHighlighterExpressionsFromQuery,
   getLokiQueryType,
@@ -14,6 +16,7 @@ import {
   isQueryPipelineErrorFiltering,
   getLogQueryFromMetricsQuery,
   getNormalizedLokiQuery,
+  getNodePositionsFromQuery,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -414,5 +417,26 @@ describe('getLogQueryFromMetricsQuery', () => {
         'sum(quantile_over_time(0.5, {label="$var"} | logfmt | __error__=`` | unwrap latency | __error__=`` [$__interval]))'
       )
     ).toBe('{label="$var"} | logfmt | __error__=``');
+  });
+});
+
+describe('getNodePositionsFromQuery', () => {
+  it('returns the right amount of positions without type', () => {
+    // LogQL, Expr, LogExpr, Selector, Matchers, Matcher, Identifier, Eq, String
+    expect(getNodePositionsFromQuery('{job="grafana"}').length).toBe(9);
+  });
+
+  it('returns the right position of a string in a stream selector', () => {
+    // LogQL, Expr, LogExpr, Selector, Matchers, Matcher, Identifier, Eq, String
+    const nodePositions = getNodePositionsFromQuery('{job="grafana"}', [String]);
+    expect(nodePositions.length).toBe(1);
+    expect(nodePositions[0].from).toBe(5);
+    expect(nodePositions[0].to).toBe(14);
+  });
+
+  it('returns an empty array with a wrong expr', () => {
+    // LogQL, Expr, LogExpr, Selector, Matchers, Matcher, Identifier, Eq, String
+    const nodePositions = getNodePositionsFromQuery('not loql', [String]);
+    expect(nodePositions.length).toBe(0);
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -176,10 +176,6 @@ export function getNodeFromQuery(query: string, nodeType: number): SyntaxNode | 
   return nodes.length > 0 ? nodes[0] : undefined;
 }
 
-export function getNodeExpressionFromQuery(query: string, node: SyntaxNode): string {
-  return query.substring(node.from, node.to);
-}
-
 export function isValidQuery(query: string): boolean {
   return !isQueryWithNode(query, ErrorId);
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -145,12 +145,12 @@ export function isQueryWithNode(query: string, nodeType: number): boolean {
   return isQueryWithNode;
 }
 
-export function getNodesFromQuery(query: string, nodeTypes: number[]): SyntaxNode[] {
+export function getNodesFromQuery(query: string, nodeTypes?: number[]): SyntaxNode[] {
   const nodes: SyntaxNode[] = [];
   const tree = parser.parse(query);
   tree.iterate({
     enter: (node): false | void => {
-      if (nodeTypes.includes(node.type.id)) {
+      if (nodeTypes === undefined || nodeTypes.includes(node.type.id)) {
         nodes.push(node.node);
       }
     },
@@ -161,6 +161,10 @@ export function getNodesFromQuery(query: string, nodeTypes: number[]): SyntaxNod
 export function getNodeFromQuery(query: string, nodeType: number): SyntaxNode | undefined {
   const nodes = getNodesFromQuery(query, [nodeType]);
   return nodes.length > 0 ? nodes[0] : undefined;
+}
+
+export function getNodeExpressionFromQuery(query: string, node: SyntaxNode): string {
+  return query.substring(node.from, node.to);
 }
 
 export function isValidQuery(query: string): boolean {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -24,7 +24,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { ErrorId } from '../prometheus/querybuilder/shared/parsingUtils';
 
-import { getStreamSelectorPositions } from './modifyQuery';
+import { getStreamSelectorPositions, NodePosition } from './modifyQuery';
 import { LokiQuery, LokiQueryType } from './types';
 
 export function formatQuery(selector: string | undefined): string {
@@ -156,6 +156,19 @@ export function getNodesFromQuery(query: string, nodeTypes?: number[]): SyntaxNo
     },
   });
   return nodes;
+}
+
+export function getNodePositionsFromQuery(query: string, nodeTypes?: number[]): NodePosition[] {
+  const positions: NodePosition[] = [];
+  const tree = parser.parse(query);
+  tree.iterate({
+    enter: (node): false | void => {
+      if (nodeTypes === undefined || nodeTypes.includes(node.type.id)) {
+        positions.push(NodePosition.fromNode(node.node));
+      }
+    },
+  });
+  return positions;
 }
 
 export function getNodeFromQuery(query: string, nodeType: number): SyntaxNode | undefined {


### PR DESCRIPTION
**What is this feature?**

This PR adds a toggle to preserve other pipeline stages in the context query. With this users will keep the same `line_format` as they set in the original query.

**Special notes for your reviewer:**

Fixes #69623

https://github.com/grafana/grafana/assets/8092184/438e8494-f02c-4409-b3af-fed097b18a3f


