### PR TITLE
Prometheus: [devenv] provision gdev-prometheus development environment with basic auth

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -56,7 +56,7 @@ datasources:
     type: prometheus
     access: proxy
     url: http://localhost:9090
-    basicAuth: true
+    basicAuth: true #username: admin, password: admin
     basicAuthUser: admin
     jsonData:
       manageAlerts: true
@@ -64,7 +64,7 @@ datasources:
       prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
       prometheusVersion: 2.40.0
     secureJsonData:
-      basicAuthPassword: admin
+      basicAuthPassword: admin #https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables
 
   - name: gdev-slow-prometheus
     uid: gdev-slow-prometheus-uid

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -56,11 +56,15 @@ datasources:
     type: prometheus
     access: proxy
     url: http://localhost:9090
+    basicAuth: true
+    basicAuthUser: admin
     jsonData:
       manageAlerts: true
       alertmanagerUid: gdev-alertmanager
       prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
       prometheusVersion: 2.40.0
+    secureJsonData:
+      basicAuthPassword: admin
 
   - name: gdev-slow-prometheus
     uid: gdev-slow-prometheus-uid

--- a/devenv/docker/blocks/prometheus/Dockerfile
+++ b/devenv/docker/blocks/prometheus/Dockerfile
@@ -2,3 +2,4 @@ FROM prom/prometheus:latest
 ADD prometheus.yml /etc/prometheus/
 ADD recording.yml /etc/prometheus/
 ADD alert.yml /etc/prometheus/
+ADD web.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus/docker-compose.yaml
@@ -10,6 +10,7 @@
       --storage.tsdb.path=/prometheus
       --web.console.libraries=/usr/share/prometheus/console_libraries
       --web.console.templates=/usr/share/prometheus/consoles
+      --web.config.file=/etc/prometheus/web.yml
 
   node_exporter:
     image: prom/node-exporter

--- a/devenv/docker/blocks/prometheus/prometheus.yml
+++ b/devenv/docker/blocks/prometheus/prometheus.yml
@@ -45,7 +45,3 @@ scrape_configs:
   #   metrics_path: /metrics/plugins/grafana-test-datasource
   #   static_configs:
   #     - targets: ['host.docker.internal:3000']
-
-    basic_auth:
-      username: 'admin'
-      password: 'admin'

--- a/devenv/docker/blocks/prometheus/prometheus.yml
+++ b/devenv/docker/blocks/prometheus/prometheus.yml
@@ -45,3 +45,7 @@ scrape_configs:
   #   metrics_path: /metrics/plugins/grafana-test-datasource
   #   static_configs:
   #     - targets: ['host.docker.internal:3000']
+
+    basic_auth:
+      username: 'admin'
+      password: 'admin'

--- a/devenv/docker/blocks/prometheus/web.yml
+++ b/devenv/docker/blocks/prometheus/web.yml
@@ -1,2 +1,3 @@
 basic_auth_users:
+  # username: admin, password: admin
   admin: $2a$12$HvzPxejEHakuEIjxQ8uQrOaZ57GmFznB6M/w.85MpdEtSFFOOyDgW

--- a/devenv/docker/blocks/prometheus/web.yml
+++ b/devenv/docker/blocks/prometheus/web.yml
@@ -1,0 +1,2 @@
+basic_auth_users:
+  admin: $2a$12$HvzPxejEHakuEIjxQ8uQrOaZ57GmFznB6M/w.85MpdEtSFFOOyDgW


### PR DESCRIPTION
**What is this feature?**

As part of my investigation into https://github.com/grafana/grafana/issues/71012, I figured we'd provision gdev-prom with basic auth by default.

**Why do we need this feature?**
Helps document how to setup Prometheus and Grafana with basic auth, provides additional layer of feedback between developers if something breaks.

**Who is this feature for?**
Tech debt/other

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
