### PR TITLE
Alerting: Fix Alertmanager change detection for receivers with secure settings

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -236,6 +236,7 @@ func TestAlertmanagerConfig(t *testing.T) {
 		getResponse := sut.RouteGetAlertingConfig(&rc)
 		require.Equal(t, 200, getResponse.Status())
 		postable, err := notifier.Load(getResponse.Body())
+		require.NoError(t, err)
 
 		r = sut.RoutePostAlertingConfig(&rc, *postable)
 		require.Equal(t, 202, r.Status())

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -174,7 +174,7 @@ func TestAlertmanagerConfig(t *testing.T) {
 				OrgID: 12,
 			},
 		}
-		request := createAmConfigRequest(t)
+		request := createAmConfigRequest(t, validConfig)
 
 		response := sut.RoutePostAlertingConfig(&rc, request)
 
@@ -191,7 +191,7 @@ func TestAlertmanagerConfig(t *testing.T) {
 				OrgID: 1,
 			},
 		}
-		request := createAmConfigRequest(t)
+		request := createAmConfigRequest(t, validConfig)
 
 		response := sut.RoutePostAlertingConfig(&rc, request)
 
@@ -208,11 +208,42 @@ func TestAlertmanagerConfig(t *testing.T) {
 				OrgID: 3, // Org 3 was initialized with broken config.
 			},
 		}
-		request := createAmConfigRequest(t)
+		request := createAmConfigRequest(t, validConfig)
 
 		response := sut.RoutePostAlertingConfig(&rc, request)
 
 		require.Equal(t, 202, response.Status())
