### PR TITLE
Alerting: Allow alertmanager to start with unused invalid receivers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890
+	github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29 //TODO: Update when PR merged
 	github.com/grafana/cuetsy v0.1.9
 	github.com/grafana/grafana-aws-sdk v0.15.0
 	github.com/grafana/grafana-azure-sdk-go v1.7.0
@@ -122,7 +122,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
-	xorm.io/builder v0.3.6
+	xorm.io/builder v0.3.6 // indirect
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.2
 )
@@ -176,7 +176,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1356,8 +1356,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890 h1:ubNIgVGX4PQ9YI1nWnt2mky3il8clWSjdo3NFSD26DQ=
-github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890/go.mod h1:zEflOvMVchYhRbFb5ziXVR/JG67FOLBzQTjhHh9xaI4=
+github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29 h1:wa5iN7I/HSYiXD+6DRzivvSOGi095jUpqiZjFhHOerE=
+github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29/go.mod h1:zEflOvMVchYhRbFb5ziXVR/JG67FOLBzQTjhHh9xaI4=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.9 h1:EwT8BqHoC0B3B4Y6Lg/D1aeYUKnQC1+2jjOHNsOuUfU=

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -115,32 +115,6 @@ func Test_APIReceiverType(t *testing.T) {
 	}
 }
 
-func Test_AllReceivers(t *testing.T) {
-	input := &Route{
-		Receiver: "foo",
-		Routes: []*Route{
-			{
-				Receiver: "bar",
-				Routes: []*Route{
-					{
-						Receiver: "bazz",
-					},
-				},
-			},
-			{
-				Receiver: "buzz",
-			},
-		},
-	}
-
-	require.Equal(t, []string{"foo", "bar", "bazz", "buzz"}, AllReceivers(input.AsAMRoute()))
-
-	// test empty
-	var empty []string
-	emptyRoute := &Route{}
-	require.Equal(t, empty, AllReceivers(emptyRoute.AsAMRoute()))
-}
-
 func Test_ApiAlertingConfig_Marshaling(t *testing.T) {
 	for _, tc := range []struct {
 		desc  string

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1,6 +1,7 @@
 package channels_config
 
 import (
+	"fmt"
 	"os"
 
 	alertingOpsgenie "github.com/grafana/alerting/receivers/opsgenie"
@@ -1245,4 +1246,21 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 			},
 		},
 	}
+}
+
+// GetSecretKeysForContactPointType returns settings keys of contact point of the given type that are expected to be secrets. Returns error is contact point type is not known.
+func GetSecretKeysForContactPointType(contactPointType string) ([]string, error) {
+	notifiers := GetAvailableNotifiers()
+	for _, n := range notifiers {
+		if n.Type == contactPointType {
+			var secureFields []string
+			for _, field := range n.Options {
+				if field.Secure {
+					secureFields = append(secureFields, field.PropertyName)
+				}
+			}
+			return secureFields, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown contact point type '%s'", contactPointType)
 }

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -242,7 +242,7 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 	if err != nil {
 		return err
 	}
-	secretKeys, err := GetSecretKeysForContactPointType(contactPoint.Type)
+	secretKeys, err := channels_config.GetSecretKeysForContactPointType(contactPoint.Type)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
@@ -519,27 +519,10 @@ func ValidateContactPoint(ctx context.Context, e apimodels.EmbeddedContactPoint,
 	return nil
 }
 
-// GetSecretKeysForContactPointType returns settings keys of contact point of the given type that are expected to be secrets. Returns error is contact point type is not known.
-func GetSecretKeysForContactPointType(contactPointType string) ([]string, error) {
-	notifiers := channels_config.GetAvailableNotifiers()
-	for _, n := range notifiers {
-		if n.Type == contactPointType {
-			var secureFields []string
-			for _, field := range n.Options {
-				if field.Secure {
-					secureFields = append(secureFields, field.PropertyName)
-				}
-			}
-			return secureFields, nil
-		}
-	}
-	return nil, fmt.Errorf("no secrets configured for type '%s'", contactPointType)
-}
-
 // RemoveSecretsForContactPoint removes all secrets from the contact point's settings and returns them as a map. Returns error if contact point type is not known.
 func RemoveSecretsForContactPoint(e *apimodels.EmbeddedContactPoint) (map[string]string, error) {
 	s := map[string]string{}
-	secretKeys, err := GetSecretKeysForContactPointType(e.Type)
+	secretKeys, err := channels_config.GetSecretKeysForContactPointType(e.Type)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR upgrades `grafana/alerting` to include https://github.com/grafana/alerting/pull/110 which makes the embedded alertmanager tacitly allow invalid receiver configs as long as they are not used in any notification policies. 

This has the grafana-side consequence of allowing POSTs to `alertmanager/grafana/config/api/v1/alerts` with invalid receiver configs to succeed if the receiver is unused. We would prefer the API to block the creation of new/modified invalid receivers. However, we should allow unchanged invalid receivers to remain in order to not block all updates to the alertmanager config until they are fixed.

This fixes the gap in the API validation by detecting and validating only new/modified receivers on POST. Code already existed in the provenance guard to detect changes in receivers, so there is some refactoring to re-use the code.

Part of #71466

**Special notes for your reviewer:**

Don't merge until we update the go.mod hash once https://github.com/grafana/alerting/pull/110 is merged.

<details>
  <summary>Preview of various API validations from UI/Admin</summary>
  
![Peek 2023-07-10 18-48](https://github.com/grafana/grafana/assets/8484471/ba4ab8ff-572b-47c2-907f-c204d459e616)

</details>