### PR TITLE
AuthN: Fix url token auth when clientTokenRotation is enabled

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -240,13 +240,12 @@ export class ContextSrv {
   }
 
   private canScheduleRotation() {
-    // skip if feature toggle is not enabled
-    if (!config.featureToggles.clientTokenRotation) {
-      return false;
-    }
-
     // skip if user is not signed in, this happens on login page or when using anonymous auth
     if (!this.isSignedIn) {
+      return false;
+    }
+    // skip if feature toggle is not enabled
+    if (!config.featureToggles.clientTokenRotation) {
       return false;
     }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -89,7 +89,7 @@ export class ContextSrv {
     this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
     this.minRefreshInterval = config.minRefreshInterval;
 
-    if (this.isSignedIn) {
+    if (this.canScheduleRotation()) {
       this.scheduleTokenRotationJob();
     }
   }
@@ -206,10 +206,8 @@ export class ContextSrv {
 
   // schedules a job to perform token ration in the background
   private scheduleTokenRotationJob() {
-    const urlParams = new URLSearchParams(window.location.search);
-    const isRenderRequest = !!urlParams.get('render');
-    // only schedule job if feature toggle is enabled, user is signed in and it's not a render request
-    if (config.featureToggles.clientTokenRotation && this.isSignedIn && !isRenderRequest) {
+    // check if we can schedula the token rotation job
+    if (this.canScheduleRotation()) {
       // get the time token is going to expire
       let expires = this.getSessionExpiry();
 
@@ -239,6 +237,32 @@ export class ContextSrv {
         this.rotateToken().then();
       }, nextRun);
     }
+  }
+
+  private canScheduleRotation() {
+    // skip if feature toggle is not enabled
+    if (!config.featureToggles.clientTokenRotation) {
+      return false;
+    }
+
+    // skip if user is not signed in, this happens on login page or when using anonymous auth
+    if (!this.isSignedIn) {
+      return false;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+
+    // skip if this is a render request
+    if (!!params.get('render')) {
+      return false;
+    }
+
+    // skip if we are using auth_token in url
+    if (!!params.get('auth_token')) {
+      return false;
+    }
+
+    return true;
   }
 
   private cancelTokenRotationJob() {

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -244,6 +244,7 @@ export class ContextSrv {
     if (!this.isSignedIn) {
       return false;
     }
+
     // skip if feature toggle is not enabled
     if (!config.featureToggles.clientTokenRotation) {
       return false;


### PR DESCRIPTION
**What is this feature?**
Prevent the token rotation job from being scheduled if we have a auth_token present in the url.

**Why do we need this feature?**
To make url tokens work when client side token rotation feature toggle is enabled

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
