### PR TITLE
Plugins: Fail installation of plugins with errors

### DIFF
--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -432,3 +432,14 @@ type FakeOauthService struct {
 func (f *FakeOauthService) RegisterExternalService(ctx context.Context, name string, svc *plugindef.ExternalServiceRegistration) (*oauth.ExternalService, error) {
 	return f.Result, nil
 }
+
+type FakePluginErrorResolver struct {
+	PluginErrorsFunc func() []*plugins.Error
+}
+
+func (f *FakePluginErrorResolver) PluginErrors() []*plugins.Error {
+	if f.PluginErrorsFunc != nil {
+		return f.PluginErrorsFunc()
+	}
+	return []*plugins.Error{}
+}

--- a/pkg/plugins/manager/installer_test.go
+++ b/pkg/plugins/manager/installer_test.go
@@ -212,7 +212,6 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 			})
 		}
 	})
-
 }
 
 func createPlugin(t *testing.T, pluginID string, class plugins.Class, managed, backend bool, cbs ...func(*plugins.Plugin)) *plugins.Plugin {

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -140,6 +140,7 @@ func (l *Loader) loadPlugins(ctx context.Context, src plugins.PluginSource, foun
 		if signingError != nil {
 			l.log.Warn("Skipping loading plugin due to problem with signature",
 				"pluginID", plugin.ID, "status", signingError.SignatureStatus)
+			plugin.SignatureError = signingError
 			l.errs[plugin.ID] = signingError
 			// skip plugin so it will not be loaded any further
 			continue

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -140,7 +140,6 @@ func (l *Loader) loadPlugins(ctx context.Context, src plugins.PluginSource, foun
 		if signingError != nil {
 			l.log.Warn("Skipping loading plugin due to problem with signature",
 				"pluginID", plugin.ID, "status", signingError.SignatureStatus)
-			plugin.SignatureError = signingError
 			l.errs[plugin.ID] = signingError
 			// skip plugin so it will not be loaded any further
 			continue
@@ -241,6 +240,9 @@ func (l *Loader) loadPlugins(ctx context.Context, src plugins.PluginSource, foun
 }
 
 func (l *Loader) Unload(ctx context.Context, pluginID string) error {
+	// clear plugin error if exists
+	delete(l.errs, pluginID)
+
 	plugin, exists := l.pluginRegistry.Plugin(ctx, pluginID)
 	if !exists {
 		return plugins.ErrPluginNotInstalled

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -1489,6 +1489,29 @@ func Test_setPathsBasedOnApp(t *testing.T) {
 	})
 }
 
+func TestLoader_Unload(t *testing.T) {
+	t.Run("Unload plugin should clean plugin errors", func(t *testing.T) {
+		reg := fakes.NewFakePluginRegistry()
+		procPrvdr := fakes.NewFakeBackendProcessProvider()
+		procMgr := fakes.NewFakeProcessManager()
+		l := newLoader(t, &config.Cfg{}, func(l *Loader) {
+			l.pluginRegistry = reg
+			l.processManager = procMgr
+			l.pluginInitializer = initializer.New(&config.Cfg{}, procPrvdr, &fakes.FakeLicensingService{})
+		})
+
+		fakeId := "fake-id"
+		l.errs[fakeId] = &plugins.SignatureError{}
+
+		require.Equal(t, 1, len(l.PluginErrors()))
+
+		l.Unload(context.Background(), fakeId)
+
+		require.Equal(t, 0, len(l.PluginErrors()))
+
+	})
+}
+
 func newLoader(t *testing.T, cfg *config.Cfg, cbs ...func(loader *Loader)) *Loader {
 	angularInspector, err := angularinspector.NewStaticInspector()
 	require.NoError(t, err)

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -1506,7 +1506,7 @@ func TestLoader_Unload(t *testing.T) {
 		require.Equal(t, 1, len(l.PluginErrors()))
 
 		err := l.Unload(context.Background(), fakeId)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, plugins.ErrPluginNotInstalled)
 
 		require.Equal(t, 0, len(l.PluginErrors()))
 	})

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -1505,10 +1505,10 @@ func TestLoader_Unload(t *testing.T) {
 
 		require.Equal(t, 1, len(l.PluginErrors()))
 
-		l.Unload(context.Background(), fakeId)
+		err := l.Unload(context.Background(), fakeId)
+		require.NoError(t, err)
 
 		require.Equal(t, 0, len(l.PluginErrors()))
-
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

1. Check for plugins errors coming from `Loader.Load` in `PluginInstaller.Add` and fail and unload plugin if there is
2. Remove errors related to the plugin on `Loader.Unload`

**Why do we need this feature?**

- Feature 1 is necessary to avoid installation of plugins when there is a load error (e.g. unsigned plugin in production)
- Feature 2 is necessary to avoid FE considering it as a installed plugin with errors

**Who is this feature for?**

This feature is for plugin users

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/68397

Fixes #68397

**Special notes for your reviewer:**

Line 143 from `pkg/plugins/manager/loader/loader.go` didn't seem to be used anywhere so I removed it.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
