### PR TITLE
docs: fix broken links in Configure legend

### DIFF
--- a/docs/sources/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/panels-visualizations/configure-legend/index.md
@@ -30,7 +30,7 @@ When you apply your changes, the visualization changes appear to all users of th
 
 This topic currently applies to the following visualizations:
 
-- [Bar chart]({{< relref "../bar-chart/" >}})
+- [Bar chart]({{< relref "../visualizations/bar-chart/" >}})
 - [Histogram]({{< relref "../histogram/" >}})
 - [Pie chart]({{< relref "../pie-chart/" >}})
 - [State timeline]({{< relref "../state-timeline/" >}})
@@ -67,7 +67,7 @@ By default, Grafana specifies the color of your series data, which you can chang
 
 ## Sort series
 
-You can change legend mode to **Table** and choose [calculations]({{< relref "../../calculation-types/" >}}) to be displayed in the legend. Click the calculation name header in the legend table to sort the values in the table in ascending or descending order.
+You can change legend mode to **Table** and choose [calculations]({{< relref "../calculation-types/" >}}) to be displayed in the legend. Click the calculation name header in the legend table to sort the values in the table in ascending or descending order.
 
 {{% admonition type="note" %}}
 This feature is only supported in these panels: Bar chart, Histogram, Time series.

--- a/docs/sources/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/panels-visualizations/configure-legend/index.md
@@ -31,11 +31,11 @@ When you apply your changes, the visualization changes appear to all users of th
 This topic currently applies to the following visualizations:
 
 - [Bar chart]({{< relref "../visualizations/bar-chart/" >}})
-- [Histogram]({{< relref "../histogram/" >}})
-- [Pie chart]({{< relref "../pie-chart/" >}})
-- [State timeline]({{< relref "../state-timeline/" >}})
-- [Status history]({{< relref "../status-history/" >}})
-- [Time series]({{< relref "../time-series/" >}})
+- [Histogram]({{< relref "../visualizations/histogram/" >}})
+- [Pie chart]({{< relref "../visualizations/pie-chart/" >}})
+- [State timeline]({{< relref "../visualizations/state-timeline/" >}})
+- [Status history]({{< relref "../visualizations/status-history/" >}})
+- [Time series]({{< relref "../visualizations/time-series/" >}})
 
 ## Add values to a legend
 


### PR DESCRIPTION
Fix links broken when content was moved on PR #67597
Backporting this change as far back as original PR was backported (9.2)