### PR TITLE
Docs: Provide absolute paths for set-up-https.md

### DIFF
--- a/docs/sources/setup-grafana/set-up-https.md
+++ b/docs/sources/setup-grafana/set-up-https.md
@@ -80,7 +80,7 @@ This section shows you how to use `openssl` tooling to generate all necessary fi
 1. Run the following command to self-sign the certificate with the private key, for a period of validity of 365 days:
 
    ```bash
-   sudo openssl x509 -req -days 365 -in grafana.csr -signkey /etc/grafana/grafana.key -out /etc/grafana/grafana.crt
+   sudo openssl x509 -req -days 365 -in /etc/grafana/grafana.csr -signkey /etc/grafana/grafana.key -out /etc/grafana/grafana.crt
    ```
 
 1. Run the following commands to set the appropriate permissions for the files:
@@ -88,7 +88,7 @@ This section shows you how to use `openssl` tooling to generate all necessary fi
    ```bash
    sudo chown grafana:grafana /etc/grafana/grafana.crt
    sudo chown grafana:grafana /etc/grafana/grafana.key
-   sudo chmod 400 grafana.key /etc/grafana/grafana.crt
+   sudo chmod 400 /etc/grafana/grafana.key /etc/grafana/grafana.crt
    ```
 
    **Note**: When using these files, browsers might provide warnings for the resulting website because a third-party source does not trust the certificate. Browsers will show trust warnings; however, the connection will remain encrypted.


### PR DESCRIPTION
**What is this feature?**

Adds absolute paths to the relative paths in the `set-up-https.md` file.

**Why do we need this feature?**

Consistency.

**Who is this feature for?**

Reader of docs.

**Which issue(s) does this PR fix?**:

Fixes #69664

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
