### PR TITLE
Alerting: don't copy original rule uid when cloning

### DIFF
--- a/public/app/features/alerting/unified/CloneRuleEditor.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.tsx
@@ -6,7 +6,7 @@ import { locationService } from '@grafana/runtime/src';
 import { Alert, LoadingPlaceholder } from '@grafana/ui/src';
 
 import { useDispatch } from '../../../types';
-import { RuleIdentifier } from '../../../types/unified-alerting';
+import { RuleIdentifier, RuleWithLocation } from '../../../types/unified-alerting';
 import { RulerRuleDTO } from '../../../types/unified-alerting-dto';
 
 import { AlertRuleForm } from './components/rule-editor/AlertRuleForm';
@@ -30,20 +30,8 @@ export function CloneRuleEditor({ sourceRuleId }: { sourceRuleId: RuleIdentifier
   }
 
   if (rule) {
-    const ruleClone = cloneDeep(rule);
-    changeRuleName(
-      ruleClone.rule,
-      generateCopiedName(getRuleName(ruleClone.rule), ruleClone.group.rules.map(getRuleName))
-    );
+    const ruleClone = cloneRuleDefinition(rule);
     const formPrefill = rulerRuleToFormValues(ruleClone);
-
-    // Provisioned alert rules have provisioned alert group which cannot be used in UI
-    if (isGrafanaRulerRule(rule.rule) && Boolean(rule.rule.grafana_alert.provenance)) {
-      formPrefill.group = '';
-    }
-
-    // Since this is a new rule, we don't want to carry over the uid of the original rule
-    formPrefill.uid = '';
 
     return <AlertRuleForm prefill={formPrefill} />;
   }
@@ -76,4 +64,23 @@ function changeRuleName(rule: RulerRuleDTO, newName: string) {
   if (isRecordingRulerRule(rule)) {
     rule.record = newName;
   }
+}
+
+export function cloneRuleDefinition(rule: RuleWithLocation<RulerRuleDTO>) {
+  const ruleClone = cloneDeep(rule);
+  changeRuleName(
+    ruleClone.rule,
+    generateCopiedName(getRuleName(ruleClone.rule), ruleClone.group.rules.map(getRuleName))
+  );
+
+  if (isGrafanaRulerRule(ruleClone.rule)) {
+    ruleClone.rule.grafana_alert.uid = '';
+
+    // Provisioned alert rules have provisioned alert group which cannot be used in UI
+    if (Boolean(ruleClone.rule.grafana_alert.provenance)) {
+      ruleClone.group = { name: '', rules: ruleClone.group.rules };
+    }
+  }
+
+  return ruleClone;
 }

--- a/public/app/features/alerting/unified/CloneRuleEditor.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.tsx
@@ -42,6 +42,9 @@ export function CloneRuleEditor({ sourceRuleId }: { sourceRuleId: RuleIdentifier
       formPrefill.group = '';
     }
 
+    // Since this is a new rule, we don't want to carry over the uid of the original rule
+    formPrefill.uid = '';
+
     return <AlertRuleForm prefill={formPrefill} />;
   }
 

--- a/public/app/features/alerting/unified/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/ExistingRuleEditor.tsx
@@ -62,5 +62,5 @@ export function ExistingRuleEditor({ identifier, id }: ExistingRuleEditorProps) 
     return <AlertWarning title="Cannot edit rule">Sorry! You do not have permission to edit this rule.</AlertWarning>;
   }
 