+	})
+
+	t.Run("assert config hash doesn't change when sending RouteGetAlertingConfig back to RoutePostAlertingConfig", func(t *testing.T) {
+		rc := contextmodel.ReqContext{
+			Context: &web.Context{
+				Req: &http.Request{},
+			},
+			SignedInUser: &user.SignedInUser{
+				OrgID: 1,
+			},
+		}
+		request := createAmConfigRequest(t, validConfigWithSecureSetting)
+
+		r := sut.RoutePostAlertingConfig(&rc, request)
+		require.Equal(t, 202, r.Status())
+
+		am, err := sut.mam.AlertmanagerFor(1)
+		require.NoError(t, err)
+		hash := am.Base.ConfigHash()
+
+		getResponse := sut.RouteGetAlertingConfig(&rc)
+		require.Equal(t, 200, getResponse.Status())
+		postable, err := notifier.Load(getResponse.Body())
+
+		r = sut.RoutePostAlertingConfig(&rc, *postable)
+		require.Equal(t, 202, r.Status())
+
+		am, err = sut.mam.AlertmanagerFor(1)
+		require.NoError(t, err)
+		newHash := am.Base.ConfigHash()
+		require.Equal(t, hash, newHash)
 	})
 
 	t.Run("when objects are not provisioned", func(t *testing.T) {
@@ -259,7 +290,7 @@ func TestAlertmanagerConfig(t *testing.T) {
 		t.Run("contact point from GET config has expected provenance", func(t *testing.T) {
 			sut := createSut(t)
 			rc := createRequestCtxInOrg(1)
-			request := createAmConfigRequest(t)
+			request := createAmConfigRequest(t, validConfig)
 
 			_ = sut.RoutePostAlertingConfig(rc, request)
 
@@ -609,11 +640,11 @@ func createSut(t *testing.T) AlertmanagerSrv {
 	}
 }
 
-func createAmConfigRequest(t *testing.T) apimodels.PostableUserConfig {
+func createAmConfigRequest(t *testing.T, config string) apimodels.PostableUserConfig {
 	t.Helper()
 
 	request := apimodels.PostableUserConfig{}
-	err := request.UnmarshalJSON([]byte(validConfig))
+	err := request.UnmarshalJSON([]byte(config))
 	require.NoError(t, err)
 
 	return request
@@ -669,6 +700,41 @@ var validConfig = `{
 				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
+				}
+			}]
+		}]
+	}
+}
+`
+
+var validConfigWithSecureSetting = `{
+	"template_files": {
+		"a": "template"
+	},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "grafana-default-email"
+		},
+		"receivers": [{
+			"name": "grafana-default-email",
+			"grafana_managed_receiver_configs": [{
+				"uid": "",
+				"name": "email receiver",
+				"type": "email",
+				"isDefault": true,
+				"settings": {
+					"addresses": "<example@email.com>"
+				}
+			}]},
+			{
+			"name": "slack",
+			"grafana_managed_receiver_configs": [{
+				"uid": "",
+				"name": "slack1",
+				"type": "slack",
+				"settings": {"text": "slack text"},
+				"secureSettings": {
+					"url": "secure url"
 				}
 			}]
 		}]

--- a/pkg/services/ngalert/notifier/crypto.go
+++ b/pkg/services/ngalert/notifier/crypto.go
@@ -74,19 +74,13 @@ func (c *alertmanagerCrypto) LoadSecureSettings(ctx context.Context, orgId int64
 
 			// Frontend sends only the secure settings that have to be updated
 			// Therefore we have to copy from the last configuration only those secure settings not included in the request
-			for key := range cgmr.SecureSettings {
+			for key, encryptedValue := range cgmr.SecureSettings {
 				_, ok := gr.SecureSettings[key]
 				if !ok {
-					decryptedValue, err := c.getDecryptedSecret(cgmr, key)
-					if err != nil {
-						return fmt.Errorf("failed to decrypt stored secure setting: %s: %w", key, err)
-					}
-
 					if receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings == nil {
 						receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings = make(map[string]string, len(cgmr.SecureSettings))
 					}
-
-					receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key] = decryptedValue
+					receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key] = encryptedValue
 				}
 			}
 		}

--- a/public/app/features/alerting/unified/utils/receiver-form.test.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.test.ts
@@ -1,4 +1,4 @@
-import { omitEmptyValues } from './receiver-form';
+import { omitEmptyValues, omitEmptyUnlessExisting } from './receiver-form';
 
 describe('Receiver form utils', () => {
   describe('omitEmptyStringValues', () => {
@@ -39,6 +39,28 @@ describe('Receiver form utils', () => {
       };
 
       expect(omitEmptyValues(original)).toEqual(expected);
+    });
+  });
+  describe('omitEmptyUnlessExisting', () => {
+    it('should omit empty strings if no entry in existing', () => {
+      const existing = {
+        five_keep: true,
+      };
+      const original = {
+        one: 'two',
+        two_remove: '',
+        three: 0,
+        four_remove: null,
+        five_keep: '',
+      };
+
+      const expected = {
+        one: 'two',
+        three: 0,
+        five_keep: '',
+      };
+
+      expect(omitEmptyUnlessExisting(original, existing)).toEqual(expected);
     });
   });
 });

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -1,5 +1,4 @@
-import { isArray, isEmpty, isNil, isPlainObject, omitBy } from 'lodash';
-import { string } from 'yargs';
+import { isArray, isNil, omitBy } from 'lodash';
 
 import {
   AlertManagerCortexConfig,

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -221,7 +221,7 @@ export function formChannelValuesToGrafanaChannelConfig(
       ...(existing && existing.type === values.type ? existing.settings ?? {} : {}),
       ...(values.settings ?? {}),
     }),
-    secureSettings: values.secureSettings ?? {},
+    secureSettings: omitEmptyUnlessExisting({ ...(values.secureSettings ?? {}) }, existing?.secureFields ?? {}),
     type: values.type,
     name,
     disableResolveMessage:
@@ -251,4 +251,21 @@ export function omitEmptyValues<T>(obj: T): T {
     });
   }
   return obj;
+}
+
+// Will remove empty ('', null, undefined) object properties unless they were previously defined.
+// existing is a map of property names that were previously defined.
+export function omitEmptyUnlessExisting<T>(
+  settings: Record<string, T>,
+  existing: Record<string, boolean>
+): Record<string, T> {
+  if (settings === null) {
+    return settings;
+  }
+  Object.entries(settings).forEach(([key, value]) => {
+    if ((value === '' || value === null || value === undefined) && !existing[key]) {
+      delete settings[key];
+    }
+  });
+  return settings;
 }


### PR DESCRIPTION
### Context
Previously, `ApplyAlertmanagerConfiguration` would decrypt and re-encrypt all secure settings. However, this caused re-encrypted secure settings to be included in the raw configuration when applied to the embedded alertmanager, resulting in changes to the hash. Consequently, even if no actual modifications were made, saving any alertmanager configuration triggered an apply/restart and created a new historical entry in the database.

### Backend
To address the issue, this modifies `ApplyAlertmanagerConfiguration`, which is called by POST `api/alertmanager/grafana/config/api/v1/alerts`, to decrypt and re-encrypt only new and updated secure settings. Unchanged secure settings are loaded directly from the database without alteration.

We determine whether secure settings have changed based on the following (already in-use) assumption: Only new or updated secure settings are provided via the POST `api/alertmanager/grafana/config/api/v1/alerts` request, while existing unchanged settings are omitted.

### Frontend
Previously, when saving a grafana-managed contact point, empty string values were transmitted for all unset secure settings. This would render the changes above less effective for notifiers that have optional secure fields since we would re-encrypt the empty string every time.

To address this, we now exclude empty `('', null, undefined)` secure settings, unless there was a pre-existing entry in `secureFields` for that specific setting. In essence, this means we only transmit an empty secure setting if a previously configured value was cleared.

**Which issue(s) does this PR fix?**:

Fixes #71219