### PR TITLE
TestDatasource: Generate refId for the flame graph

### DIFF
--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -95,7 +95,7 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
           streams.push(this.nodesQuery(target, options));
           break;
         case 'flame_graph':
-          streams.push(this.flameGraphQuery());
+          streams.push(this.flameGraphQuery(target));
           break;
         case 'trace':
           streams.push(this.trace(target, options));
@@ -242,8 +242,8 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
     return of({ data: frames }).pipe(delay(100));
   }
 
-  flameGraphQuery(): Observable<DataQueryResponse> {
-    return of({ data: [flameGraphData] }).pipe(delay(100));
+  flameGraphQuery(target: TestData): Observable<DataQueryResponse> {
+    return of({ data: [{ ...flameGraphData, refId: target.refId }] }).pipe(delay(100));
   }
 
   trace(target: TestData, options: DataQueryRequest<TestData>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/testdata/testData/flameGraphResponse.ts
+++ b/public/app/plugins/datasource/testdata/testData/flameGraphResponse.ts
@@ -2,7 +2,6 @@ import { DataFrameDTO } from '@grafana/data';
 
 export const flameGraphData: DataFrameDTO = {
   name: 'response',
-  refId: 'A',
   // @ts-ignore
   meta: { preferredVisualisationType: 'flamegraph' },
   fields: [


### PR DESCRIPTION
Fixes: #70812

There's a hardcoded refId in test data's flame graph response causing overriding the data if `A` is used as a refId in some other query.

Please check #70812 for reproduction steps and more info.