### PR TITLE
[v9.5.x] Chore: Upgrade Go to 1.20.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -74,13 +74,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-starlark .
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: lint-starlark
 trigger:
   event:
@@ -127,13 +127,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -153,7 +153,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - yarn run ci:test-frontend
@@ -162,7 +162,7 @@ steps:
   - clone-enterprise
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   event:
@@ -216,7 +216,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -225,7 +225,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -237,7 +237,7 @@ steps:
   - clone-enterprise
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: lint-frontend
 trigger:
   event:
@@ -291,7 +291,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -302,7 +302,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -312,7 +312,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -321,25 +321,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   event:
@@ -388,7 +388,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -408,13 +408,13 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - make gen-go
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -423,7 +423,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: lint-backend
 trigger:
   event:
@@ -479,7 +479,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -488,7 +488,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -496,18 +496,18 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -530,7 +530,7 @@ steps:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: trigger-test-release
   when:
     branch: main
@@ -558,7 +558,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -567,7 +567,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -576,7 +576,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -584,7 +584,7 @@ steps:
   - compile-build-cmd
   - yarn-install
   environment: null
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/build package --jobs 8 --edition oss
@@ -595,7 +595,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -608,7 +608,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -711,7 +711,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-storybook
   when:
     paths:
@@ -722,7 +722,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -853,7 +853,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -866,7 +866,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -880,7 +880,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -889,13 +889,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -911,7 +911,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -927,7 +927,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 trigger:
   event:
@@ -979,7 +979,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - |-
@@ -991,7 +991,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -999,7 +999,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1043,13 +1043,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: shellcheck
 trigger:
   event:
@@ -1090,7 +1090,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - |-
@@ -1102,7 +1102,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1110,7 +1110,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1163,13 +1163,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -1177,7 +1177,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   branch: main
@@ -1217,7 +1217,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -1228,7 +1228,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: lint-frontend
 trigger:
   branch: main
@@ -1270,7 +1270,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1279,7 +1279,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1287,25 +1287,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   branch: main
@@ -1347,12 +1347,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -1361,7 +1361,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: lint-backend
 - commands:
   - ./bin/build verify-drone
@@ -1415,7 +1415,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1424,7 +1424,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1432,25 +1432,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1459,7 +1459,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1468,7 +1468,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1478,7 +1478,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1496,7 +1496,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1509,7 +1509,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1612,7 +1612,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-storybook
   when:
     paths:
@@ -1623,7 +1623,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1667,7 +1667,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: publish-frontend-metrics
   when:
     repo:
@@ -1760,7 +1760,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: release-canary-npm-packages
   when:
     repo:
@@ -1858,7 +1858,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1871,7 +1871,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1879,13 +1879,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -1901,7 +1901,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1917,7 +1917,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -2143,13 +2143,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build whatsnew-checker
   depends_on:
   - compile-build-cmd
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: whats-new-checker
 trigger:
   event:
@@ -2199,32 +2199,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -2233,7 +2233,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -2242,7 +2242,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -2252,7 +2252,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -2270,14 +2270,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -2316,7 +2316,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2393,7 +2393,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-storybook
   when:
     event:
@@ -2452,7 +2452,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: store-npm-packages
 trigger:
   event:
@@ -2498,13 +2498,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -2512,7 +2512,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   event:
@@ -2554,7 +2554,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2563,7 +2563,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2571,25 +2571,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   event:
@@ -2704,7 +2704,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2721,7 +2721,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2729,19 +2729,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2751,7 +2751,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2760,14 +2760,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2776,7 +2776,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2785,7 +2785,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -2795,7 +2795,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2813,14 +2813,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -2860,7 +2860,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2995,7 +2995,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3012,7 +3012,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -3022,14 +3022,14 @@ steps:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - init-enterprise
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -3038,7 +3038,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   event:
@@ -3078,7 +3078,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -3101,7 +3101,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -3113,7 +3113,7 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3123,7 +3123,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3132,25 +3132,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   event:
@@ -3287,7 +3287,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3304,7 +3304,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3312,19 +3312,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3334,7 +3334,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3343,7 +3343,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3352,7 +3352,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -3362,14 +3362,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -3387,7 +3387,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package-enterprise2
 - commands:
   - ./bin/build upload-cdn --edition enterprise2
@@ -3407,7 +3407,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package-enterprise2
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise2 --shouldSave
@@ -3545,7 +3545,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3653,7 +3653,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise
@@ -3728,7 +3728,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise2
@@ -3791,7 +3791,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise2
@@ -3855,7 +3855,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise
@@ -3906,7 +3906,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
@@ -3975,7 +3975,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
@@ -4044,12 +4044,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - ./bin/build artifacts npm retrieve --tag ${DRONE_TAG}
@@ -4073,7 +4073,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: release-npm-packages
 trigger:
   event:
