### PR TITLE
Nested folders: Empty state for nested folder picker

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -52,7 +52,7 @@ export function NestedFolderList({
         </List>
       ) : (
         <div className={styles.emptyMessage}>
-          <Trans i18nKey="browse-dashboards.nested-folder-picker.empty-message">No folders found</Trans>
+          <Trans i18nKey="browse-dashboards.folder-picker.empty-message">No folders found</Trans>
         </div>
       )}
     </div>

--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -6,6 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
 import { Text } from '@grafana/ui/src/components/Text/Text';
+import { Trans } from 'app/core/internationalization';
 import { Indent } from 'app/features/browse-dashboards/components/Indent';
 import { DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { DashboardViewItem } from 'app/features/search/types';
@@ -39,15 +40,21 @@ export function NestedFolderList({
 
   return (
     <div className={styles.table}>
-      <List
-        height={ROW_HEIGHT * Math.min(6.5, items.length)}
-        width="100%"
-        itemData={virtualData}
-        itemSize={ROW_HEIGHT}
-        itemCount={items.length}
-      >
-        {Row}
-      </List>
+      {items.length > 0 ? (
+        <List
+          height={ROW_HEIGHT * Math.min(6.5, items.length)}
+          width="100%"
+          itemData={virtualData}
+          itemSize={ROW_HEIGHT}
+          itemCount={items.length}
+        >
+          {Row}
+        </List>
+      ) : (
+        <div className={styles.emptyMessage}>
+          <Trans i18nKey="browse-dashboards.nested-folder-picker.empty-message">No folders found</Trans>
+        </div>
+      )}
     </div>
   );
 }
@@ -132,7 +139,6 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
         )}
 
         <label className={styles.label} htmlFor={id}>
-          {/* TODO: text is not truncated properly, it still overflows the container */}
           <Text as="span" truncate>
             {item.title}
           </Text>
@@ -157,6 +163,12 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     table: css({
       background: theme.components.input.background,
+    }),
+
+    emptyMessage: css({
+      padding: theme.spacing(1),
+      textAlign: 'center',
+      width: '100%',
     }),
 
     // Should be the same size as the <IconButton /> for proper alignment

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -86,7 +86,7 @@ describe('NestedFolderPicker', () => {
     expect(screen.queryByRole('button', { name: 'Select folder' })).not.toBeInTheDocument();
 
     // Search input and folder tree are visible
-    expect(screen.getByPlaceholderText('Search folder')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search folders')).toBeInTheDocument();
     expect(screen.getByLabelText('Dashboards')).toBeInTheDocument();
     expect(screen.getByLabelText(folderA.item.title)).toBeInTheDocument();
     expect(screen.getByLabelText(folderB.item.title)).toBeInTheDocument();

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -173,7 +173,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
           <Skeleton width={100} />
         ) : (
           <Text as="span" truncate>
-            {label ?? <Trans i18nKey="browse-dashboards.nested-folder-picker.button-label">Select folder</Trans>}
+            {label ?? <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>}
           </Text>
         )}
       </Button>
@@ -185,7 +185,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
       <Input
         ref={setTriggerRef}
         autoFocus
-        placeholder={label ?? t('browse-dashboards.nested-folder-picker.search-placeholder', 'Search folders')}
+        placeholder={label ?? t('browse-dashboards.folder-picker.search-placeholder', 'Search folders')}
         value={search}
         className={styles.search}
         onChange={(e) => setSearch(e.currentTarget.value)}
@@ -205,11 +205,9 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
           <Alert
             className={styles.error}
             severity="warning"
-            title={t('browse-dashboards.nested-folder-picker.error-title', 'Error loading folders')}
+            title={t('browse-dashboards.folder-picker.error-title', 'Error loading folders')}
           >
-            {error.message ||
-              error.toString?.() ||
-              t('browse-dashboards.nested-folder-picker.unknown-error', 'Unknown error')}
+            {error.message || error.toString?.() || t('browse-dashboards.folder-picker.unknown-error', 'Unknown error')}
           </Alert>
         ) : (
           <div>

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -5,8 +5,9 @@ import { usePopperTooltip } from 'react-popper-tooltip';
 import { useAsync } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, FilterInput, LoadingBar, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Icon, Input, LoadingBar, useStyles2 } from '@grafana/ui';
 import { Text } from '@grafana/ui/src/components/Text/Text';
