### PR TITLE
Frontend: Upgrade cypress for better apple silicon support

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.8.1",
     "css-minimizer-webpack-plugin": "4.2.2",
-    "cypress": "9.5.1",
+    "cypress": "10.2.0",
     "esbuild": "0.18.6",
     "esbuild-loader": "3.0.1",
     "esbuild-plugin-browserslist": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14804,6 +14804,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress@npm:10.2.0":
+  version: 10.2.0
+  resolution: "cypress@npm:10.2.0"
+  dependencies:
+    "@cypress/request": ^2.88.10
+    "@cypress/xvfb": ^1.2.4
+    "@types/node": ^14.14.31
+    "@types/sinonjs__fake-timers": 8.1.1
+    "@types/sizzle": ^2.3.2
+    arch: ^2.2.0
+    blob-util: ^2.0.2
+    bluebird: ^3.7.2
+    buffer: ^5.6.0
+    cachedir: ^2.3.0
+    chalk: ^4.1.0
+    check-more-types: ^2.24.0
+    cli-cursor: ^3.1.0
+    cli-table3: ~0.6.1
+    commander: ^5.1.0
+    common-tags: ^1.8.0
+    dayjs: ^1.10.4
+    debug: ^4.3.2
+    enquirer: ^2.3.6
+    eventemitter2: ^6.4.3
+    execa: 4.1.0
+    executable: ^4.1.1
+    extract-zip: 2.0.1
+    figures: ^3.2.0
+    fs-extra: ^9.1.0
+    getos: ^3.2.1
+    is-ci: ^3.0.0
+    is-installed-globally: ~0.4.0
+    lazy-ass: ^1.6.0
+    listr2: ^3.8.3
+    lodash: ^4.17.21
+    log-symbols: ^4.0.0
+    minimist: ^1.2.6
+    ospath: ^1.2.2
+    pretty-bytes: ^5.6.0
+    proxy-from-env: 1.0.0
+    request-progress: ^3.0.0
+    semver: ^7.3.2
+    supports-color: ^8.1.1
+    tmp: ~0.2.1
+    untildify: ^4.0.0
+    yauzl: ^2.10.0
+  bin:
+    cypress: bin/cypress
+  checksum: 1fd687658e036b2fd07031bde5a2f40ab61f664ca802ae650e0e15786d8825b38bb9444dffd8528b90a8e539e18241be6d5eaab7d5ae05d941839e2481e09342
+  languageName: node
+  linkType: hard
+
 "cypress@npm:9.5.1":
   version: 9.5.1
   resolution: "cypress@npm:9.5.1"
@@ -18962,7 +19014,7 @@ __metadata:
     core-js: 3.31.0
     css-loader: 6.8.1
     css-minimizer-webpack-plugin: 4.2.2
-    cypress: 9.5.1
+    cypress: 10.2.0
     d3: 7.8.2
     d3-force: 3.0.0
     d3-scale-chromatic: 3.0.0


### PR DESCRIPTION
**What is this feature?**

[Cypress 10.2.0](https://www.cypress.io/blog/2022/06/21/cypress-10-2-0-run-tests-up-to-2x-faster-on-apple-silicon-m1/) added native support for m1/m2 processor families, currently when emulating cypress the local headless test execution can take hours, and I'm seeing lots of test flake locally as well.

**Why do we need this feature?**
It's going to be impossible to get engineers to run or create e2e tests if they take hours locally. Debugging is a nightmare.

**Who is this feature for?**
Developers working with Grafana.

**Special notes for your reviewer:**
WIP: investigating

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
