### PR TITLE
Alerting: Change alert history default time range and limit

### DIFF
--- a/public/app/features/alerting/unified/api/stateHistoryApi.ts
+++ b/public/app/features/alerting/unified/api/stateHistoryApi.ts
@@ -6,10 +6,10 @@ import { alertingApi } from './alertingApi';
 
 export const stateHistoryApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    getRuleHistory: build.query<DataFrameJSON, { ruleUid: string; from: number; to?: number }>({
-      query: ({ ruleUid, from, to = getUnixTime(new Date()) }) => ({
+    getRuleHistory: build.query<DataFrameJSON, { ruleUid: string; from: number; to?: number; limit?: number }>({
+      query: ({ ruleUid, from, to = getUnixTime(new Date()), limit = 100 }) => ({
         url: '/api/v1/rules/history',
-        params: { ruleUID: ruleUid, from, to },
+        params: { ruleUID: ruleUid, from, to, limit },
       }),
     }),
   }),

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -83,7 +83,7 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
   const emptyStateMessage =
     totalRecordsCount > 0
       ? `No matches were found for the given filters among the ${totalRecordsCount} instances`
-      : 'No state transitions have occurred in the last 60 minutes';
+      : 'No state transitions have occurred in the last week';
 
   return (
     <div className={styles.fullSize}>
@@ -199,7 +199,7 @@ const SearchFieldInput = React.forwardRef<HTMLInputElement, SearchFieldInputProp
 SearchFieldInput.displayName = 'SearchFieldInput';
 
 function getDefaultTimeRange(): TimeRange {
-  const fromDateTime = dateTime().subtract(1, 'h');
+  const fromDateTime = dateTime().subtract(168, 'h');
   const toDateTime = dateTime();
   return {
     from: fromDateTime,

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -83,7 +83,7 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
   const emptyStateMessage =
     totalRecordsCount > 0
       ? `No matches were found for the given filters among the ${totalRecordsCount} instances`
-      : 'No state transitions have occurred in the last week';
+      : 'No state transitions have occurred in the last 7 days';
 
   return (
     <div className={styles.fullSize}>
@@ -199,7 +199,7 @@ const SearchFieldInput = React.forwardRef<HTMLInputElement, SearchFieldInputProp
 SearchFieldInput.displayName = 'SearchFieldInput';
 
 function getDefaultTimeRange(): TimeRange {
-  const fromDateTime = dateTime().subtract(168, 'h');
+  const fromDateTime = dateTime().subtract(7, 'd');
   const toDateTime = dateTime();
   return {
     from: fromDateTime,


### PR DESCRIPTION
**What is this feature?**

Changes the default time range for Alert history request to **7 days** and sets a limit of 100 records.

**Why do we need this feature?**

We need a bigger interval in order to get a meaningful response as 1h is too small. We're setting the default time range to 7 days plus adding a limit of 100 records to prevent returning a very big response with this increased range.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Reported in Slack.

![image](https://github.com/grafana/grafana/assets/6271380/2b93e056-0874-411b-8f96-25294372d88f)