### PR TITLE
UI/Select: Adjust typing to support extended props

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -12,11 +12,11 @@ import {
   VirtualizedSelectAsyncProps,
 } from './types';
 
-export function Select<T>(props: SelectCommonProps<T>) {
+export function Select<T, Rest = {}>(props: SelectCommonProps<T> & Rest) {
   return <SelectBase {...props} />;
 }
 
-export function MultiSelect<T>(props: MultiSelectCommonProps<T>) {
+export function MultiSelect<T, Rest = {}>(props: MultiSelectCommonProps<T> & Rest) {
   // @ts-ignore
   return <SelectBase {...props} isMulti />;
 }
@@ -26,15 +26,15 @@ export interface AsyncSelectProps<T> extends Omit<SelectCommonProps<T>, 'options
   value?: T | SelectableValue<T> | null;
 }
 
-export function AsyncSelect<T>(props: AsyncSelectProps<T>) {
+export function AsyncSelect<T, Rest = {}>(props: AsyncSelectProps<T> & Rest) {
   return <SelectBase {...props} />;
 }
 
-export function VirtualizedSelect<T>(props: VirtualizedSelectProps<T>) {
+export function VirtualizedSelect<T, Rest = {}>(props: VirtualizedSelectProps<T> & Rest) {
   return <SelectBase virtualized {...props} />;
 }
 
-export function AsyncVirtualizedSelect<T>(props: VirtualizedSelectAsyncProps<T>) {
+export function AsyncVirtualizedSelect<T, Rest = {}>(props: VirtualizedSelectAsyncProps<T> & Rest) {
   return <SelectBase virtualized {...props} />;
 }
 
@@ -43,7 +43,7 @@ interface AsyncMultiSelectProps<T> extends Omit<MultiSelectCommonProps<T>, 'opti
   value?: Array<SelectableValue<T>>;
 }
 
-export function AsyncMultiSelect<T>(props: AsyncMultiSelectProps<T>) {
+export function AsyncMultiSelect<T, Rest = {}>(props: AsyncMultiSelectProps<T> & Rest) {
   // @ts-ignore
   return <SelectBase {...props} isMulti />;
 }

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -88,7 +88,7 @@ const CustomControl = (props: any) => {
   );
 };
 
-export function SelectBase<T>({
+export function SelectBase<T, Rest = {}>({
   allowCustomValue = false,
   allowCreateWhileLoading = false,
   'aria-label': ariaLabel,
@@ -149,7 +149,8 @@ export function SelectBase<T>({
   isValidNewOption,
   formatOptionLabel,
   hideSelectedOptions,
-}: SelectBaseProps<T>) {
+  ...rest
+}: SelectBaseProps<T> & Rest) {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
 
@@ -376,6 +377,7 @@ export function SelectBase<T>({
         {...commonSelectProps}
         {...creatableProps}
         {...asyncSelectProps}
+        {...rest}
       />
     </>
   );


### PR DESCRIPTION
As mentioned in the [docs for react-select](https://react-select.com/components#defining-components), when defining replacement components, there may be times where data or methods need to be shared between the Select component itself and a sub-component being replaced.
To support this, react-select allows for arbitrary props to be passed along with the explicitly typed ones, which can then be accessed from the sub-component via `props.selectProps`.
This PR adjusts the types so code doesn't have to be littered with `@ts-ignore` in scenarios like the one mentioned.

Slightly modified example from react-select docs:

```typescript
import React, { MouseEvent, MouseEventHandler, useState } from 'react';
import Select, {
  components,
  ControlProps,
  Props,
  StylesConfig,
} from 'react-select';
import { ColourOption, colourOptions } from '../data';

interface ExtraProps {
  emoji: string;
  onEmojiClick: (e: MouseEvent) => void;
}

const EMOJIS = ['👍', '🤙', '👏', '👌', '🙌', '✌️', '🖖', '👐'];

const Control = ({ children, ...props }: ControlProps<ColourOption, false> & { selectProps: ExtraProps }) => {
  const { emoji, onEmojiClick } = props.selectProps;
  const style = { cursor: 'pointer' };

  return (
    <components.Control {...props}>
      <span onMouseDown={onEmojiClick} style={style}>
        {emoji}
      </span>
      {children}
    </components.Control>
  );
};

const CustomSelectProps = (props: Props<ColourOption>) => {
  const [clickCount, setClickCount] = useState(0);

  const onClick: MouseEventHandler<HTMLSpanElement> = (e) => {
    setClickCount(clickCount + 1);
    e.preventDefault();
    e.stopPropagation();
  };

  const styles: StylesConfig<ColourOption, false> = {
    control: (css) => ({ ...css, paddingLeft: '1rem' }),
  };

  const emoji = EMOJIS[clickCount % EMOJIS.length];

  return (
    <Select<string, ExtraProps>
      {...props}
      emoji={emoji}
      onEmojiClick={onClick}
      components={{ Control }}
      isSearchable
      name="emoji"
      options={colourOptions}
      styles={styles}
    />
  );
};

export default CustomSelectProps;
```