### PR TITLE
[v9.3.x] Added security patch delivery workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,42 +12,215 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Documentation
-/docs/ @grafana/docs-squad
-/contribute/ @grafana/docs-squad
-/docs/sources/developers/plugins/ @grafana/docs-squad @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
-/docs/sources/developers/plugins/backend @grafana/docs-squad @grafana/plugins-platform-backend
-# Set up, dashboards/visualization, best practices: Chris Moyer
-# Alerting: Brenda Muir
-/docs/sources/administration/ @Eve832 @GrafanaWriter
-/docs/sources/alerting @brendamuir
-/docs/sources/best-practices/ @chri2547
-/docs/sources/dashboards/ @chri2547
-/docs/sources/datasources/ @Eve832 @GrafanaWriter
-/docs/sources/enterprise/ @Eve832 @GrafanaWriter
-/docs/sources/explore/ @Eve832 @GrafanaWriter
-/docs/sources/getting-started/ @chri2547
-/docs/sources/old-alerting @brendamuir
-/docs/sources/panels/ @chri2547
-/docs/sources/release-notes/ @Eve832 @GrafanaWriter
-/docs/sources/setup-grafana/ @chri2547
-/docs/sources/visualization/ @chri2547
-/docs/sources/whatsnew/ @Eve832 @GrafanaWriter
+/.changelog-archive @grafana/docs-grafana
+/CHANGELOG.md @grafana/docs-grafana
+/CODE_OF_CONDUCT.md @grafana/docs-grafana
+/CONTRIBUTING.md @grafana/docs-grafana
+/GOVERNANCE.md @RichiH
+/HALL_OF_FAME.md @grafana/docs-grafana
+/ISSUE_TRIAGE.md @grafana/grafana-community-support
+/LICENSE @torkelo
+/LICENSING.md @torkelo
+/MAINTAINERS.md @RichiH
+/NOTICE.md @torkelo
+/README.md @grafana/docs-grafana
+/ROADMAP.md @torkelo
+/SECURITY.md @grafana/security-team
+/SUPPORT.md @torkelo
+/UPGRADING_DEPENDENCIES.md @grafana/docs-grafana
+/WORKFLOW.md @torkelo
+/contribute/ @grafana/docs-grafana
+/devenv/README.md @grafana/docs-grafana
+
+# Technical documentation
+/docs/                                    @Eve832 @jdbaldry
+/docs/sources/                            @Eve832
+/docs/sources/administration/             @Eve832 @GrafanaWriter
+/docs/sources/alerting/                   @brendamuir
+/docs/sources/dashboards/                 @imatwawana
+/docs/sources/datasources/                @lwandz13
+/docs/sources/explore/                    @Eve832 @GrafanaWriter
+/docs/sources/fundamentals                @chri2547
+/docs/sources/getting-started/            @chri2547
+/docs/sources/introduction/               @chri2547
+/docs/sources/old-alerting/               @brendamuir
+/docs/sources/panels-visualizations/      @imatwawana
+/docs/sources/release-notes/              @Eve832 @GrafanaWriter
+/docs/sources/setup-grafana/              @chri2547
+/docs/sources/upgrade-guide/              @chri2547 @imatwawana
+/docs/sources/whatsnew/                   @chri2547 @imatwawana
+/docs/sources/developers/plugins/         @Eve832 @josmperez @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
+/docs/sources/developers/plugins/introduction-to-plugin-development/backend/ @Eve832 @grafana/plugins-platform-backend
 
 # Backend code
-*.go @grafana/backend-platform
-go.mod @grafana/backend-platform
-go.sum @grafana/backend-platform
-/.bingo @grafana/backend-platform
+/go.mod @grafana/backend-platform
+/go.sum @grafana/backend-platform
+/.bingo/ @grafana/backend-platform
+/pkg/README.md @grafana/backend-platform
+/pkg/ruleguard.rules.go @grafana/backend-platform
+/.bra.toml @grafana/backend-platform
+/.golangci.toml @grafana/backend-platform
+/build.go @grafana/backend-platform
+/scripts/modowners/ @grafana/backend-platform
 
