### PR TITLE
PublicDashboards: Remove non updatable fields from DTO

### DIFF
--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -150,9 +150,9 @@ func (api *Api) CreatePublicDashboard(c *contextmodel.ReqContext) response.Respo
 	}
 
 	// Always set the orgID and userID from the session
-	pdDTO.OrgId = c.OrgID
 	dto := &SavePublicDashboardDTO{
 		UserId:          c.UserID,
+		OrgID:           c.OrgID,
 		DashboardUid:    dashboardUid,
 		PublicDashboard: pdDTO,
 	}
@@ -167,7 +167,7 @@ func (api *Api) CreatePublicDashboard(c *contextmodel.ReqContext) response.Respo
 }
 
 // UpdatePublicDashboard Sets public dashboard for dashboard
-// PUT /api/dashboards/uid/:dashboardUid/public-dashboards/:uid
+// PATCH /api/dashboards/uid/:dashboardUid/public-dashboards/:uid
 func (api *Api) UpdatePublicDashboard(c *contextmodel.ReqContext) response.Response {
 	// exit if we don't have a valid dashboardUid
 	dashboardUid := web.Params(c.Req)[":dashboardUid"]
@@ -186,10 +186,10 @@ func (api *Api) UpdatePublicDashboard(c *contextmodel.ReqContext) response.Respo
 	}
 
 	// Always set the orgID and userID from the session
-	pdDTO.OrgId = c.OrgID
-	pdDTO.Uid = uid
 	dto := SavePublicDashboardDTO{
+		Uid:             uid,
 		UserId:          c.UserID,
+		OrgID:           c.OrgID,
 		DashboardUid:    dashboardUid,
 		PublicDashboard: pdDTO,
 	}

--- a/pkg/services/publicdashboards/api/query_test.go
+++ b/pkg/services/publicdashboards/api/query_test.go
@@ -313,9 +313,9 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 	isEnabled := true
 	savePubDashboardCmd := &SavePublicDashboardDTO{
 		DashboardUid: dashboard.UID,
+		OrgID:        dashboard.OrgID,
 		PublicDashboard: &PublicDashboardDTO{
 			IsEnabled: &isEnabled,
-			OrgId:     dashboard.OrgID,
 		},
 	}
 

