### PR TITLE
AzureMonitor: Remove subscriptions map

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -559,7 +559,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			azData := loadTestFile(t, tt.responseFile)
-			dframes, err := datasource.parseResponse(azData, tt.mockQuery, "http://ds")
+			dframes, err := datasource.parseResponse(azData, tt.mockQuery, "http://ds", "")
 			require.NoError(t, err)
 			require.NotNil(t, dframes)
 


### PR DESCRIPTION
Removing subscriptions map because it is causing a concurrency issue when it's trying to be written to at the same time.

I think it is best to keep plugin queries stateless to avoid concurrency issues and other issues with states. :smile_cat: 

Also a few cleanup things like `formatAzureMonitorLegendKey` parameters.