### PR TITLE
Alerting: Changes to evaluation group step

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen, within, act } from '@testing-library/react';
+import { render, waitFor, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Route } from 'react-router-dom';
@@ -6,7 +6,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { ui } from 'test/helpers/alertingRuleEditor';
 
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
-import { ADD_NEW_FOLER_OPTION } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/services/context_srv';
 import { DashboardSearchHit } from 'app/features/search/types';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
@@ -184,14 +183,8 @@ describe('RuleEditor grafana managed rules', () => {
     await userEvent.click(ui.buttons.save.get());
     await waitFor(() => expect(mocks.api.setRulerRuleGroup).toHaveBeenCalled());
 
-    //check that '+ Add new' option is in folders drop down even if we don't have values
-    const emptyFolderInput = await ui.inputs.folderContainer.find();
     mocks.searchFolders.mockResolvedValue([] as DashboardSearchHit[]);
-    await act(async () => {
-      renderRuleEditor(uid);
-    });
-    await userEvent.click(within(emptyFolderInput).getByRole('combobox'));
-    expect(screen.getByText(ADD_NEW_FOLER_OPTION)).toBeInTheDocument();
+    expect(screen.getByText('New folder')).toBeInTheDocument();
 
     expect(mocks.api.setRulerRuleGroup).toHaveBeenCalledWith(
       { dataSourceName: GRAFANA_RULES_SOURCE_NAME, apiVersion: 'legacy' },

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -125,9 +125,9 @@ const ui = {
     namespaceInput: byRole('textbox', { name: /^Namespace/ }),
     ruleGroupInput: byRole('textbox', { name: /Evaluation group/ }),
     intervalInput: byRole('textbox', {
-      name: /Rule group evaluation interval Evaluation interval should be smaller or equal to 'For' values for existing rules in this group./i,
+      name: /Evaluation interval How often is the rule evaluated. Applies to every rule within the group./i,
     }),
-    saveButton: byRole('button', { name: /Save evaluation interval/ }),
+    saveButton: byRole('button', { name: /Save/ }),
   },
 };
 
@@ -626,12 +626,7 @@ describe('RuleList', () => {
       // make changes to form
       await userEvent.clear(ui.editGroupModal.ruleGroupInput.get());
       await userEvent.type(ui.editGroupModal.ruleGroupInput.get(), 'super group');
-      await userEvent.type(
-        screen.getByRole('textbox', {
-          name: /rule group evaluation interval evaluation interval should be smaller or equal to 'for' values for existing rules in this group\./i,
-        }),
-        '5m'
-      );
+      await userEvent.type(ui.editGroupModal.intervalInput.get(), '5m');
 
       // submit, check that appropriate calls were made
       await userEvent.click(ui.editGroupModal.saveButton.get());

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -104,7 +104,7 @@ export function FolderAndGroup() {
     <div className={styles.container}>
       <Field
         label={
-          <Label htmlFor="folder" description={'Select a folder for your rule.'}>
+          <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
             <Stack gap={0.5}>
               Folder
               <InfoIcon
@@ -144,9 +144,9 @@ export function FolderAndGroup() {
       </Field>
 
       <Field
-        label="Evaluation group (interval)"
+        label="Evaluation group"
         data-testid="group-picker"
-        description="Select a group to evaluate all rules in the same group over the same time interval."
+        description="Rules within the same group are evaluated sequentially over the same time interval"
         className={styles.formInput}
         error={errors.group?.message}
         invalid={!!errors.group?.message}
@@ -201,17 +201,14 @@ export function FolderAndGroup() {
 }
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
+    margin-top: ${theme.spacing(1)};
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: baseline;
     max-width: ${theme.breakpoints.values.sm}px;
     justify-content: space-between;
   `,
   formInput: css`
-    width: 275px;
-
-    & + & {
-      margin-left: ${theme.spacing(3)};
-    }
+    width: 100%;
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -92,6 +92,7 @@ export function FolderAndGroup() {
   const onOpenEvaluationGroupCreationModal = () => setIsCreatingEvaluationGroup(true);
 
   const handleFolderCreation = (folder: Folder) => {
+    resetGroup();
     setValue('folder', folder);
     setIsCreatingFolder(false);
   };

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -243,6 +243,7 @@ export function FolderAndGroup({
             icon="plus"
             fill="outline"
             variant="secondary"
+            disabled={!folder}
           >
             New evaluation group
           </Button>
@@ -287,13 +288,14 @@ function FolderCreationModal({
     <Modal className={styles.modal} isOpen={true} title={'New folder'} onDismiss={onClose} onClickBackdrop={onClose}>
       <div className={styles.modalTitle}>Create a new folder to store your rule</div>
 
-      <>
+      <form onSubmit={onSubmit}>
         <Field
           label={<Label htmlFor="folder">Folder name</Label>}
           error={"The folder name can't contain slashes"}
           invalid={error}
         >
           <Input
+            autoFocus={true}
             id="folderName"
             placeholder="Enter a name"
             value={title}
@@ -306,11 +308,11 @@ function FolderCreationModal({
           <Button variant="secondary" type="button" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="button" disabled={!title || error} onClick={onSubmit}>
+          <Button type="submit" disabled={!title || error}>
             Create
           </Button>
         </Modal.ButtonRow>
-      </>
+      </form>
     </Modal>
   );
 }
@@ -362,48 +364,50 @@ function EvaluationGroupCreationModal({
       <div className={styles.modalTitle}>Create a new evaluation group to use for this alert rule.</div>
 
       <FormProvider {...formAPI}>
-        <Field
-          label={<Label htmlFor={'group'}>Evaluation group name</Label>}
-          error={formState.errors.group?.message}
-          invalid={!!formState.errors.group}
-        >
-          <Input
-            className={styles.formInput}
-            id={'group'}
-            placeholder="Enter a name"
-            {...register('group', { required: { value: true, message: 'Required.' } })}
-          />
-        </Field>
+        <form onSubmit={handleSubmit(() => onSubmit())}>
+          <Field
+            label={<Label htmlFor={'group'}>Evaluation group name</Label>}
+            error={formState.errors.group?.message}
+            invalid={!!formState.errors.group}
+          >
+            <Input
+              className={styles.formInput}
+              autoFocus={true}
+              id={'group'}
+              placeholder="Enter a name"
+              {...register('group', { required: { value: true, message: 'Required.' } })}
+            />
+          </Field>
 
-        <Field
-          error={formState.errors.evaluateEvery?.message}
-          invalid={!!formState.errors.evaluateEvery}
-          label={
-            <Label
-              htmlFor={evaluateEveryId}
-              description="How often is the rule evaluated. Applies to every rule within the group."
-            >
-              Evaluation interval
-            </Label>
-          }
-        >
-          <Input
-            className={styles.formInput}
-            id={evaluateEveryId}
-            placeholder="e.g. 5m"
-            {...register('evaluateEvery', evaluateEveryValidationOptions(groupRules))}
-          />
-        </Field>
+          <Field
+            error={formState.errors.evaluateEvery?.message}
+            invalid={!!formState.errors.evaluateEvery}
+            label={
+              <Label
+                htmlFor={evaluateEveryId}
+                description="How often is the rule evaluated. Applies to every rule within the group."
+              >
+                Evaluation interval
+              </Label>
+            }
+          >
+            <Input
+              className={styles.formInput}
+              id={evaluateEveryId}
+              placeholder="e.g. 5m"
+              {...register('evaluateEvery', evaluateEveryValidationOptions(groupRules))}
+            />
+          </Field>
+          <Modal.ButtonRow>
+            <Button variant="secondary" type="button" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!formState.isValid}>
+              Create
+            </Button>
+          </Modal.ButtonRow>
+        </form>
       </FormProvider>
-
-      <Modal.ButtonRow>
-        <Button variant="secondary" type="button" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button type="button" disabled={!formState.isValid} onClick={handleSubmit(() => onSubmit())}>
-          Create
-        </Button>
-      </Modal.ButtonRow>
     </Modal>
   );
 }

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -17,7 +17,6 @@ import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelect
 import { fetchRulerRulesAction } from '../../state/actions';
 import { RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
-import { AsyncRequestState } from '../../utils/redux';
 import { MINUTE } from '../../utils/rule-form';
 import { isGrafanaRulerRule } from '../../utils/rules';
 import { ProvisioningBadge } from '../Provisioning';
@@ -70,11 +69,7 @@ const findGroupMatchingLabel = (group: SelectableValue<string>, query: string) =
   return group.label?.toLowerCase().includes(query.toLowerCase());
 };
 
-export function FolderAndGroup({
-  groupfoldersForGrafana,
-}: {
-  groupfoldersForGrafana: AsyncRequestState<RulerRulesConfigDTO | null>;
-}) {
+export function FolderAndGroup({ groupfoldersForGrafana }: { groupfoldersForGrafana?: RulerRulesConfigDTO | null }) {
   const {
     formState: { errors },
     watch,
@@ -324,7 +319,7 @@ function EvaluationGroupCreationModal({
 }: {
   onClose: () => void;
   onCreate: (group: string, evaluationInterval: string) => void;
-  groupfoldersForGrafana: AsyncRequestState<RulerRulesConfigDTO | null>;
+  groupfoldersForGrafana?: RulerRulesConfigDTO | null;
 }): React.ReactElement {
   const styles = useStyles2(getStyles);
   const onSubmit = () => {
@@ -337,9 +332,7 @@ function EvaluationGroupCreationModal({
   const [groupName, folderName] = watch(['group', 'folder.title']);
 
   const groupRules =
-    (groupfoldersForGrafana.result &&
-      groupfoldersForGrafana.result[folderName]?.find((g) => g.name === groupName)?.rules) ??
-    [];
+    (groupfoldersForGrafana && groupfoldersForGrafana[folderName]?.find((g) => g.name === groupName)?.rules) ?? [];
 
   const onCancel = () => {
     onClose();

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -116,7 +116,7 @@ function FolderGroupAndEvaluationInterval({
 
   return (
     <div>
-      <FolderAndGroup groupfoldersForGrafana={groupfoldersForGrafana} />
+      <FolderAndGroup groupfoldersForGrafana={groupfoldersForGrafana.result} />
       {folderName && isEditingGroup && (
         <EditCloudGroupModal
           namespace={existingNamespace ?? emptyNamespace}

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -123,6 +123,7 @@ function FolderGroupAndEvaluationInterval({
           group={existingGroup ?? emptyGroup}
           onClose={() => closeEditGroupModal()}
           intervalEditOnly
+          hideFolder={true}
         />
       )}
       {folderName && groupName && (

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -4,7 +4,7 @@ import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Field, Icon, InlineLabel, Input, InputControl, Switch, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Field, Icon, InlineLabel, Input, InputControl, Label, Switch, Tooltip, useStyles2 } from '@grafana/ui';
 import { RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import { CombinedRuleGroup, CombinedRuleNamespace } from '../../../../../types/unified-alerting';
@@ -20,6 +20,7 @@ import { EditCloudGroupModal, evaluateEveryValidationOptions } from '../rules/Ed
 
 import { FolderAndGroup, useGetGroupOptionsFromFolder } from './FolderAndGroup';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
+import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
 
 export const MIN_TIME_RANGE_STEP_S = 10; // 10 seconds
@@ -226,14 +227,15 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
 
   return (
     <Stack direction="row" justify-content="flex-start" align-items="flex-start">
-      <InlineLabel
-        htmlFor={evaluateForId}
-        width={7}
-        tooltip='Once the condition is breached, the alert goes into pending state. If the alert is pending longer than the "for" value, it becomes a firing alert.'
-      >
-        for
-      </InlineLabel>
       <Field
+        label={
+          <Label
+            htmlFor="evaluateFor"
+            description="Period in which an alert rule can be in breach of the condition until the alert rule fires"
+          >
+            Pending period
+          </Label>
+        }
         className={styles.inlineField}
         error={errors.evaluateFor?.message}
         invalid={!!errors.evaluateFor?.message}
@@ -241,6 +243,22 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
       >
         <Input id={evaluateForId} width={8} {...register('evaluateFor', forValidationOptions(evaluateEvery))} />
       </Field>
+    </Stack>
+  );
+}
+
+function getDescription() {
+  const textToRender = 'Define how the alert rule is evaluated.';
+  const docsLink = 'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/rule-evaluation/';
+  return (
+    <Stack gap={0.5}>
+      {`${textToRender}`}
+      <NeedHelpInfo
+        contentText="Evaluation groups are containers for evaluating alert and recording rules. An evaluation group defines an evaluation interval - how often a rule is checked. Alert rules within the same evaluation group are evaluated sequentially"
+        externalLink={docsLink}
+        linkText={`Read about evaluation`}
+        title="Evaluation"
+      />
     </Stack>
   );
 }
@@ -263,7 +281,7 @@ export function GrafanaEvaluationBehavior({
 
   return (
     // TODO remove "and alert condition" for recording rules
-    <RuleEditorSection stepNo={3} title="Alert evaluation behavior">
+    <RuleEditorSection stepNo={3} title="Set evaluation behavior" description={getDescription()}>
       <Stack direction="column" justify-content="flex-start" align-items="flex-start">
         <FolderGroupAndEvaluationInterval setEvaluateEvery={setEvaluateEvery} evaluateEvery={evaluateEvery} />
         <ForInput evaluateEvery={evaluateEvery} />

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -116,7 +116,7 @@ function FolderGroupAndEvaluationInterval({
 
   return (
     <div>
-      <FolderAndGroup groupfoldersForGrafana={groupfoldersForGrafana.result} />
+      <FolderAndGroup groupfoldersForGrafana={groupfoldersForGrafana?.result} />
       {folderName && isEditingGroup && (
         <EditCloudGroupModal
           namespace={existingNamespace ?? emptyNamespace}

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
@@ -24,7 +24,7 @@ const ui = {
   input: {
     namespace: byLabelText(/^Folder|^Namespace/, { exact: true }),
     group: byLabelText(/Evaluation group/),
-    interval: byLabelText(/Rule group evaluation interval/),
+    interval: byLabelText(/Evaluation interval/),
   },
   folderLink: byTitle(/Go to folder/), // <a> without a href has the generic role
   table: byTestId('dynamic-table'),

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -20,7 +20,6 @@ import { initialAsyncRequestState } from '../../utils/redux';
 import { AlertInfo, getAlertInfo, isRecordingRulerRule } from '../../utils/rules';
 import { parsePrometheusDuration, safeParseDurationstr } from '../../utils/time';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
-import { InfoIcon } from '../InfoIcon';
 import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { MIN_TIME_RANGE_STEP_S } from '../rule-editor/GrafanaEvaluationBehavior';
 
@@ -160,6 +159,7 @@ export interface ModalProps {
   onClose: (saved?: boolean) => void;
   intervalEditOnly?: boolean;
   folderUrl?: string;
+  hideFolder?: boolean;
 }
 
 export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
@@ -234,50 +234,45 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
       <FormProvider {...formAPI}>
         <form onSubmit={(e) => e.preventDefault()} key={JSON.stringify(defaultValues)}>
           <>
-            <Field
-              label={
-                <Label
-                  htmlFor="namespaceName"
-                  description={
-                    !isGrafanaManagedGroup &&
-                    'Change the current namespace name. Moving groups between namespaces is not supported'
-                  }
-                >
-                  {nameSpaceLabel}
-                </Label>
-              }
-              invalid={!!errors.namespaceName}
-              error={errors.namespaceName?.message}
-            >
-              <Stack gap={1} direction="row">
-                <Input
-                  id="namespaceName"
-                  readOnly={intervalEditOnly || isGrafanaManagedGroup}
-                  {...register('namespaceName', {
-                    required: 'Namespace name is required.',
-                  })}
-                  className={styles.formInput}
-                />
-                {isGrafanaManagedGroup && props.folderUrl && (
-                  <LinkButton
-                    href={props.folderUrl}
-                    title="Go to folder"
-                    variant="secondary"
-                    icon="folder-open"
-                    target="_blank"
+            {!props.hideFolder && (
+              <Field
+                label={
+                  <Label
+                    htmlFor="namespaceName"
+                    description={
+                      !isGrafanaManagedGroup &&
+                      'Change the current namespace name. Moving groups between namespaces is not supported'
+                    }
+                  >
+                    {nameSpaceLabel}
+                  </Label>
+                }
+                invalid={!!errors.namespaceName}
+                error={errors.namespaceName?.message}
+              >
+                <Stack gap={1} direction="row">
+                  <Input
+                    id="namespaceName"
+                    readOnly={intervalEditOnly || isGrafanaManagedGroup}
+                    {...register('namespaceName', {
+                      required: 'Namespace name is required.',
+                    })}
+                    className={styles.formInput}
                   />
-                )}
-              </Stack>
-            </Field>
+                  {isGrafanaManagedGroup && props.folderUrl && (
+                    <LinkButton
+                      href={props.folderUrl}
+                      title="Go to folder"
+                      variant="secondary"
+                      icon="folder-open"
+                      target="_blank"
+                    />
+                  )}
+                </Stack>
+              </Field>
+            )}
             <Field
-              label={
-                <Label
-                  htmlFor="groupName"
-                  description={`Evaluation group name needs to be unique within a ${nameSpaceLabel.toLocaleLowerCase()}`}
-                >
-                  Evaluation group name
-                </Label>
-              }
+              label={<Label htmlFor="groupName">Evaluation group name</Label>}
               invalid={!!errors.groupName}
               error={errors.groupName?.message}
             >
@@ -293,12 +288,9 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               label={
                 <Label
                   htmlFor="groupInterval"
-                  description="Evaluation interval should be smaller or equal to 'For' values for existing rules in this group."
+                  description="How often is the rule evaluated. Applies to every rule within the group."
                 >
-                  <Stack gap={0.5}>
-                    Rule group evaluation interval
-                    <InfoIcon text={'How frequently to evaluate rules.'} />
-                  </Stack>
+                  <Stack gap={0.5}>Evaluation interval</Stack>
                 </Label>
               }
               invalid={!!errors.groupInterval}
@@ -314,6 +306,18 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
             {checkEvaluationIntervalGlobalLimit(watch('groupInterval')).exceedsLimit && (
               <EvaluationIntervalLimitExceeded />
             )}
+
+            {!hasSomeNoRecordingRules && <div>This group does not contain alert rules.</div>}
+            {hasSomeNoRecordingRules && (
+              <>
+                <div>List of rules that belong to this group</div>
+                <div className={styles.evalRequiredLabel}>
+                  #Eval column represents the number of evaluations needed before alert starts firing.
+                </div>
+                <RulesForGroupTable rulesWithoutRecordingRules={rulesWithoutRecordingRules} />
+              </>
+            )}
+
             <div className={styles.modalButtons}>
               <Modal.ButtonRow>
                 <Button
@@ -330,20 +334,10 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                   disabled={!isDirty || loading}
                   onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
                 >
-                  {loading ? 'Saving...' : 'Save evaluation interval'}
+                  {loading ? 'Saving...' : 'Save'}
                 </Button>
               </Modal.ButtonRow>
             </div>
-            {!hasSomeNoRecordingRules && <div>This group does not contain alert rules.</div>}
-            {hasSomeNoRecordingRules && (
-              <>
-                <div>List of rules that belong to this group</div>
-                <div className={styles.evalRequiredLabel}>
-                  #Eval column represents the number of evaluations needed before alert starts firing.
-                </div>
-                <RulesForGroupTable rulesWithoutRecordingRules={rulesWithoutRecordingRules} />
-              </>
-            )}
           </>
         </form>
       </FormProvider>

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -277,6 +277,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               error={errors.groupName?.message}
             >
               <Input
+                autoFocus={true}
                 id="groupName"
                 readOnly={intervalEditOnly}
                 {...register('groupName', {


### PR DESCRIPTION
**What is this feature?**

Improves the evaluation group step in the alert rule form.

**Why do we need this feature?**

To make this step easier to understand.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/68097

Prototype: https://www.figma.com/proto/AYMboJsnYgSAAdYM9hoMLn/Alerting?page-id=0%3A1&type=design&node-id=1323-30604&viewport=-1512%2C-6635%2C0.65&t=21RvsHATbNrd64MU-1&scaling=min-zoom&starting-point-node-id=1322%3A29730&mode=design

UI changes from rule form
![image](https://github.com/grafana/grafana/assets/6271380/5ff3a09f-7a68-4d0c-9698-9f48f9ffa60d)

Creating folder modal
![image](https://github.com/grafana/grafana/assets/6271380/bbd86da6-88ad-438d-962f-3d9a4553b75e)

Creating evaluation group modal
![image](https://github.com/grafana/grafana/assets/6271380/037a5dcd-aab5-4aac-8f57-f1d90f156f78)

Editing evaluation group modal
![image](https://github.com/grafana/grafana/assets/6271380/81557ba3-a221-4241-95ff-9f494da24d69)

Screen recording creating a folder
![2023-07-12 18 20 09](https://github.com/grafana/grafana/assets/6271380/f5f9dbf8-9058-4632-9ea1-df180a0f8cf2)

Screen recording creating an evaluation group
![2023-07-13 16 37 05](https://github.com/grafana/grafana/assets/6271380/4bc9eed0-4b2a-47f4-bea5-b6a21dac9b73)



