### PR TITLE
Docs: Escape `$` for `$__tags`

### DIFF
--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -193,7 +193,7 @@ datasources:
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
         queries:
           - name: 'Sample query'
-            query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
+            query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
       nodeGraph:
         enabled: true
       traceQuery:

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -223,7 +223,7 @@ datasources:
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
         queries:
           - name: 'Sample query'
-            query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
+            query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
       serviceMap:
         datasourceUid: 'prometheus'
       nodeGraph:

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -191,7 +191,7 @@ datasources:
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]
         queries:
           - name: 'Sample query'
-            query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
+            query: 'sum(rate(traces_spanmetrics_latency_bucket{$$__tags}[5m]))'
       nodeGraph:
         enabled: true
       traceQuery:


### PR DESCRIPTION
`$__tags` can be used in queries to use defined tags. When writing a query directly from the web UI, [as for instance shown in this blog post](https://grafana.com/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/), using `$__tags` is correct. But in YAML files, `$$__tags` must be used to specify a literal `$`, [as also stated in the Provision Grafana page](https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables). However, some documentation pages seem to report wrong examples. This PR fixes them.

More information can be found [in the discussion of this issue](https://github.com/grafana/grafana/issues/64871).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
