### PR TITLE
XYChart: Point size editor should reflect correct default (5)

### DIFF
--- a/public/app/plugins/panel/xychart/config.ts
+++ b/public/app/plugins/panel/xychart/config.ts
@@ -12,6 +12,8 @@ import { LineStyleEditor } from '../timeseries/LineStyleEditor';
 
 import { ScatterFieldConfig, ScatterShow } from './types';
 
+export const DEFAULT_POINT_SIZE = 5;
+
 export function getScatterFieldConfig(cfg: ScatterFieldConfig): SetFieldConfigOptionsArgs<ScatterFieldConfig> {
   return {
     standardOptions: {
@@ -72,7 +74,7 @@ export function getScatterFieldConfig(cfg: ScatterFieldConfig): SetFieldConfigOp
         .addSliderInput({
           path: 'pointSize.fixed',
           name: 'Point size',
-          defaultValue: cfg.pointSize?.fixed,
+          defaultValue: cfg.pointSize?.fixed ?? DEFAULT_POINT_SIZE,
           settings: {
             min: 1,
             max: 100,

--- a/public/app/plugins/panel/xychart/models.gen.ts
+++ b/public/app/plugins/panel/xychart/models.gen.ts
@@ -14,6 +14,8 @@ import {
   DimensionSupplier,
 } from 'app/features/dimensions';
 
+import { DEFAULT_POINT_SIZE } from './config';
+
 // export enum ScatterLineMode {
 //   None = 'none',
 //   Linear = 'linear',
@@ -61,7 +63,7 @@ export const defaultScatterConfig: ScatterFieldConfig = {
     fill: 'solid',
   },
   pointSize: {
-    fixed: 5,
+    fixed: DEFAULT_POINT_SIZE,
     min: 1,
     max: 20,
   },

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -28,6 +28,7 @@ import { findFieldIndex, getScaledDimensionForField } from 'app/features/dimensi
 
 import { pointWithin, Quadtree, Rect } from '../barchart/quadtree';
 
+import { DEFAULT_POINT_SIZE } from './config';
 import { isGraphable } from './dims';
 import {
   DimensionValues,
@@ -140,7 +141,7 @@ function getScatterSeries(
   // Size configs
   //----------------
   let pointSizeHints = dims.pointSizeConfig;
-  let pointSizeFixed = dims.pointSizeConfig?.fixed ?? y.config.custom?.pointSize?.fixed ?? 5;
+  let pointSizeFixed = dims.pointSizeConfig?.fixed ?? y.config.custom?.pointSize?.fixed ?? DEFAULT_POINT_SIZE;
   let pointSize: DimensionValues<number> = () => pointSizeFixed;
   if (dims.pointSizeIndex) {
     pointSize = (frame) => {


### PR DESCRIPTION
Fixes #70560 

**What is this feature?**

the actual default size is 5, but the slider is set to 1:

![image](https://github.com/grafana/grafana/assets/43234/31843811-c738-47bd-a768-b9168a126e60)

**Special notes for your reviewer:**

Maybe we should not have two editors for point size in XY? 
- in manual mode we have 
<img width="485" alt="Screenshot 2023-06-29 at 11 15 18 AM" src="https://github.com/grafana/grafana/assets/22381771/4b06a8a9-6c5f-4a8d-8931-1d594642d738">

while always having the point size slider visible (for auto + manual mode)
<img width="490" alt="Screenshot 2023-06-29 at 11 16 43 AM" src="https://github.com/grafana/grafana/assets/22381771/b175f691-8036-452a-811b-4ff9bf146cb8">

this leads to a confusing UX - ideally we should come up with a flow that is more straightforward while still supporting series by series customization of point size (in manual mode)