### PR TITLE
SSE: optimize WideToMany

### DIFF
--- a/pkg/expr/mathexp/types_test.go
+++ b/pkg/expr/mathexp/types_test.go
@@ -66,7 +66,7 @@ func TestSeriesSort(t *testing.T) {
 	}
 }
 
-func TestSeriesFromFrame(t *testing.T) {
+func TestSeriesFromFrameFields(t *testing.T) {
 	var tests = []struct {
 		name   string
 		frame  *data.Frame
@@ -75,7 +75,7 @@ func TestSeriesFromFrame(t *testing.T) {
 		Series Series
 	}{
 		{
-			name: "[]time, []float frame should convert",
+			name: "[]float, []time frame should convert",
 			frame: &data.Frame{
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{}),
@@ -94,30 +94,11 @@ func TestSeriesFromFrame(t *testing.T) {
 			},
 		},
 		{
-			name: "[]time, []*float frame should convert",
-			frame: &data.Frame{
-				Fields: []*data.Field{
-					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
-					data.NewField("value", nil, []*float64{float64Pointer(5)}),
-				},
-			},
-			errIs: assert.NoError,
-			Is:    assert.Equal,
-			Series: Series{
-				Frame: &data.Frame{
-					Fields: []*data.Field{
-						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
-						data.NewField("value", nil, []*float64{float64Pointer(5)}),
-					},
-				},
-			},
-		},
-		{
 			name: "[]*float, []time frame should convert",
 			frame: &data.Frame{
 				Fields: []*data.Field{
-					data.NewField("value", nil, []*float64{float64Pointer(5)}),
 					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
+					data.NewField("value", nil, []*float64{float64Pointer(5)}),
 				},
 			},
 			errIs: assert.NoError,
@@ -249,11 +230,20 @@ func TestSeriesFromFrame(t *testing.T) {
 			name: "[]*time, []*time frame should error",
 			frame: &data.Frame{
 				Fields: []*data.Field{
-					data.NewField("time", nil, []*time.Time{}),
-					data.NewField("time", nil, []*time.Time{}),
+					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
+					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 				},
 			},
-			errIs: assert.Error,
+			errIs: assert.NoError,
+			Is:    assert.Equal,
+			Series: Series{
+				Frame: &data.Frame{
+					Fields: []*data.Field{
+						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
+						data.NewField("time", nil, []*float64{float64Pointer(5000)}),
+					},
+				},
+			},
 		},
 		{
 			name: "[]*float64, []float64 frame should error",
@@ -277,7 +267,7 @@ func TestSeriesFromFrame(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, err := SeriesFromFrame(tt.frame)
+			s, err := SeriesFromFrameFields(tt.frame, 0, 1)
 			tt.errIs(t, err)
 			if err == nil {
 				tt.Is(t, s, tt.Series)
@@ -317,7 +307,7 @@ func TestSeriesName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, err := SeriesFromFrame(test.frame)
+			s, err := SeriesFromFrameFields(test.frame, 0, 1)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedSeriesName, s.GetName())
 		})

--- a/pkg/expr/mathexp/types_test.go
+++ b/pkg/expr/mathexp/types_test.go
@@ -67,6 +67,11 @@ func TestSeriesSort(t *testing.T) {
 }
 
 func TestSeriesFromFrameFields(t *testing.T) {
+	meta := &data.FrameMeta{
+		Type:        data.FrameTypeTimeSeriesMulti,
+		TypeVersion: data.FrameTypeVersion{0, 1},
+	}
+
 	var tests = []struct {
 		name   string
 		frame  *data.Frame
@@ -86,6 +91,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{}),
 						data.NewField("value", nil, []*float64{}),
@@ -96,6 +102,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 		{
 			name: "[]*float, []time frame should convert",
 			frame: &data.Frame{
+				Meta: meta,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 					data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -105,6 +112,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -115,6 +123,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 		{
 			name: "[]*int, []*time frame should convert",
 			frame: &data.Frame{
+				Meta: meta,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []*int64{int64Pointer(5)}),
@@ -124,6 +133,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -143,6 +153,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -162,6 +173,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -181,6 +193,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -191,6 +204,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 		{
 			name: "[]bool, []*time frame should convert",
 			frame: &data.Frame{
+				Meta: meta,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []bool{true}),
@@ -200,6 +214,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(1)}),
@@ -210,6 +225,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 		{
 			name: "[]*bool, []*time frame should convert",
 			frame: &data.Frame{
+				Meta: meta,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []*bool{boolPointer(true)}),
@@ -219,6 +235,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(1)}),
@@ -238,6 +255,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
+					Meta: meta,
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("time", nil, []*float64{float64Pointer(5000)}),
@@ -270,7 +288,7 @@ func TestSeriesFromFrameFields(t *testing.T) {
 			s, err := SeriesFromFrameFields(tt.frame, 0, 1)
 			tt.errIs(t, err)
 			if err == nil {
-				tt.Is(t, s, tt.Series)
+				tt.Is(t, tt.Series, s)
 			}
 		})
 	}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -514,34 +514,9 @@ func WideToMany(frame *data.Frame, fixSeries func(series mathexp.Series, valueFi
 		return nil, fmt.Errorf("input data must be a wide series but got type %s", tsSchema.Type)
 	}
 
-	if len(tsSchema.ValueIndices) == 1 {
-		s, err := mathexp.SeriesFromFrame(frame)
-		if err != nil {
-			return nil, err
-		}
-		if fixSeries != nil {
-			fixSeries(s, frame.Fields[tsSchema.ValueIndices[0]])
-		}
-		return []mathexp.Series{s}, nil
-	}
-
 	series := make([]mathexp.Series, 0, len(tsSchema.ValueIndices))
 	for _, valIdx := range tsSchema.ValueIndices {
-		l := frame.Rows()
-		f := data.NewFrameOfFieldTypes(frame.Name, l, frame.Fields[tsSchema.TimeIndex].Type(), frame.Fields[valIdx].Type())
-		f.Fields[0].Name = frame.Fields[tsSchema.TimeIndex].Name
-		f.Fields[1].Name = frame.Fields[valIdx].Name
-
-		// The new value fields' configs gets pointed to the one in the original frame
-		f.Fields[1].Config = frame.Fields[valIdx].Config
-
-		if frame.Fields[valIdx].Labels != nil {
-			f.Fields[1].Labels = frame.Fields[valIdx].Labels.Copy()
-		}
-		for i := 0; i < l; i++ {
-			f.SetRow(i, frame.Fields[tsSchema.TimeIndex].CopyAt(i), frame.Fields[valIdx].CopyAt(i))
-		}
-		s, err := mathexp.SeriesFromFrame(f)
+		s, err := mathexp.SeriesFromFrameFields(frame, tsSchema.TimeIndex, valIdx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/expr/nodes_bench_test.go
+++ b/pkg/expr/nodes_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkWideToMany(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := WideToMany(f)
+			_, err := WideToMany(f, nil)
 			if err != nil {
 				panic(err)
 			}
@@ -65,7 +65,7 @@ func BenchmarkWideToMany(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			_, err := WideToMany(f)
+			_, err := WideToMany(f, nil)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/expr/nodes_bench_test.go
+++ b/pkg/expr/nodes_bench_test.go
@@ -1,0 +1,74 @@
+package expr
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+func BenchmarkWideToMany(b *testing.B) {
+	b.Run("time and *float64", func(b *testing.B) {
+		f := data.NewFrame("",
+			data.NewField("Time", nil, []time.Time{}))
+		for i := 0; i < 10; i++ {
+			lbls := make(data.Labels, 5)
+			for j := 0; j < 5; j++ {
+				lbls[fmt.Sprintf("lbl%d", j)] = fmt.Sprintf("value%d", i)
+			}
+			f.Fields = append(f.Fields, data.NewField(fmt.Sprintf("val-%d", i), lbls, []*float64{}))
+		}
+		for i := 0; i < 100; i++ {
+			row := make([]interface{}, 0, len(f.Fields))
+			row = append(row, time.Now().Add(-time.Duration(i)))
+			for j := 1; j < cap(row); j++ {
+				v := rand.Float64()
+				row = append(row, &v)
+			}
+			f.AppendRow(row...)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := WideToMany(f)
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+
+	b.Run("*time and int64", func(b *testing.B) { // worst case
+		f := data.NewFrame("",
+			data.NewField("Time", nil, []*time.Time{}))
+		for i := 0; i < 10; i++ {
+			lbls := make(data.Labels, 5)
+			for j := 0; j < 5; j++ {
+				lbls[fmt.Sprintf("lbl%d", j)] = fmt.Sprintf("value%d", i)
+			}
+			f.Fields = append(f.Fields, data.NewField(fmt.Sprintf("val-%d", i), lbls, []int64{}))
+		}
+		for i := 0; i < 100; i++ {
+			row := make([]interface{}, 0, len(f.Fields))
+			now := time.Now().Add(-time.Duration(i))
+			row = append(row, &now)
+			for j := 1; j < cap(row); j++ {
+				row = append(row, rand.Int63())
+			}
+			f.AppendRow(row...)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := WideToMany(f)
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -294,7 +294,7 @@ func TestWideToMany(t *testing.T) {
 		f.AppendRow(row...)
 	}
 
-	ser, err := WideToMany(f)
+	ser, err := WideToMany(f, nil)
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -271,4 +272,43 @@ func TestConvertDataFramesToResults(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestWideToMany(t *testing.T) {
+	f := data.NewFrame("Test",
+		data.NewField("Time", nil, []time.Time{}))
+	for i := 0; i < 10; i++ {
+		lbls := make(data.Labels, 5)
+		for j := 0; j < 5; j++ {
+			lbls[fmt.Sprintf("lbl%d", j)] = fmt.Sprintf("value%d", i)
+		}
+		f.Fields = append(f.Fields, data.NewField(fmt.Sprintf("val-%d", i), lbls, []*float64{}))
+	}
+	for i := 0; i < 100; i++ {
+		row := make([]interface{}, 0, len(f.Fields))
+		row = append(row, time.Now().Add(-time.Duration(i)))
+		for j := 1; j < cap(row); j++ {
+			v := rand.Float64()
+			row = append(row, &v)
+		}
+		f.AppendRow(row...)
+	}
+
+	ser, err := WideToMany(f)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	require.Len(t, ser, 10)
+
+	timeField := f.Fields[0]
+	for idx, series := range ser {
+		field := f.Fields[idx+1]
+		require.Equal(t, field.Len(), series.Len())
+		require.EqualValues(t, field.Labels, series.GetLabels())
+		for i := 0; i < field.Len(); i++ {
+			actualTime, actualValue := series.GetPoint(i)
+			require.EqualValues(t, timeField.At(i), actualTime)
+			require.EqualValues(t, field.At(i), actualValue)
+		}
+	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR refactors function `expr.WideToMany` that converts a frame to a collection of mathexp.Series (in general case).
It optimizes the function to not create a frame for each dimension and then call mathexp.SeriesFromFrame that mutates the frame if it does not have the correct schema (e.g. *float64 value field).
The PR replaces the function mathexp.SeriesFromFrame to a new function `mathexp.SeriesFromFrameFields` that accepts frame and indices of time and value fields. The function becomes idempotent.
Performance improvement was due to the fact that the function SeriesFromFrameFields does not create a copy of all fields in the series. Instead, it creates a new frame that has fields that point to the original frame, with one exception: if fields need to be converted to Time ( from NullableTime) and\or to NullableFloat64 (from any other). In this case, a new field is created and all values, config and labels are copied from the original field

**Why do we need this feature?**

It simplifies implementation of WideToMany and increases its performance 

before changes:
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/expr
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkWideToMany
BenchmarkWideToMany/time_and_*float64
BenchmarkWideToMany/time_and_*float64-16                   15796             76782 ns/op           73936 B/op       2117 allocs/op
BenchmarkWideToMany/*time_and_int64
BenchmarkWideToMany/*time_and_int64-16                      9488            130480 ns/op          136417 B/op       4197 allocs/op
```

after changes:
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/expr
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkWideToMany
BenchmarkWideToMany/time_and_*float64
BenchmarkWideToMany/time_and_*float64-16                   37693             32045 ns/op           25456 B/op        107 allocs/op
BenchmarkWideToMany/*time_and_int64
BenchmarkWideToMany/*time_and_int64-16                     19030             63392 ns/op           96176 B/op       2157 allocs/op
PASS
```

**Who is this feature for?**

Developers and users with big queries.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
