### PR TITLE
DatasourcePicker: Call onChange only if data source changes

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.test.tsx
@@ -142,7 +142,7 @@ describe('DataSourceDropdown', () => {
       );
     });
 
-    it('should dispaly the current selected DS in the selector', async () => {
+    it('should display the current selected DS in the selector', async () => {
       getInstanceSettingsMock.mockReturnValue(mockDS2);
       render(<DataSourceDropdown onChange={jest.fn()} current={mockDS2}></DataSourceDropdown>);
       expect(screen.getByTestId('Select a data source')).toHaveAttribute('placeholder', mockDS2.name);
@@ -163,7 +163,7 @@ describe('DataSourceDropdown', () => {
       expect(await findByText(cards[0], mockDS2.name, { selector: 'span' })).toBeInTheDocument();
     });
 
-    it('should dispaly the default DS as selected when `current` is not set', async () => {
+    it('should display the default DS as selected when `current` is not set', async () => {
       getInstanceSettingsMock.mockReturnValue(mockDS2);
       render(<DataSourceDropdown onChange={jest.fn()} current={undefined}></DataSourceDropdown>);
       expect(screen.getByTestId('Select a data source')).toHaveAttribute('placeholder', mockDS2.name);
@@ -214,6 +214,14 @@ describe('DataSourceDropdown', () => {
       await user.click(await screen.findByText(mockDS2.name, { selector: 'span' }));
       expect(onChange.mock.lastCall[0]['name']).toEqual(mockDS2.name);
       expect(screen.queryByText(mockDS1.name, { selector: 'span' })).toBeNull();
+    });
+
+    it('should not call onChange when the currently selected data source is clicked', async () => {
+      const onChange = jest.fn();
+      await setupOpenDropdown(user, { onChange });
+
+      await user.click(await screen.findByText(mockDS1.name, { selector: 'span' }));
+      expect(onChange).not.toBeCalled();
     });
 
     it('should push recently used datasources when a data source is clicked', async () => {

--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -202,7 +202,10 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
               filterTerm={filterTerm}
               onChange={(ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
                 onClose();
-                onChange(ds, defaultQueries);
+                if (ds.uid !== currentValue?.uid) {
+                  onChange(ds, defaultQueries);
+                  reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.SELECT_DS, ds_type: ds.type });
+                }
               }}
               onClose={onClose}
               current={currentValue}
@@ -253,7 +256,6 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
   const changeCallback = useCallback(
     (ds: DataSourceInstanceSettings) => {
       onChange(ds);
-      reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.SELECT_DS, ds_type: ds.type });
     },
     [onChange]
   );


### PR DESCRIPTION
Fixes #71622

Please check https://github.com/grafana/grafana/issues/71622 for more details.

Note: it also changes interaction tracking - if the same data source is selected it's not tracked.

@ivanortegaalba / @grafana/dashboards-squad / @grafana/grafana-frontend-platform : I'm not sure about this one. Let me know if that's expected behavior in Dashboards. There's a check that seems to expect this to happen in runtime [here](https://github.com/grafana/grafana/blob/v10.0.2/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx#L76). If this is expected behavior I'll change it so we have the check only in Explore callbacks.