### PR TITLE
PanelInspect: Clean table display settings from field config

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
+++ b/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
@@ -30,7 +30,8 @@ export const usePanelLatestData = (
 
     querySubscription.current = panel
       .getQueryRunner()
-      .getData(options)
+      // We apply field config later
+      .getData({ withTransforms: options.withTransforms, withFieldConfig: false })
       .subscribe({
         next: (data) => {
           if (checkSchema) {
@@ -58,7 +59,7 @@ export const usePanelLatestData = (
      * Otherwise, passing different references to the same object might cause troubles.
      */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panel, options.withFieldConfig, options.withTransforms]);
+  }, [panel, options.withTransforms]);
 
   return {
     data: latestData,

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -10,7 +10,6 @@ import {
   CSVConfig,
   DataFrame,
   DataTransformerID,
-  DynamicConfigValue,
   FieldConfigSource,
   SelectableValue,
   TimeZone,

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { cloneDeep } from 'lodash';
 import React, { PureComponent } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -172,10 +173,28 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
     // We need to apply field config even though it was already applied in the PanelQueryRunner.
     // That's because transformers create new fields and data frames, so i.e. display processor is no longer there
+    let fieldConfig = panel.fieldConfig;
+
+    if (panel.type === 'table') {
+      fieldConfig = cloneDeep(fieldConfig);
+
+      if (fieldConfig.defaults.custom?.filterable) {
+        fieldConfig.defaults.custom.filterable = undefined;
+      }
+
+      const overrideProp = fieldConfig.overrides.find((override) =>
+        override.properties.find((prop) => prop.id === 'filterable')
+      );
+
+      if (overrideProp) {
+        overrideProp.properties = overrideProp.properties.filter((x) => x.id === 'filterable');
+      }
+    }
+
     return applyFieldOverrides({
       data,
       theme: config.theme2,
-      fieldConfig: panel.fieldConfig,
+      fieldConfig,
       timeZone,
       replaceVariables: (value: string) => {
         return value;


### PR DESCRIPTION
In order for the fix to work we have to always disable field config in PanelQueryRunner. This is fine as it was applied later anyway in getProcessedData. 

Issue: https://github.com/grafana/support-escalations/issues/6562
