### PR TITLE
Kinds: Fix kind publishing to the registry

### DIFF
--- a/.github/workflows/scripts/kinds/verify-kinds.go
+++ b/.github/workflows/scripts/kinds/verify-kinds.go
@@ -400,6 +400,8 @@ func (j *ckrJenny) Generate(k kindsys.Composable) (*codejen.File, error) {
 		return nil, err
 	}
 
+	newKindBytes = []byte(fmt.Sprintf("package kind\n\n%s", newKindBytes))
+
 	return codejen.NewFile(filepath.Join(j.path, "next", "composable", name+".cue"), newKindBytes, j), nil
 }
 

--- a/.github/workflows/scripts/kinds/verify-kinds.go
+++ b/.github/workflows/scripts/kinds/verify-kinds.go
@@ -351,7 +351,7 @@ func (j *kindregjenny) Generate(kind kindsys.Kind) (*codejen.File, error) {
 		return nil, err
 	}
 
-	path := filepath.Join(j.path, "next", "core", name+".cue")
+	path := filepath.Join(j.path, "next", "core", name, name+".cue")
 	return codejen.NewFile(path, newKindBytes, j), nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This ensures that core and composable kinds are published to the [kind-registry](https://github.com/grafana/kind-registry/).

Namely:

* core kinds need to be defined in a directory
* composable kinds need to be defined within a CUE package

See https://github.com/grafana/grok/pull/30 for more information

**Why do we need this feature?**

This is needed to use schemas published to the kind registry.

**Who is this feature for?**

Anyone that needs to use the content of the registry. For now, [mainly grok](https://github.com/grafana/grok/pull/30).

**Special notes for your reviewer:**

This PR leaves out everything related to dependency management & publishing, as this topic is still being discussed.