### PR TITLE
Pyroscope: Fix normalize query function

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -114,7 +114,7 @@ export const defaultQuery: Partial<Query> = {
 };
 
 export function normalizeQuery(query: Query, app?: CoreApp | string) {
-  let normalized = { ...query, ...defaultQuery };
+  let normalized = { ...defaultQuery, ...query };
   if (app !== CoreApp.Explore && normalized.queryType === 'both') {
     // In dashboards and other places, we can't show both types of graphs at the same time.
     // This will also be a default when having 'both' query and adding it from explore to dashboard


### PR DESCRIPTION
Fix this bug where query would be overwriten to default after every render or query run.

Created by https://github.com/grafana/grafana/pull/70624
