### PR TITLE
Prometheus: Remove duplicate definition in docs

### DIFF
--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -66,8 +66,6 @@ httpMethod: POST
 manageAlerts: true
 prometheusType: Prometheus
 prometheusVersion: 2.44.0
-incrementalQuerying: true
-incrementalQueryOverlapWindow: 10m
 cacheLevel: 'High'
 incrementalQuerying: true
 incrementalQueryOverlapWindow: 10m


### PR DESCRIPTION
**What is this feature?**
Provisioning example has duplicate definitions
https://grafana.com/docs/grafana/latest/datasources/prometheus/#provisioning-example