### PR TITLE
Correlations: Account for restricted datasource

### DIFF
--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -31,7 +31,9 @@ export const attachCorrelationsToDataFrames = (
       dataSourceUid = dataFrameRefIdToDataSourceUid[formattedRefID];
     }
 
-    const sourceCorrelations = correlations.filter((correlation) => correlation.source.uid === dataSourceUid);
+    const sourceCorrelations = correlations.filter((correlation) => {
+      return correlation.source ? correlation.source.uid === dataSourceUid : false;
+    });
     decorateDataFrameWithInternalDataLinks(dataFrame, sourceCorrelations);
   });
 

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -31,9 +31,7 @@ export const attachCorrelationsToDataFrames = (
       dataSourceUid = dataFrameRefIdToDataSourceUid[formattedRefID];
     }
 
-    const sourceCorrelations = correlations.filter((correlation) => {
-      return correlation.source ? correlation.source.uid === dataSourceUid : false;
-    });
+    const sourceCorrelations = correlations.filter((correlation) => correlation.source.uid === dataSourceUid);
     decorateDataFrameWithInternalDataLinks(dataFrame, sourceCorrelations);
   });
 


### PR DESCRIPTION
**What is this feature?**

Fix a bug where restricting an individual datasource broke all other queries due to correlation lookup.

When we get the list of correlations, we query the datasources the user has access to to get more information about the datasource off of the datasource UID. If the user doesn't have access to that datasource, that query returns undefined. 

This changes how we retrieve that information to filter out correlations that have a datasource the user doesn't have access to. 

This also adds some error handling if a user attempts to create or edit a correlation on a UID they dont have access to from the front end.

Note: the root cause of this is the initial correlations fetch retrieves every correlation that exists. In #65241 we change this query to only retrieve correlations the user has selected in their queries. Since a user cannot select a datasource they do not have access to, this scenario thus becomes impossible. 

**Why do we need this feature?**

Enterprise users who do not have access to a datasource with a correlation cannot run queries

**Which issue(s) does this PR fix?**:

Fixes #70714

**Special notes for your reviewer:**
Replication steps
1. Run enterprise
2. From your admin user, create a new user with the editor role and save
3. From that same admin user, find a datasource that's used for a source of a datasource
4. Remove the permission that editors can view that datasource and save
5. From an incognito window, log in with the user created in step 2
6. Go to explore and attempt to run a query from any datasource you have access to
7. Previously, would error. Now, does not.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
