### PR TITLE
Alerting: do not expand template for labels\annotations if value is not a template

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -165,6 +165,10 @@ func expand(ctx context.Context, log log.Logger, name string, original map[strin
 		expanded = make(map[string]string, len(original))
 	)
 	for k, v := range original {
+		if !strings.Contains(v, "{{") { // If value is not a template, skip expanding it.
+			expanded[k] = v
+			continue
+		}
 		result, err := template.Expand(ctx, name, v, data, externalURL, evaluatedAt)
 		if err != nil {
 			log.Error("Error in expanding template", "error", err)

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -165,10 +165,6 @@ func expand(ctx context.Context, log log.Logger, name string, original map[strin
 		expanded = make(map[string]string, len(original))
 	)
 	for k, v := range original {
-		if !strings.Contains(v, "{{") { // If value is not a template, skip expanding it.
-			expanded[k] = v
-			continue
-		}
 		result, err := template.Expand(ctx, name, v, data, externalURL, evaluatedAt)
 		if err != nil {
 			log.Error("Error in expanding template", "error", err)

--- a/pkg/services/ngalert/state/template/template.go
+++ b/pkg/services/ngalert/state/template/template.go
@@ -96,6 +96,10 @@ func (e ExpandError) Error() string {
 }
 
 func Expand(ctx context.Context, name, tmpl string, data Data, externalURL *url.URL, evaluatedAt time.Time) (string, error) {
+	if !strings.Contains(tmpl, "{{") { // If it is not a template, skip expanding it.
+		return tmpl, nil
+	}
+
 	// add __alert_ to avoid possible conflicts with other templates
 	name = "__alert_" + name
 	// add variables for the labels and values to the beginning of the template


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This is just a quick cheap optimization in state manager that calls template expand only if the label\annotation value is a template.

**Why do we need this feature?**

Benchmark before:

```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkProcessEvalResults
BenchmarkProcessEvalResults-16                99          10647847 ns/op
PASS
```

Benchmark after:

```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkProcessEvalResults
BenchmarkProcessEvalResults-16              1706            655276 ns/op
PASS
```
The performance improvement is 17x times when labels and annotations do not have templates

https://github.com/grafana/grafana/blob/7edbe724832ef9b744b793d2de82f50208c7a2e2/pkg/services/ngalert/state/manager_bench_test.go#L65-L74

**Who is this feature for?**
Users with lots of alerts

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I did some profiling comparisons. test bench: 5k rules each rule has two labels and one annotation. No templates. Real-time improvements is that CPU time decreased ~1.8x times

<details><summary>Screenshots</summary>
Baseline is the master branch:

![image](https://github.com/grafana/grafana/assets/25988953/82991ff0-1aea-4433-9a7a-cf6d50afb294)

Baseline is the 10.0.1
![image](https://github.com/grafana/grafana/assets/25988953/8cc9e926-5f04-4b87-b1bd-f18b4c76ab9c)
![image](https://github.com/grafana/grafana/assets/25988953/14dfe626-3b28-464a-ac50-0114e1d0c20e)

</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
