### PR TITLE
Alerting: Unused invalid channels no longer fail legacy migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890
+	github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29 //TODO: Update when PR merged
 	github.com/grafana/cuetsy v0.1.9
 	github.com/grafana/grafana-aws-sdk v0.15.0
 	github.com/grafana/grafana-azure-sdk-go v1.7.0
@@ -122,7 +122,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
-	xorm.io/builder v0.3.6
+	xorm.io/builder v0.3.6 // indirect
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.2
 )
@@ -176,7 +176,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1356,8 +1356,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890 h1:ubNIgVGX4PQ9YI1nWnt2mky3il8clWSjdo3NFSD26DQ=
-github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890/go.mod h1:zEflOvMVchYhRbFb5ziXVR/JG67FOLBzQTjhHh9xaI4=
+github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29 h1:wa5iN7I/HSYiXD+6DRzivvSOGi095jUpqiZjFhHOerE=
+github.com/grafana/alerting v0.0.0-20230712140658-4dc530b9ad29/go.mod h1:zEflOvMVchYhRbFb5ziXVR/JG67FOLBzQTjhHh9xaI4=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.9 h1:EwT8BqHoC0B3B4Y6Lg/D1aeYUKnQC1+2jjOHNsOuUfU=

--- a/pkg/services/sqlstore/migrations/ualert/migration_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/migration_test.go
@@ -447,6 +447,16 @@ func TestAMConfigMigration(t *testing.T) {
 			expErr: errors.New(`migration failed (id = move dashboard alerts to unified alerting): failed to validate AlertmanagerConfig in orgId 1: failed to validate integration "notifier1" (UID notifier1) of type "email": could not find addresses in settings`),
 		},
 		{
+			name: "when one invalid default integration of many valid is linked to an alert, fail migration",
+			legacyChannels: []*models.AlertNotification{
+				createAlertNotification(t, int64(1), "notifier1", "email", emailSettings, true),
+				createAlertNotification(t, int64(1), "notifier2", "email", brokenEmailSettings, true),
+				createAlertNotification(t, int64(1), "notifier3", "slack", slackSettings, true),
+			},
+			alerts: []*models.Alert{createAlert(t, int64(1), int64(1), int64(1), "alert1", []string{"notifier1", "notifier2", "notifier3"})},
+			expErr: errors.New(`migration failed (id = move dashboard alerts to unified alerting): failed to validate AlertmanagerConfig in orgId 1: failed to validate integration "notifier2" (UID notifier2) of type "email": could not find addresses in settings`),
+		},
+		{
 			name: "when unsupported channels, do not migrate them",
 			legacyChannels: []*models.AlertNotification{
 				createAlertNotification(t, int64(1), "notifier1", "email", emailSettings, false),

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -528,7 +528,9 @@ func validateReceivers(l log.Logger, r *PostableApiReceiver) error {
 		_, err = alertingNotify.BuildReceiverConfiguration(context.Background(), &alertingNotify.APIReceiver{
 			GrafanaIntegrations: alertingNotify.GrafanaIntegrations{Integrations: []*alertingNotify.GrafanaIntegrationConfig{cfg}},
 		}, decryptFunc)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, legacy notification channels that fail to validate in UA would fail the migration, even if the channel (and UA receiver) is unused.

https://github.com/grafana/alerting/pull/110 makes the embedded alertmanager tacitly allow invalid receiver configs as long as they are not used in any notification policies.

This change extends this to legacy migration by:

- Not creating a Route if the corresponding Receiver is invalid and unused by all alert rules.
- Not failing the migration if there is an invalid Receiver that is not used in any Route (and thus not used by any alert rules)

Part of #71466

**Special notes for your reviewer:**

Don't merge until we update the go.mod hash once https://github.com/grafana/alerting/pull/110 is merged.

https://github.com/grafana/grafana/pull/71499 should also be merged before this, or if it isn't the title of this PR should be changed to note that it introduces https://github.com/grafana/alerting/pull/110.