### PR TITLE
Remove relrefs for tutorials pages that have been moved

### DIFF
--- a/docs/sources/developers/_index.md
+++ b/docs/sources/developers/_index.md
@@ -11,6 +11,6 @@ This section of the documentation contains pages with resources for Grafana deve
 
 - [Grafana Contribution Guide - learn how you can contribute your skills to make Grafana even better.]({{< relref "contribute.md" >}})
 - [How to build a plugin]({{< relref "plugins" >}})
-- [Grafana Tutorials - step-by-step guides that help you make the most of Grafana](https://grafana.com/tutorials/)
+- [Grafana Tutorials - step-by-step guides that help you make the most of Grafana](/tutorials/)
 - [Grafana Community Forums - get technical support for open source Grafana, Loki, and Tempo.](https://community.grafana.com)
 - [Grafana design system - library of reusable Grafana components and guidelines that help you with contribution and plugin development](https://developers.grafana.com)

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -32,5 +32,5 @@ For panels, the rendering logic could in some cases be easily preserved but all 
 ### Links
 
 - [Migrate Angular to React](https://grafana.com/docs/grafana/latest/developers/plugins/migration-guide/#migrate-a-plugin-from-angular-to-react)
-- [Build a panel plugin](https://grafana.com/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](https://grafana.com/tutorials/build-a-data-source-plugin/)
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -22,8 +22,8 @@ npx @grafana/toolkit plugin:create my-grafana-plugin
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -33,13 +33,13 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
-- [Build a data source backend plugin]({{< relref "/tutorials/build-a-data-source-backend-plugin.md" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
+- [Build a data source backend plugin](/tutorials/build-a-data-source-backend-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js]({{< relref "/tutorials/build-a-panel-plugin-with-d3.md" >}})
+- [Build a panel plugin with D3.js](/tutorials/build-a-panel-plugin-with-d3/)
 
 ### Guides
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -6,7 +6,7 @@ title: Add support for annotations
 
 This guide explains how to add support for [annotations]({{< relref "../../dashboards/annotations.md" >}}) to an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 > **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to the [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -6,7 +6,7 @@ title: Add support for Explore queries
 
 This guide explains how to improve support for [Explore]({{< relref "../../explore/_index.md" >}}) in an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a logs data source plugin
 
 This guide explains how to build a logs data source plugin.
 
-Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}) for metrics.
+Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/) for metrics.
 
 ## Add logs support to your data source
 

--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a streaming data source plugin
 
 This guide explains how to build a streaming data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 When monitoring critical applications, you want your dashboard to refresh as soon as your data does. In Grafana, you can set your dashboards to automatically refresh at a certain interval, no matter what data source you use. Unfortunately, this means that your queries are requesting all the data to be sent again, regardless of whether the data has actually changed.
 

--- a/docs/sources/developers/plugins/legacy/_index.md
+++ b/docs/sources/developers/plugins/legacy/_index.md
@@ -32,7 +32,7 @@ Example plugins
 
 You might also be interested in the available tutorials around authoring a plugin.
 
-- [Grafana Tutorials](https://grafana.com/tutorials/)
+- [Grafana Tutorials](/tutorials/)
 
 ## What languages?
 

--- a/docs/sources/enterprise/recorded-queries.md
+++ b/docs/sources/enterprise/recorded-queries.md
@@ -19,7 +19,7 @@ For our plugins that do not return time series, it might be useful to plot histo
 
 > **Note:** An administrator must configure a Prometheus data source and associate it with a [Remote write target](#remote-write-target) before recorded queries can be used.
 
-Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
+Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
 
 - single row and column - A query that returns a single row and column.
 - row count - A query that returns meaningful rows to be counted.

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -154,10 +154,10 @@ To learn more, start with the [overview]({{< relref "../developers/plugins/backe
 
 To help you get started with Grafana, we’ve launched a brand new tutorials platform. We’ll continue to expand the platform with more tutorials, but here are some of the ones you can try out now:
 
-- [Grafana fundamentals](https://grafana.com/tutorials/grafana-fundamentals/)
-- [Create users and teams](https://grafana.com/tutorials/create-users-and-teams/)
-- [Build a panel plugin](https://grafana.com/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](https://grafana.com/tutorials/build-a-data-source-plugin/)
+- [Grafana fundamentals](/tutorials/grafana-fundamentals/)
+- [Create users and teams](/tutorials/create-users-and-teams/)
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
 
 ## Rollup indicator for Metrictank queries
 


### PR DESCRIPTION
Moved in grafana/grafana#69864.

Fixes some build errors in the website. When the aliases are in place, the redirects will take users to the correct plugin docs page. Unfortunately relrefs are not alias aware.
