### PR TITLE
Eslint: Remove scenes rule for member accessability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,12 +45,6 @@
   },
   "overrides": [
     {
-      "files": ["public/app/features/scenes/**/*.{ts,tsx}"],
-      "rules": {
-        "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "explicit" }]
-      }
-    },
-    {
       "files": ["packages/grafana-ui/src/components/uPlot/**/*.{ts,tsx}"],
       "rules": {
         "react-hooks/rules-of-hooks": "off",

--- a/public/app/features/scenes/apps/SceneRadioToggle.tsx
+++ b/public/app/features/scenes/apps/SceneRadioToggle.tsx
@@ -11,12 +11,12 @@ export interface SceneRadioToggleState extends SceneObjectState {
 }
 
 export class SceneRadioToggle extends SceneObjectBase<SceneRadioToggleState> {
-  public onChange = (value: string) => {
+  onChange = (value: string) => {
     this.setState({ value });
     this.state.onChange(value);
   };
 
-  public static Component = ({ model }: SceneComponentProps<SceneRadioToggle>) => {
+  static Component = ({ model }: SceneComponentProps<SceneRadioToggle>) => {
     const { options, value } = model.useState();
 
     return <RadioButtonGroup options={options} value={value} onChange={model.onChange} />;

--- a/public/app/features/scenes/apps/SceneSearchBox.tsx
+++ b/public/app/features/scenes/apps/SceneSearchBox.tsx
@@ -8,11 +8,11 @@ export interface SceneSearchBoxState extends SceneObjectState {
 }
 
 export class SceneSearchBox extends SceneObjectBase<SceneSearchBoxState> {
-  public onChange = (evt: React.FormEvent<HTMLInputElement>) => {
+  onChange = (evt: React.FormEvent<HTMLInputElement>) => {
     this.setState({ value: evt.currentTarget.value });
   };
 
-  public static Component = ({ model }: SceneComponentProps<SceneSearchBox>) => {
+  static Component = ({ model }: SceneComponentProps<SceneSearchBox>) => {
     const { value } = model.useState();
 
     return <Input width={25} placeholder="Search..." value={value} onChange={model.onChange} />;

--- a/public/app/features/scenes/apps/traffic.tsx
+++ b/public/app/features/scenes/apps/traffic.tsx
@@ -108,7 +108,7 @@ export interface HandlerDrilldownViewBehaviorState extends SceneObjectState {
 export class HandlerDrilldownViewBehavior extends SceneObjectBase<HandlerDrilldownViewBehaviorState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['handler'] });
 
-  public constructor() {
+  constructor() {
     super({});
 
     this.addActivationHandler(() => {
@@ -143,11 +143,11 @@ export class HandlerDrilldownViewBehavior extends SceneObjectBase<HandlerDrilldo
     });
   }
 
-  public getUrlState() {
+  getUrlState() {
     return { handler: this.state.handler };
   }
 
-  public updateFromUrl(values: SceneObjectUrlValues) {
+  updateFromUrl(values: SceneObjectUrlValues) {
     if (typeof values.handler === 'string' || values.handler === undefined) {
       this.setState({ handler: values.handler });
     }

--- a/public/app/features/scenes/dashboard/DashboardScene.tsx
+++ b/public/app/features/scenes/dashboard/DashboardScene.tsx
@@ -17,7 +17,7 @@ interface DashboardSceneState extends SceneObjectState {
 }
 
 export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
-  public static Component = DashboardSceneRenderer;
+  static Component = DashboardSceneRenderer;
 }
 
 function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {

--- a/public/app/features/scenes/dashboard/DashboardsLoader.ts
+++ b/public/app/features/scenes/dashboard/DashboardsLoader.ts
@@ -44,7 +44,7 @@ export interface DashboardLoaderState {
 export class DashboardLoader extends StateManagerBase<DashboardLoaderState> {
   private cache: Record<string, DashboardScene> = {};
 
-  public async load(uid: string) {
+  async load(uid: string) {
     const fromCache = this.cache[uid];
     if (fromCache) {
       this.setState({ dashboard: fromCache });
@@ -82,7 +82,7 @@ export class DashboardLoader extends StateManagerBase<DashboardLoaderState> {
     this.setState({ dashboard, isLoading: false });
   }
 
-  public clearState() {
+  clearState() {
     this.setState({ dashboard: undefined, loadError: undefined, isLoading: false });
   }
 }

--- a/public/app/features/scenes/dashboard/ShareQueryDataProvider.ts
+++ b/public/app/features/scenes/dashboard/ShareQueryDataProvider.ts
@@ -20,7 +20,7 @@ export class ShareQueryDataProvider extends SceneObjectBase<ShareQueryDataProvid
   private _querySub: Unsubscribable | undefined;
   private _sourceDataDeactivationHandler?: SceneDeactivationHandler;
 
-  public constructor(state: ShareQueryDataProviderState) {
+  constructor(state: ShareQueryDataProviderState) {
     super(state);
 
     this.addActivationHandler(() => {


### PR DESCRIPTION
this rule is no longer needed as the scenes framework in a separate repo, the code here in main repo is not used from plugins and the public/private is not as important. 

Although I do hate that some functions have private and the public ones do not (So would be nice to change our global eslint rule to allow public modifier)