### PR TITLE
Panel Plugins: Change array methods from read-only to writable

### DIFF
--- a/packages/grafana-data/src/types/vector.ts
+++ b/packages/grafana-data/src/types/vector.ts
@@ -19,33 +19,33 @@ if (!Object.getOwnPropertyDescriptor(Array.prototype, 'toArray')) {
       value: function (idx: number): any {
         return (this as any)[idx];
       },
-      writable: false,
+      writable: true,
       enumerable: false,
-      configurable: false,
+      configurable: true,
     },
     set: {
       value: function (idx: number, value: any) {
         (this as any)[idx] = value;
       },
-      writable: false,
+      writable: true,
       enumerable: false,
-      configurable: false,
+      configurable: true,
     },
     add: {
       value: function (value: any) {
         (this as any).push(value);
       },
-      writable: false,
+      writable: true,
       enumerable: false,
-      configurable: false,
+      configurable: true,
     },
     toArray: {
       value: function () {
         return this;
       },
-      writable: false,
+      writable: true,
       enumerable: false,
-      configurable: false,
+      configurable: true,
     },
   });
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixing regression issue by enabling property overwriting in JavaScript Arrays interface. More description of the problem in the issue - [https://github.com/grafana/grafana/issues/71314]( https://github.com/grafana/grafana/issues/71314)

**Which issue(s) does this PR fix?**:

Fixes [#71314](https://github.com/grafana/grafana/issues/71314)

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
