### PR TITLE
Elasticsearch: Fix using multiple indexes with comma separated string

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -207,7 +207,7 @@ func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchReque
 			header: map[string]interface{}{
 				"search_type":        "query_then_fetch",
 				"ignore_unavailable": true,
-				"index":              c.indices,
+				"index":              strings.Join(c.indices, ","),
 			},
 			body:     searchReq,
 			interval: searchReq.Interval,

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -96,7 +96,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		jBody, err := simplejson.NewJson(bodyBytes)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{"metrics-2018.05.15"}, jHeader.Get("index").MustStringArray())
+		assert.Equal(t, "metrics-2018.05.15", jHeader.Get("index").MustString())
 		assert.True(t, jHeader.Get("ignore_unavailable").MustBool(false))
 		assert.Equal(t, "query_then_fetch", jHeader.Get("search_type").MustString())
 		assert.Empty(t, jHeader.Get("max_concurrent_shard_requests"))

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -116,25 +116,25 @@ func TestClient_Index(t *testing.T) {
 		name                string
 		indexInDatasource   string
 		patternInDatasource string
-		indexInRequest      []string
+		indexInRequest      string
 	}{
 		{
 			name:                "empty string",
 			indexInDatasource:   "",
 			patternInDatasource: "",
-			indexInRequest:      []string{},
+			indexInRequest:      "",
 		},
 		{
 			name:                "single string",
 			indexInDatasource:   "logs-*",
 			patternInDatasource: "",
-			indexInRequest:      []string{"logs-*"},
+			indexInRequest:      "logs-*",
 		},
 		{
 			name:                "daily pattern",
 			indexInDatasource:   "[logs-]YYYY.MM.DD",
 			patternInDatasource: "Daily",
-			indexInRequest:      []string{"logs-2018.05.10", "logs-2018.05.11", "logs-2018.05.12"},
+			indexInRequest:      "logs-2018.05.10,logs-2018.05.11,logs-2018.05.12",
 		},
 	}
 
@@ -210,7 +210,7 @@ func TestClient_Index(t *testing.T) {
 			jHeader, err := simplejson.NewJson(headerBytes)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.indexInRequest, jHeader.Get("index").MustStringArray())
+			assert.Equal(t, test.indexInRequest, jHeader.Get("index").MustString())
 		})
 	}
 }

--- a/pkg/tsdb/elasticsearch/snapshot_test.go
+++ b/pkg/tsdb/elasticsearch/snapshot_test.go
@@ -82,7 +82,7 @@ func TestRequestSnapshots(t *testing.T) {
 	queryHeader := []byte(`
 	{
 		"ignore_unavailable": true,
-		"index": ["testdb-2022.11.14"],
+		"index": "testdb-2022.11.14",
 		"search_type": "query_then_fetch"
 	}
 	`)


### PR DESCRIPTION
Reverts grafana/grafana#67276

the PR introduced the bug https://github.com/grafana/grafana/issues/71092 , so we revert it.