### PR TITLE
Prometheus: Add label filters to label_values query type variable query 

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -166,7 +166,6 @@ describe('PromVariableQueryEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       query: 'label_names(that)',
-      labelFilters: [],
       refId,
     });
   });
@@ -185,7 +184,6 @@ describe('PromVariableQueryEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       query: 'label_names()',
-      labelFilters: [],
       refId,
     });
   });
@@ -224,7 +222,6 @@ describe('PromVariableQueryEditor', () => {
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({
         query: 'metrics(a)',
-        labelFilters: [],
         refId,
       })
     );
@@ -248,7 +245,6 @@ describe('PromVariableQueryEditor', () => {
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({
         query: 'label_values(this)',
-        labelFilters: [],
         refId,
       })
     );
@@ -276,7 +272,6 @@ describe('PromVariableQueryEditor', () => {
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({
         query: 'label_values(that,this)',
-        labelFilters: [],
         refId,
       })
     );
@@ -299,7 +294,6 @@ describe('PromVariableQueryEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       query: 'query_result(a)',
-      labelFilters: [],
       refId,
     });
   });
@@ -321,7 +315,6 @@ describe('PromVariableQueryEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       query: '{a: "example"}',
-      labelFilters: [],
       refId,
     });
   });

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -67,7 +67,7 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
     setQryType(variableQuery.qryType);
     setLabel(variableQuery.label ?? '');
     setMetric(variableQuery.metric ?? '');
-    setLabelFilters(query.labelFilters ?? []);
+    setLabelFilters(variableQuery.labelFilters ?? []);
     setVarQuery(variableQuery.varQuery ?? '');
     setSeriesQuery(variableQuery.seriesQuery ?? '');
   }, [query]);
@@ -119,16 +119,15 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
       refId: 'PrometheusVariableQueryEditor-VariableQuery',
     };
 
-    const updatedVar = { ...queryVar, ...updateVar };
+    let updateLabelFilters = updLabelFilters ? { labelFilters: updLabelFilters } : { labelFilters: labelFilters };
+
+    const updatedVar = { ...queryVar, ...updateVar, ...updateLabelFilters };
 
     const queryString = migrateVariableEditorBackToVariableSupport(updatedVar);
-
-    let lblFltrs = updLabelFilters ? updLabelFilters : labelFilters;
 
     // setting query.query property allows for update of variable definition
     onChange({
       query: queryString,
-      labelFilters: lblFltrs,
       refId,
     });
   };


### PR DESCRIPTION
**What is this feature?**
Bug fix: We recently introduced the metric select and label filters from the Prom query builder into the Prom variable query editor for the query type `label_values`. The label filters were not included in the variable query call though. This change fixes that by parsing the variable query object into a string that includes the label filters and is used in the variable query api call.

![Screenshot 2023-06-23 at 3 57 42 PM](https://github.com/grafana/grafana/assets/25674746/71276909-a607-4073-850d-cda4a89b1fdf)

**Why do we need this feature?**
Users want to filter their label values by a label and a metric that is also filtered by labels, possibly a regex filter. This allows them to do that.

**Who is this feature for?**
For users of the Prometheus data source variable editor.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/70638



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
