### PR TITLE
SSE: DSNode to update result with names to make each value identifiable by labels (only Graphite and TestData)

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -381,7 +381,7 @@ func convertDataFramesToResults(ctx context.Context, frames data.Frames, datasou
 }
 
 func isAllFrameVectors(datasourceType string, frames data.Frames) bool {
-	if datasourceType != "prometheus" {
+	if datasourceType != datasources.DS_PROMETHEUS {
 		return false
 	}
 	allVector := false

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -178,3 +178,106 @@ func TestCheckIfSeriesNeedToBeFixed(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertDataFramesToResults(t *testing.T) {
+	s := &Service{
+		cfg:      setting.NewCfg(),
+		features: &featuremgmt.FeatureManager{},
+		tracer:   tracing.InitializeTracerForTest(),
+		metrics:  newMetrics(nil),
+	}
+
+	t.Run("should add name label if no labels and specific data source", func(t *testing.T) {
+		supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}
+		t.Run("when only field name is specified", func(t *testing.T) {
+			t.Run("use value field names if one frame - many series", func(t *testing.T) {
+				supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}
+
+				frames := []*data.Frame{
+					data.NewFrame("test",
+						data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+						data.NewField("test-value1", nil, []*float64{fp(2)}),
+						data.NewField("test-value2", nil, []*float64{fp(2)})),
+				}
+
+				for _, dtype := range supported {
+					t.Run(dtype, func(t *testing.T) {
+						resultType, res, err := convertDataFramesToResults(context.Background(), frames, dtype, s, &logtest.Fake{})
+						require.NoError(t, err)
+						assert.Equal(t, "single frame series", resultType)
+						require.Len(t, res.Values, 2)
+
+						var names []string
+						for _, value := range res.Values {
+							require.IsType(t, mathexp.Series{}, value)
+							lbls := value.GetLabels()
+							require.Contains(t, lbls, nameLabelName)
+							names = append(names, lbls[nameLabelName])
+						}
+						require.EqualValues(t, []string{"test-value1", "test-value2"}, names)
+					})
+				}
+			})
+			t.Run("should use frame name if one frame - one series", func(t *testing.T) {
+				frames := []*data.Frame{
+					data.NewFrame("test-frame1",
+						data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+						data.NewField("test-value1", nil, []*float64{fp(2)})),
+					data.NewFrame("test-frame2",
+						data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+						data.NewField("test-value2", nil, []*float64{fp(2)})),
+				}
+
+				for _, dtype := range supported {
+					t.Run(dtype, func(t *testing.T) {
+						resultType, res, err := convertDataFramesToResults(context.Background(), frames, dtype, s, &logtest.Fake{})
+						require.NoError(t, err)
+						assert.Equal(t, "multi frame series", resultType)
+						require.Len(t, res.Values, 2)
+
+						var names []string
+						for _, value := range res.Values {
+							require.IsType(t, mathexp.Series{}, value)
+							lbls := value.GetLabels()
+							require.Contains(t, lbls, nameLabelName)
+							names = append(names, lbls[nameLabelName])
+						}
+						require.EqualValues(t, []string{"test-frame1", "test-frame2"}, names)
+					})
+				}
+			})
+		})
+		t.Run("should use fields DisplayNameFromDS when it is unique", func(t *testing.T) {
+			f1 := data.NewField("test-value1", nil, []*float64{fp(2)})
+			f1.Config = &data.FieldConfig{DisplayNameFromDS: "test-value1"}
+			f2 := data.NewField("test-value2", nil, []*float64{fp(2)})
+			f2.Config = &data.FieldConfig{DisplayNameFromDS: "test-value2"}
+			frames := []*data.Frame{
+				data.NewFrame("test-frame1",
+					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+					f1),
+				data.NewFrame("test-frame2",
+					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+					f2),
+			}
+
+			for _, dtype := range supported {
+				t.Run(dtype, func(t *testing.T) {
+					resultType, res, err := convertDataFramesToResults(context.Background(), frames, dtype, s, &logtest.Fake{})
+					require.NoError(t, err)
+					assert.Equal(t, "multi frame series", resultType)
+					require.Len(t, res.Values, 2)
+
+					var names []string
+					for _, value := range res.Values {
+						require.IsType(t, mathexp.Series{}, value)
+						lbls := value.GetLabels()
+						require.Contains(t, lbls, nameLabelName)
+						names = append(names, lbls[nameLabelName])
+					}
+					require.EqualValues(t, []string{"test-value1", "test-value2"}, names)
+				})
+			}
+		})
+	})
+}

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -1,10 +1,22 @@
 package expr
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type expectedError struct{}
@@ -39,4 +51,130 @@ func TestQueryError_Unwrap(t *testing.T) {
 		var expectedAsError expectedError
 		assert.True(t, errors.As(e, &expectedAsError))
 	})
