### PR TITLE
Elasticsearch: Put new log details filters behavior behind a feature flag

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -117,7 +117,7 @@ Experimental features might be changed or removed without prior notice.
 | `pluginsDynamicAngularDetectionPatterns` | Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones             |
 | `alertingLokiRangeToInstant`             | Rewrites eligible loki range queries to instant queries                                                      |
 | `flameGraphV2`                           | New version of flame graph with new features                                                                 |
-| `elasticFiltersToggle`                   | Enable support to toggle filters off from the query through the Logs Details component                       |
+| `elasticToggleableFilters`               | Enable support to toggle filters off from the query through the Logs Details component                       |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -117,6 +117,7 @@ Experimental features might be changed or removed without prior notice.
 | `pluginsDynamicAngularDetectionPatterns` | Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones             |
 | `alertingLokiRangeToInstant`             | Rewrites eligible loki range queries to instant queries                                                      |
 | `flameGraphV2`                           | New version of flame graph with new features                                                                 |
+| `elasticFiltersToggle`                   | Enable support to toggle filters off from the query through the Logs Details component                       |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -104,4 +104,5 @@ export interface FeatureToggles {
   pluginsDynamicAngularDetectionPatterns?: boolean;
   alertingLokiRangeToInstant?: boolean;
   flameGraphV2?: boolean;
+  elasticFiltersToggle?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -104,5 +104,5 @@ export interface FeatureToggles {
   pluginsDynamicAngularDetectionPatterns?: boolean;
   alertingLokiRangeToInstant?: boolean;
   flameGraphV2?: boolean;
-  elasticFiltersToggle?: boolean;
+  elasticToggleableFilters?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -587,7 +587,7 @@ var (
 			Owner:        grafanaObservabilityTracesAndProfilingSquad,
 		},
 		{
-			Name:         "elasticFiltersToggle",
+			Name:         "elasticToggleableFilters",
 			Description:  "Enable support to toggle filters off from the query through the Logs Details component",
 			Stage:        FeatureStageExperimental,
 			FrontendOnly: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -586,5 +586,12 @@ var (
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaObservabilityTracesAndProfilingSquad,
 		},
+		{
+			Name:         "elasticFiltersToggle",
+			Description:  "Enable support to toggle filters off from the query through the Logs Details component",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaObservabilityLogsSquad,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -85,4 +85,4 @@ recordedQueriesMulti,experimental,@grafana/observability-metrics,false,false,fal
 pluginsDynamicAngularDetectionPatterns,experimental,@grafana/plugins-platform-backend,false,false,false,false
 alertingLokiRangeToInstant,experimental,@grafana/alerting-squad,false,false,false,false
 flameGraphV2,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
-elasticFiltersToggle,experimental,@grafana/observability-logs,false,false,false,true
+elasticToggleableFilters,experimental,@grafana/observability-logs,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -85,3 +85,4 @@ recordedQueriesMulti,experimental,@grafana/observability-metrics,false,false,fal
 pluginsDynamicAngularDetectionPatterns,experimental,@grafana/plugins-platform-backend,false,false,false,false
 alertingLokiRangeToInstant,experimental,@grafana/alerting-squad,false,false,false,false
 flameGraphV2,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
+elasticFiltersToggle,experimental,@grafana/observability-logs,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -350,4 +350,8 @@ const (
 	// FlagFlameGraphV2
 	// New version of flame graph with new features
 	FlagFlameGraphV2 = "flameGraphV2"
+
+	// FlagElasticFiltersToggle
+	// Enable support to toggle filters off from the query through the Logs Details component
+	FlagElasticFiltersToggle = "elasticFiltersToggle"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -351,7 +351,7 @@ const (
 	// New version of flame graph with new features
 	FlagFlameGraphV2 = "flameGraphV2"
 
-	// FlagElasticFiltersToggle
+	// FlagElasticToggleableFilters
 	// Enable support to toggle filters off from the query through the Logs Details component
-	FlagElasticFiltersToggle = "elasticFiltersToggle"
+	FlagElasticToggleableFilters = "elasticToggleableFilters"
 )

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1185,7 +1185,7 @@ describe('modifyQuery', () => {
   let ds: ElasticDatasource;
   beforeEach(() => {
     ds = getTestContext().ds;
-    config.featureToggles.elasticFiltersToggle = true;
+    config.featureToggles.elasticToggleableFilters = true;
   });
   describe('with empty query', () => {
     let query: ElasticsearchQuery;
@@ -1247,7 +1247,7 @@ describe('modifyQuery', () => {
 
   describe('legacy behavior', () => {
     beforeEach(() => {
-      config.featureToggles.elasticFiltersToggle = false;
+      config.featureToggles.elasticToggleableFilters = false;
     });
     it('should not modify other filters in the query', () => {
       expect(

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1185,6 +1185,7 @@ describe('modifyQuery', () => {
   let ds: ElasticDatasource;
   beforeEach(() => {
     ds = getTestContext().ds;
+    config.featureToggles.elasticFiltersToggle = true;
   });
   describe('with empty query', () => {
     let query: ElasticsearchQuery;
@@ -1241,6 +1242,26 @@ describe('modifyQuery', () => {
 
     it('should do nothing on unknown type', () => {
       expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
+    });
+  });
+
+  describe('legacy behavior', () => {
+    beforeEach(() => {
+      config.featureToggles.elasticFiltersToggle = false;
+    });
+    it('should not modify other filters in the query', () => {
+      expect(
+        ds.modifyQuery(
+          { query: 'test:"value"', refId: 'A' },
+          { type: 'ADD_FILTER', options: { key: 'test', value: 'value' } }
+        ).query
+      ).toBe('test:"value"');
+      expect(
+        ds.modifyQuery(
+          { query: 'test:"value"', refId: 'A' },
+          { type: 'ADD_FILTER_OUT', options: { key: 'test', value: 'value' } }
+        ).query
+      ).toBe('test:"value" AND -test:"value"');
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -897,27 +897,38 @@ export class ElasticDatasource
     }
 
     let expression = query.query ?? '';
-    switch (action.type) {
-      case 'ADD_FILTER': {
-        // This gives the user the ability to toggle a filter on and off.
-        expression = queryHasFilter(expression, action.options.key, action.options.value)
-          ? removeFilterFromQuery(expression, action.options.key, action.options.value)
-          : addFilterToQuery(expression, action.options.key, action.options.value);
-        break;
-      }
-      case 'ADD_FILTER_OUT': {
-        /**
-         * If there is a filter with the same key and value, remove it.
-         * This prevents the user from seeing no changes in the query when they apply
-         * this filter.
-         */
-        if (queryHasFilter(expression, action.options.key, action.options.value)) {
-          expression = removeFilterFromQuery(expression, action.options.key, action.options.value);
+    if (config.featureToggles.elasticFiltersToggle) {
+      switch (action.type) {
+        case 'ADD_FILTER': {
+          // This gives the user the ability to toggle a filter on and off.
+          expression = queryHasFilter(expression, action.options.key, action.options.value)
+            ? removeFilterFromQuery(expression, action.options.key, action.options.value)
+            : addFilterToQuery(expression, action.options.key, action.options.value);
+          break;
         }
-        expression = addFilterToQuery(expression, action.options.key, action.options.value, '-');
-        break;
+        case 'ADD_FILTER_OUT': {
+          // If the opposite filter is present, remove it before adding the new one.
+          if (queryHasFilter(expression, action.options.key, action.options.value)) {
+            expression = removeFilterFromQuery(expression, action.options.key, action.options.value);
+          }
+          expression = addFilterToQuery(expression, action.options.key, action.options.value, '-');
+          break;
+        }
+      }
+    } else {
+      // Legacy behavior
+      switch (action.type) {
+        case 'ADD_FILTER': {
+          expression = addFilterToQuery(expression, action.options.key, action.options.value);
+          break;
+        }
+        case 'ADD_FILTER_OUT': {
+          expression = addFilterToQuery(expression, action.options.key, action.options.value, '-');
+          break;
+        }
       }
     }
+
     return { ...query, query: expression };
   }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -897,7 +897,7 @@ export class ElasticDatasource
     }
 
     let expression = query.query ?? '';
-    if (config.featureToggles.elasticFiltersToggle) {
+    if (config.featureToggles.elasticToggleableFilters) {
       switch (action.type) {
         case 'ADD_FILTER': {
           // This gives the user the ability to toggle a filter on and off.


### PR DESCRIPTION
As discussed in the [original PR](https://github.com/grafana/grafana/pull/70091#discussion_r1242010117), we are adding a new feature flag for the new behavior of the filters until we are sure we will not produce incorrect queries, hopefully by the addition of a query parser analog to Lezer.

**Which issue(s) does this PR fix?**:

Follow up of https://github.com/grafana/grafana/pull/70091
Part of https://github.com/grafana/grafana/issues/61765

**Special notes for your reviewer:**

Please check that:
- Without the feature flag, it works in the same way as before.
- Nothing else is being broken.

To test this, browse logs with Elasticsearch and interact with the query using the 🔎  icons of logs details.