+/pkg/api/ @grafana/backend-platform
+/pkg/bus/ @grafana/backend-platform
+/pkg/cmd/ @grafana/backend-platform
+/pkg/systemd/ @grafana/backend-platform
+/pkg/components/apikeygen/ @grafana/grafana-authnz-team
+/pkg/components/satokengen/ @grafana/grafana-authnz-team
+/pkg/components/dashdiffs/ @grafana/backend-platform
+/pkg/components/imguploader/ @grafana/backend-platform
+/pkg/components/loki/ @grafana/backend-platform
+/pkg/components/null/ @grafana/backend-platform
+/pkg/components/simplejson/ @grafana/backend-platform
+/pkg/events/ @grafana/backend-platform
+/pkg/extensions/ @grafana/backend-platform
+/pkg/ifaces/ @grafana/backend-platform
+/pkg/infra/appcontext/ @grafana/backend-platform
+/pkg/infra/db/ @grafana/backend-platform
+/pkg/infra/grn/ @grafana/backend-platform
+/pkg/infra/localcache/ @grafana/backend-platform
+/pkg/infra/log/ @grafana/backend-platform
+/pkg/infra/metrics/ @grafana/backend-platform
+/pkg/infra/network/ @grafana/backend-platform
+/pkg/infra/process/ @grafana/backend-platform
+/pkg/infra/proxy/ @grafana/hosted-grafana-team
+/pkg/infra/remotecache/ @grafana/backend-platform
+/pkg/infra/serverlock/ @grafana/backend-platform
+/pkg/infra/slugify/ @grafana/backend-platform
+/pkg/infra/tracing/ @grafana/backend-platform
+/pkg/infra/usagestats/ @grafana/backend-platform
+/pkg/middleware/ @grafana/backend-platform
+/pkg/mocks/ @grafana/backend-platform
+/pkg/models/ @grafana/backend-platform
+/pkg/server/ @grafana/backend-platform
+/pkg/services/annotations/ @grafana/backend-platform
+/pkg/services/apikey/ @grafana/grafana-authnz-team
+/pkg/services/cleanup/ @grafana/backend-platform
+/pkg/services/contexthandler/ @grafana/backend-platform
+/pkg/services/correlations/ @grafana/backend-platform
+/pkg/services/dashboardimport/ @grafana/backend-platform
+/pkg/services/dashboards/ @grafana/backend-platform
+/pkg/services/dashboardsnapshots/ @grafana/backend-platform
+/pkg/services/dashboardversion/ @grafana/backend-platform
+/pkg/services/encryption/ @grafana/backend-platform
+/pkg/services/folder/ @grafana/backend-platform
+/pkg/services/hooks/ @grafana/backend-platform
+/pkg/services/kmsproviders/ @grafana/backend-platform
+/pkg/services/licensing/ @grafana/backend-platform
+/pkg/services/navtree/ @grafana/backend-platform
+/pkg/services/notifications/ @grafana/backend-platform
+/pkg/services/org/ @grafana/backend-platform
+/pkg/services/playlist/ @grafana/backend-platform
+/pkg/services/plugindashboards/ @grafana/backend-platform
+/pkg/services/preference/ @grafana/backend-platform
+/pkg/services/provisioning/ @grafana/backend-platform
+/pkg/services/publicdashboards/ @grafana/dashboards-squad
+/pkg/services/query/ @grafana/backend-platform
+/pkg/services/queryhistory/ @grafana/backend-platform
+/pkg/services/quota/ @grafana/backend-platform
+/pkg/services/rendering/ @grafana/backend-platform
+/pkg/services/screenshot/ @grafana/backend-platform
+/pkg/services/search/ @grafana/backend-platform
+/pkg/services/searchusers/ @grafana/backend-platform
+/pkg/services/secrets/ @grafana/backend-platform
+/pkg/services/shorturls/ @grafana/backend-platform
+/pkg/services/sqlstore/ @grafana/backend-platform
+/pkg/services/star/ @grafana/backend-platform
+/pkg/services/stats/ @grafana/backend-platform
+/pkg/services/tag/ @grafana/backend-platform
+/pkg/services/team/ @grafana/grafana-authnz-team
+/pkg/services/temp_user/ @grafana/backend-platform
+/pkg/services/updatechecker/ @grafana/backend-platform
+/pkg/services/user/ @grafana/backend-platform
+/pkg/services/validations/ @grafana/backend-platform
+/pkg/setting/ @grafana/backend-platform
+/pkg/tests/ @grafana/backend-platform
+/pkg/tests/api/correlations/ @grafana/explore-squad
+/pkg/tsdb/grafanads/ @grafana/backend-platform
+/pkg/tsdb/intervalv2/ @grafana/backend-platform
+/pkg/tsdb/legacydata/ @grafana/backend-platform
+/pkg/tsdb/opentsdb/ @grafana/backend-platform
+/pkg/tsdb/sqleng/ @grafana/backend-platform
+/pkg/util/ @grafana/backend-platform
+/pkg/web/ @grafana/backend-platform
+
+/pkg/services/grpcserver/ @grafana/backend-platform
+/pkg/infra/kvstore/ @grafana/backend-platform
+/pkg/infra/fs/ @grafana/backend-platform
+/pkg/infra/x/ @grafana/backend-platform
+
+
+# devenv
 # Backend code, developers environment
-/devenv/docker/blocks/auth @grafana/grafana-authnz-team
+/devenv/docker/blocks/auth/ @grafana/grafana-authnz-team
 
 # Logs code, developers environment
 /devenv/docker/blocks/loki* @grafana/observability-logs
 /devenv/docker/blocks/elastic* @grafana/observability-logs
 
-# Performance tests
-/devenv/docker/loadtests-ts @grafana/grafana-edge-squad
+/devenv/bulk-dashboards/ @grafana/dashboards-squad
+/devenv/bulk_alerting_dashboards/ @grafana/alerting-backend-product
+/devenv/create_docker_compose.sh @grafana/backend-platform
+/devenv/dashboards.yaml @grafana/dashboards-squad
+/devenv/datasources.yaml @grafana/backend-platform
+/devenv/datasources_docker.yaml @grafana/backend-platform
+/devenv/dev-dashboards-without-uid/ @grafana/dashboards-squad
+/devenv/dev-dashboards/ @grafana/dashboards-squad
+/devenv/docker/blocks/alert_webhook_listener/ @grafana/alerting-backend-product
+/devenv/docker/blocks/clickhouse/ @grafana/partner-datasources
+/devenv/docker/blocks/collectd/ @grafana/observability-metrics
+/devenv/docker/blocks/grafana/ @grafana/grafana-as-code
+/devenv/docker/blocks/graphite/ @grafana/observability-metrics
+/devenv/docker/blocks/graphite09/ @grafana/observability-metrics
+/devenv/docker/blocks/graphite1/ @grafana/observability-metrics
+/devenv/docker/blocks/influxdb/ @grafana/observability-metrics
+/devenv/docker/blocks/influxdb1/ @grafana/observability-metrics
+/devenv/docker/blocks/jaeger/ @grafana/observability-traces-and-profiling
+/devenv/docker/blocks/maildev/ @grafana/alerting-frontend
+/devenv/docker/blocks/mariadb/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/memcached/ @grafana/backend-platform
+/devenv/docker/blocks/mssql/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mssql_arm64/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mssql_tests/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mssql_tls/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mysql/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mysql_exporter/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mysql_opendata/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mysql_tests/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/opentsdb/ @grafana/observability-metrics
+/devenv/docker/blocks/phlare/ @grafana/observability-traces-and-profiling
+/devenv/docker/blocks/postgres/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/postgres_tests/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/prometheus/ @grafana/observability-metrics
+/devenv/docker/blocks/prometheus_random_data/ @grafana/observability-metrics
+/devenv/docker/blocks/pyroscope/ @grafana/observability-traces-and-profiling
+/devenv/docker/blocks/redis/ @bergquist
+/devenv/docker/blocks/sensugo/ @grafana/backend-platform
+/devenv/docker/blocks/slow_proxy/ @bergquist
+/devenv/docker/blocks/smtp/ @bergquist
+/devenv/docker/blocks/tempo/ @grafana/observability-traces-and-profiling
+/devenv/docker/blocks/traefik/ @mckn
+/devenv/docker/blocks/zipkin/ @grafana/observability-traces-and-profiling
+/devenv/docker/buildcontainer/ @bergquist
+/devenv/docker/compose_header.yml @grafana/backend-platform
+/devenv/docker/debtest/ @bergquist
+/devenv/docker/ha-test-unified-alerting/ @grafana/alerting-backend-product
+/devenv/docker/ha_test/ @grafana/backend-platform
+/devenv/docker/loadtest/ @grafana/backend-platform
+/devenv/docker/rpmtest/ @grafana/backend-platform
+/devenv/jsonnet/ @grafana/dataviz-squad
+/devenv/local-npm/ @grafana/frontend-ops
+/devenv/vscode/ @grafana/frontend-ops
+/devenv/setup.sh @grafana/backend-platform
+
+# Emails
+/emails/ @grafana/alerting-frontend
+
+#Packaging
+/packaging/ @DanCech
+
 
 # Continuous Integration
 .drone.yml @grafana/grafana-delivery
