### PR TITLE
Alerting: Fix state in expressions footer

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -66,8 +66,8 @@ export const Expression: FC<ExpressionProps> = ({
   //const showSummary = isAlertCondition && hasResults;
 
   const groupedByState = {
-    [PromAlertingRuleState.Firing]: series.filter((serie) => getSeriesValue(serie) >= 1),
-    [PromAlertingRuleState.Inactive]: series.filter((serie) => getSeriesValue(serie) < 1),
+    [PromAlertingRuleState.Firing]: series.filter((serie) => getSeriesValue(serie) !== 0),
+    [PromAlertingRuleState.Inactive]: series.filter((serie) => getSeriesValue(serie) === 0),
   };
 
   const renderExpressionType = useCallback(


### PR DESCRIPTION
**What is this feature?**

This PR fixes status in expressions footer. The logic behind identifying a firing alert or normal was wrong.

**Special notes for your reviewer:**

Before:

<img width="872" alt="Screenshot 2023-07-12 at 13 01 03" src="https://github.com/grafana/grafana/assets/33540275/d90a08ae-021a-4abe-b4d0-a7b1b49fcd63">

After:

<img width="852" alt="Screenshot 2023-07-12 at 13 07 59" src="https://github.com/grafana/grafana/assets/33540275/5df5baed-14e0-421f-92dc-05b6eb4dbe00">



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
