### PR TITLE
[v10.0.x] Explore: Clean up query subscriptions when a query is canceled

### DIFF
--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -73,7 +73,7 @@ const createFallbackLogVolumeProvider = (
   datasourceName: string
 ): Observable<DataQueryResponse> => {
   return new Observable<DataQueryResponse>((observer) => {
-    explorePanelData.subscribe((exploreData) => {
+    return explorePanelData.subscribe((exploreData) => {
       if (
         exploreData.logsResult &&
         exploreData.logsResult.rows &&


### PR DESCRIPTION
Backport cb2cc591da5c16daffc65398091bfc1128b720ce from #70235

Automatic backport failed mainly because of ExploreId being removed in main, also the structure of ExploreItemState changed (extra `panes` property was added in main)