### PR TITLE
A11y: Add support for toggle buttons in high contrast mode

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -143,6 +143,10 @@ const getSwitchStyles = stylesFactory((theme: GrafanaTheme2, transparent?: boole
           top: 50%;
           transform: translate3d(2px, -50%, 0);
           transition: transform 0.2s cubic-bezier(0.19, 1, 0.22, 1);
+
+          @media (forced-colors: active) {
+            border: 1px solid transparent;
+          }
         }
       }
     `,


### PR DESCRIPTION
**What is this feature?**
Add support for toggle buttons in Windows High contrast mode.

When this mode is active, we can detect it using a media query checking if the [forced-colors](https://www.w3.org/TR/mediaqueries-5/#descdef-media-forced-colors) mode is active.
"[In forced colors mode, all elements have the same background color and shadows are removed](https://www.oidaisdes.org/forced-colors-mode.en/)", because of this, the circular button inside the toggle button is not visible.
This PR modifies the `Switch` component to render a border to make visible this circle only when forced-colors mode is active.

Normal mode (see enabled and disabled examples)
![Screenshot 2023-06-28 at 10 06 37](https://github.com/grafana/grafana/assets/20256983/921b3ce3-0652-47d3-b27c-81b3175579aa)

Before (with high contrast on)
![Screenshot 2023-06-28 at 10 06 52](https://github.com/grafana/grafana/assets/20256983/2dbe9201-bb45-426e-8a24-89e914a9bbc2)

After (with high contrast on)
![Screenshot 2023-06-28 at 10 09 17](https://github.com/grafana/grafana/assets/20256983/c28b24ef-1ec6-4fcb-9d0b-5237652f2cbb)

Fixes https://github.com/grafana/grafana/issues/66308

**Special notes for your reviewer:**
If you don't have a Windows machine, you can emulate the same behavior with Chrome.
Open dev tools, cmd+shift+P, type rendering, change `Emulate CSS media feature forced-colors` to `active`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
