### PR TITLE
Dashboards: Save tags on dashboard creation

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
@@ -21,6 +21,7 @@ const prepareDashboardMock = (panel: any) => {
   const json = {
     title: 'name',
     panels: [panel],
+    tags: ['tag1', 'tag2'],
   };
 
   return {
@@ -67,6 +68,7 @@ describe('SaveDashboardAsForm', () => {
       expect(savedDashboardModel.id).toBe(null);
       expect(savedDashboardModel.title).toBe('name');
       expect(savedDashboardModel.editable).toBe(true);
+      expect(savedDashboardModel.tags).toEqual(['tag1', 'tag2']);
     });
 
     it("appends 'Copy' to the name when the dashboard isnt new", async () => {
@@ -80,6 +82,8 @@ describe('SaveDashboardAsForm', () => {
       expect(spy).toBeCalledTimes(1);
       const savedDashboardModel = spy.mock.calls[0][0];
       expect(savedDashboardModel.title).toBe('name Copy');
+      // when copying a dashboard, the tags should be empty
+      expect(savedDashboardModel.tags).toEqual([]);
     });
   });
 

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -80,7 +80,7 @@ export const SaveDashboardAsForm = ({
 
         const clone = getSaveAsDashboardClone(dashboard);
         clone.title = data.title;
-        if (!data.copyTags) {
+        if (!isNew && !data.copyTags) {
           clone.tags = [];
         }
 


### PR DESCRIPTION
**What is this feature?**

When creating a dashboard with tags we weren't persisting them.
There is a flag `copyTags` which is `false` by default and we are using it to clear the `tags` array. When a dashboard is created, we shouldn't erase those tags.
Added a change to evaluate this flag along with `isNew` bool which indicates if this is a new dashboard or not.

Fixes https://github.com/grafana/grafana/issues/71387

**Special notes for your reviewer:**
How to test it:

Create a new dashboard
* Go to dashboard settings
* Add a tag
* Save the dashboard
* Validate the tag is being saved

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
