### PR TITLE
SQL: Remove double quotes for multi-value variables

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2905,6 +2905,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
+    "public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/plugins/tests/datasource_srv.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -69,7 +69,7 @@ describe('TableSelector', () => {
 });
 
 describe('SQLWhereRow', () => {
-  it('should remove quotes in a where clause including multi-value variable', async () => {
+  it('should remove quotes in a where clause including multi-value variable', () => {
     const exp: SQLExpression = {
       whereString: "hostname IN ('${multiHost}')",
     };
@@ -84,12 +84,10 @@ describe('SQLWhereRow', () => {
 
     removeQuotesForMultiVariables(exp, variables);
 
-    await waitFor(() => {
-      expect(exp.whereString).toBe('hostname IN (${multiHost})');
-    });
+    expect(exp.whereString).toBe('hostname IN (${multiHost})');
   });
 
-  it('should not remove quotes in a where clause not including a multi-value variable', async () => {
+  it('should not remove quotes in a where clause not including a multi-value variable', () => {
     const exp: SQLExpression = {
       whereString: "hostname IN ('${nonMultiHost}')",
     };
@@ -104,8 +102,6 @@ describe('SQLWhereRow', () => {
 
     removeQuotesForMultiVariables(exp, variables);
 
-    await waitFor(() => {
-      expect(exp.whereString).toBe("hostname IN ('${nonMultiHost}')");
-    });
+    expect(exp.whereString).toBe("hostname IN ('${nonMultiHost}')");
   });
 });

--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -2,10 +2,14 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { config } from '@grafana/runtime';
+import { customBuilder } from 'app/features/variables/shared/testing/builders';
+
+import { SQLExpression } from '../types';
 
 import { DatasetSelector } from './DatasetSelector';
 import { buildMockDatasetSelectorProps, buildMockTableSelectorProps } from './SqlComponents.testHelpers';
 import { TableSelector } from './TableSelector';
+import { removeQuotesForMultiVariables } from './visual-query-builder/SQLWhereRow';
 
 beforeEach(() => {
   config.featureToggles.sqlDatasourceDatabaseSelection = true;
@@ -60,6 +64,48 @@ describe('TableSelector', () => {
 
     await waitFor(() => {
       expect(mockProps.db.tables).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('SQLWhereRow', () => {
+  it('should remove quotes in a where clause including multi-value variable', async () => {
+    const exp: SQLExpression = {
+      whereString: "hostname IN ('${multiHost}')",
+    };
+
+    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
+    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
+
+    multiVar.multi = true;
+    nonMultiVar.multi = false;
+
+    const variables = [multiVar, nonMultiVar];
+
+    removeQuotesForMultiVariables(exp, variables);
+
+    await waitFor(() => {
+      expect(exp.whereString).toBe('hostname IN (${multiHost})');
+    });
+  });
+
+  it('should not remove quotes in a where clause not including a multi-value variable', async () => {
+    const exp: SQLExpression = {
+      whereString: "hostname IN ('${nonMultiHost}')",
+    };
+
+    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
+    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
+
+    multiVar.multi = true;
+    nonMultiVar.multi = false;
+
+    const variables = [multiVar, nonMultiVar];
+
+    removeQuotesForMultiVariables(exp, variables);
+
+    await waitFor(() => {
+      expect(exp.whereString).toBe("hostname IN ('${nonMultiHost}')");
     });
   });
 });

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
-import { SelectableValue } from '@grafana/data';
+import { SelectableValue, VariableWithMultiSupport } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { QueryWithDefaults } from '../../defaults';
@@ -33,14 +33,15 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
       sql={query.sql!}
       onSqlChange={(val: SQLExpression) => {
         const templateSrv = getTemplateSrv();
-        const templateVars = templateSrv.getVariables();
+        const templateVars = templateSrv.getVariables() as VariableWithMultiSupport[];
 
         if (
           templateVars.some((tv) => {
             return tv.multi && val.whereString?.includes('${' + tv.name + '}');
           })
         ) {
-          val.whereString = val.whereString?.replaceAll("'", '');
+          val.whereString = val.whereString?.replaceAll("('", '(');
+          val.whereString = val.whereString?.replaceAll("')", ')');
         }
 
         onSqlChange(val);

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -33,9 +33,14 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
       sql={query.sql!}
       onSqlChange={(val: SQLExpression) => {
         const templateSrv = getTemplateSrv();
+        const templateVars = templateSrv.getVariables();
 
-        if (templateSrv.containsTemplate(val.whereString)) {
-          val.whereString = val.whereString?.replaceAll("''", "'");
+        if (
+          templateVars.some((tv) => {
+            return tv.multi && val.whereString?.includes('${' + tv.name + '}');
+          })
+        ) {
+          val.whereString = val.whereString?.replaceAll("'", '');
         }
 
         onSqlChange(val);

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
 import { SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 
 import { QueryWithDefaults } from '../../defaults';
 import { DB, SQLExpression, SQLQuery, SQLSelectableValue } from '../../types';
@@ -31,6 +32,13 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
       config={{ fields: state.value || {} }}
       sql={query.sql!}
       onSqlChange={(val: SQLExpression) => {
+        const templateSrv = getTemplateSrv();
+
+        if (templateSrv.containsTemplate(val.whereString)) {
+          const str = templateSrv.replace(val.whereString, undefined, 'singlequote');
+          val.whereString = str.replaceAll("''", "'");
+        }
+
         onSqlChange(val);
       }}
     />

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -35,8 +35,7 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
         const templateSrv = getTemplateSrv();
 
         if (templateSrv.containsTemplate(val.whereString)) {
-          const str = templateSrv.replace(val.whereString, undefined, 'singlequote');
-          val.whereString = str.replaceAll("''", "'");
+          val.whereString = val.whereString?.replaceAll("''", "'");
         }
 
         onSqlChange(val);

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -40,8 +40,8 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
             return tv.multi && val.whereString?.includes('${' + tv.name + '}');
           })
         ) {
-          val.whereString = val.whereString?.replaceAll("('", '(');
           val.whereString = val.whereString?.replaceAll("')", ')');
+          val.whereString = val.whereString?.replaceAll("('", '(');
         }
 
         onSqlChange(val);

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -32,17 +32,8 @@ export function SQLWhereRow({ query, fields, onQueryChange, db }: WhereRowProps)
       config={{ fields: state.value || {} }}
       sql={query.sql!}
       onSqlChange={(val: SQLExpression) => {
-        const templateSrv = getTemplateSrv();
-        const templateVars = templateSrv.getVariables() as VariableWithMultiSupport[];
-
-        if (
-          templateVars.some((tv) => {
-            return tv.multi && val.whereString?.includes('${' + tv.name + '}');
-          })
-        ) {
-          val.whereString = val.whereString?.replaceAll("')", ')');
-          val.whereString = val.whereString?.replaceAll("('", '(');
-        }
+        const templateVars = getTemplateSrv().getVariables() as VariableWithMultiSupport[];
+        removeQuotesForMultiVariables(val, templateVars);
 
         onSqlChange(val);
       }}
@@ -61,4 +52,15 @@ function mapFieldsToTypes(columns: SQLSelectableValue[]) {
     };
   }
   return fields;
+}
+
+export function removeQuotesForMultiVariables(val: SQLExpression, templateVars: VariableWithMultiSupport[]) {
+  if (
+    templateVars.some((tv) => {
+      return tv.multi && (val.whereString?.includes('${' + tv.name + '}') || val.whereString?.includes('$' + tv.name));
+    })
+  ) {
+    val.whereString = val.whereString?.replaceAll("')", ')');
+    val.whereString = val.whereString?.replaceAll("('", '(');
+  }
 }

--- a/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
+++ b/public/app/features/plugins/sql/components/visual-query-builder/SQLWhereRow.tsx
@@ -55,11 +55,10 @@ function mapFieldsToTypes(columns: SQLSelectableValue[]) {
 }
 
 export function removeQuotesForMultiVariables(val: SQLExpression, templateVars: VariableWithMultiSupport[]) {
-  if (
-    templateVars.some((tv) => {
-      return tv.multi && (val.whereString?.includes('${' + tv.name + '}') || val.whereString?.includes('$' + tv.name));
-    })
-  ) {
+  const multiVariableInWhereString = (tv: VariableWithMultiSupport) =>
+    tv.multi && (val.whereString?.includes(`\${${tv.name}}`) || val.whereString?.includes(`$${tv.name}`));
+
+  if (templateVars.some((tv) => multiVariableInWhereString(tv))) {
     val.whereString = val.whereString?.replaceAll("')", ')');
     val.whereString = val.whereString?.replaceAll("('", '(');
   }

--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -89,7 +89,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
 
     if (Array.isArray(value)) {
       const quotedValues = value.map((v) => this.getQueryModel().quoteLiteral(v));
-      return quotedValues.join(',').slice(1, -1);
+      return quotedValues.join(',');
     }
 
     return value;

--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -89,7 +89,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
 
     if (Array.isArray(value)) {
       const quotedValues = value.map((v) => this.getQueryModel().quoteLiteral(v));
-      return quotedValues.join(',');
+      return quotedValues.join(',').slice(1, -1);
     }
 
     return value;


### PR DESCRIPTION
**What is this feature?**

Fix for SQL WHERE...IN... clauses such that multi-value variables are correctly queried as a list of strings e.g. ('Africa', 'America', 'Asia') rather than a quoted list of strings e.g. (''Africa', 'America', 'Asia'').

**Variable Set-Up**

<img width="350" alt="image" src="https://github.com/grafana/grafana/assets/94075844/e55ee1f7-2ade-4822-92cc-61e43e96e503">

<img width="575" alt="image" src="https://github.com/grafana/grafana/assets/94075844/bb3aa895-3f49-4bbb-b852-9b935534addb">

**Query Inspector Before**

<img width="712" alt="image" src="https://github.com/grafana/grafana/assets/94075844/5399e9ce-470b-4cd1-8079-1cc3ed099d85">

**Query Inspector After**

<img width="712" alt="image" src="https://github.com/grafana/grafana/assets/94075844/2406415c-9366-42c9-8398-11755a73f7c4">

**Why do we need this feature?**

Previously, multi-value variables could not be queried using PostgreSQL, MySQL or MSSQL datasources.

**Who is this feature for?**

Users with SQL datasources using custom variables

**Which issue(s) does this PR fix?**:

Fixes #63295

**Special notes for your reviewer:**

We're fairly convinced that using a type assertion is the only reasonable way to do this - please don't crucify me for it :)