### PR TITLE
Add 'Azure Data Explorer' as a confirmed working datasource for public dashboards

### DIFF
--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -166,6 +166,7 @@ guaranteed because plugin developers can override this functionality. The follow
     <td>
       <ul>
         <li>Altinity plugin for ClickHouse</li>
+        <li>Azure Data Explorer Datasource</li>
         <li>ClickHouse</li>
         <li>Elasticsearch</li>
         <li>Graphite</li>
@@ -207,7 +208,6 @@ If you've confirmed one of these data sources work with public dashboards, let u
         <li>Amazon Timestream</li>
         <li>Apache Cassandra</li>
         <li>AppDynamics</li>
-        <li>Azure Data Explorer Datasource</li>
         <li>Azure Monitor</li>
         <li>CSV</li>
         <li>CloudWatch</li>


### PR DESCRIPTION
What is this feature?
Update the list of confirmed working data sources for public dashboards.

Why do we need this feature?
Keep documentation up to date. 

Who is this feature for?

[Add information on what kind of user the feature is for.]

Which issue(s) does this PR fix?:

Fixes # N/A

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
