### PR TITLE
NestedFolders: Paginate nested folder picker

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -1,8 +1,11 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useId, useMemo } from 'react';
+import React, { useCallback, useId, useMemo, useRef } from 'react';
+import Skeleton from 'react-loading-skeleton';
 import { FixedSizeList as List } from 'react-window';
+import InfiniteLoader from 'react-window-infinite-loader';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
 import { Text } from '@grafana/ui/src/components/Text/Text';
@@ -22,6 +25,9 @@ interface NestedFolderListProps {
   selectedFolder: FolderUID | undefined;
   onFolderClick: (uid: string, newOpenState: boolean) => void;
   onSelectionChange: (event: React.FormEvent<HTMLInputElement>, item: DashboardViewItem) => void;
+
+  isItemLoaded: (itemIndex: number) => boolean;
+  requestLoadMore: (folderUid: string | undefined) => void;
 }
 
 export function NestedFolderList({
@@ -30,7 +36,10 @@ export function NestedFolderList({
   selectedFolder,
   onFolderClick,
   onSelectionChange,
+  isItemLoaded,
+  requestLoadMore,
 }: NestedFolderListProps) {
+  const infiniteLoaderRef = useRef<InfiniteLoader>(null);
   const styles = useStyles2(getStyles);
 
   const virtualData = useMemo(
@@ -38,18 +47,44 @@ export function NestedFolderList({
     [items, foldersAreOpenable, selectedFolder, onFolderClick, onSelectionChange]
   );
 
+  const handleIsItemLoaded = useCallback(
+    (itemIndex: number) => {
+      return isItemLoaded(itemIndex);
+    },
+    [isItemLoaded]
+  );
+
+  const handleLoadMore = useCallback(
+    (startIndex: number, endIndex: number) => {
+      const { parentUID } = items[startIndex];
+      requestLoadMore(parentUID);
+    },
+    [requestLoadMore, items]
+  );
+
   return (
     <div className={styles.table}>
-      {items.length > 0 ? (
-        <List
-          height={ROW_HEIGHT * Math.min(6.5, items.length)}
-          width="100%"
-          itemData={virtualData}
-          itemSize={ROW_HEIGHT}
+      {items.length ? (
+        <InfiniteLoader
+          ref={infiniteLoaderRef}
           itemCount={items.length}
+          isItemLoaded={handleIsItemLoaded}
+          loadMoreItems={handleLoadMore}
         >
-          {Row}
-        </List>
+          {({ onItemsRendered, ref }) => (
+            <List
+              ref={ref}
+              height={ROW_HEIGHT * Math.min(6.5, items.length)}
+              width="100%"
+              itemData={virtualData}
+              itemSize={ROW_HEIGHT}
+              itemCount={items.length}
+              onItemsRendered={onItemsRendered}
+            >
+              {Row}
+            </List>
+          )}
+        </InfiniteLoader>
       ) : (
         <div className={styles.emptyMessage}>
           <Trans i18nKey="browse-dashboards.folder-picker.empty-message">No folders found</Trans>
@@ -59,7 +94,7 @@ export function NestedFolderList({
   );
 }
 
-interface VirtualData extends NestedFolderListProps {}
+interface VirtualData extends Omit<NestedFolderListProps, 'isItemLoaded' | 'requestLoadMore'> {}
 
 interface RowProps {
   index: number;
@@ -102,10 +137,19 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
     [item.uid, foldersAreOpenable, onFolderClick]
   );
 
+  if (item.kind === 'ui' && item.uiKind === 'pagination-placeholder') {
+    return (
+      <span style={virtualStyles} className={styles.row}>
+        <Indent level={level} />
+        <SkeletonGroup index={index} />
+      </span>
+    );
+  }
+
   if (item.kind !== 'folder') {
     return process.env.NODE_ENV !== 'production' ? (
       <span style={virtualStyles} className={styles.row}>
-        Non-folder item {item.uid}
+        Non-folder {item.kind} {item.uid}
       </span>
     ) : null;
   }
@@ -226,3 +270,29 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+
+// TODO: If we like this, move this out... somewhere
+const SKELETON_COUNTS = [
+  // Each array is a set of percentages that the width is divided into for each 'word'
+  [1],
+  [0.3, 0.7],
+  [0.5, 0.5],
+  [0.7, 0.3],
+  [0.3, 0.2, 0.5],
+];
+
+const SKELETON_WIDTHS = [100, 150, 200];
+
+function SkeletonGroup({ index }: { index: number }) {
+  const count = SKELETON_COUNTS[index % SKELETON_COUNTS.length];
+  const size = SKELETON_WIDTHS[index % SKELETON_WIDTHS.length];
+
+  return (
+    <Stack gap={1}>
+      {count.map((percent, index) => {
+        const width = size * percent;
+        return <Skeleton key={index} width={width} />;
+      })}
+    </Stack>
+  );
+}

--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -5,7 +5,6 @@ import { FixedSizeList as List } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
 import { IconButton, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
 import { Text } from '@grafana/ui/src/components/Text/Text';
@@ -102,6 +101,8 @@ interface RowProps {
   data: VirtualData;
 }
 
+const SKELETON_WIDTHS = [100, 200, 130, 160, 150];
+
 function Row({ index, style: virtualStyles, data }: RowProps) {
   const { items, foldersAreOpenable, selectedFolder, onFolderClick, onSelectionChange } = data;
   const { item, isOpen, level } = items[index];
@@ -141,7 +142,7 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
     return (
       <span style={virtualStyles} className={styles.row}>
         <Indent level={level} />
-        <SkeletonGroup index={index} />
+        <Skeleton width={SKELETON_WIDTHS[index % SKELETON_WIDTHS.length]} />
       </span>
     );
   }
@@ -270,29 +271,3 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
-// TODO: If we like this, move this out... somewhere
-const SKELETON_COUNTS = [
-  // Each array is a set of percentages that the width is divided into for each 'word'
-  [1],
-  [0.3, 0.7],
-  [0.5, 0.5],
-  [0.7, 0.3],
-  [0.3, 0.2, 0.5],
-];
-
-const SKELETON_WIDTHS = [100, 150, 200];
-
-function SkeletonGroup({ index }: { index: number }) {
-  const count = SKELETON_COUNTS[index % SKELETON_COUNTS.length];
-  const size = SKELETON_WIDTHS[index % SKELETON_WIDTHS.length];
-
-  return (
-    <Stack gap={1}>
-      {count.map((percent, index) => {
-        const width = size * percent;
-        return <Skeleton key={index} width={width} />;
-      })}
-    </Stack>
-  );
-}

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -78,9 +78,11 @@ describe('NestedFolderPicker', () => {
 
   it('clicking the button opens the folder picker', async () => {
     render(<NestedFolderPicker onChange={mockOnChange} />);
-    const button = await screen.findByRole('button', { name: 'Select folder' });
 
+    // Open the picker and wait for children to load
+    const button = await screen.findByRole('button', { name: 'Select folder' });
     await userEvent.click(button);
+    await screen.findByLabelText(folderA.item.title);
 
     // Select folder button is no longer visible
     expect(screen.queryByRole('button', { name: 'Select folder' })).not.toBeInTheDocument();
@@ -95,9 +97,11 @@ describe('NestedFolderPicker', () => {
 
   it('can select a folder from the picker', async () => {
     render(<NestedFolderPicker onChange={mockOnChange} />);
-    const button = await screen.findByRole('button', { name: 'Select folder' });
 
+    // Open the picker and wait for children to load
+    const button = await screen.findByRole('button', { name: 'Select folder' });
     await userEvent.click(button);
+    await screen.findByLabelText(folderA.item.title);
 
     await userEvent.click(screen.getByLabelText(folderA.item.title));
     expect(mockOnChange).toHaveBeenCalledWith({
@@ -108,9 +112,11 @@ describe('NestedFolderPicker', () => {
 
   it('can expand and collapse a folder to show its children', async () => {
     render(<NestedFolderPicker onChange={mockOnChange} />);
-    const button = await screen.findByRole('button', { name: 'Select folder' });
 
+    // Open the picker and wait for children to load
+    const button = await screen.findByRole('button', { name: 'Select folder' });
     await userEvent.click(button);
+    await screen.findByLabelText(folderA.item.title);
 
     // Expand Folder A
     await userEvent.click(screen.getByRole('button', { name: `Expand folder ${folderA.item.title}` }));

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -35,6 +35,8 @@ interface NestedFolderPickerProps {
   onChange?: (folder: FolderChange) => void;
 }
 
+const EXCLUDED_KINDS = ['empty-folder' as const, 'dashboard' as const];
+
 export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps) {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
@@ -129,30 +131,12 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
         items: searchResults.items ?? [],
       };
 
-      const flatTree = createFlatTree(
-        undefined, // so far folder picker doesn't have a "folder view", so the top-level is always undefined
-        searchCollection,
-        childrenCollections,
-        {},
-        0,
-        false
-      );
-
-      return flatTree;
+      return createFlatTree(undefined, searchCollection, childrenCollections, {}, 0, EXCLUDED_KINDS);
     }
 
-    let flatTree = createFlatTree(
-      undefined, // so far folder picker doesn't have a "folder view", so the top-level is always undefined
-      rootCollection,
-      childrenCollections,
-      searchResults ? {} : folderOpenState,
-      0,
-      false
-    );
+    let flatTree = createFlatTree(undefined, rootCollection, childrenCollections, folderOpenState, 0, EXCLUDED_KINDS);
 
-    // Mutate the items to increase each level to make way for the root Dashboards item
-    // We don't set the initial level in createFlatTree to 1 because that currently mucks up
-    // pagination placeholder logic
+    // Increase the level of each item to 'make way' for the fake root Dashboards item
     for (const item of flatTree) {
       item.level += 1;
     }

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -70,7 +70,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
       setFolderOpenState((old) => ({ ...old, [uid]: newOpenState }));
 
       if (newOpenState) {
-        dispatch(fetchNextChildrenPage({ parentUID: uid, pageSize: PAGE_SIZE, loadDashboards: false }));
+        dispatch(fetchNextChildrenPage({ parentUID: uid, pageSize: PAGE_SIZE, excludeKinds: EXCLUDED_KINDS }));
       }
     },
     [dispatch]
@@ -107,7 +107,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
     },
   });
 
-  const baseHandleLoadMore = useLoadNextChildrenPage(false);
+  const baseHandleLoadMore = useLoadNextChildrenPage(EXCLUDED_KINDS);
   const handleLoadMore = useCallback(
     (folderUID: string | undefined) => {
       if (search) {

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -40,7 +40,7 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
       dispatch(setFolderOpenState({ folderUID: clickedFolderUID, isOpen }));
 
       if (isOpen) {
-        dispatch(fetchNextChildrenPage({ parentUID: clickedFolderUID, pageSize: PAGE_SIZE }));
+        dispatch(fetchNextChildrenPage({ parentUID: clickedFolderUID, loadDashboards: true, pageSize: PAGE_SIZE }));
       }
     },
     [dispatch]

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -40,7 +40,7 @@ export function BrowseView({ folderUID, width, height, canSelect }: BrowseViewPr
       dispatch(setFolderOpenState({ folderUID: clickedFolderUID, isOpen }));
 
       if (isOpen) {
-        dispatch(fetchNextChildrenPage({ parentUID: clickedFolderUID, loadDashboards: true, pageSize: PAGE_SIZE }));
+        dispatch(fetchNextChildrenPage({ parentUID: clickedFolderUID, pageSize: PAGE_SIZE }));
       }
     },
     [dispatch]

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -8,6 +8,7 @@ import { findItem } from './utils';
 
 interface FetchNextChildrenPageArgs {
   parentUID: string | undefined;
+  loadDashboards?: boolean;
   pageSize: number;
 }
 
@@ -87,7 +88,7 @@ export const refetchChildren = createAsyncThunk(
 export const fetchNextChildrenPage = createAsyncThunk(
   'browseDashboards/fetchNextChildrenPage',
   async (
-    { parentUID, pageSize }: FetchNextChildrenPageArgs,
+    { parentUID, loadDashboards, pageSize }: FetchNextChildrenPageArgs,
     thunkAPI
   ): Promise<undefined | FetchNextChildrenPageResult> => {
     const uid = parentUID === GENERAL_FOLDER_UID ? undefined : parentUID;
@@ -107,13 +108,13 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`FetchedChildren called for ${uid} but that collection is fully loaded`);
+      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders
       page = collection.lastFetchedPage + 1;
       fetchKind = 'folder';
-    } else {
+    } else if (loadDashboards) {
       // We've already checked if there's more folders to load, so if the last fetched is folder
       // then we fetch first page of dashboards
       page = collection.lastFetchedKind === 'folder' ? 1 : collection.lastFetchedPage + 1;
@@ -133,7 +134,7 @@ export const fetchNextChildrenPage = createAsyncThunk(
 
     // If we've loaded all folders, load the first page of dashboards.
     // This ensures dashboards are loaded if a folder contains only dashboards.
-    if (fetchKind === 'folder' && lastPageOfKind) {
+    if (fetchKind === 'folder' && lastPageOfKind && loadDashboards) {
       fetchKind = 'dashboard';
       page = 1;
 

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -3,12 +3,15 @@ import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/ty
 import { createAsyncThunk } from 'app/types';
 
 import { listDashboards, listFolders, PAGE_SIZE } from '../api/services';
+import { DashboardViewItemWithUIItems, UIDashboardViewItem } from '../types';
 
 import { findItem } from './utils';
 
 interface FetchNextChildrenPageArgs {
   parentUID: string | undefined;
-  loadDashboards?: boolean;
+
+  // Allow UI items to be excluded (they're always excluded) for convenience for callers
+  excludeKinds?: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']>;
   pageSize: number;
 }
 
@@ -88,9 +91,12 @@ export const refetchChildren = createAsyncThunk(
 export const fetchNextChildrenPage = createAsyncThunk(
   'browseDashboards/fetchNextChildrenPage',
   async (
-    { parentUID, loadDashboards, pageSize }: FetchNextChildrenPageArgs,
+    { parentUID, excludeKinds = [], pageSize }: FetchNextChildrenPageArgs,
     thunkAPI
   ): Promise<undefined | FetchNextChildrenPageResult> => {
+    // TODO: invert prop to `includeKinds`, but also support not loading folders
+    const loadDashboards = !excludeKinds.includes('dashboard');
+
     const uid = parentUID === GENERAL_FOLDER_UID ? undefined : parentUID;
 
     const state = thunkAPI.getState().browseDashboards;

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -5,7 +5,13 @@ import { DashboardViewItem } from 'app/features/search/types';
 import { useSelector, StoreState, useDispatch } from 'app/types';
 
 import { PAGE_SIZE } from '../api/services';
-import { BrowseDashboardsState, DashboardsTreeItem, DashboardTreeSelection } from '../types';
+import {
+  BrowseDashboardsState,
+  DashboardsTreeItem,
+  DashboardTreeSelection,
+  DashboardViewItemWithUIItems,
+  UIDashboardViewItem,
+} from '../types';
 
 import { fetchNextChildrenPage } from './actions';
 import { getPaginationPlaceholders } from './utils';
@@ -136,21 +142,25 @@ export function createFlatTree(
   childrenByUID: BrowseDashboardsState['childrenByParentUID'],
   openFolders: Record<string, boolean>,
   level = 0,
-  insertEmptyFolderIndicator = true
+  excludeKinds: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']> = []
 ): DashboardsTreeItem[] {
   function mapItem(item: DashboardViewItem, parentUID: string | undefined, level: number): DashboardsTreeItem[] {
+    if (excludeKinds.includes(item.kind)) {
+      return [];
+    }
+
     const mappedChildren = createFlatTree(
       item.uid,
       rootCollection,
       childrenByUID,
       openFolders,
       level + 1,
-      insertEmptyFolderIndicator
+      excludeKinds
     );
 
     const isOpen = Boolean(openFolders[item.uid]);
     const emptyFolder = childrenByUID[item.uid]?.items.length === 0;
-    if (isOpen && emptyFolder && insertEmptyFolderIndicator) {
+    if (isOpen && emptyFolder && !excludeKinds.includes('empty-folder')) {
       mappedChildren.push({
         isOpen: false,
         level: level + 1,

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -8,6 +8,7 @@ import { PAGE_SIZE } from '../api/services';
 import { BrowseDashboardsState, DashboardsTreeItem, DashboardTreeSelection } from '../types';
 
 import { fetchNextChildrenPage } from './actions';
+import { getPaginationPlaceholders } from './utils';
 
 export const rootItemsSelector = (wholeState: StoreState) => wholeState.browseDashboards.rootItems;
 export const childrenByParentUIDSelector = (wholeState: StoreState) => wholeState.browseDashboards.childrenByParentUID;
@@ -97,7 +98,7 @@ export function useActionSelectionState() {
   return useSelector((state) => selectedItemsForActionsSelector(state));
 }
 
-export function useLoadNextChildrenPage() {
+export function useLoadNextChildrenPage(loadDashboards = true) {
   const dispatch = useDispatch();
   const requestInFlightRef = useRef(false);
 
@@ -109,12 +110,12 @@ export function useLoadNextChildrenPage() {
 
       requestInFlightRef.current = true;
 
-      const promise = dispatch(fetchNextChildrenPage({ parentUID: folderUID, pageSize: PAGE_SIZE }));
+      const promise = dispatch(fetchNextChildrenPage({ parentUID: folderUID, loadDashboards, pageSize: PAGE_SIZE }));
       promise.finally(() => (requestInFlightRef.current = false));
 
       return promise;
     },
-    [dispatch]
+    [dispatch, loadDashboards]
   );
 
   return handleLoadMore;
@@ -185,19 +186,4 @@ export function createFlatTree(
   }
 
   return children;
-}
-
-function getPaginationPlaceholders(amount: number, parentUID: string | undefined, level: number) {
-  return new Array(amount).fill(null).map((_, index) => {
-    return {
-      parentUID,
-      level,
-      isOpen: false,
-      item: {
-        kind: 'ui' as const,
-        uiKind: 'pagination-placeholder' as const,
-        uid: `${parentUID}-pagination-${index}`,
-      },
-    };
-  });
 }

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { createSelector } from 'reselect';
 
 import { DashboardViewItem } from 'app/features/search/types';
@@ -110,9 +110,6 @@ export function useLoadNextChildrenPage(
   const dispatch = useDispatch();
   const requestInFlightRef = useRef(false);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedExcludeKinds = useMemo(() => excludeKinds, excludeKinds);
-
   const handleLoadMore = useCallback(
     (folderUID: string | undefined) => {
       if (requestInFlightRef.current) {
@@ -121,14 +118,12 @@ export function useLoadNextChildrenPage(
 
       requestInFlightRef.current = true;
 
-      const promise = dispatch(
-        fetchNextChildrenPage({ parentUID: folderUID, excludeKinds: memoizedExcludeKinds, pageSize: PAGE_SIZE })
-      );
+      const promise = dispatch(fetchNextChildrenPage({ parentUID: folderUID, excludeKinds, pageSize: PAGE_SIZE }));
       promise.finally(() => (requestInFlightRef.current = false));
 
       return promise;
     },
-    [dispatch, memoizedExcludeKinds]
+    [dispatch, excludeKinds]
   );
 
   return handleLoadMore;

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -40,7 +40,7 @@ export function fetchNextChildrenPageFulfilled(
   }
 
   const { children, page, kind, lastPageOfKind } = payload;
-  const { parentUID } = action.meta.arg;
+  const { parentUID, loadDashboards } = action.meta.arg;
 
   const collection = parentUID ? state.childrenByParentUID[parentUID] : state.rootItems;
   const prevItems = collection?.items ?? [];
@@ -50,7 +50,7 @@ export function fetchNextChildrenPageFulfilled(
     lastFetchedKind: kind,
     lastFetchedPage: page,
     lastKindHasMoreItems: !lastPageOfKind,
-    isFullyLoaded: kind === 'dashboard' && lastPageOfKind,
+    isFullyLoaded: loadDashboards ? kind === 'dashboard' && lastPageOfKind : lastPageOfKind,
   };
 
   if (!parentUID) {

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -40,7 +40,7 @@ export function fetchNextChildrenPageFulfilled(
   }
 
   const { children, page, kind, lastPageOfKind } = payload;
-  const { parentUID, loadDashboards } = action.meta.arg;
+  const { parentUID, excludeKinds = [] } = action.meta.arg;
 
   const collection = parentUID ? state.childrenByParentUID[parentUID] : state.rootItems;
   const prevItems = collection?.items ?? [];
@@ -50,7 +50,7 @@ export function fetchNextChildrenPageFulfilled(
     lastFetchedKind: kind,
     lastFetchedPage: page,
     lastKindHasMoreItems: !lastPageOfKind,
-    isFullyLoaded: loadDashboards ? kind === 'dashboard' && lastPageOfKind : lastPageOfKind,
+    isFullyLoaded: !excludeKinds.includes('dashboard') ? kind === 'dashboard' && lastPageOfKind : lastPageOfKind,
   };
 
   if (!parentUID) {

--- a/public/app/features/browse-dashboards/state/utils.ts
+++ b/public/app/features/browse-dashboards/state/utils.ts
@@ -28,3 +28,18 @@ export function findItem(
 
   return undefined;
 }
+
+export function getPaginationPlaceholders(amount: number, parentUID: string | undefined, level: number) {
+  return new Array(amount).fill(null).map((_, index) => {
+    return {
+      parentUID,
+      level,
+      isOpen: false,
+      item: {
+        kind: 'ui' as const,
+        uiKind: 'pagination-placeholder' as const,
+        uid: `${parentUID}-pagination-${index}`,
+      },
+    };
+  });
+}

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -33,7 +33,7 @@ export interface UIDashboardViewItem {
   uid: string;
 }
 
-type DashboardViewItemWithUIItems = DashboardViewItem | UIDashboardViewItem;
+export type DashboardViewItemWithUIItems = DashboardViewItem | UIDashboardViewItem;
 
 export interface DashboardsTreeItem<T extends DashboardViewItemWithUIItems = DashboardViewItemWithUIItems> {
   item: T;


### PR DESCRIPTION
Paginates all of the new Nested Folder Picker.

 - NestedFolderPicker now uses the same browse-dashboards redux state for fetching folders + children
 - Use skeleton loaders for loading children. Experimenting with a "SkeletonGroups" appearance so the skeletons aren't so unifor