### PR TITLE
Alerting: Convert 'Both' type Prometheus queries to 'Range' in migration

### DIFF
--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -148,6 +148,8 @@ longer supported.
 
 1. The JSON format for webhook notifications has changed in Grafana Alerting and uses the format from [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config).
 
+1. Alerting on Prometheus `Both` type queries is not supported in Grafana Alerting. Existing legacy alerts with `Both` type queries are migrated to Grafana Alerting as alerts with `Range` type queries.
+
 **Limitations**
 
 1. Since `Hipchat` and `Sensu` notification channels are no longer supported, legacy alerts associated with these channels are not automatically migrated to Grafana Alerting. Assign the legacy alerts to a supported notification channel so that you continue to receive notifications for those alerts.

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -220,7 +220,9 @@ func fixPrometheusBothTypeQuery(l log.Logger, queryData map[string]json.RawMessa
 	if instantRaw, ok := queryData["instant"]; ok {
 		if err := json.Unmarshal(instantRaw, &instant); err != nil {
 			// Nothing to do here, we can't parse the instant field.
-			l.Info("Failed to parse instant", "instant", string(instantRaw), "err", err)
+			if isPrometheus, _ := isPrometheusQuery(queryData); isPrometheus {
+				l.Info("Failed to parse instant field on Prometheus query", "instant", string(instantRaw), "err", err)
+			}
 			return queryData
 		}
 	}
@@ -228,7 +230,9 @@ func fixPrometheusBothTypeQuery(l log.Logger, queryData map[string]json.RawMessa
 	if rangeRaw, ok := queryData["range"]; ok {
 		if err := json.Unmarshal(rangeRaw, &rng); err != nil {
 			// Nothing to do here, we can't parse the range field.
-			l.Info("Failed to parse range", "range", string(rangeRaw), "err", err)
+			if isPrometheus, _ := isPrometheusQuery(queryData); isPrometheus {
+				l.Info("Failed to parse range field on Prometheus query", "range", string(rangeRaw), "err", err)
+			}
 			return queryData
 		}
 	}
@@ -240,7 +244,7 @@ func fixPrometheusBothTypeQuery(l log.Logger, queryData map[string]json.RawMessa
 
 	isPrometheus, err := isPrometheusQuery(queryData)
 	if err != nil {
-		l.Info("Failed to determine datasource type on alert rule that resembles a Prometheus 'Both' type query. Skipping conversion to range query.", "err", err)
+		l.Info("Unable to convert alert rule that resembles a Prometheus 'Both' type query to 'Range'", "err", err)
 		return queryData
 	}
 	if !isPrometheus {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -226,6 +226,7 @@ func fixPrometheusBothTypeQuery(l log.Logger, queryData map[string]json.RawMessa
 	}
 	if err := json.Unmarshal(ds, &datasource); err != nil {
 		// Nothing to do here, we can't parse the datasource.
+		l.Info("Failed to parse datasource", "datasource", string(ds), "err", err)
 		return queryData
 	}
 	if datasource.Type != "prometheus" {
@@ -238,13 +239,15 @@ func fixPrometheusBothTypeQuery(l log.Logger, queryData map[string]json.RawMessa
 	if instantRaw, ok := queryData["instant"]; ok {
 		if err := json.Unmarshal(instantRaw, &instant); err != nil {
 			// Nothing to do here, we can't parse the instant field.
+			l.Info("Failed to parse instant", "instant", string(instantRaw), "err", err)
 			return queryData
 		}
 	}
 	var rng bool
 	if rangeRaw, ok := queryData["range"]; ok {
 		if err := json.Unmarshal(rangeRaw, &rng); err != nil {
-			// Nothing to do here, we can't parse the instant field.
+			// Nothing to do here, we can't parse the range field.
+			l.Info("Failed to parse range", "range", string(rangeRaw), "err", err)
 			return queryData
 		}
 	}

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -270,10 +270,7 @@ func isPrometheusQuery(queryData map[string]json.RawMessage) (bool, error) {
 	if datasource.Type == "" {
 		return false, fmt.Errorf("missing type field '%s'", string(ds))
 	}
-	if datasource.Type != "prometheus" {
-		return false, nil
-	}
-	return true, nil
+	return datasource.Type == "prometheus", nil
 }
 
 type alertQuery struct {


### PR DESCRIPTION
**What is this feature?**

This feature updates the legacy migration to convert Prometheus queries of type `Both` to type `Range` and log a warning during migration.

**Why do we need this feature?**

Legacy supports alerting on Prometheus queries of type `Both`. This returns a mixed response with two dataframes (`TimeSeriesWide` & `NumericWide`), however Server Side Expressions and UA does not currently support this type of mixed response.

**Who is this feature for?**

Users of legacy alerting who will be migrating to UA.

**Which issue(s) does this PR fix?**:

Fixes #70768

**Special notes for your reviewer:**

There is the possibility to better support migrating this functionality by:
- Splitting the query into two: one for instant and one for range.
- Splitting the condition into two: one for each query, separated by OR.

However, relying on a `Both` query instead of multiple conditions to do this in legacy is likely
to be unintentional. In addition, this would require more robust operator precedence in classic conditions.
Given these reasons, we opt to convert them to `Range` queries and log a warning.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