@@ -60,178 +233,417 @@ go.sum @grafana/backend-platform
 /scripts/build/ @grafana/grafana-delivery
 /scripts/list-release-artifacts.sh @grafana/grafana-delivery
 
-# Cloud Datasources backend code
-/pkg/tsdb/cloudwatch @grafana/aws-plugins
-/pkg/tsdb/azuremonitor @grafana/cloud-provider-plugins
-/pkg/tsdb/cloudmonitoring @grafana/cloud-provider-plugins
+# OSS Plugin Partnerships backend code
+/pkg/tsdb/cloudwatch/ @grafana/aws-datasources
+/pkg/tsdb/azuremonitor/ @grafana/partner-datasources
+/pkg/tsdb/cloud-monitoring/ @grafana/partner-datasources
 
 # Observability backend code
-/pkg/tsdb/prometheus @grafana/observability-metrics
-/pkg/tsdb/influxdb @grafana/observability-metrics
-/pkg/tsdb/elasticsearch @grafana/observability-logs
-/pkg/tsdb/graphite @grafana/observability-metrics
-/pkg/tsdb/jaeger @grafana/observability-traces-and-profiling
-/pkg/tsdb/loki @grafana/observability-logs
-/pkg/tsdb/zipkin @grafana/observability-traces-and-profiling
-/pkg/tsdb/tempo @grafana/observability-traces-and-profiling
+/pkg/tsdb/prometheus/ @grafana/observability-metrics
+/pkg/tsdb/influxdb/ @grafana/observability-metrics
+/pkg/tsdb/elasticsearch/ @grafana/observability-logs
+/pkg/tsdb/graphite/ @grafana/observability-metrics
+/pkg/tsdb/loki/ @grafana/observability-logs
+/pkg/tsdb/tempo/ @grafana/observability-traces-and-profiling
+/pkg/tsdb/grafana-pyroscope-datasource/ @grafana/observability-traces-and-profiling
+/pkg/tsdb/parca/ @grafana/observability-traces-and-profiling
 
 # BI backend code
-/pkg/tsdb/mysql @grafana/grafana-bi-squad
-/pkg/tsdb/postgres @grafana/grafana-bi-squad
-/pkg/tsdb/mssql @grafana/grafana-bi-squad
+/pkg/tsdb/mysql/ @grafana/grafana-bi-squad
+/pkg/tsdb/postgres/ @grafana/grafana-bi-squad
+/pkg/tsdb/mssql/ @grafana/grafana-bi-squad
 
 # Database migrations
-/pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team
+/pkg/services/sqlstore/migrations/ @grafana/backend-platform @grafana/hosted-grafana-team
 *_mig.go @grafana/backend-platform @grafana/hosted-grafana-team
 
-# Grafana edge
-/pkg/services/live/ @grafana/grafana-edge-squad
-/pkg/services/searchV2/ @grafana/grafana-edge-squad
-/pkg/services/store/ @grafana/grafana-edge-squad
-/pkg/services/querylibrary/ @grafana/grafana-edge-squad
-/pkg/services/export/ @grafana/grafana-edge-squad
-/pkg/infra/filestore/ @grafana/grafana-edge-squad
-/pkg/tsdb/testdatasource/sims/ @grafana/grafana-edge-squad
+# Grafana app platform
+/pkg/services/live/ @grafana/grafana-app-platform-squad
+/pkg/services/searchV2/ @grafana/grafana-app-platform-squad
+/pkg/services/store/ @grafana/grafana-app-platform-squad
+/pkg/infra/filestorage/ @grafana/grafana-app-platform-squad
+/pkg/util/converter/ @grafana/grafana-app-platform-squad
+/pkg/modules/ @grafana/grafana-app-platform-squad
+/pkg/kindsysreport/ @grafana/grafana-app-platform-squad
 
 # Alerting
-/pkg/services/ngalert @grafana/alerting-squad-backend
-/pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad-backend
-/pkg/services/alerting @grafana/alerting-squad-backend
-/pkg/tests/api/alerting @grafana/alerting-squad-backend
-/public/app/features/alerting @grafana/alerting-squad-frontend
+/pkg/services/ngalert/ @grafana/alerting-backend-product
+/pkg/services/sqlstore/migrations/ualert/ @grafana/alerting-backend-product
+/pkg/services/alerting/ @grafana/alerting-backend-product
+/pkg/tests/api/alerting/ @grafana/alerting-backend-product
+/public/app/features/alerting/ @grafana/alerting-frontend
 
 # Library Services
-/pkg/services/libraryelements @grafana/user-essentials
-/pkg/services/librarypanels @grafana/user-essentials
+/pkg/services/libraryelements/ @grafana/grafana-frontend-platform
+/pkg/services/librarypanels/ @grafana/grafana-frontend-platform
 
 # Plugins
-/pkg/api/pluginproxy @grafana/plugins-platform-backend
-/pkg/plugins @grafana/plugins-platform-backend
-/pkg/services/datasourceproxy @grafana/plugins-platform-backend
-/pkg/services/datasources @grafana/plugins-platform-backend
-/pkg/plugins/pfs @grafana/plugins-platform-backend @grafana/grafana-as-code
-
-# Dashboard previews / crawler (behind feature flag)
-/pkg/services/thumbs @grafana/grafana-edge-squad
+/pkg/api/pluginproxy/ @grafana/plugins-platform-backend
+/pkg/infra/httpclient/ @grafana/plugins-platform-backend
+/pkg/plugins/ @grafana/plugins-platform-backend
+/pkg/services/datasourceproxy/ @grafana/plugins-platform-backend
+/pkg/services/datasources/ @grafana/plugins-platform-backend
+/pkg/services/pluginsintegration/ @grafana/plugins-platform-backend
+/pkg/plugins/pfs/ @grafana/plugins-platform-backend @grafana/grafana-as-code
+/pkg/tsdb/testdatasource/ @grafana/plugins-platform-backend
+/pkg/services/pluginsintegration/pluginsettings/ @grafana/plugins-platform-backend
 
 # Backend code docs
