### PR TITLE
Alerting: Support spaces in alert names for creating silence links

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../plugins/datasource/alertmanager/types';
 import { matcherToOperator } from '../utils/alertmanager';
 import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { wrapWithQuotes } from '../utils/misc';
 
 import { alertingApi } from './alertingApi';
 
@@ -39,7 +40,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
         // TODO Add support for active, silenced, inhibited, unprocessed filters
         const filterMatchers = filter?.matchers
           ?.filter((matcher) => matcher.name && matcher.value)
-          .map((matcher) => `${matcher.name}${matcherToOperator(matcher)}${matcher.value}`);
+          .map((matcher) => `${matcher.name}${matcherToOperator(matcher)}${wrapWithQuotes(matcher.value)}`);
 
         const { silenced, inhibited, unprocessed, active } = filter || {};
 

--- a/public/app/features/alerting/unified/utils/alertmanager.test.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.test.ts
@@ -27,7 +27,7 @@ describe('Alertmanager utils', () => {
       });
       expect(parseMatcher('foo!~ bar')).toEqual<Matcher>({
         name: 'foo',
-        value: 'bar',
+        value: ' bar',
         isRegex: true,
         isEqual: false,
       });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -12,7 +12,7 @@ const matcherOperators = [
 ];
 
 export function parseMatcher(matcher: string): Matcher {
-  const trimmed = matcher.trim();
+  const trimmed = matcher;
   if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
     throw new Error(`PromQL matchers not supported yet, sorry! PromQL matcher found: ${trimmed}`);
   }
@@ -26,7 +26,7 @@ export function parseMatcher(matcher: string): Matcher {
   }
   const [operator, idx] = operatorsFound[0];
   const name = trimmed.slice(0, idx).trim();
-  const value = trimmed.slice(idx + operator.length).trim();
+  const value = trimmed.slice(idx + operator.length);
   if (!name) {
     throw new Error(`Invalid matcher: ${trimmed}`);
   }
