### PR TITLE
[v10.0.x] CI: Fix broken env vars in publish-artifacts step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3980,7 +3980,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4049,7 +4049,7 @@ steps:
   image: golang:1.20.6
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -7016,6 +7016,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 7cd3d4407d9f8995606ccf0bdca8be8dc4c0a99ae61bacc86c129fd30180738e
+hmac: e156880e265205c24cc0e202bd10be0962631fe25344e7c64c2750d5c24c1a3b
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -561,7 +561,7 @@ def publish_artifacts_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            "./bin/build artifacts packages --tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}",
+            "./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}",
         ],
         "depends_on": ["compile-build-cmd"],
     }


### PR DESCRIPTION
Backport fd90737884093c75d98cc0257b47437b7e4ca716 from #71471

---

(cherry picked from commit 64d2ff03c80c807c03390f63ba1834c5605fc96d)

**What is this feature?**

Fixes the step, since it failed in both `10.0.2` and `9.5.6`