### PR TITLE
improve provisioning indicator for notification policies

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.test.tsx
@@ -106,8 +106,6 @@ const ui = {
 
   confirmDeleteModal: byRole('dialog'),
   confirmDeleteButton: byLabelText('Confirm Modal Danger Button'),
-
-  provisionedBadge: byText('provisioned'),
 };
 
 describe('NotificationPolicies', () => {
@@ -231,7 +229,7 @@ describe('NotificationPolicies', () => {
       template_files: {},
     });
 
-    renderNotificationPolicies();
+    await renderNotificationPolicies();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
 
@@ -286,7 +284,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    renderNotificationPolicies();
+    await renderNotificationPolicies();
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(ui.rootGroupBy.get()).toHaveTextContent('alertname');
 
@@ -348,7 +346,7 @@ describe('NotificationPolicies', () => {
       template_files: {},
     });
 
-    renderNotificationPolicies();
+    await renderNotificationPolicies();
 
     // open root route for editing
     const rootRouteContainer = await ui.rootRouteContainer.find();
@@ -412,7 +410,7 @@ describe('NotificationPolicies', () => {
       refetch: jest.fn(),
     }));
 
-    renderNotificationPolicies();
+    await renderNotificationPolicies();
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
     expect(await byText("Alertmanager has exploded. it's gone. Forget about it.").find()).toBeInTheDocument();
     expect(ui.rootReceiver.query()).not.toBeInTheDocument();
@@ -447,7 +445,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
+    await renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
 
@@ -517,7 +515,7 @@ describe('NotificationPolicies', () => {
 
     mocks.api.updateAlertManagerConfig.mockResolvedValue(Promise.resolve());
 
-    renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
+    await renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
 
     const deleteButtons = await ui.deleteRouteButton.findAll();
@@ -573,7 +571,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    renderNotificationPolicies(dataSources.am.name);
+    await renderNotificationPolicies(dataSources.am.name);
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
 
@@ -619,7 +617,7 @@ describe('NotificationPolicies', () => {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
     });
-    renderNotificationPolicies(dataSources.promAlertManager.name);
+    await renderNotificationPolicies(dataSources.promAlertManager.name);
     const rootRouteContainer = await ui.rootRouteContainer.find();
     expect(ui.editButton.query(rootRouteContainer)).not.toBeInTheDocument();
     const rows = await ui.row.findAll();
@@ -649,7 +647,7 @@ describe('NotificationPolicies', () => {
       refetch: jest.fn(),
     }));
 
-    renderNotificationPolicies(dataSources.promAlertManager.name);
+    await renderNotificationPolicies(dataSources.promAlertManager.name);
     const rootRouteContainer = await ui.rootRouteContainer.find();
     await waitFor(() =>
       expect(within(rootRouteContainer).getByTestId('matching-instances')).toHaveTextContent('0instances')
@@ -688,7 +686,7 @@ describe('NotificationPolicies', () => {
 
     mocks.api.fetchAlertManagerConfig.mockResolvedValue(defaultConfig);
 
-    renderNotificationPolicies(dataSources.am.name);
+    await renderNotificationPolicies(dataSources.am.name);
     const rows = await ui.row.findAll();
     expect(rows).toHaveLength(1);
     await userEvent.click(ui.editRouteButton.get(rows[0]));
@@ -734,7 +732,7 @@ describe('NotificationPolicies', () => {
       message: 'alertmanager storage object not found',
     });
 
-    renderNotificationPolicies();
+    await renderNotificationPolicies();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
 

--- a/public/app/features/alerting/unified/NotificationPolicies.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.test.tsx
@@ -106,6 +106,8 @@ const ui = {
 
   confirmDeleteModal: byRole('dialog'),
   confirmDeleteButton: byLabelText('Confirm Modal Danger Button'),
+
+  provisionedBadge: byText('provisioned'),
 };
 
 describe('NotificationPolicies', () => {
@@ -229,7 +231,7 @@ describe('NotificationPolicies', () => {
       template_files: {},
     });
 
-    await renderNotificationPolicies();
+    renderNotificationPolicies();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
 
@@ -284,7 +286,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    await renderNotificationPolicies();
+    renderNotificationPolicies();
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(ui.rootGroupBy.get()).toHaveTextContent('alertname');
 
@@ -346,7 +348,7 @@ describe('NotificationPolicies', () => {
       template_files: {},
     });
 
-    await renderNotificationPolicies();
+    renderNotificationPolicies();
 
     // open root route for editing
     const rootRouteContainer = await ui.rootRouteContainer.find();
@@ -410,7 +412,7 @@ describe('NotificationPolicies', () => {
       refetch: jest.fn(),
     }));
 
-    await renderNotificationPolicies();
+    renderNotificationPolicies();
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
     expect(await byText("Alertmanager has exploded. it's gone. Forget about it.").find()).toBeInTheDocument();
     expect(ui.rootReceiver.query()).not.toBeInTheDocument();
@@ -445,7 +447,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    await renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
+    renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
 
@@ -515,7 +517,7 @@ describe('NotificationPolicies', () => {
 
     mocks.api.updateAlertManagerConfig.mockResolvedValue(Promise.resolve());
 
-    await renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
+    renderNotificationPolicies(GRAFANA_RULES_SOURCE_NAME);
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
 
     const deleteButtons = await ui.deleteRouteButton.findAll();
@@ -571,7 +573,7 @@ describe('NotificationPolicies', () => {
       return Promise.resolve(currentConfig.current);
     });
 
-    await renderNotificationPolicies(dataSources.am.name);
+    renderNotificationPolicies(dataSources.am.name);
     expect(await ui.rootReceiver.find()).toHaveTextContent('default');
     expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
 
@@ -617,7 +619,7 @@ describe('NotificationPolicies', () => {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
     });
-    await renderNotificationPolicies(dataSources.promAlertManager.name);
+    renderNotificationPolicies(dataSources.promAlertManager.name);
     const rootRouteContainer = await ui.rootRouteContainer.find();
     expect(ui.editButton.query(rootRouteContainer)).not.toBeInTheDocument();
     const rows = await ui.row.findAll();
@@ -647,7 +649,7 @@ describe('NotificationPolicies', () => {
       refetch: jest.fn(),
     }));
 
-    await renderNotificationPolicies(dataSources.promAlertManager.name);
+    renderNotificationPolicies(dataSources.promAlertManager.name);
     const rootRouteContainer = await ui.rootRouteContainer.find();
     await waitFor(() =>
       expect(within(rootRouteContainer).getByTestId('matching-instances')).toHaveTextContent('0instances')
@@ -686,7 +688,7 @@ describe('NotificationPolicies', () => {
 
     mocks.api.fetchAlertManagerConfig.mockResolvedValue(defaultConfig);
 
-    await renderNotificationPolicies(dataSources.am.name);
+    renderNotificationPolicies(dataSources.am.name);
     const rows = await ui.row.findAll();
     expect(rows).toHaveLength(1);
     await userEvent.click(ui.editRouteButton.get(rows[0]));
@@ -732,7 +734,7 @@ describe('NotificationPolicies', () => {
       message: 'alertmanager storage object not found',
     });
 
-    await renderNotificationPolicies();
+    renderNotificationPolicies();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalledTimes(1));
 

--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -183,7 +183,7 @@ const AmRoutes = () => {
   }
 
   const vanillaPrometheusAlertManager = isVanillaPrometheusAlertManagerDataSource(selectedAlertmanager);
-  const readOnlyPolicies = vanillaPrometheusAlertManager || isProvisioned;
+  const readOnlyPolicies = vanillaPrometheusAlertManager;
   const readOnlyMuteTimings = vanillaPrometheusAlertManager;
 
   const numberOfMuteTimings = result?.alertmanager_config.mute_time_intervals?.length ?? 0;
@@ -227,7 +227,6 @@ const AmRoutes = () => {
             {policyTreeTabActive && (
               <>
                 <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={selectedAlertmanager} />
-                {isProvisioned && <ProvisioningAlert resource={ProvisionedResource.RootNotificationPolicy} />}
                 <Stack direction="column" gap={1}>
                   {rootRoute && (
                     <NotificationPoliciesFilter
@@ -244,6 +243,7 @@ const AmRoutes = () => {
                       alertGroups={alertGroups ?? []}
                       contactPointsState={contactPointsState.receivers}
                       readOnly={readOnlyPolicies}
+                      provisioned={isProvisioned}
                       alertManagerSourceName={selectedAlertmanager}
                       onAddPolicy={openAddModal}
                       onEditPolicy={openEditModal}

--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -16,7 +16,6 @@ import { alertmanagerApi } from './api/alertmanagerApi';
 import { useGetContactPointsState } from './api/receiversApi';
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerDeliveryWarning } from './components/GrafanaAlertmanagerDeliveryWarning';
-import { ProvisionedResource, ProvisioningAlert } from './components/Provisioning';
 import { MuteTimingsTable } from './components/mute-timings/MuteTimingsTable';
 import {
   computeInheritedTree,

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v2.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v2.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Badge, Button, Dropdown, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Dropdown, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
 import { Span } from '@grafana/ui/src/unstable';
 import ConditionalWrap from 'app/features/alerting/components/ConditionalWrap';
 import { GrafanaNotifierType } from 'app/types/alerting';
 
 import { INTEGRATION_ICONS } from '../../types/contact-points';
 import { MetaText } from '../MetaText';
+import { ProvisioningBadge } from '../Provisioning';
 import { Spacer } from '../Spacer';
 import { Strong } from '../Strong';
 
@@ -113,7 +114,7 @@ const ContactPointHeader = (props: ContactPointHeaderProps) => {
         ) : (
           <MetaText>is not used</MetaText>
         )}
-        {isProvisioned && <Badge color="purple" text="Provisioned" />}
+        {isProvisioned && <ProvisioningBadge />}
         <Spacer />
         <ConditionalWrap
           shouldWrap={isProvisioned}

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -147,60 +147,58 @@ const Policy: FC<PolicyComponentProps> = ({
                 {/* TODO maybe we should move errors to the gutter instead? */}
                 {errors.length > 0 && <Errors errors={errors} />}
                 {provisioned && <Badge text="Provisioned" color="purple" />}
-                {readOnly
-                  ? null
-                  : provisioned && (
-                      <Stack direction="row" gap={0.5}>
-                        <ConditionalWrap shouldWrap={provisioned} wrap={ProvisionedTooltip}>
-                          <Button
-                            variant="secondary"
-                            icon="plus"
-                            size="sm"
-                            onClick={() => onAddPolicy(currentRoute)}
-                            disabled={provisioned}
-                            type="button"
-                          >
-                            New nested policy
-                          </Button>
-                        </ConditionalWrap>
+                {readOnly ? null : (
+                  <Stack direction="row" gap={0.5}>
+                    <ConditionalWrap shouldWrap={provisioned} wrap={ProvisionedTooltip}>
+                      <Button
+                        variant="secondary"
+                        icon="plus"
+                        size="sm"
+                        onClick={() => onAddPolicy(currentRoute)}
+                        disabled={provisioned}
+                        type="button"
+                      >
+                        New nested policy
+                      </Button>
+                    </ConditionalWrap>
 
-                        <ConditionalWrap shouldWrap={provisioned} wrap={ProvisionedTooltip}>
-                          <Dropdown
-                            overlay={
-                              <Menu>
-                                <Menu.Item
-                                  icon="edit"
-                                  disabled={!isEditable}
-                                  label="Edit"
-                                  onClick={() => onEditPolicy(currentRoute, isDefaultPolicy)}
-                                />
-                                {isDeletable && (
-                                  <>
-                                    <Menu.Divider />
-                                    <Menu.Item
-                                      destructive
-                                      icon="trash-alt"
-                                      label="Delete"
-                                      onClick={() => onDeletePolicy(currentRoute)}
-                                    />
-                                  </>
-                                )}
-                              </Menu>
-                            }
-                          >
-                            <Button
-                              icon="ellipsis-h"
-                              variant="secondary"
-                              size="sm"
-                              type="button"
-                              aria-label="more-actions"
-                              data-testid="more-actions"
-                              disabled={provisioned}
+                    <ConditionalWrap shouldWrap={provisioned} wrap={ProvisionedTooltip}>
+                      <Dropdown
+                        overlay={
+                          <Menu>
+                            <Menu.Item
+                              icon="edit"
+                              disabled={!isEditable}
+                              label="Edit"
+                              onClick={() => onEditPolicy(currentRoute, isDefaultPolicy)}
                             />
-                          </Dropdown>
-                        </ConditionalWrap>
-                      </Stack>
-                    )}
+                            {isDeletable && (
+                              <>
+                                <Menu.Divider />
+                                <Menu.Item
+                                  destructive
+                                  icon="trash-alt"
+                                  label="Delete"
+                                  onClick={() => onDeletePolicy(currentRoute)}
+                                />
+                              </>
+                            )}
+                          </Menu>
+                        }
+                      >
+                        <Button
+                          icon="ellipsis-h"
+                          variant="secondary"
+                          size="sm"
+                          type="button"
+                          aria-label="more-actions"
+                          data-testid="more-actions"
+                          disabled={provisioned}
+                        />
+                      </Dropdown>
+                    </ConditionalWrap>
+                  </Stack>
+                )}
               </Stack>
             </div>
 

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -21,6 +21,7 @@ import { getInheritedProperties, InhertitableProperties } from '../../utils/noti
 import { HoverCard } from '../HoverCard';
 import { Label } from '../Label';
 import { MetaText } from '../MetaText';
+import { ProvisioningBadge } from '../Provisioning';
 import { Spacer } from '../Spacer';
 import { Strong } from '../Strong';
 
@@ -146,7 +147,7 @@ const Policy: FC<PolicyComponentProps> = ({
                 <Spacer />
                 {/* TODO maybe we should move errors to the gutter instead? */}
                 {errors.length > 0 && <Errors errors={errors} />}
-                {provisioned && <Badge text="Provisioned" color="purple" />}
+                {provisioned && <ProvisioningBadge />}
                 {readOnly ? null : (
                   <Stack direction="row" gap={0.5}>
                     <ConditionalWrap shouldWrap={provisioned} wrap={ProvisionedTooltip}>

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { AsyncSelect, Badge, Field, InputControl, Label, useStyles2 } from '@grafana/ui';
+import { AsyncSelect, Field, InputControl, Label, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction, useDispatch } from 'app/types';
 import { CombinedRuleGroup } from 'app/types/unified-alerting';
@@ -18,6 +18,7 @@ import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { MINUTE } from '../../utils/rule-form';
 import { isGrafanaRulerRule } from '../../utils/rules';
 import { InfoIcon } from '../InfoIcon';
+import { ProvisioningBadge } from '../Provisioning';
 
 import { Folder, RuleFolderPicker } from './RuleFolderPicker';
 import { checkForPathSeparator } from './util';
@@ -174,7 +175,7 @@ export function FolderAndGroup() {
                   {option.isDisabled && (
                     <>
                       {' '}
-                      <Badge color="purple" text="Provisioned" />
+                      <ProvisioningBadge />
                     </>
                   )}
                 </div>


### PR DESCRIPTION
**What is this feature?**

Makes some minor changes to display provisioned notification policies.

This brings it more in line with how we present provisioned resources in contact points v2.

By showing the actions with a clear tooltip for _why_ the actions are disabled we make it easier for users to understand why the actions on a resource or unavailable.

I've also opted to remove the banner since 

1. we now have both a more logical way to present the provisioned resource
2. this is more compact and doesn't nag or annoy the user quite as much

<img width="1221" alt="image" src="https://github.com/grafana/grafana/assets/868844/7c848b52-73c5-4d6c-840b-df5eaa4faad8">


## Todo 

- [ ] Still requires a test
