### PR TITLE
elastic: refactor: better metric-filtering

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -50,8 +50,10 @@ const getTypeOptions = (
     Object.entries(metricAggregationConfig)
       .filter(([_, config]) => config.impliedQueryType === 'metrics')
       // Only showing metrics type supported by the version of ES.
-      // if we cannot determine the version, we assume it is suitable.
-      .filter(([_, { versionRange = '*' }]) => (esVersion != null ? satisfies(esVersion, versionRange) : true))
+      // we only check the item, if both the following are true:
+      // - we have a working database version number
+      // - the item specifies a required versionRange
+      .filter(([_, { versionRange }]) => (esVersion != null && versionRange != null) ? satisfies(esVersion, versionRange) : true))
       // Filtering out Pipeline Aggregations if there's no basic metric selected before
       .filter(([_, config]) => includePipelineAggregations || !config.isPipelineAgg)
       .map(([key, { label }]) => ({


### PR DESCRIPTION
the current filter-metric-options-based-ony-db-version is a little more error prone than i would prefer:
- it will check every item if it satisfies the given db-version, substituting `*` for the `versionRange` for items without a `versionRange`.

this means, if we get a "strange" db-version, it may reject even the `*`. (i do not know if this can happen in reality).

the code in this PR changes the filtering, so that items without a `versionRange` are automatically accepted.