-/contribute/style-guides/backend.md @grafana/backend-platform
-/contribute/architecture/backend @grafana/backend-platform
-/contribute/engineering/backend @grafana/backend-platform
+/contribute/backend/ @grafana/backend-platform
 
-/crowdin.yml @grafana/user-essentials
-/public/locales @grafana/user-essentials
-/public/app/core/internationalization @grafana/user-essentials
-/e2e @grafana/user-essentials
-/e2e/cloud-plugins-suite @grafana/cloud-provider-plugins
-/packages @grafana/user-essentials @grafana/plugins-platform-frontend @grafana/grafana-bi-squad
-/packages/grafana-e2e-selectors @grafana/user-essentials
-/packages/grafana-e2e @grafana/user-essentials
-/packages/grafana-toolkit @grafana/plugins-platform-frontend
-/packages/grafana-ui/.storybook @grafana/plugins-platform-frontend
-/packages/grafana-ui/src/components/DateTimePickers @grafana/user-essentials
-/packages/grafana-ui/src/components/GraphNG @grafana/grafana-bi-squad
-/packages/grafana-ui/src/components/Logs @grafana/observability-logs
-/packages/grafana-ui/src/components/Table @grafana/grafana-bi-squad
-/packages/grafana-ui/src/components/TimeSeries @grafana/grafana-bi-squad
-/packages/grafana-ui/src/components/uPlot @grafana/grafana-bi-squad
-/packages/grafana-ui/src/utils/storybook @grafana/plugins-platform-frontend
-/packages/jaeger-ui-components/ @grafana/observability-traces-and-profiling
-/plugins-bundled @grafana/plugins-platform-frontend
-# public folder
-/public/app/core/components/TimePicker @grafana/grafana-bi-squad
-/public/app/core/components/Layers @grafana/grafana-edge-squad
-/public/app/features/canvas/ @grafana/grafana-edge-squad
-/public/app/features/comments/ @grafana/grafana-edge-squad
-/public/app/features/dimensions/ @grafana/grafana-edge-squad
-/public/app/features/geo/ @grafana/grafana-edge-squad
-/public/app/features/storage/ @grafana/grafana-edge-squad
-/public/app/features/live/ @grafana/grafana-edge-squad
-/public/app/features/explore/ @grafana/observability-experience-squad
-/public/app/features/plugins @grafana/plugins-platform-frontend
-/public/app/features/transformers/spatial @grafana/grafana-edge-squad
-/public/app/plugins/panel/alertlist @grafana/alerting-squad-frontend
-/public/app/plugins/panel/barchart @grafana/grafana-bi-squad
-/public/app/plugins/panel/heatmap @grafana/grafana-bi-squad
-/public/app/plugins/panel/histogram @grafana/grafana-bi-squad
-/public/app/plugins/panel/logs @grafana/observability-logs
-/public/app/plugins/panel/nodeGraph @grafana/observability-traces-and-profiling
-/public/app/plugins/panel/traces @grafana/observability-traces-and-profiling
-/public/app/plugins/panel/piechart @grafana/grafana-bi-squad
-/public/app/plugins/panel/state-timeline @grafana/grafana-bi-squad
-/public/app/plugins/panel/status-history @grafana/grafana-bi-squad
-/public/app/plugins/panel/table @grafana/grafana-bi-squad
-/public/app/plugins/panel/timeseries @grafana/grafana-bi-squad
-/public/app/plugins/panel/geomap @grafana/grafana-edge-squad
-/public/app/plugins/panel/canvas @grafana/grafana-edge-squad
-/public/app/plugins/panel/candlestick @grafana/grafana-edge-squad
-/public/app/plugins/panel/icon @grafana/grafana-edge-squad
-/scripts/build/release-packages.sh @grafana/plugins-platform-frontend
-/scripts/circle-release-next-packages.sh @grafana/plugins-platform-frontend
-/scripts/ci-frontend-metrics.sh @grafana/user-essentials @grafana/plugins-platform-frontend @grafana/grafana-bi-squad
-/scripts/grunt @grafana/frontend-ops
-/scripts/webpack @grafana/frontend-ops
-/scripts/generate-a11y-report.sh @grafana/user-essentials
+
+/crowdin.yml @grafana/grafana-frontend-platform
+/public/locales/ @grafana/grafana-frontend-platform
+/public/app/core/internationalization/ @grafana/grafana-frontend-platform
+/e2e/ @grafana/grafana-frontend-platform
+/e2e/cloud-plugins-suite/ @grafana/partner-datasources
+/packages/ @grafana/grafana-frontend-platform @grafana/plugins-platform-frontend
+/packages/grafana-e2e-selectors/ @grafana/grafana-frontend-platform
+/packages/grafana-e2e/ @grafana/grafana-frontend-platform
+/packages/grafana-toolkit/ @grafana/plugins-platform-frontend
+/packages/grafana-ui/.storybook/ @grafana/plugins-platform-frontend
+/packages/grafana-ui/src/components/ @grafana/grafana-frontend-platform
+/packages/grafana-ui/src/components/DateTimePickers/ @grafana/grafana-frontend-platform
+/packages/grafana-ui/src/components/Table/ @grafana/grafana-bi-squad
+/packages/grafana-ui/src/components/Gauge/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/BarGauge/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/GraphNG/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/Graph/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/TimeSeries/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/uPlot/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/DataLinks/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/ValuePicker/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/VizLayout/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/VizLegend/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/VizRepeater/ @grafana/dataviz-squad
+/packages/grafana-ui/src/components/VizTooltip/ @grafana/dataviz-squad
+/packages/grafana-ui/src/utils/storybook/ @grafana/plugins-platform-frontend
+/packages/grafana-data/src/**/*logs* @grafana/observability-logs
+/plugins-bundled/ @grafana/plugins-platform-frontend
+
+
+# root files, mostly frontend
+.browserslistrc @grafana/frontend-ops
 package.json @grafana/frontend-ops
 tsconfig.json @grafana/frontend-ops
