### PR TITLE
Remove relrefs for tutorials pages that have been moved

### DIFF
--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -23,7 +23,7 @@ For our plugins that do not return time series, it might be useful to plot histo
 
 > **Note:** An administrator must configure a Prometheus data source and associate it with a [Remote write target](#remote-write-target) before recorded queries can be used.
 
-Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
+Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
 
 - single row and column - A query that returns a single row and column.
 - row count - A query that returns meaningful rows to be counted.

--- a/docs/sources/alerting/fundamentals/data-source-alerting.md
+++ b/docs/sources/alerting/fundamentals/data-source-alerting.md
@@ -10,7 +10,7 @@ There are a number of data sources that are compatible with Grafana Alerting. Ea
 
 If you are creating your own data source plugin, make sure it is a backend plugin as Grafana Alerting requires this in order to be able to evaluate rules using the data source. Frontend data sources are not supported, because the evaluation engine runs on the backend.
 
-Specifying { "alerting": true, “backend”: true } in the plugin.json file indicates that the data source plugin is compatible with Grafana Alerting and includes the backend data-fetching code. For more information, refer to [Build a data source backend plugin](https://grafana.com/tutorials/build-a-data-source-backend-plugin/).
+Specifying { "alerting": true, “backend”: true } in the plugin.json file indicates that the data source plugin is compatible with Grafana Alerting and includes the backend data-fetching code. For more information, refer to [Build a data source backend plugin](/tutorials/build-a-data-source-backend-plugin/).
 
 These are the data sources that are compatible with and supported by Grafana Alerting.
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -48,4 +48,4 @@ In addition to the data sources that you have configured in your Grafana instanc
 
 ## Data source plugins
 
-You can install additional data sources as plugins. To view available data source plugins, see the [Grafana Plugins catalog](https://grafana.com/plugins). To build your own, see the ["Build a data source plugin"](https://grafana.com/tutorials/build-a-data-source-plugin/) tutorial and our documentation about [building a plugin](/developers/plugins/).
+You can install additional data sources as plugins. To view available data source plugins, see the [Grafana Plugins catalog](https://grafana.com/plugins). To build your own, see the ["Build a data source plugin"](/tutorials/build-a-data-source-plugin/) tutorial and our documentation about [building a plugin](/developers/plugins/).

--- a/docs/sources/developers/_index.md
+++ b/docs/sources/developers/_index.md
@@ -13,6 +13,6 @@ This section includes the following Grafana developer documentation:
 
 You might also find the following resources to be helpful:
 
-- [Grafana Tutorials:](https://grafana.com/tutorials/) Step-by-step guides that help you make the most of Grafana.
+- [Grafana Tutorials:](/tutorials/) Step-by-step guides that help you make the most of Grafana.
 - [Grafana Community Forums:](https://community.grafana.com) Get technical support for open source Grafana, Loki, and Tempo.
 - [Grafana design system:](https://developers.grafana.com) Library of reusable Grafana components and guidelines that help you with contribution and plugin development.

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -33,5 +33,5 @@ For panels, the rendering logic could in some cases be easily preserved but all 
 ### Links
 
 - [Migrate Angular to React](https://grafana.com/docs/grafana/latest/developers/plugins/migration-guide/#migrate-a-plugin-from-angular-to-react)
-- [Build a panel plugin](https://grafana.com/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](https://grafana.com/tutorials/build-a-data-source-plugin/)
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -713,7 +713,7 @@ Proxies all calls to the actual data source identified by the `uid`.
 
 `GET /api/datasources/:datasourceId/health`
 
-Makes a call to the health endpoint of data source identified by the given `datasourceId`. This is not mandatory - every plugin author has to <a href="https://grafana.com/tutorials/build-a-data-source-backend-plugin/#add-support-for-health-checks" target="_blank">implement support for health checks</a> in their plugin themselves.
+Makes a call to the health endpoint of data source identified by the given `datasourceId`. This is not mandatory - every plugin author has to <a href="/tutorials/build-a-data-source-backend-plugin/#add-support-for-health-checks" target="_blank">implement support for health checks</a> in their plugin themselves.
 
 ### Examples
 

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -24,8 +24,8 @@ npx @grafana/toolkit plugin:create my-grafana-plugin
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -35,13 +35,13 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}})
-- [Build a data source backend plugin]({{< relref "/tutorials/build-a-data-source-backend-plugin" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
+- [Build a data source backend plugin](/tutorials/build-a-data-source-backend-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js]({{< relref "/tutorials/build-a-panel-plugin-with-d3" >}})
+- [Build a panel plugin with D3.js](/tutorials/build-a-panel-plugin-with-d3/)
 
 ### Guides
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -6,7 +6,7 @@ title: Add support for annotations
 
 This guide explains how to add support for [annotations]({{< relref "../../dashboards/build-dashboards/annotate-visualizations" >}}) to an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 > **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -6,7 +6,7 @@ title: Add support for Explore queries
 
 This guide explains how to improve support for [Explore]({{< relref "../../explore/" >}}) in an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a logs data source plugin
 
 This guide explains how to build a logs data source plugin.
 
-Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}}) for metrics.
+Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/) for metrics.
 
 ## Add logs support to your data source
 

--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a streaming data source plugin
 
 This guide explains how to build a streaming data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 When monitoring critical applications, you want your dashboard to refresh as soon as your data does. In Grafana, you can set your dashboards to automatically refresh at a certain interval, no matter what data source you use. Unfortunately, this means that your queries are requesting all the data to be sent again, regardless of whether the data has actually changed.
 

--- a/docs/sources/developers/plugins/legacy/_index.md
+++ b/docs/sources/developers/plugins/legacy/_index.md
@@ -31,7 +31,7 @@ Example plugins
 
 You might also be interested in the available tutorials around authoring a plugin.
 
-- [Grafana Tutorials](https://grafana.com/tutorials/)
+- [Grafana Tutorials](/tutorials/)
 
 ## What languages?
 

--- a/docs/sources/setup-grafana/set-up-grafana-live.md
+++ b/docs/sources/setup-grafana/set-up-grafana-live.md
@@ -45,7 +45,7 @@ For data source plugin channels, Grafana uses `ds` scope. Namespace in the case 
 
 For example, a data source channel looks like this: `ds/<DATASOURCE_UID>/<CUSTOM_PATH>`.
 
-Refer to the tutorial about [building a streaming data source backend plugin](https://grafana.com/tutorials/build-a-streaming-data-source-plugin/) for more details.
+Refer to the tutorial about [building a streaming data source backend plugin](/tutorials/build-a-streaming-data-source-plugin/) for more details.
 
 The basic streaming example included in Grafana core streams frames with some generated data to a panel. To look at it create a new panel and point it to the `-- Grafana --` data source. Next, choose `Live Measurements` and select the `plugin/testdata/random-20Hz-stream` channel.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -154,10 +154,10 @@ To learn more, start with the [overview]({{< relref "../developers/plugins/backe
 
 To help you get started with Grafana, we’ve launched a brand new tutorials platform. We’ll continue to expand the platform with more tutorials, but here are some of the ones you can try out now:
 
-- [Grafana fundamentals](https://grafana.com/tutorials/grafana-fundamentals/)
-- [Create users and teams](https://grafana.com/tutorials/create-users-and-teams/)
-- [Build a panel plugin](https://grafana.com/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](https://grafana.com/tutorials/build-a-data-source-plugin/)
+- [Grafana fundamentals](/tutorials/grafana-fundamentals/)
+- [Create users and teams](/tutorials/create-users-and-teams/)
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
 
 ## Rollup indicator for Metrictank queries
 


### PR DESCRIPTION
Moved in grafana/grafana#69864.

Fixes some build errors in the website. When the aliases are in place, the redirects will take users to the correct plugin docs page. Unfortunately relrefs are not alias aware.
