### PR TITLE
logs: better nanosecond handling

### DIFF
--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -366,8 +366,9 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
     for (let j = 0; j < series.length; j++) {
       const ts = timeField.values[j];
       const time = toUtc(ts);
+      const timeEpochMs = time.valueOf();
       const tsNs = timeNanosecondField ? timeNanosecondField.values[j] : undefined;
-      const timeEpochNs = tsNs ? tsNs : time.valueOf() + '000000';
+      const timeEpochNs = tsNs ? tsNs : timeEpochMs + '000000';
 
       // In edge cases, this can be undefined. If undefined, we want to replace it with empty string.
       const messageValue: unknown = stringField.values[j] ?? '';
@@ -405,7 +406,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
         dataFrame: series,
         logLevel,
         timeFromNow: dateTimeFormatTimeAgo(ts),
-        timeEpochMs: time.valueOf(),
+        timeEpochMs,
         timeEpochNs,
         timeLocal: dateTimeFormat(ts, { timeZone: 'browser' }),
         timeUtc: dateTimeFormat(ts, { timeZone: 'utc' }),

--- a/public/app/core/logsModel_parse.test.ts
+++ b/public/app/core/logsModel_parse.test.ts
@@ -731,4 +731,198 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
 
     expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
+
+  it('should parse timestamps when nanosecond data in the time field and no nanosecond field', () => {
+    const frames: DataFrame[] = [
+      {
+        refId: 'A',
+        fields: [
+          {
+            name: 'timestamp',
+            type: FieldType.time,
+            config: {},
+            values: [1686142519756, 1686142520411, 1686142519997],
+            nanos: [641, 0, 123456],
+          },
+          {
+            name: 'body',
+            type: FieldType.string,
+            config: {},
+            values: ['line1', 'line2', 'line3'],
+          },
+        ],
+        length: 3,
+      },
+    ];
+
+    const expected = {
+      hasUniqueLabels: false,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756000641',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_0',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_1',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997123456',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_2',
+          uniqueLabels: {},
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
+  });
+
+  it('should parse timestamps when both nanosecond data and nanosecond field, the field wins', () => {
+    // whether the dataframe-field wins or the nanosecond-data in the time-field wins,
+    // is arbitrary at the end. we simply have to pick one option, and keep doing that.
+    const frames: DataFrame[] = [
+      {
+        refId: 'A',
+        fields: [
+          {
+            name: 'timestamp',
+            type: FieldType.time,
+            config: {},
+            values: [1686142519756, 1686142520411, 1686142519997],
+            nanos: [1, 2, 3],
+          },
+          {
+            name: 'body',
+            type: FieldType.string,
+            config: {},
+            values: ['line1', 'line2', 'line3'],
+          },
+          {
+            name: 'tsNs',
+            type: FieldType.string,
+            config: {},
+            values: ['1686142519756000004', '1686142520411000005', '1686142519997000006'],
+          },
+        ],
+        length: 3,
+      },
+    ];
+
+    const expected = {
+      hasUniqueLabels: false,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756000004',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_0',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000005',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_1',
+          uniqueLabels: {},
+        },
+        {
+          dataFrame: frames[0],
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 1,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {},
+          logLevel: 'unknown',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997000006',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_2',
+          uniqueLabels: {},
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
+  });
 });


### PR DESCRIPTION
tradidtionally the dataframe-time-fields offered only millisecond-precision. to represent timestamps with nanosecond-precision (for example the timestamps coming from Loki), we created a separate dataframe-string-field, with name `tsNs`, and stored the full nanosecond-unix-timestamps (large integers) in it.

but, since https://github.com/grafana/grafana/pull/64529 the dataframe-time-fields are able to store the extra data needed to have nanosecond-precision.

this PR adjusts `logsModel.ts` to handle this data.

how to test:
1. unfortunately there is no user-observable place where we show the parsed nanosecond timestamps (we use them to sort the log-rows), so open the browser devtools, and add a breakpoint here:  https://github.com/grafana/grafana/blob/21db5b05047c73c9aec6a101e3b440e40de17ed2/public/app/features/logs/components/LogRows.tsx#L108
2. use the test-datasource (`gdev-testdata`), choose the `raw frames` mode, and paste in the following JSON
```json
[
  {
    "schema": {
      "meta": {
        "preferredVisualisationType": "logs"
      },
      "fields": [
        { "name": "timestamp", "type": "time" },
        { "name": "body", "type": "string" }
      ]
    },
    "data": {
      "values": [
        [1686648201526, 1686648201232, 1686648200714],
        ["line1", "line2", "line3"]
      ],
      "nanos": [[123456, 0, 123], null]
    }
  }
]
```
3. when the breakpoint is hit, check the data stored in the variable `logRows`. it is an array, verify that it has 3 items, and their `timeEpochMs` attribute's value matches the values from the JSON, and their `timeEpochNs` attribute's value is combined from the millisecond-value and the nanosecond-value



(fixes https://github.com/grafana/grafana/issues/67889)