### PR TITLE
api: ignore /api/gnet proxy when gzipping responses

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -45,6 +45,7 @@ var gzipIgnoredPaths = []matcher{
 	prefix("/api/datasources"),
 	prefix("/api/plugins"),
 	prefix("/api/plugin-proxy/"),
+	prefix("/api/gnet/"), // Already gzipped by grafana.com.
 	prefix("/metrics"),
 	prefix("/api/live/ws"),   // WebSocket does not support gzip compression.
 	prefix("/api/live/push"), // WebSocket does not support gzip compression.


### PR DESCRIPTION
**What is this feature?**

This PR adds /api/gnet to the list of ignored paths in the gzip middleware.

**Why do we need this feature?**

Without this, when gzip is enabled (`server.enable_gzip = true`), responses from the gnet proxy are double compressed: once by grafana.com and once by Grafana itself. With this change we only do one round of compression for these endpoints.

**Special notes for your reviewer:**

To test this out, try a request like this with `server.enable_gzip = true` (after setting `GCOM_TOKEN` to a valid grafana.com token; you may need to change the 'bsull' slug, too):

    curl -v --user admin:admin \
        -H "X-Api-Key: $GCOM_TOKEN" \
        -H 'Accept-Encoding: gzip' \
        localhost:3000/api/gnet/instances/bsull/provisioned-plugins/grafana-ml-app | gzip -d

Note that there are two Content-Encoding: gzip headers before this PR, and the output is still compressed even after the `gzip -d`. After this PR things look as expected.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
