### PR TITLE
logs: refactor tests to make them smaller

### DIFF
--- a/public/app/core/logsModel_parse.test.ts
+++ b/public/app/core/logsModel_parse.test.ts
@@ -123,244 +123,103 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
       },
     ];
 
-    expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`
-      {
-        "hasUniqueLabels": true,
-        "meta": [
-          {
-            "kind": 2,
-            "label": "Common labels",
-            "value": {
-              "label": "val3",
-            },
+    const expected = {
+      hasUniqueLabels: true,
+      meta: [
+        {
+          kind: 2,
+          label: 'Common labels',
+          value: {
+            label: 'val3',
           },
-        ],
-        "rows": [
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {
-                    "displayName": "Time",
-                  },
-                  "name": "ts",
-                  "type": "time",
-                  "values": [
-                    "2023-06-07T12:18:36.839Z",
-                  ],
-                },
-                {
-                  "config": {},
-                  "labels": {
-                    "counter": "34543",
-                    "label": "val3",
-                    "level": "info",
-                  },
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                  ],
-                },
-                {
-                  "config": {
-                    "displayName": "Time ns",
-                  },
-                  "name": "tsNs",
-                  "type": "time",
-                  "values": [
-                    "1686140316839544212",
-                  ],
-                },
-              ],
-              "length": 1,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line1",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "34543",
-              "label": "val3",
-              "level": "info",
-            },
-            "logLevel": "info",
-            "raw": "line1",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686140316839,
-            "timeEpochNs": "1686140316839544212",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:18:36-06:00",
-            "timeLocal": "2023-06-07 06:18:36",
-            "timeUtc": "2023-06-07 12:18:36",
-            "uid": "A_id1",
-            "uniqueLabels": {
-              "counter": "34543",
-              "level": "info",
-            },
+        },
+      ],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '34543',
+            label: 'val3',
+            level: 'info',
           },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {
-                    "displayName": "Time",
-                  },
-                  "name": "ts",
-                  "type": "time",
-                  "values": [
-                    "2023-06-07T12:18:34.632Z",
-                  ],
-                },
-                {
-                  "config": {},
-                  "labels": {
-                    "counter": "34540",
-                    "label": "val3",
-                    "level": "error",
-                  },
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line2",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id2",
-                  ],
-                },
-                {
-                  "config": {
-                    "displayName": "Time ns",
-                  },
-                  "name": "tsNs",
-                  "type": "time",
-                  "values": [
-                    "1686140314632163066",
-                  ],
-                },
-              ],
-              "length": 1,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line2",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "34540",
-              "label": "val3",
-              "level": "error",
-            },
-            "logLevel": "error",
-            "raw": "line2",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686140314632,
-            "timeEpochNs": "1686140314632163066",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:18:34-06:00",
-            "timeLocal": "2023-06-07 06:18:34",
-            "timeUtc": "2023-06-07 12:18:34",
-            "uid": "A_id2",
-            "uniqueLabels": {
-              "counter": "34540",
-              "level": "error",
-            },
+          logLevel: 'info',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686140316839,
+          timeEpochNs: '1686140316839544212',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:18:36-06:00',
+          timeLocal: '2023-06-07 06:18:36',
+          timeUtc: '2023-06-07 12:18:36',
+          uid: 'A_id1',
+          uniqueLabels: {
+            counter: '34543',
+            level: 'info',
           },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {
-                    "displayName": "Time",
-                  },
-                  "name": "ts",
-                  "type": "time",
-                  "values": [
-                    "2023-06-07T12:18:35.565Z",
-                  ],
-                },
-                {
-                  "config": {},
-                  "labels": {
-                    "counter": "34541",
-                    "label": "val3",
-                    "level": "error",
-                  },
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id3",
-                  ],
-                },
-                {
-                  "config": {
-                    "displayName": "Time ns",
-                  },
-                  "name": "tsNs",
-                  "type": "time",
-                  "values": [
-                    "1686140315565682856",
-                  ],
-                },
-              ],
-              "length": 1,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line3",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "34541",
-              "label": "val3",
-              "level": "error",
-            },
-            "logLevel": "error",
-            "raw": "line3",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686140315565,
-            "timeEpochNs": "1686140315565682856",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:18:35-06:00",
-            "timeLocal": "2023-06-07 06:18:35",
-            "timeUtc": "2023-06-07 12:18:35",
-            "uid": "A_id3",
-            "uniqueLabels": {
-              "counter": "34541",
-              "level": "error",
-            },
+        },
+        {
+          dataFrame: frames[1],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '34540',
+            label: 'val3',
+            level: 'error',
           },
-        ],
-      }
-    `);
+          logLevel: 'error',
+          raw: 'line2',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686140314632,
+          timeEpochNs: '1686140314632163066',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:18:34-06:00',
+          timeLocal: '2023-06-07 06:18:34',
+          timeUtc: '2023-06-07 12:18:34',
+          uid: 'A_id2',
+          uniqueLabels: {
+            counter: '34540',
+            level: 'error',
+          },
+        },
+        {
+          dataFrame: frames[2],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '34541',
+            label: 'val3',
+            level: 'error',
+          },
+          logLevel: 'error',
+          raw: 'line3',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686140315565,
+          timeEpochNs: '1686140315565682856',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:18:35-06:00',
+          timeLocal: '2023-06-07 06:18:35',
+          timeUtc: '2023-06-07 12:18:35',
+          uid: 'A_id3',
+          uniqueLabels: {
+            counter: '34541',
+            level: 'error',
+          },
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 
   it('should parse a Loki-style frame (single-frame, labels-in-json)', () => {
@@ -425,329 +284,98 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
       },
     ];
 
