### PR TITLE
Plugin: Validate plugin version on installation

### DIFF
--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
@@ -22,14 +23,25 @@ import (
 const installArgsSize = 2
 
 func validateInput(c utils.CommandLine) error {
-	if c.Args().Len() > installArgsSize {
+	args := c.Args()
+	argsLen := args.Len()
+
+	if argsLen > installArgsSize {
 		logger.Info(color.RedString("Please specify the correct format. For example ./grafana cli (<command arguments>) plugins install <plugin ID> (<plugin version>)\n\n"))
 		return errors.New("install only supports 2 arguments: plugin and version")
 	}
 
-	arg := c.Args().First()
+	arg := args.First()
 	if arg == "" {
 		return errors.New("please specify plugin to install")
+	}
+
+	if argsLen == installArgsSize {
+		version := args.Get(1)
+		_, err := semver.NewVersion(version)
+		if err != nil {
+			return fmt.Errorf("the provided version (%s) is invalid", version)
+		}
 	}
 
 	pluginsDir := c.PluginDirectory()

--- a/pkg/cmd/grafana-cli/commands/install_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/install_command_test.go
@@ -1,14 +1,16 @@
 package commands
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateInput(t *testing.T) {
-	t.Run("should print message for ignored args", func(t *testing.T) {
+	t.Run("should return an error for wrong args number", func(t *testing.T) {
 		mockCmdLine := &utils.MockCommandLine{}
 		defer mockCmdLine.AssertExpectations(t)
 
@@ -18,9 +20,60 @@ func TestValidateInput(t *testing.T) {
 		defer mockArgs.AssertExpectations(t)
 
 		mockArgs.On("Len").Return(len(cmdArgs))
-		mockCmdLine.On("Args").Return(mockArgs).Times(1)
+		mockCmdLine.On("Args").Return(mockArgs).Once()
 
 		err := validateInput(mockCmdLine)
 		require.EqualError(t, err, "install only supports 2 arguments: plugin and version")
 	})
+
+	tests := []struct {
+		desc          string
+		versionArg    string
+		shouldSucceed bool
+	}{
+		{
+			desc:          "should successful validate semver arg",
+			versionArg:    "1.2.3",
+			shouldSucceed: true,
+		},
+		{
+			desc:          "should successful validate complex semver arg",
+			versionArg:    "1.0.0-alpha.0valid",
+			shouldSucceed: true,
+		},
+		{
+			desc:       "should fail non version arg",
+			versionArg: "bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockCmdLine := &utils.MockCommandLine{}
+			defer mockCmdLine.AssertExpectations(t)
+
+			cmdArgs := []string{"foo", tt.versionArg}
+
+			mockArgs := &utils.MockArgs{}
+			defer mockArgs.AssertExpectations(t)
+
+			mockArgs.On("Len").Return(len(cmdArgs))
+			mockArgs.On("First").Return(cmdArgs[0])
+			mockArgs.On("Get", mock.AnythingOfType("int")).Return(cmdArgs[1])
+
+			mockCmdLine.On("Args").Return(mockArgs).Once()
+
+			if tt.shouldSucceed {
+				mockCmdLine.On("PluginDirectory").Return("/tmp").Once()
+			}
+
+			err := validateInput(mockCmdLine)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, fmt.Sprintf("the provided version (%s) is invalid", cmdArgs[1]))
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Validates plugin version provided as an argument to the cli on plugin installation

**Why do we need this feature?**

This feature is needed to provide a better user experience on cli usage

**Who is this feature for?**

grafana cli users

**Special notes for your reviewer:**

This is a followup from:
#71355

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