+}
+
+func TestCheckIfSeriesNeedToBeFixed(t *testing.T) {
+	createFrame := func(m ...func(field *data.Field)) []*data.Frame {
+		f := data.NewFrame("",
+			data.NewField("Time", nil, []time.Time{}))
+		for i := 0; i < 100; i++ {
+			fld := data.NewField(fmt.Sprintf("fld-%d", i), nil, []*float64{})
+			fld.Config = &data.FieldConfig{}
+			for _, change := range m {
+				change(fld)
+			}
+			f.Fields = append(f.Fields, fld)
+		}
+		return []*data.Frame{f}
+	}
+	withLabels := func(field *data.Field) {
+		field.Labels = map[string]string{
+			"field": field.Name,
+		}
+	}
+	withDisplayNameFromDS := func(field *data.Field) {
+		field.Config.DisplayNameFromDS = fmt.Sprintf("dnds-%s", field.Name)
+	}
+	withDisplayName := func(field *data.Field) {
+		field.Config.DisplayName = fmt.Sprintf("dn-%s", field.Name)
+	}
+	withoutName := func(field *data.Field) {
+		field.Name = ""
+	}
+
+	getLabelName := func(f func(series mathexp.Series, valueField *data.Field)) string {
+		s := mathexp.NewSeries("A", nil, 0)
+		field := &data.Field{
+			Name: "Name",
+			Config: &data.FieldConfig{
+				DisplayNameFromDS: "DisplayNameFromDS",
+				DisplayName:       "DisplayName",
+			},
+		}
+		f(s, field)
+		return s.GetLabels()[nameLabelName]
+	}
+
+	testCases := []struct {
+		name         string
+		frames       []*data.Frame
+		expectedName string
+	}{
+		{
+			name:         "should return nil if at least one value field has labels",
+			frames:       createFrame(withLabels, withDisplayNameFromDS, withDisplayName),
+			expectedName: "",
+		},
+		{
+			name:         "should return nil if names are empty",
+			frames:       createFrame(withoutName),
+			expectedName: "",
+		},
+		{
+			name:         "should return patcher with DisplayNameFromDS first",
+			frames:       createFrame(withDisplayNameFromDS, withDisplayName),
+			expectedName: "DisplayNameFromDS",
+		},
+		{
+			name: "should return patcher with DisplayName if DisplayNameFromDS is not unique",
+			frames: func() []*data.Frame {
+				frames := createFrame(withDisplayNameFromDS, withDisplayName)
+				f := frames[0]
+				f.Fields[2].Config.DisplayNameFromDS = "test"
+				f.Fields[3].Config.DisplayNameFromDS = "test"
+				return frames
+			}(),
+			expectedName: "DisplayName",
+		},
+		{
+			name:         "should return patcher with DisplayName if is empty",
+			frames:       createFrame(withDisplayName),
+			expectedName: "DisplayName",
+		},
+		{
+			name: "should return patcher with Name if DisplayName and DisplayNameFromDS are not unique",
+			frames: func() []*data.Frame {
+				frames := createFrame(withDisplayNameFromDS, withDisplayName)
+				f := frames[0]
+				f.Fields[1].Config.DisplayNameFromDS = f.Fields[2].Config.DisplayNameFromDS
+				f.Fields[1].Config.DisplayName = f.Fields[2].Config.DisplayName
+				return frames
+			}(),
+			expectedName: "Name",
+		},
+		{
+			name:         "should return patcher with Name if DisplayName and DisplayNameFromDS are empty",
+			frames:       createFrame(),
+			expectedName: "Name",
+		},
+		{
+			name: "should return nil if all fields are not unique",
+			frames: func() []*data.Frame {
+				frames := createFrame(withDisplayNameFromDS, withDisplayName)
+				f := frames[0]
+				f.Fields[1].Config.DisplayNameFromDS = f.Fields[2].Config.DisplayNameFromDS
+				f.Fields[1].Config.DisplayName = f.Fields[2].Config.DisplayName
+				f.Fields[1].Name = f.Fields[2].Name
+				return frames
+			}(),
+			expectedName: "",
+		},
+	}
+
+	supportedDatasources := []string{
+		datasources.DS_GRAPHITE,
+		datasources.DS_TESTDATA,
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, datasource := range supportedDatasources {
+				fixer := checkIfSeriesNeedToBeFixed(tc.frames, datasource)
+				if tc.expectedName == "" {
+					require.Nil(t, fixer)
+				} else {
+					require.Equal(t, tc.expectedName, getLabelName(fixer))
+				}
+			}
+		})
+	}
 }

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -26,7 +26,7 @@ import (
 func TestService(t *testing.T) {
 	dsDF := data.NewFrame("test",
 		data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
-		data.NewField("value", nil, []*float64{fp(2)}))
+		data.NewField("value", data.Labels{"test": "label"}, []*float64{fp(2)}))
 
 	me := &mockEndpoint{
 		Frames: []*data.Frame{dsDF},
@@ -78,7 +78,7 @@ func TestService(t *testing.T) {
 
 	bDF := data.NewFrame("",
 		data.NewField("Time", nil, []time.Time{time.Unix(1, 0)}),
-		data.NewField("B", nil, []*float64{fp(4)}))
+		data.NewField("B", data.Labels{"test": "label"}, []*float64{fp(4)}))
 	bDF.RefID = "B"
 	bDF.SetMeta(&data.FrameMeta{
 		Type:        data.FrameTypeTimeSeriesMulti,

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -28,6 +28,7 @@ const (
 	DS_ES_OPEN_DISTRO = "grafana-es-open-distro-datasource"
 	DS_ES_OPENSEARCH  = "grafana-opensearch-datasource"
 	DS_AZURE_MONITOR  = "grafana-azure-monitor-datasource"
+	DS_TESTDATA       = "testdata"
 	// CustomHeaderName is the prefix that is used to store the name of a custom header.
 	CustomHeaderName = "httpHeaderName"
 	// CustomHeaderValue is the prefix that is used to store the value of a custom header.

--- a/pkg/services/ngalert/backtesting/eval_data.go
+++ b/pkg/services/ngalert/backtesting/eval_data.go
@@ -21,7 +21,7 @@ type dataEvaluator struct {
 }
 
 func newDataEvaluator(refID string, frame *data.Frame) (*dataEvaluator, error) {
-	series, err := expr.WideToMany(frame)
+	series, err := expr.WideToMany(frame, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
During conversion of response from data source (Graphite or Test datasource) to time series, SSE will check if all series have empty labels, and if it is true, try to find a name to make the values identifiable. It checks several fields in precedence order:
- a field DisplayNameFromDS from the value field's configuration
- a field DisplayName from the value field's configuration
- a field's Name

For example, 3 metrics with no labels. If all 3 fields are not identifiable by `DisplayNameFromDS` it will check the field DisplayName of all metrics, and if it is unique for all 3 metrics, it will add a new label `__name__` to each metric, which make those metrics to be identifiable by labels.

<details><summary>Screenshots</summary>

![image](https://github.com/grafana/grafana/assets/25988953/79b465de-d16b-4de1-89ca-452d1485f3ff)

![image](https://github.com/grafana/grafana/assets/25988953/a06cce08-f51a-4372-b895-574df9c8d48b)

![image](https://github.com/grafana/grafana/assets/25988953/79325310-6221-410f-b9f9-87e175e5c2f1)

</details>

**Why do we need this feature?**
This will let Alerting identify each dimension an stop erroring when data source response, like from Graphite 1.0, does not provide any tags\labels.

**Who is this feature for?**
Alerting users


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/65846

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
