### PR TITLE
Tempo Service Map: Optionally group nodes also by service.namespace

### DIFF
--- a/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
@@ -36,6 +36,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   search?: string;
   /**
+   * Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+   */
+  serviceMapIncludeNamespace?: boolean;
+  /**
    * Filters to be included in a PromQL query to select data for the service graph. Example: {client="app",service="app"}
    */
   serviceMapQuery?: string;

--- a/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
@@ -36,7 +36,7 @@ export interface TempoQuery extends common.DataQuery {
    */
   search?: string;
   /**
-   * Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+   * Use service.namespace in addition to service.name to uniquely identify a service.
    */
   serviceMapIncludeNamespace?: boolean;
   /**

--- a/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
@@ -98,6 +98,9 @@ type TempoQuery struct {
 	// Logfmt query to filter traces by their tags. Example: http.status_code=200 error=true
 	Search *string `json:"search,omitempty"`
 
+	// Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+	ServiceMapIncludeNamespace *bool `json:"serviceMapIncludeNamespace,omitempty"`
+
 	// Filters to be included in a PromQL query to select data for the service graph. Example: {client="app",service="app"}
 	ServiceMapQuery *string `json:"serviceMapQuery,omitempty"`
 

--- a/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
@@ -98,7 +98,7 @@ type TempoQuery struct {
 	// Logfmt query to filter traces by their tags. Example: http.status_code=200 error=true
 	Search *string `json:"search,omitempty"`
 
-	// Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+	// Use service.namespace in addition to service.name to uniquely identify a service.
 	ServiceMapIncludeNamespace *bool `json:"serviceMapIncludeNamespace,omitempty"`
 
 	// Filters to be included in a PromQL query to select data for the service graph. Example: {client="app",service="app"}

--- a/public/app/plugins/datasource/tempo/dataquery.cue
+++ b/public/app/plugins/datasource/tempo/dataquery.cue
@@ -44,6 +44,8 @@ composableKinds: DataQuery: {
 					maxDuration?: string
 					// Filters to be included in a PromQL query to select data for the service graph. Example: {client="app",service="app"}
 					serviceMapQuery?: string
+					// Use service.namespace in addition to service.name to uniquely identify a service. 
+					serviceMapIncludeNamespace?: bool
 					// Defines the maximum number of traces that are returned from Tempo
 					limit?: int64
 					filters: [...#TraceqlFilter]

--- a/public/app/plugins/datasource/tempo/dataquery.gen.ts
+++ b/public/app/plugins/datasource/tempo/dataquery.gen.ts
@@ -33,7 +33,7 @@ export interface TempoQuery extends common.DataQuery {
    */
   search?: string;
   /**
-   * Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+   * Use service.namespace in addition to service.name to uniquely identify a service.
    */
   serviceMapIncludeNamespace?: boolean;
   /**

--- a/public/app/plugins/datasource/tempo/dataquery.gen.ts
+++ b/public/app/plugins/datasource/tempo/dataquery.gen.ts
@@ -33,6 +33,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   search?: string;
   /**
+   * Use (client|server)_service_namespace labels in addition to client|server to uniquely identify a service.
+   */
+  serviceMapIncludeNamespace?: boolean;
+  /**
    * Filters to be included in a PromQL query to select data for the service graph. Example: {client="app",service="app"}
    */
   serviceMapQuery?: string;

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -694,7 +694,7 @@ export function getFieldConfig(
     links: [
       makePromLink(
         'Request rate',
-        `sum by (client, server)(rate(${totalsMetric}{${sourceField}server="\${${targetField}}"}[$__rate_interval]))`,
+        `sum by (client, server)(rate(${totalsMetric}{${sourceField}server="\${${targetField}}"}[\\$__rate_interval]))`,
         datasourceUid,
         false
       ),
@@ -739,12 +739,14 @@ function makePromServiceMapRequest(options: DataQueryRequest<TempoQuery>): DataQ
   return {
     ...options,
     targets: serviceMapMetrics.map((metric) => {
+      const { serviceMapQuery, serviceMapIncludeNamespace: serviceMapIncludeNamespace } = options.targets[0];
+      const extraSumByFields = serviceMapIncludeNamespace ? ', client_service_namespace, server_service_namespace' : '';
       return {
         format: 'table',
         refId: metric,
         // options.targets[0] is not correct here, but not sure what should happen if you have multiple queries for
         // service map at the same time anyway
-        expr: `sum by (client, server) (rate(${metric}${options.targets[0].serviceMapQuery || ''}[$__range]))`,
+        expr: `sum by (client, server${extraSumByFields}) (rate(${metric}${serviceMapQuery || ''}[$__range]))`,
         instant: true,
       };
     }),

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -694,7 +694,7 @@ export function getFieldConfig(
     links: [
       makePromLink(
         'Request rate',
-        `sum by (client, server)(rate(${totalsMetric}{${sourceField}server="\${${targetField}}"}[\\$__rate_interval]))`,
+        `sum by (client, server)(rate(${totalsMetric}{${sourceField}server="\${${targetField}}"}[$__rate_interval]))`,
         datasourceUid,
         false
       ),

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -173,7 +173,7 @@ export function mapPromMetricsToServiceMap(
   const frames = getMetricFrames(responses);
 
   // First just collect data from the metrics into a map with nodes and edges as keys
-  const nodesMap: Record<string, ServiceMapStatistics> = {};
+  const nodesMap: Record<string, NodeObject> = {};
   const edgesMap: Record<string, EdgeObject> = {};
   // At this moment we don't have any error/success or other counts so we just use these 2
   collectMetricData(frames[totalsMetric], 'total', totalsMetric, nodesMap, edgesMap);
@@ -191,6 +191,7 @@ function createServiceMapDataFrames() {
   const nodes = createDF('Nodes', [
     { name: Fields.id, type: FieldType.string },
     { name: Fields.title, type: FieldType.string, config: { displayName: 'Service name' } },
+    { name: Fields.subTitle, type: FieldType.string, config: { displayName: 'Service namespace' } },
     { name: Fields.mainStat, type: FieldType.number, config: { unit: 'ms/r', displayName: 'Average response time' } },
     {
       name: Fields.secondaryStat,
@@ -241,6 +242,11 @@ type ServiceMapStatistics = {
   failed?: number;
 };
 
+type NodeObject = ServiceMapStatistics & {
+  name: string;
+  namespace?: string;
+};
+
 type EdgeObject = ServiceMapStatistics & {
   source: string;
   target: string;
@@ -261,7 +267,7 @@ function collectMetricData(
   frame: DataFrameView | undefined,
   stat: keyof ServiceMapStatistics,
   metric: string,
-  nodesMap: Record<string, ServiceMapStatistics>,
+  nodesMap: Record<string, NodeObject>,
   edgesMap: Record<string, EdgeObject>
 ) {
   if (!frame) {
@@ -274,13 +280,16 @@ function collectMetricData(
 
   for (let i = 0; i < frame.length; i++) {
     const row = frame.get(i);
-    const edgeId = `${row.client}_${row.server}`;
+    const serverId = row.server_service_namespace ? `${row.server_service_namespace}/${row.server}` : row.server;
+    const clientId = row.client_service_namespace ? `${row.client_service_namespace}/${row.client}` : row.client;
+
+    const edgeId = `${clientId}_${serverId}`;
 
     if (!edgesMap[edgeId]) {
       // Create edge as it does not exist yet
       edgesMap[edgeId] = {
-        target: row.server,
-        source: row.client,
+        target: serverId,
+        source: clientId,
         [stat]: row[valueName],
       };
     } else {
@@ -290,20 +299,24 @@ function collectMetricData(
       edgesMap[edgeId][stat] = (edgesMap[edgeId][stat] || 0) + row[valueName];
     }
 
-    if (!nodesMap[row.server]) {
+    if (!nodesMap[serverId]) {
       // Create node for server
-      nodesMap[row.server] = {
+      nodesMap[serverId] = {
+        name: row.server,
+        namespace: row.server_service_namespace,
         [stat]: row[valueName],
       };
     } else {
       // Add stat to server node. Sum up values if there are multiple edges targeting this server node.
-      nodesMap[row.server][stat] = (nodesMap[row.server][stat] || 0) + row[valueName];
+      nodesMap[serverId][stat] = (nodesMap[serverId][stat] || 0) + row[valueName];
     }
 
-    if (!nodesMap[row.client]) {
+    if (!nodesMap[clientId]) {
       // Create the client node but don't add the stat as edge stats are attributed to the server node. This means for
       // example that the number of requests in a node show how many requests it handled not how many it generated.
-      nodesMap[row.client] = {
+      nodesMap[clientId] = {
+        name: row.client,
+        namespace: row.client_service_namespace,
         [stat]: 0,
       };
     }
@@ -311,7 +324,7 @@ function collectMetricData(
 }
 
 function convertToDataFrames(
-  nodesMap: Record<string, ServiceMapStatistics>,
+  nodesMap: Record<string, NodeObject>,
   edgesMap: Record<string, EdgeObject>,
   range: TimeRange
 ): { nodes: DataFrame; edges: DataFrame } {
@@ -320,7 +333,8 @@ function convertToDataFrames(
     const node = nodesMap[nodeId];
     nodes.add({
       [Fields.id]: nodeId,
-      [Fields.title]: nodeId,
+      [Fields.title]: node.name,
+      [Fields.subTitle]: node.namespace,
       // NaN will not be shown in the node graph. This happens for a root client node which did not process
       // any requests itself.
       [Fields.mainStat]: node.total ? (node.seconds! / node.total) * 1000 : Number.NaN, // Average response time

--- a/public/app/plugins/panel/nodeGraph/Node.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.tsx
@@ -41,7 +41,7 @@ const getStyles = (theme: GrafanaTheme2, hovering: HoverState) => ({
     overflow: hidden;
     white-space: nowrap;
     background-color: ${tinycolor(theme.colors.background.primary).setAlpha(0.6).toHex8String()};
-    width: 100px;
+    width: 140px;
   `,
 
   statsText: css`
@@ -90,9 +90,9 @@ export const Node = memo(function Node(props: {
       <g className={styles.text} style={{ pointerEvents: 'none' }}>
         <NodeContents node={node} hovering={hovering} />
         <foreignObject
-          x={node.x - (isHovered ? 100 : 50)}
+          x={node.x - (isHovered ? 100 : 70)}
           y={node.y + nodeR + 5}
-          width={isHovered ? '200' : '100'}
+          width={isHovered ? '200' : '140'}
           height="40"
         >
           <div className={cx(styles.titleText, isHovered && styles.textHovering)}>


### PR DESCRIPTION
This PR adds `serviceMapIncludeNamespace` option to tempo query. If toggled, Tempo service map will uniquely identify nodes by `service.namespace` in addition to `service.name`, adding the namespace as subtitle in node graph. This feature is needed for application observability, where we will uniquely id services by both service name and namespace.

Also: bumps node title width to 140px. Experimenting with real data we see that 100px is too short for many real world names. Don't feel strongly about it though

![image](https://github.com/grafana/grafana/assets/847684/1b99522e-e15d-4c81-8249-f853efd32169)

!!! This PR does not yet update prometheus links: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/tempo/datasource.ts#L695
Currently they are not rendered because they include `$__rate_interval`, which is treated as missing variable and thus link is omitted. Bug issue https://github.com/grafana/grafana/issues/70809