### PR TITLE
Alerting: Display a warning when a contact point is not in use

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
@@ -40,6 +40,7 @@ import { ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, ALERTMANAGER_NAME_QUERY_KEY } from
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 
 import Receivers from './ContactPoints.v1';
+
 jest.mock('../../api/alertmanager');
 jest.mock('../../api/grafana');
 jest.mock('../../utils/config');
@@ -542,7 +543,7 @@ describe('Receivers', () => {
     expect(ui.newContactPointButton.get()).toBeInTheDocument();
   });
 
-  describe('Contact points state', () => {
+  describe('Contact points health', () => {
     it('Should render error notifications when there are some points state ', async () => {
       mockAlertmanagerChoiceResponse(server, alertmanagerChoiceMockedResponse);
       mocks.api.fetchConfig.mockResolvedValue(someGrafanaAlertManagerConfig);
@@ -710,6 +711,31 @@ describe('Receivers', () => {
       expect(receiverRows[0]).toHaveTextContent('default');
       expect(receiverRows[1]).toHaveTextContent('critical');
       expect(receiverRows).toHaveLength(2);
+    });
+
+    it('Should render "Unused" warning if a contact point is not used in route configuration', async () => {
+      mockAlertmanagerChoiceResponse(server, alertmanagerChoiceMockedResponse);
+      mocks.api.updateConfig.mockResolvedValue();
+      mocks.api.fetchConfig.mockResolvedValue({
+        ...someGrafanaAlertManagerConfig,
+        alertmanager_config: { ...someGrafanaAlertManagerConfig.alertmanager_config, route: { receiver: 'default' } },
+      });
+
+      mocks.hooks.useGetContactPointsState.mockReturnValue(emptyContactPointsState);
+      renderReceivers();
+
+      await ui.receiversTable.find();
+      //should not render notification error
+      expect(ui.notificationError.query()).not.toBeInTheDocument();
+      //contact points are not expandable
+      expect(ui.contactPointsCollapseToggle.query()).not.toBeInTheDocument();
+      //should render receivers, only one dynamic table
+      let receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
+
+      expect(receiverRows).toHaveLength(2);
+      expect(receiverRows[0]).toHaveTextContent('default');
+      expect(receiverRows[1]).toHaveTextContent('critical');
+      expect(receiverRows[1]).toHaveTextContent('Unused');
     });
   });
 });

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import pluralize from 'pluralize';
 import React, { useMemo, useState } from 'react';
 
@@ -405,7 +404,7 @@ function useGetColumns(
   const tableStyles = useStyles2(getAlertTableStyles);
 
   const enableHealthColumn =
-    errorStateAvailable || Object.values(configHealth.contactPoints).some((cp) => cp === 'Unused');
+    errorStateAvailable || Object.values(configHealth.contactPoints).some((cp) => cp.matchingRoutes === 0);
 
   const baseColumns: RowTableColumnProps[] = [
     {
@@ -433,7 +432,7 @@ function useGetColumns(
     id: 'health',
     label: 'Health',
     renderCell: ({ data: { name } }) => {
-      if (configHealth.contactPoints[name] === 'Unused') {
+      if (configHealth.contactPoints[name]?.matchingRoutes === 0) {
         return <UnusedContactPointBadge />;
       }
 
@@ -479,21 +478,12 @@ function useGetColumns(
 }
 
 function UnusedContactPointBadge() {
-  const styles = useStyles2(unusedContactPointBadgeStyles);
-
   return (
     <Badge
       text="Unused"
       color="orange"
       icon="exclamation-triangle"
       tooltip="This contact point is not used in any notification policy and it will not receive any alerts"
-      className={styles.badge}
     />
   );
 }
-
-const unusedContactPointBadgeStyles = () => ({
-  badge: css`
-    cursor: default;
-  `,
-});

--- a/public/app/features/alerting/unified/components/receivers/useAlertmanagerConfigHealth.ts
+++ b/public/app/features/alerting/unified/components/receivers/useAlertmanagerConfigHealth.ts
@@ -1,0 +1,38 @@
+import { AlertmanagerConfig, Route } from '../../../../../plugins/datasource/alertmanager/types';
+
+export type ContactPointConfigHealth = 'OK' | 'Unused';
+
+export interface AlertmanagerConfigHealth {
+  contactPoints: Record<string, ContactPointConfigHealth>;
+}
+
+export function useAlertmanagerConfigHealth(config: AlertmanagerConfig): AlertmanagerConfigHealth {
+  if (!config.receivers) {
+    return { contactPoints: {} };
+  }
+
+  if (!config.route) {
+    return { contactPoints: Object.fromEntries(config.receivers.map((r) => [r.name, 'Unused'])) };
+  }
+
+  const definedContactPointNames = config.receivers?.map((receiver) => receiver.name) ?? [];
+  const usedContactPoints = getUsedContactPoints(config.route);
+
+  const contactPointsHealth: AlertmanagerConfigHealth['contactPoints'] = {};
+  const configHealth: AlertmanagerConfigHealth = { contactPoints: contactPointsHealth };
+
+  definedContactPointNames.forEach((contactPointName) => {
+    contactPointsHealth[contactPointName] = usedContactPoints.includes(contactPointName) ? 'OK' : 'Unused';
+  });
+
+  return configHealth;
+}
+
+function getUsedContactPoints(route: Route): string[] {
+  const childrenContactPoints = route.routes?.flatMap((route) => getUsedContactPoints(route)) ?? [];
+  if (route.receiver) {
+    return [route.receiver, ...childrenContactPoints];
+  }
+
+  return childrenContactPoints;
+}

--- a/public/app/features/alerting/unified/components/receivers/useAlertmanagerConfigHealth.ts
+++ b/public/app/features/alerting/unified/components/receivers/useAlertmanagerConfigHealth.ts
@@ -1,6 +1,10 @@
+import { countBy } from 'lodash';
+
 import { AlertmanagerConfig, Route } from '../../../../../plugins/datasource/alertmanager/types';
 
-export type ContactPointConfigHealth = 'OK' | 'Unused';
+export interface ContactPointConfigHealth {
+  matchingRoutes: number;
+}
 
 export interface AlertmanagerConfigHealth {
   contactPoints: Record<string, ContactPointConfigHealth>;
@@ -12,17 +16,18 @@ export function useAlertmanagerConfigHealth(config: AlertmanagerConfig): Alertma
   }
 
   if (!config.route) {
-    return { contactPoints: Object.fromEntries(config.receivers.map((r) => [r.name, 'Unused'])) };
+    return { contactPoints: Object.fromEntries(config.receivers.map((r) => [r.name, { matchingRoutes: 0 }])) };
   }
 
   const definedContactPointNames = config.receivers?.map((receiver) => receiver.name) ?? [];
   const usedContactPoints = getUsedContactPoints(config.route);
+  const usedContactPointCounts = countBy(usedContactPoints);
 
   const contactPointsHealth: AlertmanagerConfigHealth['contactPoints'] = {};
   const configHealth: AlertmanagerConfigHealth = { contactPoints: contactPointsHealth };
 
   definedContactPointNames.forEach((contactPointName) => {
-    contactPointsHealth[contactPointName] = usedContactPoints.includes(contactPointName) ? 'OK' : 'Unused';
+    contactPointsHealth[contactPointName] = { matchingRoutes: usedContactPointCounts[contactPointName] ?? 0 };
   });
 
   return configHealth;

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -18,6 +18,7 @@ import {
   AlertmanagerStatus,
   AlertState,
   GrafanaManagedReceiverConfig,
+  MatcherOperator,
   Silence,
   SilenceState,
 } from 'app/plugins/datasource/alertmanager/types';
@@ -387,6 +388,12 @@ export const someGrafanaAlertManagerConfig: AlertManagerCortexConfig = {
   alertmanager_config: {
     route: {
       receiver: 'default',
+      routes: [
+        {
+          receiver: 'critical',
+          object_matchers: [['severity', MatcherOperator.equal, 'critical']],
+        },
+      ],
     },
     receivers: [
       {
@@ -628,6 +635,7 @@ export function getGrafanaRule(override?: Partial<CombinedRule>) {
     ...override,
   });
 }
+
 export function getCloudRule(override?: Partial<CombinedRule>) {
   return mockCombinedRule({
     namespace: {

--- a/public/app/features/alerting/unified/styles/table.ts
+++ b/public/app/features/alerting/unified/styles/table.ts
@@ -27,6 +27,9 @@ export const getAlertTableStyles = (theme: GrafanaTheme2) => ({
   colExpand: css`
     width: 36px;
   `,
+  nameCell: css`
+    gap: ${theme.spacing(1)};
+  `,
   actionsCell: css`
     text-align: right;
     width: 1%;


### PR DESCRIPTION
**What is this feature?**
This PR adds a warning to contact points that are not used in a notification policy configuration

**Why do we need this feature?**
To make it easier to notice that an AM configuration might be incorrect

**Who is this feature for?**
All Alerting users

Fixes #69600 

**Special notes for your reviewer:**
Demo
![image](https://github.com/grafana/grafana/assets/6293563/868b610c-cf29-499d-9c1c-344c0bfdef30)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
