### PR TITLE
Cloudwatch Logs: Update language definition for Monaco editor

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/types.ts
@@ -1,17 +1,18 @@
 import { TokenTypes } from '../../monarch/types';
+import { CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID } from '../definition';
 
 export const LogsTokenTypes: TokenTypes = {
-  Parenthesis: 'delimiter.parenthesis.cloudwatch-logs',
-  Whitespace: 'white.cloudwatch-logs',
-  Keyword: 'keyword.cloudwatch-logs',
-  Delimiter: 'delimiter.cloudwatch-logs',
-  Operator: 'operator.cloudwatch-logs',
-  Identifier: 'identifier.cloudwatch-logs',
-  Type: 'type.cloudwatch-logs',
-  Function: 'predefined.cloudwatch-logs',
-  Number: 'number.cloudwatch-logs',
-  String: 'string.cloudwatch-logs',
-  Variable: 'variable.cloudwatch-logs',
-  Comment: 'comment.cloudwatch-logs',
-  Regexp: 'regexp.cloudwatch-logs',
+  Parenthesis: `delimiter.parenthesis.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Whitespace: `white.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Keyword: `keyword.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Delimiter: `delimiter.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Operator: `operator.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Identifier: `identifier.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Type: `type.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Function: `predefined.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Number: `number.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  String: `string.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Variable: `variable.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Comment: `comment.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
+  Regexp: `regexp.${CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID}`,
 };

--- a/public/app/plugins/datasource/cloudwatch/language/logs/definition.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/definition.ts
@@ -1,7 +1,9 @@
 import { LanguageDefinition } from '../monarch/register';
 
+export const CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID = 'cloudwatch-logs';
+
 const cloudWatchLogsLanguageDefinition: LanguageDefinition = {
-  id: 'logs',
+  id: CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID,
   extensions: [],
   aliases: [],
   mimetypes: [],

--- a/public/app/plugins/datasource/cloudwatch/language/logs/language.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/language.ts
@@ -14,8 +14,8 @@ export const STATS = 'stats';
 export const SORT = 'sort';
 export const LIMIT = 'limit';
 export const PARSE = 'parse';
-export const UNMASK = 'unmask'; //make sure we support this one
-export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, STATS, SORT, LIMIT, PARSE, UNMASK];
+export const DEDUP = 'dedup';
+export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, STATS, SORT, LIMIT, PARSE, DEDUP];
 
 export const LOGS_LOGIC_OPERATORS = ['and', 'or', 'not'];
 
@@ -71,9 +71,12 @@ export const LOGS_FUNCTION_OPERATORS = [
   'substr',
   'replace',
   'strcontains',
+  // field
+  'unmask',
 ];
 
-export const LOGS_KEYWORDS = ['like', 'by', 'in', 'desc', 'asc', 'as'];
+export const SORT_DIRECTION_KEYWORDS = ['asc', 'desc'];
+export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS];
 
 export const language: CloudWatchLogsLanguage = {
   defaultToken: 'invalid',


### PR DESCRIPTION
**What is this feature?**

Some more preparatory work for https://github.com/grafana/grafana/pull/70724.

- `CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID` is now defined as a constant
- Adds the `dedup` command
- Changes `unmask` from a command to a function. You can't actually start a new command with `unmask`, it needs to be used as a part of a command like `fields` e.g. `fields @timestamp, unmask(@message)` so I moved it to the `LOGS_FUNCTION_OPERATORS` array in the language definition.
- Extracted the `asc` and `desc` keywords to `SORT_DIRECTION_KEYWORDS` which will be used for the auto suggestion. This is just separating it from the other keywords to make it easier to iterate over.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70853

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
