### PR TITLE
Prometheus: Code editor autocomplete returns bad results when text is highlighted

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -70,8 +70,10 @@ export function getCompletionProvider(
       lineNumber: position.lineNumber,
     };
 
+    // Check to see if the browser supports window.getSelection()
     if (window.getSelection) {
       const selectedText = window.getSelection()?.toString();
+      // If the user has selected text, adjust the cursor position to be at the start of the selection, instead of the end
       if (selectedText && selectedText.length > 0) {
         positionClone.column = positionClone.column - selectedText.length;
       }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -43,6 +43,7 @@ function getMonacoCompletionItemKind(type: CompletionType, monaco: Monaco): mona
       throw new NeverCaseError(type);
   }
 }
+
 export function getCompletionProvider(
   monaco: Monaco,
   dataProvider: DataProvider
@@ -63,10 +64,19 @@ export function getCompletionProvider(
         : monaco.Range.fromPositions(position);
     // documentation says `position` will be "adjusted" in `getOffsetAt`
     // i don't know what that means, to be sure i clone it
+
     const positionClone = {
       column: position.column,
       lineNumber: position.lineNumber,
     };
+
+    if (window.getSelection) {
+      const selectedText = window.getSelection()?.toString();
+      if (selectedText && selectedText.length > 0) {
+        positionClone.column = positionClone.column - selectedText.length;
+      }
+    }
+
     const offset = model.getOffsetAt(positionClone);
     const situation = getSituation(model.getValue(), offset);
     const completionsPromise = situation != null ? getCompletions(situation, dataProvider) : Promise.resolve([]);


### PR DESCRIPTION

**What is this feature?**
Doubling clicking on part of promQL and pressing control+space for autocomplete results is a common UX pattern for code editors, but currently the promQL parsing only takes the current cursor location into consideration, which is non-intuitive for selected text.

This feature simply re-calculates the cursor position when text is selected, by subtracting the current cursor position by the length of selected text.

**Why do we need this feature?**
Better autocompletion UX.

**Who is this feature for?**
Anyone writing promQL in the Prometheus code editor.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/70562

**Special notes for your reviewer:**
Should only ever change autocomplete output when text is selected.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
