### PR TITLE
Prometheus: (devenv) add remote write for recorded queries to gdev-prometheus

### DIFF
--- a/devenv/docker/blocks/prometheus/prometheus.yml
+++ b/devenv/docker/blocks/prometheus/prometheus.yml
@@ -4,12 +4,19 @@ global:
   evaluation_interval: 10s # By default, scrape targets every 15 seconds.
   # scrape_timeout is set to the global default (10s).
 
+
+
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:
   - "alert.yml"
   - "recording.yml"
 # - "second.rules"
 
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    basic_auth:
+      username: admin
+      password: admin
 alerting:
   alertmanagers:
   - scheme: http


### PR DESCRIPTION
**What is this feature?**
Updating devenv to support remote write for recorded queries.

**Why do we need this feature?**
Helps document how to provision prometheus to work with recorded queries, reduces time and cognitive load on developers spinning up recorded query reproductions. 

**Who is this feature for?**
Grafana developers

**Which issue(s) does this PR fix?**:
NA

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
