### PR TITLE
Dashboard: Add suggestion box for Flame Graph

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4873,10 +4873,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraphTopWrapper.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/panel/flamegraph/suggestions.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "public/app/plugins/panel/gauge/GaugeMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4873,6 +4873,10 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/flamegraph/flamegraphV2/components/FlameGraphTopWrapper.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/plugins/panel/flamegraph/suggestions.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
     "public/app/plugins/panel/gauge/GaugeMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/features/panel/state/getAllSuggestions.ts
+++ b/public/app/features/panel/state/getAllSuggestions.ts
@@ -20,6 +20,7 @@ export const panelsToCheckFirst = [
   'status-history',
   'logs',
   'candlestick',
+  'flamegraph',
 ];
 
 export async function getAllSuggestions(data?: PanelData, panel?: PanelModel): Promise<VisualizationSuggestion[]> {

--- a/public/app/plugins/panel/flamegraph/module.tsx
+++ b/public/app/plugins/panel/flamegraph/module.tsx
@@ -1,5 +1,6 @@
 import { PanelPlugin } from '@grafana/data';
 
 import { FlameGraphPanel } from './FlameGraphPanel';
+import { FlameGraphSuggestionsSupplier } from './suggestions';
 
-export const plugin = new PanelPlugin(FlameGraphPanel);
+export const plugin = new PanelPlugin(FlameGraphPanel).setSuggestionsSupplier(new FlameGraphSuggestionsSupplier());

--- a/public/app/plugins/panel/flamegraph/suggestions.ts
+++ b/public/app/plugins/panel/flamegraph/suggestions.ts
@@ -1,0 +1,42 @@
+import { VisualizationSuggestionsBuilder } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { SuggestionName } from 'app/types/suggestions';
+
+import { FlameGraphDataContainer as FlameGraphDataContainer } from './components/FlameGraph/dataTransform';
+import { FlameGraphDataContainer as FlameGraphDataContainerV2 } from './flamegraphV2/components/FlameGraph/dataTransform';
+
+export class FlameGraphSuggestionsSupplier {
+  getListWithDefaults(builder: VisualizationSuggestionsBuilder) {
+    return builder.getListAppender<any, any>({
+      name: SuggestionName.FlameGraph,
+      pluginId: 'flamegraph',
+    });
+  }
+
+  getSuggestionsForData(builder: VisualizationSuggestionsBuilder) {
+    if (!builder.data) {
+      return;
+    }
+
+    // Try to instantiate FlameGraphDataContainer (depending of the version), since the instantiation can fail due
+    // to the format of the data - meaning that a Flame Graph cannot be used to visualize those data.
+    // Without this check, a suggestion containing an error is shown to the user.
+    const dataFrame = builder.data.series[0];
+    try {
+      config.featureToggles.flameGraphV2
+        ? new FlameGraphDataContainerV2(dataFrame)
+        : new FlameGraphDataContainer(dataFrame);
+    } catch (err) {
+      return;
+    }
+
+    try {
+      const list = this.getListWithDefaults(builder);
+      list.append({
+        name: SuggestionName.FlameGraph,
+      });
+    } catch {
+      console.log('Caught');
+    }
+  }
+}

--- a/public/app/plugins/panel/flamegraph/suggestions.ts
+++ b/public/app/plugins/panel/flamegraph/suggestions.ts
@@ -18,7 +18,7 @@ export class FlameGraphSuggestionsSupplier {
       return;
     }
 
-    // Try to instantiate FlameGraphDataContainer (depending of the version), since the instantiation can fail due
+    // Try to instantiate FlameGraphDataContainer (depending on the version), since the instantiation can fail due
     // to the format of the data - meaning that a Flame Graph cannot be used to visualize those data.
     // Without this check, a suggestion containing an error is shown to the user.
     const dataFrame = builder.data.series[0];

--- a/public/app/plugins/panel/flamegraph/suggestions.ts
+++ b/public/app/plugins/panel/flamegraph/suggestions.ts
@@ -7,7 +7,7 @@ import { FlameGraphDataContainer as FlameGraphDataContainerV2 } from './flamegra
 
 export class FlameGraphSuggestionsSupplier {
   getListWithDefaults(builder: VisualizationSuggestionsBuilder) {
-    return builder.getListAppender<any, any>({
+    return builder.getListAppender<{}, {}>({
       name: SuggestionName.FlameGraph,
       pluginId: 'flamegraph',
     });

--- a/public/app/plugins/panel/flamegraph/suggestions.ts
+++ b/public/app/plugins/panel/flamegraph/suggestions.ts
@@ -30,13 +30,8 @@ export class FlameGraphSuggestionsSupplier {
       return;
     }
 
-    try {
-      const list = this.getListWithDefaults(builder);
-      list.append({
-        name: SuggestionName.FlameGraph,
-      });
-    } catch {
-      console.log('Caught');
-    }
+    this.getListWithDefaults(builder).append({
+      name: SuggestionName.FlameGraph,
+    });
   }
 }

--- a/public/app/types/suggestions.ts
+++ b/public/app/types/suggestions.ts
@@ -27,4 +27,5 @@ export enum SuggestionName {
   TextPanel = 'Text',
   DashboardList = 'Dashboard list',
   Logs = 'Logs',
+  FlameGraph = 'Flame graph',
 }


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Follow-up to a comment from issue 66428 - suggestion not shown for Flame Graph.

A proper suggestion is now shown for data that conform to the format expected by a Flame Graph.
<img width="546" alt="Screenshot 2023-06-27 at 17 16 23" src="https://github.com/grafana/grafana/assets/135109076/e729997c-73d4-4c0e-9ca4-581e03ff595e">

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
