### PR TITLE
Alerting: Improve time range and max data points info in QueryEditor

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
@@ -14,7 +14,6 @@ import CustomScrollbar from '../../CustomScrollbar/CustomScrollbar';
 import { Field } from '../../Forms/Field';
 import { Icon } from '../../Icon/Icon';
 import { getInputStyles, Input } from '../../Input/Input';
-import { Portal } from '../../Portal/Portal';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { TimePickerTitle } from '../TimeRangePicker/TimePickerTitle';
 import { TimeRangeList } from '../TimeRangePicker/TimeRangeList';
@@ -123,7 +122,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
         </span>
       </button>
       {isOpen && (
-        <Portal>
+        <div>
           <div role="presentation" className={styles.backdrop} {...underlayProps} />
           <FocusScope contain autoFocus restoreFocus>
             <div ref={ref} {...overlayProps} {...dialogProps}>
@@ -178,7 +177,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
               </div>
             </div>
           </FocusScope>
-        </Portal>
+        </div>
       )}
     </div>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
-import { getDefaultRelativeTimeRange, GrafanaTheme2, RelativeTimeRange } from '@grafana/data';
+import { dateTime, getDefaultRelativeTimeRange, GrafanaTheme2, RelativeTimeRange } from '@grafana/data';
+import { relativeToTimeRange } from '@grafana/data/src/datetime/rangeutil';
 import { clearButtonStyles, Icon, RelativeTimeRangePicker, Toggletip, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
-import { AlertQueryOptions, MaxDataPointsOption } from './QueryWrapper';
+import { AlertQueryOptions, DEFAULT_MAX_DATA_POINTS, MaxDataPointsOption } from './QueryWrapper';
 
 export interface QueryOptionsProps {
   query: AlertQuery;
@@ -25,6 +26,8 @@ export const QueryOptions = ({
   const styles = useStyles2(getStyles);
 
   const [showOptions, setShowOptions] = useState(false);
+
+  const timeRange = query.relativeTimeRange ? relativeToTimeRange(query.relativeTimeRange) : undefined;
 
   return (
     <>
@@ -54,8 +57,8 @@ export const QueryOptions = ({
       </Toggletip>
 
       <div className={styles.staticValues}>
-        <span>10m, </span>
-        <span>MD 43200</span>
+        <span>{dateTime(timeRange?.from).locale('en').fromNow(true)}, </span>
+        <span>MD {queryOptions?.maxDataPoints || DEFAULT_MAX_DATA_POINTS.toLocaleString()}</span>
       </div>
     </>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -33,20 +33,25 @@ export const QueryOptions = ({
     <>
       <Toggletip
         content={
-          <>
-            {onChangeTimeRange && (
-              <RelativeTimeRangePicker
-                timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
-                onChange={(range) => onChangeTimeRange(range, index)}
-              />
-            )}
+          <div className={styles.container}>
+            <div>
+              {onChangeTimeRange && (
+                <div className={styles.timeRangeContainer}>
+                  <span className={styles.timeRangeLabel}>Time Range</span>
+                  <RelativeTimeRangePicker
+                    timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
+                    onChange={(range) => onChangeTimeRange(range, index)}
+                  />
+                </div>
+              )}
+            </div>
             <div className={styles.queryOptions}>
               <MaxDataPointsOption
                 options={queryOptions}
                 onChange={(options) => onChangeQueryOptions(options, index)}
               />
             </div>
-          </>
+          </div>
         }
         closeButton={true}
         placement="bottom-start"
@@ -68,8 +73,25 @@ const getStyles = (theme: GrafanaTheme2) => {
   const clearButton = clearButtonStyles(theme);
 
   return {
+    container: css`
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    `,
+    timeRangeContainer: css`
+      display: flex;
+    `,
+
+    timeRangeLabel: css`
+      width: 20%;
+    `,
     queryOptions: css`
       margin-bottom: -${theme.spacing(2)};
+
+      label {
+        line-height: 12px;
+        padding: 0px;
+      }
     `,
 
     staticValues: css`

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -6,7 +6,7 @@ import { relativeToTimeRange } from '@grafana/data/src/datetime/rangeutil';
 import { clearButtonStyles, Icon, RelativeTimeRangePicker, Toggletip, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
-import { AlertQueryOptions, DEFAULT_MAX_DATA_POINTS, MaxDataPointsOption } from './QueryWrapper';
+import { AlertQueryOptions, MaxDataPointsOption } from './QueryWrapper';
 
 export interface QueryOptionsProps {
   query: AlertQuery;

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -57,13 +57,13 @@ export const QueryOptions = ({
         placement="bottom-start"
       >
         <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
-          Options {showOptions ? <Icon name="angle-down" /> : <Icon name="angle-right" />}
+          Options {showOptions ? <Icon name="angle-right" /> : <Icon name="angle-down" />}
         </button>
       </Toggletip>
 
       <div className={styles.staticValues}>
-        <span>{dateTime(timeRange?.from).locale('en').fromNow(true)}, </span>
-        <span>MD {queryOptions?.maxDataPoints || DEFAULT_MAX_DATA_POINTS.toLocaleString()}</span>
+        <span>{dateTime(timeRange?.from).locale('en').fromNow(true)}</span>
+        {queryOptions.maxDataPoints && <span>, MD {queryOptions.maxDataPoints}</span>}
       </div>
     </>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,0 +1,87 @@
+import { css } from '@emotion/css';
+import React, { useState } from 'react';
+
+import { getDefaultRelativeTimeRange, GrafanaTheme2, RelativeTimeRange } from '@grafana/data';
+import { clearButtonStyles, Icon, RelativeTimeRangePicker, Toggletip, useStyles2 } from '@grafana/ui';
+import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { AlertQueryOptions, MaxDataPointsOption } from './QueryWrapper';
+
+export interface QueryOptionsProps {
+  query: AlertQuery;
+  queryOptions: AlertQueryOptions;
+  onChangeTimeRange?: (timeRange: RelativeTimeRange, index: number) => void;
+  onChangeQueryOptions: (options: AlertQueryOptions, index: number) => void;
+  index: number;
+}
+
+export const QueryOptions = ({
+  query,
+  queryOptions,
+  onChangeTimeRange,
+  onChangeQueryOptions,
+  index,
+}: QueryOptionsProps) => {
+  const styles = useStyles2(getStyles);
+
+  const [showOptions, setShowOptions] = useState(false);
+
+  return (
+    <>
+      <Toggletip
+        content={
+          <>
+            {onChangeTimeRange && (
+              <RelativeTimeRangePicker
+                timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
+                onChange={(range) => onChangeTimeRange(range, index)}
+              />
+            )}
+            <div className={styles.queryOptions}>
+              <MaxDataPointsOption
+                options={queryOptions}
+                onChange={(options) => onChangeQueryOptions(options, index)}
+              />
+            </div>
+          </>
+        }
+        closeButton={true}
+        placement="bottom-start"
+      >
+        <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
+          Options {showOptions ? <Icon name="angle-down" /> : <Icon name="angle-right" />}
+        </button>
+      </Toggletip>
+
+      <div className={styles.staticValues}>
+        <span>10m, </span>
+        <span>MD 43200</span>
+      </div>
+    </>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const clearButton = clearButtonStyles(theme);
+
+  return {
+    queryOptions: css`
+      margin-bottom: -${theme.spacing(2)};
+    `,
+
+    staticValues: css`
+      color: ${theme.colors.text.secondary};
+      margin-right: ${theme.spacing(1)};
+    `,
+
+    actionLink: css`
+      ${clearButton};
+      color: ${theme.colors.text.link};
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    `,
+  };
+};

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -228,6 +228,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-bottom: ${theme.spacing(1)};
     border: 1px solid ${theme.colors.border.weak};
     border-radius: ${theme.shape.borderRadius(1)};
+
+    button {
+      overflow: visible;
+    }
   `,
   queryOptions: css`
     margin-bottom: -${theme.spacing(2)};

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -6,7 +6,6 @@ import {
   CoreApp,
   DataSourceApi,
   DataSourceInstanceSettings,
-  getDefaultRelativeTimeRange,
   GrafanaTheme2,
   LoadingState,
   PanelData,
@@ -15,20 +14,13 @@ import {
 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { DataQuery } from '@grafana/schema';
-import {
-  GraphTresholdsStyleMode,
-  Icon,
-  InlineFormLabel,
-  Input,
-  RelativeTimeRangePicker,
-  Tooltip,
-  useStyles2,
-} from '@grafana/ui';
+import { GraphTresholdsStyleMode, Icon, InlineFormLabel, Input, Tooltip, useStyles2 } from '@grafana/ui';
 import { QueryEditorRow } from 'app/features/query/components/QueryEditorRow';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { AlertConditionIndicator } from '../expressions/AlertConditionIndicator';
 
+import { QueryOptions } from './QueryOptions';
 import { VizWrapper } from './VizWrapper';
 
 export const DEFAULT_MAX_DATA_POINTS = 43200;
@@ -123,18 +115,14 @@ export const QueryWrapper = ({
     return (
       <Stack direction="row" alignItems="baseline" gap={1}>
         <SelectingDataSourceTooltip />
-        {onChangeTimeRange && (
-          <RelativeTimeRangePicker
-            timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
-            onChange={(range) => onChangeTimeRange(range, index)}
-          />
-        )}
-        <div className={styles.queryOptions}>
-          <MaxDataPointsOption
-            options={alertQueryOptions}
-            onChange={(options) => onChangeQueryOptions(options, index)}
-          />
-        </div>
+        <QueryOptions
+          onChangeTimeRange={onChangeTimeRange}
+          query={query}
+          queryOptions={alertQueryOptions}
+          onChangeQueryOptions={onChangeQueryOptions}
+          index={index}
+        />
+
         <AlertConditionIndicator
           onSetCondition={() => onSetCondition(query.refId)}
           enabled={condition === query.refId}
@@ -187,7 +175,7 @@ export const EmptyQueryWrapper = ({ children }: React.PropsWithChildren<{}>) => 
   return <div className={styles.wrapper}>{children}</div>;
 };
 
-function MaxDataPointsOption({
+export function MaxDataPointsOption({
   options,
   onChange,
 }: {


### PR DESCRIPTION
**What is this feature?**

Adds a read-only summary of the time range and max data points. When the options button is clicked, a popup appears where these can be edited.

**Why do we need this feature?**

To make better use of the QueryEditor header space and display information in a more clear way.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/68190
Fixes https://github.com/grafana/grafana/issues/70900

![2023-06-30 17 44 59](https://github.com/grafana/grafana/assets/6271380/f62cf868-a5a0-4c33-9e70-713b0c4c8faf)

