### PR TITLE
Alerting: Display correct results when using different filters on alerting panels

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -1,6 +1,6 @@
 import { RelativeTimeRange } from '@grafana/data';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
-import { AlertGroupTotals, RuleGroup, RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
+import { AlertGroupTotals, RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
 import {
   AlertQuery,
   Annotations,

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -1,10 +1,26 @@
 import { RelativeTimeRange } from '@grafana/data';
-import { AlertQuery, Annotations, GrafanaAlertStateDecision, Labels } from 'app/types/unified-alerting-dto';
+import { Matcher } from 'app/plugins/datasource/alertmanager/types';
+import { AlertGroupTotals, RuleGroup, RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
+import {
+  AlertQuery,
+  Annotations,
+  GrafanaAlertStateDecision,
+  Labels,
+  PromRuleGroupDTO,
+} from 'app/types/unified-alerting-dto';
 
 import { Folder } from '../components/rule-editor/RuleFolderPicker';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 import { arrayKeyValuesToObject } from '../utils/labels';
+import { isCloudRuleIdentifier, isPrometheusRuleIdentifier } from '../utils/rules';
 
 import { alertingApi } from './alertingApi';
+import {
+  FetchPromRulesFilter,
+  groupRulesByFileName,
+  paramsWithMatcherAndState,
+  prepareRulesFilterQueryParams,
+} from './prometheus';
 
 export type ResponseLabels = {
   labels: AlertInstances[];
@@ -17,6 +33,8 @@ export interface Datasource {
 }
 
 export const PREVIEW_URL = '/api/v1/rule/test/grafana';
+export const PROM_RULES_URL = 'api/prometheus/grafana/api/v1/rules';
+
 export interface Data {
   refId: string;
   relativeTimeRange: RelativeTimeRange;
@@ -75,6 +93,41 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         },
         method: 'POST',
       }),
+    }),
+
+    promRules: build.query<
+      RuleNamespace[],
+      {
+        limitAlerts?: number;
+        identifier?: RuleIdentifier;
+        filter?: FetchPromRulesFilter;
+        state?: string[];
+        matcher?: Matcher[];
+      }
+    >({
+      query: ({ limitAlerts, identifier, filter, state, matcher }) => {
+        const searchParams = new URLSearchParams();
+
+        // if we're fetching for Grafana managed rules, we should add a limit to the number of alert instances
+        // we do this because the response is large otherwise and we don't show all of them in the UI anyway.
+        if (limitAlerts) {
+          searchParams.set('limit_alerts', String(limitAlerts));
+        }
+
+        if (identifier && (isPrometheusRuleIdentifier(identifier) || isCloudRuleIdentifier(identifier))) {
+          searchParams.set('file', identifier.namespace);
+          searchParams.set('rule_group', identifier.groupName);
+        }
+
+        const params = prepareRulesFilterQueryParams(searchParams, filter);
+
+        return { url: PROM_RULES_URL, params: paramsWithMatcherAndState(params, state, matcher) };
+      },
+      transformResponse: (response: {
+        data: { groups: PromRuleGroupDTO[]; totals: AlertGroupTotals };
+      }): RuleNamespace[] => {
+        return groupRulesByFileName(response.data.groups, GRAFANA_RULES_SOURCE_NAME);
+      },
     }),
   }),
 });

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -1,12 +1,12 @@
 import { RelativeTimeRange } from '@grafana/data';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
-import { AlertGroupTotals, RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
+import { RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
 import {
   AlertQuery,
   Annotations,
   GrafanaAlertStateDecision,
   Labels,
-  PromRuleGroupDTO,
+  PromRulesResponse,
 } from 'app/types/unified-alerting-dto';
 
 import { Folder } from '../components/rule-editor/RuleFolderPicker';
@@ -95,7 +95,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
       }),
     }),
 
-    promRules: build.query<
+    prometheusRulesByNamespace: build.query<
       RuleNamespace[],
       {
         limitAlerts?: number;
@@ -123,9 +123,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
 
         return { url: PROM_RULES_URL, params: paramsWithMatcherAndState(params, state, matcher) };
       },
-      transformResponse: (response: {
-        data: { groups: PromRuleGroupDTO[]; totals: AlertGroupTotals };
-      }): RuleNamespace[] => {
+      transformResponse: (response: PromRulesResponse): RuleNamespace[] => {
         return groupRulesByFileName(response.data.groups, GRAFANA_RULES_SOURCE_NAME);
       },
     }),

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -1,4 +1,3 @@
-import { groups } from 'd3';
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -1,9 +1,10 @@
+import { groups } from 'd3';
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { RuleIdentifier, RuleNamespace } from 'app/types/unified-alerting';
-import { PromRulesResponse } from 'app/types/unified-alerting-dto';
+import { PromRuleGroupDTO, PromRulesResponse } from 'app/types/unified-alerting-dto';
 
 import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 import { isCloudRuleIdentifier, isPrometheusRuleIdentifier } from '../utils/rules';
