### PR TITLE
docs: add alphaPanels feature toggle information

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -361,6 +361,13 @@ The Route layer renders data points as a route.
 
 {{< figure src="/media/docs/grafana/geomap-route-layer-basic-9-4-0.png" max-width="1200px" caption="Geomap panel Route" >}}
 
+To enable the Route layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
+
+```
+[feature_toggles]
+alphaPanels = true
+```
+
 ### Options
 
 - **Size** sets the route thickness. Fixed by default, or Min and Max range of selected field.
@@ -381,6 +388,13 @@ The Route layer renders data points as a route.
 The Photos layer renders a photo at each data point.
 
 {{< figure src="/static/img/docs/geomap-panel/geomap-photos-9-3-0.png" max-width="1200px" caption="Geomap panel Photos" >}}
+
+To enable the Route layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
+
+```
+[feature_toggles]
+alphaPanels = true
+```
 
 ### Options
 

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -361,11 +361,11 @@ The Route layer renders data points as a route.
 
 {{< figure src="/media/docs/grafana/geomap-route-layer-basic-9-4-0.png" max-width="1200px" caption="Geomap panel Route" >}}
 
-To enable the Route layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
+To enable the Route layer, set `enable_alpha` to `true` in your configuration file:
 
 ```
-[feature_toggles]
-alphaPanels = true
+[panels]
+enable_alpha = true
 ```
 
 ### Options
@@ -389,11 +389,11 @@ The Photos layer renders a photo at each data point.
 
 {{< figure src="/static/img/docs/geomap-panel/geomap-photos-9-3-0.png" max-width="1200px" caption="Geomap panel Photos" >}}
 
-To enable the Photos layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
+To enable the Photos layer, set `enable_alpha` to `true` in your configuration file:
 
 ```
-[feature_toggles]
-alphaPanels = true
+[panels]
+enable_alpha = true
 ```
 
 ### Options

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -389,7 +389,7 @@ The Photos layer renders a photo at each data point.
 
 {{< figure src="/static/img/docs/geomap-panel/geomap-photos-9-3-0.png" max-width="1200px" caption="Geomap panel Photos" >}}
 
-To enable the Route layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
+To enable the Photos layer, add the `alphaPanels` feature toggle to your `custom.ini` file.
 
 ```
 [feature_toggles]


### PR DESCRIPTION
Adds information about the `alphaPanels` feature toggle to **Route layer** (backport to v9.5) and **Photos layer** (backport to v9.4) sections