### PR TITLE
Auth: Surface organization membership error

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -427,10 +427,26 @@ func getLoginExternalError(err error) string {
 		return createTokenErr.ExternalErr
 	}
 
+	// unwrap until we get to the error message
 	gfErr := &errutil.Error{}
 	if errors.As(err, gfErr) {
-		return gfErr.Public().Message
+		return getFirstPublicErrorMessage(gfErr)
 	}
 
 	return err.Error()
+}
+
+// Get the first public error message from an error chain.
+func getFirstPublicErrorMessage(err *errutil.Error) string {
+	errPublic := err.Public()
+	if err.PublicMessage != "" {
+		return errPublic.Message
+	}
+
+	underlyingErr := &errutil.Error{}
+	if err.Underlying != nil && errors.As(err.Underlying, underlyingErr) {
+		return getFirstPublicErrorMessage(underlyingErr)
+	}
+
+	return errPublic.Message
 }

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/models/roletype"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 type SocialGithub struct {
@@ -32,8 +33,14 @@ type GithubTeam struct {
 }
 
 var (
-	ErrMissingTeamMembership         = Error{"user not a member of one of the required teams"}
-	ErrMissingOrganizationMembership = Error{"user not a member of one of the required organizations"}
+	ErrMissingTeamMembership = errutil.NewBase(errutil.StatusUnauthorized,
+		"auth.missing_team",
+		errutil.WithPublicMessage(
+			"User is not a member of one of the required teams. Please contact identity provider administrator."))
+	ErrMissingOrganizationMembership = errutil.NewBase(errutil.StatusUnauthorized,
+		"auth.missing_organization",
+		errutil.WithPublicMessage(
+			"User is not a member of one of the required organizations. Please contact identity provider administrator."))
 )
 
 func (s *SocialGithub) IsTeamMember(ctx context.Context, client *http.Client) bool {
@@ -244,11 +251,13 @@ func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token 
 	organizationsUrl := fmt.Sprintf(s.apiUrl + "/orgs?per_page=100")
 
 	if !s.IsTeamMember(ctx, client) {
-		return nil, ErrMissingTeamMembership
+		return nil, ErrMissingTeamMembership.Errorf("User is not a member of any of the allowed teams: %v", s.teamIds)
 	}
 
 	if !s.IsOrganizationMember(ctx, client, organizationsUrl) {
-		return nil, ErrMissingOrganizationMembership
+		return nil, ErrMissingOrganizationMembership.Errorf(
+			"User is not a member of any of the allowed organizations: %v",
+			s.allowedOrganizations)
 	}
 
 	if userInfo.Email == "" {

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -79,7 +79,9 @@ func (s *SocialGrafanaCom) UserInfo(ctx context.Context, client *http.Client, _ 
 	}
 
 	if !s.IsOrganizationMember(data.Orgs) {
-		return nil, ErrMissingOrganizationMembership
+		return nil, ErrMissingOrganizationMembership.Errorf(
+			"User is not a member of any of the allowed organizations: %v. Returned Organizations: %v",
+			s.allowedOrganizations, data.Orgs)
 	}
 
 	return userInfo, nil


### PR DESCRIPTION
**What is this feature?**

- Use first found Public Message in a chain of errors
- Display Organization membership error instead of Internal server error.

Before: 
![image](https://github.com/grafana/grafana/assets/8071073/4fc58adf-f2bf-4e76-8042-57971892ca22)

After

![image](https://github.com/grafana/grafana/assets/8071073/df391955-1a3e-40a9-aa60-fa73b28f9aa6)


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
