### PR TITLE
SQLStore: Fix regression in PostgreSQL connection string

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -316,12 +316,14 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 			return "", fmt.Errorf("invalid host specifier '%s': %w", ss.dbCfg.Host, err)
 		}
 
-		if ss.dbCfg.User == "" {
-			ss.dbCfg.User = "''"
+		args := []any{ss.dbCfg.User, addr.Host, addr.Port, ss.dbCfg.Name, ss.dbCfg.SslMode, ss.dbCfg.ClientCertPath,
+			ss.dbCfg.ClientKeyPath, ss.dbCfg.CaCertPath}
+		for i, arg := range args {
+			if arg == "" {
+				args[i] = "''"
+			}
 		}
-		cnnstr = fmt.Sprintf("user=%s host=%s port=%s dbname=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s",
-			ss.dbCfg.User, addr.Host, addr.Port, ss.dbCfg.Name, ss.dbCfg.SslMode, ss.dbCfg.ClientCertPath,
-			ss.dbCfg.ClientKeyPath, ss.dbCfg.CaCertPath)
+		cnnstr = fmt.Sprintf("user=%s host=%s port=%s dbname=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", args...)
 		if ss.dbCfg.Pwd != "" {
 			cnnstr += fmt.Sprintf(" password=%s", ss.dbCfg.Pwd)
 		}

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -10,87 +10,87 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 type sqlStoreTest struct {
-	name                  string
-	dbType                string
-	dbHost                string
-	dbURL                 string
-	dbUser                string
-	dbPwd                 string
-	connStrValues         []string
-	connStrExcludedValues []string
-	err                   error
+	name       string
+	dbType     string
+	dbHost     string
+	dbURL      string
+	dbUser     string
+	dbPwd      string
+	expConnStr string
+	features   []string
+	err        error
 }
 
 var sqlStoreTestCases = []sqlStoreTest{
 	{
-		name:          "MySQL IPv4",
-		dbType:        "mysql",
-		dbHost:        "1.2.3.4:5678",
-		connStrValues: []string{"tcp(1.2.3.4:5678)"},
+		name:       "MySQL IPv4",
+		dbType:     "mysql",
+		dbHost:     "1.2.3.4:5678",
+		expConnStr: ":@tcp(1.2.3.4:5678)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
 	},
 	{
-		name:          "Postgres IPv4",
-		dbType:        "postgres",
-		dbHost:        "1.2.3.4:5678",
-		connStrValues: []string{"host=1.2.3.4", "port=5678"},
+		name:       "Postgres IPv4",
+		dbType:     "postgres",
+		dbHost:     "1.2.3.4:5678",
+		expConnStr: "user='' host=1.2.3.4 port=5678 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert=''",
 	},
 	{
-		name:          "Postgres IPv4 (Default Port)",
-		dbType:        "postgres",
-		dbHost:        "1.2.3.4",
-		connStrValues: []string{"host=1.2.3.4", "port=5432"},
+		name:       "Postgres IPv4 (Default Port)",
+		dbType:     "postgres",
+		dbHost:     "1.2.3.4",
+		expConnStr: "user='' host=1.2.3.4 port=5432 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert=''",
 	},
 	{
-		name:          "Postgres username and password",
-		dbType:        "postgres",
-		dbHost:        "1.2.3.4",
-		dbUser:        "grafana",
-		dbPwd:         "password",
-		connStrValues: []string{"host=1.2.3.4", "port=5432", "user=grafana", "password=password"},
+		name:       "Postgres username and password",
+		dbType:     "postgres",
+		dbHost:     "1.2.3.4",
+		dbUser:     "grafana",
+		dbPwd:      "password",
+		expConnStr: "user=grafana host=1.2.3.4 port=5432 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert='' password=password",
 	},
 	{
-		name:                  "Postgres username no password",
-		dbType:                "postgres",
-		dbHost:                "1.2.3.4",
-		dbUser:                "grafana",
-		dbPwd:                 "",
-		connStrValues:         []string{"host=1.2.3.4", "port=5432", "user=grafana"},
-		connStrExcludedValues: []string{"password"},
+		name:       "Postgres username no password",
+		dbType:     "postgres",
+		dbHost:     "1.2.3.4",
+		dbUser:     "grafana",
+		dbPwd:      "",
+		expConnStr: "user=grafana host=1.2.3.4 port=5432 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert=''",
 	},
 	{
-		name:          "MySQL IPv4 (Default Port)",
-		dbType:        "mysql",
-		dbHost:        "1.2.3.4",
-		connStrValues: []string{"tcp(1.2.3.4)"},
+		name:       "MySQL IPv4 (Default Port)",
+		dbType:     "mysql",
+		dbHost:     "1.2.3.4",
+		expConnStr: ":@tcp(1.2.3.4)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
 	},
 	{
-		name:          "MySQL IPv6",
-		dbType:        "mysql",
-		dbHost:        "[fe80::24e8:31b2:91df:b177]:1234",
-		connStrValues: []string{"tcp([fe80::24e8:31b2:91df:b177]:1234)"},
+		name:       "MySQL IPv6",
+		dbType:     "mysql",
+		dbHost:     "[fe80::24e8:31b2:91df:b177]:1234",
+		expConnStr: ":@tcp([fe80::24e8:31b2:91df:b177]:1234)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
 	},
 	{
-		name:          "Postgres IPv6",
-		dbType:        "postgres",
-		dbHost:        "[fe80::24e8:31b2:91df:b177]:1234",
-		connStrValues: []string{"host=fe80::24e8:31b2:91df:b177", "port=1234"},
+		name:       "Postgres IPv6",
+		dbType:     "postgres",
+		dbHost:     "[fe80::24e8:31b2:91df:b177]:1234",
+		expConnStr: "user='' host=fe80::24e8:31b2:91df:b177 port=1234 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert=''",
 	},
 	{
-		name:          "MySQL IPv6 (Default Port)",
-		dbType:        "mysql",
-		dbHost:        "[::1]",
-		connStrValues: []string{"tcp([::1])"},
+		name:       "MySQL IPv6 (Default Port)",
+		dbType:     "mysql",
+		dbHost:     "[::1]",
+		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
 	},
 	{
-		name:          "Postgres IPv6 (Default Port)",
-		dbType:        "postgres",
-		dbHost:        "[::1]",
-		connStrValues: []string{"host=::1", "port=5432"},
+		name:       "Postgres IPv6 (Default Port)",
+		dbType:     "postgres",
+		dbHost:     "[::1]",
+		expConnStr: "user='' host=::1 port=5432 dbname=test_db sslmode='' sslcert='' sslkey='' sslrootcert=''",
 	},
 	{
 		name:  "Invalid database URL",
@@ -98,10 +98,18 @@ var sqlStoreTestCases = []sqlStoreTest{
 		err:   &url.Error{Op: "parse", URL: "://invalid.com/", Err: errors.New("missing protocol scheme")},
 	},
 	{
-		name:          "Sql mode set to ANSI_QUOTES",
-		dbType:        "mysql",
-		dbHost:        "[::1]",
-		connStrValues: []string{"sql_mode='ANSI_QUOTES'"},
+		name:       "MySQL with ANSI_QUOTES mode",
+		dbType:     "mysql",
+		dbHost:     "[::1]",
+		features:   []string{featuremgmt.FlagMysqlAnsiQuotes},
+		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&sql_mode='ANSI_QUOTES'",
+	},
+	{
+		name:       "New DB library",
+		dbType:     "mysql",
+		dbHost:     "[::1]",
+		features:   []string{featuremgmt.FlagNewDBLibrary},
+		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&sql_mode='ANSI_QUOTES'&parseTime=true",
 	},
 }
 
@@ -112,17 +120,11 @@ func TestIntegrationSQLConnectionString(t *testing.T) {
 	for _, testCase := range sqlStoreTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			sqlstore := &SQLStore{}
-			sqlstore.Cfg = makeSQLStoreTestConfig(t, testCase.dbType, testCase.dbHost, testCase.dbUser, testCase.dbPwd, testCase.dbURL)
+			sqlstore.Cfg = makeSQLStoreTestConfig(t, testCase)
 			connStr, err := sqlstore.buildConnectionString()
 			require.Equal(t, testCase.err, err)
 
-			for _, connSubStr := range testCase.connStrValues {
-				require.Contains(t, connStr, connSubStr)
-			}
-
-			for _, connExcludedSubStr := range testCase.connStrExcludedValues {
-				require.NotContains(t, connStr, connExcludedSubStr)
-			}
+			assert.Equal(t, testCase.expConnStr, connStr)
 		})
 	}
 }
