### PR TITLE
Elasticsearch: Make it compatible with the new log context functionality

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
+++ b/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
@@ -135,12 +135,13 @@ export class LegacyQueryRunner {
      */
     const timestampField = dataFrame.fields.find((f: Field) => f.name === this.datasource.timeField);
     const lineField = dataFrame.fields.find((f: Field) => f.name === this.datasource.logMessageField);
+    const otherFields = dataFrame.fields.filter((f) => f !== timestampField && f !== lineField);
     if (timestampField && lineField) {
       return {
         data: [
           {
             ...dataFrame,
-            fields: [ensureTimeField(timestampField), lineField],
+            fields: [ensureTimeField(timestampField), lineField, ...otherFields],
           },
         ],
       };

--- a/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
+++ b/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
@@ -135,7 +135,7 @@ export class LegacyQueryRunner {
      */
     const timestampField = dataFrame.fields.find((f: Field) => f.name === this.datasource.timeField);
     const lineField = dataFrame.fields.find((f: Field) => f.name === this.datasource.logMessageField);
-    const otherFields = dataFrame.fields.filter((f) => f !== timestampField && f !== lineField);
+    const otherFields = dataFrame.fields.filter((f: Field) => f !== timestampField && f !== lineField);
     if (timestampField && lineField) {
       return {
         data: [

--- a/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
+++ b/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
@@ -7,6 +7,7 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   dateTime,
+  ensureTimeField,
   Field,
   LogRowContextOptions,
   LogRowContextQueryDirection,
@@ -139,7 +140,7 @@ export class LegacyQueryRunner {
         data: [
           {
             ...dataFrame,
-            fields: [...dataFrame.fields, { ...timestampField, name: 'ts' }, { ...lineField, name: 'line' }],
+            fields: [ensureTimeField(timestampField), lineField],
           },
         ],
       };


### PR DESCRIPTION
if you use the logs-context feature with the elasticsearch datasource, it does not work.
the problem is, that the data returned by the datasource is not formatted the way it is assumed by the logs-context code (the timestamp-field's `type` attribute is `string`, but it should be `time`)

we correct it in this PR.

how to test:

1. go to explore, run a logs-query on elastic
2. open logs-context on a log-line
3. verify that you get rows "above" and "below" the center-row
4. verify tha tyou can open the log-details of those "above" and "below" rows, and that the log-details look roughly ok.