### PR TITLE
PublicDashboards: Remove timeSettings from API

### DIFF
--- a/pkg/services/publicdashboards/models/models.go
+++ b/pkg/services/publicdashboards/models/models.go
@@ -47,7 +47,7 @@ type PublicDashboard struct {
 	CreatedAt    time.Time `json:"createdAt" xorm:"created_at"`
 	UpdatedAt    time.Time `json:"updatedAt" xorm:"updated_at"`
 	//config fields
-	TimeSettings         *TimeSettings `json:"timeSettings" xorm:"time_settings"`
+	TimeSettings         *TimeSettings `json:"-" xorm:"time_settings"`
 	TimeSelectionEnabled bool          `json:"timeSelectionEnabled" xorm:"time_selection_enabled"`
 	IsEnabled            bool          `json:"isEnabled" xorm:"is_enabled"`
 	AnnotationsEnabled   bool          `json:"annotationsEnabled" xorm:"annotations_enabled"`
@@ -56,11 +56,10 @@ type PublicDashboard struct {
 }
 
 type PublicDashboardDTO struct {
-	TimeSettings         *TimeSettings `json:"timeSettings"`
-	TimeSelectionEnabled *bool         `json:"timeSelectionEnabled"`
-	IsEnabled            *bool         `json:"isEnabled"`
-	AnnotationsEnabled   *bool         `json:"annotationsEnabled"`
-	Share                ShareType     `json:"share"`
+	TimeSelectionEnabled *bool     `json:"timeSelectionEnabled"`
+	IsEnabled            *bool     `json:"isEnabled"`
+	AnnotationsEnabled   *bool     `json:"annotationsEnabled"`
+	Share                ShareType `json:"share"`
 }
 
 type EmailDTO struct {

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -706,8 +706,7 @@ func TestGetQueryDataResponse(t *testing.T) {
 			UserId:       7,
 			OrgID:        dashboard.OrgID,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				TimeSettings: timeSettings,
+				IsEnabled: &isEnabled,
 			},
 		}
 		pubdashDto, err := service.Create(context.Background(), SignedInUser, dto)
@@ -1216,8 +1215,7 @@ func TestBuildMetricRequest(t *testing.T) {
 		DashboardUid: publicDashboard.UID,
 		OrgID:        9999999,
 		PublicDashboard: &PublicDashboardDTO{
-			IsEnabled:    &isEnabled,
-			TimeSettings: timeSettings,
+			IsEnabled: &isEnabled,
 		},
 	}
 
@@ -1229,8 +1227,7 @@ func TestBuildMetricRequest(t *testing.T) {
 		DashboardUid: nonPublicDashboard.UID,
 		OrgID:        9999999,
 		PublicDashboard: &PublicDashboardDTO{
-			IsEnabled:    &isEnabled,
-			TimeSettings: defaultPubdashTimeSettings,
+			IsEnabled: &isEnabled,
 		},
 	}
 

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -408,11 +408,6 @@ func (pd *PublicDashboardServiceImpl) newCreatePublicDashboard(ctx context.Conte
 	annotationsEnabled := returnValueOrDefault(dto.PublicDashboard.AnnotationsEnabled, false)
 	timeSelectionEnabled := returnValueOrDefault(dto.PublicDashboard.TimeSelectionEnabled, false)
 
-	timeSettings := dto.PublicDashboard.TimeSettings
-	if dto.PublicDashboard.TimeSettings == nil {
-		timeSettings = &TimeSettings{}
-	}
-
 	share := dto.PublicDashboard.Share
 	if dto.PublicDashboard.Share == "" {
 		share = PublicShareType
@@ -427,7 +422,7 @@ func (pd *PublicDashboardServiceImpl) newCreatePublicDashboard(ctx context.Conte
 		IsEnabled:            isEnabled,
 		AnnotationsEnabled:   annotationsEnabled,
 		TimeSelectionEnabled: timeSelectionEnabled,
-		TimeSettings:         timeSettings,
+		TimeSettings:         &TimeSettings{},
 		Share:                share,
 		CreatedBy:            dto.UserId,
 		CreatedAt:            now,
@@ -443,15 +438,6 @@ func newUpdatePublicDashboard(dto *SavePublicDashboardDTO, pd *PublicDashboard) 
 	isEnabled := returnValueOrDefault(pubdashDTO.IsEnabled, pd.IsEnabled)
 	annotationsEnabled := returnValueOrDefault(pubdashDTO.AnnotationsEnabled, pd.AnnotationsEnabled)
 
-	timeSettings := pubdashDTO.TimeSettings
-	if pubdashDTO.TimeSettings == nil {
-		if pd.TimeSettings == nil {
-			timeSettings = &TimeSettings{}
-		} else {
-			timeSettings = pd.TimeSettings
-		}
-	}
-
 	share := pubdashDTO.Share
 	if pubdashDTO.Share == "" {
 		share = pd.Share
@@ -462,7 +448,7 @@ func newUpdatePublicDashboard(dto *SavePublicDashboardDTO, pd *PublicDashboard) 
 		IsEnabled:            isEnabled,
 		AnnotationsEnabled:   annotationsEnabled,
 		TimeSelectionEnabled: timeSelectionEnabled,
-		TimeSettings:         timeSettings,
+		TimeSettings:         pd.TimeSettings,
 		Share:                share,
 		UpdatedBy:            dto.UserId,
 		UpdatedAt:            time.Now(),

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -216,7 +216,6 @@ func TestCreatePublicDashboard(t *testing.T) {
 				AnnotationsEnabled:   &annotationsEnabled,
 				TimeSelectionEnabled: &timeSelectionEnabled,
 				Share:                EmailShareType,
-				TimeSettings:         timeSettings,
 			},
 		}
 
@@ -236,8 +235,6 @@ func TestCreatePublicDashboard(t *testing.T) {
 		assert.Equal(t, *dto.PublicDashboard.IsEnabled, pubdash.IsEnabled)
 		// CreatedAt set to non-zero time
 		assert.NotEqual(t, &time.Time{}, pubdash.CreatedAt)
-		// Time settings set by db
-		assert.Equal(t, timeSettings, pubdash.TimeSettings)
 		assert.Equal(t, dto.PublicDashboard.Share, pubdash.Share)
 		// accessToken is valid uuid
 		_, err = uuid.Parse(pubdash.AccessToken)
@@ -303,7 +300,6 @@ func TestCreatePublicDashboard(t *testing.T) {
 					TimeSelectionEnabled: tt.TimeSelectionEnabled,
 					AnnotationsEnabled:   tt.AnnotationsEnabled,
 					Share:                PublicShareType,
-					TimeSettings:         timeSettings,
 				},
 			}
 
@@ -454,7 +450,6 @@ func TestCreatePublicDashboard(t *testing.T) {
 			PublicDashboard: &PublicDashboardDTO{
 				AnnotationsEnabled: &annotationsEnabled,
 				IsEnabled:          &isEnabled,
-				TimeSettings:       timeSettings,
 			},
 		}
 
@@ -531,7 +526,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 				IsEnabled:            &isEnabled,
 				AnnotationsEnabled:   &annotationsEnabled,
 				TimeSelectionEnabled: &timeSelectionEnabled,
-				TimeSettings:         timeSettings,
 			},
 		}
 
@@ -550,7 +544,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 				IsEnabled:            &isEnabled,
 				AnnotationsEnabled:   &annotationsEnabled,
 				TimeSelectionEnabled: &timeSelectionEnabled,
-				TimeSettings:         timeSettings,
 			},
 		}
 
