### PR TITLE
Chore: uFuzzy v1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",
-    "@leeoniya/ufuzzy": "1.0.6",
+    "@leeoniya/ufuzzy": "1.0.8",
     "@lezer/common": "1.0.2",
     "@lezer/highlight": "1.1.3",
     "@lezer/lr": "1.3.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -53,7 +53,7 @@
     "@grafana/e2e-selectors": "10.1.0-pre",
     "@grafana/faro-web-sdk": "1.1.0",
     "@grafana/schema": "10.1.0-pre",
-    "@leeoniya/ufuzzy": "1.0.6",
+    "@leeoniya/ufuzzy": "1.0.8",
     "@monaco-editor/react": "4.5.1",
     "@popperjs/core": "2.11.6",
     "@react-aria/button": "3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,7 +4094,7 @@ __metadata:
     "@grafana/faro-web-sdk": 1.1.0
     "@grafana/schema": 10.1.0-pre
     "@grafana/tsconfig": ^1.2.0-rc1
-    "@leeoniya/ufuzzy": 1.0.6
+    "@leeoniya/ufuzzy": 1.0.8
     "@mdx-js/react": 1.6.22
     "@monaco-editor/react": 4.5.1
     "@popperjs/core": 2.11.6
@@ -4850,10 +4850,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@leeoniya/ufuzzy@npm:1.0.6"
-  checksum: e09672848e094745726331feebe6744d42563ccf160b38796eed4d72105daa052838fdec1944d5b44a27e328fc74a00547d00b894710e2720aa692ed5d3d6e3b
+"@leeoniya/ufuzzy@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@leeoniya/ufuzzy@npm:1.0.8"
+  checksum: 899a9269fa72c773c4806ff6ca7277a9ed69a8e3e7f0e8db9d3f4c9aa9c23d1d5c1df1e5cbea47d720af85ae6aa2ad88822443cd18ef94631876b96d23f4d7e2
   languageName: node
   linkType: hard
 
@@ -18835,7 +18835,7 @@ __metadata:
     "@grafana/tsconfig": ^1.3.0-rc1
     "@grafana/ui": "workspace:*"
     "@kusto/monaco-kusto": ^7.4.0
-    "@leeoniya/ufuzzy": 1.0.6
+    "@leeoniya/ufuzzy": 1.0.8
     "@lezer/common": 1.0.2
     "@lezer/highlight": 1.1.3
     "@lezer/lr": 1.3.3


### PR DESCRIPTION
- Adds support for exact terms in quotes, including symbols, e.g. "$19.95"
  (see https://github.com/leeoniya/uFuzzy/issues/30)
- Adds support for easier i18n: https://github.com/leeoniya/uFuzzy#charsets-alphabets-diacritics
- Some minor bugfixes to ranking that probably don't impact Grafana since we don't use the required opts.
  (see https://github.com/leeoniya/uFuzzy/issues/37)