### PR TITLE
TestData: CSV Metric Values - fix NoData

### DIFF
--- a/pkg/tsdb/testdatasource/scenarios.go
+++ b/pkg/tsdb/testdatasource/scenarios.go
@@ -374,6 +374,13 @@ func (s *Service) handleCSVMetricValuesScenario(ctx context.Context, req *backen
 		}
 
 		stringInput := model.StringInput
+		if strings.TrimSpace(stringInput) == "" {
+			qr := resp.Responses[q.RefID]
+			qr.Frames = data.Frames{
+				data.NewFrame("").SetMeta(&data.FrameMeta{ExecutedQueryString: stringInput}),
+			}
+			return resp, nil
+		}
 		valueField, err := csvLineToField(stringInput)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
return a valid NoData response when the input is empty in the test datasource.

Would be good to audit the datasource for stuff like this, just a one off.