-    expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`
-      {
-        "hasUniqueLabels": true,
-        "meta": [],
-        "rows": [
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "labels",
-                  "type": "other",
-                  "values": [
-                    {
-                      "counter": "38141",
-                      "label": "val2",
-                      "level": "warning",
-                    },
-                    {
-                      "counter": "38143",
-                      "label": "val2",
-                      "level": "info",
-                    },
-                    {
-                      "counter": "38142",
-                      "label": "val3",
-                      "level": "info",
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Time",
-                  "nanos": [
-                    641000,
-                    0,
-                    0,
-                  ],
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997000000",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {
-                "custom": {
-                  "frameType": "LabeledTimeValues",
-                },
-              },
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line1",
-            "entryFieldIndex": 2,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "38141",
-              "label": "val2",
-              "level": "warning",
-            },
-            "logLevel": "warning",
-            "raw": "line1",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686142519756,
-            "timeEpochNs": "1686142519756641000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_id1",
-            "uniqueLabels": {
-              "counter": "38141",
-              "label": "val2",
-              "level": "warning",
-            },
+    const expected = {
+      hasUniqueLabels: true,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 2,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38141',
+            label: 'val2',
+            level: 'warning',
           },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "labels",
-                  "type": "other",
-                  "values": [
-                    {
-                      "counter": "38141",
-                      "label": "val2",
-                      "level": "warning",
-                    },
-                    {
-                      "counter": "38143",
-                      "label": "val2",
-                      "level": "info",
-                    },
-                    {
-                      "counter": "38142",
-                      "label": "val3",
-                      "level": "info",
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Time",
-                  "nanos": [
-                    641000,
-                    0,
-                    0,
-                  ],
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997000000",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {
-                "custom": {
-                  "frameType": "LabeledTimeValues",
-                },
-              },
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line2",
-            "entryFieldIndex": 2,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "38143",
-              "label": "val2",
-              "level": "info",
-            },
-            "logLevel": "info",
-            "raw": "line2",
-            "rowIndex": 1,
-            "searchWords": [],
-            "timeEpochMs": 1686142520411,
-            "timeEpochNs": "1686142520411000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00",
-            "timeLocal": "2023-06-07 06:55:20",
-            "timeUtc": "2023-06-07 12:55:20",
-            "uid": "A_id2",
-            "uniqueLabels": {
-              "counter": "38143",
-              "label": "val2",
-              "level": "info",
-            },
+          logLevel: 'warning',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756641000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_id1',
+          uniqueLabels: {
+            counter: '38141',
+            label: 'val2',
+            level: 'warning',
           },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "labels",
-                  "type": "other",
-                  "values": [
-                    {
-                      "counter": "38141",
-                      "label": "val2",
-                      "level": "warning",
-                    },
-                    {
-                      "counter": "38143",
-                      "label": "val2",
-                      "level": "info",
-                    },
-                    {
-                      "counter": "38142",
-                      "label": "val3",
-                      "level": "info",
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Time",
-                  "nanos": [
-                    641000,
-                    0,
-                    0,
-                  ],
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "Line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997000000",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {
-                "custom": {
-                  "frameType": "LabeledTimeValues",
-                },
-              },
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line3",
-            "entryFieldIndex": 2,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {
-              "counter": "38142",
-              "label": "val3",
-              "level": "info",
-            },
-            "logLevel": "info",
-            "raw": "line3",
-            "rowIndex": 2,
-            "searchWords": [],
-            "timeEpochMs": 1686142519997,
-            "timeEpochNs": "1686142519997000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_id3",
-            "uniqueLabels": {
-              "counter": "38142",
-              "label": "val3",
-              "level": "info",
-            },
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 2,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38143',
+            label: 'val2',
+            level: 'info',
           },
-        ],
-      }
-    `);
+          logLevel: 'info',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_id2',
+          uniqueLabels: {
+            counter: '38143',
+            label: 'val2',
+            level: 'info',
+          },
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 2,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38142',
+            label: 'val3',
+            level: 'info',
+          },
+          logLevel: 'info',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_id3',
+          uniqueLabels: {
+            counter: '38142',
+            label: 'val3',
+            level: 'info',
+          },
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 
   it('should parse an Elasticsearch-style frame', () => {
@@ -844,659 +472,74 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
       },
     ];
 
