### PR TITLE
Variables: Remount query editor when datasource changed

### DIFF
--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -152,6 +152,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
       return (
         <Field label="Query">
           <VariableQueryEditor
+            key={datasource.uid}
             datasource={datasource}
             query={query}
             templateSrv={getTemplateSrv()}
@@ -167,6 +168,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
       return (
         <Field label="Query">
           <VariableQueryEditor
+            key={datasource.uid}
             datasource={datasource}
             query={query}
             onChange={this.onQueryChange}


### PR DESCRIPTION
There was an issue where dropdown values weren't refreshed when switching between datasources of the same type (e.g. both prometheus).
Setting the key on the query editor component as the datasource UID should fix this.