### PR TITLE
UI/IndicatorsContainer: Increase IndicatorsContainer z-index

### DIFF
--- a/packages/grafana-ui/src/components/Select/IndicatorsContainer.tsx
+++ b/packages/grafana-ui/src/components/Select/IndicatorsContainer.tsx
@@ -15,6 +15,7 @@ export const IndicatorsContainer = React.forwardRef<HTMLDivElement, React.PropsW
         styles.suffix,
         css`
           position: relative;
+          z-index: 9999;
         `
       )}
       ref={ref}


### PR DESCRIPTION
Increases the z-index of the element wrapping `IndicatorsContainer` enough that contained elements can be clicked.
Needed for ongoing work allowing LoadingIndicator to be clicked to cancel a variable query