### PR TITLE
CI: Fix broken env vars in publish-artifacts step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4250,7 +4250,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4319,7 +4319,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -7413,6 +7413,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 99d1c7416eed610594287de748406afc9cd73da82fb0f09907401ade2c861f1f
+hmac: 0d2d6275d62dea9c46f950ecd6a94c8310f760b2b47347a106f122578d99812d
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -563,7 +563,7 @@ def publish_artifacts_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            "./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}",
+            "./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}",
         ],
         "depends_on": ["compile-build-cmd"],
     }


### PR DESCRIPTION
(cherry picked from commit 64d2ff03c80c807c03390f63ba1834c5605fc96d)

**What is this feature?**

Fixes the step, since it failed in both `10.0.2` and `9.5.6`