### PR TITLE
Alerting: added description to api resource

### DIFF
--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -105,7 +105,7 @@ DELETE /api/v1/provisioning/alert-rules/{UID}
 | Name                 | Source   | Type   | Go type  | Separator | Required | Default | Description    |
 | -------------------- | -------- | ------ | -------- | --------- | :------: | ------- | -------------- |
 | UID                  | `path`   | string | `string` |           |    ✓     |         | Alert rule UID |
-| X-Disable-Provenance | `header` | string | `string` |           |          |         |                |
+| X-Disable-Provenance | `header` | string | `string` |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 
 {{% /responsive-table %}}
 
@@ -608,7 +608,7 @@ POST /api/v1/provisioning/alert-rules
 
 | Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description |
 | -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ----------- |
-| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |             |
+| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |             |
 
 {{% /responsive-table %}}
@@ -654,7 +654,7 @@ POST /api/v1/provisioning/contact-points
 
 | Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description |
 | -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ----------- |
-| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |             |
+| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |             |
 
 {{% /responsive-table %}}
@@ -700,7 +700,7 @@ POST /api/v1/provisioning/mute-timings
 
 | Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description |
 | -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | ----------- |
-| X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         |             |
+| X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |             |
 
 {{% /responsive-table %}}
@@ -747,7 +747,7 @@ PUT /api/v1/provisioning/alert-rules/{UID}
 | Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description    |
 | -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | -------------- |
 | UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | Alert rule UID |
-| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |                |
+| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                |
 
 {{% /responsive-table %}}
@@ -795,7 +795,7 @@ PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}
 | -------------------- | -------- | ----------------------------------- | ----------------------- | --------- | :------: | ------- | ----------- |
 | FolderUID            | `path`   | string                              | `string`                |           |    ✓     |         |             |
 | Group                | `path`   | string                              | `string`                |           |    ✓     |         |             |
