### PR TITLE
Explore: Replaced deprecated 'query' property with 'queries' in splitOpen

### DIFF
--- a/packages/grafana-data/src/utils/dataLinks.ts
+++ b/packages/grafana-data/src/utils/dataLinks.ts
@@ -56,7 +56,7 @@ export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkMod
       ? () => {
           onClickFn({
             datasourceUid: internalLink.datasourceUid,
-            query: interpolatedQuery,
+            queries: interpolatedQuery,
             panelsState: interpolatedPanelsState,
             range,
           });

--- a/packages/grafana-data/src/utils/dataLinks.ts
+++ b/packages/grafana-data/src/utils/dataLinks.ts
@@ -56,7 +56,7 @@ export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkMod
       ? () => {
           onClickFn({
             datasourceUid: internalLink.datasourceUid,
-            queries: interpolatedQuery,
+            queries: [interpolatedQuery],
             panelsState: interpolatedPanelsState,
             range,
           });

--- a/public/app/features/explore/ExplorePage.test.tsx
+++ b/public/app/features/explore/ExplorePage.test.tsx
@@ -178,7 +178,7 @@ describe('ExplorePage', () => {
       });
 
       act(() => {
-        store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', query: { expr: 'error', refId: 'A' } }));
+        store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', queries: [{ expr: 'error', refId: 'A' }] }));
       });
 
       // Editor renders the new query

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -304,10 +304,12 @@ function useFocusSpanLink(options: {
         ? () =>
             options.splitOpenFn({
               datasourceUid: options.datasource?.uid!,
-              query: {
-                ...query!,
-                query: traceId,
-              },
+              queries: [
+                {
+                  ...query!,
+                  query: traceId,
+                },
+              ],
               panelsState: {
                 trace: {
                   spanId,

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -111,7 +111,7 @@ describe('explore links utils', () => {
 
       expect(splitfn).toBeCalledWith({
         datasourceUid: 'uid_1',
-        query: { query: 'query_1' },
+        queries: [{ query: 'query_1' }],
         range,
         panelsState: {
           trace: {


### PR DESCRIPTION
This PR replaces deprecated usage of `query` property with `queries` in `splitOpen` function

# Deprecation notice

The query parameter of Explore's `SplitOpen` function is deprecated (passed in `mapInternalLinkToExplore`). Please use the `queries` parameter instead, which allows passing multiple queries to `SplitOpen` function. To pass a single query to `SplitOpen` function, set the `queries` parameter to an array containing that single query.

Fixes: https://github.com/grafana/grafana/issues/62567