### PR TITLE
Docs: fixes broken alias redirect

### DIFF
--- a/docs/sources/alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/alerting-rules/_index.md
@@ -4,6 +4,7 @@ aliases:
   - old-alerting/create-alerts/
   - rules/
   - unified-alerting/alerting-rules/
+  - ./create-alerts/
 description: Configure alerting
 title: Configure Alerting
 weight: 130


### PR DESCRIPTION
fixes broken alias

new: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/
old: https://grafana.com/docs/grafana/latest/alerting/create-alerts/