### PR TITLE
CI: Provide a Drone promotion to build the build-container

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -30,6 +30,7 @@ load(
 )
 load(
     "scripts/drone/pipelines/ci_images.star",
+    "publish_ci_build_container_image_pipeline",
     "publish_ci_windows_test_image_pipeline",
 )
 load("scripts/drone/pipelines/github.star", "publish_github_pipeline")
@@ -66,6 +67,7 @@ def main(_ctx):
         version_branch_pipelines() +
         integration_test_pipelines() +
         publish_ci_windows_test_image_pipeline() +
+        publish_ci_build_container_image_pipeline() +
         cronjobs() +
         secrets()
     )

--- a/.drone.yml
+++ b/.drone.yml
@@ -6995,11 +6995,19 @@ steps:
 - commands:
   - if [ -z "${BUILD_CONTAINER_VERSION}" ]; then echo Missing BUILD_CONTAINER_VERSION;
     false; fi
+  image: alpine:3.17.1
+  name: validate-version
+- commands:
   - printenv GCP_KEY > /tmp/key.json
-  - printenv DOCKER_USERNAME
-  - printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
   - gcloud auth activate-service-account --key-file=/tmp/key.json
   - gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz
+  environment:
+    GCP_KEY:
+      from_secret: gcp_download_build_container_assets_key
+  image: google/cloud-sdk:431.0.0
+  name: download-macos-sdk
+- commands:
+  - printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker build -t "grafana/build-container:${BUILD_CONTAINER_VERSION}" ./scripts/build/ci-build
   - docker push "grafana/build-container:${BUILD_CONTAINER_VERSION}"
   environment:
@@ -7007,10 +7015,8 @@ steps:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_download_build_container_assets_key
   image: google/cloud-sdk:431.0.0
-  name: build
+  name: build-and-publish
   volumes:
   - name: docker
     path: /var/run/docker.sock
@@ -7407,6 +7413,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 5e58f53a746fe95b05776c2e27d1e59ec3aca775ccee2909271c8ed64f66aad3
+hmac: 992db6d1af741f53ab58777764b03bf713ae2fc3ad7a3bdf8805d23b9bf2f9eb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6980,6 +6980,53 @@ volumes:
 ---
 clone:
   retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-ci-build-container-image
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - if [ -z "${BUILD_CONTAINER_VERSION}" ]; then echo Missing BUILD_CONTAINER_VERSION;
+    false; fi
+  - printenv GCP_KEY > /tmp/key.json
+  - printenv DOCKER_USERNAME
+  - printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - gcloud auth activate-service-account --key-file=/tmp/key.json
+  - gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz
+  - docker build -t "grafana/build-container:${BUILD_CONTAINER_VERSION}" ./scripts/build/ci-build
+  - docker push "grafana/build-container:${BUILD_CONTAINER_VERSION}"
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+    GCP_KEY:
+      from_secret: gcp_download_build_container_assets_key
+  image: google/cloud-sdk:431.0.0
+  name: build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - promote
+  target:
+  - ci-build-container-image
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
 kind: pipeline
 name: scan-grafana/grafana:latest-image
 platform:
@@ -7228,6 +7275,12 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 get:
+  name: credentials.json
+  path: infra/data/ci/grafana/assets-downloader-build-container-service-account
+kind: secret
+name: gcp_download_build_container_assets_key
+---
+get:
   name: application_id
   path: infra/data/ci/datasources/cpp-azure-resourcemanager-credentials
 kind: secret