+/.editorconfig @grafana/frontend-ops
+/.eslintignore @grafana/frontend-ops
+/.gitattributes @grafana/frontend-ops
+/.gitignore @grafana/frontend-ops
+/.husky/pre-commit @grafana/frontend-ops
+/.nvmrc @grafana/frontend-ops
+/.prettierignore @grafana/frontend-ops
+/.yarn @grafana/frontend-ops
+/.yarnrc.yml @grafana/frontend-ops
+/yarn.lock @grafana/frontend-ops
+/.linguirc @grafana/grafana-frontend-platform
+/babel.config.json @grafana/frontend-ops
 lerna.json @grafana/frontend-ops
-.babelrc @grafana/frontend-ops
-.prettierrc.js @grafana/frontend-ops
-.eslintrc @grafana/frontend-ops
-.pa11yci.conf.js @grafana/user-essentials
-.pa11yci-pr.conf.js @grafana/user-essentials
-.betterer.results @joshhunt
+/.prettierrc.js @grafana/frontend-ops
+/.eslintrc @grafana/frontend-ops
+/.vim @zoltanbedi
+/jest.config.js @grafana/frontend-ops
+/latest.json @grafana/frontend-ops
+/metadata.md @grafana/plugins-platform
+/stylelint.config.js @grafana/frontend-ops
+/tools/ @grafana/frontend-ops
+
+
+# public folder
+/public/app/core/ @grafana/grafana-frontend-platform
+/public/app/core/components/TimePicker/ @grafana/grafana-frontend-platform
+/public/app/core/components/Layers/ @grafana/dataviz-squad
+/public/app/features/all.ts @grafana/grafana-frontend-platform
+/public/app/features/admin/ @grafana/grafana-authnz-team
+/public/app/features/auth-config/ @grafana/grafana-authnz-team
+/public/app/features/annotations/ @grafana/grafana-frontend-platform
+/public/app/features/api-keys/ @grafana/grafana-authnz-team
+/public/app/features/canvas/ @grafana/dataviz-squad
+/public/app/features/geo/ @grafana/dataviz-squad
+/public/app/features/visualization/data-hover/ @grafana/dataviz-squad
+/public/app/features/commandPalette/ @grafana/grafana-frontend-platform
+/public/app/features/connections/ @grafana/plugins-platform-frontend
+/public/app/features/correlations/ @grafana/explore-squad
+/public/app/features/dashboard/ @grafana/dashboards-squad
+/public/app/features/datasources/ @grafana/plugins-platform-frontend
+/public/app/features/dimensions/ @grafana/dataviz-squad
+/public/app/features/dataframe-import/ @grafana/grafana-bi-squad
+/public/app/features/explore/ @grafana/explore-squad
+/public/app/features/expressions/ @grafana/observability-metrics
+/public/app/features/folders/ @grafana/grafana-frontend-platform
+/public/app/features/inspector/ @grafana/dashboards-squad
+/public/app/features/invites/ @grafana/grafana-frontend-platform
+/public/app/features/library-panels/ @grafana/grafana-frontend-platform
+/public/app/features/logs/ @grafana/observability-logs
+/public/app/features/live/ @grafana/grafana-app-platform-squad
+/public/app/features/manage-dashboards/ @grafana/dashboards-squad
+/public/app/features/notifications/ @grafana/grafana-frontend-platform
+/public/app/features/org/ @grafana/grafana-frontend-platform
+/public/app/features/panel/ @grafana/dashboards-squad
+/public/app/features/playlist/ @grafana/dashboards-squad
+/public/app/features/plugins/ @grafana/plugins-platform-frontend
+/public/app/features/profile/ @grafana/grafana-frontend-platform
+/public/app/features/runtime/ @ryantxu
+/public/app/features/query/ @grafana/dashboards-squad
+/public/app/features/sandbox/ @grafana/grafana-frontend-platform
+/public/app/features/scenes/ @grafana/dashboards-squad
+/public/app/features/browse-dashboards/ @grafana/grafana-frontend-platform
+/public/app/features/search/ @grafana/grafana-frontend-platform
+/public/app/features/serviceaccounts/ @grafana/grafana-authnz-team
+/public/app/features/storage/ @grafana/grafana-app-platform-squad
+/public/app/features/teams/ @grafana/grafana-authnz-team
+/public/app/features/templating/ @grafana/dashboards-squad
+/public/app/features/transformers/ @grafana/dataviz-squad
+/public/app/features/users/ @grafana/grafana-authnz-team
+/public/app/features/variables/ @grafana/dashboards-squad
+/public/app/plugins/panel/alertGroups/ @grafana/alerting-frontend
+/public/app/plugins/panel/alertlist/ @grafana/alerting-frontend
+/public/app/plugins/panel/annolist/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/barchart/ @grafana/dataviz-squad
+/public/app/plugins/panel/bargauge/ @grafana/dataviz-squad
+/public/app/plugins/panel/dashlist/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/debug/ @ryantxu
+/public/app/plugins/panel/datagrid/ @grafana/grafana-bi-squad
+/public/app/plugins/panel/gauge/ @grafana/dataviz-squad
+/public/app/plugins/panel/gettingstarted/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/graph/ @grafana/dataviz-squad
+/public/app/plugins/panel/heatmap/ @grafana/dataviz-squad
+/public/app/plugins/panel/histogram/ @grafana/dataviz-squad
+/public/app/plugins/panel/logs/ @grafana/observability-logs
+/public/app/plugins/panel/nodeGraph/ @grafana/observability-traces-and-profiling
+/public/app/plugins/panel/traces/ @grafana/observability-traces-and-profiling
+/public/app/plugins/panel/flamegraph/ @grafana/observability-traces-and-profiling
+/public/app/plugins/panel/piechart/ @grafana/dataviz-squad
+/public/app/plugins/panel/state-timeline/ @grafana/dataviz-squad
+/public/app/plugins/panel/status-history/ @grafana/dataviz-squad
+/public/app/plugins/panel/table/ @grafana/grafana-bi-squad
+/public/app/plugins/panel/table-old/ @grafana/grafana-bi-squad
+/public/app/plugins/panel/timeseries/ @grafana/dataviz-squad
+/public/app/plugins/panel/trend/ @grafana/dataviz-squad
+/public/app/plugins/panel/geomap/ @grafana/dataviz-squad
+/public/app/plugins/panel/canvas/ @grafana/dataviz-squad
+/public/app/plugins/panel/candlestick/ @grafana/dataviz-squad
+/public/app/plugins/panel/live/ @grafana/grafana-app-platform-squad
+/public/app/plugins/panel/news/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/stat/ @grafana/dataviz-squad
+/public/app/plugins/panel/text/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/welcome/ @grafana/grafana-frontend-platform
+/public/app/plugins/panel/xychart/ @grafana/dataviz-squad
+/public/app/plugins/sdk.ts @grafana/plugins-platform-frontend
+/public/app/polyfills/old-mediaquerylist.ts @grafana/grafana-frontend-platform
+/public/app/routes/ @grafana/grafana-frontend-platform
+/public/app/store/ @grafana/grafana-frontend-platform
+/public/app/types/ @grafana/grafana-frontend-platform
+/public/dashboards/ @grafana/dashboards-squad
+/public/fonts/ @grafana/alerting-frontend
+/public/gazetteer/ @ryantxu
+/public/img/ @grafana/grafana-frontend-platform
+/public/lib/ @grafana/grafana-frontend-platform
+/public/lib/monaco-languages/kusto.ts @grafana/partner-datasources
+/public/maps/ @ryantxu
+/public/robots.txt @grafana/frontend-ops
+/public/sass/ @grafana/grafana-frontend-platform
+/public/test/ @grafana/grafana-frontend-platform
+/public/testdata/ @grafana/grafana-frontend-platform
+/public/views/ @grafana/grafana-frontend-platform
+
+/public/app/features/explore/Logs/ @grafana/observability-logs
+
+/public/app/features/explore/RawPrometheus/ @grafana/observability-metrics
+
+/public/app/features/explore/NodeGraph/ @grafana/observability-traces-and-profiling
+/public/app/features/explore/FlameGraph/ @grafana/observability-traces-and-profiling
+/public/app/features/explore/TraceView/ @grafana/observability-traces-and-profiling
+
+/public/api-merged.json @grafana/backend-platform
+/public/openapi3.json @grafana/backend-platform
+/public/app/angular/ @torkelo
+/public/app/app.ts @grafana/frontend-ops
+/public/app/dev.ts @grafana/frontend-ops
+/public/app/core/utils/metrics.ts @grafana/plugins-platform-frontend
+/public/app/index.ts @grafana/frontend-ops
+/public/app/AppWrapper.tsx @grafana/frontend-ops
+/public/app/partials/ @grafana/grafana-frontend-platform
+
+
+
+
+/scripts/benchmark-access-control.sh @grafana/grafana-authnz-team
+/scripts/check-breaking-changes.sh @grafana/plugins-platform-frontend
+/scripts/ci-* @grafana/grafana-delivery
+/scripts/circle-* @grafana/grafana-delivery
+/scripts/publish-npm-packages.sh @grafana/grafana-delivery @grafana/plugins-platform-frontend
+/scripts/validate-npm-packages.sh @grafana/grafana-delivery @grafana/plugins-platform-frontend
+/scripts/ci-frontend-metrics.sh @grafana/grafana-frontend-platform @grafana/plugins-platform-frontend @grafana/grafana-bi-squad
+/scripts/cli/ @grafana/grafana-frontend-platform
+/scripts/clean-git-or-error.sh @grafana/grafana-as-code
+/scripts/grafana-server/ @grafana/grafana-frontend-platform
+/scripts/helpers/ @grafana/grafana-delivery
+/scripts/import_many_dashboards.sh @torkelo
+/scripts/mixin-check.sh @bergquist
+/scripts/openapi3/ @grafana/grafana-operator-experience-squad
+/scripts/prepare-packagejson.js @grafana/frontend-ops
+/scripts/protobuf-check.sh @grafana/plugins-platform-backend
+/scripts/stripnulls.sh @grafana/grafana-as-code
+/scripts/tag_release.sh @grafana/grafana-delivery
+/scripts/trigger_docker_build.sh @grafana/grafana-delivery
+/scripts/trigger_grafana_packer.sh @grafana/grafana-delivery
+/scripts/trigger_windows_build.sh @grafana/grafana-delivery
+/scripts/verify-repo-update/ @grafana/grafana-delivery
+
+/scripts/webpack/ @grafana/frontend-ops
+/scripts/generate-a11y-report.sh @grafana/grafana-frontend-platform
+.pa11yci.conf.js @grafana/grafana-frontend-platform
+.pa11yci-pr.conf.js @grafana/grafana-frontend-platform
+.betterer.results @grafanabot
+.betterer.ts @grafana/grafana-frontend-platform
 
 # @grafana/ui component documentation
 *.mdx @grafana/plugins-platform-frontend
 
