### PR TITLE
Explore: Fix Query History flakey test

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -312,7 +312,6 @@ export function RichHistoryCard(props: Props) {
       )}
       <IconButton name="trash-alt" title="Delete query" tooltip="Delete query" onClick={onDeleteQuery} />
       <IconButton
-        data-testid="query-history-card-star"
         name={query.starred ? 'favorite' : 'star'}
         iconType={query.starred ? 'mono' : 'default'}
         onClick={onStarrQuery}

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -312,6 +312,7 @@ export function RichHistoryCard(props: Props) {
       )}
       <IconButton name="trash-alt" title="Delete query" tooltip="Delete query" onClick={onDeleteQuery} />
       <IconButton
+        data-testid="query-history-card-star"
         name={query.starred ? 'favorite' : 'star'}
         iconType={query.starred ? 'mono' : 'default'}
         onClick={onStarrQuery}

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -193,7 +193,7 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
         </div>
       </div>
 
-      <div className={styles.containerContent}>
+      <div className={styles.containerContent} data-testid="query-history-queries-tab">
         <div className={styles.selectors}>
           {!richHistorySettings.activeDatasourceOnly && (
             <MultiSelect

--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -35,6 +35,8 @@ export const assertQueryHistoryComment = async (expectedQueryComments: string[],
 export const assertQueryHistoryIsStarred = async (expectedStars: boolean[], exploreId = 'left') => {
   const selector = withinExplore(exploreId);
   const starButtons = selector.getAllByRole('button', { name: /Star query|Unstar query/ });
+  // const starButtons = selector.getAllByTestId('query-history-card-star');
+
   await waitFor(() =>
     expectedStars.forEach((starred, queryIndex) => {
       expect(starButtons[queryIndex]).toHaveAccessibleName(starred ? 'Unstar query' : 'Star query');

--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -34,7 +34,7 @@ export const assertQueryHistoryComment = async (expectedQueryComments: string[],
 
 export const assertQueryHistoryIsStarred = async (expectedStars: boolean[], exploreId = 'left') => {
   const selector = withinExplore(exploreId);
-  // const starButtons = selector.getAllByRole('button', { name: /Star query|Unstar query/ });
+  // Test ID is used to avoid test timeouts reported in #70158, #59116 and #47635
   const starButtons = selector.getAllByTestId('query-history-card-star');
 
   await waitFor(() =>

--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 
 import { withinExplore } from './setup';
 
@@ -35,7 +35,8 @@ export const assertQueryHistoryComment = async (expectedQueryComments: string[],
 export const assertQueryHistoryIsStarred = async (expectedStars: boolean[], exploreId = 'left') => {
   const selector = withinExplore(exploreId);
   // Test ID is used to avoid test timeouts reported in #70158, #59116 and #47635
-  const starButtons = selector.getAllByTestId('query-history-card-star');
+  const queriesContainer = selector.getByTestId('query-history-queries-tab');
+  const starButtons = within(queriesContainer).getAllByRole('button', { name: /Star query|Unstar query/ });
 
   await waitFor(() =>
     expectedStars.forEach((starred, queryIndex) => {

--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -34,8 +34,8 @@ export const assertQueryHistoryComment = async (expectedQueryComments: string[],
 
 export const assertQueryHistoryIsStarred = async (expectedStars: boolean[], exploreId = 'left') => {
   const selector = withinExplore(exploreId);
-  const starButtons = selector.getAllByRole('button', { name: /Star query|Unstar query/ });
-  // const starButtons = selector.getAllByTestId('query-history-card-star');
+  // const starButtons = selector.getAllByRole('button', { name: /Star query|Unstar query/ });
+  const starButtons = selector.getAllByTestId('query-history-card-star');
 
   await waitFor(() =>
     expectedStars.forEach((starred, queryIndex) => {

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -143,7 +143,7 @@ describe('Explore: Query History', () => {
   });
 
   // FIXME: flaky test
-  it('updates the state in both Explore panes', async () => {
+  it.only('updates the state in both Explore panes', async () => {
     console.time('QUERY HISTORY TEST TIME');
     const urlParams = {
       left: serializeStateToUrlParam({

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -143,7 +143,8 @@ describe('Explore: Query History', () => {
   });
 
   // FIXME: flaky test
-  it.skip('updates the state in both Explore panes', async () => {
+  it('updates the state in both Explore panes', async () => {
+    console.time('QUERY HISTORY TEST TIME');
     const urlParams = {
       left: serializeStateToUrlParam({
         datasource: 'loki',
@@ -183,6 +184,7 @@ describe('Explore: Query History', () => {
     expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_deleted', {
       queryHistoryEnabled: false,
     });
+    console.timeEnd('QUERY HISTORY TEST TIME');
   });
 
   it('add comments to query history', async () => {

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -142,9 +142,7 @@ describe('Explore: Query History', () => {
     await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}']);
   });
 
-  // FIXME: flaky test
-  it.only('updates the state in both Explore panes', async () => {
-    console.time('QUERY HISTORY TEST TIME');
+  it('updates the state in both Explore panes', async () => {
     const urlParams = {
       left: serializeStateToUrlParam({
         datasource: 'loki',
@@ -184,7 +182,6 @@ describe('Explore: Query History', () => {
     expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_deleted', {
       queryHistoryEnabled: false,
     });
-    console.timeEnd('QUERY HISTORY TEST TIME');
   });
 
   it('add comments to query history', async () => {

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -142,45 +142,53 @@ describe('Explore: Query History', () => {
     await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}']);
   });
 
-  it('updates the state in both Explore panes', async () => {
-    const urlParams = {
-      left: serializeStateToUrlParam({
-        datasource: 'loki',
-        queries: [{ refId: 'A', expr: 'query #1' }],
-        range: { from: 'now-1h', to: 'now' },
-      }),
-      right: serializeStateToUrlParam({
-        datasource: 'loki',
-        queries: [{ refId: 'A', expr: 'query #2' }],
-        range: { from: 'now-1h', to: 'now' },
-      }),
-    };
+  describe('updates the state in both Explore panes', () => {
+    beforeEach(async () => {
+      const urlParams = {
+        left: serializeStateToUrlParam({
+          datasource: 'loki',
+          queries: [{ refId: 'A', expr: 'query #1' }],
+          range: { from: 'now-1h', to: 'now' },
+        }),
+        right: serializeStateToUrlParam({
+          datasource: 'loki',
+          queries: [{ refId: 'A', expr: 'query #2' }],
+          range: { from: 'now-1h', to: 'now' },
+        }),
+      };
 
-    const { datasources } = setupExplore({ urlParams });
-    jest.mocked(datasources.loki.query).mockReturnValue(makeLogsQueryResponse());
-    await waitForExplore();
-    await waitForExplore('right');
+      const { datasources } = setupExplore({ urlParams });
+      jest.mocked(datasources.loki.query).mockReturnValue(makeLogsQueryResponse());
+      await waitForExplore();
+      await waitForExplore('right');
 
-    // queries in history
-    await openQueryHistory('left');
-    await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'left');
-    await openQueryHistory('right');
-    await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'right');
-
-    // star one one query
-    await starQueryHistory(1, 'left');
-    await assertQueryHistoryIsStarred([false, true], 'left');
-    await assertQueryHistoryIsStarred([false, true], 'right');
-    expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_starred', {
-      queryHistoryEnabled: false,
-      newValue: true,
+      await openQueryHistory('left');
+      await openQueryHistory('right');
     });
 
-    await deleteQueryHistory(0, 'left');
-    await assertQueryHistory(['{"expr":"query #1"}'], 'left');
-    await assertQueryHistory(['{"expr":"query #1"}'], 'right');
-    expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_deleted', {
-      queryHistoryEnabled: false,
+    it('initial state is in sync', async () => {
+      await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'left');
+      await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'right');
+    });
+
+    it('starred queries are synced', async () => {
+      // star one one query
+      await starQueryHistory(1, 'left');
+      await assertQueryHistoryIsStarred([false, true], 'left');
+      await assertQueryHistoryIsStarred([false, true], 'right');
+      expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_starred', {
+        queryHistoryEnabled: false,
+        newValue: true,
+      });
+    });
+
+    it('deleted queries are synced', async () => {
+      await deleteQueryHistory(0, 'left');
+      await assertQueryHistory(['{"expr":"query #1"}'], 'left');
+      await assertQueryHistory(['{"expr":"query #1"}'], 'right');
+      expect(reportInteractionMock).toBeCalledWith('grafana_explore_query_history_deleted', {
+        queryHistoryEnabled: false,
+      });
     });
   });
 


### PR DESCRIPTION
This PR is to improve the execution time of a flakey query history test. 

Based on findings from [here](https://github.com/grafana/grafana/issues/59116#issuecomment-1398434676). The test still takes a lot of time on CI, but hopefully, this will avoid timeouts.

<details><summary>Approach 1</summary>

This approach was to use test id on the RichHistoryCard and use it to get all cards instead of using getAllByRole

Benchmark tests (3 runs each):

Locally (~20-30% faster):
* Before 15.8-16.5s
* After 11.1-12.4s

CI: (https://github.com/grafana/grafana/pull/71189) (~20-30% faster)
* Before 21.8-23.6s
* After 16.3-18.1s

Fixes: #70158
Fixes: #59116

If it becomes a problem again, I'd suggest splitting the test into 2 (for starring and deleting separately)

</details>

Approach 2

As described by Gio in [the comment below](https://github.com/grafana/grafana/pull/71190#pullrequestreview-1518728122). Additionally, I've split the test into 3 separate tests getting locally times around these values:

    updates the state in both Explore panes
      ✓ initial state is in sync (5005 ms)
      ✓ starred queries are synced (8569 ms)
      ✓ deleted queries are synced (5851 ms)

Previously, entire test would take ~16s. Now each test is max 9s with extra 3s added in total because of repeating same logic on each test that was split.