### PR TITLE
Plugins: Only configure plugin proxy transport once

### DIFF
--- a/pkg/api/plugin_proxy.go
+++ b/pkg/api/plugin_proxy.go
@@ -14,9 +14,12 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+var (
+	once                 sync.Once
+	pluginProxyTransport *http.Transport
+)
+
 func (hs *HTTPServer) ProxyPluginRequest(c *contextmodel.ReqContext) {
-	var once sync.Once
-	var pluginProxyTransport *http.Transport
 	once.Do(func() {
 		pluginProxyTransport = &http.Transport{
 			TLSClientConfig: &tls.Config{


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where plugin proxy transport is re-created for each request.

**Why do we need this feature?**

Connections are not re-used.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