+# Design system
+/public/img/icons/unicons/ @grafana/design-system
+
 # Core datasources
-/public/app/plugins/datasource/cloudwatch @grafana/aws-plugins
-/public/app/plugins/datasource/elasticsearch @grafana/observability-logs
-/public/app/plugins/datasource/grafana-azure-monitor-datasource @grafana/cloud-provider-plugins
-/public/app/plugins/datasource/graphite @grafana/observability-metrics
-/public/app/plugins/datasource/influxdb @grafana/observability-metrics
-/public/app/plugins/datasource/jaeger @grafana/observability-traces-and-profiling
-/public/app/plugins/datasource/loki @grafana/observability-logs
-/public/app/plugins/datasource/mssql @grafana/grafana-bi-squad
-/public/app/plugins/datasource/mysql @grafana/grafana-bi-squad
-/public/app/plugins/datasource/opentsdb @grafana/backend-platform
-/public/app/plugins/datasource/postgres @grafana/grafana-bi-squad
-/public/app/plugins/datasource/prometheus @grafana/observability-metrics
-/public/app/plugins/datasource/cloud-monitoring @grafana/cloud-provider-plugins
-/public/app/plugins/datasource/zipkin @grafana/observability-traces-and-profiling
-/public/app/plugins/datasource/tempo @grafana/observability-traces-and-profiling
-/public/app/plugins/datasource/alertmanager @grafana/alerting-squad
+/public/app/plugins/datasource/dashboard/ @grafana/dashboards-squad
+/public/app/plugins/datasource/cloudwatch/ @grafana/aws-datasources
+/public/app/plugins/datasource/elasticsearch/ @grafana/observability-logs
+/public/app/plugins/datasource/grafana/ @grafana/grafana-frontend-platform
+/public/app/plugins/datasource/testdata/ @grafana/plugins-platform-frontend
+/public/app/plugins/datasource/azuremonitor/ @grafana/partner-datasources
+/public/app/plugins/datasource/graphite/ @grafana/observability-metrics
+/public/app/plugins/datasource/influxdb/ @grafana/observability-metrics
+/public/app/plugins/datasource/jaeger/ @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/loki/ @grafana/observability-logs
+/public/app/plugins/datasource/mixed/ @grafana/dashboards-squad
+/public/app/plugins/datasource/mssql/ @grafana/grafana-bi-squad
+/public/app/plugins/datasource/mysql/ @grafana/grafana-bi-squad
+/public/app/plugins/datasource/opentsdb/ @grafana/observability-metrics
+/public/app/plugins/datasource/postgres/ @grafana/grafana-bi-squad
+/public/app/plugins/datasource/prometheus/ @grafana/observability-metrics
+/public/app/plugins/datasource/cloud-monitoring/ @grafana/partner-datasources
+/public/app/plugins/datasource/zipkin/ @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/tempo/ @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/grafana-pyroscope-datasource/ @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/parca/ @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/alertmanager/ @grafana/alerting-squad
+
+# SSE - Server Side Expressions
+/pkg/expr/ @grafana/observability-metrics
 
 # Cloud middleware
 /grafana-mixin/ @grafana/hosted-grafana-team
 
 # Grafana authentication and authorization