+import { Trans, t } from 'app/core/internationalization';
 import { skipToken, useGetFolderQuery } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { listFolders, PAGE_SIZE } from 'app/features/browse-dashboards/api/services';
 import { createFlatTree } from 'app/features/browse-dashboards/state';
@@ -172,7 +173,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
           <Skeleton width={100} />
         ) : (
           <Text as="span" truncate>
-            {label ?? 'Select folder'}
+            {label ?? <Trans i18nKey="browse-dashboards.nested-folder-picker.button-label">Select folder</Trans>}
           </Text>
         )}
       </Button>
@@ -181,14 +182,15 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
 
   return (
     <>
-      <FilterInput
+      <Input
         ref={setTriggerRef}
         autoFocus
-        placeholder={label ?? 'Search folder'}
+        placeholder={label ?? t('browse-dashboards.nested-folder-picker.search-placeholder', 'Search folders')}
         value={search}
-        escapeRegex={false}
         className={styles.search}
-        onChange={(val) => setSearch(val)}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        role="combobox"
+        suffix={<Icon name="search" />}
       />
       <fieldset
         ref={setTooltipRef}
@@ -200,8 +202,14 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
         })}
       >
         {error ? (
-          <Alert className={styles.error} severity="warning" title="Error loading folders">
-            {error.message || error.toString?.() || 'Unknown error'}
+          <Alert
+            className={styles.error}
+            severity="warning"
+            title={t('browse-dashboards.nested-folder-picker.error-title', 'Error loading folders')}
+          >
+            {error.message ||
+              error.toString?.() ||
+              t('browse-dashboards.nested-folder-picker.unknown-error', 'Unknown error')}
           </Alert>
         ) : (
           <div>

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -61,19 +61,19 @@
       "manage-permissions": "",
       "move": ""
     },
+    "folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "manage-folder-nav": {
       "alert-rules": "",
       "dashboards": "",
       "panels": "",
       "permissions": "",
       "settings": ""
-    },
-    "nested-folder-picker": {
-      "button-label": "",
-      "empty-message": "",
-      "error-title": "",
-      "search-placeholder": "",
-      "unknown-error": ""
     },
     "new-folder-form": {
       "cancel-label": "",

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -68,6 +68,13 @@
       "permissions": "",
       "settings": ""
     },
+    "nested-folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "new-folder-form": {
       "cancel-label": "",
       "create-label": "",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -61,19 +61,19 @@
       "manage-permissions": "Manage permissions",
       "move": "Move"
     },
+    "folder-picker": {
+      "button-label": "Select folder",
+      "empty-message": "No folders found",
+      "error-title": "Error loading folders",
+      "search-placeholder": "Search folders",
+      "unknown-error": "Unknown error"
+    },
     "manage-folder-nav": {
       "alert-rules": "Alert rules",
       "dashboards": "Dashboards",
       "panels": "Panels",
       "permissions": "Permissions",
       "settings": "Settings"
-    },
-    "nested-folder-picker": {
-      "button-label": "Select folder",
-      "empty-message": "No folders found",
-      "error-title": "Error loading folders",
-      "search-placeholder": "Search folders",
-      "unknown-error": "Unknown error"
     },
     "new-folder-form": {
       "cancel-label": "Cancel",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -68,6 +68,13 @@
       "permissions": "Permissions",
       "settings": "Settings"
     },
+    "nested-folder-picker": {
+      "button-label": "Select folder",
+      "empty-message": "No folders found",
+      "error-title": "Error loading folders",
+      "search-placeholder": "Search folders",
+      "unknown-error": "Unknown error"
+    },
     "new-folder-form": {
       "cancel-label": "Cancel",
       "create-label": "Create",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -66,19 +66,19 @@
       "manage-permissions": "",
       "move": ""
     },
+    "folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "manage-folder-nav": {
       "alert-rules": "",
       "dashboards": "",
       "panels": "",
       "permissions": "",
       "settings": ""
