### PR TITLE
Alert: Change error icon to exclamation-circle

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -101,6 +101,7 @@ Alert.displayName = 'Alert';
 export const getIconFromSeverity = (severity: AlertVariant): IconName => {
   switch (severity) {
     case 'error':
+      return 'exclamation-circle';
     case 'warning':
       return 'exclamation-triangle';
     case 'info':


### PR DESCRIPTION
The icons for warning Alert and Error alert where the same (exclamation-triangle). This changes so that error Alert is using exclamation-circle 

<img width="838" alt="Screenshot 2023-07-11 at 20 11 14" src="https://github.com/grafana/grafana/assets/10999/4fe275ef-927c-4685-a388-f69074a8f6f0">

