### PR TITLE
add setupListeners to the redux store

### DIFF
--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -1,4 +1,5 @@
 import { configureStore as reduxConfigureStore, createListenerMiddleware } from '@reduxjs/toolkit';
+import { setupListeners } from '@reduxjs/toolkit/dist/query';
 
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { publicDashboardApi } from 'app/features/dashboard/api/publicDashboardApi';
@@ -35,6 +36,9 @@ export function configureStore(initialState?: Partial<StoreState>) {
       ...initialState,
     },
   });
+
+  // this enables "refetchOnFocus" and "refetchOnReconnect" for RTK Query
+  setupListeners(store.dispatch);
 
   setStore(store);
   return store;

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -1,5 +1,5 @@
 import { configureStore as reduxConfigureStore, createListenerMiddleware } from '@reduxjs/toolkit';
-import { setupListeners } from '@reduxjs/toolkit/dist/query';
+import { setupListeners } from '@reduxjs/toolkit/query';
 
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { publicDashboardApi } from 'app/features/dashboard/api/publicDashboardApi';


### PR DESCRIPTION
This PR adds `setupListeners` (see [docs](https://redux-toolkit.js.org/rtk-query/api/setupListeners))  so `refetchOnFocus` and `refetchOnReconnect` can be used in RTK Query

In the alerting squad we work with a lot of lists showing the state of your alert rules, we currently use polling in a few places where we can afford to but being able to refetch information when the window is focussed again when working with multiple tabs or when a network reconnect event occurs gets us closer to a soft real-time presentation.
