### PR TITLE
Loki: Fix wrong query expression with inline comments

### DIFF
--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -161,6 +161,7 @@ describe('removeCommentsFromQuery', () => {
     ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello'} | ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl '}
     ${`#sum(rate(\n{host="containers"}\n#[1m]))`}                                     | ${`\n{host="containers"}\n`}
     ${`#sum(rate(\n{host="containers"}\n#| logfmt\n#[1m]))`}                          | ${`\n{host="containers"}\n\n`}
+    ${'{job="grafana"}\n#hello\n| logfmt'}                                            | ${'{job="grafana"}\n\n| logfmt'}
   `('strips comments in log query:  {$query}', ({ query, expectedResult }) => {
     expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -241,6 +241,7 @@ export function removeCommentsFromQuery(query: string): string {
     newQuery = newQuery + query.substring(prev, lineCommentPosition.from);
     prev = lineCommentPosition.to;
   }
+  newQuery = newQuery + query.substring(prev);
   return newQuery;
 }
 


### PR DESCRIPTION
**What is this feature?**

When using multiline queries with comments, we are currently generating wrong query expressions.

E.g. 
```
{app="foo"}
# test
|= `bar`
```

will be parsed to
```
{app="foo"}
```

With this PR it will be
```
{app="foo"}

|= `bar`
```

