### PR TITLE
A11y: Do not force colors in the color swatch and icon series

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
@@ -82,6 +82,9 @@ const getStyles = (
       '&:hover': {
         transform: 'scale(1.1)',
       },
+      '@media (forced-colors: active)': {
+        forcedColorAdjust: 'none',
+      },
     }),
   };
 };

--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -1,8 +1,9 @@
+import { css, cx } from '@emotion/css';
 import React, { CSSProperties } from 'react';
 
 import { fieldColorModeRegistry } from '@grafana/data';
 
-import { useTheme2 } from '../../themes';
+import { useTheme2, useStyles2 } from '../../themes';
 
 export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   color?: string;
@@ -12,6 +13,8 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
 export const SeriesIcon = React.memo(
   React.forwardRef<HTMLDivElement, Props>(({ color, className, gradient, ...restProps }, ref) => {
     const theme = useTheme2();
+    const styles2 = useStyles2(getStyles);
+
     let cssColor: string;
 
     if (gradient) {
@@ -35,8 +38,24 @@ export const SeriesIcon = React.memo(
       marginRight: '8px',
     };
 
-    return <div data-testid="series-icon" ref={ref} className={className} style={styles} {...restProps} />;
+    return (
+      <div
+        data-testid="series-icon"
+        ref={ref}
+        className={cx(className, styles2.forcedColors)}
+        style={styles}
+        {...restProps}
+      />
+    );
   })
 );
+
+const getStyles = () => ({
+  forcedColors: css`
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+    }
+  `,
+});
 
 SeriesIcon.displayName = 'SeriesIcon';


### PR DESCRIPTION

**What is this feature?**
Show the colors in the Color Swatch and the Icon Series when the Windows High Contrast mode is active.
When `forced-colors` is active, all shadows are removed. That is why the color swatch appears to be empty.
Grafana relies on colors to display data, when the High Contrast mode is on it still makes sense to display custom colors in some cases.

This PR addresses the `ColorSwatch` and the `SeriesIcon` components so a user with High Contrast mode can still interact with the data visualization colors.

**Before**

https://github.com/grafana/grafana/assets/20256983/9fc1af14-caf3-4962-b61b-dd17c7034bc4

**After**

https://github.com/grafana/grafana/assets/20256983/8f337970-192e-4343-9fe0-e41e42a1da78

Fixes https://github.com/grafana/grafana/issues/66311

**Special notes for your reviewer:**
If you don't have a Windows machine, you can emulate the same behavior with Chrome.
Open dev tools, cmd+shift+P, type rendering, change `Emulate CSS media feature forced-colors` to `active`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
