### PR TITLE
[v9.5.x] CI: Fix broken env vars in publish-artifacts step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3909,7 +3909,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -3978,7 +3978,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -6885,6 +6885,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 35192e2a51d31c9468629bcd4d72e2bc0840dcc81d770e24bc9dd57fb24ec00f
+hmac: 37c2d1623b9816fac3e31dc9c03125c90c421702730ea00652459e6be03a2c8a
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -558,7 +558,7 @@ def publish_artifacts_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            "./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}",
+            "./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}",
         ],
         "depends_on": ["compile-build-cmd"],
     }


### PR DESCRIPTION
Backport fd90737884093c75d98cc0257b47437b7e4ca716 from #71471

---

(cherry picked from commit 64d2ff03c80c807c03390f63ba1834c5605fc96d)

**What is this feature?**

Fixes the step, since it failed in both `10.0.2` and `9.5.6`