### PR TITLE
Log rows performance: Render LogRowMenuCell on demand

### DIFF
--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -298,12 +298,12 @@ describe('Logs', () => {
       const row = screen.getAllByRole('row');
       await userEvent.hover(row[0]);
 
-      const linkButtons = row[1].querySelectorAll('button');
-      await userEvent.click(linkButtons[2]);
+      const linkButton = screen.getByLabelText('Copy shortlink');
+      await userEvent.click(linkButton);
 
       expect(reportInteraction).toHaveBeenCalledWith('grafana_explore_logs_permalink_clicked', {
         datasourceType: 'unknown',
-        logRowUid: '2',
+        logRowUid: '1',
         logRowLevel: 'debug',
       });
     });
@@ -315,11 +315,11 @@ describe('Logs', () => {
       const row = screen.getAllByRole('row');
       await userEvent.hover(row[0]);
 
-      const linkButtons = row[1].querySelectorAll('button');
-      await userEvent.click(linkButtons[2]);
+      const linkButton = screen.getByLabelText('Copy shortlink');
+      await userEvent.click(linkButton);
 
       expect(createAndCopyShortLink).toHaveBeenCalledWith(
-        'http://localhost:3000/explore?left=%7B%22datasource%22:%22%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22id%22%7D%7D%5D,%22range%22:%7B%22from%22:%222019-01-01T10:00:00.000Z%22,%22to%22:%222019-01-01T16:00:00.000Z%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22id%22:%222%22%7D%7D%7D'
+        'http://localhost:3000/explore?left=%7B%22datasource%22:%22%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22id%22%7D%7D%5D,%22range%22:%7B%22from%22:%222019-01-01T10:00:00.000Z%22,%22to%22:%222019-01-01T16:00:00.000Z%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22id%22:%221%22%7D%7D%7D'
       );
     });
   });

--- a/public/app/features/logs/components/LogRow.test.tsx
+++ b/public/app/features/logs/components/LogRow.test.tsx
@@ -110,4 +110,14 @@ describe('LogRow', () => {
       expect(scrollIntoView).not.toHaveBeenCalled();
     });
   });
