### PR TITLE
AzureMonitor: Fix resource selection growing over resource selection table

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.tsx
@@ -170,7 +170,7 @@ const ResourcePicker = ({
   );
 
   return (
-    <div>
+    <>
       <Search searchFn={handleSearch} />
       {shouldShowLimitFlag ? (
         <p className={styles.resultLimit}>Showing first {resourcePickerData.resultLimit} results</p>
@@ -188,7 +188,7 @@ const ResourcePicker = ({
         </thead>
       </table>
 
-      <div className={styles.tableScroller}>
+      <div className={cx(styles.scrollableTable, styles.tableScroller)}>
         <table className={styles.table}>
           <tbody>
             {isLoading && (
@@ -223,12 +223,12 @@ const ResourcePicker = ({
         </table>
       </div>
 
-      <div className={styles.selectionFooter}>
+      <footer className={styles.selectionFooter}>
         {selectedRows.length > 0 && (
           <>
             <h5>Selection</h5>
 
-            <div className={styles.tableScroller}>
+            <div className={cx(styles.scrollableTable, styles.selectedTableScroller)}>
               <table className={styles.table}>
                 <tbody>
                   {selectedRows.map((row) => (
@@ -282,8 +282,8 @@ const ResourcePicker = ({
             Apply
           </Button>
         </Modal.ButtonRow>
-      </div>
-    </div>
+      </footer>
+    </>
   );
 };
 

--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/styles.ts
@@ -6,10 +6,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   table: css({
     width: '100%',
     tableLayout: 'fixed',
+    overflow: 'scroll',
   }),
 
   tableScroller: css({
-    maxHeight: '50vh',
+    maxHeight: '20vh',
     overflow: 'auto',
   }),
 

--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/styles.ts
@@ -9,9 +9,16 @@ const getStyles = (theme: GrafanaTheme2) => ({
     overflow: 'scroll',
   }),
 
-  tableScroller: css({
-    maxHeight: '20vh',
+  scrollableTable: css({
     overflow: 'auto',
+  }),
+
+  tableScroller: css({
+    maxHeight: '16vh',
+  }),
+
+  selectedTableScroller: css({
+    maxHeight: '13vh',
   }),
 
   header: css({
@@ -82,8 +89,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 
   selectionFooter: css({
-    position: 'sticky',
-    bottom: 0,
     background: theme.colors.background.primary,
     paddingTop: theme.spacing(2),
   }),


### PR DESCRIPTION
Fixes #68306.

This PR fixes an issue where, when choosing multiple resources using the resource picker in the Explore view, eventually the current selection grows beyond the table where you can select new resources, leading to the inability to select more.

https://github.com/grafana/grafana/assets/16296989/4e6e07b2-729e-4598-a293-5bec72d1a2b1
