### PR TITLE
Export: Templateize datasource uid when it's a library panel

### DIFF
--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
@@ -1,6 +1,7 @@
 import { find } from 'lodash';
 
 import { DataSourceInstanceSettings, DataSourceRef, PanelPluginMeta } from '@grafana/data';
+import { Dashboard, ThresholdsMode } from '@grafana/schema';
 import config from 'app/core/config';
 
 import { LibraryElementKind } from '../../../library-panels/types';
@@ -91,6 +92,80 @@ it('handles a default datasource in a template variable', async () => {
   const exporter = new DashboardExporter();
   const exported: any = await exporter.makeExportable(dashboardModel);
   expect(exported.templating.list[0].datasource.uid).toBe('${DS_GFDB}');
+});
+
+it('replaces datasource ref in library panel', async () => {
+  const dashboard: Dashboard = {
+    style: 'dark',
+    editable: true,
+    graphTooltip: 1,
+    schemaVersion: 38,
+    panels: [
+      {
+        id: 1,
+        title: 'Panel title',
+        type: 'timeseries',
+        options: {
+          cellHeight: 'sm',
+          footer: {
+            countRows: false,
+            fields: '',
+            reducer: ['sum'],
+            show: false,
+          },
+          showHeader: true,
+        },
+        transformations: [],
+        transparent: false,
+        fieldConfig: {
+          defaults: {
+            custom: {
+              align: 'auto',
+              cellOptions: {
+                type: 'auto',
+              },
+              inspect: false,
+            },
+            mappings: [],
+            thresholds: {
+              mode: ThresholdsMode.Absolute,
+              steps: [
+                {
+                  color: 'green',
+                  value: 10,
+                },
+                {
+                  color: 'red',
+                  value: 80,
+                },
+              ],
+            },
+          },
+          overrides: [],
+        },
+        gridPos: {
+          h: 8,
+          w: 12,
+          x: 0,
+          y: 0,
+        },
+        libraryPanel: {
+          name: 'Testing lib panel',
+          uid: 'c46a6b49-de40-43b3-982c-1b5e1ec084a4',
+        },
+      },
+    ],
+  };
+
+  const dashboardModel = new DashboardModel(dashboard, {});
+
+  const exporter = new DashboardExporter();
+  const exported = await exporter.makeExportable(dashboardModel);
+  if ('error' in exported) {
+    throw new Error('error should not be returned when making exportable json');
+  }
+  expect(exported.__elements['c46a6b49-de40-43b3-982c-1b5e1ec084a4'].model.datasource.uid).toBe('${DS_GFDB}');
+  expect(exported.__inputs[0].name).toBe('DS_GFDB');
 });
 
 it('If a panel queries has no datasource prop ignore it', async () => {
@@ -376,8 +451,7 @@ describe('given dashboard with repeated panels', () => {
     expect(element.name).toBe('Library Panel 2');
     expect(element.kind).toBe(LibraryElementKind.Panel);
     expect(element.model).toEqual({
-      datasource: { type: 'other2', uid: '$ds' },
-      targets: [{ refId: 'A', datasource: { type: 'other2', uid: '$ds' } }],
+      datasource: { type: 'testdb', uid: '${DS_GFDB}' },
       type: 'graph',
     });
   });

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -177,6 +177,8 @@ export class DashboardExporter {
           model = libPanel.model;
         }
 
+        await templateizeDatasourceUsage(model);
+
         const { gridPos, id, ...rest } = model as any;
         if (!libraryPanels.has(uid)) {
           libraryPanels.set(uid, { name, uid, kind: LibraryElementKind.Panel, model: rest });
@@ -221,13 +223,9 @@ export class DashboardExporter {
         version: config.buildInfo.version,
       };
 
-      each(datasources, (value: any) => {
-        inputs.push(value);
-      });
-
       // we need to process all panels again after all the promises are resolved
       // so all data sources, variables and targets have been templateized when we process library panels
-      for (const panel of dashboard.panels) {
+      for (const panel of saveModel.panels) {
         await processLibraryPanels(panel);
         if (panel.collapsed !== undefined && panel.collapsed === true && panel.panels) {
           for (const rowPanel of panel.panels) {
@@ -235,6 +233,10 @@ export class DashboardExporter {
           }
         }
       }
+
+      each(datasources, (value: any) => {
+        inputs.push(value);
+      });
 
       // templatize constants
       for (const variable of saveModel.getVariables()) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There's a bug where, if you export a dashboard that contains library panels, the exported JSON will have the concrete datasource id in the library panel, instead of having the normal ${DS_NAME} placeholder, which will be replaced once the user imports the dashboard and selects a specific and concrete datasource.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#67899](https://github.com/grafana/grafana/issues/67899)

**Special notes for your reviewer:**

There's another [draft PR](https://github.com/grafana/grafana/pull/69412) where I also make some modifications when importing the json, since the datasource input is shown although that datasource is related to an already existing library panel. In that case, we should remove that datasource as an input.
Because of the complex of the PR, I decided to first make this quick fix and then keep working on that new behavior.

Should we backport it? The bug was introduced after v9.2.19.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
