### PR TITLE
QueryBuilder: Preserve queries when switching from Mixed

### DIFF
--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -289,6 +289,44 @@ describe('updateQueries', () => {
     expect(updated.length).toEqual(1);
   });
 
+  it('will not preserve query when switch from mixed with a ds variable query to the same datasource (non-variable)', async () => {
+    templateSrv.init([
+      {
+        current: {
+          text: 'Azure Monitor',
+          value: 'ds-uid',
+        },
+        name: 'ds',
+        type: 'datasource',
+        id: 'ds',
+      },
+    ]);
+    const updated = await updateQueries(
+      newUidDS,
+      'new-uid',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: '$ds',
+            type: 'new-type',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid',
+            type: 'other-type',
+          },
+        },
+      ],
+      mixedDS
+    );
+
+    expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+    expect(updated.length).toEqual(1);
+  });
+
   it('should update query refs when switching from mixed to a datasource where queries exist for new datasource', async () => {
     const updated = await updateQueries(
       newUidDS,

--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -215,6 +215,68 @@ describe('updateQueries', () => {
     expect(updated[0].datasource).toEqual({ type: 'old-type', uid: 'old-uid' });
     expect(updated[1].datasource).toEqual({ type: 'other-type', uid: 'other-uid' });
   });
+
+  it('should preserve query when switching from mixed to a datasource where a query exists for the new datasource', async () => {
+    const updated = await updateQueries(
+      newUidDS,
+      'new-uid',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'new-uid',
+            type: 'new-type',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid',
+            type: 'other-type',
+          },
+        },
+      ],
+      mixedDS
+    );
+
+    expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+    expect(updated.length).toEqual(1);
+  });
+
+  it('should update query refs when switching from mixed to a datasource where queries exist for new datasource', async () => {
+    const updated = await updateQueries(
+      newUidDS,
+      'new-uid',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'new-uid',
+            type: 'new-type',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid',
+            type: 'other-type',
+          },
+        },
+        {
+          refId: 'C',
+          datasource: {
+            uid: 'new-uid',
+            type: 'new-type',
+          },
+        },
+      ],
+      mixedDS
+    );
+
+    expect(updated.length).toEqual(2);
+    expect(updated[0].refId).toEqual('A');
+    expect(updated[1].refId).toEqual('B');
+  });
 });
 
 describe('updateQueries with import', () => {

--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -252,7 +252,7 @@ describe('updateQueries', () => {
   });
 
   it('should preserve query when switching from mixed to a datasource where a query exists for the new datasource - when using datasource template variable', async () => {
-    const vars = templateSrv.init([
+    templateSrv.init([
       {
         current: {
           text: 'Azure Monitor',

--- a/public/app/features/query/state/updateQueries.ts
+++ b/public/app/features/query/state/updateQueries.ts
@@ -34,6 +34,8 @@ export async function updateQueries(
         const templateSrv = getTemplateSrv();
         const reducedQueries: DataQuery[] = [];
         const nextUid = templateSrv.replace(nextDS.uid);
+        // Queries will only be preserved if the datasource UID of the query matches the UID
+        // of the next chosen datasource
         const nextDsQueries = queries.reduce((reduced, currentQuery) => {
           if (currentQuery.datasource) {
             const currUid = templateSrv.replace(currentQuery.datasource.uid);


### PR DESCRIPTION
Paraphrasing from grafana/grafana#66968:

This PR preserves all relevant queries when switching from mixed to another data source. If there are no relevant queries, then the default query will be set.

NOTE: The original issue indicated that this was an issue with Azure Monitor but it actually applies to all data sources because of how the data source picker worked.

This should improve UX as queries will be maintained leading to less effort from users. A follow-up would be to determine if Expression queries should be migrated or cleared (they are cleared for now).

Fixes #50831