### PR TITLE
Geomap: Address tooltip performance issue

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4881,7 +4881,7 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/geomap/utils/selection.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/panel/geomap/utils/tootltip.ts:5381": [
+    "public/app/plugins/panel/geomap/utils/tooltip.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/graph/GraphContextMenuCtrl.ts:5381": [

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -29,7 +29,7 @@ import { ControlsOptions, Options, MapLayerState, MapViewConfig, TooltipMode } f
 import { getActions } from './utils/actions';
 import { getLayersExtent } from './utils/getLayersExtent';
 import { applyLayerFilter, initLayer } from './utils/layers';
-import { pointerClickListener, pointerMoveListener, setTooltipListeners } from './utils/tootltip';
+import { pointerClickListener, pointerMoveListener, setTooltipListeners } from './utils/tooltip';
 import { updateMap, getNewOpenLayersMap, notifyPanelEditor } from './utils/utils';
 import { centerPointRegistry, MapCenterID } from './view';
 

--- a/public/app/plugins/panel/geomap/utils/tooltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.ts
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash';
 import { MapBrowserEvent } from 'ol';
 import { toLonLat } from 'ol/proj';
 
@@ -12,7 +13,7 @@ import { getMapLayerState } from './layers';
 export const setTooltipListeners = (panel: GeomapPanel) => {
   // Tooltip listener
   panel.map?.on('singleclick', panel.pointerClickListener);
-  panel.map?.on('pointermove', panel.pointerMoveListener);
+  panel.map?.on('pointermove', debounce(panel.pointerMoveListener, 200));
   panel.map?.getViewport().addEventListener('mouseout', (evt: MouseEvent) => {
     panel.props.eventBus.publish(new DataHoverClearEvent());
   });


### PR DESCRIPTION
When rendering hundreds to thousands of points the Geomap panel would freeze up as well as interactivity with the entire DOM.

The cause of this performance issue has been narrowed down to https://github.com/grafana/grafana/blob/4e6f51b6205ee2ec52762cba5f8c1edd01533cec/public/app/plugins/panel/geomap/utils/tootltip.ts#L61

We should do a deeper dive / investigation into addressing this performance bottleneck without impeding tooltip functionality (adding slight delay) (see [this issue here](https://github.com/grafana/grafana/issues/71609)) - but for now we should try and address this so that the panel is at least usable.

Before

https://github.com/grafana/grafana/assets/22381771/8636b4ff-92d9-4bca-af2a-7c7f6bcb45bb



After

https://github.com/grafana/grafana/assets/22381771/76d3f80e-1550-4de7-957b-51b6c4b182b0




Fixes https://github.com/grafana/grafana/issues/71507

| Key | Value |
|--|--|
| Panel | geomap @ 10.0.2-cloud.1.94a6f396 |
| Grafana | 10.0.2-cloud.1.94a6f396 (b2bbe10fbc) // Enterprise |
<details><summary>Panel debug snapshot dashboard</summary>

```json
{
  "panels": [
    {
      "datasource": {
        "type": "grafana",
        "uid": "grafana"
      },
      "fieldConfig": {
        "defaults": {
          "custom": {
            "hideFrom": {
              "tooltip": false,
              "viz": false,
              "legend": false
            }
          },
          "mappings": [
            {
              "options": {
                "0": {
                  "color": "red",
                  "index": 2,
                  "text": "Down"
                },
                "5": {
                  "color": "green",
                  "index": 0,
                  "text": "Healthy"
                }
              },
              "type": "value"
            },
            {
              "options": {
                "from": 1,
                "result": {
                  "color": "yellow",
                  "index": 1,
                  "text": "Degraded"
                },
                "to": 4
              },
              "type": "range"
            }
          ],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "red",
                "value": null
              },
              {
                "color": "red",
                "value": 0
              },
              {
                "color": "#EAB839",
                "value": 1
              },
              {
                "color": "green",
                "value": 5
              }
            ]
          },
          "color": {
            "mode": "continuous-GrYlRd"
          },
          "noValue": "0"
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "storeName.keyword"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "Location"
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Min"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "Log Agent"
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "location"
            },
            "properties": [
              {
                "id": "custom.hideFrom",
                "value": {
                  "legend": true,
                  "tooltip": true,
                  "viz": true
                }
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Min agents"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "LogAgents"
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Min prometheus"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "Prometheus"
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Min squid"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "Squid"
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "Min rmp"
            },
            "properties": [
              {
                "id": "custom.hideFrom",
                "value": {
                  "legend": true,
                  "tooltip": true,
                  "viz": true
                }
              }
            ]
          },
          {
            "matcher": {
              "id": "byName",
              "options": "storeNumber.keyword"
            },
            "properties": [
              {
                "id": "displayName",
                "value": "Number"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "maxDataPoints": 20000,
      "options": {
        "view": {
          "allLayers": true,
          "id": "coords",
          "lat": 20,
          "lon": -25,
          "zoom": 3.5,
          "shared": false
        },
        "controls": {
          "showZoom": true,
          "mouseWheelZoom": true,
          "showAttribution": false,
          "showScale": false,
          "showMeasure": false,
          "showDebug": false
        },
        "tooltip": {
          "mode": "details"
        },
        "basemap": {
          "config": {},
          "name": "Layer 0",
          "opacity": 0,
          "tooltip": false,
          "type": "osm-standard"
        },
        "layers": [
          {
            "config": {
              "rules": [],
              "src": "public/maps/usa-states.geojson",
              "style": {
                "color": {
                  "fixed": "#C0D8FF"
                },
                "opacity": 0,
                "rotation": {
                  "fixed": 0,
                  "max": 360,
                  "min": -360,
                  "mode": "mod"
                },
                "size": {
                  "fixed": 5,
                  "max": 15,
                  "min": 2
                },
                "symbol": {
                  "fixed": "img/icons/marker/circle.svg",
                  "mode": "fixed"
                },
                "textConfig": {
                  "fontSize": 12,
                  "offsetX": 0,
                  "offsetY": 0,
                  "textAlign": "center",
                  "textBaseline": "middle"
                }
              }
            },
            "name": "States",
            "opacity": 0.5,
            "tooltip": false,
            "type": "geojson"
          },
          {
            "config": {
              "rules": [],
              "src": "public/maps/countries.geojson",
              "style": {
                "color": {
                  "fixed": "#5794F2"
                },
                "opacity": 0.1,
                "rotation": {
                  "fixed": 0,
                  "max": 360,
                  "min": -360,
                  "mode": "mod"
                },
                "size": {
                  "fixed": 5,
                  "max": 15,
                  "min": 2
                },
                "symbol": {
                  "fixed": "img/icons/marker/circle.svg",
                  "mode": "fixed"
                },
                "textConfig": {
                  "fontSize": 12,
                  "offsetX": 0,
                  "offsetY": 0,
                  "textAlign": "center",
                  "textBaseline": "middle"
                }
              }
            },
            "name": "Countries",
            "opacity": 1,
            "tooltip": false,
            "type": "geojson"
          },
          {
            "config": {
              "rules": [],
              "src": "https://cache.genoplot.com/maps/geomapv2.json",
              "style": {
                "color": {
                  "fixed": "#ffffff05"
                },
                "opacity": 0.1,
                "rotation": {
                  "fixed": 1,
                  "max": 360,
                  "min": -360,
                  "mode": "mod"
                },
                "size": {
                  "fixed": 5,
                  "max": 15,
                  "min": 2
                },
                "symbol": {
                  "fixed": "img/icons/marker/circle.svg",
                  "mode": "fixed"
                },
                "textConfig": {
                  "fontSize": 12,
                  "offsetX": 0,
                  "offsetY": 0,
                  "textAlign": "center",
                  "textBaseline": "middle"
                }
              }
            },
            "name": "Stores",
            "opacity": 0.3,
            "tooltip": true,
            "type": "geojson"
          },
          {
            "config": {
              "showLegend": false,
              "style": {
                "color": {
                  "field": "Min rmp",
                  "fixed": "red"
                },
                "opacity": 1,
                "rotation": {
                  "fixed": 0,
                  "max": 360,
                  "min": -360,
                  "mode": "mod"
                },
                "size": {
                  "field": "Min rmp",
                  "fixed": 5,
                  "max": 4,
                  "min": 4
                },
                "symbol": {
                  "field": "",
                  "fixed": "img/icons/marker/circle.svg",
                  "mode": "fixed"
                },
                "text": {
                  "fixed": "",
                  "mode": "field"
                },
                "textConfig": {
                  "fontSize": 12,
                  "offsetX": 0,
                  "offsetY": 0,
                  "textAlign": "center",
                  "textBaseline": "middle"
                }
              }
            },
            "filterData": {
              "id": "byRefId",
              "options": "B"
            },
            "location": {
              "geohash": "location",
              "mode": "geohash"
            },
            "name": "Store Status",
            "tooltip": true,
            "type": "markers"
          }
        ]
      },
      "pluginVersion": "10.0.2-cloud.1.94a6f396",
      "targets": [
        {
          "refId": "A",
          "datasource": {
            "type": "grafana",
            "uid": "grafana"
          },
          "queryType": "snapshot",
          "snapshot": []
        }
      ],
      "title": "Reproduced with embedded data",
      "transparent": true,
      "type": "geomap"
    },
    {
      "gridPos": {
        "h": 7,
        "w": 9,
        "x": 15,
        "y": 0
      },
      "id": 5,
      "options": {
        "content": "<table width=\"100%\">\n    <tr>\n      <th width=\"2%\">Panel</th>\n      <td >geomap @ 10.0.2-cloud.1.94a6f396</td>\n    </tr>\n    <tr>\n      <th>Queries</th>\n      <td>B[elasticsearch]</td>\n    </tr>\n    \n    <tr><th>Data</th><td>Error 0 frames, 0 fields, 0 rows </td></tr>\n    \n    <tr>\n      <th>Grafana</th>\n      <td>10.0.2-cloud.1.94a6f396 (b2bbe10fbc) // Enterprise</td>\n    </tr>\n  </table>",
        "mode": "html"
      },
      "title": "Debug info",
      "type": "text"
    },
    {
      "id": 6,
      "title": "Original Panel JSON",
      "type": "text",
      "gridPos": {
        "h": 13,
        "w": 9,
        "x": 15,
        "y": 7
      },
      "options": {
        "content": "{\n  \"datasource\": {\n    \"type\": \"elasticsearch\",\n    \"uid\": \"Urn8BHVVk\"\n  },\n  \"fieldConfig\": {\n    \"defaults\": {\n      \"custom\": {\n        \"hideFrom\": {\n          \"tooltip\": false,\n          \"viz\": false,\n          \"legend\": false\n        }\n      },\n      \"mappings\": [\n        {\n          \"options\": {\n            \"0\": {\n              \"color\": \"red\",\n              \"index\": 2,\n              \"text\": \"Down\"\n            },\n            \"5\": {\n              \"color\": \"green\",\n              \"index\": 0,\n              \"text\": \"Healthy\"\n            }\n          },\n          \"type\": \"value\"\n        },\n        {\n          \"options\": {\n            \"from\": 1,\n            \"result\": {\n              \"color\": \"yellow\",\n              \"index\": 1,\n              \"text\": \"Degraded\"\n            },\n            \"to\": 4\n          },\n          \"type\": \"range\"\n        }\n      ],\n      \"thresholds\": {\n        \"mode\": \"absolute\",\n        \"steps\": [\n          {\n            \"color\": \"red\",\n            \"value\": null\n          },\n          {\n            \"color\": \"red\",\n            \"value\": 0\n          },\n          {\n            \"color\": \"#EAB839\",\n            \"value\": 1\n          },\n          {\n            \"color\": \"green\",\n            \"value\": 5\n          }\n        ]\n      },\n      \"color\": {\n        \"mode\": \"continuous-GrYlRd\"\n      },\n      \"noValue\": \"0\"\n    },\n    \"overrides\": [\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"storeName.keyword\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"Location\"\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"Min\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"Log Agent\"\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"location\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"custom.hideFrom\",\n            \"value\": {\n              \"legend\": true,\n              \"tooltip\": true,\n              \"viz\": true\n            }\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"Min agents\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"LogAgents\"\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"Min prometheus\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"Prometheus\"\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"Min squid\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"Squid\"\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"Min rmp\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"custom.hideFrom\",\n            \"value\": {\n              \"legend\": true,\n              \"tooltip\": true,\n              \"viz\": true\n            }\n          }\n        ]\n      },\n      {\n        \"matcher\": {\n          \"id\": \"byName\",\n          \"options\": \"storeNumber.keyword\"\n        },\n        \"properties\": [\n          {\n            \"id\": \"displayName\",\n            \"value\": \"Number\"\n          }\n        ]\n      }\n    ]\n  },\n  \"gridPos\": {\n    \"h\": 31,\n    \"w\": 24,\n    \"x\": 0,\n    \"y\": 6\n  },\n  \"id\": 2,\n  \"maxDataPoints\": 20000,\n  \"options\": {\n    \"view\": {\n      \"allLayers\": true,\n      \"id\": \"coords\",\n      \"lat\": 20,\n      \"lon\": -25,\n      \"zoom\": 3.5,\n      \"shared\": false\n    },\n    \"controls\": {\n      \"showZoom\": true,\n      \"mouseWheelZoom\": true,\n      \"showAttribution\": false,\n      \"showScale\": false,\n      \"showMeasure\": false,\n      \"showDebug\": false\n    },\n    \"tooltip\": {\n      \"mode\": \"details\"\n    },\n    \"basemap\": {\n      \"config\": {},\n      \"name\": \"Layer 0\",\n      \"opacity\": 0,\n      \"tooltip\": false,\n      \"type\": \"osm-standard\"\n    },\n    \"layers\": [\n      {\n        \"config\": {\n          \"rules\": [],\n          \"src\": \"public/maps/usa-states.geojson\",\n          \"style\": {\n            \"color\": {\n              \"fixed\": \"#C0D8FF\"\n            },\n            \"opacity\": 0,\n            \"rotation\": {\n              \"fixed\": 0,\n              \"max\": 360,\n              \"min\": -360,\n              \"mode\": \"mod\"\n            },\n            \"size\": {\n              \"fixed\": 5,\n              \"max\": 15,\n              \"min\": 2\n            },\n            \"symbol\": {\n              \"fixed\": \"img/icons/marker/circle.svg\",\n              \"mode\": \"fixed\"\n            },\n            \"textConfig\": {\n              \"fontSize\": 12,\n              \"offsetX\": 0,\n              \"offsetY\": 0,\n              \"textAlign\": \"center\",\n              \"textBaseline\": \"middle\"\n            }\n          }\n        },\n        \"name\": \"States\",\n        \"opacity\": 0.5,\n        \"tooltip\": false,\n        \"type\": \"geojson\"\n      },\n      {\n        \"config\": {\n          \"rules\": [],\n          \"src\": \"public/maps/countries.geojson\",\n          \"style\": {\n            \"color\": {\n              \"fixed\": \"#5794F2\"\n            },\n            \"opacity\": 0.1,\n            \"rotation\": {\n              \"fixed\": 0,\n              \"max\": 360,\n              \"min\": -360,\n              \"mode\": \"mod\"\n            },\n            \"size\": {\n              \"fixed\": 5,\n              \"max\": 15,\n              \"min\": 2\n            },\n            \"symbol\": {\n              \"fixed\": \"img/icons/marker/circle.svg\",\n              \"mode\": \"fixed\"\n            },\n            \"textConfig\": {\n              \"fontSize\": 12,\n              \"offsetX\": 0,\n              \"offsetY\": 0,\n              \"textAlign\": \"center\",\n              \"textBaseline\": \"middle\"\n            }\n          }\n        },\n        \"name\": \"Countries\",\n        \"opacity\": 1,\n        \"tooltip\": false,\n        \"type\": \"geojson\"\n      },\n      {\n        \"config\": {\n          \"rules\": [],\n          \"src\": \"https://cache.genoplot.com/maps/geomapv2.json\",\n          \"style\": {\n            \"color\": {\n              \"fixed\": \"#ffffff05\"\n            },\n            \"opacity\": 0.1,\n            \"rotation\": {\n              \"fixed\": 1,\n              \"max\": 360,\n              \"min\": -360,\n              \"mode\": \"mod\"\n            },\n            \"size\": {\n              \"fixed\": 5,\n              \"max\": 15,\n              \"min\": 2\n            },\n            \"symbol\": {\n              \"fixed\": \"img/icons/marker/circle.svg\",\n              \"mode\": \"fixed\"\n            },\n            \"textConfig\": {\n              \"fontSize\": 12,\n              \"offsetX\": 0,\n              \"offsetY\": 0,\n              \"textAlign\": \"center\",\n              \"textBaseline\": \"middle\"\n            }\n          }\n        },\n        \"name\": \"Stores\",\n        \"opacity\": 0.3,\n        \"tooltip\": true,\n        \"type\": \"geojson\"\n      },\n      {\n        \"config\": {\n          \"showLegend\": false,\n          \"style\": {\n            \"color\": {\n              \"field\": \"Min rmp\",\n              \"fixed\": \"red\"\n            },\n            \"opacity\": 1,\n            \"rotation\": {\n              \"fixed\": 0,\n              \"max\": 360,\n              \"min\": -360,\n              \"mode\": \"mod\"\n            },\n            \"size\": {\n              \"field\": \"Min rmp\",\n              \"fixed\": 5,\n              \"max\": 4,\n              \"min\": 4\n            },\n            \"symbol\": {\n              \"field\": \"\",\n              \"fixed\": \"img/icons/marker/circle.svg\",\n              \"mode\": \"fixed\"\n            },\n            \"text\": {\n              \"fixed\": \"\",\n              \"mode\": \"field\"\n            },\n            \"textConfig\": {\n              \"fontSize\": 12,\n              \"offsetX\": 0,\n              \"offsetY\": 0,\n              \"textAlign\": \"center\",\n              \"textBaseline\": \"middle\"\n            }\n          }\n        },\n        \"filterData\": {\n          \"id\": \"byRefId\",\n          \"options\": \"B\"\n        },\n        \"location\": {\n          \"geohash\": \"location\",\n          \"mode\": \"geohash\"\n        },\n        \"name\": \"Store Status\",\n        \"tooltip\": true,\n        \"type\": \"markers\"\n      }\n    ]\n  },\n  \"pluginVersion\": \"10.0.2-cloud.1.94a6f396\",\n  \"targets\": [\n    {\n      \"alias\": \"\",\n      \"bucketAggs\": [\n        {\n          \"field\": \"location\",\n          \"id\": \"6\",\n          \"settings\": {\n            \"precision\": \"10\"\n          },\n          \"type\": \"geohash_grid\"\n        },\n        {\n          \"field\": \"storeName.keyword\",\n          \"id\": \"10\",\n          \"settings\": {\n            \"min_doc_count\": \"1\",\n            \"missing\": \"0\",\n            \"order\": \"desc\",\n            \"orderBy\": \"_term\",\n            \"size\": \"1\"\n          },\n          \"type\": \"terms\"\n        },\n        {\n          \"field\": \"storeNumber.keyword\",\n          \"id\": \"11\",\n          \"settings\": {\n            \"min_doc_count\": \"1\",\n            \"order\": \"desc\",\n            \"orderBy\": \"_term\",\n            \"size\": \"1\"\n          },\n          \"type\": \"terms\"\n        }\n      ],\n      \"datasource\": {\n        \"type\": \"elasticsearch\",\n        \"uid\": \"Urn8BHVVk\"\n      },\n      \"hide\": false,\n      \"metrics\": [\n        {\n          \"field\": \"rmp\",\n          \"id\": \"1\",\n          \"settings\": {\n            \"missing\": \"0\"\n          },\n          \"type\": \"min\"\n        },\n        {\n          \"field\": \"prometheus\",\n          \"id\": \"7\",\n          \"settings\": {\n            \"missing\": \"0\",\n            \"script\": \"_value*5\"\n          },\n          \"type\": \"min\"\n        },\n        {\n          \"field\": \"squid\",\n          \"id\": \"8\",\n          \"settings\": {\n            \"missing\": \"0\",\n            \"script\": \"_value*5\"\n          },\n          \"type\": \"min\"\n        },\n        {\n          \"field\": \"agents\",\n          \"id\": \"9\",\n          \"settings\": {\n            \"missing\": \"0\"\n          },\n          \"type\": \"min\"\n        }\n      ],\n      \"query\": \"storeNumber:${store}\",\n      \"refId\": \"B\",\n      \"timeField\": \"@timestamp\"\n    }\n  ],\n  \"title\": \"RMP Status\",\n  \"transparent\": true,\n  \"type\": \"geomap\"\n}",
        "mode": "code",
        "code": {
          "language": "json",
          "showLineNumbers": true,
          "showMiniMap": true
        }
      }
    },
    {
      "id": 3,
      "title": "Data from panel above",
      "type": "table",
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "gridPos": {
        "h": 7,
        "w": 15,
        "x": 0,
        "y": 13
      },
      "options": {
        "showTypeIcons": true
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 2,
          "withTransforms": true,
          "refId": "A"
        }
      ]
    }
  ],
  "schemaVersion": 37,
  "title": "Debug: RMP Status // 2023-07-12 14:55:55",
  "tags": [
    "debug",
    "debug-geomap"
  ],
  "time": {
    "from": "2023-07-12T20:55:55.101Z",
    "to": "2023-07-12T21:55:55.101Z"
  }
}
```
</details>