-/pkg/services/accesscontrol @grafana/grafana-authnz-team
-/pkg/services/auth @grafana/grafana-authnz-team
+/pkg/login/ @grafana/grafana-authnz-team
+/pkg/services/accesscontrol/ @grafana/grafana-authnz-team
+/pkg/services/anonymous/ @grafana/grafana-authnz-team
+/pkg/services/auth/ @grafana/grafana-authnz-team
+/pkg/services/authn/ @grafana/grafana-authnz-team
+/pkg/services/signingkeys/ @grafana/grafana-authnz-team
 /pkg/services/dashboards/accesscontrol.go @grafana/grafana-authnz-team
-/pkg/services/datasources/permissions @grafana/grafana-authnz-team
-/pkg/services/datasources/permissions/accesscontrol.go @grafana/grafana-authnz-team
-/pkg/services/guardian @grafana/grafana-authnz-team
-/pkg/services/ldap @grafana/grafana-authnz-team
-/pkg/services/login @grafana/grafana-authnz-team
-/pkg/services/multildap @grafana/grafana-authnz-team
-/pkg/services/oauthtoken @grafana/grafana-authnz-team
-/pkg/services/teamguardian @grafana/grafana-authnz-team
-/pkg/services/serviceaccounts @grafana/grafana-authnz-team
+/pkg/services/datasources/permissions/ @grafana/grafana-authnz-team
+/pkg/services/guardian/ @grafana/grafana-authnz-team
+/pkg/services/ldap/ @grafana/grafana-authnz-team
+/pkg/services/login/ @grafana/grafana-authnz-team
+/pkg/services/loginattempt/ @grafana/grafana-authnz-team
+/pkg/services/oauthserver/ @grafana/grafana-authnz-team
+/pkg/services/oauthtoken/ @grafana/grafana-authnz-team
+/pkg/services/serviceaccounts/ @grafana/grafana-authnz-team
 
-# Grafana Partnerships Team
-/pkg/infra/httpclient/httpclientprovider/sigv4_middleware.go @grafana/grafana-partnerships-team
+# Support bundles
+/public/app/features/support-bundles/ @grafana/grafana-authnz-team
+/pkg/services/supportbundles/ @grafana/grafana-authnz-team
+
+# Grafana Operator Experience Team
+/pkg/infra/httpclient/httpclientprovider/sigv4_middleware.go @grafana/grafana-operator-experience-squad
+/pkg/infra/httpclient/httpclientprovider/sigv4_middleware_test.go @grafana/grafana-operator-experience-squad
+/pkg/services/caching/ @grafana/grafana-operator-experience-squad
+/pkg/services/featuremgmt/ @grafana/grafana-operator-experience-squad
+
+# Kind definitions
+/kinds/dashboard @grafana/dashboards-squad
+/kinds/ @grafana/grafana-as-code
 
 # Kind system and code generation
 embed.go @grafana/grafana-as-code
