### PR TITLE
Alerting: Add legend for mixed in Loki alert history and use highlight instead of scroll

### DIFF
--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -55,6 +55,7 @@ export const LogRecordViewerByTimestamp = React.memo(
               key={key}
               data-testid={key}
               ref={(element) => element && timestampRefs.set(key, element)}
+              className={styles.listItemWrapper}
             >
               <Timestamp time={key} />
               <div className={styles.logsContainer}>
@@ -170,11 +171,17 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   timestampWrapper: css`
     color: ${theme.colors.text.secondary};
-    padding: ${theme.spacing(1)} 0;
   `,
   timestampText: css`
     color: ${theme.colors.text.primary};
     font-size: ${theme.typography.bodySmall.fontSize};
     font-weight: ${theme.typography.fontWeightBold};
+  `,
+  listItemWrapper: css`
+    background: transparent;
+    outline: 1px solid transparent;
+
+    transition: background 150ms, outline 150ms;
+    padding: ${theme.spacing(1)} ${theme.spacing(1.5)};
   `,
 });

--- a/public/app/features/alerting/unified/components/rules/state-history/LogTimelineViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogTimelineViewer.tsx
@@ -43,6 +43,7 @@ export const LogTimelineViewer = React.memo(({ frames, timeRange, onPointerMove 
             { label: 'Pending', color: theme.colors.warning.main, yAxis: 1 },
             { label: 'Alerting', color: theme.colors.error.main, yAxis: 1 },
             { label: 'NoData', color: theme.colors.info.main, yAxis: 1 },
+            { label: 'Mixed', color: theme.colors.text.secondary, yAxis: 1 },
           ]}
         >
           {(builder) => {

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -66,14 +66,20 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
     setValue('query', '');
   }, [setInstancesFilter, setValue]);
 
+  const [refToHighlight, setRefToHighlight] = useState<HTMLElement | undefined>(undefined);
+
+  refToHighlight?.classList.add(styles.highlightedLogRecord);
+
   const onTimelinePointerMove = useCallback(
     (seriesIdx: number, pointIdx: number) => {
       const timestamp = frameSubsetTimestamps[pointIdx];
 
       const refToScroll = logsRef.current.get(timestamp);
-      refToScroll?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // remove the highlight from the previous refToHighlight
+      refToHighlight?.classList.remove(styles.highlightedLogRecord);
+      setRefToHighlight(refToScroll);
     },
-    [frameSubsetTimestamps]
+    [frameSubsetTimestamps, styles.highlightedLogRecord, refToHighlight?.classList]
   );
 
   if (isLoading) {
@@ -258,6 +264,9 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   commonLabels: css`
     display: grid;
     grid-template-columns: max-content auto;
+  `,
+  highlightedLogRecord: css`
+    border: 1px solid ${theme.colors.text.primary};
   `,
 });
 

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -66,20 +66,24 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
     setValue('query', '');
   }, [setInstancesFilter, setValue]);
 
-  const [refToHighlight, setRefToHighlight] = useState<HTMLElement | undefined>(undefined);
-
-  refToHighlight?.classList.add(styles.highlightedLogRecord);
+  const refToHighlight = useRef<HTMLElement | undefined>(undefined);
 
   const onTimelinePointerMove = useCallback(
     (seriesIdx: number, pointIdx: number) => {
-      const timestamp = frameSubsetTimestamps[pointIdx];
-
-      const refToScroll = logsRef.current.get(timestamp);
       // remove the highlight from the previous refToHighlight
-      refToHighlight?.classList.remove(styles.highlightedLogRecord);
-      setRefToHighlight(refToScroll);
+      refToHighlight.current?.classList.remove(styles.highlightedLogRecord);
+
+      const timestamp = frameSubsetTimestamps[pointIdx];
+      const newTimestampRef = logsRef.current.get(timestamp);
+
+      // now we have the new ref, add the styles
+      newTimestampRef?.classList.add(styles.highlightedLogRecord);
+      // keeping this here (commented) in case we decide we want to go back to this
+      // newTimestampRef?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      refToHighlight.current = newTimestampRef;
     },
-    [frameSubsetTimestamps, styles.highlightedLogRecord, refToHighlight?.classList]
+    [frameSubsetTimestamps, styles.highlightedLogRecord]
   );
 
   if (isLoading) {
@@ -265,8 +269,10 @@ export const getStyles = (theme: GrafanaTheme2) => ({
     display: grid;
     grid-template-columns: max-content auto;
   `,
+  // we need !important here to override the list item default styles
   highlightedLogRecord: css`
-    border: 1px solid ${theme.colors.text.primary};
+    background: ${theme.colors.primary.transparent} !important;
+    outline: 1px solid ${theme.colors.primary.shade} !important;
   `,
 });
 


### PR DESCRIPTION
**What is this feature?**

This PR  includes a missing legend for the 'mixed' state in the alert state history with Loki. This ensures that all alert states are properly represented in the timeline.

Second, removes the scrolling behavior when hovering over the timeline. Instead of scrolling, we now highlight the row that corresponds to the hovered time.

This eliminates an unexpected scroll behavior that occurs when accidentally hovering that may disrupt their browsing experience.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/33540275/d123a678-4c52-4d36-b769-8bcbc4269590


the new legend:

<img width="640" alt="Screenshot 2023-07-06 at 14 12 00" src="https://github.com/grafana/grafana/assets/33540275/ea3d7fdf-770c-4399-9f32-fefd52155346">



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
