### PR TITLE
Prometheus: Add description component to Prometheus config page

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -3,6 +3,7 @@ import React, { useRef } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings, GrafanaTheme2 } from '@grafana/data';
+import { DataSourceDescription } from '@grafana/experimental';
 import { Alert, DataSourceHttpSettings, FieldValidationMessage, useTheme2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 
@@ -40,6 +41,11 @@ export const ConfigEditor = (props: Props) => {
           Browser access mode in the Prometheus data source is no longer available. Switch to server access mode.
         </Alert>
       )}
+      <DataSourceDescription
+        dataSourceName="Prometheus"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/"
+      ></DataSourceDescription>
+      <div className={styles.hrTopSpace} />
       <DataSourceHttpSettings
         defaultUrl="http://localhost:9090"
         dataSourceConfig={options}


### PR DESCRIPTION
**What is this feature?**
This adds the experiment description component to the prometheus config page. The description component takes the data source name and a link to the docs. The text is not configurable.

I have also added space between the description component and the HTTP section. Note* the space between the data source name and the description component is set by the BasicSettings component.
![Screenshot 2023-07-06 at 5 36 12 PM](https://github.com/grafana/grafana/assets/25674746/da6ce199-64fa-47d4-bfe3-3bb4686dc8f5)

**Why do we need this feature?**
This is part of the config overhaul https://docs.google.com/document/d/11XMaYHSMSra8AoN2-yVW-5QPbjEXgkAFbTIF6N84cGE/edit

**Who is this feature for?**
Prometheus users who are setting up their data source.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
