### PR TITLE
Chore: run `make gen-cue` to fix CI

### DIFF
--- a/packages/grafana-schema/src/raw/composable/candlestick/panelcfg/x/CandlestickPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/candlestick/panelcfg/x/CandlestickPanelCfg_types.gen.ts
@@ -11,6 +11,8 @@
 
 import * as common from '@grafana/schema';
 
+export const pluginVersion = "10.0.2";
+
 export enum VizDisplayMode {
   Candles = 'candles',
   CandlesVolume = 'candles+volume',

--- a/public/app/plugins/panel/candlestick/panelcfg.gen.ts
+++ b/public/app/plugins/panel/candlestick/panelcfg.gen.ts
@@ -10,8 +10,6 @@
 
 import * as common from '@grafana/schema';
 
-export const PanelCfgModelVersion = Object.freeze([0, 0]);
-
 export enum VizDisplayMode {
   Candles = 'candles',
   CandlesVolume = 'candles+volume',

--- a/public/app/plugins/panel/candlestick/types.ts
+++ b/public/app/plugins/panel/candlestick/types.ts
@@ -10,7 +10,6 @@ import {
   VizDisplayMode,
   CandlestickFieldMap,
   FieldConfig,
-  PanelCfgModelVersion,
 } from './panelcfg.gen';
 
 export const defaultOptions: Partial<Options> = {
@@ -33,5 +32,4 @@ export {
   VizDisplayMode,
   CandlestickFieldMap,
   FieldConfig,
-  PanelCfgModelVersion,
 };


### PR DESCRIPTION
v10.0.x CI is currently failing on `verify-gen-cue`. Some example builds: [1](https://drone.grafana.net/grafana/grafana/123550) [2](https://drone.grafana.net/grafana/grafana/123567/3/5) [3](https://drone.grafana.net/grafana/grafana/123560)

This reruns `make gen-cue` and fixes a linting issue by removing the unused `PanelCfgModelVersion` export in candlestick `types.ts`.

NB: Main is up-to-date WRT `gen-cue`, no need to run there. Likely cause is https://github.com/grafana/grafana/pull/70735