### PR TITLE
Docs: Add reference to Grafana Cloud doc

### DIFF
--- a/docs/sources/introduction/grafana-cloud.md
+++ b/docs/sources/introduction/grafana-cloud.md
@@ -7,3 +7,5 @@ weight: 300
 # Grafana Cloud
 
 Grafana Cloud is a highly available, fast, fully-managed OpenSaaS logging and metrics platform. It is everything you love about Grafana, hosted by Grafana Labs.
+
+Visit the [Grafana Cloud documentation](/docs/grafana-cloud) for more information.


### PR DESCRIPTION
This PR proposes to add a more visible link to the Grafana Cloud documentation for [this page](https://grafana.com/docs/grafana/latest/introduction/grafana-cloud/), namely to have:
<img width="805" src="https://github.com/grafana/grafana/assets/135109076/211c4a0e-d11d-4146-b724-779549a9357e">

Note that the same link is also available in the "Related documentation" section:
<img width="836" src="https://github.com/grafana/grafana/assets/135109076/bccb106c-ac5b-45ea-8534-f618ddb45cf8">
But IMO it is harder to notice, so I'd still add a more visible link.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