-| X-Disable-Provenance | `header` | string                              | `string`                |           |          |         |             |
+| X-Disable-Provenance | `header` | string                              | `string`                |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [AlertRuleGroup](#alert-rule-group) | `models.AlertRuleGroup` |           |          |         |             |
 
 {{% /responsive-table %}}
@@ -842,8 +842,8 @@ PUT /api/v1/provisioning/contact-points/{UID}
 | Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                |
 | -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ------------------------------------------ |
 | UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | UID is the contact point unique identifier |
-| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |                                            |
-| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                            |
+| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |  Allows editing of provisioned resources in the Grafana UI |
+| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                    |
 
 {{% /responsive-table %}}
 
@@ -889,7 +889,7 @@ PUT /api/v1/provisioning/mute-timings/{name}
 | Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description      |
 | -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | ---------------- |
 | name                 | `path`   | string                                  | `string`                  |           |    ✓     |         | Mute timing name |
-| X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         |                  |
+| X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                  |
 
 {{% /responsive-table %}}
@@ -935,7 +935,7 @@ PUT /api/v1/provisioning/policies
 
 | Name                 | Source   | Type            | Go type        | Separator | Required | Default | Description                              |
 | -------------------- | -------- | --------------- | -------------- | --------- | :------: | ------- | ---------------------------------------- |
-| X-Disable-Provenance | `header` | string          | `string`       |           |          |         |                                          |
+| X-Disable-Provenance | `header` | string          | `string`       |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [Route](#route) | `models.Route` |           |          |         | The new notification routing tree to use |
 
 {{% /responsive-table %}}
@@ -982,7 +982,7 @@ PUT /api/v1/provisioning/templates/{name}
 | Name                 | Source   | Type                                                          | Go type                              | Separator | Required | Default | Description   |
 | -------------------- | -------- | ------------------------------------------------------------- | ------------------------------------ | --------- | :------: | ------- | ------------- |
 | name                 | `path`   | string                                                        | `string`                             |           |    ✓     |         | Template Name |
-| X-Disable-Provenance | `header` | string                                                        | `string`                             |           |          |         |               |
+| X-Disable-Provenance | `header` | string                                                        | `string`                             |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 | Body                 | `body`   | [NotificationTemplateContent](#notification-template-content) | `models.NotificationTemplateContent` |           |          |         |               |
 
 {{% /responsive-table %}}

--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -102,9 +102,9 @@ DELETE /api/v1/provisioning/alert-rules/{UID}
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type   | Go type  | Separator | Required | Default | Description    |
-| -------------------- | -------- | ------ | -------- | --------- | :------: | ------- | -------------- |
-| UID                  | `path`   | string | `string` |           |    ✓     |         | Alert rule UID |
+| Name                 | Source   | Type   | Go type  | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ------ | -------- | --------- | :------: | ------- | --------------------------------------------------------- |
+| UID                  | `path`   | string | `string` |           |    ✓     |         | Alert rule UID                                            |
 | X-Disable-Provenance | `header` | string | `string` |           |          |         | Allows editing of provisioned resources in the Grafana UI |
 
 {{% /responsive-table %}}
@@ -606,10 +606,10 @@ POST /api/v1/provisioning/alert-rules
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description |
-| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ----------- |
+| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
 | X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |             |
+| Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -652,10 +652,10 @@ POST /api/v1/provisioning/contact-points
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description |
-| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ----------- |
+| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
 | X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |             |
+| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -698,10 +698,10 @@ POST /api/v1/provisioning/mute-timings
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description |
-| -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | ----------- |
+| Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
 | X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |             |
+| Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -744,11 +744,11 @@ PUT /api/v1/provisioning/alert-rules/{UID}
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description    |
-| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | -------------- |
-| UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | Alert rule UID |
+| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
+| UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | Alert rule UID                                            |
 | X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                |
+| Body                 | `body`   | [ProvisionedAlertRule](#provisioned-alert-rule) | `models.ProvisionedAlertRule` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -791,12 +791,12 @@ PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                | Go type                 | Separator | Required | Default | Description |
-| -------------------- | -------- | ----------------------------------- | ----------------------- | --------- | :------: | ------- | ----------- |
-| FolderUID            | `path`   | string                              | `string`                |           |    ✓     |         |             |
-| Group                | `path`   | string                              | `string`                |           |    ✓     |         |             |
+| Name                 | Source   | Type                                | Go type                 | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ----------------------------------- | ----------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
+| FolderUID            | `path`   | string                              | `string`                |           |    ✓     |         |                                                           |
+| Group                | `path`   | string                              | `string`                |           |    ✓     |         |                                                           |
 | X-Disable-Provenance | `header` | string                              | `string`                |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [AlertRuleGroup](#alert-rule-group) | `models.AlertRuleGroup` |           |          |         |             |
+| Body                 | `body`   | [AlertRuleGroup](#alert-rule-group) | `models.AlertRuleGroup` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -839,11 +839,11 @@ PUT /api/v1/provisioning/contact-points/{UID}
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                |
-| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | ------------------------------------------ |
-| UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | UID is the contact point unique identifier |
-| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         |  Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                    |
+| Name                 | Source   | Type                                            | Go type                       | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ----------------------------------------------- | ----------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
+| UID                  | `path`   | string                                          | `string`                      |           |    ✓     |         | UID is the contact point unique identifier                |
+| X-Disable-Provenance | `header` | string                                          | `string`                      |           |          |         | Allows editing of provisioned resources in the Grafana UI |
+| Body                 | `body`   | [EmbeddedContactPoint](#embedded-contact-point) | `models.EmbeddedContactPoint` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -886,11 +886,11 @@ PUT /api/v1/provisioning/mute-timings/{name}
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description      |
-| -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | ---------------- |
-| name                 | `path`   | string                                  | `string`                  |           |    ✓     |         | Mute timing name |
+| Name                 | Source   | Type                                    | Go type                   | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | --------------------------------------- | ------------------------- | --------- | :------: | ------- | --------------------------------------------------------- |
+| name                 | `path`   | string                                  | `string`                  |           |    ✓     |         | Mute timing name                                          |
 | X-Disable-Provenance | `header` | string                                  | `string`                  |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                  |
+| Body                 | `body`   | [MuteTimeInterval](#mute-time-interval) | `models.MuteTimeInterval` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 
@@ -933,10 +933,10 @@ PUT /api/v1/provisioning/policies
 
 {{% responsive-table %}}
 
-| Name                 | Source   | Type            | Go type        | Separator | Required | Default | Description                              |
-| -------------------- | -------- | --------------- | -------------- | --------- | :------: | ------- | ---------------------------------------- |
+| Name                 | Source   | Type            | Go type        | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | --------------- | -------------- | --------- | :------: | ------- | --------------------------------------------------------- |
 | X-Disable-Provenance | `header` | string          | `string`       |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [Route](#route) | `models.Route` |           |          |         | The new notification routing tree to use |
+| Body                 | `body`   | [Route](#route) | `models.Route` |           |          |         | The new notification routing tree to use                  |
 
 {{% /responsive-table %}}
 
@@ -979,11 +979,11 @@ PUT /api/v1/provisioning/templates/{name}
 
 #### Parameters
 
-| Name                 | Source   | Type                                                          | Go type                              | Separator | Required | Default | Description   |
-| -------------------- | -------- | ------------------------------------------------------------- | ------------------------------------ | --------- | :------: | ------- | ------------- |
-| name                 | `path`   | string                                                        | `string`                             |           |    ✓     |         | Template Name |
+| Name                 | Source   | Type                                                          | Go type                              | Separator | Required | Default | Description                                               |
+| -------------------- | -------- | ------------------------------------------------------------- | ------------------------------------ | --------- | :------: | ------- | --------------------------------------------------------- |
+| name                 | `path`   | string                                                        | `string`                             |           |    ✓     |         | Template Name                                             |
 | X-Disable-Provenance | `header` | string                                                        | `string`                             |           |          |         | Allows editing of provisioned resources in the Grafana UI |
-| Body                 | `body`   | [NotificationTemplateContent](#notification-template-content) | `models.NotificationTemplateContent` |           |          |         |               |
+| Body                 | `body`   | [NotificationTemplateContent](#notification-template-content) | `models.NotificationTemplateContent` |           |          |         |                                                           |
 
 {{% /responsive-table %}}
 


### PR DESCRIPTION

**What is this feature?**

Added a description for the  request header `X-Disable-Provenance` across the whole [document](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)

**Why do we need this feature?**

Users from the community forum are sometimes unaware that they can use this header in their requests (and so they end up not being able to modify the different alerting API resources, that they are provisioning, in the UI). Adding description in the API endpoints might help this. 
