### PR TITLE
[v10.0.x] Variables: Page refreshes hitting enter to select a variable value

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -42,6 +42,10 @@ class SubMenuUnConnected extends PureComponent<Props> {
     this.forceUpdate();
   };
 
+  disableSubmitOnEnter = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
   render() {
     const { dashboard, variables, links, annotations } = this.props;
 
@@ -53,7 +57,7 @@ class SubMenuUnConnected extends PureComponent<Props> {
 
     return (
       <div className="submenu-controls">
-        <form aria-label="Template variables" className={styles}>
+        <form aria-label="Template variables" className={styles} onSubmit={this.disableSubmitOnEnter}>
           <SubMenuItems variables={variables} readOnly={readOnlyVariables} />
         </form>
         <Annotations


### PR DESCRIPTION
Backport 699e499cc7d93143a8f005da46d3491c133a3910 from #70996

---

**Problem**
Fixes #70433 

**Solution**
Disable the onSubmit for the variable form, since the form is never going to be submitted.

|Before|After|
|-|-|
![2023-06-30 17 53 50](https://github.com/grafana/grafana/assets/5699976/39541a49-f9bd-4ce2-b8e6-a1b3c5b66b3f)|![2023-06-30 17 50 34](https://github.com/grafana/grafana/assets/5699976/1f2a3225-a5a3-444e-9082-b8cd27cde86f)
