### PR TITLE
Added security patch delivery workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -610,6 +610,8 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-codeql-analysis-python.yml @DanCech
 /.github/workflows/pr-commands-closed.yml @tolzhabayev
 /.github/workflows/pr-commands.yml @marefr
+/.github/workflows/pr-security-patch-check.yml @grafana/grafana-delivery
+/.github/workflows/pr-security-patch-mirror-and-apply.yml @grafana/grafana-delivery
 /.github/workflows/publish-technical-documentation-next.yml @grafana/docs-grafana
 /.github/workflows/publish-technical-documentation-release.yml @grafana/docs-grafana
 /.github/workflows/remove-milestone.yml @grafana/grafana-delivery

--- a/.github/workflows/pr-security-patch-check.yml
+++ b/.github/workflows/pr-security-patch-check.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "main"
       - "v*.*.*"
+      - "release-*"
 
 # Since this is run on a pull request, we want to apply the patches intended for the
 # target branch onto the source branch, to verify compatibility before merging.

--- a/.github/workflows/pr-security-patch-check.yml
+++ b/.github/workflows/pr-security-patch-check.yml
@@ -1,0 +1,23 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo Ex: grafana/grafana 
+name: Check for security patch conflicts
+run-name: check-security-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - "main"
+      - "v*.*.*"
+
+# Since this is run on a pull request, we want to apply the patches intended for the
+# target branch onto the source branch, to verify compatibility before merging.
+jobs:
+  trigger_downstream_patch_check:
+    uses: grafana/security-patch-actions/.github/workflows/test-patches.yml@main
+    with:
+      src_repo: "${{ github.repository }}"
+      src_ref: "${{ github.head_ref }}" # this is the source branch name, Ex: "feature/newthing"
+      patch_repo: "${{ github.repository }}-security-patches"
+      patch_ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
+    secrets: inherit

--- a/.github/workflows/pr-security-patch-mirror-and-apply.yml
+++ b/.github/workflows/pr-security-patch-mirror-and-apply.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "main"
       - "v*.*.*"
+      - "release-*"
 
 # This is run after the pull request has been merged, so we'll run against the target branch
 jobs:

--- a/.github/workflows/pr-security-patch-mirror-and-apply.yml
+++ b/.github/workflows/pr-security-patch-mirror-and-apply.yml
@@ -1,0 +1,34 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo, Ex: grafana/grafana
+name: Sync to security mirror
+run-name: sync-to-security-mirror-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - "main"
+      - "v*.*.*"
+
+# This is run after the pull request has been merged, so we'll run against the target branch
+jobs:
+  trigger_downstream_security_mirror:
+    concurrency: security-mirror-${{ github.ref }}
+    if: github.event.pull_request.merged == true
+    uses: grafana/security-patch-actions/.github/workflows/mirror-branch.yml@main
+    with:
+      ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
+      src_repo: "${{ github.repository }}"
+      dest_repo: "${{ github.repository }}-security-mirror"
+    secrets: inherit
+
+  trigger_downstream_security_patching:
+    needs: trigger_downstream_security_mirror
+    concurrency: security-mirror-${{ github.ref }}
+    if: github.event.pull_request.merged == true
+    uses: grafana/security-patch-actions/.github/workflows/apply-patches.yml@main
+    with:
+      ref: "${{ github.base_ref }}"
+      dest_repo: "${{ github.repository }}-security-mirror"
+      patch_repo: "${{ github.repository }}-security-patches"
+    secrets: inherit

--- a/.github/workflows/pr-security-patch-mirror-and-apply.yml
+++ b/.github/workflows/pr-security-patch-mirror-and-apply.yml
@@ -16,20 +16,11 @@ jobs:
   trigger_downstream_security_mirror:
     concurrency: security-mirror-${{ github.ref }}
     if: github.event.pull_request.merged == true
-    uses: grafana/security-patch-actions/.github/workflows/mirror-branch.yml@main
+    uses: grafana/security-patch-actions/.github/workflows/mirror-branch-and-apply-patches.yml@main
     with:
       ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
       src_repo: "${{ github.repository }}"
       dest_repo: "${{ github.repository }}-security-mirror"
-    secrets: inherit
-
-  trigger_downstream_security_patching:
-    needs: trigger_downstream_security_mirror
-    concurrency: security-mirror-${{ github.ref }}
-    if: github.event.pull_request.merged == true
-    uses: grafana/security-patch-actions/.github/workflows/apply-patches.yml@main
-    with:
-      ref: "${{ github.base_ref }}"
-      dest_repo: "${{ github.repository }}-security-mirror"
       patch_repo: "${{ github.repository }}-security-patches"
     secrets: inherit
+


### PR DESCRIPTION
**What is this feature?**

These pipelines are part of a new security patching workflow owned by the grafana delivery squad. They will automatically update a downstream security mirror on merge to main, version, and release branches, and will check for conflicts in that mirror when PRs are opened.

These pipelines have been tested against the grafana-ci-sandbox.

**Why do we need this feature?**

To pave the way for CI/CD, and to simplify future releases.

For further insight ping the #grafana-delivery-squad slack channel.

