### PR TITLE
[v9.4.x] CI: Fix broken env vars in publish-artifacts step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3802,7 +3802,7 @@ steps:
   image: golang:1.20.4
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -3871,7 +3871,7 @@ steps:
   image: golang:1.20.4
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -6778,6 +6778,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 01a94154697ac7510d31d5736151456ba68a2275e31c392ecc237baa6862bf53
+hmac: 1a98cd9e5f6971a50cc1fb18c0b637c50f7e5a6ebda9664b63658e356b21a312
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -557,7 +557,7 @@ def publish_artifacts_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            "./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}",
+            "./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}",
         ],
         "depends_on": ["compile-build-cmd"],
     }


### PR DESCRIPTION
Backport fd90737884093c75d98cc0257b47437b7e4ca716 from #71471

---

(cherry picked from commit 64d2ff03c80c807c03390f63ba1834c5605fc96d)

**What is this feature?**

Fixes the step, since it failed in both `10.0.2` and `9.5.6`