### PR TITLE
Prometheus: Metrics explorer feature toggle default to on

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -33,6 +33,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `disablePrometheusExemplarSampling`              | Disable Prometheus exemplar sampling                                                                                                                                                                |                    |
 | `logsSampleInExplore`                            | Enables access to the logs sample feature in Explore                                                                                                                                                | Yes                |
 | `logsContextDatasourceUi`                        | Allow datasource to provide custom UI for context view                                                                                                                                              | Yes                |
+| `prometheusMetricEncyclopedia`                   | Adds the metrics explorer component to the Prometheus query builder as an option in metric select                                                                                                   | Yes                |
 | `prometheusDataplane`                            | Changes responses to from Prometheus to be compliant with the dataplane specification. In particular it sets the numeric Field.Name from 'Value' to the value of the `__name__` label when present. | Yes                |
 | `lokiMetricDataplane`                            | Changes metric responses from Loki to be compliant with the dataplane specification.                                                                                                                | Yes                |
 | `dataplaneFrontendFallback`                      | Support dataplane contract field name change for transformations and field name matchers where the name is different                                                                                | Yes                |
@@ -97,7 +98,6 @@ Experimental features might be changed or removed without prior notice.
 | `individualCookiePreferences`      | Support overriding cookie preferences per user                                                               |
 | `onlyExternalOrgRoleSync`          | Prohibits a user from changing organization roles synced with external auth providers                        |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries    |
-| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component         |
 | `timeSeriesTable`                  | Enable time series table transformer & sparkline cell type                                                   |
 | `prometheusResourceBrowserCache`   | Displays browser caching options in Prometheus data source configuration                                     |
 | `influxdbBackendMigration`         | Query InfluxDB InfluxQL without the proxy                                                                    |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -357,8 +357,9 @@ var (
 		},
 		{
 			Name:         "prometheusMetricEncyclopedia",
-			Description:  "Replaces the Prometheus query builder metric select option with a paginated and filterable component",
-			Stage:        FeatureStageExperimental,
+			Description:  "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
+			Expression:   "true",
+			Stage:        FeatureStageGeneralAvailability,
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityMetricsSquad,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -51,7 +51,7 @@ lokiQuerySplittingConfig,experimental,@grafana/observability-logs,false,false,fa
 individualCookiePreferences,experimental,@grafana/backend-platform,false,false,false,false
 onlyExternalOrgRoleSync,experimental,@grafana/grafana-authnz-team,false,false,false,false
 traceqlSearch,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
-prometheusMetricEncyclopedia,experimental,@grafana/observability-metrics,false,false,false,true
+prometheusMetricEncyclopedia,GA,@grafana/observability-metrics,false,false,false,true
 timeSeriesTable,experimental,@grafana/app-o11y,false,false,false,true
 prometheusResourceBrowserCache,experimental,@grafana/observability-metrics,false,false,false,true
 influxdbBackendMigration,experimental,@grafana/observability-metrics,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -216,7 +216,7 @@ const (
 	FlagTraceqlSearch = "traceqlSearch"
 
 	// FlagPrometheusMetricEncyclopedia
-	// Replaces the Prometheus query builder metric select option with a paginated and filterable component
+	// Adds the metrics explorer component to the Prometheus query builder as an option in metric select
 	FlagPrometheusMetricEncyclopedia = "prometheusMetricEncyclopedia"
 
 	// FlagTimeSeriesTable


### PR DESCRIPTION
**What is this feature?**
This turns the metrics explorer feature toggle on by default. 

The metrics explorer is a paginated and filterable metrics search in the Prometheus query builder. You can find it in ops currently. After testing in ops and performing user testing, it has made it to the stage for general availability. It will be GA in Grafana v10.1. See https://github.com/grafana/grafana/pull/69528 for the last progress in testing.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
