### PR TITLE
Explore: make sure panes are initialized in order

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -237,10 +237,10 @@ export function useStateSync(params: ExploreQueryParams) {
         // we need to use partial here beacuse replace doesn't encode the query params.
         location.partial(
           {
-            // partial doesn't remove other parameters, so we delete all the current one before adding the new ones.
-            ...Object.keys(location.getSearchObject()).reduce<Record<string, unknown>>((acc_1, key) => {
-              acc_1[key] = undefined;
-              return acc_1;
+            // partial doesn't remove other parameters, so we delete (by setting them to undefined) all the current one before adding the new ones.
+            ...Object.keys(location.getSearchObject()).reduce<Record<string, unknown>>((acc, key) => {
+              acc[key] = undefined;
+              return acc;
             }, {}),
             panes: JSON.stringify(newParams.panes),
             schemaVersion: urlState.schemaVersion,

--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -170,88 +170,86 @@ export function useStateSync(params: ExploreQueryParams) {
 
       Promise.all(
         Object.entries(urlState.panes).map(([exploreId, { datasource, queries, range, panelsState }]) => {
-          return getPaneDatasource(datasource, queries, orgId, !!exploreMixedDatasource).then(
-            async (paneDatasource) => {
-              return Promise.resolve(
-                // FIXME: In theory, given the Grafana datasource will always be present, this should always be defined.
-                paneDatasource
-                  ? queries.length
-                    ? // if we have queries in the URL, we use them
-                      withUniqueRefIds(queries)
-                        // but filter out the ones that are not compatible with the pane datasource
-                        .filter(getQueryFilter(paneDatasource))
-                        .map(
-                          isMixedDatasource(paneDatasource)
-                            ? identity<DataQuery>
-                            : (query) => ({ ...query, datasource: paneDatasource.getRef() })
-                        )
-                    : getDatasourceSrv()
-                        // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
-                        .get(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef())
-                        .then((ds) => [getDefaultQuery(ds)])
-                  : []
-              )
-                .then(async (queries) => {
-                  // we remove queries that have an invalid datasources
-                  const validQueries = await removeQueriesWithInvalidDatasource(queries);
+          return getPaneDatasource(datasource, queries, orgId, !!exploreMixedDatasource).then((paneDatasource) => {
+            return Promise.resolve(
+              // Given the Grafana datasource will always be present, this should always be defined.
+              paneDatasource
+                ? queries.length
+                  ? // if we have queries in the URL, we use them
+                    withUniqueRefIds(queries)
+                      // but filter out the ones that are not compatible with the pane datasource
+                      .filter(getQueryFilter(paneDatasource))
+                      .map(
+                        isMixedDatasource(paneDatasource)
+                          ? identity<DataQuery>
+                          : (query) => ({ ...query, datasource: paneDatasource.getRef() })
+                      )
+                  : getDatasourceSrv()
+                      // otherwise we get a default query from the pane datasource or from the default datasource if the pane datasource is mixed
+                      .get(isMixedDatasource(paneDatasource) ? undefined : paneDatasource.getRef())
+                      .then((ds) => [getDefaultQuery(ds)])
+                : []
+            ).then(async (queries) => {
+              // we remove queries that have an invalid datasources
+              let validQueries = await removeQueriesWithInvalidDatasource(queries);
 
-                  if (!validQueries.length && paneDatasource) {
-                    // and in case there's no query left we add a default one.
-                    return [
-                      getDefaultQuery(
-                        isMixedDatasource(paneDatasource) ? await getDatasourceSrv().get() : paneDatasource
-                      ),
-                    ];
-                  }
+              if (!validQueries.length && paneDatasource) {
+                // and in case there's no query left we add a default one.
+                validQueries = [
+                  getDefaultQuery(isMixedDatasource(paneDatasource) ? await getDatasourceSrv().get() : paneDatasource),
+                ];
+              }
 
-                  return validQueries;
-                })
-                .then((queries) => {
-                  return dispatch(
-                    initializeExplore({
-                      exploreId,
-                      datasource: paneDatasource,
-                      queries,
-                      range,
-                      panelsState,
-                    })
-                  ).unwrap();
-                });
-            }
-          );
+              return { exploreId, range, panelsState, queries: validQueries, datasource: paneDatasource };
+            });
+          });
         })
       ).then((panes) => {
-        const newParams = panes.reduce(
-          (acc, { exploreId, state }) => {
-            return {
-              ...acc,
-              panes: {
-                ...acc.panes,
-                [exploreId]: getUrlStateFromPaneState(state),
-              },
-            };
-          },
-          {
-            panes: {},
-          }
-        );
+        Promise.all(
+          panes.map(({ exploreId, range, panelsState, queries, datasource }) => {
+            return dispatch(
+              initializeExplore({
+                exploreId,
+                datasource,
+                queries,
+                range,
+                panelsState,
+              })
+            ).unwrap();
+          })
+        ).then((panes) => {
+          const newParams = panes.reduce(
+            (acc, { exploreId, state }) => {
+              return {
+                ...acc,
+                panes: {
+                  ...acc.panes,
+                  [exploreId]: getUrlStateFromPaneState(state),
+                },
+              };
+            },
+            {
+              panes: {},
+            }
+          );
 
-        initState.current = 'done';
+          initState.current = 'done';
 
-        // we need to use partial here beacuse replace doesn't encode the query params.
-        location.partial(
-          {
-            // partial doesn't remove other parameters, so we delete all the current one before adding the new ones.
-            ...Object.keys(location.getSearchObject()).reduce<Record<string, unknown>>((acc, key) => {
-              acc[key] = undefined;
-              return acc;
-            }, {}),
-            panes: JSON.stringify(newParams.panes),
-            schemaVersion: urlState.schemaVersion,
-            orgId,
-          },
-          true
-        );
+          // we need to use partial here beacuse replace doesn't encode the query params.
+          location.partial(
+            {
+              // partial doesn't remove other parameters, so we delete all the current one before adding the new ones.
+              ...Object.keys(location.getSearchObject()).reduce<Record<string, unknown>>((acc, key) => {
+                acc[key] = undefined;
+                return acc;
+              }, {}),
+              panes: JSON.stringify(newParams.panes),
+              schemaVersion: urlState.schemaVersion,
+              orgId,
+            },
+            true
+          );
+        });
       });
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.
8. 


-->

**What is this feature?**

Ensures panes in Explore are initialized in the same order as defined in the URL. Given how we lazy load plugins (or in general because of the async nature of the init process) it may have happened that loading a ds on the right pane finished before than loading the left pane one, which caused Explore to switch the panes in the state.


**Why do we need this feature?**

Panes ordering should be consistent across reloads

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Not backporting this as this behaviour was not present in 10.0.x

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


**How to test it:**
Reproducing the issue in main is quite easy: open Explore with 2 panes, on the left pick Loki as a datasource (Prometheus or Elastic would work as well), on the right pick testdata and reload the page. without this fix the panes will be swapped.
