### PR TITLE
LogContext: Fix a bug where multiple logs with similar nanosecond timestamps were loaded too often

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -170,33 +170,45 @@ async function sendOldLogs() {
   const delays = calculateDelays(DAYS * POINTS_PER_DAY);
   const timeRange = DAYS * 24 * 60 * 60 * 1000;
   let timestampMs = new Date().getTime() - timeRange;
-  for(let i =0; i < delays.length; i++ ) { // i cannot do a forEach because of the `await` inside
+  for (let i = 0; i < delays.length; i++) { // i cannot do a forEach because of the `await` inside
     const delay = delays[i];
     timestampMs += Math.trunc(delay * timeRange);
     const timestampNs = `${timestampMs}${getRandomNanosecPart()}`;
     globalCounter += 1;
     const item = getRandomLogItem(globalCounter)
-    await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'old', place:'moon', ...sharedLabels});
-    await lokiSendLogLine(timestampNs, logFmtLine(item), {age:'old', place:'luna', ...sharedLabels});
+    await lokiSendLogLine(timestampNs, JSON.stringify(item), { age: 'old', place: 'moon', ...sharedLabels });
+    await lokiSendLogLine(timestampNs, logFmtLine(item), { age: 'old', place: 'luna', ...sharedLabels });
   };
 }
 
 async function sendNewLogs() {
-  while(true) {
+  while (true) {
     globalCounter += 1;
     const nowMs = new Date().getTime();
-    const timestampNs = `${nowMs}${getRandomNanosecPart()}`;
+    const rnd = Math.random()
+    const ns = Math.trunc(rnd * 1000000).toString().padStart(6, '0');
+    const ns1 = Math.trunc((rnd * 1000000)+1).toString().padStart(6, '0');
+    const ns2 = Math.trunc((rnd * 1000000)+2).toString().padStart(6, '0');
+
+    const timestampNs = `${nowMs}${ns}`;
+    const timestampNs1 = `${nowMs}${ns1}`;
+    const timestampNs2 = `${nowMs}${ns2}`;
+
     const item = getRandomLogItem(globalCounter)
-    await lokiSendLogLine(timestampNs, JSON.stringify(item), {age:'new', place:'moon', ...sharedLabels});
-    await lokiSendLogLine(timestampNs, logFmtLine(item), {age:'new', place:'luna', ...sharedLabels});
-    const sleepDuration  = 200 + Math.random() * 800; // between 0.2 and 1 seconds
+
+    await lokiSendLogLine(timestampNs, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
+    await lokiSendLogLine(timestampNs1, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
+    await lokiSendLogLine(timestampNs2, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
+    
+    const sleepDuration = 200 + Math.random() * 800; // between 0.2 and 1 seconds
     await sleep(sleepDuration);
+    process.exit(0);
   }
 }
 
 async function main() {
   // we generate both old-logs and new-logs at the same time
-  await Promise.all([sendOldLogs(), sendNewLogs()])
+  await Promise.all([sendNewLogs()])
 }
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -155,6 +155,10 @@ const getLoadMoreDirection = (place: Place, sortOrder: LogsSortOrder): LogRowCon
   return LogRowContextQueryDirection.Backward;
 };
 
+const containsRow = (rows: LogRowModel[], row: LogRowModel) => {
+  return rows.some((r) => r.entry === row.entry && r.timeEpochNs === row.timeEpochNs);
+};
+
 const PAGE_SIZE = 50;
 
 export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps> = ({
@@ -269,7 +273,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     }
 
     const out = newRows.filter((r) => {
-      return r.timeEpochNs !== refRow.timeEpochNs || r.entry !== refRow.entry;
+      return !containsRow(allRows, r);
     });
 
     return out;


### PR DESCRIPTION
**What is this feature?**
In some occasions and due to the fact that requests in Grafana are based on miliseconds, Loki will return the same log liens as already present in the LogContext component. For such cases it is not enough to only compare the ref-logline but we would need to filter out all logs that are already present.

**Special notes for your reviewer:**

1. I will remove the `data.js` change after review, but that should help you create the edge case.
2. Query logs with `{place="moon",time="ns"} | line_format "{{__timestamp__}}"`

Without the fix:

https://github.com/grafana/grafana/assets/8092184/eef238cb-80bd-4c02-91c6-297e00fb7f5e

With the fix:

https://github.com/grafana/grafana/assets/8092184/9fcf7c4e-f4bd-4ea5-92a4-0067be51b9ca