--- a/pkg/services/publicdashboards/models/models.go
+++ b/pkg/services/publicdashboards/models/models.go
@@ -56,21 +56,11 @@ type PublicDashboard struct {
 }
 
 type PublicDashboardDTO struct {
-	Uid          string    `json:"uid"`
-	DashboardUid string    `json:"dashboardUid"`
-	OrgId        int64     `json:"-"` // Don't ever marshal orgId to Json
-	AccessToken  string    `json:"accessToken"`
-	CreatedBy    int64     `json:"createdBy"`
-	UpdatedBy    int64     `json:"updatedBy"`
-	CreatedAt    time.Time `json:"createdAt"`
-	UpdatedAt    time.Time `json:"updatedAt"`
-	//config fields
 	TimeSettings         *TimeSettings `json:"timeSettings"`
 	TimeSelectionEnabled *bool         `json:"timeSelectionEnabled"`
 	IsEnabled            *bool         `json:"isEnabled"`
 	AnnotationsEnabled   *bool         `json:"annotationsEnabled"`
 	Share                ShareType     `json:"share"`
-	Recipients           []EmailDTO    `json:"recipients,omitempty"`
 }
 
 type EmailDTO struct {
@@ -143,7 +133,9 @@ func (ts *TimeSettings) ToDB() ([]byte, error) {
 
 // DTO for transforming user input in the api
 type SavePublicDashboardDTO struct {
+	Uid             string
 	DashboardUid    string
+	OrgID           int64
 	UserId          int64
 	PublicDashboard *PublicDashboardDTO
 }

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -704,10 +704,9 @@ func TestGetQueryDataResponse(t *testing.T) {
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: dashboard.UID,
 			UserId:       7,
+			OrgID:        dashboard.OrgID,
 			PublicDashboard: &PublicDashboardDTO{
 				IsEnabled:    &isEnabled,
-				DashboardUid: "NOTTHESAME",
-				OrgId:        dashboard.OrgID,
 				TimeSettings: timeSettings,
 			},
 		}
@@ -1215,10 +1214,9 @@ func TestBuildMetricRequest(t *testing.T) {
 	isEnabled := true
 	dto := &SavePublicDashboardDTO{
 		DashboardUid: publicDashboard.UID,
+		OrgID:        9999999,
 		PublicDashboard: &PublicDashboardDTO{
 			IsEnabled:    &isEnabled,
-			DashboardUid: "NOTTHESAME",
-			OrgId:        9999999,
 			TimeSettings: timeSettings,
 		},
 	}
@@ -1229,10 +1227,9 @@ func TestBuildMetricRequest(t *testing.T) {
 	isEnabled = false
 	nonPublicDto := &SavePublicDashboardDTO{
 		DashboardUid: nonPublicDashboard.UID,
+		OrgID:        9999999,
 		PublicDashboard: &PublicDashboardDTO{
 			IsEnabled:    &isEnabled,
-			DashboardUid: "NOTTHESAME",
-			OrgId:        9999999,
 			TimeSettings: defaultPubdashTimeSettings,
 		},
 	}

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -208,11 +208,11 @@ func (pd *PublicDashboardServiceImpl) Update(ctx context.Context, u *user.Signed
 	}
 
 	// get existing public dashboard if exists
-	existingPubdash, err := pd.store.Find(ctx, dto.PublicDashboard.Uid)
+	existingPubdash, err := pd.store.Find(ctx, dto.Uid)
 	if err != nil {
-		return nil, ErrInternalServerError.Errorf("Update: failed to find public dashboard by uid: %s: %w", dto.PublicDashboard.Uid, err)
+		return nil, ErrInternalServerError.Errorf("Update: failed to find public dashboard by uid: %s: %w", dto.Uid, err)
 	} else if existingPubdash == nil {
-		return nil, ErrPublicDashboardNotFound.Errorf("Update: public dashboard not found by uid: %s", dto.PublicDashboard.Uid)
+		return nil, ErrPublicDashboardNotFound.Errorf("Update: public dashboard not found by uid: %s", dto.Uid)
 	}
 
 	publicDashboard := newUpdatePublicDashboard(dto, existingPubdash)
@@ -230,7 +230,7 @@ func (pd *PublicDashboardServiceImpl) Update(ctx context.Context, u *user.Signed
 
 	// 404 if not found
 	if affectedRows == 0 {
-		return nil, ErrPublicDashboardNotFound.Errorf("Update: failed to update public dashboard not found by uid: %s", dto.PublicDashboard.Uid)
+		return nil, ErrPublicDashboardNotFound.Errorf("Update: failed to update public dashboard not found by uid: %s", dto.Uid)
 	}
 
 	// get latest public dashboard to return
@@ -418,17 +418,21 @@ func (pd *PublicDashboardServiceImpl) newCreatePublicDashboard(ctx context.Conte
 		share = PublicShareType
 	}
 
+	now := time.Now()
+
 	return &PublicDashboard{
 		Uid:                  uid,
 		DashboardUid:         dto.DashboardUid,
-		OrgId:                dto.PublicDashboard.OrgId,
+		OrgId:                dto.OrgID,
 		IsEnabled:            isEnabled,
 		AnnotationsEnabled:   annotationsEnabled,
 		TimeSelectionEnabled: timeSelectionEnabled,
 		TimeSettings:         timeSettings,
 		Share:                share,
 		CreatedBy:            dto.UserId,
-		CreatedAt:            time.Now(),
+		CreatedAt:            now,
+		UpdatedBy:            dto.UserId,
+		UpdatedAt:            now,
 		AccessToken:          accessToken,
 	}, nil
 }

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -210,13 +210,12 @@ func TestCreatePublicDashboard(t *testing.T) {
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: dashboard.UID,
 			UserId:       7,
+			OrgID:        dashboard.OrgID,
 			PublicDashboard: &PublicDashboardDTO{
 				IsEnabled:            &isEnabled,
 				AnnotationsEnabled:   &annotationsEnabled,
 				TimeSelectionEnabled: &timeSelectionEnabled,
 				Share:                EmailShareType,
-				DashboardUid:         "NOTTHESAME",
-				OrgId:                dashboard.OrgID,
 				TimeSettings:         timeSettings,
 			},
 		}
@@ -298,13 +297,12 @@ func TestCreatePublicDashboard(t *testing.T) {
 			dto := &SavePublicDashboardDTO{
 				DashboardUid: dashboard.UID,
 				UserId:       7,
+				OrgID:        dashboard.OrgID,
 				PublicDashboard: &PublicDashboardDTO{
 					IsEnabled:            tt.IsEnabled,
 					TimeSelectionEnabled: tt.TimeSelectionEnabled,
 					AnnotationsEnabled:   tt.AnnotationsEnabled,
 					Share:                PublicShareType,
-					DashboardUid:         "NOTTHESAME",
-					OrgId:                dashboard.OrgID,
 					TimeSettings:         timeSettings,
 				},
 			}
@@ -338,11 +336,10 @@ func TestCreatePublicDashboard(t *testing.T) {
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: dashboard.UID,
+			OrgID:        dashboard.OrgID,
 			UserId:       7,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				DashboardUid: "NOTTHESAME",
-				OrgId:        dashboard.OrgID,
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -373,11 +370,10 @@ func TestCreatePublicDashboard(t *testing.T) {
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: dashboard.UID,
+			OrgID:        dashboard.OrgID,
 			UserId:       7,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				DashboardUid: "NOTTHESAME",
-				OrgId:        dashboard.OrgID,
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -418,11 +414,10 @@ func TestCreatePublicDashboard(t *testing.T) {
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: "an-id",
+			OrgID:        dashboard.OrgID,
 			UserId:       7,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				DashboardUid: "NOTTHESAME",
-				OrgId:        dashboard.OrgID,
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -487,11 +482,10 @@ func TestCreatePublicDashboard(t *testing.T) {
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
 			DashboardUid: dashboard.UID,
+			OrgID:        dashboard.OrgID,
 			UserId:       7,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				DashboardUid: "NOTTHESAME",
-				OrgId:        dashboard.OrgID,
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -546,24 +540,20 @@ func TestUpdatePublicDashboard(t *testing.T) {
 		require.NoError(t, err)
 
 		isEnabled, annotationsEnabled, timeSelectionEnabled = true, true, true
-		// attempt to overwrite settings
+
 		dto = &SavePublicDashboardDTO{
+			Uid:          savedPubdash.Uid,
 			DashboardUid: dashboard.UID,
+			OrgID:        9,
 			UserId:       8,
 			PublicDashboard: &PublicDashboardDTO{
-				Uid:          savedPubdash.Uid,
-				OrgId:        9,
-				DashboardUid: "abc1234",
-				CreatedBy:    9,
-				CreatedAt:    time.Time{},
-
 				IsEnabled:            &isEnabled,
 				AnnotationsEnabled:   &annotationsEnabled,
 				TimeSelectionEnabled: &timeSelectionEnabled,
 				TimeSettings:         timeSettings,
-				AccessToken:          "NOTAREALUUID",
 			},
 		}
+
 		updatedPubdash, err := service.Update(context.Background(), SignedInUser, dto)
 		require.NoError(t, err)
 
@@ -612,19 +602,14 @@ func TestUpdatePublicDashboard(t *testing.T) {
 		savedPubdash, err := service.Create(context.Background(), SignedInUser, dto)
 		require.NoError(t, err)
 
-		// attempt to overwrite settings
 		dto = &SavePublicDashboardDTO{
+			Uid:          savedPubdash.Uid,
 			DashboardUid: dashboard.UID,
+			OrgID:        9,
 			UserId:       8,
 			PublicDashboard: &PublicDashboardDTO{
-				Uid:          savedPubdash.Uid,
-				OrgId:        9,
-				DashboardUid: "abc1234",
-				CreatedBy:    9,
-				CreatedAt:    time.Time{},
 				IsEnabled:    &isEnabled,
 				TimeSettings: &TimeSettings{},
-				AccessToken:  "NOTAREALUUID",
 			},
 		}
 
@@ -714,22 +699,17 @@ func TestUpdatePublicDashboard(t *testing.T) {
 			savedPubdash, err := service.Create(context.Background(), SignedInUser, dto)
 			require.NoError(t, err)
 
-			// attempt to overwrite settings
 			dto = &SavePublicDashboardDTO{
+				Uid:          savedPubdash.Uid,
 				DashboardUid: dashboard.UID,
+				OrgID:        9,
 				UserId:       8,
 				PublicDashboard: &PublicDashboardDTO{
-					Uid:                  savedPubdash.Uid,
-					OrgId:                9,
-					DashboardUid:         "abc1234",
-					CreatedBy:            9,
-					CreatedAt:            time.Time{},
 					IsEnabled:            tt.IsEnabled,
 					AnnotationsEnabled:   tt.AnnotationsEnabled,
 					TimeSelectionEnabled: tt.TimeSelectionEnabled,
 					TimeSettings:         tt.TimeSettings,
 					Share:                tt.ShareType,
-					AccessToken:          "NOTAREALUUID",
 				},
 			}
 			updatedPubdash, err := service.Update(context.Background(), SignedInUser, dto)


### PR DESCRIPTION
**What is this feature?**
- Refactor for removing non-updatable fields from DTO. This removes the necessity of mutating the DTO and the possibility of updating fields that are not updatable by the user.
- Update audit fields `updateAt` and `updateBy` on public dashboard creation

Fixes https://github.com/grafana/grafana/issues/69024

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
