### PR TITLE
Settings: Add tests for handleAWSConfig

### DIFF
--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -878,5 +878,4 @@ func TestHandleAWSSettings(t *testing.T) {
 			assert.Equal(t, 500, cfg.AWSListMetricsPageLimit)
 			ConfigCleanup(t)
 		})
-
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -841,16 +841,6 @@ func TestHandleAWSSettings(t *testing.T) {
 		cfg.handleAWSConfig()
 		assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
 	})
-	t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
-		cfg := NewCfg()
-		awsSection, err := cfg.Raw.NewSection("aws")
-		require.NoError(t, err)
-		_, err = awsSection.NewKey("assume_role_enabled", "false")
-		require.NoError(t, err)
-
-		cfg.handleAWSConfig()
-		assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
-	})
 	t.Run("Should set assume role to true if defined as true in the config", func(t *testing.T) {
 		cfg := NewCfg()
 		awsSection, err := cfg.Raw.NewSection("aws")

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -811,7 +811,7 @@ func TestRedactedValue(t *testing.T) {
 }
 
 func TestHandleAWSSettings(t *testing.T) {
-	t.Run("Should set deafult auth providers if not defined", func(t *testing.T) {
+	t.Run("Should set default auth providers if not defined", func(t *testing.T) {
 		cfg := NewCfg()
 		awsSection, err := cfg.Raw.NewSection("aws")
 		require.NoError(t, err)
@@ -861,7 +861,7 @@ func TestHandleAWSSettings(t *testing.T) {
 		cfg.handleAWSConfig()
 		assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
 	})
-	t.Run("Should set deafult page limit if not defined", func(t *testing.T) {
+	t.Run("Should set default page limit if not defined", func(t *testing.T) {
 		cfg := NewCfg()
 		awsSection, err := cfg.Raw.NewSection("aws")
 		require.NoError(t, err)

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -882,4 +882,15 @@ func TestHandleAWSSettings(t *testing.T) {
 
 		assert.Equal(t, 500, cfg.AWSListMetricsPageLimit)
 	})
+	t.Run("Should pass on the limit if it is defined in the config", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("list_metrics_page_limit", "400")
+		require.NoError(t, err)
+
+		cfg.handleAWSConfig()
+
+		assert.Equal(t, 400, cfg.AWSListMetricsPageLimit)
+	})
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -811,71 +811,75 @@ func TestRedactedValue(t *testing.T) {
 }
 
 func TestHandleAWSSettings(t *testing.T) {
-	cfg := NewCfg()
-	awsSection, err := cfg.Raw.NewSection("aws")
-	require.NoError(t, err)
-	ConfigCleanup := func(t *testing.T) {
-		t.Cleanup(func() {
-		cfg = NewCfg()
-		awsSection, err = cfg.Raw.NewSection("aws")
+	t.Run("Should set deafult auth providers if not defined", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
 		require.NoError(t, err)
+		_, err = awsSection.NewKey("allowed_auth_providers", "")
+		require.NoError(t, err)
+
+		cfg.handleAWSConfig()
+		assert.Equal(t, []string{"default", "keys", "credentials"}, cfg.AWSAllowedAuthProviders)
 	})
-}
-		t.Run("Should set deafult auth providers if not defined", func(t *testing.T) {
-			_, err = awsSection.NewKey("allowed_auth_providers", "")
-			require.NoError(t, err)
+	t.Run("Should pass on auth providers defined in config", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("allowed_auth_providers", "keys, credentials")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, []string{"default", "keys", "credentials"}, cfg.AWSAllowedAuthProviders)
-			ConfigCleanup(t)
-		})
-		t.Run("Should pass on auth providers defined in config", func(t *testing.T) {
-			_, err = awsSection.NewKey("allowed_auth_providers", "keys, credentials")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
+		assert.Equal(t, []string{"keys", "credentials"}, cfg.AWSAllowedAuthProviders)
+	})
+	t.Run("Should set assume role to true if not defined", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("assume_role_enabled", "")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, []string{"keys", "credentials"}, cfg.AWSAllowedAuthProviders)
-			ConfigCleanup(t)
-		})
-		t.Run("Should set assume role to true if not defined", func(t *testing.T) {
-			_, err = awsSection.NewKey("assume_role_enabled", "")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
+		assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
+	})
+	t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("assume_role_enabled", "false")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
-			ConfigCleanup(t)
-		})
-		t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
-			_, err = awsSection.NewKey("assume_role_enabled", "false")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
+		assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
+	})
+	t.Run("Should set assume role to true if defined as true in the config", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("assume_role_enabled", "true")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
-			ConfigCleanup(t)
-		})
-		t.Run("Should set assume role to true if defined as true in the config", func(t *testing.T) {
-			_, err = awsSection.NewKey("assume_role_enabled", "true")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
+		assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
+	})
+	t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("assume_role_enabled", "false")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
-			ConfigCleanup(t)
-		})
-		t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
-			_, err = awsSection.NewKey("assume_role_enabled", "false")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
+		assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
+	})
+	t.Run("Should set deafult page limit if not defined", func(t *testing.T) {
+		cfg := NewCfg()
+		awsSection, err := cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+		_, err = awsSection.NewKey("list_metrics_page_limit", "")
+		require.NoError(t, err)
 
-			cfg.handleAWSConfig()
-			assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
-			ConfigCleanup(t)
-		})
-		t.Run("Should set deafult page limit if not defined", func(t *testing.T) {
-			_, err = awsSection.NewKey("list_metrics_page_limit", "")
-			require.NoError(t, err)
+		cfg.handleAWSConfig()
 
-			cfg.handleAWSConfig()
-
-			assert.Equal(t, 500, cfg.AWSListMetricsPageLimit)
-			ConfigCleanup(t)
-		})
+		assert.Equal(t, 500, cfg.AWSListMetricsPageLimit)
+	})
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -809,3 +809,74 @@ func TestRedactedValue(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleAWSSettings(t *testing.T) {
+	cfg := NewCfg()
+	awsSection, err := cfg.Raw.NewSection("aws")
+	require.NoError(t, err)
+	ConfigCleanup := func(t *testing.T) {
+		t.Cleanup(func() {
+		cfg = NewCfg()
+		awsSection, err = cfg.Raw.NewSection("aws")
+		require.NoError(t, err)
+	})
+}
+		t.Run("Should set deafult auth providers if not defined", func(t *testing.T) {
+			_, err = awsSection.NewKey("allowed_auth_providers", "")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, []string{"default", "keys", "credentials"}, cfg.AWSAllowedAuthProviders)
+			ConfigCleanup(t)
+		})
+		t.Run("Should pass on auth providers defined in config", func(t *testing.T) {
+			_, err = awsSection.NewKey("allowed_auth_providers", "keys, credentials")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, []string{"keys", "credentials"}, cfg.AWSAllowedAuthProviders)
+			ConfigCleanup(t)
+		})
+		t.Run("Should set assume role to true if not defined", func(t *testing.T) {
+			_, err = awsSection.NewKey("assume_role_enabled", "")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
+			ConfigCleanup(t)
+		})
+		t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
+			_, err = awsSection.NewKey("assume_role_enabled", "false")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
+			ConfigCleanup(t)
+		})
+		t.Run("Should set assume role to true if defined as true in the config", func(t *testing.T) {
+			_, err = awsSection.NewKey("assume_role_enabled", "true")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, true, cfg.AWSAssumeRoleEnabled)
+			ConfigCleanup(t)
+		})
+		t.Run("Should set assume role to false if defined as false in the config", func(t *testing.T) {
+			_, err = awsSection.NewKey("assume_role_enabled", "false")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+			assert.Equal(t, false, cfg.AWSAssumeRoleEnabled)
+			ConfigCleanup(t)
+		})
+		t.Run("Should set deafult page limit if not defined", func(t *testing.T) {
+			_, err = awsSection.NewKey("list_metrics_page_limit", "")
+			require.NoError(t, err)
+
+			cfg.handleAWSConfig()
+
+			assert.Equal(t, 500, cfg.AWSListMetricsPageLimit)
+			ConfigCleanup(t)
+		})
+
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds tests that cover setting default values in handleAWSConfig (awsAuthProviders, assumeRole and limit). 


**Why do we need this feature?**

Since [this PR in aws-sdk-react](https://github.com/grafana/grafana-aws-sdk-react/pull/50) will remove the check on the frontend for undefined values, this is to make sure we don't change the functionality on the BE accidentally. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
