### PR TITLE
Auth: Resolve isGrafanaAdmin for debug logging

### DIFF
--- a/pkg/services/ldap/api/service.go
+++ b/pkg/services/ldap/api/service.go
@@ -277,8 +277,6 @@ func (s *Service) GetUserFromLDAP(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusNotFound, "No user was found in the LDAP server(s) with that username", err)
 	}
 
-	s.log.Debug("user found", "user", user)
-
 	name, surname := splitName(user.Name)
 
 	u := &LDAPUserDTO{

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -306,7 +306,7 @@ func (server *Server) Users(logins []string) (
 	}
 
 	server.log.Debug(
-		"LDAP users found", "users", fmt.Sprintf("%v", serializedUsers),
+		"LDAP users found", "users", fmt.Sprintf("%+v", serializedUsers),
 	)
 
 	return serializedUsers, nil

--- a/pkg/services/login/model.go
+++ b/pkg/services/login/model.go
@@ -67,7 +67,12 @@ type ExternalUserInfo struct {
 }
 
 func (e *ExternalUserInfo) String() string {
-	return fmt.Sprintf("%+v", *e)
+	isGrafanaAdmin := "nil"
+	if e.IsGrafanaAdmin != nil {
+		isGrafanaAdmin = fmt.Sprintf("%v", *e.IsGrafanaAdmin)
+	}
+	return fmt.Sprintf("OAuthToken: %+v, AuthModule: %v, AuthId: %v, UserId: %v, Email: %v, Login: %v, Name: %v, Groups: %v, OrgRoles: %v, IsGrafanaAdmin: %v, IsDisabled: %v, SkipTeamSync: %v",
+		e.OAuthToken, e.AuthModule, e.AuthId, e.UserId, e.Email, e.Login, e.Name, e.Groups, e.OrgRoles, isGrafanaAdmin, e.IsDisabled, e.SkipTeamSync)
 }
 
 type LoginInfo struct {


### PR DESCRIPTION
**What is this feature?**

- Show isGrafanaAdmin value in debug logs instead of pointer address 

**Why do we need this feature?**

Fixes https://github.com/grafana/grafana/issues/70840

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
