### PR TITLE
Alerting: Improve error message handling within response payload 

### DIFF
--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -51,7 +52,7 @@ func (f *AlertmanagerApiHandler) RouteCreateGrafanaSilence(ctx *contextmodel.Req
 	// Parse Request Body
 	conf := apimodels.PostableSilence{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRouteCreateGrafanaSilence(ctx, conf)
 }
@@ -61,7 +62,7 @@ func (f *AlertmanagerApiHandler) RouteCreateSilence(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.PostableSilence{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRouteCreateSilence(ctx, conf, datasourceUIDParam)
 }
@@ -147,7 +148,7 @@ func (f *AlertmanagerApiHandler) RoutePostAMAlerts(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.PostableAlerts{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostAMAlerts(ctx, conf, datasourceUIDParam)
 }
@@ -157,7 +158,7 @@ func (f *AlertmanagerApiHandler) RoutePostAlertingConfig(ctx *contextmodel.ReqCo
 	// Parse Request Body
 	conf := apimodels.PostableUserConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostAlertingConfig(ctx, conf, datasourceUIDParam)
 }
@@ -165,7 +166,7 @@ func (f *AlertmanagerApiHandler) RoutePostGrafanaAlertingConfig(ctx *contextmode
 	// Parse Request Body
 	conf := apimodels.PostableUserConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostGrafanaAlertingConfig(ctx, conf)
 }
@@ -178,7 +179,7 @@ func (f *AlertmanagerApiHandler) RoutePostTestGrafanaReceivers(ctx *contextmodel
 	// Parse Request Body
 	conf := apimodels.TestReceiversConfigBodyParams{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostTestGrafanaReceivers(ctx, conf)
 }
@@ -186,7 +187,7 @@ func (f *AlertmanagerApiHandler) RoutePostTestGrafanaTemplates(ctx *contextmodel
 	// Parse Request Body
 	conf := apimodels.TestTemplatesConfigBodyParams{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostTestGrafanaTemplates(ctx, conf)
 }

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -42,7 +43,7 @@ func (f *ConfigurationApiHandler) RoutePostNGalertConfig(ctx *contextmodel.ReqCo
 	// Parse Request Body
 	conf := apimodels.PostableNGalertConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostNGalertConfig(ctx, conf)
 }

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -121,7 +122,7 @@ func (f *ProvisioningApiHandler) RoutePostAlertRule(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostAlertRule(ctx, conf)
 }
@@ -129,7 +130,7 @@ func (f *ProvisioningApiHandler) RoutePostContactpoints(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostContactpoints(ctx, conf)
 }
@@ -137,7 +138,7 @@ func (f *ProvisioningApiHandler) RoutePostMuteTiming(ctx *contextmodel.ReqContex
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostMuteTiming(ctx, conf)
 }
@@ -147,7 +148,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRule(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutAlertRule(ctx, conf, uIDParam)
 }
@@ -158,7 +159,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRuleGroup(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.AlertRuleGroup{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutAlertRuleGroup(ctx, conf, folderUIDParam, groupParam)
 }
@@ -168,7 +169,7 @@ func (f *ProvisioningApiHandler) RoutePutContactpoint(ctx *contextmodel.ReqConte
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutContactpoint(ctx, conf, uIDParam)
 }
@@ -178,7 +179,7 @@ func (f *ProvisioningApiHandler) RoutePutMuteTiming(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutMuteTiming(ctx, conf, nameParam)
 }
@@ -186,7 +187,7 @@ func (f *ProvisioningApiHandler) RoutePutPolicyTree(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.Route{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutPolicyTree(ctx, conf)
 }
@@ -196,7 +197,7 @@ func (f *ProvisioningApiHandler) RoutePutTemplate(ctx *contextmodel.ReqContext) 
 	// Parse Request Body
 	conf := apimodels.NotificationTemplateContent{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePutTemplate(ctx, conf, nameParam)
 }

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -95,7 +96,7 @@ func (f *RulerApiHandler) RoutePostNameGrafanaRulesConfig(ctx *contextmodel.ReqC
 	// Parse Request Body
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostNameGrafanaRulesConfig(ctx, conf, namespaceParam)
 }
@@ -106,7 +107,7 @@ func (f *RulerApiHandler) RoutePostNameRulesConfig(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRoutePostNameRulesConfig(ctx, conf, datasourceUIDParam, namespaceParam)
 }

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -29,7 +30,7 @@ func (f *TestingApiHandler) BacktestConfig(ctx *contextmodel.ReqContext) respons
 	// Parse Request Body
 	conf := apimodels.BacktestConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleBacktestConfig(ctx, conf)
 }
@@ -37,7 +38,7 @@ func (f *TestingApiHandler) RouteEvalQueries(ctx *contextmodel.ReqContext) respo
 	// Parse Request Body
 	conf := apimodels.EvalQueriesPayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRouteEvalQueries(ctx, conf)
 }
@@ -47,7 +48,7 @@ func (f *TestingApiHandler) RouteTestRuleConfig(ctx *contextmodel.ReqContext) re
 	// Parse Request Body
 	conf := apimodels.TestRulePayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRouteTestRuleConfig(ctx, conf, datasourceUIDParam)
 }
@@ -55,7 +56,7 @@ func (f *TestingApiHandler) RouteTestRuleGrafanaConfig(ctx *contextmodel.ReqCont
 	// Parse Request Body
 	conf := apimodels.PostableExtendedRuleNodeExtended{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	return f.handleRouteTestRuleGrafanaConfig(ctx, conf)
 }

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3681,6 +3681,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3716,7 +3717,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "Userinfo": {
@@ -4024,6 +4025,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4079,13 +4081,13 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3681,7 +3681,7 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4024,7 +4024,6 @@
    "type": "object"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4087,7 +4086,6 @@
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -4136,13 +4134,13 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -4324,7 +4322,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -6451,7 +6451,7 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
       "type": "object",
       "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
@@ -6796,7 +6796,6 @@
       }
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -6861,7 +6860,6 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6911,6 +6909,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -6918,7 +6917,6 @@
       "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -7102,7 +7100,6 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -26,7 +26,7 @@ func (f *{{classname}}Handler) {{nickname}}(ctx *contextmodel.ReqContext) respon
 	// Parse Request Body
 	conf := apimodels.{{dataType}}{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err.Error()), err)
 	}
 	{{/bodyParams}}return f.handle{{nickname}}(ctx{{#bodyParams}}, conf{{/bodyParams}}{{#pathParams}}, {{paramName}}Param{{/pathParams}})
 }


### PR DESCRIPTION
- in production mode, error handling in payload is reduced and is not attached to the response payload
- instead of attaching the error message into the "error" key, it will be appended to the payload message
- changed the controller-api.mustache to reflect change in all generated api files

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/56387

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
