### PR TITLE
Remove empty main block at the end

### DIFF
--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -108,5 +108,3 @@ Additional technical information on tabular time series formats and how dimensio
 [time-series-databases]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"
 [time-series-databases]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"
 {{% /docs/reference %}}
-
-> > > > > > > main


### PR DESCRIPTION
Removed empty block at the end of the page

![image](https://github.com/grafana/grafana/assets/79632099/230643c9-dd03-44d2-aa88-31c0aadd7afc)


