### PR TITLE
Loki: Improve query cache hits

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -263,7 +263,11 @@ export class LokiDatasource
 
     const transformed = queries.map((query) => {
       const sorted = sortLabelSelectors(query);
-      return sorted;
+
+      const lines = sorted.expr.split('\n');
+      const trimmedLines = lines.map((line) => line.trim());
+      const trimmedExpr = trimmedLines.join('\n');
+      return { ...sorted, expr: trimmedExpr };
     });
 
     const fixedRequest: DataQueryRequest<LokiQuery> = {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -261,14 +261,7 @@ export class LokiDatasource
       .map(getNormalizedLokiQuery) // "fix" the `.queryType` prop
       .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }));
 
-    const transformed = queries.map((query) => {
-      const sorted = sortLabelSelectors(query);
-
-      const lines = sorted.expr.split('\n');
-      const trimmedLines = lines.map((line) => line.trim());
-      const trimmedExpr = trimmedLines.join('\n');
-      return { ...sorted, expr: trimmedExpr };
-    });
+    const transformed = queries.map((query) => sortLabelSelectors(query));
 
     const fixedRequest: DataQueryRequest<LokiQuery> = {
       ...request,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -79,6 +79,7 @@ import {
   isLogsQuery,
   isQueryWithError,
   requestSupportsSplitting,
+  sortLabelSelectors,
 } from './queryUtils';
 import { doLokiChannelStream } from './streaming';
 import { trackQuery } from './tracking';
@@ -260,9 +261,14 @@ export class LokiDatasource
       .map(getNormalizedLokiQuery) // "fix" the `.queryType` prop
       .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }));
 
+    const transformed = queries.map((query) => {
+      const sorted = sortLabelSelectors(query);
+      return sorted;
+    });
+
     const fixedRequest: DataQueryRequest<LokiQuery> = {
       ...request,
-      targets: queries,
+      targets: transformed,
     };
 
     const streamQueries = fixedRequest.targets.filter((q) => q.queryType === LokiQueryType.Stream);

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -17,6 +17,8 @@ import {
   getLogQueryFromMetricsQuery,
   getNormalizedLokiQuery,
   getNodePositionsFromQuery,
+  sortLabelSelectors,
+  trimAllLines,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -438,5 +440,24 @@ describe('getNodePositionsFromQuery', () => {
     // LogQL, Expr, LogExpr, Selector, Matchers, Matcher, Identifier, Eq, String
     const nodePositions = getNodePositionsFromQuery('not loql', [String]);
     expect(nodePositions.length).toBe(0);
+  });
+});
+
+describe('sortLabelSelectors', () => {
+  it('sorts labels in a log query', () => {
+    const query: LokiQuery = { refId: 'A', expr: '{job="grafana", instance="localhost"}' };
+    expect(sortLabelSelectors(query)).toEqual({ refId: 'A', expr: '{instance="localhost", job="grafana"}' });
+  });
+
+  it('sorts labels in a metric query', () => {
+    const query: LokiQuery = { refId: 'A', expr: 'rate({label_b="B", label_a="A"}[1s])' };
+    expect(sortLabelSelectors(query)).toEqual({ refId: 'A', expr: 'rate({label_a="A", label_b="B"}[1s])' });
+  });
+});
+
+describe('trimAllLines', () => {
+  it('trims all lines of a query', () => {
+    const query: LokiQuery = { refId: 'A', expr: 'rate(    \n    {label_a="A", label_b="B"}\n   [1s]  \n ) ' };
+    expect(trimAllLines(query)).toEqual({ refId: 'A', expr: 'rate(\n{label_a="A", label_b="B"}\n[1s]\n)' });
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -318,22 +318,18 @@ export const sortLabelSelectors = (query: LokiQuery): LokiQuery => {
         return -1;
       }
 
-      if (labelNameA > labelNameB) {
-        return 1;
-      }
-
-      return 0;
+      return labelNameA > labelNameB ? 1 : 0;
     });
 
     let response = '';
 
     matcherNodes.forEach((node) => {
       const labelNode = node.getChild(Identifier);
-      const operatorNode = labelNode ? labelNode.nextSibling : null;
+      const operatorNode = labelNode ? labelNode.nextSibling : '';
       const valueNode = node.getChild(String);
-      const label = labelNode ? selector.substring(labelNode.from, labelNode.to) : null;
-      const operator = operatorNode ? selector.substring(operatorNode.from, operatorNode.to) : null;
-      const value = valueNode ? selector.substring(valueNode.from, valueNode.to) : null;
+      const label = labelNode ? selector.substring(labelNode.from, labelNode.to) : '';
+      const operator = operatorNode ? selector.substring(operatorNode.from, operatorNode.to) : '';
+      const value = valueNode ? selector.substring(valueNode.from, valueNode.to) : '';
       response += `${label}${operator}${value}, `;
     });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -344,5 +344,12 @@ export const sortLabelSelectors = (query: LokiQuery): LokiQuery => {
     query.expr = query.expr.replace(selector.old, selector.new);
   });
 
-  return query;
+  return trimAllLines(query);
+};
+
+const trimAllLines = (query: LokiQuery): LokiQuery => {
+  const lines = query.expr.split('\n');
+  const trimmedLines = lines.map((line) => line.trim());
+  const trimmedExpr = trimmedLines.join('\n');
+  return { ...query, expr: trimmedExpr };
 };

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -343,7 +343,7 @@ export const sortLabelSelectors = (query: LokiQuery): LokiQuery => {
   return trimAllLines(query);
 };
 
-const trimAllLines = (query: LokiQuery): LokiQuery => {
+export const trimAllLines = (query: LokiQuery): LokiQuery => {
   const lines = query.expr.split('\n');
   const trimmedLines = lines.map((line) => line.trim());
   const trimmedExpr = trimmedLines.join('\n');


### PR DESCRIPTION
**What is this feature?**
this takes the first steps towards our goal of trying to improve cache hits in loki

changes in this pr:

1. reorder selectors before running loki queries
2. trim queries of whitespace

> NOTE: THE QUERY DOES NOT CHANGE FOR THE USER, TO SEE THE REFLECTED CHANGE YOU WILL HAVE TO CHECK THE NETWORK TAB

```
input query:
{b_label="second", c_label="third", a_label="first"}

---

executed query:
{a_label="first", b_label="second", c_label="third"}
```


```
input query:
rate(  
    {b_label="second", a_label="first"}
  |=""
   |logfmt 
           |label=""
           [1s]        
) 

---

exectued query:
rate(
{a_label="first", b_label="second"}
|=""
|logfmt
|label=""
[1s]
)

```


**Which issue(s) does this PR fix?**:
Fixes #65994
