### PR TITLE
Alerting: Add duration to saving alert states done

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -385,9 +385,10 @@ func (st *Manager) saveAlertStates(ctx context.Context, logger log.Logger, state
 		return nil
 	}
 
+	start := time.Now()
 	logger.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", st.maxStateSaveConcurrency)
 	_ = concurrency.ForEachJob(ctx, len(states), st.maxStateSaveConcurrency, saveState)
-	logger.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", st.maxStateSaveConcurrency)
+	logger.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", st.maxStateSaveConcurrency, "duration", time.Since(start))
 }
 
 func (st *Manager) deleteAlertStates(ctx context.Context, logger log.Logger, states []StateTransition) {


### PR DESCRIPTION
**What is this feature?**

Adds duration to `Saving alert states done` log lines:

```
logger=ngalert.state.manager rule_uid=b2328d31-2a3d-45cd-b18c-b974a3d7b1f7 org_id=1 t=2023-06-28T15:07:06.015778+01:00 level=debug msg="Saving alert states" count=4096 max_state_save_concurrency=1
logger=ngalert.state.manager rule_uid=b2328d31-2a3d-45cd-b18c-b974a3d7b1f7 org_id=1 t=2023-06-28T15:07:09.64314+01:00 level=debug msg="Saving alert states done" count=4096 max_state_save_concurrency=1 duration=3.627573084s
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
