### PR TITLE
Format go resource

### DIFF
--- a/pkg/codegen/jenny_go_resources.go
+++ b/pkg/codegen/jenny_go_resources.go
@@ -49,6 +49,7 @@ func (ag *ResourceGoTypesJenny) Generate(kind kindsys.Kind) (*codejen.File, erro
 		PackageName:      mname,
 		KindName:         kind.Props().Common().Name,
 		Version:          sch.Version().String(),
+		Spaces:           formatSpaces(subr),
 		SubresourceNames: subr,
 	}); err != nil {
 		return nil, fmt.Errorf("failed executing core resource template: %w", err)
@@ -58,6 +59,22 @@ func (ag *ResourceGoTypesJenny) Generate(kind kindsys.Kind) (*codejen.File, erro
 		return nil, err
 	}
 	return codejen.NewFile(fmt.Sprintf("pkg/kinds/%s/%s_gen.go", mname, mname), buf.Bytes(), ag), nil
+}
+
+func formatSpaces(subr []string) []string {
+	spaces := make([]string, len(subr))
+	maxLength := 0
+	for _, s := range subr {
+		if len(s) > maxLength {
+			maxLength = len(s)
+		}
+	}
+
+	for i, s := range subr {
+		spaces[i] = strings.Repeat(" ", maxLength-len(s)+1)
+	}
+
+	return spaces
 }
 
 type SubresourceGoTypesJenny struct {

--- a/pkg/codegen/jenny_go_resources.go
+++ b/pkg/codegen/jenny_go_resources.go
@@ -59,14 +59,12 @@ func (ag *ResourceGoTypesJenny) Generate(kind kindsys.Kind) (*codejen.File, erro
 		return nil, err
 	}
 
-	f := codejen.NewFile(fmt.Sprintf("pkg/kinds/%s/%s_gen.go", mname, mname), buf.Bytes(), ag)
-	content, err := format.Source(f.Data)
+	content, err := format.Source(buf.Bytes())
 	if err != nil {
 		return nil, err
 	}
 
-	f.Data = content
-	return f, nil
+	return codejen.NewFile(fmt.Sprintf("pkg/kinds/%s/%s_gen.go", mname, mname), content, ag), nil
 }
 
 type SubresourceGoTypesJenny struct {

--- a/pkg/codegen/tmpl.go
+++ b/pkg/codegen/tmpl.go
@@ -42,7 +42,6 @@ type (
 		PackageName      string
 		KindName         string
 		Version          string
-		Spaces           []string
 		SubresourceNames []string
 	}
 )

--- a/pkg/codegen/tmpl.go
+++ b/pkg/codegen/tmpl.go
@@ -42,6 +42,7 @@ type (
 		PackageName      string
 		KindName         string
 		Version          string
+		Spaces           []string
 		SubresourceNames []string
 	}
 )

--- a/pkg/codegen/tmpl/core_resource.tmpl
+++ b/pkg/codegen/tmpl/core_resource.tmpl
@@ -24,6 +24,6 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of {{ .KindName }}.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    {{- range $i, $val := .SubresourceNames }}
-    {{ $val }}{{index $.Spaces $i}}{{ $val }}{{index $.Spaces $i}}`json:"{{ $val | ToLower }}"`{{end}}
+	{{- range $i, $val := .SubresourceNames }}
+	{{ $val }}{{index $.Spaces $i}}{{ $val }}{{index $.Spaces $i}}`json:"{{ $val | ToLower }}"`{{end}}
 }

--- a/pkg/codegen/tmpl/core_resource.tmpl
+++ b/pkg/codegen/tmpl/core_resource.tmpl
@@ -21,10 +21,9 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of {{ .KindName }}.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    {{- range .SubresourceNames }}
-	{{ . }} {{ . }} `json:"{{ . | ToLower }}"`{{end}}
+    {{- range $i, $val := .SubresourceNames }}
+    {{ $val }}{{index $.Spaces $i}}{{ $val }}{{index $.Spaces $i}}`json:"{{ $val | ToLower }}"`{{end}}
 }