+
+  it('should render the menu cell on mouse over', async () => {
+    setup({ showContextToggle: jest.fn().mockReturnValue(true) });
+
+    expect(screen.queryByLabelText('Show context')).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('test123'));
+
+    expect(screen.getByLabelText('Show context')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -50,6 +50,7 @@ interface Props extends Themeable2 {
 interface State {
   highlightBackround: boolean;
   showDetails: boolean;
+  mouseIsOver: boolean;
 }
 
 /**
@@ -63,6 +64,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   state: State = {
     highlightBackround: false,
     showDetails: false,
+    mouseIsOver: false,
   };
   logLineRef: React.RefObject<HTMLTableRowElement>;
 
@@ -108,12 +110,14 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   }
 
   onMouseEnter = () => {
+    this.setState({ mouseIsOver: true });
     if (this.props.onLogRowHover) {
       this.props.onLogRowHover(this.props.row);
     }
   };
 
   onMouseLeave = () => {
+    this.setState({ mouseIsOver: false });
     if (this.props.onLogRowHover) {
       this.props.onLogRowHover(undefined);
     }
@@ -249,6 +253,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               onPinLine={this.props.onPinLine}
               onUnpinLine={this.props.onUnpinLine}
               pinned={this.props.pinned}
+              mouseIsOver={this.state.mouseIsOver}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -15,6 +15,7 @@ interface Props {
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
   styles: LogRowStyles;
+  mouseIsOver: boolean;
 }
 
 export const LogRowMenuCell = React.memo(
@@ -28,6 +29,7 @@ export const LogRowMenuCell = React.memo(
     row,
     showContextToggle,
     styles,
+    mouseIsOver,
   }: Props) => {
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
     const onLogRowClick = useCallback((e: SyntheticEvent) => {
@@ -43,7 +45,7 @@ export const LogRowMenuCell = React.memo(
     const getLogText = useCallback(() => logText, [logText]);
     return (
       <>
-        {pinned && (
+        {pinned && !mouseIsOver && (
           // TODO: fix keyboard a11y
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
           <span className={styles.rowMenu} onClick={onLogRowClick}>
@@ -58,62 +60,64 @@ export const LogRowMenuCell = React.memo(
             />
           </span>
         )}
-        {/* TODO: fix keyboard a11y */}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <span className={styles.rowMenu} onClick={onLogRowClick}>
-          {shouldShowContextToggle && (
-            <IconButton
+        {mouseIsOver && (
+          // TODO: fix keyboard a11y
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+          <span className={styles.rowMenu} onClick={onLogRowClick}>
+            {shouldShowContextToggle && (
+              <IconButton
+                size="md"
+                name="gf-show-context"
+                onClick={onShowContextClick}
+                tooltip="Show context"
+                tooltipPlacement="top"
+                aria-label="Show context"
+              />
+            )}
+            <ClipboardButton
+              className={styles.copyLogButton}
+              icon="copy"
+              variant="secondary"
+              fill="text"
               size="md"
-              name="gf-show-context"
-              onClick={onShowContextClick}
-              tooltip="Show context"
+              getText={getLogText}
+              tooltip="Copy to clipboard"
               tooltipPlacement="top"
-              aria-label="Show context"
             />
-          )}
-          <ClipboardButton
-            className={styles.copyLogButton}
-            icon="copy"
-            variant="secondary"
-            fill="text"
-            size="md"
-            getText={getLogText}
-            tooltip="Copy to clipboard"
-            tooltipPlacement="top"
-          />
-          {pinned && onUnpinLine && (
-            <IconButton
-              className={styles.unPinButton}
-              size="md"
-              name="gf-pin"
-              onClick={() => onUnpinLine && onUnpinLine(row)}
-              tooltip="Unpin line"
-              tooltipPlacement="top"
-              aria-label="Unpin line"
-            />
-          )}
-          {!pinned && onPinLine && (
-            <IconButton
-              className={styles.unPinButton}
-              size="md"
-              name="gf-pin"
-              onClick={() => onPinLine && onPinLine(row)}
-              tooltip="Pin line"
-              tooltipPlacement="top"
-              aria-label="Pin line"
-            />
-          )}
-          {onPermalinkClick && row.uid && (
-            <IconButton
-              tooltip="Copy shortlink"
-              aria-label="Copy shortlink"
-              tooltipPlacement="top"
-              size="md"
-              name="share-alt"
-              onClick={() => onPermalinkClick(row)}
-            />
-          )}
-        </span>
+            {pinned && onUnpinLine && (
+              <IconButton
+                className={styles.unPinButton}
+                size="md"
+                name="gf-pin"
+                onClick={() => onUnpinLine && onUnpinLine(row)}
+                tooltip="Unpin line"
+                tooltipPlacement="top"
+                aria-label="Unpin line"
+              />
+            )}
+            {!pinned && onPinLine && (
+              <IconButton
+                className={styles.unPinButton}
+                size="md"
+                name="gf-pin"
+                onClick={() => onPinLine && onPinLine(row)}
+                tooltip="Pin line"
+                tooltipPlacement="top"
+                aria-label="Pin line"
+              />
+            )}
+            {onPermalinkClick && row.uid && (
+              <IconButton
+                tooltip="Copy shortlink"
+                aria-label="Copy shortlink"
+                tooltipPlacement="top"
+                size="md"
+                name="share-alt"
+                onClick={() => onPermalinkClick(row)}
+              />
+            )}
+          </span>
+        )}
       </>
     );
   }

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -46,7 +46,7 @@ export const LogRowMenuCell = React.memo(
     return (
       // TODO: fix keyboard a11y
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <span className={styles.rowMenu} onClick={onLogRowClick}>
+      <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick}>
         {pinned && !mouseIsOver && (
           <IconButton
             className={styles.unPinButton}

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -44,26 +44,22 @@ export const LogRowMenuCell = React.memo(
     );
     const getLogText = useCallback(() => logText, [logText]);
     return (
-      <>
+      // TODO: fix keyboard a11y
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <span className={styles.rowMenu} onClick={onLogRowClick}>
         {pinned && !mouseIsOver && (
-          // TODO: fix keyboard a11y
-          // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-          <span className={styles.rowMenu} onClick={onLogRowClick}>
-            <IconButton
-              className={styles.unPinButton}
-              size="md"
-              name="gf-pin"
-              onClick={() => onUnpinLine && onUnpinLine(row)}
-              tooltip="Unpin line"
-              tooltipPlacement="top"
-              aria-label="Unpin line"
-            />
-          </span>
+          <IconButton
+            className={styles.unPinButton}
+            size="md"
+            name="gf-pin"
+            onClick={() => onUnpinLine && onUnpinLine(row)}
+            tooltip="Unpin line"
+            tooltipPlacement="top"
+            aria-label="Unpin line"
+          />
         )}
         {mouseIsOver && (
-          // TODO: fix keyboard a11y
-          // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-          <span className={styles.rowMenu} onClick={onLogRowClick}>
+          <>
             {shouldShowContextToggle && (
               <IconButton
                 size="md"
@@ -116,9 +112,9 @@ export const LogRowMenuCell = React.memo(
                 onClick={() => onPermalinkClick(row)}
               />
             )}
-          </span>
+          </>
         )}
-      </>
+      </span>
     );
   }
 );

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -46,7 +46,7 @@ export const LogRowMenuCell = React.memo(
         {pinned && (
           // TODO: fix keyboard a11y
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-          <span className={`log-row-menu log-row-menu-visible ${styles.rowMenu}`} onClick={onLogRowClick}>
+          <span className={styles.rowMenu} onClick={onLogRowClick}>
             <IconButton
               className={styles.unPinButton}
               size="md"
@@ -60,7 +60,7 @@ export const LogRowMenuCell = React.memo(
         )}
         {/* TODO: fix keyboard a11y */}
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <span className={`log-row-menu ${styles.rowMenu} ${styles.hidden}`} onClick={onLogRowClick}>
+        <span className={styles.rowMenu} onClick={onLogRowClick}>
           {shouldShowContextToggle && (
             <IconButton
               size="md"

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -18,6 +18,7 @@ const setup = (propOverrides?: Partial<ComponentProps<typeof LogRowMessage>>, ro
     prettifyLogMessage: false,
     app: CoreApp.Explore,
     styles,
+    mouseIsOver: true,
     ...(propOverrides || {}),
   };
 

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -41,8 +41,9 @@ describe('LogRowMessage', () => {
   });
 
   describe('with show context', () => {
-    it('should show context button', () => {
+    it('should show context button', async () => {
       setup({ showContextToggle: () => true });
+      await userEvent.hover(screen.getByText('test123'));
       expect(screen.queryByLabelText('Show context')).toBeInTheDocument();
     });
 
@@ -54,6 +55,7 @@ describe('LogRowMessage', () => {
     it('should call `onOpenContext` with row on click', async () => {
       const showContextToggle = jest.fn();
       const props = setup({ showContextToggle: () => true, onOpenContext: showContextToggle });
+      await userEvent.hover(screen.getByText('test123'));
       const button = screen.getByLabelText('Show context');
 
       await userEvent.click(button);
@@ -63,8 +65,9 @@ describe('LogRowMessage', () => {
   });
 
   describe('with permalinking', () => {
-    it('should show permalinking button when `onPermalinkClick` is defined', () => {
+    it('should show permalinking button when `onPermalinkClick` is defined', async () => {
       setup({ onPermalinkClick: jest.fn() });
+      await userEvent.hover(screen.getByText('test123'));
       expect(screen.queryByLabelText('Copy shortlink')).toBeInTheDocument();
     });
 
@@ -76,6 +79,7 @@ describe('LogRowMessage', () => {
     it('should call `onPermalinkClick` with row on click', async () => {
       const permalinkClick = jest.fn();
       const props = setup({ onPermalinkClick: permalinkClick });
+      await userEvent.hover(screen.getByText('test123'));
       const button = screen.getByLabelText('Copy shortlink');
 
       await userEvent.click(button);
@@ -86,8 +90,9 @@ describe('LogRowMessage', () => {
 
   describe('with pinning', () => {
     describe('for `onPinLine`', () => {
-      it('should show pinning button when `onPinLine` is defined', () => {
+      it('should show pinning button when `onPinLine` is defined', async () => {
         setup({ onPinLine: jest.fn() });
+        await userEvent.hover(screen.getByText('test123'));
         expect(screen.queryByLabelText('Pin line')).toBeInTheDocument();
       });
 
@@ -104,6 +109,7 @@ describe('LogRowMessage', () => {
       it('should call `onPinLine` on click', async () => {
         const onPinLine = jest.fn();
         setup({ onPinLine });
+        await userEvent.hover(screen.getByText('test123'));
         const button = screen.getByLabelText('Pin line');
 
         await userEvent.click(button);
@@ -118,10 +124,10 @@ describe('LogRowMessage', () => {
         expect(screen.queryByLabelText('Unpin line')).not.toBeInTheDocument();
       });
 
-      it('should show 2 pinning buttons when `onUnpinLine` and `pinned` is defined', () => {
-        // we show 2 because we now have an "always visible" menu, and a "hover" menu
+      it('should show 1 pinning buttons when `onUnpinLine` and `pinned` is defined', () => {
+        // we show 1 because we now have an "always visible" menu, the others are rendered on mouse over
         setup({ onUnpinLine: jest.fn(), pinned: true });
-        expect(screen.queryAllByLabelText('Unpin line').length).toBe(2);
+        expect(screen.queryAllByLabelText('Unpin line').length).toBe(1);
       });
 
       it('should not show pinning button when `onUnpinLine` is not defined', () => {
@@ -132,7 +138,7 @@ describe('LogRowMessage', () => {
       it('should call `onUnpinLine` on click', async () => {
         const onUnpinLine = jest.fn();
         setup({ onUnpinLine, pinned: true });
-        const button = screen.getAllByLabelText('Unpin line')[0];
+        const button = screen.getByLabelText('Unpin line');
 
         await userEvent.click(button);
 

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
@@ -140,7 +140,8 @@ describe('LogRowMessage', () => {
         setup({ onUnpinLine, pinned: true });
         const button = screen.getByLabelText('Unpin line');
 
-        await userEvent.click(button);
+        // There's an issue with userEvent and this button, so we use fireEvent instead
+        fireEvent.click(button);
 
         expect(onUnpinLine).toHaveBeenCalledTimes(1);
       });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -84,7 +84,6 @@ export const LogRowMessage = React.memo((props: Props) => {
     setHover(false);
   }, []);
   const shouldShowMenu = useMemo(() => hover || pinned, [hover, pinned]);
-
   return (
     <>
       {
@@ -97,6 +96,8 @@ export const LogRowMessage = React.memo((props: Props) => {
             <LogMessage hasAnsi={hasAnsi} entry={restructuredEntry} highlights={row.searchWords} styles={styles} />
           </button>
         </div>
+      </td>
+      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
         {shouldShowMenu && (
           <LogRowMenuCell
             logText={restructuredEntry}

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { CoreApp, findHighlightChunksInText, LogRowModel } from '@grafana/data';
@@ -76,31 +76,39 @@ export const LogRowMessage = React.memo((props: Props) => {
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
+  const [hover, setHover] = useState(false);
+  const showMenu = useCallback(() => {
+    setHover(true);
+  }, []);
+  const hideMenu = useCallback(() => {
+    setHover(false);
+  }, []);
+
   return (
     <>
       {
         // When context is open, the position has to be NOT relative. // Setting the postion as inline-style to
         // overwrite the more sepecific style definition from `styles.logsRowMessage`.
       }
-      <td className={styles.logsRowMessage}>
+      <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
         <div className={wrapLogMessage ? styles.positionRelative : styles.horizontalScroll}>
           <button className={`${styles.logLine} ${styles.positionRelative}`}>
             <LogMessage hasAnsi={hasAnsi} entry={restructuredEntry} highlights={row.searchWords} styles={styles} />
           </button>
         </div>
-      </td>
-      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`}>
-        <LogRowMenuCell
-          logText={restructuredEntry}
-          row={row}
-          showContextToggle={showContextToggle}
-          onOpenContext={onOpenContext}
-          onPermalinkClick={onPermalinkClick}
-          onPinLine={onPinLine}
-          onUnpinLine={onUnpinLine}
-          pinned={pinned}
-          styles={styles}
-        />
+        {hover && (
+          <LogRowMenuCell
+            logText={restructuredEntry}
+            row={row}
+            showContextToggle={showContextToggle}
+            onOpenContext={onOpenContext}
+            onPermalinkClick={onPermalinkClick}
+            onPinLine={onPinLine}
+            onUnpinLine={onUnpinLine}
+            pinned={pinned}
+            styles={styles}
+          />
+        )}
       </td>
     </>
   );

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { CoreApp, findHighlightChunksInText, LogRowModel } from '@grafana/data';
@@ -21,6 +21,7 @@ interface Props {
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
   styles: LogRowStyles;
+  mouseIsOver: boolean;
 }
 
 interface LogMessageProps {
@@ -73,31 +74,25 @@ export const LogRowMessage = React.memo((props: Props) => {
     onUnpinLine,
     onPinLine,
     pinned,
+    mouseIsOver,
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const [hover, setHover] = useState(false);
-  const showMenu = useCallback(() => {
-    setHover(true);
-  }, []);
-  const hideMenu = useCallback(() => {
-    setHover(false);
-  }, []);
-  const shouldShowMenu = useMemo(() => hover || pinned, [hover, pinned]);
+  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>
       {
         // When context is open, the position has to be NOT relative. // Setting the postion as inline-style to
         // overwrite the more sepecific style definition from `styles.logsRowMessage`.
       }
-      <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
+      <td className={styles.logsRowMessage}>
         <div className={wrapLogMessage ? styles.positionRelative : styles.horizontalScroll}>
           <button className={`${styles.logLine} ${styles.positionRelative}`}>
             <LogMessage hasAnsi={hasAnsi} entry={restructuredEntry} highlights={row.searchWords} styles={styles} />
           </button>
         </div>
       </td>
-      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
+      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`}>
         {shouldShowMenu && (
           <LogRowMenuCell
             logText={restructuredEntry}
@@ -109,7 +104,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             onUnpinLine={onUnpinLine}
             pinned={pinned}
             styles={styles}
-            mouseIsOver={hover}
+            mouseIsOver={mouseIsOver}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -83,6 +83,7 @@ export const LogRowMessage = React.memo((props: Props) => {
   const hideMenu = useCallback(() => {
     setHover(false);
   }, []);
+  const shouldShowMenu = useMemo(() => hover || pinned, [hover, pinned]);
 
   return (
     <>
@@ -96,7 +97,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             <LogMessage hasAnsi={hasAnsi} entry={restructuredEntry} highlights={row.searchWords} styles={styles} />
           </button>
         </div>
-        {hover && (
+        {shouldShowMenu && (
           <LogRowMenuCell
             logText={restructuredEntry}
             row={row}
@@ -107,6 +108,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             onUnpinLine={onUnpinLine}
             pinned={pinned}
             styles={styles}
+            mouseIsOver={hover}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { LogRowModel, Field, LinkModel, DataFrame } from '@grafana/data';
 
@@ -22,39 +22,47 @@ export interface Props {
 }
 
 export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
+  const [hover, setHover] = useState(false);
   const { row, detectedFields, getFieldLinks, wrapLogMessage, styles, ...rest } = props;
   const fields = getAllFields(row, getFieldLinks);
   const wrapClassName = wrapLogMessage ? '' : displayedFieldsStyles.noWrap;
   // only single key/value rows are filterable, so we only need the first field key for filtering
-  const line = detectedFields
-    .map((parsedKey) => {
-      const field = fields.find((field) => {
-        const { keys } = field;
-        return keys[0] === parsedKey;
-      });
+  const line = useMemo(
+    () =>
+      detectedFields
+        .map((parsedKey) => {
+          const field = fields.find((field) => {
+            const { keys } = field;
+            return keys[0] === parsedKey;
+          });
 
-      if (field !== undefined && field !== null) {
-        return `${parsedKey}=${field.values}`;
-      }
+          if (field !== undefined && field !== null) {
+            return `${parsedKey}=${field.values}`;
+          }
 
-      if (row.labels[parsedKey] !== undefined && row.labels[parsedKey] !== null) {
-        return `${parsedKey}=${row.labels[parsedKey]}`;
-      }
+          if (row.labels[parsedKey] !== undefined && row.labels[parsedKey] !== null) {
+            return `${parsedKey}=${row.labels[parsedKey]}`;
+          }
 
-      return null;
-    })
-    .filter((s) => s !== null)
-    .join(' ');
+          return null;
+        })
+        .filter((s) => s !== null)
+        .join(' '),
+    [detectedFields, fields, row.labels]
+  );
+
+  const showMenu = useCallback(() => {
+    setHover(true);
+  }, []);
+  const hideMenu = useCallback(() => {
+    setHover(false);
+  }, []);
 
   return (
-    <>
-      <td className={styles.logsRowMessage}>
-        <div className={wrapClassName}>{line}</div>
-      </td>
-      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`}>
-        <LogRowMenuCell logText={line} row={row} styles={styles} {...rest} />
-      </td>
-    </>
+    <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
+      <div className={wrapClassName}>{line}</div>
+      {hover && <LogRowMenuCell logText={line} row={row} styles={styles} {...rest} />}
+    </td>
   );
 });
 

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -23,7 +23,7 @@ export interface Props {
 
 export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
   const [hover, setHover] = useState(false);
-  const { row, detectedFields, getFieldLinks, wrapLogMessage, styles, ...rest } = props;
+  const { row, detectedFields, getFieldLinks, wrapLogMessage, styles, pinned, ...rest } = props;
   const fields = getAllFields(row, getFieldLinks);
   const wrapClassName = wrapLogMessage ? '' : displayedFieldsStyles.noWrap;
   // only single key/value rows are filterable, so we only need the first field key for filtering
@@ -58,10 +58,14 @@ export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
     setHover(false);
   }, []);
 
+  const shouldShowMenu = useMemo(() => hover || pinned, [hover, pinned]);
+
   return (
     <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
       <div className={wrapClassName}>{line}</div>
-      {hover && <LogRowMenuCell logText={line} row={row} styles={styles} {...rest} />}
+      {shouldShowMenu && (
+        <LogRowMenuCell logText={line} row={row} styles={styles} pinned={pinned} mouseIsOver={hover} {...rest} />
+      )}
     </td>
   );
 });

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -57,16 +57,19 @@ export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
   const hideMenu = useCallback(() => {
     setHover(false);
   }, []);
-
   const shouldShowMenu = useMemo(() => hover || pinned, [hover, pinned]);
 
   return (
-    <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
-      <div className={wrapClassName}>{line}</div>
-      {shouldShowMenu && (
-        <LogRowMenuCell logText={line} row={row} styles={styles} pinned={pinned} mouseIsOver={hover} {...rest} />
-      )}
-    </td>
+    <>
+      <td className={styles.logsRowMessage} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
+        <div className={wrapClassName}>{line}</div>
+      </td>
+      <td className={`log-row-menu-cell ${styles.logRowMenuCell}`} onMouseEnter={showMenu} onMouseLeave={hideMenu}>
+        {shouldShowMenu && (
+          <LogRowMenuCell logText={line} row={row} styles={styles} pinned={pinned} {...rest} mouseIsOver={false} />
+        )}
+      </td>
+    </>
   );
 });
 

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -84,23 +84,10 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       vertical-align: top;
 
       &:hover {
-        .log-row-menu {
-          visibility: visible;
-          z-index: 1;
-        }
-
-        .log-row-menu-visible {
-          visibility: hidden;
-        }
-
         background: ${hoverBgColor};
       }
 
-      td:not(.log-row-menu-cell):last-child {
-        width: 100%;
-      }
-
-      > td:not(.log-row-menu-cell) {
+      > td {
         position: relative;
         padding-right: ${theme.spacing(1)};
         border-top: 1px solid transparent;
@@ -247,6 +234,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       align-items: center;
       position: absolute;
       top: 0;
+      right: 0;
       bottom: auto;
       background: ${theme.colors.background.primary};
       box-shadow: ${theme.shadows.z3};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -84,10 +84,18 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       vertical-align: top;
 
       &:hover {
+        .log-row-menu {
+          z-index: 1;
+        }
+
         background: ${hoverBgColor};
       }
 
-      > td {
+      td:not(.log-row-menu-cell):last-child {
+        width: 100%;
+      }
+
+      > td:not(.log-row-menu-cell) {
         position: relative;
         padding-right: ${theme.spacing(1)};
         border-top: 1px solid transparent;
@@ -234,7 +242,6 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       align-items: center;
       position: absolute;
       top: 0;
-      right: 0;
       bottom: auto;
       background: ${theme.colors.background.primary};
       box-shadow: ${theme.shadows.z3};

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -476,7 +476,9 @@ describe('LogRowContextModal', () => {
     });
     const unpinButtons = screen.getAllByLabelText('Unpin line')[0];
     fireEvent.click(unpinButtons);
-    const rows = screen.getByTestId('entry-row');
-    expect(rows).not.toHaveStyle('position: sticky');
+    await waitFor(() => {
+      const rows = screen.getByTestId('entry-row');
+      expect(rows).not.toHaveStyle('position: sticky');
+    });
   });
 });

--- a/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render } from 'test/redux-rtl';
@@ -475,7 +475,7 @@ describe('LogRowContextModal', () => {
       expect(rows).toHaveStyle('position: sticky');
     });
     const unpinButtons = screen.getAllByLabelText('Unpin line')[0];
-    await userEvent.click(unpinButtons);
+    fireEvent.click(unpinButtons);
     const rows = screen.getByTestId('entry-row');
     expect(rows).not.toHaveStyle('position: sticky');
   });


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/issues/70217 I realized that:

- Rendering LogRowMenuCell for every log line was a **very** expensive operation.
- Browser repainting on-mouse-over of LogRowMenuCell using a table was a **very** expensive operation.

For the first point, the reason was that in order to render a log line we also needed to render a log row menu, even if it wasn't visible. This is not noticeable for a few lines, but becomes very troublesome for 1000 lines or more.

For the second point, the log row menu used to be a table cell, and changing its visibility and ajusting the table layout for multiple log lines required a lot of effort for the browser.

This PR changes the implementation to only render a LogRowMenuCell when the mouse is over a log line, and the log row menu is no longer a table cell.

**What is this feature?**

Performance optimization.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/60687
Part of https://github.com/grafana/grafana/issues/70217

**Special notes for your reviewer:**

Nothing should visually change.

Before:

![Before](https://github.com/grafana/grafana/assets/1069378/c5dd7e77-6d8d-46ea-9946-09cad032c83e)

After:

![After](https://github.com/grafana/grafana/assets/1069378/fb3cd6fd-abe2-4b53-a142-ab97141aca8b)

Performance before:

https://github.com/grafana/grafana/assets/1069378/26f1c626-7f04-429a-8989-d7ad99884001

Performance after:

https://github.com/grafana/grafana/assets/1069378/5ca26e1f-ed4b-4fa7-9d94-baf46b3b57ef

Rendering before:

https://github.com/grafana/grafana/assets/1069378/1c2b3f5a-795b-4fff-925d-433112ad6804

Rendering after:

https://github.com/grafana/grafana/assets/1069378/821cfde6-7ec1-41c2-8adf-40fdb38e11f9

Here you can see that not only rendering of log lines is faster, but also toggling displayed fields on and off is also faster.

### What to test to see the performance differences

- Render 5000 lines, should be faster in this branch.
- Toggle displayed fields on and off, should be faster in this branch.
- Resize the window, should be faster in this branch.
- With 5000 lines, move the mouse over, should be faster in this branch.