### PR TITLE
Tracing: Reduce the max packet size for Jaeger exporter

### DIFF
--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -268,7 +268,7 @@ func (ots *Opentelemetry) initJaegerTracerProvider() (*tracesdk.TracerProvider, 
 	var ep jaeger.EndpointOption
 	// Create the Jaeger exporter: address can be either agent address (host:port) or collector URL
 	if host, port, err := net.SplitHostPort(ots.Address); err == nil {
-		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port))
+		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port), jaeger.WithMaxPacketSize(64000))
 	} else {
 		ep = jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(ots.Address))
 	}


### PR DESCRIPTION



**What is this feature?**

This PR should fix the off-by-one error that seems to be happening in the underlying Jaeger reporter

The proposed change reduces the max packet size to 64000.


**Why do we need this feature?**

A lot of Grafana instances running in Grafana Cloud are seeing messages like the following from the opentelemetry handler:

```
err="data does not fit within one UDP packet; size 65001, max 65000, spans 139"
```

which means we are losing spans for these instances.

**Who is this feature for?**

Operators who would like to receive all of their spans in their tracing store!


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>