@@ -83,6 +84,26 @@ export function paramsWithMatcherAndState(
   return paramsResult;
 }
 
+export const groupRulesByFileName = (groups: PromRuleGroupDTO[], dataSourceName: string) => {
+  const nsMap: { [key: string]: RuleNamespace } = {};
+  groups.forEach((group) => {
+    group.rules.forEach((rule) => {
+      rule.query = rule.query || '';
+    });
+    if (!nsMap[group.file]) {
+      nsMap[group.file] = {
+        dataSourceName,
+        name: group.file,
+        groups: [group],
+      };
+    } else {
+      nsMap[group.file].groups.push(group);
+    }
+  });
+
+  return Object.values(nsMap);
+};
+
 export async function fetchRules(
   dataSourceName: string,
   filter?: FetchPromRulesFilter,
@@ -116,21 +137,5 @@ export async function fetchRules(
     throw e;
   });
 
-  const nsMap: { [key: string]: RuleNamespace } = {};
-  response.data.data.groups.forEach((group) => {
-    group.rules.forEach((rule) => {
-      rule.query = rule.query || '';
-    });
-    if (!nsMap[group.file]) {
-      nsMap[group.file] = {
-        dataSourceName,
-        name: group.file,
-        groups: [group],
-      };
-    } else {
-      nsMap[group.file].groups.push(group);
-    }
-  });
-
-  return Object.values(nsMap);
+  return groupRulesByFileName(response.data.data.groups, dataSourceName);
 }

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -48,7 +48,7 @@ interface CacheValue {
 // can limit to a single rules source
 export function useCombinedRuleNamespaces(
   rulesSourceName?: string,
-  promRuleNamespaces?: RuleNamespace[]
+  grafanaPromRuleNamespaces?: RuleNamespace[]
 ): CombinedRuleNamespace[] {
   const promRulesResponses = useUnifiedAlertingSelector((state) => state.promRules);
   const rulerRulesResponses = useUnifiedAlertingSelector((state) => state.rulerRules);
@@ -71,11 +71,11 @@ export function useCombinedRuleNamespaces(
     return rulesSources
       .map((rulesSource): CombinedRuleNamespace[] => {
         const rulesSourceName = isCloudRulesSource(rulesSource) ? rulesSource.name : rulesSource;
-        let promRules = promRulesResponses[rulesSourceName]?.result;
         const rulerRules = rulerRulesResponses[rulesSourceName]?.result;
 
-        if (rulesSourceName === GRAFANA_RULES_SOURCE_NAME && promRuleNamespaces) {
-          promRules = promRuleNamespaces;
+        let promRules = promRulesResponses[rulesSourceName]?.result;
+        if (rulesSourceName === GRAFANA_RULES_SOURCE_NAME && grafanaPromRuleNamespaces) {
+          promRules = grafanaPromRuleNamespaces;
         }
 
         const cached = cache.current[rulesSourceName];
@@ -112,7 +112,7 @@ export function useCombinedRuleNamespaces(
         return result;
       })
       .flat();
-  }, [promRulesResponses, rulerRulesResponses, rulesSources, promRuleNamespaces]);
+  }, [promRulesResponses, rulerRulesResponses, rulesSources, grafanaPromRuleNamespaces]);
 }
 
 // merge all groups in case of grafana managed, essentially treating namespaces (folders) as groups

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -24,6 +24,7 @@ import {
 import {
   getAllRulesSources,
   getRulesSourceByName,
+  GRAFANA_RULES_SOURCE_NAME,
   isCloudRulesSource,
   isGrafanaRulesSource,
 } from '../utils/datasource';
@@ -45,7 +46,10 @@ interface CacheValue {
 
 // this little monster combines prometheus rules and ruler rules to produce a unified data structure
 // can limit to a single rules source
-export function useCombinedRuleNamespaces(rulesSourceName?: string): CombinedRuleNamespace[] {
+export function useCombinedRuleNamespaces(
+  rulesSourceName?: string,
+  promRuleNamespaces?: RuleNamespace[]
+): CombinedRuleNamespace[] {
   const promRulesResponses = useUnifiedAlertingSelector((state) => state.promRules);
   const rulerRulesResponses = useUnifiedAlertingSelector((state) => state.rulerRules);
 
@@ -67,8 +71,12 @@ export function useCombinedRuleNamespaces(rulesSourceName?: string): CombinedRul
     return rulesSources
       .map((rulesSource): CombinedRuleNamespace[] => {
         const rulesSourceName = isCloudRulesSource(rulesSource) ? rulesSource.name : rulesSource;
-        const promRules = promRulesResponses[rulesSourceName]?.result;
+        let promRules = promRulesResponses[rulesSourceName]?.result;
         const rulerRules = rulerRulesResponses[rulesSourceName]?.result;
+
+        if (rulesSourceName === GRAFANA_RULES_SOURCE_NAME && promRuleNamespaces) {
+          promRules = promRuleNamespaces;
+        }
 
         const cached = cache.current[rulesSourceName];
         if (cached && cached.promRules === promRules && cached.rulerRules === rulerRules) {
@@ -104,7 +112,7 @@ export function useCombinedRuleNamespaces(rulesSourceName?: string): CombinedRul
         return result;
       })
       .flat();
-  }, [promRulesResponses, rulerRulesResponses, rulesSources]);
+  }, [promRulesResponses, rulerRulesResponses, rulesSources, promRuleNamespaces]);
 }
 
 // merge all groups in case of grafana managed, essentially treating namespaces (folders) as groups

