### PR TITLE
Heatmap: Add datalink support

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
@@ -10,7 +10,7 @@ import {
   TimeRange,
   getLinksSupplier,
   InterpolateFunction,
-  ScopedVars
+  ScopedVars,
 } from '@grafana/data';
 import { HeatmapCellLayout } from '@grafana/schema';
 import { LinkButton, VerticalGroup } from '@grafana/ui';
@@ -127,10 +127,12 @@ const HeatmapHoverCell = ({ data, hover, showHistogram, scopedVars, replaceVars 
   for (const field of visibleFields ?? []) {
     const hasLinks = field.config.links && field.config.links.length > 0;
     if (hasLinks && data.heatmap) {
-      let appropriateScopedVars = scopedVars.filter((sv) => sv && sv.__dataContext && sv.__dataContext.value.field.name === nonNumericOrdinalDisplay)[0]
-      field.getLinks = getLinksSupplier(data.heatmap, field, appropriateScopedVars ?? {}, replaceVars)
+      let appropriateScopedVars = scopedVars.filter(
+        (sv) => sv && sv.__dataContext && sv.__dataContext.value.field.name === nonNumericOrdinalDisplay
+      )[0];
+      field.getLinks = getLinksSupplier(data.heatmap, field, appropriateScopedVars ?? {}, replaceVars);
     }
-    
+
     if (field.getLinks) {
       const v = field.values[index];
       const disp = field.display ? field.display(v) : { text: `${v}`, numeric: +v };

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -43,6 +43,15 @@ export const HeatmapPanel = ({
   const styles = useStyles2(getStyles);
   const { sync } = usePanelContext();
 
+  let scopedVarsFromRawData = []
+  for(const series of data.series) {
+    for(const field of series.fields) {
+      if(field.state?.scopedVars){
+        scopedVarsFromRawData.push(field.state?.scopedVars)
+      }
+    }
+  }
+
   // ugh
   let timeRangeRef = useRef<TimeRange>(timeRange);
   timeRangeRef.current = timeRange;
@@ -210,6 +219,8 @@ export const HeatmapPanel = ({
               data={info}
               hover={hover}
               showHistogram={options.tooltip.yHistogram}
+              replaceVars={replaceVariables}
+              scopedVars={scopedVarsFromRawData}
             />
           </VizTooltipContainer>
         )}

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -43,11 +43,12 @@ export const HeatmapPanel = ({
   const styles = useStyles2(getStyles);
   const { sync } = usePanelContext();
 
-  let scopedVarsFromRawData = []
-  for(const series of data.series) {
-    for(const field of series.fields) {
-      if(field.state?.scopedVars){
-        scopedVarsFromRawData.push(field.state?.scopedVars)
+  //  necessary for enabling datalinks in hover view
+  let scopedVarsFromRawData = [];
+  for (const series of data.series) {
+    for (const field of series.fields) {
+      if (field.state?.scopedVars) {
+        scopedVarsFromRawData.push(field.state?.scopedVars);
       }
     }
   }


### PR DESCRIPTION
Enables showing of datalinks in the tooltip when hovering over heatmap cells. Datalinks for heatmaps were previously left undefined.