### PR TITLE
logs: add more tests

### DIFF
--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -49,6 +49,34 @@ describe('logParser', () => {
       expect(fields.find((field) => field.keys[0] === 'labels')).not.toBe(undefined);
     });
 
+    it('should not filter out field with labels name and other type and datalinks', () => {
+      const logRow = createLogRow({
+        entryFieldIndex: 10,
+        dataFrame: new MutableDataFrame({
+          refId: 'A',
+          fields: [
+            testStringField,
+            {
+              name: 'labels',
+              type: FieldType.other,
+              config: {
+                links: [
+                  {
+                    title: 'test1',
+                    url: 'url1',
+                  },
+                ],
+              },
+              values: [{ place: 'luna', source: 'data' }],
+            },
+          ],
+        }),
+      });
+      const fields = getAllFields(logRow);
+      expect(fields.length).toBe(2);
+      expect(fields.find((field) => field.keys[0] === 'labels')).not.toBe(undefined);
+    });
+
     it('should filter out field with id name', () => {
       const logRow = createLogRow({
         entryFieldIndex: 10,


### PR DESCRIPTION
when we show fields in log-details, we do not show certain "system" fields, like the timestamp-field, the logline-field etc... but there's some complex logic there, and one scenario did not have a test-case, so i added it.
(when we have a labels-field, then we do not show that, because it is a system field, but, if it has a data-link, we must show it)