### PR TITLE
[v9.2.x] CI: Fix broken env vars in publish-artifacts step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3833,7 +3833,7 @@ steps:
   image: golang:1.20.4
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -3902,7 +3902,7 @@ steps:
   image: golang:1.20.4
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -6743,6 +6743,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: d858ad5bd274da1242076f3d09ab4feecb65620a1dca3002218df82e9333a7ba
+hmac: d378b461caa69e474809fe079af913c95249553dddc52b39ddd29a27a3af0262
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -557,7 +557,7 @@ def publish_artifacts_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            "./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}",
+            "./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}",
         ],
         "depends_on": ["compile-build-cmd"],
     }


### PR DESCRIPTION
Backport fd90737884093c75d98cc0257b47437b7e4ca716 from #71471

---

(cherry picked from commit 64d2ff03c80c807c03390f63ba1834c5605fc96d)

**What is this feature?**

Fixes the step, since it failed in both `10.0.2` and `9.5.6`