### PR TITLE
Feat: Match allowed cookies with optional character

### DIFF
--- a/pkg/services/datasources/models_test.go
+++ b/pkg/services/datasources/models_test.go
@@ -1,0 +1,60 @@
+package datasources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+func TestAllowedCookies(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		given map[string]interface{}
+		want  []string
+	}{
+		{
+			desc: "Usual json data with keepCookies",
+			given: map[string]interface{}{
+				"keepCookies": []string{"cookie2"},
+			},
+			want: []string{"cookie2"},
+		},
+		{
+			desc: "Usual json data without kepCookies",
+			given: map[string]interface{}{
+				"something": "somethingelse",
+			},
+			want: []string(nil),
+		},
+		{
+			desc: "Usual json data that has multiple values in keepCookies",
+			given: map[string]interface{}{
+				"keepCookies": []string{"cookie1", "cookie2", "special[]"},
+			},
+			want: []string{"cookie1", "cookie2", "special[]"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			jsonDataBytes, err := json.Marshal(&test.given)
+			require.NoError(t, err)
+			jsonData, err := simplejson.NewJson(jsonDataBytes)
+			require.NoError(t, err)
+
+			ds := DataSource{
+				ID:       1235,
+				JsonData: jsonData,
+				UID:      "test",
+			}
+
+			actual := ds.AllowedCookies()
+			assert.Equal(t, test.want, actual)
+			assert.EqualValues(t, test.want, actual)
+		})
+	}
+}

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -52,13 +53,14 @@ func ClearCookieHeader(req *http.Request, keepCookiesNames []string, skipCookies
 				continue
 			}
 
-			l := len(v) - 2
-			if v[l:] == "[]" {
-				if len(c.Name) >= l && c.Name[:l] == v[:l] {
+			if strings.HasSuffix(v, "[]") {
+				// match prefix
+				pattern := strings.TrimSuffix(v, "[]")
+				if strings.HasPrefix(c.Name, pattern) {
 					keepCookies[c.Name] = c
 				}
 			} else {
-				// look for exact match
+				// exact match
 				if c.Name == v {
 					keepCookies[c.Name] = c
 				}

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -46,8 +46,22 @@ func ClearCookieHeader(req *http.Request, keepCookiesNames []string, skipCookies
 	keepCookies := map[string]*http.Cookie{}
 	for _, c := range req.Cookies() {
 		for _, v := range keepCookiesNames {
-			if c.Name == v {
+			// match all
+			if v == "[]" {
 				keepCookies[c.Name] = c
+				continue
+			}
+
+			l := len(v) - 2
+			if v[l:] == "[]" {
+				if len(c.Name) >= l && c.Name[:l] == v[:l] {
+					keepCookies[c.Name] = c
+				}
+			} else {
+				// look for exact match
+				if c.Name == v {
+					keepCookies[c.Name] = c
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

This adds a new option for "Allowed Cookies". Allowed cookies can be determined via their name or an optional part. 
This optional part will be matched with `[]`. If the allowed cookie name ends with `[]` we match all cookies that start with the given string.

Example:
Allowed Cookie: `cookie[]`
Matched Cookies: `cookie1, cookie2, cookie__special, cookieeeeee`
**NOT** Matched Cookies: `supercookie1, super_cookie2, special_cookie__special`

More details are here: https://github.com/grafana/observability-metrics-squad/issues/124

This PR is an up-to-date version of [this PR](https://github.com/grafana/grafana/pull/70278). The old one had some weird change list so I created a new PR to prevent confusion.

**Why do we need this feature?**

To have an easier matcher for allowed cookies.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/observability-metrics-squad/issues/124
Fixes https://github.com/grafana/observability-metrics-squad/issues/102

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
