### PR TITLE
Loki/Elasticsearch config: Add DataSourceDescription component

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { ConfigSection } from '@grafana/experimental';
+import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { Alert, DataSourceHttpSettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 import { config } from 'app/core/config';
@@ -38,6 +38,11 @@ export const ConfigEditor = (props: Props) => {
           Browser access mode in the Elasticsearch datasource is no longer available. Switch to server access mode.
         </Alert>
       )}
+      <DataSourceDescription
+        dataSourceName="Elasticsearch"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/elasticsearch"
+        hasRequiredFields={false}
+      />
 
       <Divider />
 

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { ConfigSection } from '@grafana/experimental';
+import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataSourceHttpSettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
@@ -43,6 +43,12 @@ export const ConfigEditor = (props: Props) => {
 
   return (
     <>
+      <DataSourceDescription
+        dataSourceName="Loki"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/loki"
+        hasRequiredFields={false}
+      />
+
       <Divider />
 
       <DataSourceHttpSettings


### PR DESCRIPTION
As part of the data sources config page redesign, we're adding a `DataSourceDescription` component to Loki and Elastic.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/67383
Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

ES:
![ES](https://github.com/grafana/grafana/assets/1069378/c3d40240-27d0-4f6e-95ae-99136f4be392)

Loki:
![Loki](https://github.com/grafana/grafana/assets/1069378/f1d9c499-9e0d-4875-b242-cd0784c68073)

Other data sources, e.g. Zipkin:

![Zipkin](https://github.com/grafana/grafana/assets/1069378/88f3605c-2b9e-4021-b965-bcc058027af6)
