### PR TITLE
Annotations: Fix database lock while updating annotations

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -143,7 +143,13 @@ func (r *xormRepositoryImpl) synchronizeTags(ctx context.Context, item *annotati
 }
 
 func (r *xormRepositoryImpl) Update(ctx context.Context, item *annotations.Item) error {
-	return r.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	return r.db.InTransaction(ctx, func(ctx context.Context) error {
+		return r.update(ctx, item)
+	})
+}
+
+func (r *xormRepositoryImpl) update(ctx context.Context, item *annotations.Item) error {
+	return r.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var (
 			isExist bool
 			err     error

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -368,6 +368,35 @@ func TestIntegrationAnnotations(t *testing.T) {
 			assert.Greater(t, items[0].Updated, items[0].Created)
 		})
 
+		t.Run("Can update annotation with additional tags", func(t *testing.T) {
+			query := &annotations.ItemQuery{
+				OrgID:        1,
+				DashboardID:  1,
+				From:         0,
+				To:           15,
+				SignedInUser: testUser,
+			}
+			items, err := repo.Get(context.Background(), query)
+			require.NoError(t, err)
+
+			annotationId := items[0].ID
+			err = repo.Update(context.Background(), &annotations.Item{
+				ID:    annotationId,
+				OrgID: 1,
+				Text:  "something new",
+				Tags:  []string{"newtag1", "newtag3"},
+			})
+			require.NoError(t, err)
+
+			items, err = repo.Get(context.Background(), query)
+			require.NoError(t, err)
+
+			assert.Equal(t, annotationId, items[0].ID)
+			assert.Equal(t, []string{"newtag1", "newtag3"}, items[0].Tags)
+			assert.Equal(t, "something new", items[0].Text)
+			assert.Greater(t, items[0].Updated, items[0].Created)
+		})
+
 		t.Run("Can update annotations with data", func(t *testing.T) {
 			query := &annotations.ItemQuery{
 				OrgID:        1,


### PR DESCRIPTION
**What is this feature?**

Updating annotations is done in a transaction that is unfortunately not carried over to subqueries, leading to a database lock when updating tags.

Changing the transaction to wrap the entire update.

**Why do we need this feature?**

At least with sqlite, updating annotations with new tags is not at all possible at the moment, see https://github.com/grafana/grafana-api-tests/pull/53 (hopefully this repo can be made public in a not too distant future, but until then, this links to a k6 script for creating, checking, updating, and checking annotations, #58305 contains curl queries that should have the same effect).

**Who is this feature for?**

End users updating annotations.

**Which issue(s) does this PR fix?**:

Fixes #58305 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
