### PR TITLE
Chore: Update ubuntu image to 22.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
 	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
-	--build-arg BASE_IMAGE=ubuntu:20.04 \
+	--build-arg BASE_IMAGE=ubuntu:22.04 \
 	--build-arg GO_IMAGE=golang:1.20.8 \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -62,7 +62,7 @@ docker_build () {
     base_image="${base_arch}alpine:3.18.3"
   else
     libc=""
-    base_image="${base_arch}ubuntu:20.04"
+    base_image="${base_arch}ubuntu:22.04"
   fi
 
   grafana_tgz=${GRAFANA_TGZ:-"grafana-latest.linux-${arch}${libc}.tar.gz"}

--- a/pkg/build/docker/build.go
+++ b/pkg/build/docker/build.go
@@ -74,7 +74,7 @@ func BuildImage(version string, arch config.Architecture, grafanaDir string, use
 	tagSuffix := ""
 	if useUbuntu {
 		libc = ""
-		baseImage = fmt.Sprintf("%subuntu:20.04", baseArch)
+		baseImage = fmt.Sprintf("%subuntu:22.04", baseArch)
 		tagSuffix = "-ubuntu"
 	}
 

--- a/scripts/verify-repo-update/Dockerfile.deb
+++ b/scripts/verify-repo-update/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG REPO_CONFIG=grafana.list.oss
 ARG PACKAGE=grafana


### PR DESCRIPTION
**What is this feature?**

Update ubuntu image to 22.04

**Why do we need this feature?**

Ubuntu 20.04 is getting dated.

**Who is this feature for?**

Docker users.

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
