### PR TITLE
Docs: Add tested with BrowserStack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If you're interested in contributing to the Grafana project:
 - If you have a specific question, check out our [discussion forums](https://community.grafana.com/).
 - For general discussions, join us on the [official Slack](https://slack.grafana.com) team.
 
+This project is tested with [BrowserStack](https://www.browserstack.com/)
+
 ## License
 
 Grafana is distributed under [AGPL-3.0-only](LICENSE). For Apache-2.0 exceptions, see [LICENSING.md](https://github.com/grafana/grafana/blob/HEAD/LICENSING.md).


### PR DESCRIPTION
**What is this feature?**

Adds "Tested with BroserStack" to README

**Why do we need this feature?**

To obtain Sponsorship status with Browser stack as an open source project