-  return <AlertRuleForm existing={result} id={id} />;
+  return <AlertRuleForm existing={result} />;
 }

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -163,7 +163,6 @@ describe('RuleEditor grafana managed rules', () => {
               is_paused: false,
               no_data_state: 'NoData',
               title: 'my great new rule',
-              uid: '',
             },
           },
         ],

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -72,10 +72,9 @@ const AlertRuleNameInput = () => {
 type Props = {
   existing?: RuleWithLocation;
   prefill?: Partial<RuleFormValues>; // Existing implies we modify existing rule. Prefill only provides default form values
-  id?: string;
 };
 
-export const AlertRuleForm = ({ existing, prefill, id }: Props) => {
+export const AlertRuleForm = ({ existing, prefill }: Props) => {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
   const notifyApp = useAppNotification();
@@ -83,8 +82,9 @@ export const AlertRuleForm = ({ existing, prefill, id }: Props) => {
   const [showEditYaml, setShowEditYaml] = useState(false);
   const [evaluateEvery, setEvaluateEvery] = useState(existing?.group.interval ?? MINUTE);
 
-  const routeParams = useParams<{ type: string }>();
+  const routeParams = useParams<{ type: string; id: string }>();
   const ruleType = translateRouteParamToRuleType(routeParams.type);
+  const uid_fromparams = routeParams.id;
 
   const returnTo: string = (queryParams['returnTo'] as string | undefined) ?? '/alerting/list';
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -252,7 +252,7 @@ export const AlertRuleForm = ({ existing, prefill, id }: Props) => {
                     <CloudEvaluationBehavior />
                   )}
                   <DetailsStep />
-                  <NotificationsStep alertUid={id} />
+                  <NotificationsStep alertUid={uid_fromparams} />
                 </>
               )}
             </div>

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -84,7 +84,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
 
   const routeParams = useParams<{ type: string; id: string }>();
   const ruleType = translateRouteParamToRuleType(routeParams.type);
-  const uid_fromparams = routeParams.id;
+  const uidFromParams = routeParams.id;
 
   const returnTo: string = (queryParams['returnTo'] as string | undefined) ?? '/alerting/list';
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -252,7 +252,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
                     <CloudEvaluationBehavior />
                   )}
                   <DetailsStep />
-                  <NotificationsStep alertUid={uid_fromparams} />
+                  <NotificationsStep alertUid={uidFromParams} />
                 </>
               )}
             </div>

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -11,7 +11,6 @@ export enum RuleFormType {
 export interface RuleFormValues {
   // common
   name: string;
-  uid: string;
   type?: RuleFormType;
   dataSourceName: string | null;
   group: string;

--- a/public/app/features/alerting/unified/utils/__snapshots__/rule-form.test.ts.snap
+++ b/public/app/features/alerting/unified/utils/__snapshots__/rule-form.test.ts.snap
@@ -15,7 +15,6 @@ exports[`formValuesToRulerGrafanaRuleDTO should correctly convert rule form valu
     "is_paused": false,
     "no_data_state": "NoData",
     "title": "",
-    "uid": "",
   },
   "labels": {
     "": "",
@@ -54,7 +53,6 @@ exports[`formValuesToRulerGrafanaRuleDTO should not save both instant and range 
     "is_paused": false,
     "no_data_state": "NoData",
     "title": "",
-    "uid": "",
   },
   "labels": {
     "": "",

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -131,7 +131,6 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
     return {
       grafana_alert: {
         title: name,
-        uid: values.uid,
         condition,
         no_data_state: noDataState,
         exec_err_state: execErrState,
@@ -157,7 +156,6 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
       return {
         ...defaultFormValues,
         name: ga.title,
-        uid: ga.uid,
         type: RuleFormType.grafana,
         group: group.name,
         evaluateEvery: group.interval || defaultFormValues.evaluateEvery,


### PR DESCRIPTION
**What is this feature?**

Currently we're unable to clone rules because the cloned one is being assigned the original rule's uid, giving an error when saving the form.

**Why do we need this feature?**

To be able to clone rules.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Reported on Slack.

**Special notes for your reviewer:**

Before

![2023-06-23 18 03 29](https://github.com/grafana/grafana/assets/6271380/23a15be3-ecb5-4e47-b21d-7cdb5d8288a4)


After

![2023-06-23 18 04 53](https://github.com/grafana/grafana/assets/6271380/ffe17a60-2154-435c-977b-c4e9d1e1930a)