@@ -568,7 +561,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 		assert.Equal(t, *dto.PublicDashboard.IsEnabled, updatedPubdash.IsEnabled)
 		assert.Equal(t, *dto.PublicDashboard.AnnotationsEnabled, updatedPubdash.AnnotationsEnabled)
 		assert.Equal(t, *dto.PublicDashboard.TimeSelectionEnabled, updatedPubdash.TimeSelectionEnabled)
-		assert.Equal(t, dto.PublicDashboard.TimeSettings, updatedPubdash.TimeSettings)
 		assert.Equal(t, dto.UserId, updatedPubdash.UpdatedBy)
 		assert.NotEqual(t, &time.Time{}, updatedPubdash.UpdatedAt)
 	})
@@ -594,8 +586,7 @@ func TestUpdatePublicDashboard(t *testing.T) {
 			DashboardUid: dashboard.UID,
 			UserId:       7,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				TimeSettings: timeSettings,
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -608,8 +599,7 @@ func TestUpdatePublicDashboard(t *testing.T) {
 			OrgID:        9,
 			UserId:       8,
 			PublicDashboard: &PublicDashboardDTO{
-				IsEnabled:    &isEnabled,
-				TimeSettings: &TimeSettings{},
+				IsEnabled: &isEnabled,
 			},
 		}
 
@@ -690,7 +680,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 					IsEnabled:            &isEnabled,
 					AnnotationsEnabled:   &annotationsEnabled,
 					TimeSelectionEnabled: &timeSelectionEnabled,
-					TimeSettings:         timeSettings,
 					Share:                PublicShareType,
 				},
 			}
@@ -708,7 +697,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 					IsEnabled:            tt.IsEnabled,
 					AnnotationsEnabled:   tt.AnnotationsEnabled,
 					TimeSelectionEnabled: tt.TimeSelectionEnabled,
-					TimeSettings:         tt.TimeSettings,
 					Share:                tt.ShareType,
 				},
 			}
@@ -719,11 +707,6 @@ func TestUpdatePublicDashboard(t *testing.T) {
 			assertOldValueIfNull(t, updatedPubdash.AnnotationsEnabled, savedPubdash.AnnotationsEnabled, dto.PublicDashboard.AnnotationsEnabled)
 			assertOldValueIfNull(t, updatedPubdash.TimeSelectionEnabled, savedPubdash.TimeSelectionEnabled, dto.PublicDashboard.TimeSelectionEnabled)
 
-			if dto.PublicDashboard.TimeSettings == nil {
-				assert.Equal(t, updatedPubdash.TimeSettings, savedPubdash.TimeSettings)
-			} else {
-				assert.Equal(t, updatedPubdash.TimeSettings, dto.PublicDashboard.TimeSettings)
-			}
 			if dto.PublicDashboard.Share == "" {
 				assert.Equal(t, updatedPubdash.Share, savedPubdash.Share)
 			} else {


### PR DESCRIPTION
**What is this feature?**
A public dashboard does not have time settings at this moment, a default value is retrieved from the original dashboard.
In this PR I'm removing the `timeSettings` from the API to avoid confusion, it doesn't make sense to expose it if the code is not using it.

This is still something that we could introduce in the future so I didn't remove all the logic on the backend to keep the logic of saving an empty JSON in the DB for the `time_settings` column.
If we decide to implement this in the future, we can revert or leverage part of this code.

Fixes https://github.com/grafana/grafana/issues/69024

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
