### PR TITLE
Plugins: Remove logs button instead of disabling it

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -278,7 +278,6 @@ export default function SpanDetail(props: SpanDetailProps) {
   }
 
   const focusSpanLink = createFocusSpanLink(traceID, spanID);
-
   return (
     <div data-testid="span-detail-component">
       <div className={styles.header}>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 
 import { dateTimeFormat, GrafanaTheme2, LinkModel, TimeZone } from '@grafana/data';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
-import { Button, DataLinkButton, Icon, TextArea, useStyles2 } from '@grafana/ui';
+import { DataLinkButton, Icon, TextArea, useStyles2 } from '@grafana/ui';
 
 import { autoColor } from '../../Theme';
 import { Divider } from '../../common/Divider';
@@ -274,24 +274,11 @@ export default function SpanDetail(props: SpanDetailProps) {
           buttonProps={{ icon: 'gf-logs' }}
         />
       );
-    } else {
-      logLinkButton = (
-        <Button
-          variant="primary"
-          size="sm"
-          icon={'gf-logs'}
-          disabled
-          tooltip={
-            'We did not match any variables between the link and this span. Check your configuration or this span attributes.'
-          }
-        >
-          Logs for this span
-        </Button>
-      );
     }
   }
 
   const focusSpanLink = createFocusSpanLink(traceID, spanID);
+
   return (
     <div data-testid="span-detail-component">
       <div className={styles.header}>


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/66996

This PR proposes to simply remove the logs button instead of showing it as disabled. The addressed GitHub issue proposes to provide an option to choose whether the button should be removed or disabled, but we discussed this internally and we thought this to be a more pragmatic approach for the moment.

Example:
<img width="691" alt="removed_button" src="https://github.com/grafana/grafana/assets/135109076/fd070d2f-c14b-4667-8fd0-bcf9c04ba16b">

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
