### PR TITLE
Revert "Logs: Change permalink icon back to `link`"

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -128,7 +128,7 @@ export class LogRowMessage extends PureComponent<Props> {
                 aria-label="Copy shortlink"
                 tooltipPlacement="top"
                 size="md"
-                name="link"
+                name="share-alt"
                 onClick={() => onPermalinkClick(row)}
               />
             )}


### PR DESCRIPTION
Reverts grafana/grafana#70362

After further discussions we should use `share-alt`.