### PR TITLE
[v10.0.x] CI: Provide a Drone promotion to build the build-container

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -30,6 +30,7 @@ load(
 )
 load(
     "scripts/drone/pipelines/ci_images.star",
+    "publish_ci_build_container_image_pipeline",
     "publish_ci_windows_test_image_pipeline",
 )
 load("scripts/drone/pipelines/github.star", "publish_github_pipeline")
@@ -66,6 +67,7 @@ def main(_ctx):
         version_branch_pipelines() +
         integration_test_pipelines() +
         publish_ci_windows_test_image_pipeline() +
+        publish_ci_build_container_image_pipeline() +
         cronjobs() +
         secrets()
     )

--- a/.drone.yml
+++ b/.drone.yml
@@ -6565,6 +6565,59 @@ volumes:
 ---
 clone:
   retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-ci-build-container-image
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - if [ -z "${BUILD_CONTAINER_VERSION}" ]; then echo Missing BUILD_CONTAINER_VERSION;
+    false; fi
+  image: alpine:3.17.1
+  name: validate-version
+- commands:
+  - printenv GCP_KEY > /tmp/key.json
+  - gcloud auth activate-service-account --key-file=/tmp/key.json
+  - gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz
+  environment:
+    GCP_KEY:
+      from_secret: gcp_download_build_container_assets_key
+  image: google/cloud-sdk:431.0.0
+  name: download-macos-sdk
+- commands:
+  - printenv DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker build -t "grafana/build-container:${BUILD_CONTAINER_VERSION}" ./scripts/build/ci-build
+  - docker push "grafana/build-container:${BUILD_CONTAINER_VERSION}"
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  image: google/cloud-sdk:431.0.0
+  name: build-and-publish
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+trigger:
+  event:
+  - promote
+  target:
+  - ci-build-container-image
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
 kind: pipeline
 name: scan-grafana/grafana:latest-image
 platform:
@@ -6813,6 +6866,12 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 get:
+  name: credentials.json
+  path: infra/data/ci/grafana/assets-downloader-build-container-service-account
+kind: secret
+name: gcp_download_build_container_assets_key
+---
+get:
   name: application_id
   path: infra/data/ci/datasources/cpp-azure-resourcemanager-credentials
 kind: secret
@@ -6957,6 +7016,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 733767a2830589f178ac52a8851189ed2671d4455c9a6c251acbc42741c402e2
+hmac: 66deda3e7f58ed026747b64d671147eaca082806747fc1b1dc7f56ec3864095e
 
 ...

--- a/scripts/drone/pipelines/ci_images.star
+++ b/scripts/drone/pipelines/ci_images.star
@@ -9,10 +9,15 @@ load(
 load(
     "scripts/drone/vault.star",
     "from_secret",
+    "gcp_download_build_container_assets_key",
 )
 load(
     "scripts/drone/utils/windows_images.star",
     "windows_images",
+)
+load(
+    "scripts/drone/utils/images.star",
+    "images",
 )
 
 def publish_ci_windows_test_image_pipeline():
@@ -63,5 +68,53 @@ def publish_ci_windows_test_image_pipeline():
     pl["clone"] = {
         "disable": True,
     }
+
+    return [pl]
+
+def publish_ci_build_container_image_pipeline():
+    trigger = {
+        "event": ["promote"],
+        "target": ["ci-build-container-image"],
+    }
+    pl = pipeline(
+        name = "publish-ci-build-container-image",
+        trigger = trigger,
+        edition = "",
+        steps = [
+            {
+                "name": "validate-version",
+                "image": images["alpine_image"],
+                "commands": [
+                    "if [ -z \"${BUILD_CONTAINER_VERSION}\" ]; then echo Missing BUILD_CONTAINER_VERSION; false; fi",
+                ],
+            },
+            {
+                "name": "download-macos-sdk",
+                "image": images["cloudsdk_image"],
+                "environment": {
+                    "GCP_KEY": from_secret(gcp_download_build_container_assets_key),
+                },
+                "commands": [
+                    "printenv GCP_KEY > /tmp/key.json",
+                    "gcloud auth activate-service-account --key-file=/tmp/key.json",
+                    "gsutil cp gs://grafana-private-downloads/MacOSX10.15.sdk.tar.xz ./scripts/build/ci-build/MacOSX10.15.sdk.tar.xz",
+                ],
+            },
+            {
+                "name": "build-and-publish",  # Consider splitting the build and the upload task.
+                "image": images["cloudsdk_image"],
+                "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+                "environment": {
+                    "DOCKER_USERNAME": from_secret("docker_username"),
+                    "DOCKER_PASSWORD": from_secret("docker_password"),
+                },
+                "commands": [
+                    "printenv DOCKER_PASSWORD | docker login -u \"$DOCKER_USERNAME\" --password-stdin",
+                    "docker build -t \"grafana/build-container:${BUILD_CONTAINER_VERSION}\" ./scripts/build/ci-build",
+                    "docker push \"grafana/build-container:${BUILD_CONTAINER_VERSION}\"",
+                ],
+            },
+        ],
+    )
 
     return [pl]

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -5,6 +5,7 @@ pull_secret = "dockerconfigjson"
 drone_token = "drone_token"
 prerelease_bucket = "prerelease_bucket"
 gcp_upload_artifacts_key = "gcp_upload_artifacts_key"
+gcp_download_build_container_assets_key = "gcp_download_build_container_assets_key"
 azure_sp_app_id = "azure_sp_app_id"
 azure_sp_app_pw = "azure_sp_app_pw"
 azure_tenant = "azure_tenant"
@@ -36,6 +37,11 @@ def secrets():
         vault_secret(
             gcp_upload_artifacts_key,
             "infra/data/ci/grafana/releng/artifacts-uploader-service-account",
+            "credentials.json",
+        ),
+        vault_secret(
+            gcp_download_build_container_assets_key,
+            "infra/data/ci/grafana/assets-downloader-build-container-service-account",
             "credentials.json",
         ),
         vault_secret(


### PR DESCRIPTION
Backport 7a9847e1962e09c8a098079d5d5a53ad97a9fcc0 from #71133

---

**What is this feature?**

Provides an option to build the build container through Drone to streamline our CI processes.

**Why do we need this feature?**

Faster and more reliable toolchain upgrades.

**Who is this feature for?**

Grafana maintainers.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-backend-platform-squad/issues/8
Fixes https://github.com/grafana/grafana-backend-platform-squad/issues/9

**Special notes for your reviewer:**

Missing pushing the build container to Docker Hub, that's tracked by https://github.com/grafana/grafana-backend-platform-squad/issues/9. Shouldn't be too hard to add it, but I'm having some minor problems with Docker Hub secret management when I tried it out in the CI sandbox.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
