### PR TITLE
Transformations: Fix `extractFields` throwing Error if one value is undefined or null

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const { now } = require('lodash');
 
 if (process.argv.length !== 3) {
   throw new Error('invalid command line: use node sendLogs.js LOKIC_BASE_URL');
@@ -195,8 +196,31 @@ async function sendNewLogs() {
 }
 
 async function main() {
-  // we generate both old-logs and new-logs at the same time
-  await Promise.all([sendOldLogs(), sendNewLogs()])
+  function myFunction() {
+    // Perform your desired actions here
+    console.log("This function will be executed at exact 10-second intervals.");
+    
+    // Calculate the time for the next execution
+    var now = new Date();
+    var seconds = now.getSeconds();
+    var milliseconds = now.getMilliseconds();
+    var delay = (10 - (seconds % 10)) * 1000 - milliseconds;
+    
+    // Call the function again after the calculated delay
+    setTimeout(()=>{
+      setInterval(async () => {
+        console.log("SEND LOG")
+        globalCounter += 1;
+        const item = getRandomLogItem(globalCounter);
+        const nowMs = new Date().getTime();
+        const timestampNs = `${nowMs}${getRandomNanosecPart()}`;
+        await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'new', place:'moon', ...sharedLabels});
+      }, 1000);
+    }, delay);
+  }
+  
+  // Start the initial execution
+  myFunction();
 }
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast

--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -1,5 +1,4 @@
 const http = require('http');
-const { now } = require('lodash');
 
 if (process.argv.length !== 3) {
   throw new Error('invalid command line: use node sendLogs.js LOKIC_BASE_URL');
@@ -196,31 +195,8 @@ async function sendNewLogs() {
 }
 
 async function main() {
-  function myFunction() {
-    // Perform your desired actions here
-    console.log("This function will be executed at exact 10-second intervals.");
-    
-    // Calculate the time for the next execution
-    var now = new Date();
-    var seconds = now.getSeconds();
-    var milliseconds = now.getMilliseconds();
-    var delay = (10 - (seconds % 10)) * 1000 - milliseconds;
-    
-    // Call the function again after the calculated delay
-    setTimeout(()=>{
-      setInterval(async () => {
-        console.log("SEND LOG")
-        globalCounter += 1;
-        const item = getRandomLogItem(globalCounter);
-        const nowMs = new Date().getTime();
-        const timestampNs = `${nowMs}${getRandomNanosecPart()}`;
-        await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'new', place:'moon', ...sharedLabels});
-      }, 1000);
-    }, delay);
-  }
-  
-  // Start the initial execution
-  myFunction();
+  // we generate both old-logs and new-logs at the same time
+  await Promise.all([sendOldLogs(), sendNewLogs()])
 }
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -200,7 +200,7 @@ describe('Fields from JSON', () => {
         { config: {}, name: 'Time', type: FieldType.time, values: [1, 2] },
         { config: {}, name: 'line', type: FieldType.other, values: ['{"foo":"bar"}', null] },
       ],
-      length: 1,
+      length: 2,
     };
 
     const frames = extractFieldsTransformer.transformer(cfg, ctx)([testDataFrame]);
@@ -225,12 +225,12 @@ describe('Fields from JSON', () => {
         },
         {
           name: 'foo',
-          values: ['bar'],
+          values: ['bar', undefined],
           type: 'string',
           config: {},
         },
       ],
-      length: 1,
+      length: 2,
     });
   });
 });

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -188,7 +188,7 @@ describe('Fields from JSON', () => {
     `);
   });
 
-  it('adds fields from JSON in string', async () => {
+  it('skips null values', async () => {
     const cfg: ExtractFieldsOptions = {
       source: 'line',
       replace: false,

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -187,6 +187,52 @@ describe('Fields from JSON', () => {
       }
     `);
   });
+
+  it('adds fields from JSON in string', async () => {
+    const cfg: ExtractFieldsOptions = {
+      source: 'line',
+      replace: false,
+    };
+    const ctx = { interpolate: (v: string) => v };
+
+    const testDataFrame: DataFrame = {
+      fields: [
+        { config: {}, name: 'Time', type: FieldType.time, values: [1, 2] },
+        { config: {}, name: 'line', type: FieldType.other, values: ['{"foo":"bar"}', null] },
+      ],
+      length: 1,
+    };
+
+    const frames = extractFieldsTransformer.transformer(cfg, ctx)([testDataFrame]);
+    expect(frames.length).toEqual(1);
+    expect(frames[0]).toEqual({
+      fields: [
+        {
+          config: {},
+          name: 'Time',
+          type: 'time',
+          values: [1, 2],
+          state: {
+            displayName: 'Time',
+            multipleFrames: false,
+          },
+        },
+        {
+          config: {},
+          name: 'line',
+          type: 'other',
+          values: ['{"foo":"bar"}', null],
+        },
+        {
+          name: 'foo',
+          values: ['bar'],
+          type: 'string',
+          config: {},
+        },
+      ],
+      length: 1,
+    });
+  });
 });
 
 const testFieldTime: Field = {

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -77,6 +77,10 @@ function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): Da
       }
     }
 
+    if (!obj) {
+      continue;
+    }
+
     for (const [key, val] of Object.entries(obj)) {
       let buffer = values.get(key);
       if (buffer == null) {

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -77,7 +77,7 @@ function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): Da
       }
     }
 
-    if (!obj) {
+    if (obj == null) {
       continue;
     }
 

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -62,6 +62,10 @@ function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): Da
       }
     }
 
+    if (obj == null) {
+      continue;
+    }
+
     if (options.format === FieldExtractorID.JSON && options.jsonPaths && options.jsonPaths?.length > 0) {
       const newObj: { [k: string]: unknown } = {};
       // filter out empty paths
@@ -75,10 +79,6 @@ function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): Da
 
         obj = newObj;
       }
-    }
-
-    if (obj == null) {
-      continue;
     }
 
     for (const [key, val] of Object.entries(obj)) {


### PR DESCRIPTION
**What is this feature?**

If one value of a DataFrame field is either `null` or `undefined`, the "Extract Fields" transformation will throw an error, because it can not call `Object.entries(obj)` in https://github.com/grafana/grafana/blob/main/public/app/features/transformers/extractFields/extractFields.ts#L80 with `obj` being `null` or `undefined`. 
This PR simply skips those DataFrame rows.