### PR TITLE
PanelChrome: Fixes issues with hover header and resizing panel above

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { ReactElement, useCallback, useRef, useState } from 'react';
+import React, { ReactElement, useCallback, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';

--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -31,18 +31,12 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32, on
     draggableRef.current?.releasePointerCapture(e.pointerId);
   }, []);
 
-  const [menuOpen, setMenuOpen] = useState(false);
-
   if (children === undefined || React.Children.count(children) === 0) {
     return null;
   }
 
   return (
-    <div
-      className={cx(styles.container, { 'show-on-hover': !menuOpen })}
-      style={{ top: `${offset}px` }}
-      data-testid={selectors.container}
-    >
+    <div className={cx(styles.container, 'show-on-hover')} style={{ top: offset }} data-testid={selectors.container}>
       {dragClass && (
         <div
           className={cx(styles.square, styles.draggable, dragClass)}
@@ -62,7 +56,6 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32, on
           title={title}
           placement="bottom"
           menuButtonClass={styles.menuButton}
-          onVisibleChange={setMenuOpen}
           onOpenMenu={onOpenMenu}
         />
       )}
@@ -72,10 +65,6 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32, on
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    hidden: css({
-      visibility: 'hidden',
-      opacity: '0',
-    }),
     container: css({
       label: 'hover-container-widget',
       transition: `all .1s linear`,

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2, useTheme2 } from '../../themes';
+import { getFocusStyles } from '../../themes/mixins';
 import { DelayRender } from '../../utils/DelayRender';
 import { Icon } from '../Icon/Icon';
 import { LoadingBar } from '../LoadingBar/LoadingBar';
@@ -157,7 +158,9 @@ export function PanelChrome({
   );
 
   return (
-    <div className={styles.container} style={containerStyles} data-testid={testid}>
+    // tabIndex={0} is needed for keyboard accessibility in the plot area
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div className={styles.container} style={containerStyles} data-testid={testid} tabIndex={0}>
       <div className={styles.loadingBarContainer}>
         {loadingState === LoadingState.Loading ? <LoadingBar width={width} ariaLabel="Panel loading bar" /> : null}
       </div>
@@ -273,9 +276,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         },
       },
 
-      '&:focus-visible': {
-        outline: `1px solid ${theme.colors.action.focus}`,
-      },
+      '&:focus-visible': getFocusStyles(theme),
 
       '&:focus-within': {
         '.show-on-hover': {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -262,12 +262,14 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '.show-on-hover': {
         opacity: '0',
+        visibility: 'hidden',
       },
 
       '&:focus-visible, &:hover': {
         // only show menu icon on hover or focused panel
         '.show-on-hover': {
           opacity: '1',
+          visibility: 'visible',
         },
       },
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -278,7 +278,8 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '&:focus-visible': getFocusStyles(theme),
 
-      '&:focus-within': {
+      // The not:(:focus) clause is so that this rule is only applied when decendants are focused (important otherwise the hover header is visible when panel is clicked).
+      '&:focus-within:not(:focus)': {
         '.show-on-hover': {
           visibility: 'visible',
           opacity: '1',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelMenu.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelMenu.tsx
@@ -14,7 +14,6 @@ interface PanelMenuProps {
   title?: string;
   placement?: TooltipPlacement;
   offset?: [number, number];
-  onVisibleChange?: (state: boolean) => void;
   onOpenMenu?: () => void;
 }
 
@@ -25,7 +24,6 @@ export function PanelMenu({
   offset,
   dragClassCancel,
   menuButtonClass,
-  onVisibleChange,
   onOpenMenu,
 }: PanelMenuProps) {
   const testId = title ? selectors.components.Panels.Panel.menu(title) : `panel-menu-button`;
@@ -35,9 +33,8 @@ export function PanelMenu({
       if (show && onOpenMenu) {
         onOpenMenu();
       }
-      return onVisibleChange;
     },
-    [onOpenMenu, onVisibleChange]
+    [onOpenMenu]
   );
 
   return (

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -42,9 +42,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
   if (!legend) {
     return (
       <>
-        {/* tabIndex={0} is needed for keyboard accessibility in the plot area */}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-        <div tabIndex={0} style={containerStyle} className={styles.viz}>
+        <div style={containerStyle} className={styles.viz}>
           {children(width, height)}
         </div>
       </>
@@ -97,11 +95,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
 
   return (
     <div style={containerStyle}>
-      {/* tabIndex={0} is needed for keyboard accessibility in the plot area */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-      <div tabIndex={0} className={styles.viz}>
-        {size && children(size.width, size.height)}
-      </div>
+      <div className={styles.viz}>{size && children(size.width, size.height)}</div>
       <div style={legendStyle} ref={legendRef}>
         <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
       </div>

--- a/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
@@ -13,12 +13,12 @@ const SHIFT_MULTIPLIER = 2 as const;
 const KNOWN_KEYS = new Set(['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Shift', ' ']);
 
 const initHook = (u: uPlot) => {
-  let vizLayoutViz: HTMLElement | null = u.root.closest('[tabindex]');
+  let parentWithFocus: HTMLElement | null = u.root.closest('[tabindex]');
   let pressedKeys = new Set<string>();
   let dragStartX: number | null = null;
   let keysLastHandledAt: number | null = null;
 
-  if (!vizLayoutViz) {
+  if (!parentWithFocus) {
     return;
   }
 
@@ -133,7 +133,7 @@ const initHook = (u: uPlot) => {
 
   const onFocus = () => {
     // We only want to initialize the cursor if the user is using keyboard controls
-    if (!vizLayoutViz?.matches(':focus-visible')) {
+    if (!parentWithFocus?.matches(':focus-visible')) {
       return;
     }
 
@@ -150,18 +150,17 @@ const initHook = (u: uPlot) => {
     u.setSelect({ left: 0, top: 0, width: 0, height: 0 }, false);
   };
 
-  vizLayoutViz.addEventListener('keydown', onKeyDown);
-  vizLayoutViz.addEventListener('keyup', onKeyUp);
-  vizLayoutViz.addEventListener('focus', onFocus);
-  vizLayoutViz.addEventListener('blur', onBlur);
+  parentWithFocus.addEventListener('keydown', onKeyDown);
+  parentWithFocus.addEventListener('keyup', onKeyUp);
+  parentWithFocus.addEventListener('focus', onFocus);
+  parentWithFocus.addEventListener('blur', onBlur);
 
   const onDestroy = () => {
-    vizLayoutViz?.removeEventListener('keydown', onKeyDown);
-    vizLayoutViz?.removeEventListener('keyup', onKeyUp);
-    vizLayoutViz?.removeEventListener('focus', onFocus);
-    vizLayoutViz?.removeEventListener('blur', onBlur);
-
-    vizLayoutViz = null;
+    parentWithFocus?.removeEventListener('keydown', onKeyDown);
+    parentWithFocus?.removeEventListener('keyup', onKeyUp);
+    parentWithFocus?.removeEventListener('focus', onFocus);
+    parentWithFocus?.removeEventListener('blur', onBlur);
+    parentWithFocus = null;
   };
 
   (u.hooks.destroy ??= []).push(onDestroy);

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -93,6 +93,7 @@ export class DashboardGrid extends PureComponent<Props> {
     }
 
     this.props.dashboard.sortPanelsByGridPos();
+    this.forceUpdate();
   };
 
   triggerForceUpdate = () => {


### PR DESCRIPTION
Noticed an issue with the hover header preventing me from resizing the panel above. This was due to the fact that the hover header is always there just with opacity 0 (placed above panel overlapping the resize element). 

* Fixed by setting visibility to hidden when opacity is 0 
* Removed unused emotion css class "hidden" 
* Removed left over logic that removed `show-on-hover` class when menu was opened, this logic was not working as the setMenuOpen callback was never called as PanelMenu never called onVisibleChange (so removed this). 

Also required changes to
* Make PanelChrome itself have focus instead of VizLayout  (this is to make sure the hover header actions & menu can be focused) 
