### PR TITLE
[v8.5.x] CI: Ignore .pr-body.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ public/locales/**/*.js
 
 deployment_tools_config.json
 
+# Temporary file for backporting PRs
+.pr-body.txt


### PR DESCRIPTION
Backport 2b10d31bac4b3ad018ea9d207b06fdf52e11a173 from #70798

---

This file is used during the backporting process but should never be committed.