-    expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`
-      {
-        "hasUniqueLabels": false,
-        "meta": [],
-        "rows": [
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "@timestamp",
-                  "type": "time",
-                  "values": [
-                    1686143280325,
-                    1686143279324,
-                    1686143278324,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_index",
-                  "type": "string",
-                  "values": [
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_source",
-                  "type": "other",
-                  "values": [
-                    {
-                      "@timestamp": "2023-06-07T13:08:00.325Z",
-                      "counter": "300",
-                      "label": "val2",
-                      "level": "info",
-                      "line": "line1",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:59.324Z",
-                      "counter": "299",
-                      "label": "val1",
-                      "level": "error",
-                      "line": "line2",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:58.324Z",
-                      "counter": "298",
-                      "label": "val2",
-                      "level": "error",
-                      "line": "line3",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "counter",
-                  "type": "string",
-                  "values": [
-                    "300",
-                    "299",
-                    "298",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "label",
-                  "type": "string",
-                  "values": [
-                    "val2",
-                    "val1",
-                    "val2",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "level",
-                  "type": "string",
-                  "values": [
-                    "info",
-                    "error",
-                    "error",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "shapes",
-                  "type": "other",
-                  "values": [
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line1",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "info",
-            "raw": "line1",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686143280325,
-            "timeEpochNs": "1686143280325000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T07:08:00-06:00",
-            "timeLocal": "2023-06-07 07:08:00",
-            "timeUtc": "2023-06-07 13:08:00",
-            "uid": "A_0",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "@timestamp",
-                  "type": "time",
-                  "values": [
-                    1686143280325,
-                    1686143279324,
-                    1686143278324,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_index",
-                  "type": "string",
-                  "values": [
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_source",
-                  "type": "other",
-                  "values": [
-                    {
-                      "@timestamp": "2023-06-07T13:08:00.325Z",
-                      "counter": "300",
-                      "label": "val2",
-                      "level": "info",
-                      "line": "line1",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:59.324Z",
-                      "counter": "299",
-                      "label": "val1",
-                      "level": "error",
-                      "line": "line2",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:58.324Z",
-                      "counter": "298",
-                      "label": "val2",
-                      "level": "error",
-                      "line": "line3",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "counter",
-                  "type": "string",
-                  "values": [
-                    "300",
-                    "299",
-                    "298",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "label",
-                  "type": "string",
-                  "values": [
-                    "val2",
-                    "val1",
-                    "val2",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "level",
-                  "type": "string",
-                  "values": [
-                    "info",
-                    "error",
-                    "error",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "shapes",
-                  "type": "other",
-                  "values": [
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line2",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "error",
-            "raw": "line2",
-            "rowIndex": 1,
-            "searchWords": [],
-            "timeEpochMs": 1686143279324,
-            "timeEpochNs": "1686143279324000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T07:07:59-06:00",
-            "timeLocal": "2023-06-07 07:07:59",
-            "timeUtc": "2023-06-07 13:07:59",
-            "uid": "A_1",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "@timestamp",
-                  "type": "time",
-                  "values": [
-                    1686143280325,
-                    1686143279324,
-                    1686143278324,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "line",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_id",
-                  "type": "string",
-                  "values": [
-                    "id1",
-                    "id2",
-                    "id3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_index",
-                  "type": "string",
-                  "values": [
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                    "logs-2023.06.07",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "_source",
-                  "type": "other",
-                  "values": [
-                    {
-                      "@timestamp": "2023-06-07T13:08:00.325Z",
-                      "counter": "300",
-                      "label": "val2",
-                      "level": "info",
-                      "line": "line1",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:59.324Z",
-                      "counter": "299",
-                      "label": "val1",
-                      "level": "error",
-                      "line": "line2",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                    {
-                      "@timestamp": "2023-06-07T13:07:58.324Z",
-                      "counter": "298",
-                      "label": "val2",
-                      "level": "error",
-                      "line": "line3",
-                      "shapes": [
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "triangle",
-                        },
-                        {
-                          "type": "square",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "counter",
-                  "type": "string",
-                  "values": [
-                    "300",
-                    "299",
-                    "298",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "label",
-                  "type": "string",
-                  "values": [
-                    "val2",
-                    "val1",
-                    "val2",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "level",
-                  "type": "string",
-                  "values": [
-                    "info",
-                    "error",
-                    "error",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "shapes",
-                  "type": "other",
-                  "values": [
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                    [
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "triangle",
-                      },
-                      {
-                        "type": "square",
-                      },
-                    ],
-                  ],
-                },
-              ],
-              "length": 3,
-              "meta": {},
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line3",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "error",
-            "raw": "line3",
-            "rowIndex": 2,
-            "searchWords": [],
-            "timeEpochMs": 1686143278324,
-            "timeEpochNs": "1686143278324000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T07:07:58-06:00",
-            "timeLocal": "2023-06-07 07:07:58",
-            "timeUtc": "2023-06-07 13:07:58",
-            "uid": "A_2",
-            "uniqueLabels": {},
-          },
-        ],
-      }
-    `);
+    const expected = {
+      hasUniqueLabels: false,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'info',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686143280325,
+          timeEpochNs: '1686143280325000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T07:08:00-06:00',
+          timeLocal: '2023-06-07 07:08:00',
+          timeUtc: '2023-06-07 13:08:00',
+          uid: 'A_0',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'error',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686143279324,
+          timeEpochNs: '1686143279324000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T07:07:59-06:00',
+          timeLocal: '2023-06-07 07:07:59',
+          timeUtc: '2023-06-07 13:07:59',
+          uid: 'A_1',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'error',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686143278324,
+          timeEpochNs: '1686143278324000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T07:07:58-06:00',
+          timeLocal: '2023-06-07 07:07:58',
+          timeUtc: '2023-06-07 13:07:58',
+          uid: 'A_2',
+          uniqueLabels: {},
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 
   it('should parse timestamps when no nanosecond data and no nanosecond field', () => {
@@ -1521,149 +564,74 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
       },
     ];
 
-    expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`
-      {
-        "hasUniqueLabels": false,
-        "meta": [],
-        "rows": [
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line1",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line1",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686142519756,
-            "timeEpochNs": "1686142519756000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_0",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line2",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line2",
-            "rowIndex": 1,
-            "searchWords": [],
-            "timeEpochMs": 1686142520411,
-            "timeEpochNs": "1686142520411000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00",
-            "timeLocal": "2023-06-07 06:55:20",
-            "timeUtc": "2023-06-07 12:55:20",
-            "uid": "A_1",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line3",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line3",
-            "rowIndex": 2,
-            "searchWords": [],
-            "timeEpochMs": 1686142519997,
-            "timeEpochNs": "1686142519997000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_2",
-            "uniqueLabels": {},
-          },
-        ],
-      }
-    `);
+    const expected = {
+      hasUniqueLabels: false,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_0',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_1',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_2',
+          uniqueLabels: {},
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 
   it('should parse timestamps when no nanosecond data and nanosecond field', () => {
@@ -1694,178 +662,73 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
       },
     ];
 
-    expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`
-      {
-        "hasUniqueLabels": false,
-        "meta": [],
-        "rows": [
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997123456",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line1",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line1",
-            "rowIndex": 0,
-            "searchWords": [],
-            "timeEpochMs": 1686142519756,
-            "timeEpochNs": "1686142519756641000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_0",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997123456",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line2",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line2",
-            "rowIndex": 1,
-            "searchWords": [],
-            "timeEpochMs": 1686142520411,
-            "timeEpochNs": "1686142520411000000",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00",
-            "timeLocal": "2023-06-07 06:55:20",
-            "timeUtc": "2023-06-07 12:55:20",
-            "uid": "A_1",
-            "uniqueLabels": {},
-          },
-          {
-            "dataFrame": {
-              "fields": [
-                {
-                  "config": {},
-                  "name": "timestamp",
-                  "type": "time",
-                  "values": [
-                    1686142519756,
-                    1686142520411,
-                    1686142519997,
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "body",
-                  "type": "string",
-                  "values": [
-                    "line1",
-                    "line2",
-                    "line3",
-                  ],
-                },
-                {
-                  "config": {},
-                  "name": "tsNs",
-                  "type": "string",
-                  "values": [
-                    "1686142519756641000",
-                    "1686142520411000000",
-                    "1686142519997123456",
-                  ],
-                },
-              ],
-              "length": 3,
-              "refId": "A",
-            },
-            "datasourceType": undefined,
-            "entry": "line3",
-            "entryFieldIndex": 1,
-            "hasAnsi": false,
-            "hasUnescapedContent": false,
-            "labels": {},
-            "logLevel": "unknown",
-            "raw": "line3",
-            "rowIndex": 2,
-            "searchWords": [],
-            "timeEpochMs": 1686142519997,
-            "timeEpochNs": "1686142519997123456",
-            "timeFromNow": "mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00",
-            "timeLocal": "2023-06-07 06:55:19",
-            "timeUtc": "2023-06-07 12:55:19",
-            "uid": "A_2",
-            "uniqueLabels": {},
-          },
-        ],
-      }
-    `);
+    const expected = {
+      hasUniqueLabels: false,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756641000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_0',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_1',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997123456',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_2',
+          uniqueLabels: {},
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
we have snapshot-tests that verify `LogRowModel` objects in the result. but, every `LogRowModel` links to it's "source" dataframe, so these snapshots are very large.
i adjusted the test so that the `expected` structures just link to the expected source dataframe, this makes the file shorter , from 1800lines to 800lines.

there are no logical changes in the tests, the change is like:
before:
```ts
const frames = [...];

expect(logSeriesToLogsModel(frames)).toMatchInlineSnapshot(`large snapshot`)
```

after:
```ts
const frames = [...];
const expected = {...dataFrame: frames[0], .... dataFrame:frames[1],....}

expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
```