### PR TITLE
Fix width for Resample label

### DIFF
--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -13,7 +13,7 @@ import { getDefaults } from './utils/expressionTypes';
 
 type Props = QueryEditorProps<DataSourceApi<ExpressionQuery>, ExpressionQuery>;
 
-const labelWidth = 14;
+const labelWidth = 15;
 
 type NonClassicExpressionType = Exclude<ExpressionQueryType, ExpressionQueryType.classic>;
 type ExpressionTypeConfigStorage = Partial<Record<NonClassicExpressionType, string>>;


### PR DESCRIPTION
The width of the `Resample to` label was `114px` which was causing the text from the label to break & overflow out of the container

![image](https://github.com/grafana/grafana/assets/47709856/c243ba0e-b304-4973-8828-e09a392d862d)


This has been fixed by increasing the label width to `120px`

![Screenshot 2023-07-02 135905](https://github.com/grafana/grafana/assets/47709856/9a244938-b872-4edf-a36d-5092dc927d2c)

Fixes #70469 