### PR TITLE
Loki: Use better query validation before requesting stats

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.test.ts
@@ -1,4 +1,4 @@
-import { validateQuery, isValidQuery } from './validation';
+import { validateQuery } from './validation';
 
 describe('Monaco Query Validation', () => {
   test('Identifies empty queries as valid', () => {
@@ -97,45 +97,5 @@ logfmt fail
         startLineNumber: 5,
       },
     ]);
-  });
-});
-
-describe('isValidQuery()', () => {
-  test('Identifies empty queries as valid', () => {
-    expect(isValidQuery('')).toBe(true);
-  });
-
-  test('Identifies valid queries', () => {
-    expect(isValidQuery('{place="luna"}')).toBe(true);
-  });
-
-  test('Validates logs queries', () => {
-    expect(isValidQuery('{place="incomplete"')).toBe(false);
-    expect(isValidQuery('{place="luna"} | notaparser')).toBe(false);
-    expect(isValidQuery('{place="luna"} | logfmt |')).toBe(false);
-  });
-
-  test('Validates metric queries', () => {
-    expect(isValidQuery('sum(count_over_time({place="luna" | unwrap request_time [5m])) by (level)')).toBe(false);
-    expect(isValidQuery('sum(count_over_time({place="luna"} | unwrap [5m])) by (level)')).toBe(false);
-    expect(isValidQuery('sum()')).toBe(false);
-  });
-
-  test('Validates multi-line queries', () => {
-    let query = `
-{place="luna"} 
-# this is a comment 
-|
-logfmt
-|= "a"`;
-    expect(isValidQuery(query)).toBe(true);
-
-    query = `
-{place="luna"} 
-# this is a comment 
-|
-logfmt fail
-|= "a"`;
-    expect(isValidQuery(query)).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.test.ts
@@ -1,4 +1,4 @@
-import { validateQuery } from './validation';
+import { validateQuery, isValidQuery } from './validation';
 
 describe('Monaco Query Validation', () => {
   test('Identifies empty queries as valid', () => {
@@ -97,5 +97,45 @@ logfmt fail
         startLineNumber: 5,
       },
     ]);
+  });
+});
+
+describe('isValidQuery()', () => {
+  test('Identifies empty queries as valid', () => {
+    expect(isValidQuery('')).toBe(true);
+  });
+
+  test('Identifies valid queries', () => {
+    expect(isValidQuery('{place="luna"}')).toBe(true);
+  });
+
+  test('Validates logs queries', () => {
+    expect(isValidQuery('{place="incomplete"')).toBe(false);
+    expect(isValidQuery('{place="luna"} | notaparser')).toBe(false);
+    expect(isValidQuery('{place="luna"} | logfmt |')).toBe(false);
+  });
+
+  test('Validates metric queries', () => {
+    expect(isValidQuery('sum(count_over_time({place="luna" | unwrap request_time [5m])) by (level)')).toBe(false);
+    expect(isValidQuery('sum(count_over_time({place="luna"} | unwrap [5m])) by (level)')).toBe(false);
+    expect(isValidQuery('sum()')).toBe(false);
+  });
+
+  test('Validates multi-line queries', () => {
+    let query = `
+{place="luna"} 
+# this is a comment 
+|
+logfmt
+|= "a"`;
+    expect(isValidQuery(query)).toBe(true);
+
+    query = `
+{place="luna"} 
+# this is a comment 
+|
+logfmt fail
+|= "a"`;
+    expect(isValidQuery(query)).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
@@ -17,16 +17,6 @@ interface ParseError {
 }
 
 /**
- * Simplified version of `validateQuery` to determine if a given query is valid or not.
- * Grafana variables are errors to the parser, so it is ideal to call this function with the
- * interpolated query.
- * @alpha
- */
-export function isValidQuery(interpolatedQuery: string): boolean {
-  return validateQuery(interpolatedQuery, interpolatedQuery, interpolatedQuery.split('\\n')) === false ? true : false;
-}
-
-/**
  * Conceived to work in combination with the MonacoQueryField component.
  * Given an original query, and it's interpolated version, it will return an array of ParserErrorBoundary
  * objects containing nodes which are actual errors. The interpolated version (even with placeholder variables)

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
@@ -16,6 +16,10 @@ interface ParseError {
   node: SyntaxNode;
 }
 
+export function isValidQuery(query: string, interpolatedQuery: string, queryLines: string[]): boolean {
+  return validateQuery(query, interpolatedQuery, queryLines) === false ? true : false;
+}
+
 export function validateQuery(
   query: string,
   interpolatedQuery: string,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/validation.ts
@@ -16,10 +16,23 @@ interface ParseError {
   node: SyntaxNode;
 }
 
-export function isValidQuery(query: string, interpolatedQuery: string, queryLines: string[]): boolean {
-  return validateQuery(query, interpolatedQuery, queryLines) === false ? true : false;
+/**
+ * Simplified version of `validateQuery` to determine if a given query is valid or not.
+ * Grafana variables are errors to the parser, so it is ideal to call this function with the
+ * interpolated query.
+ * @alpha
+ */
+export function isValidQuery(interpolatedQuery: string): boolean {
+  return validateQuery(interpolatedQuery, interpolatedQuery, interpolatedQuery.split('\\n')) === false ? true : false;
 }
 
+/**
+ * Conceived to work in combination with the MonacoQueryField component.
+ * Given an original query, and it's interpolated version, it will return an array of ParserErrorBoundary
+ * objects containing nodes which are actual errors. The interpolated version (even with placeholder variables)
+ * is required because variables look like errors for Lezer.
+ * @internal
+ */
 export function validateQuery(
   query: string,
   interpolatedQuery: string,

--- a/public/app/plugins/datasource/loki/components/stats.test.ts
+++ b/public/app/plugins/datasource/loki/components/stats.test.ts
@@ -5,44 +5,43 @@ import { createLokiDatasource } from '../mocks';
 import { getStats, shouldUpdateStats } from './stats';
 
 describe('shouldUpdateStats', () => {
+  const timerange = getDefaultTimeRange();
   it('should return true if the query has changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="not-grafana"}';
-    const timerange = getDefaultTimeRange();
-    const prevTimerange = timerange;
-    expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(true);
+    expect(shouldUpdateStats(query, prevQuery, timerange, timerange)).toBe(true);
   });
 
   it('should return true if the timerange has changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="grafana"}';
-    const timerange = getDefaultTimeRange();
     timerange.raw.from = 'now-14h';
     const prevTimerange = getDefaultTimeRange();
     expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(true);
   });
 
-  it('should return false if the query and timerange have not changed', () => {
+  it('should return true if the previous query was undefined', () => {
     const query = '{job="grafana"}';
+    const prevQuery = undefined;
+    expect(shouldUpdateStats(query, prevQuery, timerange, timerange)).toBe(true);
+  });
+
+  it('should return true if the query really changed, otherwise false', () => {
     const prevQuery = '{job="grafana"}';
-    const timerange = getDefaultTimeRange();
-    const prevTimerange = timerange;
-    expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(false);
+    const query = `${prevQuery} `;
+    expect(shouldUpdateStats(query, prevQuery, timerange, timerange)).toBe(false);
   });
 
   it('should return false if the query and timerange have not changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="grafana"}';
-    const timerange = getDefaultTimeRange();
-    const prevTimerange = getDefaultTimeRange();
-    expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(false);
+    expect(shouldUpdateStats(query, prevQuery, timerange, timerange)).toBe(false);
   });
 
   it('should return false if the query and timerange with absolute and relative mixed have not changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="grafana"}';
     const now = dateTime(Date.now());
-    const timerange = getDefaultTimeRange();
     timerange.raw.from = now;
 
     const prevTimerange = getDefaultTimeRange();
@@ -73,6 +72,23 @@ describe('makeStatsRequest', () => {
   it('should return the stats if the response has data', () => {
     const query = '{job="grafana"}';
 
+    datasource.getQueryStats = jest
+      .fn()
+      .mockResolvedValue({ streams: 1, chunks: 12611, bytes: 12913664, entries: 78344 });
+    expect(getStats(datasource, query)).resolves.toEqual({
+      streams: 1,
+      chunks: 12611,
+      bytes: 12913664,
+      entries: 78344,
+    });
+  });
+
+  it('should support queries with variables', () => {
+    const query = 'count_over_time({job="grafana"}[$__interval])';
+
+    datasource.interpolateString = jest
+      .fn()
+      .mockImplementationOnce((value: string) => value.replace('$__interval', '1h'));
     datasource.getQueryStats = jest
       .fn()
       .mockResolvedValue({ streams: 1, chunks: 12611, bytes: 12913664, entries: 78344 });

--- a/public/app/plugins/datasource/loki/components/stats.ts
+++ b/public/app/plugins/datasource/loki/components/stats.ts
@@ -39,7 +39,7 @@ export function shouldUpdateStats(
   timerange: TimeRange,
   prevTimerange: TimeRange | undefined
 ): boolean {
-  if (query !== prevQuery) {
+  if (prevQuery === undefined || query.trim() !== prevQuery.trim()) {
     return true;
   }
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1204,6 +1204,25 @@ describe('LokiDatasource', () => {
       ds.getQueryStats('{foo="bar"}');
       expect(spy).toHaveBeenCalled();
     });
+
+    it('validates queries with variables', async () => {
+      const ds = createLokiDatasource(templateSrvStub);
+      ds.statsMetadataRequest = jest.fn().mockResolvedValue({ streams: 0, chunks: 0, bytes: 0, entries: 0 });
+
+      expect(ds.getQueryStats('rate({instance="server\\1"}[$__interval])')).resolves.toEqual({
+        streams: 0,
+        chunks: 0,
+        bytes: 0,
+        entries: 0,
+      });
+    });
+
+    // it('does not call stats if the query is invalid', () => {
+    //   const ds = createLokiDatasource(templateSrvStub);
+    //   const spy = jest.spyOn(ds, 'statsMetadataRequest');
+    //   ds.getQueryStats('rate({label="value"} [$__interval');
+    //   expect(spy).not.toHaveBeenCalled();
+    // });
   });
 
   describe('statsMetadataRequest', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -51,10 +51,7 @@ import { LiveStreams, LokiLiveTarget } from './LiveStreams';
 import { LogContextProvider } from './LogContextProvider';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
-import {
-  isValidQuery,
-  placeHolderScopedVars,
-} from './components/monaco-query-field/monaco-completion-provider/validation';
+import { placeHolderScopedVars } from './components/monaco-query-field/monaco-completion-provider/validation';
 import { escapeLabelValueInSelector, isRegexSelector } from './languageUtils';
 import { labelNamesRegex, labelValuesRegex } from './migrations/variableQueryMigrations';
 import {
@@ -455,7 +452,7 @@ export class LokiDatasource
 
   async getQueryStats(query: string): Promise<QueryStats | undefined> {
     // if query is invalid, clear stats, and don't request
-    if (!isValidQuery(this.interpolateString(query, placeHolderScopedVars))) {
+    if (isQueryWithError(this.interpolateString(query, placeHolderScopedVars))) {
       return undefined;
     }
 
@@ -574,7 +571,7 @@ export class LokiDatasource
 
   async getDataSamples(query: LokiQuery): Promise<DataFrame[]> {
     // Currently works only for logs sample
-    if (isQueryWithError(query.expr) || !isLogsQuery(query.expr)) {
+    if (!isLogsQuery(query.expr) || isQueryWithError(this.interpolateString(query.expr, placeHolderScopedVars))) {
       return [];
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -455,7 +455,7 @@ export class LokiDatasource
 
   async getQueryStats(query: string): Promise<QueryStats | undefined> {
     // if query is invalid, clear stats, and don't request
-    if (!isValidQuery(query, this.interpolateString(query, placeHolderScopedVars), [])) {
+    if (!isValidQuery(this.interpolateString(query, placeHolderScopedVars))) {
       return undefined;
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -51,6 +51,10 @@ import { LiveStreams, LokiLiveTarget } from './LiveStreams';
 import { LogContextProvider } from './LogContextProvider';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
+import {
+  placeHolderScopedVars,
+  validateQuery,
+} from './components/monaco-query-field/monaco-completion-provider/validation';
 import { escapeLabelValueInSelector, isRegexSelector } from './languageUtils';
 import { labelNamesRegex, labelValuesRegex } from './migrations/variableQueryMigrations';
 import {
@@ -451,7 +455,8 @@ export class LokiDatasource
 
   async getQueryStats(query: string): Promise<QueryStats | undefined> {
     // if query is invalid, clear stats, and don't request
-    if (!isValidQuery(query)) {
+    const errors = validateQuery(query, this.interpolateString(query, placeHolderScopedVars), []);
+    if (typeof errors === 'object') {
       return undefined;
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -52,8 +52,8 @@ import { LogContextProvider } from './LogContextProvider';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
 import {
+  isValidQuery,
   placeHolderScopedVars,
-  validateQuery,
 } from './components/monaco-query-field/monaco-completion-provider/validation';
 import { escapeLabelValueInSelector, isRegexSelector } from './languageUtils';
 import { labelNamesRegex, labelValuesRegex } from './migrations/variableQueryMigrations';
@@ -455,8 +455,7 @@ export class LokiDatasource
 
   async getQueryStats(query: string): Promise<QueryStats | undefined> {
     // if query is invalid, clear stats, and don't request
-    const errors = validateQuery(query, this.interpolateString(query, placeHolderScopedVars), []);
-    if (typeof errors === 'object') {
+    if (!isValidQuery(query, this.interpolateString(query, placeHolderScopedVars), [])) {
       return undefined;
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -80,7 +80,7 @@ import {
   getNormalizedLokiQuery,
   getStreamSelectorsFromQuery,
   isLogsQuery,
-  isValidQuery,
+  isQueryWithError,
   requestSupportsSplitting,
 } from './queryUtils';
 import { doLokiChannelStream } from './streaming';
@@ -575,7 +575,7 @@ export class LokiDatasource
 
   async getDataSamples(query: LokiQuery): Promise<DataFrame[]> {
     // Currently works only for logs sample
-    if (!isValidQuery(query.expr) || !isLogsQuery(query.expr)) {
+    if (isQueryWithError(query.expr) || !isLogsQuery(query.expr)) {
       return [];
     }
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -6,7 +6,7 @@ import {
   isLogsQuery,
   isQueryWithLabelFormat,
   isQueryWithParser,
-  isValidQuery,
+  isQueryWithError,
   parseToNodeNamesArray,
   getParserFromQuery,
   obfuscate,
@@ -188,12 +188,12 @@ describe('getLokiQueryType', () => {
   });
 });
 
-describe('isValidQuery', () => {
+describe('isQueryWithError', () => {
   it('returns false if invalid query', () => {
-    expect(isValidQuery('{job="grafana')).toBe(false);
+    expect(isQueryWithError('{job="grafana')).toBe(true);
   });
   it('returns true if valid query', () => {
-    expect(isValidQuery('{job="grafana"}')).toBe(true);
+    expect(isQueryWithError('{job="grafana"}')).toBe(false);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -176,8 +176,8 @@ export function getNodeFromQuery(query: string, nodeType: number): SyntaxNode | 
   return nodes.length > 0 ? nodes[0] : undefined;
 }
 
-export function isValidQuery(query: string): boolean {
-  return !isQueryWithNode(query, ErrorId);
+export function isQueryWithError(query: string): boolean {
+  return isQueryWithNode(query, ErrorId);
 }
 
 export function isLogsQuery(query: string): boolean {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -176,6 +176,11 @@ export function getNodeFromQuery(query: string, nodeType: number): SyntaxNode | 
   return nodes.length > 0 ? nodes[0] : undefined;
 }
 
+/**
+ * Parses the query and looks for error nodes. If there is at least one, it returns false.
+ * Grafana variables are considered errors, so if you need to validate a query
+ * with variables you should interpolate it first.
+ */
 export function isQueryWithError(query: string): boolean {
   return isQueryWithNode(query, ErrorId);
 }

--- a/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
@@ -5,6 +5,7 @@ import { Select } from '@grafana/ui';
 
 import { getOperationParamId } from '../../../prometheus/querybuilder/shared/operationUtils';
 import { QueryBuilderOperationParamEditorProps } from '../../../prometheus/querybuilder/shared/types';
+import { placeHolderScopedVars } from '../../components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiDatasource } from '../../datasource';
 import { getLogQueryFromMetricsQuery, isQueryWithError } from '../../queryUtils';
 import { extractUnwrapLabelKeysFromDataFrame } from '../../responseUtils';
@@ -56,7 +57,7 @@ async function loadUnwrapOptions(
 ): Promise<Array<SelectableValue<string>>> {
   const queryExpr = lokiQueryModeller.renderQuery(query);
   const logExpr = getLogQueryFromMetricsQuery(queryExpr);
-  if (isQueryWithError(logExpr)) {
+  if (isQueryWithError(datasource.interpolateString(logExpr, placeHolderScopedVars))) {
     return [];
   }
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
@@ -6,7 +6,7 @@ import { Select } from '@grafana/ui';
 import { getOperationParamId } from '../../../prometheus/querybuilder/shared/operationUtils';
 import { QueryBuilderOperationParamEditorProps } from '../../../prometheus/querybuilder/shared/types';
 import { LokiDatasource } from '../../datasource';
-import { getLogQueryFromMetricsQuery, isValidQuery } from '../../queryUtils';
+import { getLogQueryFromMetricsQuery, isQueryWithError } from '../../queryUtils';
 import { extractUnwrapLabelKeysFromDataFrame } from '../../responseUtils';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { LokiVisualQuery } from '../types';
@@ -56,7 +56,7 @@ async function loadUnwrapOptions(
 ): Promise<Array<SelectableValue<string>>> {
   const queryExpr = lokiQueryModeller.renderQuery(query);
   const logExpr = getLogQueryFromMetricsQuery(queryExpr);
-  if (!isValidQuery(logExpr)) {
+  if (isQueryWithError(logExpr)) {
     return [];
   }
 


### PR DESCRIPTION
**What is this feature?**
Uses a better validation function before requesting stats
- before stats where not requested if the query had any variables
- now stats are requested for queries with variables

Additional change:
- Trim queries before comparing, to prevent spamming stats endpoint.
- Added missing coverage for getQueryStats.

**Which issue(s) does this PR fix?**:
Fixes #70774