@@ -7354,6 +7407,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 804a6690ecc4900ed6d0ed55902de1858562f2a07e359204d5c0e2313e5f61ca
+hmac: 5e58f53a746fe95b05776c2e27d1e59ec3aca775ccee2909271c8ed64f66aad3
 
 ...

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -82,20 +82,34 @@ def publish_ci_build_container_image_pipeline():
         edition = "",
         steps = [
             {
-                "name": "build",
+                "name": "validate-version",
+                "image": images["alpine_image"],
+                "commands": [
+                    "if [ -z \"${BUILD_CONTAINER_VERSION}\" ]; then echo Missing BUILD_CONTAINER_VERSION; false; fi",
+                ],
+            },
+            {
+                "name": "download-macos-sdk",
+                "image": images["cloudsdk_image"],
+                "environment": {
+                    "GCP_KEY": from_secret(gcp_download_build_container_assets_key),
+                },
+                "commands": [
+                    "printenv GCP_KEY > /tmp/key.json",
+                    "gcloud auth activate-service-account --key-file=/tmp/key.json",
+                    "gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz",
+                ],
+            },
+            {
+                "name": "build-and-publish",  # Consider splitting the build and the upload task.
                 "image": images["cloudsdk_image"],
                 "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
                 "environment": {
-                    "GCP_KEY": from_secret(gcp_download_build_container_assets_key),
                     "DOCKER_USERNAME": from_secret("docker_username"),
                     "DOCKER_PASSWORD": from_secret("docker_password"),
                 },
                 "commands": [
-                    "if [ -z \"${BUILD_CONTAINER_VERSION}\" ]; then echo Missing BUILD_CONTAINER_VERSION; false; fi",
-                    "printenv GCP_KEY > /tmp/key.json",
                     "printenv DOCKER_PASSWORD | docker login -u \"$DOCKER_USERNAME\" --password-stdin",
-                    "gcloud auth activate-service-account --key-file=/tmp/key.json",
-                    "gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz",
                     "docker build -t \"grafana/build-container:${BUILD_CONTAINER_VERSION}\" ./scripts/build/ci-build",
                     "docker push \"grafana/build-container:${BUILD_CONTAINER_VERSION}\"",
                 ],

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -9,10 +9,15 @@ load(
 load(
     "scripts/drone/vault.star",
     "from_secret",
+    "gcp_download_build_container_assets_key",
 )
 load(
     "scripts/drone/utils/windows_images.star",
     "windows_images",
+)
+load(
+    "scripts/drone/utils/images.star",
+    "images",
 )
 
 def publish_ci_windows_test_image_pipeline():
@@ -63,5 +68,40 @@ def publish_ci_windows_test_image_pipeline():
     pl["clone"] = {
         "disable": True,
     }
+
+    return [pl]
+
+def publish_ci_build_container_image_pipeline():
+    trigger = {
+        "event": ["promote"],
+        "target": ["ci-build-container-image"],
+    }
+    pl = pipeline(
+        name = "publish-ci-build-container-image",
+        trigger = trigger,
+        edition = "",
+        steps = [
+            {
+                "name": "build",
+                "image": images["cloudsdk_image"],
+                "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+                "environment": {
+                    "GCP_KEY": from_secret(gcp_download_build_container_assets_key),
+                    "DOCKER_USERNAME": from_secret("docker_username"),
+                    "DOCKER_PASSWORD": from_secret("docker_password"),
+                },
+                "commands": [
+                    "if [ -z \"${BUILD_CONTAINER_VERSION}\" ]; then echo Missing BUILD_CONTAINER_VERSION; false; fi",
+                    "printenv GCP_KEY > /tmp/key.json",
+                    "printenv DOCKER_USERNAME", # FIXME: Remove this line before merging.
+                    "printenv DOCKER_PASSWORD | docker login -u \"$DOCKER_USERNAME\" --password-stdin",
+                    "gcloud auth activate-service-account --key-file=/tmp/key.json",
+                    "gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz",
+                    "docker build -t \"grafana/build-container:${BUILD_CONTAINER_VERSION}\" ./scripts/build/ci-build",
+                    "docker push \"grafana/build-container:${BUILD_CONTAINER_VERSION}\"",
+                ],
+            },
+        ],
+    )
 
     return [pl]

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -93,7 +93,6 @@ def publish_ci_build_container_image_pipeline():
                 "commands": [
                     "if [ -z \"${BUILD_CONTAINER_VERSION}\" ]; then echo Missing BUILD_CONTAINER_VERSION; false; fi",
                     "printenv GCP_KEY > /tmp/key.json",
-                    "printenv DOCKER_USERNAME", # FIXME: Remove this line before merging.
                     "printenv DOCKER_PASSWORD | docker login -u \"$DOCKER_USERNAME\" --password-stdin",
                     "gcloud auth activate-service-account --key-file=/tmp/key.json",
                     "gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz",

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -5,6 +5,7 @@ pull_secret = "dockerconfigjson"
 drone_token = "drone_token"
 prerelease_bucket = "prerelease_bucket"
 gcp_upload_artifacts_key = "gcp_upload_artifacts_key"
+gcp_download_build_container_assets_key = "gcp_download_build_container_assets_key"
 azure_sp_app_id = "azure_sp_app_id"
 azure_sp_app_pw = "azure_sp_app_pw"
 azure_tenant = "azure_tenant"
@@ -36,6 +37,11 @@ def secrets():
         vault_secret(
             gcp_upload_artifacts_key,
             "infra/data/ci/grafana/releng/artifacts-uploader-service-account",
+            "credentials.json",
+        ),
+        vault_secret(
+            gcp_download_build_container_assets_key,
+            "infra/data/ci/grafana/assets-downloader-build-container-service-account",
             "credentials.json",
         ),
         vault_secret(


### PR DESCRIPTION
**What is this feature?**

Provides an option to build the build container through Drone to streamline our CI processes.

**Why do we need this feature?**

Faster and more reliable toolchain upgrades.

**Who is this feature for?**

Grafana maintainers.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-backend-platform-squad/issues/8
Fixes https://github.com/grafana/grafana-backend-platform-squad/issues/9

**Special notes for your reviewer:**

Missing pushing the build container to Docker Hub, that's tracked by https://github.com/grafana/grafana-backend-platform-squad/issues/9. Shouldn't be too hard to add it, but I'm having some minor problems with Docker Hub secret management when I tried it out in the CI sandbox.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
