### PR TITLE
Explore: Ensure old panes are removed before opening split view

### DIFF
--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -94,7 +94,7 @@ export function changeSize(exploreId: string, { width }: { width: number }): Pay
   return changeSizeAction({ exploreId, width });
 }
 
-interface InitializeExploreOptions {
+export interface InitializeExploreOptions {
   exploreId: string;
   datasource: DataSourceRef | string | undefined;
   queries: DataQuery[];


### PR DESCRIPTION
This ensures we clean up the right pane before opening a new one. When using "Split open" button it it's not a problem because once in a split mode, it cannot be triggered again. However, when clicking on data links, spilt open can be invoked multiple times.

Fixes #70665

**Special notes for your reviewer:**

<details><summary>How to test it?</summary>

You need to create a data link. The easiest way is to create a correlation using test data source (target and source pointing to a test data source), example:

Use ${State} variable in a CVS content scenario just to see if the split view is updated:

<img width="560" alt="Screenshot 2023-06-26 at 12 09 13" src="https://github.com/grafana/grafana/assets/745532/0c267c29-8d75-42f8-8070-bb0d7689b31c">

Use "State" as results field in source setup:

<img width="360" alt="Screenshot 2023-06-26 at 12 08 22" src="https://github.com/grafana/grafana/assets/745532/db4b59f0-07d7-43e4-be36-e3904bb533e3">

And run "flight info" scenario to get links in State column:

<img width="450" alt="Screenshot 2023-06-26 at 12 08 37" src="https://github.com/grafana/grafana/assets/745532/bbc653c5-18fe-487a-a7ff-4facfe417c79">

Click o links. You should see the right pane being updated correctly when clicking on the link on the left side pane. If you click on a link in the right side pane, the pane should be replaced. 

</details>