--- a/public/app/features/alerting/unified/mocks/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertRuleApi.ts
@@ -1,8 +1,14 @@
 import { rest } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import { PreviewResponse, PREVIEW_URL } from '../api/alertRuleApi';
+import { RuleNamespace } from 'app/types/unified-alerting';
+
+import { PreviewResponse, PREVIEW_URL, PROM_RULES_URL } from '../api/alertRuleApi';
 
 export function mockPreviewApiResponse(server: SetupServer, result: PreviewResponse) {
   server.use(rest.post(PREVIEW_URL, (req, res, ctx) => res(ctx.json<PreviewResponse>(result))));
+}
+
+export function mockPromRulesApiResponse(server: SetupServer, result: RuleNamespace[]) {
+  server.use(rest.get(PROM_RULES_URL, (req, res, ctx) => res(ctx.json<RuleNamespace[]>(result))));
 }

--- a/public/app/features/alerting/unified/mocks/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertRuleApi.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import { RuleNamespace } from 'app/types/unified-alerting';
+import { PromRulesResponse } from 'app/types/unified-alerting-dto';
 
 import { PreviewResponse, PREVIEW_URL, PROM_RULES_URL } from '../api/alertRuleApi';
 
@@ -9,6 +9,6 @@ export function mockPreviewApiResponse(server: SetupServer, result: PreviewRespo
   server.use(rest.post(PREVIEW_URL, (req, res, ctx) => res(ctx.json<PreviewResponse>(result))));
 }
 
