### PR TITLE
Alerting: (Chore/Instrumentation) Add traceID to logs with contextual logger

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -369,7 +369,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 	}
 
 	evaluate := func(ctx context.Context, f fingerprint, attempt int64, e *evaluation, span tracing.Span) {
-		logger := logger.New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt)
+		logger := logger.New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt).FromContext(ctx)
 		start := sch.clock.Now()
 
 		evalCtx := eval.NewContext(ctx, SchedulerUserFor(e.rule.OrgID))


### PR DESCRIPTION
**What is this feature?**

Changes the logger in the alerting scheduler to use the context, and this makes it so the logs will show an associated traceID. Now it will look like:

```ERROR[07-10|10:59:55] Failed to evaluate rule                  logger=ngalert.scheduler rule_uid=tMr3ZIA4z org_id=1 version=1 fingerprint=67bfba14ea0e51d9 attempt=0 now=2023-07-10T10:59:50-04:00 traceID=ec2dc2b1bb0fb1fac98b020533e572bd rule_uid=tMr3ZIA4z org_id=1 error="failed to execute query A: bad_data: 1:1: parse error: unexpected \",\"" duration=4.650332ms```

See https://github.com/grafana/grafana/blob/main/contribute/backend/instrumentation.md#contextual-logging

Related: https://github.com/grafana/grafana/issues/55196
Reference: https://github.com/grafana/grafana/pull/61057

Note: Want to backport this so we can troubleshoot some issues ASAP
