### PR TITLE
Alerting: Fix provisioning merge when renaming last receiver

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -494,6 +494,58 @@ func TestStitchReceivers(t *testing.T) {
 			},
 		},
 		{
+			name: "rename with only one receiver in group to another existing group: moves receiver, renames group and references, removes old group",
+			new: &definitions.PostableGrafanaReceiver{
+				UID:  "abc",
+				Name: "receiver-2",
+				Type: "slack",
+			},
+			expModified: true,
+			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-2",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-2",
+							},
+						},
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-2",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "def",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+								{
+									UID:  "ghi",
+									Name: "receiver-2",
+									Type: "email",
+								},
+								{
+									UID:  "jkl",
+									Name: "receiver-2",
+									Type: "discord",
+								},
+								{
+									UID:  "abc",
+									Name: "receiver-2",
+									Type: "slack",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "rename to another, larger group",
 			initial: &definitions.PostableUserConfig{
 				AlertmanagerConfig: definitions.PostableApiAlertingConfig{


### PR DESCRIPTION
Currently, when moving the last provisioned receiver in a contact point to another contact point, provisioning will create two contact points of the same name instead of merging them.

This change will:

- Ensure they merge into a single contact point containing both receivers and the correct name.
- Replace all references to the removed contact point in notification policies with the new name. (alternatively we could leave an empty contact point and keep the same routes, WDYT?)

**Which issue(s) does this PR fix?**:

Fixes #71619

**Special notes for your reviewer:**

Example provisioning file (first provision, then combine the two and provision again):

```yaml
apiVersion: 1
contactPoints:
  - orgId: 1
    name: pagerduty test
    receivers:
      - uid: b9bf06f8-bde2-4438-9d4a-bba0522dcd4d
        type: pagerduty
        settings:
          client: some client
          integrationKey: some key
          severity: criticalish
        disableResolveMessage: false
  - orgId: 1
    name: slack test
    receivers:
      - uid: cbfd0976-8228-4126-b672-4419f30a9e50
        type: slack
        settings:
          text: title body test
          title: title test
          url: some secure slack webhook
        disableResolveMessage: true

```

<details>
  <summary>Fix confirmation GIF</summary>
  
![Peek 2023-07-13 23-28](https://github.com/grafana/grafana/assets/8484471/df7d7165-1555-468c-a92d-3432eca7bf4d)
</details>


