### PR TITLE
DS Picker: Apply filters consistently to every list in the picker

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -2,8 +2,8 @@
 // however there are many cases where your component may not need an aria-label
 // (a <button> with clear text, for example, does not need an aria-label as it's already labeled)
 // but you still might need to select it for testing,
-// in that case please add the attribute data-test-id={selector} in the component and
-// prefix your selector string with 'data-test-id' so that when create the selectors we know to search for it on the right attribute
+// in that case please add the attribute data-testid={selector} in the component and
+// prefix your selector string with 'data-testid' so that when create the selectors we know to search for it on the right attribute
 /**
  * Selectors grouped/defined in Components
  *
@@ -78,7 +78,7 @@ export const Components = {
       headerCornerInfo: (mode: string) => `Panel header ${mode}`,
       loadingBar: () => `Panel loading bar`,
       HoverWidget: {
-        container: 'data-test-id hover-header-container',
+        container: 'data-testid hover-header-container',
         dragIcon: 'data-testid drag-icon',
       },
     },

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -259,7 +259,7 @@ export function FileDropzoneDefaultChildren({ primaryText = 'Drop file here or c
   const styles = getStyles(theme);
 
   return (
-    <div className={cx(styles.defaultDropZone)} data-test-id="file-drop-zone-default-children">
+    <div className={cx(styles.defaultDropZone)} data-testid="file-drop-zone-default-children">
       <Icon className={cx(styles.icon)} name="upload" size="xl" />
       <h6 className={cx(styles.primaryText)}>{primaryText}</h6>
       <small className={styles.small}>{secondaryText}</small>

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -259,7 +259,7 @@ export function FileDropzoneDefaultChildren({ primaryText = 'Drop file here or c
   const styles = getStyles(theme);
 
   return (
-    <div className={cx(styles.defaultDropZone)} data-test-id="default-file-drop-zone">
+    <div className={cx(styles.defaultDropZone)} data-test-id="file-drop-zone-default-children">
       <Icon className={cx(styles.icon)} name="upload" size="xl" />
       <h6 className={cx(styles.primaryText)}>{primaryText}</h6>
       <small className={styles.small}>{secondaryText}</small>

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -259,7 +259,7 @@ export function FileDropzoneDefaultChildren({ primaryText = 'Drop file here or c
   const styles = getStyles(theme);
 
   return (
-    <div className={cx(styles.defaultDropZone)}>
+    <div className={cx(styles.defaultDropZone)} data-test-id="default-file-drop-zone">
       <Icon className={cx(styles.icon)} name="upload" size="xl" />
       <h6 className={cx(styles.primaryText)}>{primaryText}</h6>
       <small className={styles.small}>{secondaryText}</small>

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
@@ -22,7 +22,7 @@ describe('TopSearchBarSection', () => {
 
     const { container } = renderComponent();
 
-    expect(container.querySelector('[data-test-id="wrapper"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="wrapper"]')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /test item/i })).toBeInTheDocument();
   });
 
@@ -35,7 +35,7 @@ describe('TopSearchBarSection', () => {
 
     const { container } = renderComponent();
 
-    expect(container.querySelector('[data-test-id="wrapper"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="wrapper"]')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /test item/i })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
@@ -20,9 +20,9 @@ describe('TopSearchBarSection', () => {
       matches: true,
     }));
 
-    const { container } = renderComponent();
+    const component = renderComponent();
 
-    expect(container.querySelector('[data-testid="wrapper"]')).toBeInTheDocument();
+    expect(component.queryByTestId('wrapper')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /test item/i })).toBeInTheDocument();
   });
 
@@ -33,9 +33,9 @@ describe('TopSearchBarSection', () => {
       matches: false,
     }));
 
-    const { container } = renderComponent();
+    const component = renderComponent();
 
-    expect(container.querySelector('[data-testid="wrapper"]')).not.toBeInTheDocument();
+    expect(component.queryByTestId('wrapper')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /test item/i })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.tsx
@@ -29,7 +29,7 @@ export function TopSearchBarSection({ children, align = 'left' }: TopSearchBarSe
   }
 
   return (
-    <div data-test-id="wrapper" className={cx(styles.wrapper, { [styles[align]]: align === 'right' })}>
+    <div data-testid="wrapper" className={cx(styles.wrapper, { [styles[align]]: align === 'right' })}>
       {children}
     </div>
   );

--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -18,16 +18,55 @@ interface BuiltInDataSourceListProps {
   className?: string;
   current: DataSourceRef | string | null | undefined;
   onChange: (ds: DataSourceInstanceSettings) => void;
-  dashboard?: boolean;
+
+  // DS filters
+  filter?: (ds: DataSourceInstanceSettings) => boolean;
+  tracing?: boolean;
   mixed?: boolean;
+  dashboard?: boolean;
+  metrics?: boolean;
+  type?: string | string[];
+  annotations?: boolean;
+  variables?: boolean;
+  alerting?: boolean;
+  pluginId?: string;
+  logs?: boolean;
 }
 
-export function BuiltInDataSourceList({ className, current, onChange, dashboard, mixed }: BuiltInDataSourceListProps) {
-  const grafanaDataSources = useDatasources({ mixed, dashboard, filter: (ds) => !!ds.meta.builtIn });
+export function BuiltInDataSourceList({
+  className,
+  current,
+  onChange,
+  tracing,
+  dashboard,
+  mixed,
+  metrics,
+  type,
+  annotations,
+  variables,
+  alerting,
+  pluginId,
+  logs,
+  filter,
+}: BuiltInDataSourceListProps) {
+  const grafanaDataSources = useDatasources({
+    tracing,
+    dashboard,
+    mixed,
+    metrics,
+    type,
+    annotations,
+    variables,
+    alerting,
+    pluginId,
+    logs,
+  });
+
+  const filteredResults = grafanaDataSources.filter((ds) => (filter ? filter?.(ds) : true) && !!ds.meta.builtIn);
 
   return (
     <div className={className} data-testid="built-in-data-sources-list">
-      {grafanaDataSources.map((ds) => {
+      {filteredResults.map((ds) => {
         return (
           <DataSourceCard
             key={ds.uid}

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
@@ -100,7 +100,7 @@ describe('DataSourceDropdown', () => {
   describe('configuration', () => {
     const user = userEvent.setup();
 
-    it('should call the dataSourceSrv.getDatasourceList with the correct filters', async () => {
+    it('should fetch the DS applying the correct filters consistently across lists', async () => {
       const filters = {
         mixed: true,
         tracing: true,
@@ -119,12 +119,27 @@ describe('DataSourceDropdown', () => {
         current: mockDS1.name,
         ...filters,
       };
-      const dropdown = render(<DataSourceDropdown {...props}></DataSourceDropdown>);
 
-      const searchBox = dropdown.container.querySelector('input');
+      render(
+        <ModalsProvider>
+          <DataSourceDropdown {...props}></DataSourceDropdown>
+          <ModalRoot />
+        </ModalsProvider>
+      );
+
+      const searchBox = await screen.findByRole('textbox');
       expect(searchBox).toBeInTheDocument();
+
+      getListMock.mockClear();
       await user.click(searchBox!);
-      expect(getListMock.mock.lastCall[0]).toEqual(filters);
+      await user.click(await screen.findByText('Open advanced data source picker'));
+      expect(await screen.findByText('Select data source')); //Data source modal is open
+      // Every call to the service must contain same filters
+      getListMock.mock.calls.forEach((call) =>
+        expect(call[0]).toMatchObject({
+          ...filters,
+        })
+      );
     });
 
     it('should dispaly the current selected DS in the selector', async () => {
@@ -180,7 +195,7 @@ describe('DataSourceDropdown', () => {
       // Doesn't try to get the default DS
       expect(getListMock).not.toBeCalled();
       expect(getInstanceSettingsMock).not.toBeCalled();
-      expect(screen.getByTestId('Select a data source')).toHaveAttribute('placeholder', 'Select a data source');
+      expect(screen.getByTestId('Select a data source')).toHaveAttribute('placeholder', 'Select data source');
     });
   });
 

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
@@ -266,7 +266,7 @@ describe('DataSourceDropdown', () => {
     it('should call onChange with the default query when add csv is clicked', async () => {
       config.featureToggles.editPanelCSVDragAndDrop = true;
       const onChange = jest.fn();
-      await setupOpenDropdown(user, { onChange });
+      await setupOpenDropdown(user, { onChange, uploadFile: true });
 
       await user.click(await screen.findByText('Add csv or spreadsheet'));
 

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -53,7 +53,7 @@ export interface DataSourceDropdownProps {
   alerting?: boolean;
   pluginId?: string;
   logs?: boolean;
-  uploadCSV?: boolean;
+  uploadFile?: boolean;
   filter?: (ds: DataSourceInstanceSettings) => boolean;
 }
 
@@ -247,7 +247,7 @@ export interface PickerContentProps extends DataSourceDropdownProps {
 }
 
 const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((props, ref) => {
-  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter, uploadCSV } = props;
+  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter, uploadFile } = props;
   const changeCallback = useCallback(
     (ds: DataSourceInstanceSettings) => {
       onChange(ds);
@@ -303,6 +303,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
                   pluginId: props.pluginId,
                   logs: props.logs,
                   filter: props.filter,
+                  uploadFile: props.uploadFile,
                   current: props.current,
                   onDismiss: hideModal,
                   onChange: (ds, defaultQueries) => {
@@ -318,7 +319,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
             </Button>
           )}
         </ModalsController>
-        {uploadCSV && config.featureToggles.editPanelCSVDragAndDrop && (
+        {uploadFile && config.featureToggles.editPanelCSVDragAndDrop && (
           <Button variant="secondary" size="sm" onClick={clickAddCSVCallback}>
             Add csv or spreadsheet
           </Button>

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -53,6 +53,7 @@ export interface DataSourceDropdownProps {
   alerting?: boolean;
   pluginId?: string;
   logs?: boolean;
+  uploadCSV?: boolean;
   filter?: (ds: DataSourceInstanceSettings) => boolean;
 }
 
@@ -246,7 +247,7 @@ export interface PickerContentProps extends DataSourceDropdownProps {
 }
 
 const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((props, ref) => {
-  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter } = props;
+  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter, uploadCSV } = props;
   const changeCallback = useCallback(
     (ds: DataSourceInstanceSettings) => {
       onChange(ds);
@@ -317,7 +318,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
             </Button>
           )}
         </ModalsController>
-        {onClickAddCSV && config.featureToggles.editPanelCSVDragAndDrop && (
+        {uploadCSV && config.featureToggles.editPanelCSVDragAndDrop && (
           <Button variant="secondary" size="sm" onClick={clickAddCSVCallback}>
             Add csv or spreadsheet
           </Button>

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
-import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { Button, CustomScrollbar, Icon, Input, ModalsController, Portal, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
@@ -32,14 +32,15 @@ const INTERACTION_ITEM = {
 };
 
 export interface DataSourceDropdownProps {
-  onChange: (ds: DataSourceInstanceSettings<DataSourceJsonData>, defaultQueries?: DataQuery[] | GrafanaQuery[]) => void;
-  current?: DataSourceInstanceSettings<DataSourceJsonData> | string | DataSourceRef | null | undefined;
+  onChange: (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => void;
+  current?: DataSourceInstanceSettings | string | DataSourceRef | null;
   recentlyUsed?: string[];
   hideTextValue?: boolean;
   width?: number;
   inputId?: string;
   noDefault?: boolean;
   disabled?: boolean;
+  placeholder?: string;
 
   // DS filters
   tracing?: boolean;
@@ -52,6 +53,7 @@ export interface DataSourceDropdownProps {
   alerting?: boolean;
   pluginId?: string;
   logs?: boolean;
+  filter?: (ds: DataSourceInstanceSettings) => boolean;
 }
 
 export function DataSourceDropdown(props: DataSourceDropdownProps) {
@@ -63,6 +65,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
     inputId,
     noDefault = false,
     disabled = false,
+    placeholder = 'Select data source',
     ...restProps
   } = props;
 
@@ -161,7 +164,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
           data-testid={selectors.components.DataSourcePicker.inputV2}
           prefix={currentValue ? prefixIcon : undefined}
           suffix={<Icon name={isOpen ? 'search' : 'angle-down'} />}
-          placeholder={hideTextValue ? '' : dataSourceLabel(currentValue)}
+          placeholder={hideTextValue ? '' : dataSourceLabel(currentValue) || placeholder}
           onClick={openDropdown}
           onFocus={() => {
             setInputHasFocus(true);
@@ -194,10 +197,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
             <PickerContent
               keyboardEvents={keyboardEvents}
               filterTerm={filterTerm}
-              onChange={(
-                ds: DataSourceInstanceSettings<DataSourceJsonData>,
-                defaultQueries?: DataQuery[] | GrafanaQuery[]
-              ) => {
+              onChange={(ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
                 onClose();
                 onChange(ds, defaultQueries);
               }}
@@ -246,9 +246,9 @@ export interface PickerContentProps extends DataSourceDropdownProps {
 }
 
 const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((props, ref) => {
-  const { filterTerm, onChange, onClose, onClickAddCSV, current } = props;
+  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter } = props;
   const changeCallback = useCallback(
-    (ds: DataSourceInstanceSettings<DataSourceJsonData>) => {
+    (ds: DataSourceInstanceSettings) => {
       onChange(ds);
       reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.SELECT_DS, ds_type: ds.type });
     },
@@ -272,7 +272,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
           className={styles.dataSourceList}
           current={current}
           onChange={changeCallback}
-          filter={(ds) => matchDataSourceWithSearch(ds, filterTerm)}
+          filter={(ds) => (filter ? filter?.(ds) : true) && matchDataSourceWithSearch(ds, filterTerm)}
           onClickEmptyStateCTA={() =>
             reportInteraction(INTERACTION_EVENT_NAME, {
               item: INTERACTION_ITEM.CONFIG_NEW_DS_EMPTY_STATE,
@@ -291,9 +291,18 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
                 onClose();
                 showModal(DataSourceModal, {
                   reportedInteractionFrom: 'ds_picker',
+                  tracing: props.tracing,
                   dashboard: props.dashboard,
                   mixed: props.mixed,
-                  current,
+                  metrics: props.metrics,
+                  type: props.type,
+                  annotations: props.annotations,
+                  variables: props.variables,
+                  alerting: props.alerting,
+                  pluginId: props.pluginId,
+                  logs: props.logs,
+                  filter: props.filter,
+                  current: props.current,
                   onDismiss: hideModal,
                   onChange: (ds, defaultQueries) => {
                     onChange(ds, defaultQueries);

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -103,7 +103,7 @@ describe('DataSourceDropdown', () => {
       config.featureToggles.editPanelCSVDragAndDrop = true;
       setup({ uploadCSV: true });
 
-      expect(await screen.findByText('Drop file here or click to upload')).toBeInTheDocument();
+      expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeInTheDocument();
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
     });
 
@@ -112,7 +112,7 @@ describe('DataSourceDropdown', () => {
       config.featureToggles.editPanelCSVDragAndDrop = false;
 
       setup({ uploadCSV: true });
-      expect(screen.queryByText('Drop file here or click to upload')).toBeNull();
+      expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeNull();
 
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
     });
@@ -132,7 +132,7 @@ describe('DataSourceDropdown', () => {
       config.featureToggles.editPanelCSVDragAndDrop = true;
       setup({ uploadCSV: true });
 
-      expect(await screen.findByText('Drop file here or click to upload')).toBeInTheDocument();
+      expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeInTheDocument();
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
     });
 
@@ -195,7 +195,7 @@ describe('DataSourceDropdown', () => {
       setup({ onChange, uploadCSV: true });
 
       const fileInput = (
-        await screen.findByText('Drop file here or click to upload')
+        await screen.queryByTestId('file-drop-zone-default-children')!
       ).parentElement!.parentElement!.querySelector('input');
       const file = new File([''], 'test.csv', { type: 'text/plain' });
       await user.upload(fileInput!, file);

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -1,4 +1,4 @@
-import { findByText, queryByTestId, queryByText, render, screen } from '@testing-library/react';
+import { queryByTestId, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -101,7 +101,7 @@ describe('DataSourceDropdown', () => {
     it('only displays the file drop area when the the ff is enabled', async () => {
       const defaultValue = config.featureToggles.editPanelCSVDragAndDrop;
       config.featureToggles.editPanelCSVDragAndDrop = true;
-      setup({ uploadCSV: true });
+      setup({ uploadFile: true });
 
       expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeInTheDocument();
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
@@ -111,7 +111,7 @@ describe('DataSourceDropdown', () => {
       const defaultValue = config.featureToggles.editPanelCSVDragAndDrop;
       config.featureToggles.editPanelCSVDragAndDrop = false;
 
-      setup({ uploadCSV: true });
+      setup({ uploadFile: true });
       expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeNull();
 
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
@@ -127,10 +127,10 @@ describe('DataSourceDropdown', () => {
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
     });
 
-    it('should display the drop zone when uploadCSV is enabled', async () => {
+    it('should display the drop zone when uploadFile is enabled', async () => {
       const defaultValue = config.featureToggles.editPanelCSVDragAndDrop;
       config.featureToggles.editPanelCSVDragAndDrop = true;
-      setup({ uploadCSV: true });
+      setup({ uploadFile: true });
 
       expect(await screen.queryByTestId('file-drop-zone-default-children')).toBeInTheDocument();
       config.featureToggles.editPanelCSVDragAndDrop = defaultValue;
@@ -192,7 +192,7 @@ describe('DataSourceDropdown', () => {
     it('calls the onChange with the default query containing the file', async () => {
       config.featureToggles.editPanelCSVDragAndDrop = true;
       const onChange = jest.fn();
-      setup({ onChange, uploadCSV: true });
+      setup({ onChange, uploadFile: true });
 
       const fileInput = (
         await screen.queryByTestId('file-drop-zone-default-children')!

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -43,6 +43,7 @@ interface DataSourceModalProps {
   reportedInteractionFrom?: string;
 
   // DS filters
+  filter?: (ds: DataSourceInstanceSettings) => boolean;
   tracing?: boolean;
   mixed?: boolean;
   dashboard?: boolean;
@@ -56,8 +57,17 @@ interface DataSourceModalProps {
 }
 
 export function DataSourceModal({
+  tracing,
   dashboard,
   mixed,
+  metrics,
+  type,
+  annotations,
+  variables,
+  alerting,
+  pluginId,
+  logs,
+  filter,
   onChange,
   current,
   onDismiss,
@@ -106,6 +116,29 @@ export function DataSourceModal({
     }
   });
 
+  // Built-in data sources used twice because of mobile layout adjustments
+  // In movile the list is appended to the bottom of the DS list
+  const BuiltInList = ({ className }: { className?: string }) => {
+    return (
+      <BuiltInDataSourceList
+        className={className}
+        onChange={onChangeDataSource}
+        current={current}
+        filter={filter}
+        variables={variables}
+        tracing={tracing}
+        metrics={metrics}
+        type={type}
+        annotations={annotations}
+        alerting={alerting}
+        pluginId={pluginId}
+        logs={logs}
+        dashboard={dashboard}
+        mixed={mixed}
+      />
+    );
+  };
+
   return (
     <Modal
       title="Select data source"
@@ -132,10 +165,6 @@ export function DataSourceModal({
         />
         <CustomScrollbar>
           <DataSourceList
-            dashboard={false}
-            mixed={false}
-            variables
-            filter={(ds) => matchDataSourceWithSearch(ds, search) && !ds.meta.builtIn}
             onChange={onChangeDataSource}
             current={current}
             onClickEmptyStateCTA={() =>
@@ -144,25 +173,25 @@ export function DataSourceModal({
                 src: analyticsInteractionSrc,
               })
             }
-          />
-          <BuiltInDataSourceList
+            filter={(ds) => (filter ? filter?.(ds) : true) && matchDataSourceWithSearch(ds, search) && !ds.meta.builtIn}
+            variables={variables}
+            tracing={tracing}
+            metrics={metrics}
+            type={type}
+            annotations={annotations}
+            alerting={alerting}
+            pluginId={pluginId}
+            logs={logs}
             dashboard={dashboard}
             mixed={mixed}
-            className={styles.appendBuiltInDataSourcesList}
-            onChange={onChangeDataSource}
-            current={current}
           />
+          <BuiltInList className={styles.appendBuiltInDataSourcesList} />
         </CustomScrollbar>
       </div>
       <div className={styles.rightColumn}>
         <div className={styles.builtInDataSources}>
           <CustomScrollbar className={styles.builtInDataSourcesList}>
-            <BuiltInDataSourceList
-              onChange={onChangeDataSource}
-              current={current}
-              dashboard={dashboard}
-              mixed={mixed}
-            />
+            <BuiltInList />
           </CustomScrollbar>
           {config.featureToggles.editPanelCSVDragAndDrop && (
             <FileDropzone

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -54,7 +54,7 @@ export interface DataSourceModalProps {
   alerting?: boolean;
   pluginId?: string;
   logs?: boolean;
-  uploadCSV?: boolean;
+  uploadFile?: boolean;
 }
 
 export function DataSourceModal({
@@ -68,7 +68,7 @@ export function DataSourceModal({
   alerting,
   pluginId,
   logs,
-  uploadCSV,
+  uploadFile,
   filter,
   onChange,
   current,
@@ -195,7 +195,7 @@ export function DataSourceModal({
           <CustomScrollbar className={styles.builtInDataSourcesList}>
             <BuiltInList />
           </CustomScrollbar>
-          {uploadCSV && config.featureToggles.editPanelCSVDragAndDrop && (
+          {uploadFile && config.featureToggles.editPanelCSVDragAndDrop && (
             <FileDropzone
               readAs="readAsArrayBuffer"
               fileListRenderer={() => undefined}

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -35,7 +35,7 @@ const INTERACTION_ITEM = {
   DISMISS: 'dismiss',
 };
 
-interface DataSourceModalProps {
+export interface DataSourceModalProps {
   onChange: (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => void;
   current: DataSourceRef | string | null | undefined;
   onDismiss: () => void;
@@ -54,6 +54,7 @@ interface DataSourceModalProps {
   alerting?: boolean;
   pluginId?: string;
   logs?: boolean;
+  uploadCSV?: boolean;
 }
 
 export function DataSourceModal({
@@ -67,6 +68,7 @@ export function DataSourceModal({
   alerting,
   pluginId,
   logs,
+  uploadCSV,
   filter,
   onChange,
   current,
@@ -193,7 +195,7 @@ export function DataSourceModal({
           <CustomScrollbar className={styles.builtInDataSourcesList}>
             <BuiltInList />
           </CustomScrollbar>
-          {config.featureToggles.editPanelCSVDragAndDrop && (
+          {uploadCSV && config.featureToggles.editPanelCSVDragAndDrop && (
             <FileDropzone
               readAs="readAsArrayBuffer"
               fileListRenderer={() => undefined}

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -20,7 +20,7 @@ export function dataSourceLabel(
   dataSource: DataSourceInstanceSettings<DataSourceJsonData> | string | DataSourceRef | null | undefined
 ) {
   if (!dataSource) {
-    return 'Select a data source';
+    return undefined;
   }
 
   if (typeof dataSource === 'string') {
@@ -35,7 +35,7 @@ export function dataSourceLabel(
     return `${dataSource.uid} - not found`;
   }
 
-  return 'Select a data source';
+  return undefined;
 }
 
 export function getDataSourceCompareFn(

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -277,7 +277,7 @@ export class QueryGroup extends PureComponent<Props, State> {
       dashboard: true,
       variables: true,
       current: this.props.options.dataSource,
-      uploadCSV: true,
+      uploadFile: true,
       onChange: async (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
         await this.onChangeDataSource(ds, defaultQueries);
         this.onCloseDataSourceModal();

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -272,6 +272,10 @@ export class QueryGroup extends PureComponent<Props, State> {
     const { isDataSourceModalOpen } = this.state;
 
     const commonProps = {
+      metrics: true,
+      mixed: true,
+      dashboard: true,
+      variables: true,
       current: this.props.options.dataSource,
       onChange: async (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
         await this.onChangeDataSource(ds, defaultQueries);
@@ -284,7 +288,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         {isDataSourceModalOpen && config.featureToggles.advancedDataSourcePicker && (
           <DataSourceModal {...commonProps} onDismiss={this.onCloseDataSourceModal}></DataSourceModal>
         )}
-        <DataSourcePicker {...commonProps} metrics={true} mixed={true} dashboard={true} variables={true} />
+        <DataSourcePicker {...commonProps} />
       </>
     );
   };

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -277,6 +277,7 @@ export class QueryGroup extends PureComponent<Props, State> {
       dashboard: true,
       variables: true,
       current: this.props.options.dataSource,
+      uploadCSV: true,
       onChange: async (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
         await this.onChangeDataSource(ds, defaultQueries);
         this.onCloseDataSourceModal();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The picker has 3 different lists: the dropdown list, the modal searchable list, and the built-in ds list. Each of the list calls the `dsService.getList(filters)` to get the list of DS. To ensure consistency between them we are forwarding and testing all the list receives the same query filters.

**Why do we need this feature?**

We were causing an inconsistent issue where the `type` filter was not passed to the searchable list but it was available in the dropdown one, so the number of ds was different.

**Who is this feature for?**

To make sure this https://github.com/grafana/grafana-enterprise/pull/5334 works properly
|Before the fix|After the fix|
|-|-|
![2023-06-23 17 39 44](https://github.com/grafana/grafana/assets/5699976/b064039b-e614-4560-8422-30dee773f57c)|![2023-06-23 17 39 14](https://github.com/grafana/grafana/assets/5699976/fab09db9-1bc9-4485-b930-3f89e3575e26)

**Special notes for your reviewer:**
If you want to test this PR manually, you can run grafana-enterprise with the PR previously mentioned.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
