### PR TITLE
[v9.2.x] Chore: Add auto-milestone workflow for pull-requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -569,6 +569,7 @@ embed.go @grafana/grafana-as-code
 /.github/pr-commands.json @marefr
 /.github/renovate.json5 @grafana/frontend-ops
 /.github/teams.yml @armandgrillet
+/.github/workflows/auto-milestone.yml @grafana/grafana-delivery
 /.github/workflows/backport.yml @grafana/grafana-delivery
 /.github/workflows/bump-version.yml @grafana/grafana-delivery
 /.github/workflows/close-milestone.yml @grafana/grafana-delivery

--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -1,12 +1,5 @@
 [
   {
-    "type": "check-milestone",
-    "title": "Milestone Check",
-    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
-    "success": "Milestone set",
-    "failure": "Milestone not set"
-  },
-  {
     "type": "check-label",
     "title": "Backport Check",
     "labels": {

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,22 @@
+name: Auto-milestone
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - name: Run auto-milestone
+        uses: grafana/grafana-github-actions-go/auto-milestone@main
+        with:
+          pr: ${{ github.event.pull_request.number }}
+          token: ${{ steps.generate_token.outputs.token }}

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -13,7 +13,6 @@ The following checklist/summary should give you a quick overview of what to ask/
 - Reviewed and approved?
 - All checks passed?
 - Proper pull request title?
-- Milestone assigned?
 - Add to changelog/release notes?
 - Needs backporting?
 
@@ -40,9 +39,17 @@ See [formatting guidelines](create-pull-request.md#formatting-guidelines) for mo
 
 ### Assign a milestone
 
-A milestone **should** be added to every pull request. Several things in the Grafana release process requires at least pull requests to be in a milestone, for example [generating changelog/release notes](#include-in-changelog-and-release-notes).
+Several things in the Grafana release process requires at least pull requests to be in a milestone, for example [generating changelog/release notes](#include-in-changelog-and-release-notes).
 
 This makes it easier to track what changes go into a certain release. Without this information, release managers have to go through git commits which is not an efficient process.
+
+That being said, _you don't have to assign a milestone manually_ to a pull request.
+Instead, when it is merged & closed then a bot will look for the most appropriate miletone and assign it to the pull request.
+
+That milestone should always reflect the branch that the pull request is merged into.
+For every major and minor release there is a milestone ending with `.x` (e.g. `10.0.x` for the 10.0.x releases).
+Pull requests targetting `main` should use the `.x` milestone of the next minor (or major) version (you can find that version number inside the `package.json` file).
+Backport pull requestss should use the version of the target branch (e.g. `9.4.x` for the `v9.4.x` branch).
 
 ### Include in changelog and release notes?
 
@@ -78,15 +85,15 @@ The changelog/release notes are divided into sections and here's a description o
 
 **Features and enhancements:**
 
-Milestone assigned and labeled with `add to changelog` and any of the other section rules don't apply.
+Labeled with `add to changelog` and any of the other section rules don't apply.
 
 **Bug fixes:**
 
-Milestone assigned and labeled with `add to changelog` and either labeled with `type/bug` or the pull request title contains `fix` or `fixes`.
+Labeled with `add to changelog` and either labeled with `type/bug` or the pull request title contains `fix` or `fixes`.
 
 **Plugin development fixes & changes:**
 
-Milestone assigned and labeled with `area/grafana/toolkit`, `area/grafana/ui` or `area/grafana/runtime`.
+Labeled with `area/grafana/toolkit`, `area/grafana/ui` or `area/grafana/runtime`.
 
 **Deprecations:**
 


### PR DESCRIPTION
Backport 8ae92db53dda5b6236bcf50c7c7e39259a54c0ed from #71177

---

This adds a new auto-milestone workflow that will set the milestone for a PR when it is closed. This way, contributors no longer have to think about milestone at all.

With this the first two parts of "2023/06 DesignDoc: Milestone automation (External)" are implemented. What's missing is the check that only @grafana/grafana-delivery should be able to set the milestone of a PR but I think that's mostly optional.

Note: This PR depends on https://github.com/grafana/grafana-github-actions-go/pull/50

Part of https://github.com/grafana/grafana-delivery/issues/177