@@ -4110,7 +4110,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -4201,7 +4201,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -4555,32 +4555,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -4589,7 +4589,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -4598,7 +4598,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -4608,7 +4608,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -4626,14 +4626,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -4672,7 +4672,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -4749,7 +4749,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-storybook
   when:
     paths:
@@ -4830,13 +4830,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -4844,7 +4844,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   ref:
@@ -4880,7 +4880,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4889,7 +4889,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4897,25 +4897,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   ref:
@@ -4979,7 +4979,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4987,13 +4987,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -5009,7 +5009,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -5025,7 +5025,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 trigger:
   ref:
@@ -5130,7 +5130,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5146,7 +5146,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -5154,19 +5154,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5176,7 +5176,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5185,14 +5185,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5201,7 +5201,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5210,7 +5210,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -5220,7 +5220,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5239,14 +5239,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -5286,7 +5286,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -5427,7 +5427,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5443,7 +5443,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -5453,14 +5453,14 @@ steps:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - init-enterprise
   - yarn-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -5469,7 +5469,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-frontend
 trigger:
   ref:
@@ -5503,7 +5503,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -5525,7 +5525,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -5537,7 +5537,7 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5547,7 +5547,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5556,25 +5556,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: test-backend-integration
 trigger:
   ref:
@@ -5644,7 +5644,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5660,7 +5660,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5670,7 +5670,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5679,13 +5679,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -5701,7 +5701,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -5717,7 +5717,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -5728,7 +5728,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -5739,7 +5739,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: memcached-integration-tests
 trigger:
   ref:
@@ -5866,7 +5866,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5882,7 +5882,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -5890,19 +5890,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5912,7 +5912,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5921,7 +5921,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5930,7 +5930,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -5940,7 +5940,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -5948,7 +5948,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -5967,7 +5967,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: package-enterprise2
 - commands:
   - ./bin/build upload-cdn --edition enterprise2
@@ -5987,7 +5987,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package-enterprise2
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise2 --shouldSave
@@ -6141,7 +6141,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -6149,13 +6149,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -6171,7 +6171,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -6187,7 +6187,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 trigger:
   event:
@@ -6264,7 +6264,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -6281,7 +6281,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -6291,7 +6291,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -6300,13 +6300,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: wire-install
 - commands:
   - apt-get update
@@ -6322,7 +6322,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -6338,7 +6338,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -6349,7 +6349,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -6360,7 +6360,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.4
+  image: grafana/build-container:1.7.5
   name: memcached-integration-tests
 trigger:
   event:
@@ -6611,11 +6611,11 @@ platform:
 steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.4
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.17.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.4
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.6
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
@@ -6633,11 +6633,11 @@ steps:
   name: scan-unknown-low-medium-vulnerabilities
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.4
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.17.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.4
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.6
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
@@ -6680,7 +6680,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.4
+  image: golang:1.20.6
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss
@@ -6885,6 +6885,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 2838a4ea6de63512556ec81bcc6fe0f6875453f059efa8d71faa7849bd6fdb2f
+hmac: 35192e2a51d31c9468629bcd4d72e2bc0840dcc81d770e24bc9dd57fb24ec00f
 
 ...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.2'
+        go-version: '1.20.6'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.2'
+        go-version: '1.20.6'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=alpine:3.17
 ARG JS_IMAGE=node:18-alpine3.17
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.20.4-alpine3.17
+ARG GO_IMAGE=golang:1.20.6-alpine3.17
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
-	--build-arg GO_IMAGE=golang:1.20.4 \
+	--build-arg GO_IMAGE=golang:1.20.6 \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (LTS into 2024) in order to ensure binary compatibility with older glibc's.
 FROM debian:buster-20220822
 
-ENV GOVERSION=1.20.4 \
+ENV GOVERSION=1.20.6 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=18.12.0-1nodesource1 \

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -4,11 +4,11 @@ This module contains all the docker images that are used to build test and publi
 
 images = {
     "cloudsdk_image": "google/cloud-sdk:431.0.0",
-    "build_image": "grafana/build-container:1.7.4",
+    "build_image": "grafana/build-container:1.7.5",
     "publish_image": "grafana/grafana-ci-deploy:1.3.3",
     "alpine_image": "alpine:3.17.1",
     "curl_image": "byrnedo/alpine-curl:0.1.8",
-    "go_image": "golang:1.20.4",
+    "go_image": "golang:1.20.6",
     "plugins_slack_image": "plugins/slack",
     "postgres_alpine_image": "postgres:12.3-alpine",
     "mysql5_image": "mysql:5.7.39",


### PR DESCRIPTION
Updates Grafana's Go version to 1.20.6.