### PR TITLE
feat: do not put NaNs as first in legend desc sort

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -54,7 +54,9 @@ export const VizLegendTable = <T extends unknown>({
           if (item.getDisplayValues) {
             const stat = item.getDisplayValues().filter((stat) => stat.title === sortKey)[0];
 
-            return isNaN(stat.numeric) ? -Infinity : stat.numeric;
+            if (stat) {
+              return isNaN(stat.numeric) ? -Infinity : stat.numeric;
+            }
           }
           return undefined;
         },

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -54,9 +54,7 @@ export const VizLegendTable = <T extends unknown>({
           if (item.getDisplayValues) {
             const stat = item.getDisplayValues().filter((stat) => stat.title === sortKey)[0];
 
-    if (stat) {
-        return isNaN(stat.numeric) ? -Infinity : stat.numeric;
-    }
+            return isNaN(stat.numeric) ? -Infinity : stat.numeric;
           }
           return undefined;
         },

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -54,7 +54,9 @@ export const VizLegendTable = <T extends unknown>({
           if (item.getDisplayValues) {
             const stat = item.getDisplayValues().filter((stat) => stat.title === sortKey)[0];
 
-            return isNaN(stat.numeric) ? -Infinity : stat.numeric;
+    if (stat) {
+        return isNaN(stat.numeric) ? -Infinity : stat.numeric;
+    }
           }
           return undefined;
         },

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -53,7 +53,8 @@ export const VizLegendTable = <T extends unknown>({
 
           if (item.getDisplayValues) {
             const stat = item.getDisplayValues().filter((stat) => stat.title === sortKey)[0];
-            return stat && stat.numeric;
+
+            return isNaN(stat.numeric) ? -Infinity : stat.numeric;
           }
           return undefined;
         },


### PR DESCRIPTION
**What is this feature?**

When desc sorting legend, NaN values are on top.

<img width="256" alt="image" src="https://github.com/grafana/grafana/assets/327717/92a6359f-d974-4615-a958-557acfda95df">

This fixes the issue and puts NaN to the bottom position.

**Why do we need this feature?**

User expects to see max values when desc sorting.

**Who is this feature for?**

User watching graphs


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
