### PR TITLE
XYChart: Ensure color scale is field-local and synced with data updates

### DIFF
--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -115,18 +115,20 @@ function getScatterSeries(
   if (dims.pointColorIndex) {
     const f = frames[frameIndex].fields[dims.pointColorIndex];
     if (f) {
-      const disp =
-        f.display ??
-        getDisplayProcessor({
-          field: f,
-          theme: config.theme2,
-        });
       pointColorMode = getFieldColorModeForField(y);
       if (pointColorMode.isByValue) {
         const index = dims.pointColorIndex;
         pointColor = (frame: DataFrame) => {
-          // Yes we can improve this later
-          return frame.fields[index].values.map((v) => disp(v).color!);
+          const field = frame.fields[index];
+
+          if (field.state?.range) {
+            // this forces local min/max recalc, rather than using global min/max from field.state
+            field.state.range = undefined;
+          }
+
+          field.display = getDisplayProcessor({ field, theme: config.theme2 });
+
+          return field.values.map((v) => field.display!(v).color!); // slow!
         };
       } else {
         seriesColor = pointColorMode.getCalculator(f, config.theme2)(f.values[0], 1);


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/6404

there were two issues:

1. the color scale was taken from global min/max of all number fields instead of just the color field. this is the result of `doStandardCalcs()` and/or `getDisplayProcessor()` at the `PanelQueryRunner` level which sets a global & shared min/max on each number `field.state.range`. i had to hack around this by unsetting the global range we get and re-init the displayProcessor to re-calc the field-local range.
2. the field range that was used was always the one which existed during initial chart setup and was not kept in sync with data updates.

the correct behavior:

<details><summary>xy-color-test</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 724,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "continuous-BlYlRd"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "pointSize": {
              "fixed": 50
            },
            "scaleDistribution": {
              "type": "linear"
            },
            "show": "points"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "series": [
          {
            "pointColor": {
              "field": "c"
            },
            "x": "x",
            "y": "y"
          }
        ],
        "seriesMapping": "manual",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "x,y,c\n0,0,0\n50,50,25\n100,100,50",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "xychart"
    }
  ],
  "refresh": "",
  "schemaVersion": 38,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "xy-color-test",
  "uid": "aa6ab0e1-be4b-455c-b06d-a45b27ec63d4",
  "version": 2,
  "weekStart": ""
}
```
</details>

https://github.com/grafana/grafana/assets/43234/fabadd50-91bc-409c-b2d1-c61f933149d7