### PR TITLE
AzureMonitor: Fix metric names for multi-resources.

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -269,27 +269,33 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
       });
   }
 
-  getMetricNames(query: GetMetricNamesQuery) {
+  getMetricNames(query: GetMetricNamesQuery, multipleResources?: boolean, region?: string) {
+    const apiVersion = multipleResources ? this.apiPreviewVersion : this.apiVersion;
     const url = UrlBuilder.buildAzureMonitorGetMetricNamesUrl(
       this.resourcePath,
-      this.apiVersion,
+      apiVersion,
       // Only use the first query, as the metric names should be the same for all queries
       this.replaceSingleTemplateVariables(query),
-      this.templateSrv
+      this.templateSrv,
+      multipleResources,
+      region
     );
     return this.getResource(url).then((result: AzureAPIResponse<Metric>) => {
       return ResponseParser.parseResponseValues(result, 'name.localizedValue', 'name.value');
     });
   }
 
-  getMetricMetadata(query: GetMetricMetadataQuery) {
+  getMetricMetadata(query: GetMetricMetadataQuery, multipleResources?: boolean, region?: string) {
     const { metricName } = query;
+    const apiVersion = multipleResources ? this.apiPreviewVersion : this.apiVersion;
     const url = UrlBuilder.buildAzureMonitorGetMetricNamesUrl(
       this.resourcePath,
-      this.apiVersion,
+      apiVersion,
       // Only use the first query, as the metric metadata should be the same for all queries
       this.replaceSingleTemplateVariables(query),
-      this.templateSrv
+      this.templateSrv,
+      multipleResources,
+      region
     );
     return this.getResource(url).then((result: AzureMonitorMetricsMetadataResponse) => {
       return ResponseParser.parseMetadata(result, this.templateSrv.replace(metricName));

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
@@ -398,5 +398,23 @@ describe('AzureMonitorUrlBuilder', () => {
         );
       });
     });
+    describe('when multiple resources are selected', () => {
+      it('passes metricNamespace as query param', () => {
+        const url = UrlBuilder.buildAzureMonitorGetMetricNamesUrl(
+          '',
+          '2017-05-01-preview',
+          {
+            resourceUri: '/subscriptions/sub/resource-uri/resource',
+            metricNamespace: 'Microsoft.Sql/servers',
+          },
+          templateSrv,
+          true,
+          'region'
+        );
+        expect(url).toBe(
+          '/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricdefinitions?api-version=2017-05-01-preview&metricnamespace=Microsoft.Sql%2Fservers&region=region'
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
**What is this feature?**
When building a query for multiple resources only a subset of metrics are valid and that selection is only available via the API version `2017-12-01-preview`.

**To verify**

- Head over to explore for AzureMonitor
- Select a single VM instance and note one of the Metric Names is "Inbound Flows"
- Open the Resource Picker back up and select another VM
- Note that "Inbound Flows" is no longer available in the Metric Names dropdown.

Fixes #68603

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
