### PR TITLE
Docs: Adding alias to package a plugin

### DIFF
--- a/docs/sources/developers/plugins/publish-a-plugin/package-a-plugin.md
+++ b/docs/sources/developers/plugins/publish-a-plugin/package-a-plugin.md
@@ -10,6 +10,8 @@ keywords:
   - packages
 description: How to package a plugin
 weight: 100
+aliases:
+  - ../package-a-plugin/
 ---
 
 # Package a plugin


### PR DESCRIPTION
Fixing a 404 for the "old" url: https://grafana.com/docs/grafana/latest/developers/plugins/package-a-plugin/ which is index in google when you search for "package a plugin grafana".

The currently active url is: https://grafana.com/docs/grafana/latest/developers/plugins/publish-a-plugin/package-a-plugin/

I hope this is the correct syntax...