### PR TITLE
Explore: Add checking for target datasources and add test

### DIFF
--- a/public/app/features/correlations/CorrelationsPage.test.tsx
+++ b/public/app/features/correlations/CorrelationsPage.test.tsx
@@ -548,6 +548,82 @@ describe('CorrelationsPage', () => {
     });
   });
 
+  describe('With correlations with datasources the user cannot access', () => {
+    let queryCellsByColumnName: (columnName: Matcher) => HTMLTableCellElement[];
+    beforeEach(async () => {
+      const renderResult = await renderWithContext(
+        {
+          loki: mockDataSource(
+            {
+              uid: 'loki',
+              name: 'loki',
+              readOnly: false,
+              jsonData: {},
+              access: 'direct',
+              type: 'datasource',
+            },
+            {
+              logs: true,
+            }
+          ),
+        },
+        [
+          {
+            sourceUID: 'loki',
+            targetUID: 'loki',
+            uid: '1',
+            label: 'Loki to Loki',
+            config: {
+              field: 'line',
+              target: {},
+              type: 'query',
+              transformations: [
+                { type: SupportedTransformationType.Regex, expression: 'url=http[s]?://(S*)', mapValue: 'path' },
+              ],
+            },
+          },
+          {
+            sourceUID: 'loki',
+            targetUID: 'prometheus',
+            uid: '2',
+            label: 'Loki to Prometheus',
+            config: {
+              field: 'line',
+              target: {},
+              type: 'query',
+              transformations: [
+                { type: SupportedTransformationType.Regex, expression: 'url=http[s]?://(S*)', mapValue: 'path' },
+              ],
+            },
+          },
+          {
+            sourceUID: 'prometheus',
+            targetUID: 'loki',
+            uid: '3',
+            label: 'Prometheus to Loki',
+            config: { field: 'label', target: {}, type: 'query' },
+          },
+          {
+            sourceUID: 'prometheus',
+            targetUID: 'prometheus',
+            uid: '4',
+            label: 'Prometheus to Prometheus',
+            config: { field: 'label', target: {}, type: 'query' },
+          },
+        ]
+      );
+      queryCellsByColumnName = renderResult.queryCellsByColumnName;
+    });
+
+    it("doesn't show correlations from source or target datasources the user doesn't have access to", async () => {
+      await screen.findByRole('table');
+
+      const labels = queryCellsByColumnName('Label');
+      expect(labels.length).toBe(1);
+      expect(labels[0].textContent).toBe('Loki to Loki');
+    });
+  });
+
   describe('Read only correlations', () => {
     const correlations: Correlation[] = [
       {

--- a/public/app/features/correlations/useCorrelations.ts
+++ b/public/app/features/correlations/useCorrelations.ts
@@ -26,11 +26,18 @@ const toEnrichedCorrelationData = ({
   ...correlation
 }: Correlation): CorrelationData | undefined => {
   const sourceDatasource = getDataSourceSrv().getInstanceSettings(sourceUID);
-  if (sourceDatasource) {
+  const targetDatasource = getDataSourceSrv().getInstanceSettings(targetUID);
+
+  if (
+    sourceDatasource &&
+    sourceDatasource?.uid !== undefined &&
+    targetDatasource &&
+    targetDatasource.uid !== undefined
+  ) {
     return {
       ...correlation,
       source: sourceDatasource,
-      target: getDataSourceSrv().getInstanceSettings(targetUID)!,
+      target: targetDatasource,
     };
   } else {
     return undefined;


### PR DESCRIPTION
**What is this feature?**

This slightly extends and adds a test for #70717 

**Why do we need this feature?**

This adds on a check to only show correlations for users if they have access to both the source and target datasource. It also adds a test for this.

**Special notes for your reviewer:**
Eagle eyed reviewers may notice we no longer just test that a datasource exists when returning correlations after enhancing it with datasource data, we ensure it has a uid as well. This is because the test mock `getInstanceSettings` returns an empty `meta` object if the datasource is not found ([src](https://github.com/grafana/grafana/blob/main/public/app/features/alerting/unified/mocks.ts#L360)) whereas the actual`getInstanceSettings` returns undefined. Simply removing it makes other things fail and, technically, that mock falls within the alerting team's code, so I don't really want to mess with it. This extra check shouldn't hurt anything and seems like the most efficient way to move forward. I reached out to the alerting team to discuss moving that mock somewhere global and letting alerting specific code handle any special alerting scenarios. I'd like for that discussion to continue outside of this PR.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
