### PR TITLE
Alerting: Save and restore condition reference while switching type

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -303,8 +303,9 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
     [dispatch]
   );
 
-  // we need to keep track of the previous expressions to be able to restore them when switching back to grafana managed
+  // we need to keep track of the previous expressions and condition reference to be able to restore them when switching back to grafana managed
   const [prevExpressions, setPrevExpressions] = useState<AlertQuery[]>([]);
+  const [prevCondition, setPrevCondition] = useState<string | null>(null);
 
   const restoreExpressionsInQueries = useCallback(() => {
     addExpressionsInQueries(prevExpressions);
@@ -314,14 +315,26 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
     const typeInForm = getValues('type');
     if (typeInForm === RuleFormType.cloudAlerting) {
       setValue('type', RuleFormType.grafana);
-      setPrevExpressions.length > 0 && restoreExpressionsInQueries();
+      prevExpressions.length > 0 && restoreExpressionsInQueries();
+      prevCondition && setValue('condition', prevCondition);
     } else {
       setValue('type', RuleFormType.cloudAlerting);
       const expressions = queries.filter((query) => query.datasourceUid === ExpressionDatasourceUID);
       setPrevExpressions(expressions);
       removeExpressionsInQueries();
+      setPrevCondition(condition);
     }
-  }, [getValues, setValue, queries, removeExpressionsInQueries, restoreExpressionsInQueries, setPrevExpressions]);
+  }, [
+    getValues,
+    setValue,
+    queries,
+    removeExpressionsInQueries,
+    restoreExpressionsInQueries,
+    setPrevExpressions,
+    prevExpressions,
+    prevCondition,
+    condition,
+  ]);
 
   return (
     <RuleEditorSection stepNo={2} title="Define query and alert condition">


### PR DESCRIPTION
**What is this feature?**

This PR saves and restores condition reference in the alert rule form when creating a new rule and switching between types.
The problem was that once user switch to cloud rule type the condition is set to the query and we loose this reference to the grafana managed expression or query condition. 

**Why do we need this feature?**

We want to help user to keep the options they have while switching between alert rule types.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

Before this change:


https://github.com/grafana/grafana/assets/33540275/75d7eacf-2fc9-48a4-bf0e-74d25b63f904



After the change:


https://github.com/grafana/grafana/assets/33540275/28623411-b0a1-4e30-a80e-4fc930a312a1



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
