### PR TITLE
Login: Fix footer from displaying under the login box

### DIFF
--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -19,7 +19,7 @@ const LoginBackground: FC<BrandComponentProps> = ({ className, children }) => {
   const background = css`
     &:before {
       content: '';
-      position: absolute;
+      position: fixed;
       left: 0;
       right: 0;
       bottom: 0;

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -36,21 +36,23 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
     <Branding.LoginBackground
       className={cx(loginStyles.container, startAnim && loginStyles.loginAnim, branding?.loginBackground)}
     >
-      <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
-        <div className={loginStyles.loginLogoWrapper}>
-          <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
-          <div className={loginStyles.titleWrapper}>
-            {isChangingPassword ? (
-              <h1 className={loginStyles.mainTitle}>Update your password</h1>
-            ) : (
-              <>
-                <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
-                {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
-              </>
-            )}
+      <div className={loginStyles.loginMain}>
+        <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
+          <div className={loginStyles.loginLogoWrapper}>
+            <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
+            <div className={loginStyles.titleWrapper}>
+              {isChangingPassword ? (
+                <h1 className={loginStyles.mainTitle}>Update your password</h1>
+              ) : (
+                <>
+                  <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
+                  {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
+                </>
+              )}
+            </div>
           </div>
+          <div className={loginStyles.loginOuterBox}>{children}</div>
         </div>
-        <div className={loginStyles.loginOuterBox}>{children}</div>
       </div>
       {branding?.hideFooter ? <></> : <Footer customLinks={branding?.footerLinks} />}
     </Branding.LoginBackground>
@@ -70,6 +72,14 @@ to{
 
 export const getLoginStyles = (theme: GrafanaTheme2) => {
   return {
+    loginMain: css({
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: '100%',
+    }),
     container: css({
       minHeight: '100%',
       backgroundPosition: 'center',

--- a/public/sass/components/_footer.scss
+++ b/public/sass/components/_footer.scss
@@ -47,8 +47,6 @@
 .login-page {
   .footer {
     display: block;
-    bottom: $spacer;
-    position: absolute;
     padding: $space-md 0 $space-md 0;
     color: $text-color;
 


### PR DESCRIPTION
Fixes the issue where at small viewport sizes (and large login box configurations, like many oauth providers) the login box would overlap with the footer links.

Also fixes an issue when the login box requires the page to scroll the branded background would not scroll properly.

![image](https://github.com/grafana/grafana/assets/46142/0671d8fb-1f25-4d4f-9b83-ce2a781b0d43)


Fixes https://github.com/grafana/grafana/issues/70470