### PR TITLE
Alerting: Adds in-app documentation for Classic Conditions

### DIFF
--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -36,7 +36,7 @@ export const gelTypes: Array<SelectableValue<ExpressionQueryType>> = [
     value: ExpressionQueryType.classic,
     label: 'Classic condition',
     description:
-      'Takes one or more time series returned from a query or an expression and checks if any of the series match the condition.',
+      'Takes one or more time series returned from a query or an expression and checks if any of the series match the condition. Disables multi-dimensional alerts for this rule.',
   },
   {
     value: ExpressionQueryType.threshold,


### PR DESCRIPTION
**What is this feature?**

This commit adds in-app documentation that explains using Classic Conditions disables multi-dimensional alerts for the rule.

![Screenshot 2023-06-22 at 6 28 28 pm](https://github.com/grafana/grafana/assets/85952834/d88dfc6d-e660-478d-9b81-b6890d5840f5)

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
