### PR TITLE
Nested folders: Unify visual styles between tree + search view

### DIFF
--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -38,8 +38,8 @@ interface DashboardsTreeProps {
   requestLoadMore: (folderUid: string | undefined) => void;
 }
 
-const HEADER_HEIGHT = 35;
-const ROW_HEIGHT = 35;
+const HEADER_HEIGHT = 36;
+const ROW_HEIGHT = 36;
 
 export function DashboardsTree({
   items,

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -5,7 +5,6 @@ import { Button, Card } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
 import { SearchResultsProps, SearchResultsTable } from 'app/features/search/page/components/SearchResultsTable';
-import { LOADING_ID } from 'app/features/search/page/components/columns';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { DashboardViewItemKind } from 'app/features/search/types';
 import { useDispatch, useSelector } from 'app/types';
@@ -23,7 +22,7 @@ const loadingView = {
     toDataFrame({
       fields: [
         { name: 'uid', display: true, values: Array(50).fill(null) },
-        { name: 'name', display: true, values: Array(50).fill(LOADING_ID) },
+        { name: 'name', display: true, values: Array(50).fill('') },
         { name: 'tags', display: true, values: Array(50).fill([]) },
       ],
       meta: {
@@ -34,7 +33,7 @@ const loadingView = {
     })
   ),
   loadMoreItems: () => Promise.resolve(),
-  isItemLoaded: () => true,
+  isItemLoaded: () => false,
   totalRows: 50,
 };
 

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -24,8 +24,13 @@ const loadingView = {
       fields: [
         { name: 'uid', display: true, values: Array(50).fill(null) },
         { name: 'name', display: true, values: Array(50).fill(LOADING_ID) },
-        { name: 'tags', display: false, values: Array(50).fill(null) },
+        { name: 'tags', display: true, values: Array(50).fill([]) },
       ],
+      meta: {
+        custom: {
+          locationInfo: [],
+        },
+      },
     })
   ),
   loadMoreItems: () => Promise.resolve(),

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -18,12 +18,14 @@ interface SearchViewProps {
 }
 
 const NUM_PLACEHOLDER_ROWS = 50;
-const loadingView = {
+const initialLoadingView = {
   view: new DataFrameView(
     toDataFrame({
       fields: [
         { name: 'uid', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill(null) },
+        { name: 'kind', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill('dashboard') },
         { name: 'name', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill('') },
+        { name: 'location', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill('') },
         { name: 'tags', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill([]) },
       ],
       meta: {
@@ -47,7 +49,7 @@ export function SearchView({ width, height, canSelect }: SearchViewProps) {
   const { keyboardEvents } = useKeyNavigationListener();
   const [searchState, stateManager] = useSearchStateManager();
 
-  const value = searchState.result ?? loadingView;
+  const value = searchState.result ?? initialLoadingView;
 
   const selectionChecker = useCallback(
     (kind: string | undefined, uid: string): boolean => {

--- a/public/app/features/browse-dashboards/components/SearchView.tsx
+++ b/public/app/features/browse-dashboards/components/SearchView.tsx
@@ -17,13 +17,14 @@ interface SearchViewProps {
   canSelect: boolean;
 }
 
+const NUM_PLACEHOLDER_ROWS = 50;
 const loadingView = {
   view: new DataFrameView(
     toDataFrame({
       fields: [
-        { name: 'uid', display: true, values: Array(50).fill(null) },
-        { name: 'name', display: true, values: Array(50).fill('') },
-        { name: 'tags', display: true, values: Array(50).fill([]) },
+        { name: 'uid', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill(null) },
+        { name: 'name', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill('') },
+        { name: 'tags', display: true, values: Array(NUM_PLACEHOLDER_ROWS).fill([]) },
       ],
       meta: {
         custom: {
@@ -33,8 +34,9 @@ const loadingView = {
     })
   ),
   loadMoreItems: () => Promise.resolve(),
+  // this is key and controls whether to show the skeleton in generateColumns
   isItemLoaded: () => false,
-  totalRows: 50,
+  totalRows: NUM_PLACEHOLDER_ROWS,
 };
 
 export function SearchView({ width, height, canSelect }: SearchViewProps) {

--- a/public/app/features/search/page/components/SearchResultsTable.test.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.test.tsx
@@ -43,7 +43,7 @@ describe('SearchResultsTable', () => {
     });
 
     const mockSearchResult: QueryResponse = {
-      isItemLoaded: jest.fn(),
+      isItemLoaded: jest.fn().mockReturnValue(true),
       loadMoreItems: jest.fn(),
       totalRows: searchData.length,
       view: new DataFrameView<DashboardQueryResult>(dataFrames[0]),

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable react/jsx-no-undef */
 import { css } from '@emotion/css';
 import React, { useEffect, useMemo, useRef, useCallback, useState, CSSProperties } from 'react';
-import { useTable, Column, TableOptions, Cell, useAbsoluteLayout } from 'react-table';
+import { useTable, Column, TableOptions, Cell } from 'react-table';
 import { FixedSizeList } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
 import { Observable } from 'rxjs';
@@ -11,6 +10,7 @@ import { TableCellHeight } from '@grafana/schema';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 import { TableCell } from '@grafana/ui/src/components/Table/TableCell';
 import { useTableStyles } from '@grafana/ui/src/components/Table/styles';
+import { useCustomFlexLayout } from 'app/features/browse-dashboards/components/customFlexTableLayout';
 
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
 import { QueryResponse } from '../../service';
@@ -35,7 +35,7 @@ export type TableColumn = Column & {
   field?: Field;
 };
 
-const HEADER_HEIGHT = 36; // pixels
+const ROW_HEIGHT = 36; // pixels
 
 export const SearchResultsTable = React.memo(
   ({
@@ -101,7 +101,7 @@ export const SearchResultsTable = React.memo(
       [memoizedColumns, memoizedData]
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable(options, useAbsoluteLayout);
+    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = useTable(options, useCustomFlexLayout);
 
     const handleLoadMore = useCallback(
       async (startIndex: number, endIndex: number) => {
@@ -162,24 +162,24 @@ export const SearchResultsTable = React.memo(
 
     return (
       <div {...getTableProps()} aria-label="Search results table" role="table">
-        <div>
-          {headerGroups.map((headerGroup) => {
-            const { key, ...headerGroupProps } = headerGroup.getHeaderGroupProps();
+        {headerGroups.map((headerGroup) => {
+          const { key, ...headerGroupProps } = headerGroup.getHeaderGroupProps({
+            style: { width },
+          });
 
-            return (
-              <div key={key} {...headerGroupProps} className={styles.headerRow}>
-                {headerGroup.headers.map((column) => {
-                  const { key, ...headerProps } = column.getHeaderProps();
-                  return (
-                    <div key={key} {...headerProps} role="columnheader" className={styles.headerCell}>
-                      {column.render('Header')}
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })}
-        </div>
+          return (
+            <div key={key} {...headerGroupProps} className={styles.headerRow}>
+              {headerGroup.headers.map((column) => {
+                const { key, ...headerProps } = column.getHeaderProps();
+                return (
+                  <div key={key} {...headerProps} role="columnheader" className={styles.headerCell}>
+                    {column.render('Header')}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
 
         <div {...getTableBodyProps()}>
           <InfiniteLoader
@@ -195,10 +195,10 @@ export const SearchResultsTable = React.memo(
                   setListEl(innerRef);
                 }}
                 onItemsRendered={onItemsRendered}
-                height={height - HEADER_HEIGHT}
+                height={height - ROW_HEIGHT}
                 itemCount={rows.length}
                 itemSize={tableStyles.rowHeight}
-                width="100%"
+                width={width}
                 style={{ overflow: 'hidden auto' }}
               >
                 {RenderRow}
@@ -224,18 +224,24 @@ const getStyles = (theme: GrafanaTheme2) => {
       height: 100%;
     `,
     headerCell: css`
+      align-items: center;
+      display: flex;
       padding: ${theme.spacing(1)};
     `,
     headerRow: css`
       background-color: ${theme.colors.background.secondary};
-      height: ${HEADER_HEIGHT}px;
-      align-items: center;
+      display: flex;
+      gap: ${theme.spacing(1)};
+      height: ${ROW_HEIGHT}px;
     `,
     selectedRow: css`
       background-color: ${rowHoverBg};
       box-shadow: inset 3px 0px ${theme.colors.primary.border};
     `,
     rowContainer: css`
+      display: flex;
+      gap: ${theme.spacing(1)};
+      height: ${ROW_HEIGHT}px;
       label: row;
       &:hover {
         background-color: ${rowHoverBg};
@@ -253,27 +259,22 @@ const getStyles = (theme: GrafanaTheme2) => {
 // CSS for columns from react table
 const getColumnStyles = (theme: GrafanaTheme2) => {
   return {
+    cell: css({
+      padding: theme.spacing(1),
+      overflow: 'hidden', // Required so flex children can do text-overflow: ellipsis
+      display: 'flex',
+      alignItems: 'center',
+    }),
     nameCellStyle: css`
-      border-right: none;
-      padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(2)};
       overflow: hidden;
       text-overflow: ellipsis;
       user-select: text;
       white-space: nowrap;
-      &:hover {
-        box-shadow: none;
-      }
     `,
-    headerNameStyle: css`
-      padding-left: ${theme.spacing(1)};
-    `,
-
+    typeCell: css({
+      gap: theme.spacing(0.5),
+    }),
     typeIcon: css`
-      margin-left: 5px;
-      margin-right: 9.5px;
-      vertical-align: middle;
-      display: inline-block;
-      margin-bottom: ${theme.v1.spacing.xxs};
       fill: ${theme.colors.text.secondary};
     `,
     datasourceItem: css`
@@ -291,13 +292,12 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       color: ${theme.colors.error.main};
       text-decoration: line-through;
     `,
-    typeText: css`
-      color: ${theme.colors.text.secondary};
-      padding-top: ${theme.spacing(1)};
-    `,
     locationItem: css`
+      align-items: center;
       color: ${theme.colors.text.secondary};
-      margin-right: 12px;
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 4px;
     `,
     sortedHeader: css`
       text-align: right;
@@ -312,20 +312,7 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(1)} ${theme.spacing(1)};
       cursor: pointer;
     `,
-    locationCellStyle: css`
-      padding-top: ${theme.spacing(1)};
-      padding-right: ${theme.spacing(1)};
-    `,
-    checkboxHeader: css`
-      margin-left: 2px;
-    `,
-    checkbox: css`
-      margin-left: 10px;
-      margin-right: 10px;
-      margin-top: 5px;
-    `,
     tagList: css`
-      padding-top: ${theme.spacing(0.5)};
       justify-content: flex-start;
       flex-wrap: nowrap;
     `,

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -226,6 +226,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     headerCell: css`
       align-items: center;
       display: flex;
+      overflo: hidden;
       padding: ${theme.spacing(1)};
     `,
     headerRow: css`
@@ -292,24 +293,21 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       color: ${theme.colors.error.main};
       text-decoration: line-through;
     `,
+    locationContainer: css({
+      display: 'flex',
+      flexWrap: 'nowrap',
+      gap: theme.spacing(1),
+      overflow: 'hidden',
+    }),
     locationItem: css`
       align-items: center;
       color: ${theme.colors.text.secondary};
       display: flex;
       flex-wrap: nowrap;
       gap: 4px;
-    `,
-    sortedHeader: css`
-      text-align: right;
-      padding-right: ${theme.spacing(2)};
-    `,
-    sortedItems: css`
-      text-align: right;
-      padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(1)} ${theme.spacing(1)};
+      overflow: hidden;
     `,
     explainItem: css`
-      text-align: right;
-      padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(1)} ${theme.spacing(1)};
       cursor: pointer;
     `,
     tagList: css`

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -71,10 +71,13 @@ export const generateColumns = (
             onChange={(e) => {
               const { view } = response;
               const count = Math.min(view.length, 50);
+              const hasSelection = selection('*', '*');
               for (let i = 0; i < count; i++) {
                 const item = view.get(i);
                 if (item.uid && item.kind) {
-                  selectionToggle(item.kind, item.uid);
+                  if (hasSelection === selection(item.kind, item.uid)) {
+                    selectionToggle(item.kind, item.uid);
+                  }
                 }
               }
             }}

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -26,7 +26,6 @@ import { TableColumn } from './SearchResultsTable';
 
 const TYPE_COLUMN_WIDTH = 175;
 const DATASOURCE_COLUMN_WIDTH = 200;
-export const LOADING_ID = '__loading-placeholder';
 
 export const generateColumns = (
   response: QueryResponse,
@@ -117,7 +116,7 @@ export const generateColumns = (
       }
       return (
         <div className={styles.cell} {...p.cellProps}>
-          {name === LOADING_ID ? (
+          {!response.isItemLoaded(p.row.index) ? (
             <Skeleton width={200} />
           ) : (
             <a href={p.userProps.href} onClick={p.userProps.onClick} className={classNames} title={name}>

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -1,5 +1,6 @@
 import { cx } from '@emotion/css';
 import React from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import {
   DisplayProcessor,
@@ -25,6 +26,7 @@ import { TableColumn } from './SearchResultsTable';
 
 const TYPE_COLUMN_WIDTH = 175;
 const DATASOURCE_COLUMN_WIDTH = 200;
+export const LOADING_ID = '__loading-placeholder';
 
 export const generateColumns = (
   response: QueryResponse,
@@ -115,9 +117,13 @@ export const generateColumns = (
       }
       return (
         <div className={styles.cell} {...p.cellProps}>
-          <a href={p.userProps.href} onClick={p.userProps.onClick} className={classNames} title={name}>
-            {name}
-          </a>
+          {name === LOADING_ID ? (
+            <Skeleton width={200} />
+          ) : (
+            <a href={p.userProps.href} onClick={p.userProps.onClick} className={classNames} title={name}>
+              {name}
+            </a>
+          )}
         </div>
       );
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- **IMPORTANT NOTE**: this is not feature toggled so will modify the old search view as well.
- unifies the table styling between the browse tree view and the browse search view
  - adjusts row height of tree view from 35 to 36 to match search view
  - removes lots of custom cell padding in favour of the more universal flex/cell styling in tree view
  - adds skeleton loading rows to replace spinner when first opening search view
  - adds skeleton loading rows when scrolling the search view
    - this only really affects searchV2 for now since that's the one that's paginated
  - replaces the janky select all checkbox with the indeterminate checkbox
    - this is **almost** exactly the same behaviour as in tree view.
    - **HOWEVER** there is one difference! there is no way to tell if **everything** is selected currently, so in this case it will show an indeterminate checkbox instead of fully selected.
    - we can maybe fix this in a follow up PR? either way, i think this is significantly better than the old checkbox (which had the opposite problem of showing everything selected when it was not) 😅 
    
# before (note the checkbox icon having to load 🤮 )

https://github.com/grafana/grafana/assets/20999846/766847f5-eff9-4e0c-8aa5-4a65810988b1

# after

https://github.com/grafana/grafana/assets/20999846/cccc824a-204c-4e80-8672-bbd9f9fa4e71

**Why do we need this feature?**

- better UX

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
