### PR TITLE
Logs: Fix nanosecond partition in log context

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -194,7 +194,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'time',
           type: FieldType.time,
-          values: [1689052469935, 1689052469935],
+          values: [1, 1],
         },
         {
           name: 'message',
@@ -204,7 +204,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'tsNs',
           type: FieldType.string,
-          values: ['1689052469935083353', '1689052469935083354'],
+          values: ['1', '2'],
         },
       ],
     });
@@ -213,7 +213,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'time',
           type: FieldType.time,
-          values: [1689052469935],
+          values: [1],
         },
         {
           name: 'message',
@@ -223,7 +223,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'tsNs',
           type: FieldType.string,
-          values: ['1689052469935083354'],
+          values: ['2'],
         },
       ],
     });
@@ -232,7 +232,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'time',
           type: FieldType.time,
-          values: [1689052469935, 1689052469935],
+          values: [1, 1],
         },
         {
           name: 'message',
@@ -242,7 +242,7 @@ describe('LogRowContextModal', () => {
         {
           name: 'tsNs',
           type: FieldType.string,
-          values: ['1689052469935083354', '1689052469935083355'],
+          values: ['2', '3'],
         },
       ],
     });
@@ -253,7 +253,7 @@ describe('LogRowContextModal', () => {
     const getRowContext = jest.fn().mockImplementation(async (_, options) => {
       uniqueRefIdCounter += 1;
       const refId = `refid_${uniqueRefIdCounter}`;
-      if (options.direction === LogRowContextQueryDirection.Forward) {
+      if (uniqueRefIdCounter === 2) {
         return {
           data: [
             {
@@ -262,7 +262,7 @@ describe('LogRowContextModal', () => {
             },
           ],
         };
-      } else {
+      } else if (uniqueRefIdCounter === 3) {
         return {
           data: [
             {
@@ -272,6 +272,7 @@ describe('LogRowContextModal', () => {
           ],
         };
       }
+      return { data: [] };
     });
 
     render(
@@ -284,8 +285,11 @@ describe('LogRowContextModal', () => {
         logsSortOrder={LogsSortOrder.Descending}
       />
     );
-    // there need to be 2 lines with that message. 1 in before, 1 in now, 1 in after
-    await waitFor(() => expect(screen.getAllByText('foo123').length).toBe(3));
+
+    // there need to be 3 lines with that message. 1 in before, 1 in now, 1 in after
+    await waitFor(() => {
+      expect(screen.getAllByText('foo123').length).toBe(3);
+    });
   });
 
   it('should show a split view button', async () => {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -189,7 +189,7 @@ describe('LogRowContextModal', () => {
   });
 
   it('should render 3 lines containing `foo123` with the same ms timestamp', async () => {
-    const dfBefore = createDataFrame({
+    const dfBeforeNs = createDataFrame({
       fields: [
         {
           name: 'time',
@@ -208,7 +208,7 @@ describe('LogRowContextModal', () => {
         },
       ],
     });
-    const dfNow = createDataFrame({
+    const dfNowNs = createDataFrame({
       fields: [
         {
           name: 'time',
@@ -227,7 +227,7 @@ describe('LogRowContextModal', () => {
         },
       ],
     });
-    const dfAfter = createDataFrame({
+    const dfAfterNs = createDataFrame({
       fields: [
         {
           name: 'time',
@@ -248,7 +248,7 @@ describe('LogRowContextModal', () => {
     });
 
     let uniqueRefIdCounter = 1;
-    const logs = dataFrameToLogsModel([dfNow]);
+    const logs = dataFrameToLogsModel([dfNowNs]);
     const row = logs.rows[0];
     const getRowContext = jest.fn().mockImplementation(async (_, options) => {
       uniqueRefIdCounter += 1;
@@ -258,7 +258,7 @@ describe('LogRowContextModal', () => {
           data: [
             {
               refId,
-              ...dfBefore,
+              ...dfBeforeNs,
             },
           ],
         };
@@ -267,7 +267,7 @@ describe('LogRowContextModal', () => {
           data: [
             {
               refId,
-              ...dfAfter,
+              ...dfAfterNs,
             },
           ],
         };

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -324,15 +324,16 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       const newAbove = logsSortOrder === LogsSortOrder.Ascending ? newer : older;
       const newBelow = logsSortOrder === LogsSortOrder.Ascending ? older : newer;
       if (currentGen === generationRef.current) {
-        setSection('above', () => ({
-          rows: sortLogRows([...newAbove, ...above.rows], logsSortOrder),
-          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
-        }));
-
-        setSection('below', () => ({
-          rows: sortLogRows([...below.rows, ...newBelow], logsSortOrder),
-          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
-        }));
+        setContext({
+          above: {
+            rows: sortLogRows([...newAbove, ...above.rows], logsSortOrder),
+            loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+          },
+          below: {
+            rows: sortLogRows([...below.rows, ...newBelow], logsSortOrder),
+            loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+          },
+        });
       }
     } catch {
       setSection(place, (section) => ({

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { partition } from 'lodash';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useAsync } from 'react-use';
 
@@ -253,11 +254,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
     generationRef.current += 1; // results from currently running loadMore calls will be ignored
   };
 
-  const loadMore = async (place: Place): Promise<LogRowModel[]> => {
-    const { below, above } = context;
-    // we consider all the currently existing rows, even the original row,
-    // this way this array of rows will never be empty
-    const allRows = [...above.rows, row, ...below.rows];
+  const loadMore = async (place: Place, allRows: LogRowModel[]): Promise<LogRowModel[]> => {
     const refRow = allRows.at(place === 'above' ? 0 : -1);
     if (refRow == null) {
       throw new Error('should never happen. the array always contains at least 1 item (the middle row)');
@@ -305,6 +302,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   };
 
   const maybeLoadMore = async (place: Place) => {
+    const { below, above } = context;
     const section = context[place];
     if (section.loadingState === LoadingState.Loading) {
       return;
@@ -317,11 +315,23 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
 
     const currentGen = generationRef.current;
     try {
-      const newRows = await loadMore(place);
+      // we consider all the currently existing rows, even the original row,
+      // this way this array of rows will never be empty
+      const allRows = [...above.rows, row, ...below.rows];
+
+      const newRows = await loadMore(place, allRows);
+      const [older, newer] = partition(newRows, (newRow) => newRow.timeEpochNs > row.timeEpochNs);
+      const newAbove = logsSortOrder === LogsSortOrder.Ascending ? newer : older;
+      const newBelow = logsSortOrder === LogsSortOrder.Ascending ? older : newer;
       if (currentGen === generationRef.current) {
-        setSection(place, (section) => ({
-          rows: place === 'above' ? [...newRows, ...section.rows] : [...section.rows, ...newRows],
-          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+        setSection('above', () => ({
+          rows: sortLogRows([...newAbove, ...above.rows], logsSortOrder),
+          loadingState: newAbove.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+        }));
+
+        setSection('below', () => ({
+          rows: sortLogRows([...below.rows, ...newBelow], logsSortOrder),
+          loadingState: newBelow.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
         }));
       }
     } catch {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -326,12 +326,12 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       if (currentGen === generationRef.current) {
         setSection('above', () => ({
           rows: sortLogRows([...newAbove, ...above.rows], logsSortOrder),
-          loadingState: newAbove.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
         }));
 
         setSection('below', () => ({
           rows: sortLogRows([...below.rows, ...newBelow], logsSortOrder),
-          loadingState: newBelow.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
+          loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
         }));
       }
     } catch {

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -323,17 +323,18 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       const [older, newer] = partition(newRows, (newRow) => newRow.timeEpochNs > row.timeEpochNs);
       const newAbove = logsSortOrder === LogsSortOrder.Ascending ? newer : older;
       const newBelow = logsSortOrder === LogsSortOrder.Ascending ? older : newer;
+
       if (currentGen === generationRef.current) {
-        setContext({
+        setContext((c) => ({
           above: {
-            rows: sortLogRows([...newAbove, ...above.rows], logsSortOrder),
+            rows: sortLogRows([...newAbove, ...c.above.rows], logsSortOrder),
             loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
           },
           below: {
-            rows: sortLogRows([...below.rows, ...newBelow], logsSortOrder),
+            rows: sortLogRows([...c.below.rows, ...newBelow], logsSortOrder),
             loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
           },
-        });
+        }));
       }
     } catch {
       setSection(place, (section) => ({


### PR DESCRIPTION
**What is this feature?**

Multiple log lines with the same ms but different ns might end up if the wrong section of LogContext with wrong ordering. This PR fixes it.

**Special notes for your reviewer:**

use the following `data.js`:

```
const http = require('http');

if (process.argv.length !== 3) {
  throw new Error('invalid command line: use node sendLogs.js LOKIC_BASE_URL');
}

const LOKI_BASE_URL = process.argv[2];

// helper function, do a http request
async function jsonRequest(data, method, url, expectedStatusCode) {
  return new Promise((resolve, reject) => {
    const req = http.request(
      {
        protocol: url.protocol,
        host: url.hostname,
        port: url.port,
        path: `${url.pathname}${url.search}`,
        method,
        headers: { 'content-type': 'application/json' },
      },
      (res) => {
        if (res.statusCode !== expectedStatusCode) {
          reject(new Error(`Invalid response: ${res.statusCode}`));
        } else {
          resolve();
        }
      }
    );

    req.on('error', (err) => reject(err));

    req.write(JSON.stringify(data));
    req.end();
  });
}

// helper function, choose a random element from an array
function chooseRandomElement(items) {
  const index = Math.trunc(Math.random() * items.length);
  return items[index];
}

// helper function, sleep for a duration
async function sleep(duration) {
  return new Promise((resolve) => {
    setTimeout(resolve, duration);
  });
}

async function lokiSendLogLine(timestampNs, line, tags) {
  const data = {
    streams: [
      {
        stream: tags,
        values: [[timestampNs, line]],
      },
    ],
  };

  const url = new URL(LOKI_BASE_URL);
  url.pathname = '/loki/api/v1/push';

  await jsonRequest(data, 'POST', url, 204);
}

function getSineValue(counter, loopLength) {
  // we try to make a sine-wave, where one full "loop" takes loopLength steps
  return Math.sin((Math.PI * 2 * counter) / loopLength);
}

function getRandomLogItem(counter) {
  const randomText = `${Math.trunc(Math.random() * 1000 * 1000 * 1000)}`;
  const maybeAnsiText = Math.random() < 0.5 ? 'with ANSI \u001b[31mpart of the text\u001b[0m' : '';
  return {
    _entry: `log text ${maybeAnsiText} [${randomText}]`,
    counter: counter.toString(),
    float: Math.random() > 0.2 ? (Math.trunc(100000 * Math.random())/1000).toString() : 'NaN',
    wave: getSineValue(counter, 20), // let's loop in 20 steps
    label: chooseRandomElement(['val1', 'val2', 'val3']),
    level: chooseRandomElement(['debug','info', 'info', 'info', 'info', 'warning', 'error', 'error']),
  };
}

function getRandomJSONLogLine(counter) {
  const item = getRandomLogItem(counter)
  return JSON.stringify(item)
}

const logFmtProblemRe = /[="\n]/;

// we are not really escaping things, we just check
// that we don't need to escape :-)
function escapeLogFmtKey(key) {
  if (logFmtProblemRe.test(key)) {
    throw new Error(`invalid logfmt-key: ${key}`)
  }
  return key;
}

function escapeLogFmtValue(value) {
  if (logFmtProblemRe.test(value)) {
    throw new Error(`invalid logfmt-value: ${value}`)
  }

  // we must handle the space-character because we have values with spaces :-(
  return value.indexOf(' ') === -1 ? value : `"${value}"`
}

function logFmtLine(item) {
  const parts = Object.entries(item).map(([k,v]) => {
    const key = escapeLogFmtKey(k.toString());
    const value = escapeLogFmtValue(v.toString());
    return `${key}=${value}`;
  });

  return parts.join(' ');
}

const DAYS = 7;
const POINTS_PER_DAY = 1000;

// it's important to have good "delays" between
// log-line-timestamps, because the "density" of log-lines
// is what gives the loki metric queries shape.
function calculateDelays(pointsCount) {
  const delays = [];
  for(let i=0;i<pointsCount; i+=1) {
    const delay = Math.random();
    delays.push(delay);
  }
  // now, i want to normalize the delays-array, so that the sum of
  // all it's items adds up to `1`.
  const allDelays = delays.reduce((acc, current) => acc + current, 0);

  for(let i=0;i<delays.length; i++) {
    delays[i] = delays[i] / allDelays
  }

  return delays;
}

function getRandomNanosecPart() {
  // we want to have cases with milliseconds-only, with microsec and nanosec.
  const mode = Math.random();

  if (mode < 0.333) {
    // only milisec precision
    return '000000';
  }

  if (mode < 0.666) {
    // microsec precision
    return Math.trunc(Math.random()*1000).toString().padStart(3, '0') + '000'
  }

  // nanosec precision
  return Math.trunc(Math.random()*1000000).toString().padStart(6, '0')
}

const sharedLabels = {
  source: 'data',
  instance: 'server\\1',
  re: 'one.two$three^four', // to test regex escaping
  job: '"grafana/data"'
};

let globalCounter = 0;

async function sendOldLogs() {
  const delays = calculateDelays(DAYS * POINTS_PER_DAY);
  const timeRange = DAYS * 24 * 60 * 60 * 1000;
  let timestampMs = new Date().getTime() - timeRange;
  for (let i = 0; i < delays.length; i++) { // i cannot do a forEach because of the `await` inside
    const delay = delays[i];
    timestampMs += Math.trunc(delay * timeRange);
    const timestampNs = `${timestampMs}${getRandomNanosecPart()}`;
    globalCounter += 1;
    const item = getRandomLogItem(globalCounter)
    await lokiSendLogLine(timestampNs, JSON.stringify(item), { age: 'old', place: 'moon', ...sharedLabels });
    await lokiSendLogLine(timestampNs, logFmtLine(item), { age: 'old', place: 'luna', ...sharedLabels });
  };
}

async function sendNewLogs() {
  while (true) {
    globalCounter += 1;
    const nowMs = new Date().getTime();
    const rnd = Math.random()
    const ns = Math.trunc(rnd * 1000000).toString().padStart(6, '0');
    const ns1 = Math.trunc((rnd * 1000000)+1).toString().padStart(6, '0');
    const ns2 = Math.trunc((rnd * 1000000)+2).toString().padStart(6, '0');

    const timestampNs = `${nowMs}${ns}`;
    const timestampNs1 = `${nowMs}${ns1}`;
    const timestampNs2 = `${nowMs}${ns2}`;

    const item = getRandomLogItem(globalCounter)

    await lokiSendLogLine(timestampNs, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
    await lokiSendLogLine(timestampNs1, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
    await lokiSendLogLine(timestampNs2, JSON.stringify(item), { time: 'ns', age: 'new', place: 'moon', ...sharedLabels });
    
    const sleepDuration = 200 + Math.random() * 800; // between 0.2 and 1 seconds
    await sleep(sleepDuration);
    process.exit(0);
  }
}

async function main() {
  // we generate both old-logs and new-logs at the same time
  await Promise.all([sendNewLogs()])
}

// when running in docker, we catch the needed stop-signal, to shutdown fast
process.on('SIGTERM', () => {
  console.log('shutdown requested');
  process.exit(0);
});

main();
```

Working:

https://github.com/grafana/grafana/assets/8092184/2ea1706c-b2fe-43bd-a894-8663fa32ad90



Not working:

https://github.com/grafana/grafana/assets/8092184/58c8520c-4eaa-4fbf-8359-ce8e9a8a1313