-    },
-    "nested-folder-picker": {
-      "button-label": "",
-      "empty-message": "",
-      "error-title": "",
-      "search-placeholder": "",
-      "unknown-error": ""
     },
     "new-folder-form": {
       "cancel-label": "",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -73,6 +73,13 @@
       "permissions": "",
       "settings": ""
     },
+    "nested-folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "new-folder-form": {
       "cancel-label": "",
       "create-label": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -66,19 +66,19 @@
       "manage-permissions": "",
       "move": ""
     },
+    "folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "manage-folder-nav": {
       "alert-rules": "",
       "dashboards": "",
       "panels": "",
       "permissions": "",
       "settings": ""
-    },
-    "nested-folder-picker": {
-      "button-label": "",
-      "empty-message": "",
-      "error-title": "",
-      "search-placeholder": "",
-      "unknown-error": ""
     },
     "new-folder-form": {
       "cancel-label": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -73,6 +73,13 @@
       "permissions": "",
       "settings": ""
     },
+    "nested-folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "new-folder-form": {
       "cancel-label": "",
       "create-label": "",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -61,19 +61,19 @@
       "manage-permissions": "Mäŉäģę pęřmįşşįőŉş",
       "move": "Mővę"
     },
+    "folder-picker": {
+      "button-label": "Ŝęľęčŧ ƒőľđęř",
+      "empty-message": "Ńő ƒőľđęřş ƒőūŉđ",
+      "error-title": "Ēřřőř ľőäđįŉģ ƒőľđęřş",
+      "search-placeholder": "Ŝęäřčĥ ƒőľđęřş",
+      "unknown-error": "Ůŉĸŉőŵŉ ęřřőř"
+    },
     "manage-folder-nav": {
       "alert-rules": "Åľęřŧ řūľęş",
       "dashboards": "Đäşĥþőäřđş",
       "panels": "Päŉęľş",
       "permissions": "Pęřmįşşįőŉş",
       "settings": "Ŝęŧŧįŉģş"
-    },
-    "nested-folder-picker": {
-      "button-label": "Ŝęľęčŧ ƒőľđęř",
-      "empty-message": "Ńő ƒőľđęřş ƒőūŉđ",
-      "error-title": "Ēřřőř ľőäđįŉģ ƒőľđęřş",
-      "search-placeholder": "Ŝęäřčĥ ƒőľđęřş",
-      "unknown-error": "Ůŉĸŉőŵŉ ęřřőř"
     },
     "new-folder-form": {
       "cancel-label": "Cäŉčęľ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -68,6 +68,13 @@
       "permissions": "Pęřmįşşįőŉş",
       "settings": "Ŝęŧŧįŉģş"
     },
+    "nested-folder-picker": {
+      "button-label": "Ŝęľęčŧ ƒőľđęř",
+      "empty-message": "Ńő ƒőľđęřş ƒőūŉđ",
+      "error-title": "Ēřřőř ľőäđįŉģ ƒőľđęřş",
+      "search-placeholder": "Ŝęäřčĥ ƒőľđęřş",
+      "unknown-error": "Ůŉĸŉőŵŉ ęřřőř"
+    },
     "new-folder-form": {
       "cancel-label": "Cäŉčęľ",
       "create-label": "Cřęäŧę",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -63,6 +63,13 @@
       "permissions": "",
       "settings": ""
     },
+    "nested-folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "new-folder-form": {
       "cancel-label": "",
       "create-label": "",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -56,19 +56,19 @@
       "manage-permissions": "",
       "move": ""
     },
+    "folder-picker": {
+      "button-label": "",
+      "empty-message": "",
+      "error-title": "",
+      "search-placeholder": "",
+      "unknown-error": ""
+    },
     "manage-folder-nav": {
       "alert-rules": "",
       "dashboards": "",
       "panels": "",
       "permissions": "",
       "settings": ""
-    },
-    "nested-folder-picker": {
-      "button-label": "",
-      "empty-message": "",
-      "error-title": "",
-      "search-placeholder": "",
-      "unknown-error": ""
     },
     "new-folder-form": {
       "cancel-label": "",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds an empty state to the dropdown
- moves the strings into the translations file

**Why do we need this feature?**

- so it's clear when no folders are found
- so all the strings are translated correctly!

**Who is this feature for?**

- anyone using nested folder picker

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/65745

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
