### PR TITLE
Alerting: Fixes clone url for instances hosted on sub path

### DIFF
--- a/public/app/features/alerting/unified/components/rules/CloneRuleButton.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloneRuleButton.tsx
@@ -7,7 +7,6 @@ import { ConfirmModal, LinkButton, useStyles2 } from '@grafana/ui';
 import { RuleIdentifier } from 'app/types/unified-alerting';
 
 import * as ruleId from '../../utils/rule-id';
-import { createUrl } from '../../utils/url';
 
 interface CloneRuleButtonProps {
   ruleIdentifier: RuleIdentifier;
@@ -20,10 +19,10 @@ export const CloneRuleButton = React.forwardRef<HTMLAnchorElement, CloneRuleButt
   ({ text, ruleIdentifier, isProvisioned, className }, ref) => {
     // For provisioned rules an additional confirmation step is required
     // Users have to be aware that the cloned rule will NOT be marked as provisioned
-    const [provRuleCloneUrl, setProvRuleCloneUrl] = useState<string | undefined>(undefined);
+    const [showModal, setShowModal] = useState(false);
 
     const styles = useStyles2(getStyles);
-    const cloneUrl = createUrl('/alerting/new', { copyFrom: ruleId.stringifyIdentifier(ruleIdentifier) });
+    const cloneUrl = '/alerting/new?copyFrom=' + ruleId.stringifyIdentifier(ruleIdentifier);
 
     return (
       <>
@@ -35,14 +34,14 @@ export const CloneRuleButton = React.forwardRef<HTMLAnchorElement, CloneRuleButt
           variant="secondary"
           icon="copy"
           href={isProvisioned ? undefined : cloneUrl}
-          onClick={isProvisioned ? () => setProvRuleCloneUrl(cloneUrl) : undefined}
+          onClick={isProvisioned ? () => setShowModal(true) : undefined}
           ref={ref}
         >
           {text}
         </LinkButton>
 
         <ConfirmModal
-          isOpen={!!provRuleCloneUrl}
+          isOpen={showModal}
           title="Copy provisioned alert rule"
           body={
             <div>
@@ -57,11 +56,9 @@ export const CloneRuleButton = React.forwardRef<HTMLAnchorElement, CloneRuleButt
           }
           confirmText="Copy"
           onConfirm={() => {
-            if (provRuleCloneUrl) {
-              locationService.push(provRuleCloneUrl);
-            }
+            locationService.push(cloneUrl);
           }}
-          onDismiss={() => setProvRuleCloneUrl(undefined)}
+          onDismiss={() => setShowModal(false)}
         />
       </>
     );


### PR DESCRIPTION
**What is this feature?**

A small fix for cloning alert rules when Grafana is hosted on a sub path.

**Special notes for your reviewer:**

The code changes will seem counter-intuitive because I'm no longer using the function that _prepends_ the sub path. This is because `history.push` already accounts for the sub path on which Grafana is currently mounted.

https://github.com/grafana/grafana/blob/cda5a0c6824f145db25249567aeb97e8c46897e9/packages/grafana-runtime/src/services/LocationService.ts#L40
