### PR TITLE
Dashboard: Slider overlapping with right input field

### DIFF
--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -131,7 +131,7 @@ function getTextWidth(text: string, font: string): number | null {
 const getStylesSlider = (theme: GrafanaTheme2, width: number) => {
   return {
     numberInputWrapper: css`
-      margin-left: 10px;
+      margin-left: 24px;
       max-height: 32px;
       max-width: ${width}px;
       min-width: ${width}px;

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -131,7 +131,7 @@ function getTextWidth(text: string, font: string): number | null {
 const getStylesSlider = (theme: GrafanaTheme2, width: number) => {
   return {
     numberInputWrapper: css`
-      margin-left: 24px;
+      margin-left: ${theme.spacing(3)};
       max-height: 32px;
       max-width: ${width}px;
       min-width: ${width}px;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There is a slider component on the field config right-side component. The slider's top range number is overlapping with the right-standing input field.

Current view:
<img width="100" alt="Screenshot 2023-07-07 at 17 10 33" src="https://github.com/grafana/grafana/assets/1418924/6f72da33-be05-45e9-bc4b-51a52430842f">


Possible solution (align number by the right edge of slider):
<img width="99" alt="Screenshot 2023-07-07 at 17 13 24" src="https://github.com/grafana/grafana/assets/1418924/5461ba3f-4e07-4b58-ae36-befaa6dee049">

I decided to go a bit different way and just added left-margin based on [Grafana Labs Storybook](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-slider--with-marks). Works fine for me. I think in most case scenarios max value is 100 so it shouldn't be any overlapping.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #71220 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
