### PR TITLE
Flamegraph: Prevent cropping of tooltip by bottom of the viewport

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
@@ -165,7 +165,9 @@ const FlameGraph = ({
           );
 
           if (barIndex !== -1 && !isNaN(levelIndex) && !isNaN(barIndex)) {
-            if (e.clientY < document.documentElement.clientHeight / 2) {
+            // tooltip has a set number of lines of text so 200 should be good enough (with some buffer) without going
+            // into measuring rendered sizes
+            if (e.clientY < document.documentElement.clientHeight - 200) {
               tooltipRef.current.style.top = e.clientY + 'px';
               tooltipRef.current.style.bottom = 'auto';
             } else {
@@ -173,7 +175,8 @@ const FlameGraph = ({
               tooltipRef.current.style.top = 'auto';
             }
 
-            if (e.clientX < document.documentElement.clientWidth / 2) {
+            // 400 is max width of the tooltip
+            if (e.clientX < document.documentElement.clientWidth - 400) {
               tooltipRef.current.style.left = e.clientX + 15 + 'px';
               tooltipRef.current.style.right = 'auto';
             } else {

--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
@@ -165,13 +165,20 @@ const FlameGraph = ({
           );
 
           if (barIndex !== -1 && !isNaN(levelIndex) && !isNaN(barIndex)) {
-            tooltipRef.current.style.top = e.clientY + 'px';
-            if (document.documentElement.clientWidth - e.clientX < 400) {
-              tooltipRef.current.style.right = document.documentElement.clientWidth - e.clientX + 15 + 'px';
-              tooltipRef.current.style.left = 'auto';
+            if (e.clientY < document.documentElement.clientHeight / 2) {
+              tooltipRef.current.style.top = e.clientY + 'px';
+              tooltipRef.current.style.bottom = 'auto';
             } else {
+              tooltipRef.current.style.bottom = document.documentElement.clientHeight - e.clientY + 'px';
+              tooltipRef.current.style.top = 'auto';
+            }
+
+            if (e.clientX < document.documentElement.clientWidth / 2) {
               tooltipRef.current.style.left = e.clientX + 15 + 'px';
               tooltipRef.current.style.right = 'auto';
+            } else {
+              tooltipRef.current.style.right = document.documentElement.clientWidth - e.clientX + 15 + 'px';
+              tooltipRef.current.style.left = 'auto';
             }
 
             setTooltipItem(levels[levelIndex][barIndex]);

--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraphTooltip.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraphTooltip.tsx
@@ -90,6 +90,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   tooltip: css`
     title: tooltip;
     position: fixed;
+    z-index: ${theme.zIndex.tooltip};
   `,
   tooltipContent: css`
     title: tooltipContent;
@@ -101,7 +102,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     font-size: ${theme.typography.bodySmall.fontSize};
     padding: ${theme.spacing(0.5, 1)};
     transition: opacity 0.3s;
-    z-index: ${theme.zIndex.tooltip};
     max-width: 400px;
     overflow-wrap: break-word;
   `,

--- a/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraph.tsx
@@ -143,7 +143,9 @@ const FlameGraph = ({
         );
 
         if (barIndex !== -1 && !isNaN(levelIndex) && !isNaN(barIndex)) {
-          if (e.clientY < document.documentElement.clientHeight / 2) {
+          // tooltip has a set number of lines of text so 200 should be good enough (with some buffer) without going
+          // into measuring rendered sizes
+          if (e.clientY < document.documentElement.clientHeight - 200) {
             tooltipRef.current.style.top = e.clientY + 'px';
             tooltipRef.current.style.bottom = 'auto';
           } else {
@@ -151,7 +153,8 @@ const FlameGraph = ({
             tooltipRef.current.style.top = 'auto';
           }
 
-          if (e.clientX < document.documentElement.clientWidth / 2) {
+          // 400 is max width of the tooltip
+          if (e.clientX < document.documentElement.clientWidth - 400) {
             tooltipRef.current.style.left = e.clientX + 15 + 'px';
             tooltipRef.current.style.right = 'auto';
           } else {

--- a/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraph.tsx
@@ -143,13 +143,20 @@ const FlameGraph = ({
         );
 
         if (barIndex !== -1 && !isNaN(levelIndex) && !isNaN(barIndex)) {
-          tooltipRef.current.style.top = e.clientY + 'px';
-          if (document.documentElement.clientWidth - e.clientX < 400) {
-            tooltipRef.current.style.right = document.documentElement.clientWidth - e.clientX + 15 + 'px';
-            tooltipRef.current.style.left = 'auto';
+          if (e.clientY < document.documentElement.clientHeight / 2) {
+            tooltipRef.current.style.top = e.clientY + 'px';
+            tooltipRef.current.style.bottom = 'auto';
           } else {
+            tooltipRef.current.style.bottom = document.documentElement.clientHeight - e.clientY + 'px';
+            tooltipRef.current.style.top = 'auto';
+          }
+
+          if (e.clientX < document.documentElement.clientWidth / 2) {
             tooltipRef.current.style.left = e.clientX + 15 + 'px';
             tooltipRef.current.style.right = 'auto';
+          } else {
+            tooltipRef.current.style.right = document.documentElement.clientWidth - e.clientX + 15 + 'px';
+            tooltipRef.current.style.left = 'auto';
           }
 
           setTooltipItem(levels[levelIndex][barIndex]);

--- a/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraphTooltip.tsx
+++ b/public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraph/FlameGraphTooltip.tsx
@@ -90,6 +90,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   tooltip: css`
     title: tooltip;
     position: fixed;
+    z-index: ${theme.zIndex.tooltip};
   `,
   tooltipContent: css`
     title: tooltipContent;
@@ -101,7 +102,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     font-size: ${theme.typography.bodySmall.fontSize};
     padding: ${theme.spacing(0.5, 1)};
     transition: opacity 0.3s;
-    z-index: ${theme.zIndex.tooltip};
     max-width: 400px;
     overflow-wrap: break-word;
   `,


### PR DESCRIPTION
Flips the position of the tooltip also vertically so it does not get clipped by bottom of the viewport.

<img width="831" alt="Screenshot 2023-06-23 at 19 53 20" src="https://github.com/grafana/grafana/assets/1014802/cc14bf53-9c58-4b29-a10a-19abff2194d4">

Note:
Fixing this both in V2 version and old version just in case.

