### PR TITLE
Alerting: Use ToggleTip instead of Hovercard in the info popup on Math expressions

### DIFF
--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
@@ -1,4 +1,4 @@
-import { cx } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { Placement } from '@popperjs/core';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
@@ -29,8 +29,8 @@ export interface ToggletipProps {
   footer?: JSX.Element | string;
   /** The UI control users interact with to display toggletips */
   children: JSX.Element;
-  /** The class name to be applied to the toggletip's container */
-  containerClassName?: string;
+  /** Determine whether the toggletip should fit its content or not */
+  fitContent?: boolean;
 }
 
 export const Toggletip = React.memo(
@@ -43,7 +43,7 @@ export const Toggletip = React.memo(
     closeButton = true,
     onClose,
     footer,
-    containerClassName,
+    fitContent = false,
   }: ToggletipProps) => {
     const styles = useStyles2(getStyles);
     const style = styles[theme];
@@ -95,7 +95,7 @@ export const Toggletip = React.memo(
             <div
               data-testid="toggletip-content"
               ref={setTooltipRef}
-              {...getTooltipProps({ className: cx(style.container, containerClassName) })}
+              {...getTooltipProps({ className: cx(style.container, fitContent && styles.fitContent) })}
             >
               {Boolean(title) && <div className={style.header}>{title}</div>}
               {closeButton && (
@@ -143,5 +143,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     info,
     error,
+    fitContent: css`
+      max-width: fit-content;
+    `,
   };
 };

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
@@ -1,3 +1,4 @@
+import { cx } from '@emotion/css';
 import { Placement } from '@popperjs/core';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
@@ -28,6 +29,8 @@ export interface ToggletipProps {
   footer?: JSX.Element | string;
   /** The UI control users interact with to display toggletips */
   children: JSX.Element;
+  /** The class name to be applied to the toggletip's container */
+  containerClassName?: string;
 }
 
 export const Toggletip = React.memo(
@@ -40,6 +43,7 @@ export const Toggletip = React.memo(
     closeButton = true,
     onClose,
     footer,
+    containerClassName,
   }: ToggletipProps) => {
     const styles = useStyles2(getStyles);
     const style = styles[theme];
@@ -91,7 +95,7 @@ export const Toggletip = React.memo(
             <div
               data-testid="toggletip-content"
               ref={setTooltipRef}
-              {...getTooltipProps({ className: style.container })}
+              {...getTooltipProps({ className: cx(style.container, containerClassName) })}
             >
               {Boolean(title) && <div className={style.header}>{title}</div>}
               {closeButton && (

--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -37,7 +37,7 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
         label={
           <InlineLabel width="auto">
             <Toggletip
-              containerClassName={styles.toggletip}
+              fitContent
               content={
                 <div className={styles.documentationContainer}>
                   <div>
@@ -113,9 +113,9 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
               closeButton={true}
               placement="bottom-start"
             >
-              <span>
+              <div className={styles.info}>
                 Expression <Icon name="info-circle" />
-              </span>
+              </div>
             </Toggletip>
           </InlineLabel>
         }
@@ -172,8 +172,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     grid-template-columns: max-content auto;
     column-gap: ${theme.spacing(2)};
   `,
-  toggletip: css`
-    max-width: fit-content;
+  info: css`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    cursor: pointer;
+    gap: ${theme.spacing(1)};
   `,
 });
 

--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -3,8 +3,7 @@ import React, { ChangeEvent } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Icon, InlineField, InlineLabel, TextArea, useStyles2 } from '@grafana/ui';
-import { HoverCard } from 'app/features/alerting/unified/components/HoverCard';
+import { Icon, InlineField, InlineLabel, TextArea, Toggletip, useStyles2 } from '@grafana/ui';
 
 import { ExpressionQuery } from '../types';
 
@@ -37,12 +36,10 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
       <InlineField
         label={
           <InlineLabel width="auto">
-            <HoverCard
+            <Toggletip
+              containerClassName={styles.toggletip}
               content={
                 <div className={styles.documentationContainer}>
-                  <header className={styles.documentationHeader}>
-                    <Icon name="book-open" /> Math operator
-                  </header>
                   <div>
                     Run math operations on one or more queries. You reference the query by {'${refId}'} ie. $A, $B, $C
                     etc.
@@ -92,25 +89,34 @@ export const Math = ({ labelWidth, onChange, query, onRunQuery }: Props) => {
                       description="rounds the number down to the nearest integer value. It's able to operate on series or escalar values."
                     />
                   </div>
-                  <div>
-                    See our additional documentation on{' '}
-                    <a
-                      className={styles.documentationLink}
-                      target="_blank"
-                      href="https://grafana.com/docs/grafana/latest/panels/query-a-data-source/use-expressions-to-manipulate-data/about-expressions/#math"
-                      rel="noreferrer"
-                    >
-                      <Icon size="xs" name="external-link-alt" /> Math expressions
-                    </a>
-                    .
-                  </div>
                 </div>
               }
+              title={
+                <Stack gap={1} direction="row">
+                  <Icon name="book-open" /> Math operator
+                </Stack>
+              }
+              footer={
+                <div>
+                  See our additional documentation on{' '}
+                  <a
+                    className={styles.documentationLink}
+                    target="_blank"
+                    href="https://grafana.com/docs/grafana/latest/panels/query-a-data-source/use-expressions-to-manipulate-data/about-expressions/#math"
+                    rel="noreferrer"
+                  >
+                    <Icon size="xs" name="external-link-alt" /> Math expressions
+                  </a>
+                  .
+                </div>
+              }
+              closeButton={true}
+              placement="bottom-start"
             >
               <span>
                 Expression <Icon name="info-circle" />
               </span>
-            </HoverCard>
+            </Toggletip>
           </InlineLabel>
         }
         labelWidth={labelWidth}
@@ -165,6 +171,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: grid;
     grid-template-columns: max-content auto;
     column-gap: ${theme.spacing(2)};
+  `,
+  toggletip: css`
+    max-width: fit-content;
   `,
 });
 


### PR DESCRIPTION
This PR updates the Math expression component to use `ToggleTip` instead of `HoverCard` . The motivation behind this change is to address the annoyance caused by accidental popup when hovering over this large modal.

In this PR we add also a new optional property in the `ToogleTip` component to be able to override the `max-width`and not use the fixed 400px we have so far.

**What is this feature?**

All users

**Why do we need this feature?**

To make a better user experience. 

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

Before:


https://github.com/grafana/grafana/assets/33540275/52973ae2-4176-42f0-aae1-198dece7041f

After: 



https://github.com/grafana/grafana/assets/33540275/c58710dc-83fc-4200-80cb-8d79093bd6e6




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
