### PR TITLE
Fix: Hide Forward OAuth Identity toggle when azure auth is enabled

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -148,6 +148,12 @@ export const DataSourceHttpSettings = (props: HttpSettingsProps) => {
   const azureAuthEnabled: boolean =
     (azureAuthSettings?.azureAuthSupported && azureAuthSettings.getAzureAuthEnabled(dataSourceConfig)) || false;
 
+  // Azure Authentication doesn't work correctly when Forward OAuth Identity is enabled.
+  // The Authorization header that has been set by the ApplyAzureAuth middleware gets overwritten
+  // with the Authorization header set by the OAuthTokenMiddleware.
+  dataSourceConfig.jsonData.oauthPassThru = azureAuthEnabled ? false : dataSourceConfig.jsonData.oauthPassThru;
+  const shouldShowForwardOAuthIdentityOption = azureAuthEnabled ? false : showForwardOAuthIdentityOption;
+
   return (
     <div className="gf-form-group">
       <>
@@ -295,7 +301,7 @@ export const DataSourceHttpSettings = (props: HttpSettingsProps) => {
             <HttpProxySettings
               dataSourceConfig={dataSourceConfig}
               onChange={(jsonData) => onSettingsChange({ jsonData })}
-              showForwardOAuthIdentityOption={showForwardOAuthIdentityOption}
+              showForwardOAuthIdentityOption={shouldShowForwardOAuthIdentityOption}
             />
           )}
         </div>


### PR DESCRIPTION
**What is this feature?**

Azure Authentication doesn't work correctly when Forward OAuth Identity is enabled.

More info: The Authorization header that has been set by the ApplyAzureAuth middleware gets overwritten with the Authorization header set by the OAuthTokenMiddleware here: https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go#L53

**Why do we need this feature?**

To prevent authentication problems when the azure auth is enabled.

**Who is this feature for?**

Users who have azure auth

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/66832

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
