### PR TITLE
Use docs/reference style links for all Alerting links

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -21,7 +21,7 @@ Grafana Alerting is available for Grafana OSS, Grafana Enterprise, or Grafana Cl
 
 Watch this video to learn more about Grafana Alerting: {{< vimeo 720001629 >}}
 
-_Refer to [Manage your alert rules]({{< relref "../alerting/alerting-rules" >}}) for current instructions._
+_Refer to [Manage your alert rules][alerting-rules] for current instructions._
 
 ## Key features and benefits
 
@@ -82,4 +82,12 @@ Here are some tips on how to create an effective alert management set up for you
 
 ## Useful links
 
-- [Introduction to Alerting]({{< relref "./fundamentals" >}})
+- [Introduction to Alerting][fundamentals]
+
+{{% docs/reference %}}
+[alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+
+[fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -86,8 +86,8 @@ Here are some tips on how to create an effective alert management set up for you
 
 {{% docs/reference %}}
 [alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
-[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules"
 
 [fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
-[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/alerting-rules/_index.md
@@ -41,20 +41,20 @@ For information on how to configure notification policies, see [Configure notifi
 
 {{% docs/reference %}}
 [create-mimir-loki-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule"
-[create-mimir-loki-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule"
+[create-mimir-loki-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-mimir-loki-managed-rule"
 
 [create-mimir-loki-managed-recording-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
-[create-mimir-loki-managed-recording-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
+[create-mimir-loki-managed-recording-rule]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
 
 [edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
-[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/edit-mimir-loki-namespace-group"
 
 [create-grafana-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule"
-[create-grafana-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule"
+[create-grafana-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule"
 
 [manage-contact-points]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/manage-contact-points"
-[manage-contact-points]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/manage-contact-points"
+[manage-contact-points]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/manage-contact-points"
 
 [create-notification-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-notification-policy"
-[create-notification-policy]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-notification-policy"
+[create-notification-policy]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-notification-policy"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/alerting-rules/_index.md
@@ -21,10 +21,10 @@ While queries and expressions select the data set to evaluate, a condition sets 
 
 You can:
 
-- [Create Grafana Mimir or Loki managed alert rules]({{< relref "./create-mimir-loki-managed-rule" >}})
-- [Create Grafana Mimir or Loki managed recording rules]({{< relref "./create-mimir-loki-managed-recording-rule" >}})
-- [Edit Grafana Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group" >}})
-- [Create Grafana managed alert rules]({{< relref "./create-grafana-managed-rule" >}})
+- [Create Grafana Mimir or Loki managed alert rules][create-mimir-loki-managed-rule].
+- [Create Grafana Mimir or Loki managed recording rules][create-mimir-loki-managed-recording-rule].
+- [Edit Grafana Mimir or Loki rule groups and namespaces][edit-mimir-loki-namespace-group].
+- [Create Grafana managed alert rules][create-grafana-managed-rule].
 
 **Note:**
 Grafana managed alert rules can only be edited or deleted by users with Edit permissions for the folder storing the rules.
@@ -33,8 +33,28 @@ Alert rules for an external Grafana Mimir or Loki instance can be edited or dele
 
 **Configure contact points**
 
-For information on how to configure contact points, see [Configure contact points]({{< relref "./manage-contact-points/_index.md" >}})
+For information on how to configure contact points, see [Configure contact points][manage-contact-points].
 
 **Configure notification policies**
 
-For information on how to configure notification policies, see [Configure notification policies]({{< relref "./create-notification-policy" >}})
+For information on how to configure notification policies, see [Configure notification policies][create-notification-policy].
+
+{{% docs/reference %}}
+[create-mimir-loki-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule"
+[create-mimir-loki-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule"
+
+[create-mimir-loki-managed-recording-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
+[create-mimir-loki-managed-recording-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
+
+[edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+
+[create-grafana-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule"
+[create-grafana-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule"
+
+[manage-contact-points]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/manage-contact-points"
+[manage-contact-points]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/manage-contact-points"
+
+[create-notification-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-notification-policy"
+[create-notification-policy]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-notification-policy"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -121,16 +121,16 @@ Stale alert instances that are in the **Alerting**/**NoData**/**Error** states a
 [add-a-query]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#add-a-query"
 
 [alerting-on-numeric-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1")
-[alerting-on-numeric-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1")
+[alerting-on-numeric-data]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1")
 
 [annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
-[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label"
 
 [expression-queries]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/expression-queries"
 [expression-queries]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/expression-queries"
 
 [fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
-[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals"
 
 [time-units-and-relative-ranges]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/use-dashboards#time-units-and-relative-ranges"
 [time-units-and-relative-ranges]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/use-dashboards#time-units-and-relative-ranges"

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -18,7 +18,7 @@ Grafana-managed rules are the most flexible alert rule type. They allow you to c
 
 Multiple alert instances can be created as a result of one alert rule (also known as a multi-dimensional alerting).
 
-For information on Grafana Alerting, see [Introduction to Grafana Alerting]({{< relref "../fundamentals" >}}), which explains the key concepts and features of Grafana Alerting.
+For information on Grafana Alerting, see [Introduction to Grafana Alerting][fundamentals], which explains the key concepts and features of Grafana Alerting.
 
 Watch this video to learn more about creating alerts: {{< vimeo 720001934 >}}
 
@@ -32,14 +32,14 @@ To create a Grafana-managed alert rule, complete the following steps.
 5. In Step 2, add queries and expressions to evaluate, and then select the alert condition.
 
    - For queries, select a data source from the dropdown.
-   - Specify a [time range]({{< relref "../../dashboards/use-dashboards#time-units-and-relative-ranges" >}}).
+   - Specify a [time range][time-units-and-relative-ranges].
 
      **Note:**
      Grafana Alerting only supports fixed relative time ranges, for example, `now-24hr: now`.
 
      It does not support absolute time ranges: `2021-12-02 00:00:00 to 2021-12-05 23:59:592` or semi-relative time ranges: `now/d to: now`.
 
-   - Add one or more [queries]({{< relref "../../panels-visualizations/query-transform-data#add-a-query" >}}) or [expressions]({{< relref "../../panels-visualizations/query-transform-data/expression-queries" >}}).
+   - Add one or more [queries][add-a-query] or [expressions][expression-queries].
    - For each expression, select either **Classic condition** to create a single alert rule, or choose from the **Math**, **Reduce**, and **Resample** options to generate separate alert for each series. For details on these options, see [Single and multi dimensional rule](#single-and-multi-dimensional-rule).
    - Click **Run queries** to verify that the query is successful.
    - Next, select the query or expression for your alert condition.
@@ -60,7 +60,7 @@ To create a Grafana-managed alert rule, complete the following steps.
 7. In Step 4, add the storage location, rule group, as well as additional metadata associated with the rule.
    - From the **Folder** dropdown, select the folder where you want to store the rule.
    - For **Group**, specify a pre-defined group. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting]({{< relref "../fundamentals/annotation-label" >}}).
+   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting][annotation-label].
    - Add Runbook URL, panel, dashboard, and alert IDs.
 8. In Step 5, add custom labels.
    - Add custom labels selecting existing key-value pairs from the drop down, or add new labels by entering the new key or value .
@@ -75,13 +75,13 @@ For Grafana managed alerts, you can create a rule with a classic condition or yo
 
 Use the classic condition expression to create a rule that triggers a single alert when its condition is met. For a query that returns multiple series, Grafana does not track the alert state of each series. As a result, Grafana sends only a single alert even when alert conditions are met for multiple series.
 
-For more information, see [expressions documentation]({{< relref "../../panels-visualizations/query-transform-data/expression-queries" >}}).
+For more information, see [expressions documentation][expression-queries].
 
 **Multi-dimensional rule**
 
 To generate a separate alert for each series, create a multi-dimensional rule. Use `Math`, `Reduce`, or `Resample` expressions to create a multi-dimensional rule. For example:
 
-- Add a `Reduce` expression for each query to aggregate values in the selected time range into a single value. (Not needed for [rules using numeric data]({{< relref "../fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1" >}})).
+- Add a `Reduce` expression for each query to aggregate values in the selected time range into a single value. (Not needed for [rules using numeric data][alerting-on-numeric-data].
 - Add a `Math` expression with the condition for the rule. Not needed in case a query or a reduce expression already returns 0 if rule should not fire, or a positive number if it should fire. Some examples: `$B > 70` if it should fire in case value of B query/expression is more than 70. `$B < $C * 100` in case it should fire if value of B is less than value of C multiplied by 100. If queries being compared have multiple series in their results, series from different queries are matched if they have the same labels or one is a subset of the other.
 
 ![Query section multi dimensional](/static/img/docs/alerting/unified/rule-edit-multi-8-0.png 'Query section multi dimensional screenshot')
@@ -115,3 +115,23 @@ If your evaluation returns an error, you can set the state on your alert rule to
 An alert instance is considered stale if its dimension or series has disappeared from the query results entirely for two evaluation intervals.
 
 Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
+
+{{% docs/reference %}}
+[add-a-query]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#add-a-query"
+[add-a-query]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#add-a-query"
+
+[alerting-on-numeric-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1")
+[alerting-on-numeric-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/evaluate-grafana-alerts#alerting-on-numeric-data-1")
+
+[annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+
+[expression-queries]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/expression-queries"
+[expression-queries]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/expression-queries"
+
+[fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+
+[time-units-and-relative-ranges]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/use-dashboards#time-units-and-relative-ranges"
+[time-units-and-relative-ranges]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/use-dashboards#time-units-and-relative-ranges"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -65,11 +65,11 @@ To create a Grafana Mimir or Loki managed recording rule
 
 {{% docs/reference %}}
 [annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
-[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label"
 
 [configure-grafana]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
 [configure-grafana]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
 
 [edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
-[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/edit-mimir-loki-namespace-group"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -22,7 +22,7 @@ You can create and manage recording rules for an external Grafana Mimir or Loki 
 
 Recording rules are run as instant rules, which means that they run every 10s. To overwrite this configuration, update the min_interval in your custom configuration file.
 
-[min_interval]({{< relref "../../setup-grafana/configure-grafana" >}}) sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time.
+[min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time.
 
 This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
 
@@ -55,10 +55,21 @@ To create a Grafana Mimir or Loki managed recording rule
 1. In Step 3, add alert evaluation behavior.
    - Enter a valid **For** duration. The expression has to be true for this long for the alert to be fired.
 1. In Step 4, add additional metadata associated with the rule.
-   - From the **Namespace** dropdown, select an existing rule namespace or add a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Grafana Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group" >}}).
+   - From the **Namespace** dropdown, select an existing rule namespace or add a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Grafana Mimir or Loki rule groups and namespaces][edit-mimir-loki-namespace-group].
    - From the **Group** dropdown, select an existing group within the selected namespace or add a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting]({{< relref "../fundamentals/annotation-label" >}}).
+   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting][annotation-label].
    - Add Runbook URL, panel, dashboard, and alert IDs.
 1. In Step 5, add custom labels.
    - Add custom labels selecting existing key-value pairs from the drop down, or add new labels by entering the new key or value .
 1. Click **Save** to save the rule or **Save and exit** to save the rule and go back to the Alerting page.
+
+{{% docs/reference %}}
+[annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+
+[configure-grafana]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
+[configure-grafana]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
+
+[edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -61,14 +61,14 @@ If you do not want to manage alerting rules for a particular Loki or Prometheus 
 
 {{% docs/reference %}}
 [alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
-[alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+[alerting]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting"
 
 [annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
-[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label"
 
 [edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
-[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/edit-mimir-loki-namespace-group"
 
 [fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
-[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -16,7 +16,7 @@ weight: 400
 
 # Create Grafana Mimir or Loki managed alert rules
 
-Grafana allows you to create alerting rules for an external Grafana Mimir or Loki instance that has ruler API enabled. For information on Grafana Alerting, see [About Grafana Alerting]({{< relref "../../alerting" >}}) which explains the various components of Grafana Alerting. We also recommend that you familiarize yourself with some of the [fundamental concepts]({{< relref "../fundamentals" >}}) of Grafana Alerting.
+Grafana allows you to create alerting rules for an external Grafana Mimir or Loki instance that has ruler API enabled. For information on Grafana Alerting, see [About Grafana Alerting][alerting] which explains the various components of Grafana Alerting. We also recommend that you familiarize yourself with some of the [fundamental concepts][fundamentals] of Grafana Alerting.
 
 ## Before you begin
 
@@ -50,11 +50,25 @@ If you do not want to manage alerting rules for a particular Loki or Prometheus 
    - In the **For** text box, specify the duration for which the condition must be true before an alert fires. If you specify `5m`, the condition must be true for 5 minutes before the alert fires.
      > **Note:** Once a condition is met, the alert goes into the `Pending` state. If the condition remains active for the duration specified, the alert transitions to the `Firing` state, else it reverts to the `Normal` state.
 1. In Step 4, add the namespace, rule group, as well as additional metadata associated with the rule.
-   - From the **Namespace** dropdown, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Grafana Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group" >}}).
+   - From the **Namespace** dropdown, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Grafana Mimir or Loki rule groups and namespaces][edit-mimir-loki-namespace-group].
    - From the **Group** dropdown, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting]({{< relref "../fundamentals/annotation-label" >}}).
+   - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting][annotation-label].
    - Add Runbook URL, panel, dashboard, and alert IDs.
 1. In Step 5, add custom labels.
    - Add custom labels selecting existing key-value pairs from the drop down, or add new labels by entering the new key or value .
 1. Click **Save** to save the rule or **Save and exit** to save the rule and go back to the Alerting page.
 1. Next, create a notification for the rule.
+
+{{% docs/reference %}}
+[alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+[alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+
+[annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+
+[edit-mimir-loki-namespace-group]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+[edit-mimir-loki-namespace-group]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/edit-mimir-loki-namespace-group"
+
+[fundamentals]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+[fundamentals]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-notification-policy.md
+++ b/docs/sources/alerting/alerting-rules/create-notification-policy.md
@@ -26,7 +26,7 @@ If the **Continue matching subsequent sibling nodes** option is enabled for a ne
 
 You can configure Grafana-managed notification policies as well as notification policies for an external Alertmanager data source.
 
-For more information on notification policies, see [fundamentals of Notification Policies]({{< relref "../fundamentals/notification-policies" >}}).
+For more information on notification policies, see [fundamentals of Notification Policies][notification-policies].
 
 ## Edit default notification policy
 
@@ -101,3 +101,8 @@ An example of an alert configuration.
 - Create specific route for alerts coming from the development cluster with an appropriate contact point.
 - Create a specific route for alerts with "critical" severity with a more invasive contact point integration, like pager duty notification.
 - Create specific routes for particular teams that handle their own on-call rotations.
+
+{{% docs/reference %}}
+[notification-policies]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/alerting-rules/create-notification-policy.md
+++ b/docs/sources/alerting/alerting-rules/create-notification-policy.md
@@ -104,5 +104,5 @@ An example of an alert configuration.
 
 {{% docs/reference %}}
 [notification-policies]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
-[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notification-policies"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -46,7 +46,7 @@ Set where, when, and how firing alert instances get routed.
 
 Each notification policy contains a set of label matchers to indicate which alerts rules or instances it is responsible for. It also has a contact point assigned to it that consists of one or more contact point types, such as Slack or email. Contact points define how your contacts are notified when an alert instance fires.
 
-For more information on notification policies, see [fundamentals of Notification Policies]({{< relref "../fundamentals/notification-policies" >}}).
+For more information on notification policies, see [fundamentals of Notification Policies][notification-policies].
 
 **Message templates**
 
@@ -57,3 +57,8 @@ Use message templates for your notifications to create reusable custom templates
 Add silences to stop notifications from one or more alert instances or use mute timings to specify time intervals when you don’t want new notifications to be generated or sent out.
 
 The difference between the two being that a silence only lasts for only a specified window of time whereas a mute timing recurs on a schedule, for example, during a maintenance period.
+
+{{% docs/reference %}}
+[notification-policies]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -60,5 +60,5 @@ The difference between the two being that a silence only lasts for only a specif
 
 {{% docs/reference %}}
 [notification-policies]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
-[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/notification-policies"
+[notification-policies]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notification-policies"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -16,7 +16,21 @@ While queries and expressions select the data set to evaluate, a condition sets 
 
 An interval specifies how frequently an alerting rule is evaluated. Duration, when configured, indicates how long a condition must be met. The alert rules can also define alerting behavior in the absence of data.
 
-- [Alert rule types]({{< relref "./alert-rule-types" >}})
-- [Alert instances]({{< relref "./alert-instances" >}})
-- [Organising alert rules]({{< relref "./organising-alerts" >}})
-- [Annotation and labels]({{< relref "../annotation-label" >}})
+- [Alert rule types][alert-rule-types]
+- [Alert instances][alert-instances]
+- [Organising alert rules][organising-alerts]
+- [Annotation and labels][annotation-label]
+
+{{% docs/reference %}}
+[alert-instances]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-instances"
+[alert-instances]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-instances"
+
+[alert-rule-types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-rule-types"
+[alert-rule-types]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-rule-types"
+
+[annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+
+[organising-alerts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/organising-alerts"
+[organising-alerts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/organising-alerts"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -23,14 +23,14 @@ An interval specifies how frequently an alerting rule is evaluated. Duration, wh
 
 {{% docs/reference %}}
 [alert-instances]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-instances"
-[alert-instances]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-instances"
+[alert-instances]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/alert-instances"
 
 [alert-rule-types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-rule-types"
-[alert-rule-types]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/alert-rule-types"
+[alert-rule-types]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/alert-rule-types"
 
 [annotation-label]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
-[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label"
+[annotation-label]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label"
 
 [organising-alerts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/organising-alerts"
-[organising-alerts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alert-rules/organising-alerts"
+[organising-alerts]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/organising-alerts"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
@@ -103,7 +103,7 @@ By default, the last expression added is used as the alert condition.
 
 {{% docs/reference %}}
 [data-source-alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
-[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/data-source-alerting"
 
 [query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
 [query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
@@ -13,7 +13,7 @@ keywords:
 
 In Grafana, queries play a vital role in fetching and transforming data from supported data sources, which include databases like MySQL and PostgreSQL, time series databases like Prometheus, InfluxDB and Graphite, and services like Elasticsearch, AWS CloudWatch, Azure Monitor and Google Cloud Monitoring.
 
-For more information on supported data sources, see [Data sources]({{< relref "../../data-source-alerting.md" >}}).
+For more information on supported data sources, see [Data sources][data-source-alerting].
 
 The process of executing a query involves defining the data source, specifying the desired data to retrieve, and applying relevant filters or transformations. Query languages or syntaxes specific to the chosen data source are utilized for constructing these queries.
 
@@ -21,7 +21,7 @@ In Alerting, you define a query to get the data you want to measure and a condit
 
 An alert rule consists of one or more queries and expressions that select the data you want to measure.
 
-For more information on queries and expressions, see [Query and transform data]({{< relref "../../../../panels-visualizations/query-transform-data" >}}).
+For more information on queries and expressions, see [Query and transform data][query-transform-data].
 
 ## Data source queries
 
@@ -100,3 +100,11 @@ After you have defined your queries and/or expressions, choose one of them as th
 When the queried data satisfies the defined condition, Grafana triggers the associated alert, which can be configured to send notifications through various channels like email, Slack, or PagerDuty. The notifications inform you about the condition being met, allowing you to take appropriate actions or investigate the underlying issue.
 
 By default, the last expression added is used as the alert condition.
+
+{{% docs/reference %}}
+[data-source-alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/alertmanager.md
@@ -45,4 +45,9 @@ If you are provisioning your data source, set the flag `handleGrafanaManagedAler
 
 [Prometheus Alertmanager documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
-[Add an external Alertmanager]({{< relref "../set-up/configure-alertmanager" >}})
+[Add an external Alertmanager][configure-alertmanager]
+
+{{% docs/reference %}}
+[configure-alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/alertmanager.md
@@ -49,5 +49,5 @@ If you are provisioning your data source, set the flag `handleGrafanaManagedAler
 
 {{% docs/reference %}}
 [configure-alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
-[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-alertmanager"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/annotation-label/_index.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/_index.md
@@ -43,5 +43,5 @@ Annotations are named pairs that add additional information to existing alerts. 
 
 {{% docs/reference %}}
 [variables-label-annotation]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/variables-label-annotation"
-[variables-label-annotation]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/variables-label-annotation"
+[variables-label-annotation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label/variables-label-annotation"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/annotation-label/_index.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/_index.md
@@ -19,7 +19,7 @@ Labels and annotations contain information about an alert. Both labels and annot
 
 The main difference between a label and an annotation is that labels are used to differentiate an alert from all other alerts, while annotations are used to add additional information to an existing alert.
 
-For example, consider two high CPU alerts: one for `server1` and another for `server2`. In such an example we might have a label called `server` where the first alert has the label `server="server1"` and the second alert has the label `server="server2"`. However, we might also want to add a description to each alert such as `"The CPU usage for server1 is above 75%."`, where `server1` and `75%` are replaced with the name and CPU usage of the server (please refer to the documentation on [templating labels and annotations]({{< relref "./variables-label-annotation" >}}) for how to do this). This kind of description would be more suitable as an annotation.
+For example, consider two high CPU alerts: one for `server1` and another for `server2`. In such an example we might have a label called `server` where the first alert has the label `server="server1"` and the second alert has the label `server="server2"`. However, we might also want to add a description to each alert such as `"The CPU usage for server1 is above 75%."`, where `server1` and `75%` are replaced with the name and CPU usage of the server (please refer to the documentation on [templating labels and annotations][variables-label-annotation] for how to do this). This kind of description would be more suitable as an annotation.
 
 ## Labels
 
@@ -31,7 +31,7 @@ The label set for an alert is a combination of the labels from the datasource, c
 
 ### Custom Labels
 
-Custom labels are additional labels from the alert rule. Like annotations, custom labels must have a name, and their value can contain a combination of text and template code that is evaluated when an alert is fired. Documentation on how to template custom labels can be found [here]({{< relref "./variables-label-annotation" >}}).
+Custom labels are additional labels from the alert rule. Like annotations, custom labels must have a name, and their value can contain a combination of text and template code that is evaluated when an alert is fired. Documentation on how to template custom labels can be found [here][variables-label-annotation].
 
 When using custom labels with templates it is important to make sure that the label value does not change between consecutive evaluations of the alert rule as this will end up creating large numbers of distinct alerts. However, it is OK for the template to produce different label values for different alerts. For example, do not put the value of the query in a custom label as this will end up creating a new set of alerts each time the value changes. Instead use annotations.
 
@@ -39,4 +39,9 @@ It is also important to make sure that the label set for an alert does not have 
 
 ## Annotations
 
-Annotations are named pairs that add additional information to existing alerts. There are a number of suggested annotations in Grafana such as `description`, `summary`, `runbook_url`, `dashboardUId` and `panelId`. Like custom labels, annotations must have a name, and their value can contain a combination of text and template code that is evaluated when an alert is fired. If an annotation contains template code, the template is evaluated once when the alert is fired. It is not re-evaluated, even when the alert is resolved. Documentation on how to template annotations can be found [here]({{< relref "./variables-label-annotation" >}}).
+Annotations are named pairs that add additional information to existing alerts. There are a number of suggested annotations in Grafana such as `description`, `summary`, `runbook_url`, `dashboardUId` and `panelId`. Like custom labels, annotations must have a name, and their value can contain a combination of text and template code that is evaluated when an alert is fired. If an annotation contains template code, the template is evaluated once when the alert is fired. It is not re-evaluated, even when the alert is resolved. Documentation on how to template annotations can be found [here][variables-label-annotation].
+
+{{% docs/reference %}}
+[variables-label-annotation]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/variables-label-annotation"
+[variables-label-annotation]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/variables-label-annotation"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
@@ -50,7 +50,7 @@ Grafana reserved labels can be used in the same way as manually configured label
 
 {{% docs/reference %}}
 [alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
-[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules"
 
 [unified-alerting-reserved-labels]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#unified_alertingreserved_labels"
 [unified-alerting-reserved-labels]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#unified_alertingreserved_labels"

--- a/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
@@ -17,7 +17,7 @@ This topic explains why labels are a fundamental component of alerting.
 - The Alertmanager uses labels to match alerts for silences and alert groups in notification policies.
 - The alerting UI shows labels for every alert instance generated during evaluation of that rule.
 - Contact points can access labels to dynamically generate notifications that contain information specific to the alert that is resulting in a notification.
-- You can add labels to an [alerting rule]({{< relref "../../alerting-rules" >}}). Labels are manually configurable, use template functions, and can reference other labels. Labels added to an alerting rule take precedence in the event of a collision between labels (except in the case of [Grafana reserved labels](#grafana-reserved-labels)).
+- You can add labels to an [alerting rule][alerting-rules]. Labels are manually configurable, use template functions, and can reference other labels. Labels added to an alerting rule take precedence in the event of a collision between labels (except in the case of [Grafana reserved labels](#grafana-reserved-labels)).
 
 {{< figure src="/static/img/docs/alerting/unified/rule-edit-details-8-0.png" max-width="550px" caption="Alert details" >}}
 
@@ -39,7 +39,7 @@ Example: A label key/value pair `Alert! 🔔="🔥"` will become `Alert_0x1f514=
 
 {{% admonition type="note" %}}
 Labels prefixed with `grafana_` are reserved by Grafana for special use. If a manually configured label is added beginning with `grafana_` it may be overwritten in case of collision.
-To stop the Grafana Alerting engine from adding a reserved label, you can disable it via the `disabled_labels` option in [unified_alerting.reserved_labels]({{< relref "../../../setup-grafana/configure-grafana#unified_alertingreserved_labels" >}}) configuration.
+To stop the Grafana Alerting engine from adding a reserved label, you can disable it via the `disabled_labels` option in [unified_alerting.reserved_labels][unified-alerting-reserved-labels] configuration.
 {{% /admonition %}}
 
 Grafana reserved labels can be used in the same way as manually configured labels. The current list of available reserved labels are:
@@ -47,3 +47,11 @@ Grafana reserved labels can be used in the same way as manually configured label
 | Label          | Description                               |
 | -------------- | ----------------------------------------- |
 | grafana_folder | Title of the folder containing the alert. |
+
+{{% docs/reference %}}
+[alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+
+[unified-alerting-reserved-labels]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#unified_alertingreserved_labels"
+[unified-alerting-reserved-labels]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#unified_alertingreserved_labels"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
@@ -164,7 +164,7 @@ https://example.com/grafana
 
 ### graphLink
 
-The `graphLink` function returns the path to the graphical view in [Explore]({{< relref "../../../explore" >}}) for the given expression and data source.
+The `graphLink` function returns the path to the graphical view in [Explore][explore] for the given expression and data source.
 
 #### Example
 
@@ -276,7 +276,7 @@ The `pathPrefix` function returns the path of the Grafana server as configured i
 
 ### tableLink
 
-The `tableLink` function returns the path to the tabular view in [Explore]({{< relref "../../../explore" >}}) for the given expression and data source.
+The `tableLink` function returns the path to the tabular view in [Explore][explore] for the given expression and data source.
 
 #### Example
 
@@ -343,3 +343,8 @@ The `reReplaceAll` function replaces text matching the regular expression.
 ```
 example.com:8080
 ```
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/data-source-alerting.md
+++ b/docs/sources/alerting/fundamentals/data-source-alerting.md
@@ -14,23 +14,75 @@ Specifying `{ "alerting": true, “backend”: true }` in the plugin.json file i
 
 These are the data sources that are compatible with and supported by Grafana Alerting.
 
-- [AWS CloudWatch]({{< relref "../../datasources/aws-cloudwatch" >}})
-- [Azure Monitor]({{< relref "../../datasources/azure-monitor" >}})
-- [Elasticsearch]({{< relref "../../datasources/elasticsearch" >}})
-- [Google Cloud Monitoring]({{< relref "../../datasources/google-cloud-monitoring" >}})
-- [Graphite]({{< relref "../../datasources/graphite" >}})
-- [InfluxDB]({{< relref "../../datasources/influxdb" >}})
-- [Loki]({{< relref "../../datasources/loki" >}})
-- [Microsoft SQL Server MSSQL]({{< relref "../../datasources/mssql" >}})
-- [MySQL]({{< relref "../../datasources/mysql" >}})
-- [Open TSDB]({{< relref "../../datasources/opentsdb" >}})
-- [PostgreSQL]({{< relref "../../datasources/postgres" >}})
-- [Prometheus]({{< relref "../../datasources/prometheus" >}})
-- [Jaeger]({{< relref "../../datasources/jaeger" >}})
-- [Zipkin]({{< relref "../../datasources/zipkin" >}})
-- [Tempo]({{< relref "../../datasources/tempo" >}})
-- [Testdata]({{< relref "../../datasources/testdata" >}})
+- [AWS CloudWatch][aws-cloudwatch]
+- [Azure Monitor][azure-monitor]
+- [Elasticsearch][elasticsearch]
+- [Google Cloud Monitoring][google-cloud-monitoring]
+- [Graphite][graphite]
+- [InfluxDB][influxdb]
+- [Loki][loki]
+- [Microsoft SQL Server MSSQL][mssql]
+- [MySQL][mysql]
+- [Open TSDB][opentsdb]
+- [PostgreSQL][postgres]
+- [Prometheus][prometheus]
+- [Jaeger][jaeger]
+- [Zipkin][zipkin]
+- [Tempo][tempo]
+- [Testdata][testdata]
 
 ## Useful links
 
-- [Grafana data sources]({{< relref "../../datasources" >}})
+- [Grafana data sources][datasources]
+
+{{% docs/reference %}}
+[datasources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources"
+
+[aws-cloudwatch]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/aws-cloudwatch"
+[aws-cloudwatch]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/aws-cloudwatch"
+
+[azure-monitor]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/azure-monitor"
+[azure-monitor]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/azure-monitor"
+
+[elasticsearch]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/elasticsearch"
+[elasticsearch]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/elasticsearch"
+
+[google-cloud-monitoring]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/google-cloud-monitoring"
+[google-cloud-monitoring]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/google-cloud-monitoring"
+
+[graphite]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/graphite"
+[graphite]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/graphite"
+
+[influxdb]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/influxdb"
+[influxdb]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/influxdb"
+
+[loki]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/loki"
+[loki]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/loki"
+
+[mssql]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/mssql"
+[mssql]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/mssql"
+
+[mysql]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/mysql"
+[mysql]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/mysql"
+
+[opentsdb]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/opentsdb"
+[opentsdb]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/opentsdb"
+
+[postgres]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/postgres"
+[postgres]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/postgres"
+
+[prometheus]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus"
+[prometheus]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus"
+
+[jaeger]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/jaeger"
+[jaeger]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/jaeger"
+
+[zipkin]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/zipkin"
+[zipkin]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/zipkin"
+
+[tempo]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/tempo"
+[tempo]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/tempo"
+
+[testdata]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/testdata"
+[testdata]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/testdata"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
@@ -24,11 +24,11 @@ Grafana managed alerts query the following backend data sources that have alerti
 
 - built-in data sources or those developed and maintained by Grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Monitor`
-- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata" >}}))
+- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json][metadata])
 
 ### Metrics from the alerting engine
 
-The alerting engine publishes some internal metrics about itself. You can read more about how Grafana publishes [internal metrics]({{< relref "../../setup-grafana/set-up-grafana-monitoring" >}}).
+The alerting engine publishes some internal metrics about itself. You can read more about how Grafana publishes [internal metrics][set-up-grafana-monitoring].
 
 | Metric Name                                       | Type      | Description                                                                              |
 | ------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |
@@ -100,3 +100,11 @@ When this query is used as the **condition** in an alert rule, then the non-zero
 | {Host=web1,disk=/etc} | Alerting |
 | {Host=web2,disk=/var} | Alerting |
 | {Host=web3,disk=/var} | Normal   |
+
+{{% docs/reference %}}
+[metadata]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/metadata"
+[metadata]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/metadata"
+
+[set-up-grafana-monitoring]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+[set-up-grafana-monitoring]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/high-availability/_index.md
+++ b/docs/sources/alerting/fundamentals/high-availability/_index.md
@@ -32,4 +32,9 @@ The notification logs and silences are persisted in the database periodically an
 
 ## Useful links
 
-[Configure alerting high availability]({{< relref "../../set-up/configure-high-availability" >}})
+[Configure alerting high availability][configure-high-availability]
+
+{{% docs/reference %}}
+[configure-high-availability]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/high-availability/_index.md
+++ b/docs/sources/alerting/fundamentals/high-availability/_index.md
@@ -36,5 +36,5 @@ The notification logs and silences are persisted in the database periodically an
 
 {{% docs/reference %}}
 [configure-high-availability]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
-[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-high-availability"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/notification-policies/notifications.md
+++ b/docs/sources/alerting/fundamentals/notification-policies/notifications.md
@@ -139,5 +139,5 @@ The waiting time to resend an alert after they have successfully been sent. This
 
 {{% docs/reference %}}
 [labels-and-label-matchers]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/labels-and-label-matchers"
-[labels-and-label-matchers]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/labels-and-label-matchers"
+[labels-and-label-matchers]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/annotation-label/labels-and-label-matchers"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/notification-policies/notifications.md
+++ b/docs/sources/alerting/fundamentals/notification-policies/notifications.md
@@ -26,7 +26,7 @@ Notification policies are _not_ a list, but rather are structured according to a
 
 Each policy consists of a set of label matchers (0 or more) that specify which labels they are or aren't interested in handling.
 
-For more information on label matching, see [how label matching works]({{< relref "../annotation-label/labels-and-label-matchers.md" >}}).
+For more information on label matching, see [how label matching works][labels-and-label-matchers].
 
 {{% admonition type="note" %}}
 If you haven't configured any label matchers for your notification policy, your notification policy will match _all_ alert instances. This may prevent child policies from being evaluated unless you have enabled **Continue matching siblings** on the notification policy.
@@ -136,3 +136,8 @@ This means that notifications will **not** be sent any sooner than 5 minutes (de
 The waiting time to resend an alert after they have successfully been sent. This means notifications for **firing** alerts will be re-delivered every 4 hours (default).
 
 **Default** 4 hours
+
+{{% docs/reference %}}
+[labels-and-label-matchers]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/labels-and-label-matchers"
+[labels-and-label-matchers]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/annotation-label/labels-and-label-matchers"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -13,12 +13,29 @@ weight: 160
 
 Once you have set up your alert rules, contact points, and notification policies, you can use Grafana Alerting to:
 
-[Create silences]({{< relref "./create-silence" >}})
+[Create silences][create-silence]
 
-[Create mute timings]({{< relref "./mute-timings" >}})
+[Create mute timings][mute-timings]
 
-[Declare incidents from firing alerts]({{< relref "./declare-incident-from-alert" >}})
+[Declare incidents from firing alerts][declare-incident-from-firing-alert]
 
-[View the state and health of alert rules]({{< relref "./view-state-health" >}})
+[View the state and health of alert rules][view-state-health]
 
-[View and filter alert rules]({{< relref "./view-alert-rules" >}})
+[View and filter alert rules][view-alert-rules]
+
+{{% docs/reference %}}
+[create-silence]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/create-silence"
+[create-silence]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/create-silence"
+
+[declare-incident-from-firing-alert]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/declare-incident-from-alert"
+[declare-incident-from-firing-alert]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/declare-incident-from-alert"
+
+[mute-timings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/mute-timings"
+[mute-timings]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/mute-timings"
+
+[view-alert-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-alert-rules"
+[view-alert-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-alert-rules"
+
+[view-state-health]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-state-health"
+[view-state-health]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-state-health"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -25,17 +25,17 @@ Once you have set up your alert rules, contact points, and notification policies
 
 {{% docs/reference %}}
 [create-silence]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/create-silence"
-[create-silence]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/create-silence"
+[create-silence]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/create-silence"
 
 [declare-incident-from-firing-alert]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/declare-incident-from-alert"
-[declare-incident-from-firing-alert]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/declare-incident-from-alert"
+[declare-incident-from-firing-alert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/declare-incident-from-alert"
 
 [mute-timings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/mute-timings"
-[mute-timings]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/mute-timings"
+[mute-timings]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/mute-timings"
 
 [view-alert-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-alert-rules"
-[view-alert-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-alert-rules"
+[view-alert-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/view-alert-rules"
 
 [view-state-health]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-state-health"
-[view-state-health]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/view-state-health"
+[view-state-health]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/view-state-health"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -27,9 +27,9 @@ Refer to the table at the end of this page for a list of contact points and thei
 
 ## Requirements
 
-1. To use images in notifications, Grafana must be set up to use [image rendering]({{< relref "../../setup-grafana/image-rendering" >}}). You can either install the image rendering plugin or run it as a remote rendering service.
+1. To use images in notifications, Grafana must be set up to use [image rendering][image-rendering]. You can either install the image rendering plugin or run it as a remote rendering service.
 
-2. When a screenshot is taken it is saved to the [data]({{< relref "../../setup-grafana/configure-grafana#paths" >}}) folder, even if Grafana is configured to upload screenshots to a cloud storage service. Grafana must have write-access to this folder otherwise screenshots cannot be saved to disk and an error will be logged for each failed screenshot attempt.
+2. When a screenshot is taken it is saved to the [data][paths] folder, even if Grafana is configured to upload screenshots to a cloud storage service. Grafana must have write-access to this folder otherwise screenshots cannot be saved to disk and an error will be logged for each failed screenshot attempt.
 
 3. You should use a cloud storage service unless sending alerts to Discord, Email, Pushover, Slack or Telegram. These integrations support either embedding screenshots in the email or attaching screenshots to the notification, while other integrations must link screenshots uploaded to a cloud storage bucket. If a cloud storage service has been configured then integrations that support both will link screenshots from the cloud storage bucket instead of embedding or attaching screenshots to the notification.
 
@@ -133,3 +133,11 @@ For example, if a screenshot could not be taken within the expected time (10 sec
 - `grafana_screenshot_successes_total`
 - `grafana_screenshot_upload_failures_total`
 - `grafana_screenshot_upload_successes_total`
+
+{{% docs/reference %}}
+[image-rendering]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/image-rendering"
+[image-rendering]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/image-rendering"
+
+[paths]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#paths"
+[paths]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#paths"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -20,7 +20,7 @@ A mute timing is a recurring interval of time when no new notifications for a po
 
 Similar to silences, mute timings do not prevent alert rules from being evaluated, nor do they stop alert instances from being shown in the user interface. They only prevent notifications from being created.
 
-You can configure Grafana managed mute timings as well as mute timings for an [external Alertmanager data source]({{< relref "../../datasources/alertmanager" >}}). For more information, refer to [Alertmanager documentation]({{< relref "../fundamentals/alertmanager" >}}).
+You can configure Grafana managed mute timings as well as mute timings for an [external Alertmanager data source][datasources/alertmanager]. For more information, refer to [Alertmanager documentation][fundamentals/alertmanager].
 
 ## Mute timings vs silences
 
@@ -69,3 +69,11 @@ If you want to specify an exact duration, specify all the options. For example, 
 - Days of the week: `monday`
 - Months: `3, 6, 9, 12`
 - Days of the month: `1:7`
+
+{{% docs/reference %}}
+[datasources/alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/alertmanager"
+[datasources/alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/alertmanager"
+
+[fundamentals/alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alertmanager"
+[fundamentals/alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alertmanager"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -75,5 +75,5 @@ If you want to specify an exact duration, specify all the options. For example, 
 [datasources/alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/alertmanager"
 
 [fundamentals/alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alertmanager"
-[fundamentals/alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/alertmanager"
+[fundamentals/alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alertmanager"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -29,16 +29,27 @@ You cannot use notification templates to:
 - Change the data in webhook notifications, including the structure of the JSON request or sending data in other formats such as XML
 - Add or remove HTTP headers in webhook notifications other than those in the contact point configuration
 
-[Using Go's templating language]({{< relref "./using-go-templating-language" >}})
+[Using Go's templating language][using-go-templating-language]
 
 Learn how to write the content of your notification templates in Go’s templating language.
 
 Create reusable notification templates for your contact points.
 
-[Use notification templates]({{< relref "./use-notification-templates" >}})
+[Use notification templates][use-notication-templates]
 
 Use notification templates to send notifications to your contact points.
 
-[Reference]({{< relref "./reference" >}})
+[Reference][reference]
 
 Data that is available when writing templates.
+
+{{% docs/reference %}}
+[reference]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+[reference]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+
+[use-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/use-notification-templates"
+[use-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/use-notification-templates"
+
+[using-go-templating-language]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -45,11 +45,11 @@ Data that is available when writing templates.
 
 {{% docs/reference %}}
 [reference]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
-[reference]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+[reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/reference"
 
 [use-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/use-notification-templates"
-[use-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/use-notification-templates"
+[use-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/use-notification-templates"
 
 [using-go-templating-language]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
-[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/using-go-templating-language"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
@@ -30,8 +30,8 @@ In the Contact points tab, you can see a list of your contact points.
 
 {{% docs/reference %}}
 [create-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
-[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/create-notification-templates"
 
 [using-go-templating-language]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
-[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/using-go-templating-language"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
@@ -24,6 +24,14 @@ In the Contact points tab, you can see a list of your contact points.
 
    {{< figure max-width="940px" src="/static/img/docs/alerting/unified/use-notification-template-9-4.png" caption="Use notification template" >}}
 
-   For more information on how to write and execute templates, refer to [Using Go's templating language]({{< relref "./using-go-templating-language" >}}) and [Create notification templates]({{< relref "./create-notification-templates" >}}).
+   For more information on how to write and execute templates, refer to [Using Go's templating language][using-go-templating-language] and [Create notification templates][create-notification-templates].
 
 3. Click Save template.
+
+{{% docs/reference %}}
+[create-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+
+[using-go-templating-language]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+[using-go-templating-language]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/using-go-templating-language"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
@@ -18,7 +18,7 @@ Before you start creating your own notification templates, we recommend that you
 
 ## Dot
 
-In text/template there is a special cursor called dot, and is written as `.`. You can think of this cursor as a variable whose value changes depending where in the template it is used. For example, at the start of a notification template `.` refers to something called [`ExtendedData`]({{< relref "./reference#extendeddata" >}}) which contains a number of fields including `Alerts`, `Status`, `GroupLabels`, `CommonLabels`, `CommonAnnotations` and `ExternalURL`. However, dot might refer to something else when used in a range over a list, when used inside a `with`, or when writing feature templates to be used in other templates. You can see examples of this in [Create notification templates]({{< relref "./create-notification-templates" >}}), and all data and functions in the [Reference]({{< relref "./reference" >}}).
+In text/template there is a special cursor called dot, and is written as `.`. You can think of this cursor as a variable whose value changes depending where in the template it is used. For example, at the start of a notification template `.` refers to something called [`ExtendedData`][extendeddata] which contains a number of fields including `Alerts`, `Status`, `GroupLabels`, `CommonLabels`, `CommonAnnotations` and `ExternalURL`. However, dot might refer to something else when used in a range over a list, when used inside a `with`, or when writing feature templates to be used in other templates. You can see examples of this in [Create notification templates][create-notification-templates], and all data and functions in the [Reference][reference].
 
 ## Opening and closing tags
 
@@ -272,3 +272,14 @@ The indentation and line breaks in the template are now absent from the text:
 alertname = "Test"
 grafana_folder = "Test alerts"
 ```
+
+{{% docs/reference %}}
+[create-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+
+[extendeddata]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference#extendeddata"
+[extendeddata]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference#extendeddata"
+
+[reference]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+[reference]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
@@ -275,11 +275,11 @@ grafana_folder = "Test alerts"
 
 {{% docs/reference %}}
 [create-notification-templates]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
-[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/create-notification-templates"
+[create-notification-templates]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/create-notification-templates"
 
 [extendeddata]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference#extendeddata"
-[extendeddata]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference#extendeddata"
+[extendeddata]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/reference#extendeddata"
 
 [reference]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
-[reference]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/manage-notifications/template-notifications/reference"
+[reference]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications/reference"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -62,23 +62,23 @@ The following topics provide you with advanced configuration options for Grafana
 
 {{% docs/reference %}}
 [configure-alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
-[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-alertmanager"
 
 [configure-high-availability]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
-[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-high-availability"
 
 [data-source-alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
-[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/data-source-alerting"
 
 [data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
 [data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
 
 [file-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning"
-[file-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning"
+[file-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/file-provisioning"
 
 [set-up-cloud]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/set-up-cloud"
-[set-up-cloud]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/set-up-cloud"
+[set-up-cloud]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/set-up-cloud"
 
 [terraform-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
-[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/terraform-provisioning"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -18,12 +18,12 @@ Set up or upgrade your implementation of Grafana Alerting.
 
 These are set-up instructions for Grafana Alerting Open Source.
 
-To set up Grafana Alerting for Cloud, see [Set up Alerting for Cloud]({{< relref "../set-up/set-up-cloud" >}}).
+To set up Grafana Alerting for Cloud, see [Set up Alerting for Cloud][set-up-cloud].
 
 ## Before you begin
 
-- Configure your [data sources]({{< relref "../../administration/data-source-management" >}})
-- Check which data sources are compatible with and supported by [Grafana Alerting]({{< relref "../fundamentals/data-source-alerting" >}})
+- Configure your [data sources][data-source-management]
+- Check which data sources are compatible with and supported by [Grafana Alerting][data-source-alerting]
 
 ## Set up Alerting
 
@@ -55,7 +55,30 @@ Grafana Alerting supports many additional configuration options, from configurin
 
 The following topics provide you with advanced configuration options for Grafana Alerting.
 
-- [Provision alert rules using file provisioning]({{< relref "../set-up/provision-alerting-resources/file-provisioning" >}})
-- [Provision alert rules using Terraform]({{< relref "../set-up/provision-alerting-resources/terraform-provisioning" >}})
-- [Add an external Alertmanager]({{< relref "../set-up/configure-alertmanager" >}})
-- [Configure high availability]({{< relref "../set-up/configure-high-availability" >}})
+- [Provision alert rules using file provisioning][file-provisioning]
+- [Provision alert rules using Terraform][terraform-provisioning]
+- [Add an external Alertmanager][configure-alertmanager]
+- [Configure high availability][configure-high-availability]
+
+{{% docs/reference %}}
+[configure-alertmanager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+[configure-alertmanager]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-alertmanager"
+
+[configure-high-availability]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+[configure-high-availability]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/configure-high-availability"
+
+[data-source-alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+[data-source-alerting]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/fundamentals/data-source-alerting"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[file-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning"
+[file-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning"
+
+[set-up-cloud]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/set-up-cloud"
+[set-up-cloud]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/set-up-cloud"
+
+[terraform-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
@@ -51,5 +51,5 @@ Refer to our [upgrade instructions][migrating-alerts].
 [angular_deprecation]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/angular_deprecation"
 
 [migrating-alerts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/migrating-alerts"
-[migrating-alerts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/migrating-alerts"
+[migrating-alerts]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/migrating-alerts"
 {{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
@@ -21,7 +21,7 @@ Users who are still using legacy alerting are encouraged to migrate their alerts
 
 However, we will still patch CVEs until legacy alerting is completely removed in Grafana 11; honoring our commitment to building and distributing secure software.
 
-We have provided [instructions]({{< relref "./_index.md" >}}) on how to migrate to the new alerting system, making the process as easy as possible for users.
+We have provided [instructions][migrating-alerts] on how to migrate to the new alerting system, making the process as easy as possible for users.
 
 ## Why are we deprecating legacy alerting?
 
@@ -31,17 +31,25 @@ The new system is based on Prometheus Alertmanager, which offers a more comprehe
 
 Overall, the new alerting system in Grafana is a major improvement over the legacy alerting feature, providing users with a more powerful and flexible alerting experience.
 
-Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it]({{< relref "../../../developers/angular_deprecation" >}}) in Grafana 11.
+Additionally, legacy alerting still requires Angular to function and we are [planning to remove support for it][angular_deprecation] in Grafana 11.
 
 ## When will we remove legacy alerting completely?
 
-Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation]({{< relref "../../../developers/angular_deprecation" >}}).
+Legacy alerting will be removed from the code-base in Grafana 11, following the same timeline as the [Angular deprecation][angular_deprecation].
 
 ## How do I migrate to the new Grafana alerting?
 
-Refer to our [upgrade instructions]({{< relref "./_index.md" >}}).
+Refer to our [upgrade instructions][migrating-alerts].
 
 ### Useful links
 
-- [Upgrade Alerting]({{< relref "./_index.md" >}})
-- [Angular support deprecation]({{< relref "../../../developers/angular_deprecation" >}})
+- [Upgrade Alerting][migrating-alerts]
+- [Angular support deprecation][angular_deprecation]
+
+{{% docs/reference %}}
+[angular_deprecation]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/angular_deprecation"
+[angular_deprecation]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/angular_deprecation"
+
+[migrating-alerts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/migrating-alerts"
+[migrating-alerts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/migrating-alerts"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/view-filter-rules.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/view-filter-rules.md
@@ -37,6 +37,11 @@ You can control which alerts you see and in what order they appear several ways.
 
 ## View alert in Explore
 
-Click **View in Explore** or click the `expr` link to open the `expr` in [Explore](/docs/grafana/latest/explore/).
+Click **View in Explore** or click the `expr` link to open the `expr` in [Explore][explore].
 
 > **Note:** Only users with Admin or Editor roles in an organization can use the Explore feature unless the viewers can edit.
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/-> /docs/grafana/<GRAFANA VERSION>/explore"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -47,7 +47,6 @@ To allow editing of provisioned resources in the Grafana UI, add the `X-Disable-
 
 [Grafana Alerting provisioning API][alerting_provisioning]
 
-
 {{% docs/reference %}}
 [alerting_provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"
 [alerting_provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"

--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -41,8 +41,17 @@ To allow editing of provisioned resources in the Grafana UI, add the `X-Disable-
 
 **Useful Links:**
 
-[Grafana provisioning](/docs/grafana/latest/administration/provisioning/)
+[Grafana provisioning][provisioning]
 
 [Grafana Cloud provisioning](/docs/grafana-cloud/infrastructure-as-code/terraform/)
 
-[Grafana Alerting provisioning API](/docs/grafana/latest/developers/http_api/alerting_provisioning)
+[Grafana Alerting provisioning API][alerting_provisioning]
+
+
+{{% docs/reference %}}
+[alerting_provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"
+[alerting_provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"
+
+[provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning"
+[provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -22,14 +22,14 @@ Details on how to set up the files and which fields are required for each object
 
 **Note:**
 
-Provisioning takes place during the initial set up of your Grafana system, but you can re-run it at any time using the [Grafana Admin API]({{< relref "../../../../developers/http_api/admin#reload-provisioning-configurations" >}}).
+Provisioning takes place during the initial set up of your Grafana system, but you can re-run it at any time using the [Grafana Admin API][reload-provisioning-configurations].
 
 ### Provision alert rules
 
 Create or delete alert rules in your Grafana instance(s).
 
 1. Create alert rules in Grafana.
-1. Use the [Alerting provisioning API]({{< relref "../../../../developers/http_api/alerting_provisioning" >}}) export endpoints to download a provisioning file for your alert rules.
+1. Use the [Alerting provisioning API][alerting_provisioning] export endpoints to download a provisioning file for your alert rules.
 1. Copy the contents into a YAML or JSON configuration file in the default provisioning directory or in your configured directory.
 
    Example configuration files can be found below.
@@ -708,3 +708,11 @@ spec:
 ```
 
 This eliminates the need for a persistent database to use Grafana Alerting in Kubernetes; all your provisioned resources appear after each restart or re-deployment.
+
+{{% docs/reference %}}
+[alerting_provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"
+[alerting_provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/alerting_provisioning"
+
+[reload-provisioning-configurations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/admin#reload-provisioning-configurations"
+[reload-provisioning-configurations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/admin#reload-provisioning-configurations"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -324,7 +324,7 @@ For example, if you chose Slack as a contact point, Grafana’s embedded [Alertm
 
 {{% docs/reference %}}
 [alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
-[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules"
 
 [api-keys]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/api-keys"
 [api-keys]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/api-keys"

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -33,9 +33,9 @@ Complete the following tasks to create and manage your alerting resources using 
 
 ## Create an API key for provisioning
 
-You can [create a normal Grafana API key]({{< relref "../../../../administration/api-keys" >}}) to authenticate Terraform with Grafana. Most existing tooling using API keys should automatically work with the new Grafana Alerting support.
+You can [create a normal Grafana API key][api-keys] to authenticate Terraform with Grafana. Most existing tooling using API keys should automatically work with the new Grafana Alerting support.
 
-There are also dedicated RBAC roles for alerting provisioning. This lets you easily authenticate as a [service account]({{< relref "../../../../administration/service-accounts" >}}) with the minimum permissions needed to provision your Alerting infrastructure.
+There are also dedicated RBAC roles for alerting provisioning. This lets you easily authenticate as a [service account][service-accounts] with the minimum permissions needed to provision your Alerting infrastructure.
 
 To create an API key for provisioning, complete the following steps.
 
@@ -222,13 +222,13 @@ You cannot edit resources provisioned from Terraform from the UI. This ensures t
 
 ## Provision alert rules
 
-[Alert rules]({{< relref "../../../alerting-rules" >}}) enable you to alert against any Grafana data source. This can be a data source that you already have configured, or you can [define your data sources in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) alongside your alert rules.
+[Alert rules][alerting-rules] enable you to alert against any Grafana data source. This can be a data source that you already have configured, or you can [define your data sources in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) alongside your alert rules.
 
 To provision alert rules, complete the following steps.
 
 1. Create a data source to query and a folder to store your rules in.
 
-In this example, the [TestData]({{< relref "../../../../datasources/testdata" >}}) data source is used.
+In this example, the [TestData][testdata] data source is used.
 
 Alerts can be defined against any backend datasource in Grafana.
 
@@ -321,3 +321,17 @@ You can see whether or not the alert rule is firing. You can also see a visualiz
 When the alert fires, Grafana routes a notification through the policy you defined.
 
 For example, if you chose Slack as a contact point, Grafana’s embedded [Alertmanager](https://github.com/prometheus/alertmanager) automatically posts a message to Slack.
+
+{{% docs/reference %}}
+[alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+[alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules"
+
+[api-keys]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/api-keys"
+[api-keys]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/api-keys"
+
+[service-accounts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/service-accounts"
+[service-accounts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/service-accounts"
+
+[testdata]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/testdata"
+[testdata]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/testdata"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/set-up-cloud/_index.md
+++ b/docs/sources/alerting/set-up/set-up-cloud/_index.md
@@ -30,7 +30,7 @@ Grafana Cloud Alerting's Prometheus-style alerts are built by querying directly 
 
 These are set up instructions for Grafana Alerting Cloud.
 
-To set up Grafana Alerting for Open Source, see [Set up]({{< relref "../_index.md" >}}).
+To set up Grafana Alerting for Open Source, see [Set up][set-up].
 
 To set up Alerting, you need to:
 
@@ -248,4 +248,12 @@ After you upload a working Alertmanager configuration file, you can access the A
 
 ### Provision alert rules using Terraform
 
-For information on how to provision alert rule using Terraform, see [Provision alert rules using Terraform]({{< relref "../provision-alerting-resources/terraform-provisioning" >}}).
+For information on how to provision alert rule using Terraform, see [Provision alert rules using Terraform][terraform-provisioning].
+
+{{% docs/reference %}}
+[set-up]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up"
+[set-up]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up"
+
+[terraform-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+{{% /docs/reference %}}

--- a/docs/sources/alerting/set-up/set-up-cloud/_index.md
+++ b/docs/sources/alerting/set-up/set-up-cloud/_index.md
@@ -252,8 +252,8 @@ For information on how to provision alert rule using Terraform, see [Provision a
 
 {{% docs/reference %}}
 [set-up]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up"
-[set-up]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up"
+[set-up]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up"
 
 [terraform-provisioning]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
-[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning"
+[terraform-provisioning]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/terraform-provisioning"
 {{% /docs/reference %}}

--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -102,8 +102,8 @@ Additional technical information on tabular time series formats and how dimensio
 [create-grafana-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule#single-and-multi-dimensional-rule"
 [create-grafana-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule#single-and-multi-dimensional-rule"
 
-[data-frames-as-time-series]: "/docs/grafana/ -> docs/grafana/<GRAFANA VERSION>/developers/plugins//introduction-to-plugin-development/data-frames#data-frames-as-time-series"
-[data-frames-as-time-series]: "/docs/grafana-cloud/ -> docs/grafana/<GRAFANA VERSION>/developers/plugins//introduction-to-plugin-development/data-frames#data-frames-as-time-series"
+[data-frames-as-time-series]: "/docs/grafana/ -> docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#data-frames-as-time-series"
+[data-frames-as-time-series]: "/docs/grafana-cloud/ -> docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#data-frames-as-time-series"
 
 [time-series-databases]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"
 [time-series-databases]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"


### PR DESCRIPTION
Means that links can resolve different depending on where the page is published. In Grafana Cloud documentation, links to Alerting go to the Grafana Cloud Alerting documentation. In Grafana documentation, links to Alerting go to Grafana documentation.

Note, I think we need to consider whether some of the content in `/docs/sources/alerting/set-up` is appropriate for Grafana Cloud.

To be merged alongside: https://github.com/grafana/website/pull/13872.


All links have been replaced with `/docs/reference` style links. The link destination for any link label is determined when the page is built and checked with relrefs. There are no broken relrefs in the alerting docs when running `make docs` so I believe all the links are working as intended when it comes to Grafana docs.

For Grafana Cloud, any links that direct the reader to Alerting documentation have been updated so that they instead keep the reader in Grafana Cloud content. For links that go to other parts of the Grafana documentation, the destination is kept the same as for Grafana so readers are taken from Grafana Cloud documentation to Grafana documentation. Note that the Grafana Cloud content links to the "next" version of Grafana documentation. The `<GRAFANA VERSION>` variable is replaced with `next` in Grafana Cloud pages because we set `grafana_version: next` in the Grafana Cloud documentation front matter.