### PR TITLE
Docs: Added queried table to start of Time Series section

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -276,7 +276,20 @@ The resulting table panel:
 
 ## Time series queries
 
-If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
+The examples in this section query the following table:
+```text
++---------------------+--------------+---------------------+----------+
+| time_date_time      | value_double | CreatedAt           | hostname |
++---------------------+--------------+---------------------+----------+
+| 2020-01-02 03:05:00 | 3.0          | 2020-01-02 03:05:00 | 10.0.1.1 |
+| 2020-01-02 03:06:00 | 4.0          | 2020-01-02 03:06:00 | 10.0.1.2 |
+| 2020-01-02 03:10:00 | 6.0          | 2020-01-02 03:10:00 | 10.0.1.1 |
+| 2020-01-02 03:11:00 | 7.0          | 2020-01-02 03:11:00 | 10.0.1.2 |
+| 2020-01-02 03:20:00 | 5.0          | 2020-01-02 03:20:00 | 10.0.1.2 |
++---------------------+--------------+---------------------+----------+
+```
+
+If the `Format as` query option is set to `Time Series` then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
 A time series query result is returned in a [wide data frame format]({{< relref "../../developers/plugins/data-frames#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
@@ -307,6 +320,7 @@ Data frame result:
 +---------------------+-----------------+
 | 2020-01-02 03:05:00 | 3               |
 | 2020-01-02 03:10:00 | 6               |
+| 2020-01-02 03:20:00 | 5               |
 +---------------------+-----------------+
 ```
 
@@ -336,6 +350,8 @@ Data frame result:
 +---------------------+---------------------------+---------------------------+
 | 2020-01-02 03:05:00 | 3                         | 4                         |
 | 2020-01-02 03:10:00 | 6                         | 7                         |
+| 2020-01-02 03:15:00 | 0                         | 0                         |
+| 2020-01-02 03:20:00 | 0                         | 5                         |
 +---------------------+---------------------------+---------------------------+
 ```
 
@@ -360,8 +376,9 @@ Data frame result:
 | Labels:             | Labels:         | Labels:         |
 | Type: []time.Time   | Type: []float64 | Type: []float64 |
 +---------------------+-----------------+-----------------+
-| 2020-01-02 03:04:00 | 3               | 4               |
-| 2020-01-02 03:05:00 | 6               | 7               |
+| 2020-01-02 03:05:00 | 3               | 4               |
+| 2020-01-02 03:10:00 | 6               | 7               |
+| 2020-01-02 03:20:00 | 5               | 5               |
 +---------------------+-----------------+-----------------+
 ```
 

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -277,6 +277,7 @@ The resulting table panel:
 ## Time series queries
 
 The examples in this section query the following table:
+
 ```text
 +---------------------+--------------+---------------------+----------+
 | time_date_time      | value_double | CreatedAt           | hostname |


### PR DESCRIPTION
**What is this feature?**

Adding SQL table being queried to beginning of "Time Series" section, and updating result tables of each query so they have suitable data.

**Why do we need this feature?**

Makes the Time Series queries easier to understand.

**Who is this feature for?**

Those learning to use the MySQL datasource

**Which issue(s) does this PR fix?**:

Fixes #44494

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
