### PR TITLE
refactor: remove cta for users with reading rights

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -9,7 +9,8 @@ import { wellFormedTree } from '../fixtures/dashboardsTreeItem.fixture';
 
 import { BrowseView } from './BrowseView';
 
-const [mockTree, { folderA, folderA_folderA, folderA_folderB, folderA_folderB_dashbdB, dashbdD }] = wellFormedTree();
+const [mockTree, { folderA, folderA_folderA, folderA_folderB, folderA_folderB_dashbdB, dashbdD, folderB_empty }] =
+  wellFormedTree();
 
 function render(...[ui, options]: Parameters<typeof rtlRender>) {
   rtlRender(<TestProvider>{ui}</TestProvider>, options);
@@ -146,12 +147,12 @@ describe('browse-dashboards BrowseView', () => {
 
   describe('when there is no item in the folder', () => {
     it('shows a CTA for creating a dashboard if the user has editor rights', async () => {
-      render(<BrowseView canSelect={true} folderUID="folderB_empty" width={WIDTH} height={HEIGHT} />);
+      render(<BrowseView canSelect={true} folderUID={folderB_empty.item.uid} width={WIDTH} height={HEIGHT} />);
       expect(await screen.findByText('Create Dashboard')).toBeInTheDocument();
     });
 
     it('shows a simple message if the user has viewer rights', async () => {
-      render(<BrowseView canSelect={false} folderUID="folderB_empty" width={WIDTH} height={HEIGHT} />);
+      render(<BrowseView canSelect={false} folderUID={folderB_empty.item.uid} width={WIDTH} height={HEIGHT} />);
       expect(await screen.findByText('This folder is empty')).toBeInTheDocument();
     });
   });

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -146,12 +146,12 @@ describe('browse-dashboards BrowseView', () => {
 
   describe('when there is no item in the folder', () => {
     it('shows a CTA for creating a dashboard if the user has editor rights', async () => {
-      render(<BrowseView canSelect={true} folderUID="fakeFolderUID" width={WIDTH} height={HEIGHT} />);
+      render(<BrowseView canSelect={true} folderUID="folderB_empty" width={WIDTH} height={HEIGHT} />);
       expect(await screen.findByText('Create Dashboard')).toBeInTheDocument();
     });
 
     it('shows a simple message if the user has viewer rights', async () => {
-      render(<BrowseView canSelect={false} folderUID="fakeFolderUID" width={WIDTH} height={HEIGHT} />);
+      render(<BrowseView canSelect={false} folderUID="folderB_empty" width={WIDTH} height={HEIGHT} />);
       expect(await screen.findByText('This folder is empty')).toBeInTheDocument();
     });
   });

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -143,6 +143,18 @@ describe('browse-dashboards BrowseView', () => {
     expect(grandparentCheckbox).not.toBeChecked();
     expect(grandparentCheckbox).toBePartiallyChecked();
   });
+
+  describe('when there is no item in the folder', () => {
+    it('shows a CTA for creating a dashboard if the user has editor rights', async () => {
+      render(<BrowseView canSelect={true} folderUID="fakeFolderUID" width={WIDTH} height={HEIGHT} />);
+      expect(await screen.findByText('Create Dashboard')).toBeInTheDocument();
+    });
+
+    it('shows a simple message if the user has viewer rights', async () => {
+      render(<BrowseView canSelect={false} folderUID="fakeFolderUID" width={WIDTH} height={HEIGHT} />);
+      expect(await screen.findByText('This folder is empty')).toBeInTheDocument();
+    });
+  });
 });
 
 async function expandFolder(uid: string) {

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 
+import { CallToActionCard } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { DashboardViewItem } from 'app/features/search/types';
 import { useDispatch } from 'app/types';
@@ -115,16 +116,20 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
   if (status === 'fulfilled' && flatTree.length === 0) {
     return (
       <div style={{ width }}>
-        <EmptyListCTA
-          title={folderUID ? "This folder doesn't have any dashboards yet" : 'No dashboards yet. Create your first!'}
-          buttonIcon="plus"
-          buttonTitle="Create Dashboard"
-          buttonLink={folderUID ? `dashboard/new?folderUid=${folderUID}` : 'dashboard/new'}
-          proTip={folderUID && 'Add/move dashboards to your folder at ->'}
-          proTipLink={folderUID && 'dashboards'}
-          proTipLinkTitle={folderUID && 'Browse dashboards'}
-          proTipTarget=""
-        />
+        {canSelect ? (
+          <EmptyListCTA
+            title={folderUID ? "This folder doesn't have any dashboards yet" : 'No dashboards yet. Create your first!'}
+            buttonIcon="plus"
+            buttonTitle="Create Dashboard"
+            buttonLink={folderUID ? `dashboard/new?folderUid=${folderUID}` : 'dashboard/new'}
+            proTip={folderUID && 'Add/move dashboards to your folder at ->'}
+            proTipLink={folderUID && 'dashboards'}
+            proTipLinkTitle={folderUID && 'Browse dashboards'}
+            proTipTarget=""
+          />
+        ) : (
+          <CallToActionCard callToActionElement={<span>This folder is empty</span>} />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
**What is this feature?**

Previously the Create Dashboard button was also shown to users with reading rights only. When clicking the button they got back to the dashboards page.

**Why do we need this feature?**

In order to improve the UX

**Who is this feature for?**

Users that have only reading rights

**Which issue(s) does this PR fix?**:

Fixes #71174

**Special notes for your reviewer:**

In order to check the change please login with a user that is a viewer.

<img width="2297" alt="Screenshot 2023-07-11 at 16 50 43" src="https://github.com/grafana/grafana/assets/48948963/e8191106-d41d-4ee2-9015-6a8ea39292b9">

Please check that:
- [ ] It works as expected from a user's perspective.
