### PR TITLE
Chore: Fix DiffReporter.Paths to properly initialize slice

### DIFF
--- a/pkg/util/cmputil/reporter.go
+++ b/pkg/util/cmputil/reporter.go
@@ -86,7 +86,7 @@ func (r DiffReport) String() string {
 
 // Paths returns the slice of paths of the current DiffReport
 func (r DiffReport) Paths() []string {
-	var result = make([]string, len(r))
+	var result = make([]string, 0, len(r))
 	for _, diff := range r {
 		result = append(result, diff.Path)
 	}

--- a/pkg/util/cmputil/reporter_test.go
+++ b/pkg/util/cmputil/reporter_test.go
@@ -92,6 +92,7 @@ func TestIsAddedDeleted_Collections(t *testing.T) {
 			t.Run("IsAddOperation=true, IsDeleted=false", func(t *testing.T) {
 				diff := testStructDiff(left, right)
 				require.Lenf(t, diff, 1, "diff was expected to have only one field %s but got %v", field, diff.String())
+				require.Len(t, diff.Paths(), 1)
 				d := diff[0]
 				require.Truef(t, d.IsAddOperation(), "diff %v should be treated as Add operation but it wasn't", d)
 				require.Falsef(t, d.IsDeleteOperation(), "diff %v should not be treated as Delete operation but it was", d)
@@ -99,6 +100,7 @@ func TestIsAddedDeleted_Collections(t *testing.T) {
 			t.Run("IsDeleted=true, IsAddOperation=false", func(t *testing.T) {
 				diff := testStructDiff(right, left)
 				require.Lenf(t, diff, 1, "diff was expected to have only one field %s but got %v", field, diff.String())
+				require.Len(t, diff.Paths(), 1)
 				d := diff[0]
 				require.Truef(t, d.IsDeleteOperation(), "diff %v should be treated as Delete operation but it wasn't", d)
 				require.Falsef(t, d.IsAddOperation(), "diff %v should not be treated as Delete operation but it was", d)
@@ -123,6 +125,7 @@ func TestIsAddedDeleted_Collections(t *testing.T) {
 
 		diff := testStructDiff(left, right)
 		require.Len(t, diff, 8)
+		require.Len(t, diff.Paths(), 8)
 		for _, d := range diff {
 			assert.Falsef(t, d.IsAddOperation(), "diff %v was not supposed to be Add operation", d.String())
 			assert.Falsef(t, d.IsDeleteOperation(), "diff %v was not supposed to be Delete operation", d.String())
@@ -143,6 +146,7 @@ func TestGetDiffsForField(t *testing.T) {
 
 		result := diff.GetDiffsForField("Property")
 		require.Len(t, result, 1)
+		require.Len(t, result.Paths(), 1)
 		require.Equal(t, "Property", result[0].Path)
 	})
 
@@ -158,6 +162,7 @@ func TestGetDiffsForField(t *testing.T) {
 
 		result := diff.GetDiffsForField("Property")
 		require.Len(t, result, 2)
+		require.Len(t, result.Paths(), 2)
 	})
 
 	t.Run("should return all elements of array", func(t *testing.T) {
@@ -175,6 +180,7 @@ func TestGetDiffsForField(t *testing.T) {
 
 		result := diff.GetDiffsForField("Property")
 		require.Len(t, result, 3)
+		require.Len(t, result.Paths(), 3)
 	})
 
 	t.Run("should find nothing if parent path does not exist", func(t *testing.T) {
@@ -192,5 +198,6 @@ func TestGetDiffsForField(t *testing.T) {
 
 		result := diff.GetDiffsForField("Proper")
 		require.Empty(t, result)
+		require.Empty(t, result.Paths())
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes DiffReport.Paths() to specify capacity instead of length.


This method is not used anywhere (yet).