### PR TITLE
Prometheus: Metrics explorer remove select dropdown behavior

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -226,7 +226,7 @@ export function MetricSelect({
               // add the modal butoon option to the options
               metrics: [...metricsModalOption, ...metrics],
               isLoading: undefined,
-              // pass the initial metrics into the Metrics Modal
+              // pass the initial metrics into the metrics explorer
               initialMetrics: initialMetrics,
             });
           } else {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/FeedbackLink.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/FeedbackLink.tsx
@@ -17,7 +17,7 @@ export function FeedbackLink({ feedbackUrl }: Props) {
       <a
         href={feedbackUrl}
         className={styles.link}
-        title="The Metrics Modal is new, please let us know how we can improve it"
+        title="The metrics explorer is new, please let us know how we can improve it"
         target="_blank"
         rel="noreferrer noopener"
       >

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -66,7 +66,6 @@ const {
   setIncludeNullMetadata,
   setSelectedTypes,
   setUseBackend,
-  setSelectedIdx,
   setDisableTextWrap,
   showAdditionalSettings,
 } = stateSlice.actions;
@@ -158,22 +157,6 @@ export const MetricsModal = (props: MetricsModalProps) => {
     }
   }
 
-  function keyFunction(e: React.KeyboardEvent<HTMLElement>) {
-    if (e.code === 'ArrowDown' && state.selectedIdx < state.resultsPerPage - 1) {
-      dispatch(setSelectedIdx(state.selectedIdx + 1));
-    } else if (e.code === 'ArrowUp' && state.selectedIdx > 0) {
-      dispatch(setSelectedIdx(state.selectedIdx - 1));
-    } else if (e.code === 'Enter') {
-      const metric = displayedMetrics(state, dispatch)[state.selectedIdx];
-
-      onChange({ ...query, metric: metric.value });
-
-      tracking('grafana_prom_metric_encycopedia_tracking', state, metric.value);
-
-      onClose();
-    }
-  }
-
   /* Settings switches */
   const additionalSettings = (
     <AdditionalSettings
@@ -233,9 +216,6 @@ export const MetricsModal = (props: MetricsModalProps) => {
               const value = e.currentTarget.value ?? '';
               dispatch(setFuzzySearchQuery(value));
               searchCallback(value, state.fullMetaSearch);
-            }}
-            onKeyDown={(e) => {
-              keyFunction(e);
             }}
           />
         </div>
@@ -299,9 +279,7 @@ export const MetricsModal = (props: MetricsModalProps) => {
             onClose={onClose}
             query={query}
             state={state}
-            selectedIdx={state.selectedIdx}
             disableTextWrap={state.disableTextWrap}
-            onFocusRow={(idx: number) => dispatch(setSelectedIdx(idx))}
           />
         )}
       </div>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -165,7 +165,6 @@ export const MetricsModal = (props: MetricsModalProps) => {
         const newVal = !state.fullMetaSearch;
         dispatch(setFullMetaSearch(newVal));
         onChange({ ...query, fullMetaSearch: newVal });
-
         searchCallback(state.fuzzySearchQuery, newVal);
       }}
       onChangeIncludeNullMetadata={() => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/ResultsTable.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/ResultsTable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { ReactElement, useEffect, useRef } from 'react';
+import React, { ReactElement } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -18,22 +18,14 @@ type ResultsTableProps = {
   onClose: () => void;
   query: PromVisualQuery;
   state: MetricsModalState;
-  selectedIdx: number;
   disableTextWrap: boolean;
-  onFocusRow: (idx: number) => void;
 };
 
 export function ResultsTable(props: ResultsTableProps) {
-  const { metrics, onChange, onClose, query, state, selectedIdx, disableTextWrap, onFocusRow } = props;
+  const { metrics, onChange, onClose, query, state, disableTextWrap } = props;
 
   const theme = useTheme2();
   const styles = getStyles(theme, disableTextWrap);
-
-  const tableRef = useRef<HTMLTableElement | null>(null);
-
-  function isSelectedRow(idx: number): boolean {
-    return idx === selectedIdx;
-  }
 
   function selectMetric(metric: MetricData) {
     if (metric.value) {
@@ -42,11 +34,6 @@ export function ResultsTable(props: ResultsTableProps) {
       onClose();
     }
   }
-
-  useEffect(() => {
-    const tr = tableRef.current?.getElementsByClassName('selected-row')[0];
-    tr?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-  }, [selectedIdx]);
 
   function metaRows(metric: MetricData) {
     if (state.fullMetaSearch && metric) {
@@ -149,7 +136,7 @@ export function ResultsTable(props: ResultsTableProps) {
   }
 
   return (
-    <table className={styles.table} ref={tableRef}>
+    <table className={styles.table}>
       <thead className={styles.stickyHeader}>
         <tr>
           <th className={`${styles.nameWidth} ${styles.tableHeaderPadding}`}>Name</th>
@@ -167,16 +154,7 @@ export function ResultsTable(props: ResultsTableProps) {
           {metrics.length > 0 &&
             metrics.map((metric: MetricData, idx: number) => {
               return (
-                <tr
-                  key={metric?.value ?? idx}
-                  className={`${styles.row} ${isSelectedRow(idx) ? `${styles.selectedRow} selected-row` : ''}`}
-                  onFocus={() => onFocusRow(idx)}
-                  onKeyDown={(e) => {
-                    if (e.code === 'Enter' && e.currentTarget.classList.contains('selected-row')) {
-                      selectMetric(metric);
-                    }
-                  }}
-                >
+                <tr key={metric?.value ?? idx} className={styles.row}>
                   <td className={styles.nameOverflow}>
                     <Highlighter
                       textToHighlight={metric?.value ?? ''}
@@ -207,8 +185,6 @@ export function ResultsTable(props: ResultsTableProps) {
 }
 
 const getStyles = (theme: GrafanaTheme2, disableTextWrap: boolean) => {
-  const rowHoverBg = theme.colors.emphasize(theme.colors.background.primary, 0.03);
-
   return {
     table: css`
       ${disableTextWrap ? '' : 'table-layout: fixed;'}
@@ -234,9 +210,6 @@ const getStyles = (theme: GrafanaTheme2, disableTextWrap: boolean) => {
     `,
     tableHeaderPadding: css`
       padding: 8px;
-    `,
-    selectedRow: css`
-      background-color: ${rowHoverBg};
     `,
     matchHighLight: css`
       background: inherit;

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/ResultsTable.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/ResultsTable.tsx
@@ -231,9 +231,6 @@ const getStyles = (theme: GrafanaTheme2, disableTextWrap: boolean) => {
       &:last-child {
         border-bottom: 0;
       }
-      :hover {
-        background-color: ${rowHoverBg};
-      }
     `,
     tableHeaderPadding: css`
       padding: 8px;

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/state.ts
@@ -84,7 +84,7 @@ export const stateSlice = createSlice({
 });
 
 /**
- * Initial state for the Metrics Modal
+ * Initial state for the metrics explorer
  * @returns
  */
 export function initialState(query?: PromVisualQuery): MetricsModalState {
@@ -113,7 +113,7 @@ export function initialState(query?: PromVisualQuery): MetricsModalState {
 }
 
 /**
- * The Metrics Modal state object
+ * The metrics explorer state object
  */
 export interface MetricsModalState {
   /** Used for the loading spinner */

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/state.ts
@@ -48,7 +48,6 @@ export const stateSlice = createSlice({
     setFuzzySearchQuery: (state, action: PayloadAction<string>) => {
       state.fuzzySearchQuery = action.payload;
       state.pageNum = 1;
-      state.selectedIdx = 0;
     },
     setNameHaystack: (state, action: PayloadAction<string[][]>) => {
       state.nameHaystackOrder = action.payload[0];
@@ -74,9 +73,6 @@ export const stateSlice = createSlice({
       state.useBackend = action.payload;
       state.fullMetaSearch = false;
       state.pageNum = 1;
-    },
-    setSelectedIdx: (state, action: PayloadAction<number>) => {
-      state.selectedIdx = action.payload;
     },
     setDisableTextWrap: (state) => {
       state.disableTextWrap = !state.disableTextWrap;
@@ -112,7 +108,6 @@ export function initialState(query?: PromVisualQuery): MetricsModalState {
     selectedTypes: [],
     useBackend: query?.useBackend ?? false,
     disableTextWrap: query?.disableTextWrap ?? false,
-    selectedIdx: 0,
     showAdditionalSettings: false,
   };
 }
@@ -163,8 +158,6 @@ export interface MetricsModalState {
   useBackend: boolean;
   /** Disable text wrap for descriptions in the results table */
   disableTextWrap: boolean;
-  /** The selected metric in the table represented by hover style highlighting */
-  selectedIdx: number;
   /** Display toggle switches for settings */
   showAdditionalSettings: boolean;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/uFuzzy.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/uFuzzy.ts
@@ -37,6 +37,8 @@ export function fuzzySearch(haystack: string[], query: string, dispatcher: (data
     }
 
     dispatcher([haystackOrder, [...matchesSet]]);
+  } else if (!query) {
+    dispatcher([[], []]);
   }
 }
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/types.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/types.ts
@@ -9,7 +9,7 @@ export interface PromVisualQuery {
   labels: QueryBuilderLabelFilter[];
   operations: QueryBuilderOperation[];
   binaryQueries?: PromVisualQueryBinary[];
-  // metrics modal additional settings
+  // metrics explorer additional settings
   useBackend?: boolean;
   disableTextWrap?: boolean;
   includeNullMetadata?: boolean;

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -16,7 +16,7 @@ export interface PromQuery extends GenPromQuery, DataQuery {
   showingTable?: boolean;
   hinting?: boolean;
   interval?: string;
-  // store the metrics modal additional settings
+  // store the metrics explorer additional settings
   useBackend?: boolean;
   disableTextWrap?: boolean;
   fullMetaSearch?: boolean;


### PR DESCRIPTION
**What is this feature?**
This purpose of this PR is to remove the behavior that mimics the select dropdown from the metrics explorer table of results. 

- remove hover/selected index highlighting style from the results table list 
- remove keyboard events to navigate and select
- remove state functionality for a selected index (used for both style and and metric selection)

**Why do we need this feature?**
The purpose of the metrics explorer is to explore metrics and select a metric. To select a metric, we have included a button. In previous implementations we had the results table mimic a select dropdown (row highlighting on hover, click row to select metric, arrow keys to navigate, enter to select a metric). During user testing 4/6 users closed out the modal by accidentally clicking a metric. This is not an optimal UX experience because it takes extra time for someone to get back to the metrics explorer and the past filters / search.

We have a button to select a metric which reduces accidental clicking. The button allows users to tab through results to select a metric which supports accessibility.

**Who is this feature for?**
Users of the metrics explorer, beginning prom users

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
