### PR TITLE
CI: Ignore .pr-body.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ public/api-spec.json
 deployment_tools_config.json
 
 .betterer.cache
+
+# Temporary file for backporting PRs
+.pr-body.txt


### PR DESCRIPTION
This file is used during the backporting process but should never be committed.