-export function mockPromRulesApiResponse(server: SetupServer, result: RuleNamespace[]) {
-  server.use(rest.get(PROM_RULES_URL, (req, res, ctx) => res(ctx.json<RuleNamespace[]>(result))));
+export function mockPromRulesApiResponse(server: SetupServer, result: PromRulesResponse) {
+  server.use(rest.get(PROM_RULES_URL, (req, res, ctx) => res(ctx.json<PromRulesResponse>(result))));
 }

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -18,6 +18,7 @@ import {
 import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import alertDef from 'app/features/alerting/state/alertDef';
+import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/components/rules/RuleDetails';
 import { useCombinedRuleNamespaces } from 'app/features/alerting/unified/hooks/useCombinedRuleNamespaces';
 import { useUnifiedAlertingSelector } from 'app/features/alerting/unified/hooks/useUnifiedAlertingSelector';
@@ -60,6 +61,8 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
   const [limitInstances, toggleLimit] = useToggle(true);
 
+  const { usePromRulesQuery } = alertRuleApi;
+
   // backwards compat for "Inactive" state filter
   useEffect(() => {
     if (props.options.stateFilter.inactive === true) {
@@ -90,7 +93,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   useEffect(() => {
     if (props.options.groupMode === GroupMode.Default) {
       dispatch(
-        fetchAllPromAndRulerRulesAction(true, {
+        fetchAllPromAndRulerRulesAction(false, {
           limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
           matcher: matcherList,
           state: stateList,
@@ -153,9 +156,19 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   const promRulesRequests = useUnifiedAlertingSelector((state) => state.promRules);
   const rulerRulesRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
-  const combinedRules = useCombinedRuleNamespaces();
 
   const somePromRulesDispatched = rulesDataSourceNames.some((name) => promRulesRequests[name]?.dispatched);
+
+  //For grafana managed rules, get the result using RTK Query to avoid the need of using the redux store
+  //See https://github.com/grafana/grafana/pull/70482
+  const { currentData: promRules = [] } = usePromRulesQuery({
+    limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
+    matcher: matcherList,
+    state: stateList,
+  });
+
+  const combinedRules = useCombinedRuleNamespaces(undefined, promRules);
+
   const someRulerRulesDispatched = rulesDataSourceNames.some((name) => rulerRulesRequests[name]?.dispatched);
   const dispatched = somePromRulesDispatched || someRulerRulesDispatched;
 

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -61,7 +61,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
   const [limitInstances, toggleLimit] = useToggle(true);
 
-  const { usePromRulesQuery } = alertRuleApi;
+  const { usePrometheusRulesByNamespaceQuery } = alertRuleApi;
 
   // backwards compat for "Inactive" state filter
   useEffect(() => {
@@ -161,7 +161,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   //For grafana managed rules, get the result using RTK Query to avoid the need of using the redux store
   //See https://github.com/grafana/grafana/pull/70482
-  const { currentData: promRules = [] } = usePromRulesQuery({
+  const { currentData: promRules = [] } = usePrometheusRulesByNamespaceQuery({
     limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
     matcher: matcherList,
     state: stateList,

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -90,7 +90,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   useEffect(() => {
     if (props.options.groupMode === GroupMode.Default) {
       dispatch(
-        fetchAllPromAndRulerRulesAction(false, {
+        fetchAllPromAndRulerRulesAction(true, {
           limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
           matcher: matcherList,
           state: stateList,

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -161,7 +161,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   //For grafana managed rules, get the result using RTK Query to avoid the need of using the redux store
   //See https://github.com/grafana/grafana/pull/70482
-  const { currentData: promRules = [] } = usePrometheusRulesByNamespaceQuery({
+  const { currentData: promRules = [], isLoading: grafanaRulesLoading } = usePrometheusRulesByNamespaceQuery({
     limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
     matcher: matcherList,
     state: stateList,
@@ -196,7 +196,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   return (
     <CustomScrollbar autoHeightMin="100%" autoHeightMax="100%">
       <div className={styles.container}>
-        {dispatched && loading && !haveResults && <LoadingPlaceholder text="Loading..." />}
+        {(grafanaRulesLoading || (dispatched && loading && !haveResults)) && <LoadingPlaceholder text="Loading..." />}
         {noAlertsMessage && <div className={styles.noAlertsMessage}>{noAlertsMessage}</div>}
         <section>
           {props.options.viewMode === ViewMode.Stat && haveResults && (


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where showing several alerting panels within a dashboard don't respect each panel's alert state filter settings.

**Why do we need this feature?**

To be able to respect alert state filters within a dashboard with several alerting panels.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/6423

**Special notes for your reviewer:**

When loading several alert list panels where each panel uses a different state filter, the request called to obtain the rules information remains the same. It doesn't trigger a new request if the param changes (in the example `state=pending` and `state=firing` are different filters that should trigger a separate request each). 

After some investigation we concluded the reason behind this is the Redux store keeps the data from the latest loaded panel. This started happening after [the filtering logic was moved to the backend.](https://github.com/grafana/grafana/pull/66267) In order to fix this, a potential solution (that is implemented in this PR) is to fetch the grafana alert rules using RTK query instead of getting it from the store for prom rules, which are the ones that are filtered in the backend.

**We are only getting promrules from RTKQ instead of the Redux Store for grafana managed alerts because so far, are the only ones that the filter is done in the BE.** 

Before - Only one request with `state=firing` when there is one missing with `state=pending`.
![Screenshot 2023-06-21 at 19 06 12](https://github.com/grafana/grafana/assets/6271380/23dfbb44-72c3-4b47-9f55-f959f82f23f2)

Before - Two requests with `state=firing` and `state=pending` after forcing the request calls. The problem here is that the firing panel is not showing all instances due an incorrect result from the redux store.
![Screenshot 2023-06-21 at 19 06 39](https://github.com/grafana/grafana/assets/6271380/f52ce1d1-3d0e-4943-9d01-7082f3274ed0)


After - Using RTK Query the panels show the correct instances as we skip reading it from the store.
![2023-06-22 16 20 24](https://github.com/grafana/grafana/assets/6271380/4197f1de-dfab-4219-b3ec-2148c1cf87d1)