-/kinds/ @grafana/grafana-as-code
-/pkg/codegen @grafana/grafana-as-code
-/pkg/kindsys @grafana/grafana-as-code
+/pkg/kinds/ @grafana/grafana-as-code
+/pkg/cuectx/ @grafana/grafana-as-code
+/pkg/registry/ @grafana/grafana-as-code
+/pkg/codegen/ @grafana/grafana-as-code
 /pkg/kinds/*/*_gen.go @grafana/grafana-as-code
-/pkg/registry/corekind @grafana/grafana-as-code
+/pkg/registry/corekind/ @grafana/grafana-as-code
 /public/app/plugins/*gen.go @grafana/grafana-as-code
+/cue.mod/ @grafana/grafana-as-code
 
-# Specific core kinds
-/kinds/raw/ @grafana/grafana-edge-squad
-/kinds/structured/dashboard @grafana/dashboards-squad
+# GitHub Workflows and Templates
+/.github/CODEOWNERS @tolzhabayev
+/.github/ISSUE_TEMPLATE/ @torkelo
+/.github/PULL_REQUEST_TEMPLATE.md @torkelo
+/.github/bot.md @torkelo
+/.github/commands.json @torkelo
+/.github/dependabot.yml @grafana/frontend-ops
+/.github/issue-opened.json @grafana/grafana-community-support
+/.github/metrics-collector.json @torkelo
+/.github/pr-checks.json @marefr
+/.github/pr-commands.json @marefr
+/.github/renovate.json5 @grafana/frontend-ops
+/.github/teams.yml @armandgrillet
+/.github/workflows/backport.yml @grafana/grafana-delivery
+/.github/workflows/bump-version.yml @grafana/grafana-delivery
+/.github/workflows/close-milestone.yml @grafana/grafana-delivery
+/.github/workflows/cloud-data-sources-code-coverage.yml @grafana/partner-datasources @grafana/aws-datasources
+/.github/workflows/codeowners-validator.yml @tolzhabayev
+/.github/workflows/codeql-analysis.yml @DanCech
+/.github/workflows/commands.yml @torkelo
+/.github/workflows/detect-breaking-changes-* @grafana/plugins-platform-frontend
+/.github/workflows/doc-validator.yml @grafana/docs-grafana
+/.github/workflows/epic-add-to-platform-ux-parent-project.yml @meanmina
+/.github/workflows/github-release.yml @torkelo
+/.github/workflows/issue-labeled.yml @armandgrillet
+/.github/workflows/issue-opened.yml @grafana/grafana-community-support
+/.github/workflows/metrics-collector.yml @torkelo
+/.github/workflows/milestone.yml @marefr
+/.github/workflows/ox-code-coverage.yml @grafana/explore-squad
+/.github/workflows/pr-checks.yml @marefr
+/.github/workflows/pr-codeql-analysis-go.yml @DanCech
+/.github/workflows/pr-codeql-analysis-javascript.yml @DanCech
+/.github/workflows/pr-codeql-analysis-python.yml @DanCech
+/.github/workflows/pr-commands-closed.yml @tolzhabayev
+/.github/workflows/pr-commands.yml @marefr
+/.github/workflows/pr-security-patch-check.yml @grafana/grafana-delivery
+/.github/workflows/pr-security-patch-mirror-and-apply.yml @grafana/grafana-delivery
+/.github/workflows/publish-technical-documentation-next.yml @grafana/docs-grafana
+/.github/workflows/publish-technical-documentation-release.yml @grafana/docs-grafana
+/.github/workflows/remove-milestone.yml @grafana/grafana-delivery
+/.github/workflows/sbom-report.yml @grafana/security-team
+/.github/workflows/scripts/json-file-to-job-output.js @grafana/plugins-platform-frontend
+/.github/workflows/scripts/pr-get-job-link.js @grafana/plugins-platform-frontend
+/.github/workflows/stale.yml @grafana/grafana-delivery
+/.github/workflows/update-changelog.yml @grafana/grafana-delivery
+/.github/workflows/snyk.yml @grafana/security-team
+/.github/workflows/scripts/kinds/verify-kinds.go @grafana/grafana-as-code
+/.github/workflows/publish-kinds-next.yml @grafana/grafana-as-code
+/.github/workflows/publish-kinds-release.yml @grafana/grafana-as-code
+/.github/workflows/verify-kinds.yml @grafana/grafana-as-code
+/.github/workflows/dashboards-issue-add-label.yml @grafana/dashboards-squad
+
+
+# Generated files not requiring owner approval
+/packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot
+/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md @grafanabot
+/pkg/services/featuremgmt/toggles_gen.csv @grafanabot
+/pkg/services/featuremgmt/toggles_gen.go @grafanabot
+/public/emails/ @grafanabot
+
+# Conf
+/conf/defaults.ini @torkelo
+/conf/sample.ini @torkelo
+/conf/ldap.toml @grafana/grafana-authnz-team
+/conf/ldap_multiple.toml @grafana/grafana-authnz-team
+/conf/provisioning/access-control/ @grafana/grafana-authnz-team
+/conf/provisioning/alerting/ @grafana/alerting-backend-product
+/conf/provisioning/dashboards/ @grafana/dashboards-squad
+/conf/provisioning/datasources/ @grafana/plugins-platform-backend
+/conf/provisioning/notifiers/ @bergquist
+/conf/provisioning/plugins/ @grafana/plugins-platform-backend

--- a/.github/workflows/pr-security-patch-check.yml
+++ b/.github/workflows/pr-security-patch-check.yml
@@ -1,0 +1,24 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo Ex: grafana/grafana 
+name: Check for security patch conflicts
+run-name: check-security-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - "main"
+      - "v*.*.*"
+      - "release-*"
+
+# Since this is run on a pull request, we want to apply the patches intended for the
+# target branch onto the source branch, to verify compatibility before merging.
+jobs:
+  trigger_downstream_patch_check:
+    uses: grafana/security-patch-actions/.github/workflows/test-patches.yml@main
+    with:
+      src_repo: "${{ github.repository }}"
+      src_ref: "${{ github.head_ref }}" # this is the source branch name, Ex: "feature/newthing"
+      patch_repo: "${{ github.repository }}-security-patches"
+      patch_ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
+    secrets: inherit

--- a/.github/workflows/pr-security-patch-mirror-and-apply.yml
+++ b/.github/workflows/pr-security-patch-mirror-and-apply.yml
@@ -1,0 +1,26 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo, Ex: grafana/grafana
+name: Sync to security mirror
+run-name: sync-to-security-mirror-${{ github.base_ref }}-${{ github.head_ref }}
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - "main"
+      - "v*.*.*"
+      - "release-*"
+
+# This is run after the pull request has been merged, so we'll run against the target branch
+jobs:
+  trigger_downstream_security_mirror:
+    concurrency: security-mirror-${{ github.ref }}
+    if: github.event.pull_request.merged == true
+    uses: grafana/security-patch-actions/.github/workflows/mirror-branch-and-apply-patches.yml@main
+    with:
+      ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
+      src_repo: "${{ github.repository }}"
+      dest_repo: "${{ github.repository }}-security-mirror"
+      patch_repo: "${{ github.repository }}-security-patches"
+    secrets: inherit
+


### PR DESCRIPTION
Backport d88046d3d4b3c94c87cc608f01c994964c1e61d7 from #71101

---

**What is this feature?**

These pipelines are part of a new security patching workflow owned by the grafana delivery squad. They will automatically update a downstream security mirror on merge to main, version, and release branches, and will check for conflicts in that mirror when PRs are opened.

These pipelines have been tested against the grafana-ci-sandbox.

**Why do we need this feature?**

To pave the way for CI/CD, and to simplify future releases.

For further insight ping the #grafana-delivery-squad slack channel.

