### PR TITLE
Elasticsearch: fix support for multiple indices

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -207,7 +207,7 @@ func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchReque
 			header: map[string]interface{}{
 				"search_type":        "query_then_fetch",
 				"ignore_unavailable": true,
-				"index":              c.indices,
+				"index":              strings.Join(c.indices, ","),
 			},
 			body:     searchReq,
 			interval: searchReq.Interval,

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,7 +97,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		jBody, err := simplejson.NewJson(bodyBytes)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{"metrics-2018.05.15"}, jHeader.Get("index").MustStringArray())
+		assert.Equal(t, "metrics-2018.05.15", jHeader.Get("index").MustString())
 		assert.True(t, jHeader.Get("ignore_unavailable").MustBool(false))
 		assert.Equal(t, "query_then_fetch", jHeader.Get("search_type").MustString())
 		assert.Empty(t, jHeader.Get("max_concurrent_shard_requests"))
@@ -210,7 +211,7 @@ func TestClient_Index(t *testing.T) {
 			jHeader, err := simplejson.NewJson(headerBytes)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.indexInRequest, jHeader.Get("index").MustStringArray())
+			assert.Equal(t, strings.Join(test.indexInRequest, ","), jHeader.Get("index").MustString())
 		})
 	}
 }

--- a/pkg/tsdb/elasticsearch/snapshot_test.go
+++ b/pkg/tsdb/elasticsearch/snapshot_test.go
@@ -82,7 +82,7 @@ func TestRequestSnapshots(t *testing.T) {
 	queryHeader := []byte(`
 	{
 		"ignore_unavailable": true,
-		"index": ["testdb-2022.11.14"],
+		"index": "testdb-2022.11.14",
 		"search_type": "query_then_fetch"
 	}
 	`)


### PR DESCRIPTION
Originally reported in an escalation, this PR fixes support for multiple configured indices, as a comma-separated list.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71092

**Special notes for your reviewer:**

To verify:
- Provision an Elasticsearch instance with multiple indices
- Configure the data source with a comma-separated list of indices

 Expected results: without the fix, no data is returned by the data source; with the code changes, it should work as usual.