### PR TITLE
Alerting: Render folder selector in options for Alert List Panel only when having Grafana datasource

### DIFF
--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -11,6 +11,8 @@ import {
 } from 'app/core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker';
 import { PermissionLevelString } from 'app/types';
 
+import { GRAFANA_DATASOURCE_NAME } from '../../../features/alerting/unified/utils/datasource';
+
 import { AlertList } from './AlertList';
 import { alertListPanelMigrationHandler } from './AlertListMigrationHandler';
 import { GroupBy } from './GroupByWithLoading';
@@ -244,6 +246,27 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       category: ['Filter'],
     })
     .addCustomEditor({
+      path: 'datasource',
+      name: 'Datasource',
+      description: 'Filter alerts from selected datasource',
+      id: 'datasource',
+      defaultValue: null,
+      editor: function RenderDatasourcePicker(props) {
+        return (
+          <DataSourcePicker
+            {...props}
+            type={['prometheus', 'loki', 'grafana']}
+            noDefault
+            current={props.value}
+            onChange={(ds) => props.onChange(ds.name)}
+            onClear={() => props.onChange(null)}
+          />
+        );
+      },
+      category: ['Filter'],
+    })
+    .addCustomEditor({
+      showIf: (options) => options.datasource === GRAFANA_DATASOURCE_NAME || !Boolean(options.datasource),
       path: 'folder',
       name: 'Folder',
       description: 'Filter for alerts in the selected folder (only for Grafana alerts)',
@@ -260,26 +283,6 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
             permissionLevel={PermissionLevelString.View}
             onClear={() => props.onChange('')}
             {...props}
-          />
-        );
-      },
-      category: ['Filter'],
-    })
-    .addCustomEditor({
-      path: 'datasource',
-      name: 'Datasource',
-      description: 'Filter alerts from selected datasource',
-      id: 'datasource',
-      defaultValue: null,
-      editor: function RenderDatasourcePicker(props) {
-        return (
-          <DataSourcePicker
-            {...props}
-            type={['prometheus', 'loki', 'grafana']}
-            noDefault
-            current={props.value}
-            onChange={(ds) => props.onChange(ds.name)}
-            onClear={() => props.onChange(null)}
           />
         );
       },


### PR DESCRIPTION
**What is this feature?**

This PR modifies the alert list panel to render the folder selector in the options section only when either no datasource is selected or "Grafana" is chosen as the datasource. 

Additional this PR makes a small change to the order in which the folder and datasource are displayed.It swaps their positions to improve the user experience.

**Why do we need this feature?**

This change improves the user experience by providing the folder selector specifically for these scenarios, ensuring relevant options are displayed.

**Who is this feature for?**

All users

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/33540275/d5466b97-79ed-48a3-ae05-48555fad3e11



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
