### PR TITLE
Sandbox: Fix react class components stale state

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -11,6 +11,7 @@ import {
   isDomElement,
   isLiveTarget,
   markDomElementStyleAsALiveTarget,
+  patchObjectAsLiveTarget,
 } from './document_sandbox';
 import { sandboxPluginDependencies } from './plugin_dependencies';
 import { sandboxPluginComponents } from './sandbox_components';
@@ -48,6 +49,8 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<unknown>
       // the element.style attribute should be a live target to work in chrome
       markDomElementStyleAsALiveTarget(element);
       return element;
+    } else {
+      patchObjectAsLiveTarget(originalValue);
     }
     const distortion = generalDistortionMap.get(originalValue);
     if (distortion) {

--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -11,8 +11,5 @@ export function assertNever(x: never): never {
 }
 
 export function isReactClassComponent(obj: unknown): obj is React.Component {
-  if (obj instanceof React.Component) {
-    return true;
-  }
-  return false;
+  return obj instanceof React.Component;
 }

--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { SandboxedPluginObject } from './types';
 
 export function isSandboxedPluginObject(value: unknown): value is SandboxedPluginObject {
@@ -6,4 +8,11 @@ export function isSandboxedPluginObject(value: unknown): value is SandboxedPlugi
 
 export function assertNever(x: never): never {
   throw new Error(`Unexpected object: ${x}. This should never happen.`);
+}
+
+export function isReactClassComponent(obj: unknown): obj is React.Component {
+  if (obj instanceof React.Component) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
**What is this feature?**

Fixes an issue in [plugin frontend sandbox](https://github.com/grafana/grafana/pull/68889) where react class components will always render with a stale state.

**Why do we need this feature?**

To make plugins using react class components work correctly when running inside the sandbox

**Who is this feature for?**

All grafana frontend plugin developers

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/70360

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
