### PR TITLE
Docs: Remove duplicate keys in Prometheus provisioning example

### DIFF
--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -96,8 +96,6 @@ datasources:
       incrementalQuerying: true
       incrementalQueryOverlapWindow: 10m
       cacheLevel: 'High'
-      incrementalQuerying: true
-      incrementalQueryOverlapWindow: 10m
       exemplarTraceIdDestinations:
         # Field with internal link pointing to data source in Grafana.
         # datasourceUid value can be anything, but it should be unique across all defined data source uids.


### PR DESCRIPTION
We already have the same keys two lines above.