### PR TITLE
Auth: Fix US gov azure ad oauth URL parsing

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -334,7 +334,7 @@ func (s *SocialAzureAD) SupportBundleContent(bf *bytes.Buffer) error {
 
 func (s *SocialAzureAD) extractTenantID(authURL string) (string, error) {
 	if s.compiledTenantRegex == nil {
-		compiledTenantRegex, err := regexp.Compile(`https://login.microsoftonline.com/([^/]+)/oauth2`)
+		compiledTenantRegex, err := regexp.Compile(`https://login.microsoftonline.(com|us)/([^/]+)/oauth2`)
 		if err != nil {
 			return "", err
 		}
@@ -342,10 +342,10 @@ func (s *SocialAzureAD) extractTenantID(authURL string) (string, error) {
 	}
 
 	matches := s.compiledTenantRegex.FindStringSubmatch(authURL)
-	if len(matches) < 2 {
+	if len(matches) < 3 {
 		return "", fmt.Errorf("unable to extract tenant ID from URL")
 	}
-	return matches[1], nil
+	return matches[2], nil
 }
 
 func (s *SocialAzureAD) retrieveJWKS(client *http.Client) (*jose.JSONWebKeySet, error) {


### PR DESCRIPTION
Updates regex for tenant ID parsing to support .us domains in addition to .com domains for Azure AD.

Fixes #71252

**What is this feature?**

Allows for Azure AD URLs with domains that end in ".us" in addition to ".com" to support US Gov Azure deployments.

**Why do we need this feature?**

Fixes a bug that prevents groups using US Gov Azure from integrating Grafana to the [azure.read] Auth scheme.

**Who is this feature for?**

US Gov Azure organizations.

**Which issue(s) does this PR fix?**:

Fixes: #71252

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