--- a/pkg/codegen/tmpl/core_resource.tmpl
+++ b/pkg/codegen/tmpl/core_resource.tmpl
@@ -24,6 +24,6 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of {{ .KindName }}.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	{{- range $i, $val := .SubresourceNames }}
-	{{ $val }}{{index $.Spaces $i}}{{ $val }}{{index $.Spaces $i}}`json:"{{ $val | ToLower }}"`{{end}}
+	{{- range  .SubresourceNames }}
+	{{ . }} {{ . }} `json:"{{ . | ToLower }}"`{{end}}
 }

--- a/pkg/codegen/tmpl/core_resource.tmpl
+++ b/pkg/codegen/tmpl/core_resource.tmpl
@@ -24,6 +24,6 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of {{ .KindName }}.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	{{- range  .SubresourceNames }}
+    {{- range .SubresourceNames }}
 	{{ . }} {{ . }} `json:"{{ . | ToLower }}"`{{end}}
 }

--- a/pkg/kinds/accesspolicy/accesspolicy_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of AccessPolicy.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/accesspolicy/accesspolicy_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of AccessPolicy.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/dashboard/dashboard_gen.go
+++ b/pkg/kinds/dashboard/dashboard_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Dashboard.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/dashboard/dashboard_gen.go
+++ b/pkg/kinds/dashboard/dashboard_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Dashboard.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/folder/folder_gen.go
+++ b/pkg/kinds/folder/folder_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Folder.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/folder/folder_gen.go
+++ b/pkg/kinds/folder/folder_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Folder.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/librarypanel/librarypanel_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of LibraryPanel.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/librarypanel/librarypanel_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of LibraryPanel.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/playlist/playlist_gen.go
+++ b/pkg/kinds/playlist/playlist_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Playlist.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/playlist/playlist_gen.go
+++ b/pkg/kinds/playlist/playlist_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Playlist.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/preferences/preferences_gen.go
+++ b/pkg/kinds/preferences/preferences_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Preferences.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/preferences/preferences_gen.go
+++ b/pkg/kinds/preferences/preferences_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Preferences.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/publicdashboard/publicdashboard_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of PublicDashboard.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/publicdashboard/publicdashboard_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of PublicDashboard.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/role/role_gen.go
+++ b/pkg/kinds/role/role_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Role.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/role/role_gen.go
+++ b/pkg/kinds/role/role_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Role.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/rolebinding/rolebinding_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of RoleBinding.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }

--- a/pkg/kinds/rolebinding/rolebinding_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of RoleBinding.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/team/team_gen.go
+++ b/pkg/kinds/team/team_gen.go
@@ -33,7 +33,7 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 // Resource is the wire representation of Team.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-    Metadata Metadata `json:"metadata"`
-    Spec     Spec     `json:"spec"`
-    Status   Status   `json:"status"`
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
 }

--- a/pkg/kinds/team/team_gen.go
+++ b/pkg/kinds/team/team_gen.go
@@ -30,11 +30,10 @@ func NewK8sResource(name string, s *Spec) K8sResource {
 	}
 }
 
-
 // Resource is the wire representation of Team.
 // It currently will soon be merged into the k8s flavor (TODO be better)
 type Resource struct {
-	Metadata Metadata `json:"metadata"`
-	Spec Spec `json:"spec"`
-	Status Status `json:"status"`
+    Metadata Metadata `json:"metadata"`
+    Spec     Spec     `json:"spec"`
+    Status   Status   `json:"status"`
 }


### PR DESCRIPTION
Contributes to: https://github.com/grafana/schematization-and-as-code-project/issues/106

When we generate the Go Resource, the template isn't Go formatted. For this reason, when is formatted and pushed into a PR, the CI complains because the formatted file ins't the same than the generated.

This change adds the same spaces like Go format to generate the file formatted and avoid CI errors when people format these files by mistake. 