### PR TITLE
ValueFormats: Add support for Turkish Lira (₺)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -440,6 +440,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Turkish Lira (₺)",
+              "value": "currencyTRY"
             }
           ],
           "text": "currency"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -440,6 +440,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Turkish Lira (₺)",
+              "value": "currencyTRY"
             }
           ],
           "text": "currency"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -138,6 +138,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Indonesian Rupiah (Rp)', id: 'currencyIDR', fn: currency('Rp') },
       { name: 'Philippine Peso (PHP)', id: 'currencyPHP', fn: currency('PHP') },
       { name: 'Vietnamese Dong (VND)', id: 'currencyVND', fn: currency('đ', true) },
+      { name: 'Turkish Lira (₺)', id: 'currencyTRY', fn: currency('₺', true) },
     ],
   },
   {


### PR DESCRIPTION
Hello,

Why is this component needed:
The addition of the Turkish Lira (₺) as a currency formatting option is needed to facilitate users in Turkey or those dealing with the Turkish Lira in their data visualizations. Currently, Grafana supports various currencies, but Turkish Lira is not one of them. This update would extend Grafana's versatility and usability for a broader range of financial data visualization scenarios.

[x] Is/could it be used in more than one place in Grafana?

Where is/could it be used?:
The Turkish Lira (₺) formatting option could be used anywhere in Grafana where currency formatting options are provided. This includes, but is not limited to, panels displaying financial data, in the Graph, Table, Singlestat, and other panel types where monetary values might be represented.

[x] It has a single use case.
[x] It is/could be used in multiple places.

Thank you! 🙌🏻