### PR TITLE
Plugins: App plugins running inside a sandbox div will have height 100%

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_components.tsx
+++ b/public/app/features/plugins/sandbox/sandbox_components.tsx
@@ -1,7 +1,7 @@
 import { isFunction } from 'lodash';
 import React, { ComponentType, FC } from 'react';
 
-import { PluginConfigPage, PluginExtensionConfig, PluginMeta } from '@grafana/data';
+import { PluginConfigPage, PluginExtensionConfig, PluginMeta, PluginType } from '@grafana/data';
 
 import { SandboxedPluginObject } from './types';
 import { isSandboxedPluginObject } from './utils';
@@ -40,21 +40,21 @@ export async function sandboxPluginComponents(
 
   // wrap panel component
   if (Reflect.has(pluginObject, 'panel')) {
-    Reflect.set(pluginObject, 'panel', withSandboxWrapper(Reflect.get(pluginObject, 'panel'), meta.id));
+    Reflect.set(pluginObject, 'panel', withSandboxWrapper(Reflect.get(pluginObject, 'panel'), meta));
   }
 
   // wrap datasource components
   if (Reflect.has(pluginObject, 'components')) {
     const components: Record<string, ComponentType> = Reflect.get(pluginObject, 'components');
     Object.entries(components).forEach(([key, value]) => {
-      Reflect.set(components, key, withSandboxWrapper(value, meta.id));
+      Reflect.set(components, key, withSandboxWrapper(value, meta));
     });
     Reflect.set(pluginObject, 'components', components);
   }
 
   // wrap app components
   if (Reflect.has(pluginObject, 'root')) {
-    Reflect.set(pluginObject, 'root', withSandboxWrapper(Reflect.get(pluginObject, 'root'), meta.id));
+    Reflect.set(pluginObject, 'root', withSandboxWrapper(Reflect.get(pluginObject, 'root'), meta));
   }
 
   // extension components
@@ -62,7 +62,7 @@ export async function sandboxPluginComponents(
     const extensions: PluginExtensionConfig[] = Reflect.get(pluginObject, 'extensionConfigs');
     for (const extension of extensions) {
       if (Reflect.has(extension, 'component')) {
-        Reflect.set(extension, 'component', withSandboxWrapper(Reflect.get(extension, 'component'), meta.id));
+        Reflect.set(extension, 'component', withSandboxWrapper(Reflect.get(extension, 'component'), meta));
       }
     }
     Reflect.set(pluginObject, 'extensionConfigs', extensions);
@@ -77,7 +77,7 @@ export async function sandboxPluginComponents(
       }
       Reflect.set(configPages, key, {
         ...value,
-        body: withSandboxWrapper(value.body, meta.id),
+        body: withSandboxWrapper(value.body, meta),
       });
     }
     Reflect.set(pluginObject, 'configPages', configPages);
@@ -88,11 +88,11 @@ export async function sandboxPluginComponents(
 
 const withSandboxWrapper = <P extends object>(
   WrappedComponent: ComponentType<P>,
-  pluginId: string
+  pluginMeta: PluginMeta
 ): React.MemoExoticComponent<FC<P>> => {
   const WithWrapper = React.memo((props: P) => {
     return (
-      <div data-plugin-sandbox={pluginId}>
+      <div data-plugin-sandbox={pluginMeta.id} style={{ height: pluginMeta.type === PluginType.app ? '100%' : 'auto' }}>
         <WrappedComponent {...props} />
       </div>
     );


### PR DESCRIPTION
**What is this feature?**

Adds `height: 100%` to divs wrapping app plugins to fix an issue where some apps won't render correctly due to this new wrapper div

**Why do we need this feature?**

To fix some app plugins currently not rendering correctly inside the sandbox

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
