### PR TITLE
Checkbox: Fix alignment in Safari

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -74,13 +74,15 @@ export const getCheckboxStyles = (theme: GrafanaTheme2, invalid = false) => {
   };
 
   return {
-    wrapper: css`
-      display: inline-grid;
-      align-items: center;
-      column-gap: ${theme.spacing(labelPadding)};
-      position: relative;
-      vertical-align: middle;
-    `,
+    wrapper: css({
+      display: 'inline-grid',
+      alignItems: 'center',
+      columnGap: theme.spacing(labelPadding),
+      // gridAutoRows is needed to prevent https://github.com/grafana/grafana/issues/68570 in safari
+      gridAutoRows: 'max-content',
+      position: 'relative',
+      verticalAlign: 'middle',
+    }),
     input: css`
       position: absolute;
       z-index: 1;

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
@@ -60,7 +60,7 @@ export const SaveDashboardForm = ({
       {({ register, errors }) => {
         const messageProps = register('message');
         return (
-          <Stack gap={2}>
+          <Stack gap={2} direction="column" alignItems="flex-start">
             {hasTimeChanged && (
               <Checkbox
                 checked={!!options.saveTimerange}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- first, explicitly setting an alignment of `flex-start` on the parent `Stack` component (which is needed anyway) fixes the problem **in this specific case**
- more generally, adds `gridAutoRows: max-content` to the checkbox styling to prevent incorrect positioning in any other case
- still not 100% on why this is needed, but let's look at a screenshot: 
![image](https://github.com/grafana/grafana/assets/20999846/0bc7653e-90f9-4520-a9f9-a80afead9253)
  - although the label element is the correct size, the grid row is taking the full height of the drawer
  - i _think_ there's a bug/difference in the spec of `grid-auto-rows` between safari and chrome/firefox here
  - explicitly setting `grid-auto-rows` to `max-content` seems to fix the problem


**Why do we need this feature?**

- so checkboxes always position correctly in flex containers in safari

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/68570
Alternative to https://github.com/grafana/grafana/pull/69247

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
