### PR TITLE
Loki: Fix duplicated rendering of resolution

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -94,10 +94,11 @@ describe('LokiQueryBuilderOptions', () => {
   });
 
   it('shows correct options for metric query', async () => {
-    setup({ expr: 'rate({foo="bar"}[5m]', step: '1m' });
+    setup({ expr: 'rate({foo="bar"}[5m]', step: '1m', resolution: 2 });
     expect(screen.queryByText('Line limit: 20')).not.toBeInTheDocument();
     expect(screen.getByText('Type: Range')).toBeInTheDocument();
     expect(screen.getByText('Step: 1m')).toBeInTheDocument();
+    expect(screen.getByText('Resolution: 1/2')).toBeInTheDocument();
   });
 
   it('does not shows resolution field if resolution is not set', async () => {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -186,10 +186,6 @@ function getCollapsedInfo(
     items.push(`Legend: ${query.legendFormat}`);
   }
 
-  if (query.resolution) {
-    items.push(`Resolution: ${resolutionLabel?.label}`);
-  }
-
   items.push(`Type: ${queryTypeLabel?.label}`);
 
   if (isLogQuery) {


### PR DESCRIPTION
We render resolution if query is a metric query, but this "extra" one was accidentally left behind. 

<img width="736" alt="image" src="https://github.com/grafana/grafana/assets/30407135/3b68feee-18c2-4eef-bc46-63ef98413edf">

I have added test to check that Resolution is correctly rendered once. 

Fixes: https://github.com/grafana/grafana/issues/71105

We have deprecated `Resolution` and don't show it again if you don't have it already selected. So the easiest way how to manually test this is by manually editing url and adding `"resolution":2` to it - e.g. 
 `http://localhost:3000/explore?panes={"22q":{"datasource":"PDDA8E780A17E7EF1","queries":[{"refId":"A","resolution":2,"expr":"rate({compose_project=\"docker-compose\"}[5m])","queryType":"range","datasource":{"type":"loki","uid":"PDDA8E780A17E7EF1"},"editorMode":"code"}],"range":{"from":"now-6h","to":"now"}}}&schemaVersion=1&orgId=1` - see where `"resolution":2` is. And checking if it is rendered once in the query options preview. The query need to be metric.

<img width="425" alt="image" src="https://github.com/grafana/grafana/assets/30407135/4eaf4b8c-87be-4f15-bc86-2c58890aa8de">

The change is not released yet and therefore fix doesn't need to be backported.  