### PR TITLE
NestedFolderPicker: Truncate overflowing text, fix selected state

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -205,13 +205,14 @@ export const getButtonStyles = (props: StyleProps) => {
       : css({
           marginRight: theme.spacing(padding / 2),
         }),
-    content: css`
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      white-space: nowrap;
-      height: 100%;
-    `,
+    content: css({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      height: '100%',
+    }),
   };
 };
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -116,8 +116,8 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
         onKeyDown={handleKeyDown}
       />
 
-      <Indent level={level} />
       <div className={styles.rowBody}>
+        <Indent level={level} />
         {foldersAreOpenable ? (
           <IconButton
             size={CHEVRON_SIZE}
@@ -150,7 +150,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     alignItems: 'center',
     flexGrow: 1,
     gap: theme.spacing(0.5),
-    paddingLeft: theme.spacing(1),
+    overflow: 'hidden',
+    padding: theme.spacing(0, 1),
   });
 
   return {
@@ -161,14 +162,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     // Should be the same size as the <IconButton /> for proper alignment
     folderButtonSpacer: css({
       paddingLeft: `calc(${getSvgSize(CHEVRON_SIZE)}px + ${theme.spacing(0.5)})`,
-    }),
-
-    headerRow: css({
-      backgroundColor: theme.colors.background.secondary,
-      height: ROW_HEIGHT,
-      lineHeight: ROW_HEIGHT + 'px',
-      margin: 0,
-      paddingLeft: theme.spacing(3.5),
     }),
 
     row: css({
@@ -210,6 +203,10 @@ const getStyles = (theme: GrafanaTheme2) => {
     label: css({
       lineHeight: ROW_HEIGHT + 'px',
       flexGrow: 1,
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
       '&:hover': {
         textDecoration: 'underline',
         cursor: 'pointer',

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -6,6 +6,7 @@ import { useAsync } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, FilterInput, LoadingBar, useStyles2 } from '@grafana/ui';
+import { Text } from '@grafana/ui/src/components/Text/Text';
 import { skipToken, useGetFolderQuery } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { listFolders, PAGE_SIZE } from 'app/features/browse-dashboards/api/services';
 import { createFlatTree } from 'app/features/browse-dashboards/state';
@@ -167,7 +168,13 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
         icon={value !== undefined ? 'folder' : undefined}
         ref={setTriggerRef}
       >
-        {selectedFolder.isLoading ? <Skeleton width={100} /> : label ?? 'Select folder'}
+        {selectedFolder.isLoading ? (
+          <Skeleton width={100} />
+        ) : (
+          <Text as="span" truncate>
+            {label ?? 'Select folder'}
+          </Text>
+        )}
       </Button>
     );
   }

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -142,8 +142,8 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
     offset: [0, 0],
     trigger: 'click',
     onVisibleChange: (value: boolean) => {
-      // Clear search state when closing the overlay
-      if (!value) {
+      // ensure search state is clean on opening the overlay
+      if (value) {
         setSearch('');
       }
       setOverlayOpen(value);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes the selection state so it now shows correctly (i accidentally broke this as part of https://github.com/grafana/grafana/pull/71042)
- truncates the button text correctly for long folder names
- truncates the option text correctly for long folder names
- ensures the search state is always clean when opening the overlay

|  | button | options |
| --- | --- | --- |
| before | ![image](https://github.com/grafana/grafana/assets/20999846/e870f30c-60f0-40f0-9951-be33e33b99b5) | ![image](https://github.com/grafana/grafana/assets/20999846/3fb31ad8-e95f-4dd3-8e8d-9391c8ef114d) |
| after | ![image](https://github.com/grafana/grafana/assets/20999846/dc832da0-78cf-4bb4-b72c-538c5ccdb89b) | ![image](https://github.com/grafana/grafana/assets/20999846/7e875391-1a02-4413-a586-e4213eb2fe37) |

**Why do we need this feature?**

- so it looks nicer

**Who is this feature for?**

- anyone using the new nested folder picker

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
