### PR TITLE
Nested folders: Paginate child folder items

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -13,7 +13,7 @@ import { DashboardDTO, DescendantCount, DescendantCountDTO, FolderDTO, SaveDashb
 import { refetchChildren, refreshParents } from '../state';
 import { DashboardTreeSelection } from '../types';
 
-import { PAGE_SIZE, ROOT_PAGE_SIZE } from './services';
+import { PAGE_SIZE } from './services';
 
 interface RequestOptions extends BackendSrvRequest {
   manageError?: (err: unknown) => { error: unknown };
@@ -74,7 +74,7 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: parentUid,
-              pageSize: parentUid ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
           locationService.push(locationUtil.stripBaseFromUrl(folder.url));
@@ -100,7 +100,7 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: parentUid,
-              pageSize: parentUid ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
         });
@@ -120,13 +120,13 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: parentUid,
-              pageSize: parentUid ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
           dispatch(
             refetchChildren({
               parentUID: destinationUID,
-              pageSize: destinationUID ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
         });
@@ -148,7 +148,7 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: parentUid,
-              pageSize: parentUid ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
         });
@@ -228,7 +228,7 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: destinationUID,
-              pageSize: destinationUID ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
           dispatch(refreshParents([...selectedFolders, ...selectedDashboards]));
@@ -291,7 +291,7 @@ export const browseDashboardsAPI = createApi({
           dispatch(
             refetchChildren({
               parentUID: folderUid,
-              pageSize: folderUid ? PAGE_SIZE : ROOT_PAGE_SIZE,
+              pageSize: PAGE_SIZE,
             })
           );
         });

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -5,7 +5,7 @@ import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 
 export const ROOT_PAGE_SIZE = 50;
-export const PAGE_SIZE = 999;
+export const PAGE_SIZE = 50;
 
 export async function listFolders(
   parentUID?: string,

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -4,7 +4,6 @@ import { getGrafanaSearcher, NestedFolderDTO } from 'app/features/search/service
 import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 
-export const ROOT_PAGE_SIZE = 50;
 export const PAGE_SIZE = 50;
 
 export async function listFolders(

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -110,7 +110,7 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
     [flatTree]
   );
 
-  const handleLoadMore = useLoadNextChildrenPage(folderUID);
+  const handleLoadMore = useLoadNextChildrenPage();
 
   if (status === 'fulfilled' && flatTree.length === 0) {
     return (

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -35,7 +35,7 @@ interface DashboardsTreeProps {
   onItemSelectionChange: (item: DashboardViewItem, newState: boolean) => void;
 
   isItemLoaded: (itemIndex: number) => boolean;
-  requestLoadMore: (startIndex: number, endIndex: number) => void;
+  requestLoadMore: (folderUid: string | undefined) => void;
 }
 
 const HEADER_HEIGHT = 35;
@@ -119,9 +119,10 @@ export function DashboardsTree({
 
   const handleLoadMore = useCallback(
     (startIndex: number, endIndex: number) => {
-      requestLoadMore(startIndex, endIndex);
+      const { parentUID } = items[startIndex];
+      requestLoadMore(parentUID);
     },
-    [requestLoadMore]
+    [requestLoadMore, items]
   );
 
   return (

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -2,7 +2,7 @@ import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types';
 
-import { listDashboards, listFolders, PAGE_SIZE, ROOT_PAGE_SIZE } from '../api/services';
+import { listDashboards, listFolders, PAGE_SIZE } from '../api/services';
 
 import { findItem } from './utils';
 
@@ -44,7 +44,7 @@ export const refreshParents = createAsyncThunk(
     }
 
     for (const parentUID of parentsToRefresh) {
-      dispatch(refetchChildren({ parentUID, pageSize: parentUID ? PAGE_SIZE : ROOT_PAGE_SIZE }));
+      dispatch(refetchChildren({ parentUID, pageSize: PAGE_SIZE }));
     }
   }
 );

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 import { DashboardViewItem } from 'app/features/search/types';
 import { useSelector, StoreState, useDispatch } from 'app/types';
 
-import { ROOT_PAGE_SIZE } from '../api/services';
+import { PAGE_SIZE } from '../api/services';
 import { BrowseDashboardsState, DashboardsTreeItem, DashboardTreeSelection } from '../types';
 
 import { fetchNextChildrenPage } from './actions';
@@ -109,7 +109,7 @@ export function useLoadNextChildrenPage() {
 
       requestInFlightRef.current = true;
 
-      const promise = dispatch(fetchNextChildrenPage({ parentUID: folderUID, pageSize: ROOT_PAGE_SIZE }));
+      const promise = dispatch(fetchNextChildrenPage({ parentUID: folderUID, pageSize: PAGE_SIZE }));
       promise.finally(() => (requestInFlightRef.current = false));
 
       return promise;
@@ -171,7 +171,7 @@ function createFlatTree(
   let children = (items || []).flatMap((item) => mapItem(item, folderUID, level));
 
   if ((level === 0 && !collection) || (isOpen && collection && !collection.isFullyLoaded)) {
-    children = children.concat(getPaginationPlaceholders(ROOT_PAGE_SIZE, folderUID, level));
+    children = children.concat(getPaginationPlaceholders(PAGE_SIZE, folderUID, level));
   }
 
   return children;

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -39,6 +39,7 @@ export interface DashboardsTreeItem<T extends DashboardViewItemWithUIItems = Das
   item: T;
   level: number;
   isOpen: boolean;
+  parentUID?: string;
 }
 
 export const INDENT_AMOUNT_CSS_VAR = '--dashboards-tree-indentation';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- extends pagination behaviour to child folder items
  - adjusts `useLoadNextChildrenPage` hook to return a function which requires the folder uid as the argument
    - this then allows for it to be called for different folders, not just the root folder for the page
    - `handleLoadMore` is passed the `startIndex` requesting the load. we can then find this item in the list, find the `parentUID` of this item and load more items from the correct `parentUID` 🥳 
- adjusts when pagination placeholders are added
  - before, these were only added at the root
  - now they are also added for child folders that are open whose collection isn't fully loaded
- consolidates `PAGE_SIZE` and `ROOT_PAGE_SIZE` into 1 variable: `PAGE_SIZE`

**Why do we need this feature?**

- better performance when opening a child folder

**Who is this feature for?**

- anyone using nested folders

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/70574

**Special notes for your reviewer:**

was expecting this to be much trickier... logic is very simple but seems to be working pretty well. still testing some edge case scenarios. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