@@ -175,27 +177,34 @@ func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
 	}
 }
 
-func makeSQLStoreTestConfig(t *testing.T, dbType, host, user, password, dbURL string) *setting.Cfg {
+func makeSQLStoreTestConfig(t *testing.T, tc sqlStoreTest) *setting.Cfg {
 	t.Helper()
 
 	cfg := setting.NewCfg()
 
 	sec, err := cfg.Raw.NewSection("database")
 	require.NoError(t, err)
-	_, err = sec.NewKey("type", dbType)
+	_, err = sec.NewKey("type", tc.dbType)
 	require.NoError(t, err)
-	_, err = sec.NewKey("host", host)
+	_, err = sec.NewKey("host", tc.dbHost)
 	require.NoError(t, err)
-	_, err = sec.NewKey("url", dbURL)
+	_, err = sec.NewKey("url", tc.dbURL)
 	require.NoError(t, err)
-	_, err = sec.NewKey("user", user)
+	_, err = sec.NewKey("user", tc.dbUser)
 	require.NoError(t, err)
 	_, err = sec.NewKey("name", "test_db")
 	require.NoError(t, err)
-	_, err = sec.NewKey("password", password)
+	_, err = sec.NewKey("password", tc.dbPwd)
 	require.NoError(t, err)
 
-	cfg.IsFeatureToggleEnabled = func(key string) bool { return true }
+	cfg.IsFeatureToggleEnabled = func(key string) bool {
+		for _, f := range tc.features {
+			if f == key {
+				return true
+			}
+		}
+		return false
+	}
 
 	return cfg
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

After merging #61517 authentication to a PostgreSQL backend with password used to fail.
The reason is that the password was set after options (`sslrootcert`) with empty values.
As a result, lib/pq's [parseOpts()](https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/conn.go#L485) would parse options wrongly:

eg
the following connection string:
`postgres user=grafana host=127.0.0.1 port=5432 dbname=grafana sslmode=disable sslcert= sslkey= sslrootcert= password=password`

is parsed as:
`
map[dbname:grafana extra_float_digits:2 host:127.0.0.1 port:5432 sslcert:sslkey= sslmode:disable sslrootcert:password=password user:grafana]
`

**Why do we need this feature?**

This fix makes sure that any empty connection option is replaced by `''` and rewrites the tests to catch those cases.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
