### PR TITLE
Cloudwatch: Add comment and regexp to TokenTypes interface

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/completion/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/completion/types.ts
@@ -12,4 +12,6 @@ export const SQLTokenTypes: TokenTypes = {
   Number: 'number.sql',
   String: 'string.sql',
   Variable: 'variable.sql',
+  Comment: 'comment.sql',
+  Regexp: 'regexp.sql',
 };

--- a/public/app/plugins/datasource/cloudwatch/language/dynamic-labels/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/dynamic-labels/CompletionItemProvider.ts
@@ -24,6 +24,8 @@ export class DynamicLabelsCompletionItemProvider implements Completeable {
       Number: 'number.cloudwatch-dynamicLabels',
       String: 'string.cloudwatch-dynamicLabels',
       Variable: 'variable.cloudwatch-dynamicLabels',
+      Comment: 'comment.cloudwatch-dynamicLabels',
+      Regexp: 'regexp.cloudwatch-dynamicLabels',
     };
   }
 

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
@@ -12,4 +12,6 @@ export const LogsTokenTypes: TokenTypes = {
   Number: 'number.cloudwatch-logs',
   String: 'string.cloudwatch-logs',
   Variable: 'variable.cloudwatch-logs',
+  Comment: 'comment.cloudwatch-logs',
+  Regexp: 'regexp.cloudwatch-logs',
 };

--- a/public/app/plugins/datasource/cloudwatch/language/metric-math/completion/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/metric-math/completion/types.ts
@@ -12,4 +12,6 @@ export const MetricMathTokenTypes: TokenTypes = {
   Number: 'number.cloudwatch-MetricMath',
   String: 'string.cloudwatch-MetricMath',
   Variable: 'variable.cloudwatch-MetricMath',
+  Comment: 'comment.cloudwatch-MetricMath',
+  Regexp: 'regexp.cloudwatch-MetricMath',
 };

--- a/public/app/plugins/datasource/cloudwatch/language/monarch/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/monarch/CompletionItemProvider.ts
@@ -40,6 +40,8 @@ export class CompletionItemProvider implements Completeable {
       Number: 'number',
       String: 'string',
       Variable: 'variable',
+      Comment: 'comment',
+      Regexp: 'regexp',
     };
   }
 

--- a/public/app/plugins/datasource/cloudwatch/language/monarch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/monarch/types.ts
@@ -14,6 +14,8 @@ export interface TokenTypes {
   Number: string;
   String: string;
   Variable: string;
+  Comment: string;
+  Regexp: string;
 }
 
 export enum StatementPosition {


### PR DESCRIPTION
**What is this feature?**

Adds comment and regexp token types for Cloudwatch. This is preparatory work for https://github.com/grafana/grafana/pull/70724 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
