### PR TITLE
Dashboard: Fix end time precision in date range by adding milliseconds 

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -469,3 +469,14 @@ export function relativeToTimeRange(relativeTimeRange: RelativeTimeRange, now: D
     raw: { from, to },
   };
 }
+
+/**
+ * Add 999 milliseconds to dateTime
+ */
+export const adjustDateTimeToMaxMillis = (datetime: DateTime): string => {
+  const millis = datetime.valueOf().toString().slice(-3);
+  if (millis === '000') {
+    return (datetime.valueOf() + 999).valueOf().toString();
+  }
+  return datetime.valueOf().toString();
+};

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -54,6 +54,11 @@ export class DashNavTimeControls extends Component<Props> {
     const hasDelay = panel.nowDelay && timeRange.raw.to === 'now';
 
     const adjustedFrom = dateMath.isMathString(timeRange.raw.from) ? timeRange.raw.from : timeRange.from;
+
+    if (!dateMath.isMathString(timeRange.raw.to)) {
+      timeRange.to.add(999, 'milliseconds');
+    }
+
     const adjustedTo = dateMath.isMathString(timeRange.raw.to) ? timeRange.raw.to : timeRange.to;
     const nextRange = {
       from: adjustedFrom,

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -334,7 +334,7 @@ export class TimeSrv {
       range.from = range.from.valueOf().toString();
     }
     if (isDateTime(range.to)) {
-      range.to = range.to.valueOf().toString();
+      range.to = rangeUtil.adjustDateTimeToMaxMillis(range.to);
     }
 
     return range;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update adjusts the precision of date-time values in Grafana's date range feature. It modifies the `to` dateTime in ranges by adding 999 milliseconds, ensuring that the end time includes the very last part of the given second.

**Why do we need this feature?**

Previously, Grafana's date range could lack precision, as the `to` datetime might not include the final millisecond of the given second. This could potentially lead to incorrect data representations or calculations, particularly in situations where precision at the level of milliseconds is essential. This update enhances date-time precision, improving the accuracy and reliability of Grafana's data visualization and analysis.

**Who is this feature for?**

This feature is for Grafana users who require high-precision date-time values in their data ranges, such as data analysts, data scientists, and developers working with real-time or high-frequency data.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
