### PR TITLE
logs: scanning: add tracking

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -282,11 +282,11 @@ class UnthemedLogs extends PureComponent<Props, State> {
     event.preventDefault();
     if (this.props.onStartScanning) {
       this.props.onStartScanning();
+      reportInteraction('grafana_explore_logs_scanning_button_clicked', {
+        type: 'start',
+        datasourceType: this.props.datasourceType,
+      });
     }
-    reportInteraction('grafana_explore_logs_scanning_button_clicked', {
-      type: 'start',
-      datasourceType: this.props.datasourceType,
-    });
   };
 
   onClickStopScan = (event: React.SyntheticEvent) => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -283,6 +283,10 @@ class UnthemedLogs extends PureComponent<Props, State> {
     if (this.props.onStartScanning) {
       this.props.onStartScanning();
     }
+    reportInteraction('grafana_explore_logs_scanning_button_clicked', {
+      type: 'start',
+      datasourceType: this.props.datasourceType,
+    });
   };
 
   onClickStopScan = (event: React.SyntheticEvent) => {


### PR DESCRIPTION
if a logs-search returns no logs we display the "scan for older logs" button. we will track how often it is used.


how to test:
- verify that clicking "scan for older logs" call `reportInteraction` (for example, by adding a breakpoint in `reportInteraction`


(note: technically there is also a "stop scanning" button, but there are some complications with that one, so for now we start tracking the 'start" button)