### PR TITLE
AppChromeService: Fixes update to breadcrumb parent URL

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -167,7 +167,7 @@ export class AppChromeService {
 /**
  * Checks if text, url, active child url and parent are the same
  **/
-function navItemsAreTheSame(a: NavModelItem | undefined, b: NavModelItem | undefined) {
+function navItemsAreTheSame(a: NavModelItem | undefined, b: NavModelItem | undefined): boolean {
   if (a === b) {
     return true;
   }
@@ -179,6 +179,6 @@ function navItemsAreTheSame(a: NavModelItem | undefined, b: NavModelItem | undef
     a?.text === b?.text &&
     a?.url === b?.url &&
     aActiveChild?.url === bActiveChild?.url &&
-    a?.parentItem === b?.parentItem
+    navItemsAreTheSame(a?.parentItem, b?.parentItem)
   );
 }


### PR DESCRIPTION
This was already fixed in main (10.1) but not in 10.0 via https://github.com/grafana/grafana/pull/68673 

This just tweaks that fix and makes it easier to backport in isolation. 