### PR TITLE
Docs: Add note for setting root_url in case of NGINX TLS termination

### DIFF
--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -127,7 +127,9 @@ If your Grafana configuration does not set `serve_from_sub_path` to true then yo
  rewrite  ^/grafana/(.*)  /$1 break;
 ```
 
-> If Grafana is being served from behind a NGINX proxy with TLS termination enabled, then the `root_url` should be set accordingly. For example, if Grafana is being served from `https://example.com/grafana` then the `root_url` should be set to `https://example.com/grafana/` or `https://%(domain)s/grafana/` (and the corresponding `domain` should be set to `example.com`) in the `server` section of the Grafana configuration file. The `protocol` setting should be set to `http`, because the TLS handshake is being handled by NGINX.
+{{% admonition type="note" %}}
+If Grafana is being served from behind a NGINX proxy with TLS termination enabled, then the `root_url` should be set accordingly. For example, if Grafana is being served from `https://example.com/grafana` then the `root_url` should be set to `https://example.com/grafana/` or `https://%(domain)s/grafana/` (and the corresponding `domain` should be set to `example.com`) in the `server` section of the Grafana configuration file. The `protocol` setting should be set to `http`, because the TLS handshake is being handled by NGINX.
+{{% /admonition %}}
 
 ## Configure HAProxy
 

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -127,6 +127,8 @@ If your Grafana configuration does not set `serve_from_sub_path` to true then yo
  rewrite  ^/grafana/(.*)  /$1 break;
 ```
 
+> If Grafana is being served from behind a NGINX proxy with TLS termination enabled, then the `root_url` should be set accordingly. For example, if Grafana is being served from `https://example.com/grafana` then the `root_url` should be set to `https://example.com/grafana/` or `https://%(domain)s/grafana/` (and the corresponding `domain` should be set to `example.com`) in the `server` section of the Grafana configuration file. The `protocol` setting should be set to `http`, because the TLS handshake is being handled by NGINX.
+
 ## Configure HAProxy
 
 To configure HAProxy to serve Grafana under a _sub path_:


### PR DESCRIPTION
**What is this feature?**
This PR adds a note to the `Configure NGINX` section for configuring the `root_url` parameter when TLS termination is configured on NGINX side.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #70304

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
