### PR TITLE
FeatureToggles: Support changing feature toggles with localstorage

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -795,7 +795,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "packages/grafana-runtime/src/services/AngularLoader.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -795,8 +795,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "packages/grafana-runtime/src/services/AngularLoader.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -223,7 +223,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
     for (const feature of features) {
       const [featureName, featureValue] = feature.split('=');
       const toggleState = featureValue === 'true' || featureValue === '1';
-      // eslint-disable-next-line
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
       console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
     }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -223,6 +223,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
     for (const feature of features) {
       const [featureName, featureValue] = feature.split('=');
       const toggleState = featureValue === 'true' || featureValue === '1';
+      // eslint-disable-next-line
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
       console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
     }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -199,6 +199,8 @@ export class GrafanaBootConfig implements GrafanaConfig {
       overrideFeatureTogglesFromUrl(this);
     }
 
+    overrideFeatureTogglesFromLocalStorage(this);
+
     if (this.featureToggles.disableAngular) {
       this.angularSupportEnabled = false;
     }
@@ -207,6 +209,21 @@ export class GrafanaBootConfig implements GrafanaConfig {
     this.theme2 = getThemeById(this.bootData.user.theme);
     this.bootData.user.lightTheme = this.theme2.isLight;
     this.theme = this.theme2.v1;
+  }
+}
+
+function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
+  const featureToggles = config.featureToggles;
+  const localStorageKey = 'grafana.featureToggles';
+  const localStorageValue = window.localStorage.getItem(localStorageKey);
+  if (localStorageValue) {
+    const features = localStorageValue.split(',');
+    for (const feature of features) {
+      const [featureName, featureValue] = feature.split('=');
+      const toggleState = featureValue === 'true' || featureValue === '1';
+      featureToggles[featureName as keyof FeatureToggles] = toggleState;
+      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+    }
   }
 }
 
@@ -223,7 +240,7 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       const toggleState = value === 'true' || value === ''; // browser rewrites true as ''
       if (toggleState !== featureToggles[key]) {
         featureToggles[featureName] = toggleState;
-        console.log(`Setting feature toggle ${featureName} = ${toggleState}`);
+        console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
       }
     }
   });

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -212,6 +212,8 @@ export class GrafanaBootConfig implements GrafanaConfig {
   }
 }
 
+// localstorage key: grafana.featureToggles
+// example value: panelEditor=1,panelInspector=1
 function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
   const featureToggles = config.featureToggles;
   const localStorageKey = 'grafana.featureToggles';


### PR DESCRIPTION
**What is this feature?**

Allows to set feature toggles frontend-only using localstorage.

**Why do we need this feature?**

This functionality was originally introduced here https://github.com/grafana/grafana/pull/50275/files but later downgraded to only development in here https://github.com/grafana/grafana/pull/70731

The PR brings back the functionality to all environments but using localstorage instead of query parameters for enhanced security

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
