### PR TITLE
AsyncSegment: Display no-options placeholder for no items status

### DIFF
--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -110,9 +110,5 @@ function mapStateToNoOptionsMessage<T>(state: AsyncState<Array<SelectableValue<T
     return t('grafana-ui.segment-async.error', 'Failed to load options');
   }
 
-  if (!Array.isArray(state.value) || state.value.length === 0) {
-    return t('grafana-ui.segment-async.no-options', 'No options found');
-  }
-
-  return '';
+  return t('grafana-ui.segment-async.no-options', 'No options found');
 }


### PR DESCRIPTION
The no-options default handler should always return a no-options message since it is only going to be called when no options are called.

|Before|After|
|-|-|
![2023-06-30 17 40 52](https://github.com/grafana/grafana/assets/5699976/99844663-f6dc-49aa-9109-c35cd6ded895)|![2023-06-30 17 14 51](https://github.com/grafana/grafana/assets/5699976/84667745-647a-4f02-83fa-cfaa632752ab)
