### PR TITLE
Build: Rework the verify-kinds.go script to not depend on GitHub API

### DIFF
--- a/.github/workflows/publish-kinds-next.yml
+++ b/.github/workflows/publish-kinds-next.yml
@@ -14,8 +14,12 @@ jobs:
     steps:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v3"
+
+      - name: "Checkout kind-registry repo"
+        uses: "actions/checkout@v3"
         with:
-          fetch-depth: 0
+          repository: grafana/kind-registry
+          path: ./kind-registry
 
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
@@ -23,9 +27,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: "Verify kinds"
-        run: go run .github/workflows/scripts/kinds/verify-kinds.go
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: go run .github/workflows/scripts/kinds/verify-kinds.go ${{ github.workspace }}/kind-registry
 
       - name: "Generate token"
         id: generate_token

--- a/.github/workflows/publish-kinds-release.yml
+++ b/.github/workflows/publish-kinds-release.yml
@@ -17,7 +17,14 @@ jobs:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v3"
         with:
+          # required for the `grafana/grafana-github-actions/has-matching-release-tag` action to work
           fetch-depth: 0
+
+      - name: "Checkout kind-registry repo"
+        uses: "actions/checkout@v3"
+        with:
+          repository: grafana/kind-registry
+          path: ./kind-registry
 
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
@@ -25,9 +32,7 @@ jobs:
           go-version: '1.20.4'
 
       - name: "Verify kinds"
-        run: go run .github/workflows/scripts/kinds/verify-kinds.go
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: go run .github/workflows/scripts/kinds/verify-kinds.go ${{ github.workspace }}/kind-registry
 
       - name: "Checkout Actions library"
         uses: "actions/checkout@v3"

--- a/.github/workflows/verify-kinds.yml
+++ b/.github/workflows/verify-kinds.yml
@@ -12,8 +12,12 @@ jobs:
     steps:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v3"
+
+      - name: "Checkout kind-registry repo"
+        uses: "actions/checkout@v3"
         with:
-          fetch-depth: 0
+          repository: grafana/kind-registry
+          path: ./kind-registry
 
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
@@ -21,7 +25,6 @@ jobs:
           go-version: '1.20.4'
 
       - name: "Verify kinds"
-        run: go run .github/workflows/scripts/kinds/verify-kinds.go
+        run: go run .github/workflows/scripts/kinds/verify-kinds.go ${{ github.workspace }}/kind-registry
         env:
           CODEGEN_VERIFY: 1
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**What is this feature?**

There has been issues with the [`verify-kinds.go` script hitting GH rate limits](https://github.com/grafana/grafana/pull/70162) in the past.

To ensure that this script will run smoothly, we rework it to not depend on the GH API at all. Instead, we clone the [`kind-registry`](https://github.com/grafana/kind-registry/) repository and work from it.

This rework has the additional benefit of speeding up the `verify-kinds.go` script.
