### PR TITLE
Remove alert for feature transformationsRedesign

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -348,7 +348,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
 
     return (
       <>
-        {noTransforms && (
+        {noTransforms && !config.featureToggles.transformationsRedesign && (
           <Container grow={1}>
             <LocalStorageValueProvider<boolean> storageKey={LOCAL_STORAGE_KEY} defaultValue={false}>
               {(isDismissed, onDismiss) => {


### PR DESCRIPTION
When the feature transformationsRedesign is ON, we want to disable the alert when there is no transformation, as we provide a link in the feature.

Before:
![Screenshot 2023-07-14 194223](https://github.com/grafana/grafana/assets/9373203/9678f3ee-282e-462a-b881-62903c0f8ef9)


After:
![Screenshot 2023-07-14 194200](https://github.com/grafana/grafana/assets/9373203/a92cc8bd-70e1-4902-b295-454b0b86375b)

