### PR TITLE
SSE: improve error handling in DSNode

### DIFF
--- a/pkg/expr/dataplane.go
+++ b/pkg/expr/dataplane.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func shouldUseDataplane(frames data.Frames, logger *log.ConcreteLogger, disable bool) (dt data.FrameType, b bool, e error) {
+func shouldUseDataplane(frames data.Frames, logger log.Logger, disable bool) (dt data.FrameType, b bool, e error) {
 	if disable {
 		return
 	}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -291,7 +291,7 @@ func getResponseFrame(resp *backend.QueryDataResponse, refID string) (data.Frame
 
 func convertDataFramesToResults(ctx context.Context, frames data.Frames, datasourceType string, s *Service, logger log.Logger) (string, mathexp.Results, error) {
 	if len(frames) == 0 {
-		return "no-data", mathexp.Results{Values: mathexp.Values{mathexp.NoData{}}}, nil
+		return "no-data", mathexp.Results{Values: mathexp.Values{mathexp.NewNoData()}}, nil
 	}
 
 	vals := make([]mathexp.Value, 0)

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -268,7 +268,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 	}
 
 	var result mathexp.Results
-	responseType, result, err = convertDataFramesToResults(ctx, dataFrames, dn.datasource.Type, s)
+	responseType, result, err = convertDataFramesToResults(ctx, dataFrames, dn.datasource.Type, s, logger)
 	return result, err
 }
 
@@ -294,7 +294,7 @@ func getResponseFrame(resp *backend.QueryDataResponse, refID string) (data.Frame
 	return response.Frames, nil
 }
 
-func convertDataFramesToResults(ctx context.Context, frames data.Frames, datasourceType string, s *Service) (string, mathexp.Results, error) {
+func convertDataFramesToResults(ctx context.Context, frames data.Frames, datasourceType string, s *Service, logger log.Logger) (string, mathexp.Results, error) {
 	vals := make([]mathexp.Value, 0)
 	var dt data.FrameType
 	dt, useDataplane, _ := shouldUseDataplane(frames, logger, s.features.IsEnabled(featuremgmt.FlagDisableSSEDataplane))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR refactors DSNode a bit:
- adds data source UID to QueryError.
- adds a new error event to the span `SSE.ExecuteDatasourceQuery` 
- adds the data source UID to the span `SSE.ExecuteDatasourceQuery` attributes

- fixes logger in convertDataFramesToResults to use the one with the context.

**Why do we need this feature?**
1. This will allow us to better report which query in the expression tree caused the failure.
2. Improves observability

**Who is this feature for?**

Alerting

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/71467

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