@@ -41,7 +41,7 @@ export function parseMatcher(matcher: string): Matcher {
 
 // Parses a list of entries like like "['foo=bar', 'baz=~bad*']" into SilenceMatcher[]
 export function parseQueryParamMatchers(matcherPairs: string[]): Matcher[] {
-  const parsedMatchers = matcherPairs.filter((x) => !!x.trim()).map((x) => parseMatcher(x.trim()));
+  const parsedMatchers = matcherPairs.filter((x) => !!x.trim()).map((x) => parseMatcher(x));
 
   // Due to migration, old alert rules might have a duplicated alertname label
   // To handle that case want to filter out duplicates and make sure there are only unique labels

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -12,23 +12,22 @@ const matcherOperators = [
 ];
 
 export function parseMatcher(matcher: string): Matcher {
-  const trimmed = matcher;
-  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-    throw new Error(`PromQL matchers not supported yet, sorry! PromQL matcher found: ${trimmed}`);
+  if (matcher.startsWith('{') && matcher.endsWith('}')) {
+    throw new Error(`PromQL matchers not supported yet, sorry! PromQL matcher found: ${matcher}`);
   }
   const operatorsFound = matcherOperators
-    .map((op): [MatcherOperator, number] => [op, trimmed.indexOf(op)])
+    .map((op): [MatcherOperator, number] => [op, matcher.indexOf(op)])
     .filter(([_, idx]) => idx > -1)
     .sort((a, b) => a[1] - b[1]);
 
   if (!operatorsFound.length) {
-    throw new Error(`Invalid matcher: ${trimmed}`);
+    throw new Error(`Invalid matcher: ${matcher}`);
   }
   const [operator, idx] = operatorsFound[0];
-  const name = trimmed.slice(0, idx).trim();
-  const value = trimmed.slice(idx + operator.length);
+  const name = matcher.slice(0, idx).trim();
+  const value = matcher.slice(idx + operator.length);
   if (!name) {
-    throw new Error(`Invalid matcher: ${trimmed}`);
+    throw new Error(`Invalid matcher: ${matcher}`);
   }
 
   return {

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -1,4 +1,4 @@
-import { sortAlerts, wrapWithQuotes } from 'app/features/alerting/unified/utils/misc';
+import { sortAlerts, wrapWithQuotes, escapeQuotes } from 'app/features/alerting/unified/utils/misc';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
 import { Alert } from 'app/types/unified-alerting';
 import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
@@ -35,9 +35,19 @@ function permute(inputArray: any[]): any[] {
 
 describe('wrapWithQuotes', () => {
   it('should work as expected', () => {
-    expect(wrapWithQuotes('"hello, world!"')).toBe('"hello, world!"');
+    expect(wrapWithQuotes('"hello, world!"')).toBe('\\"hello, world!\\"');
     expect(wrapWithQuotes('hello, world!')).toBe('"hello, world!"');
     expect(wrapWithQuotes('hello, "world"!')).toBe('"hello, \\"world\\"!"');
+    expect(wrapWithQuotes('"hello""')).toBe('\\"hello\\"\\"');
+  });
+});
+
+describe('escapeQuotes', () => {
+  it('should escape all quotes', () => {
+    expect(escapeQuotes('"hello, world!"')).toBe('\\"hello, world!\\"');
+    expect(escapeQuotes('hello, world!')).toBe('hello, world!');
+    expect(escapeQuotes('hello, "world"!')).toBe('hello, \\"world\\"!');
+    expect(escapeQuotes('hello"')).toBe('hello\\"');
   });
 });
 

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -34,7 +34,7 @@ function permute(inputArray: any[]): any[] {
 }
 
 describe('wrapWithQuotes', () => {
-  it('should not wrap already wrapper input', () => {
+  it('should work as expected', () => {
     expect(wrapWithQuotes('"hello, world!"')).toBe('"hello, world!"');
     expect(wrapWithQuotes('hello, world!')).toBe('"hello, world!"');
     expect(wrapWithQuotes('hello, "world"!')).toBe('"hello, \\"world\\"!"');

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -1,4 +1,4 @@
-import { sortAlerts } from 'app/features/alerting/unified/utils/misc';
+import { sortAlerts, wrapWithQuotes } from 'app/features/alerting/unified/utils/misc';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
 import { Alert } from 'app/types/unified-alerting';
 import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
@@ -32,6 +32,14 @@ function permute(inputArray: any[]): any[] {
     );
   }, []);
 }
+
+describe('wrapWithQuotes', () => {
+  it('should not wrap already wrapper input', () => {
+    expect(wrapWithQuotes('"hello, world!"')).toBe('"hello, world!"');
+    expect(wrapWithQuotes('hello, world!')).toBe('"hello, world!"');
+    expect(wrapWithQuotes('hello, "world"!')).toBe('"hello, \\"world\\"!"');
+  });
+});
 
 describe('Unified Altering misc', () => {
   describe('sortAlerts', () => {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -1,4 +1,4 @@
-import { mapValues, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 import { UrlQueryMap, Labels, DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { alertInstanceKey } from 'app/features/alerting/unified/utils/rules';
@@ -112,8 +112,8 @@ export function wrapWithQuotes(input: string) {
 export function makeRuleBasedSilenceLink(alertManagerSourceName: string, rule: CombinedRule) {
   // we wrap the name of the alert with quotes since it might contain starting and trailing spaces
   const labels: Labels = {
-    alertname: wrapWithQuotes(rule.name),
-    ...mapValues(rule.labels, wrapWithQuotes),
+    alertname: rule.name,
+    ...rule.labels,
   };
 
   return makeLabelBasedSilenceLink(alertManagerSourceName, labels);

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -102,9 +102,17 @@ export function makeAMLink(path: string, alertManagerName?: string, options?: UR
   return `${path}?${search.toString()}`;
 }
 
+const escapeQuotes = (input: string) => `"${input.replace(/\"/g, '\\"')}"`;
+
+export function wrapWithQuotes(input: string) {
+  const alreadyWrapped = input.startsWith('"') && input.endsWith('"');
+  return alreadyWrapped ? input : escapeQuotes(input);
+}
+
 export function makeRuleBasedSilenceLink(alertManagerSourceName: string, rule: CombinedRule) {
+  // we wrap the name of the alert with quotes since it might contain starting and trailing spaces
   const labels: Labels = {
-    alertname: rule.name,
+    alertname: wrapWithQuotes(rule.name),
     ...rule.labels,
   };
 

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import { mapValues, sortBy } from 'lodash';
 
 import { UrlQueryMap, Labels, DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { alertInstanceKey } from 'app/features/alerting/unified/utils/rules';
@@ -102,18 +102,18 @@ export function makeAMLink(path: string, alertManagerName?: string, options?: UR
   return `${path}?${search.toString()}`;
 }
 
-const escapeQuotes = (input: string) => `"${input.replace(/\"/g, '\\"')}"`;
+export const escapeQuotes = (input: string) => input.replace(/\"/g, '\\"');
 
 export function wrapWithQuotes(input: string) {
   const alreadyWrapped = input.startsWith('"') && input.endsWith('"');
-  return alreadyWrapped ? input : escapeQuotes(input);
+  return alreadyWrapped ? escapeQuotes(input) : `"${escapeQuotes(input)}"`;
 }
 
 export function makeRuleBasedSilenceLink(alertManagerSourceName: string, rule: CombinedRule) {
   // we wrap the name of the alert with quotes since it might contain starting and trailing spaces
   const labels: Labels = {
     alertname: wrapWithQuotes(rule.name),
-    ...rule.labels,
+    ...mapValues(rule.labels, wrapWithQuotes),
   };
 
   return makeLabelBasedSilenceLink(alertManagerSourceName, labels);


### PR DESCRIPTION
A small PR that adds support for starting and trailing spaces in alert rule names by wrapping them in quotes when creating the link.

The added utility function can perhaps we used a bit more broadly in other places but decided to keep it close to where we call `makeRuleBasedSilenceLink` for now.

Tested for both alert rules with trailing spaces and alert rules with quotes in them.

Fixes #63645