### PR TITLE
Alerting: Use unsafe.Slice for hashing a string during rule fingerprint calculation

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -263,12 +263,8 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 			writeBytes(nil)
 			return
 		}
-		// TODO fix it when upgraded to in GO1.20 to
-		/*
-			writeBytes(unsafe.Slice(unsafe.StringData(s), len(s))) //nolint:gosec
-		*/
 		// avoid allocation when converting string to byte slice
-		writeBytes(*(*[]byte)(unsafe.Pointer(&s))) //nolint:gosec
+		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s)))
 	}
 	// this temp slice is used to convert ints to bytes.
 	tmp := make([]byte, 8)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This is a follow-up for https://github.com/grafana/grafana/issues/66531 which introduced calculating the hash of the rule. At that time we used a technique to avoid unnecessary allocation of byte slices that has problems in some edge cases (https://github.com/grafana/grafana/pull/66531#discussion_r1176465641). Now, since we migrated to G 1.20+ we can use a more safe alternative.
