### PR TITLE
Chore: Make grafana-delivery-bot non-external

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -187,7 +187,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]","dependabot[bot]"],
+    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },


### PR DESCRIPTION
Not sure if the naming syntax is right but if it is it should stop adding label `pr/external` to backport PRs lke https://github.com/grafana/grafana/pull/71115