### PR TITLE
logs: added test for parsing a dataplane-logs-frame

### DIFF
--- a/public/app/features/logs/logsModel_parse.test.ts
+++ b/public/app/features/logs/logsModel_parse.test.ts
@@ -1,4 +1,4 @@
-import { DataFrame, FieldType, dateTimeFormatISO, DateTimeInput, DateTimeOptions } from '@grafana/data';
+import { DataFrame, FieldType, dateTimeFormatISO, DateTimeInput, DateTimeOptions, DataFrameType } from '@grafana/data';
 
 import { logSeriesToLogsModel } from './logsModel';
 
@@ -11,6 +11,154 @@ jest.mock('@grafana/data', () => ({
 }));
 
 describe('logSeriesToLogsModel should parse different logs-dataframe formats', () => {
+  it('should parse a dataplane-formatted logs-frame)', () => {
+    const frames: DataFrame[] = [
+      {
+        refId: 'A',
+        fields: [
+          {
+            name: 'severity',
+            type: FieldType.string,
+            config: {},
+            values: ['info', 'debug', 'error'],
+          },
+          {
+            name: 'attributes',
+            type: FieldType.other,
+            config: {},
+            values: [
+              {
+                counter: '38141',
+                label: 'val2',
+              },
+              {
+                counter: '38143',
+                label: 'val2',
+              },
+              {
+                counter: '38142',
+                label: 'val3',
+              },
+            ],
+          },
+          {
+            name: 'timestamp',
+            type: FieldType.time,
+            config: {},
+            values: [1686142519756, 1686142520411, 1686142519997],
+            nanos: [641000, 0, 0],
+          },
+          {
+            name: 'id',
+            type: FieldType.string,
+            config: {},
+            values: ['id1', 'id2', 'id3'],
+          },
+          {
+            name: 'body',
+            type: FieldType.string,
+            config: {},
+            values: ['line1', 'line2', 'line3'],
+          },
+        ],
+        length: 3,
+        meta: {
+          type: DataFrameType.LogLines,
+        },
+      },
+    ];
+
+    const expected = {
+      hasUniqueLabels: true,
+      meta: [],
+      rows: [
+        {
+          dataFrame: frames[0],
+          rowId: 'id1',
+          datasourceType: undefined,
+          entry: 'line1',
+          entryFieldIndex: 4,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38141',
+            label: 'val2',
+          },
+          logLevel: 'info',
+          raw: 'line1',
+          rowIndex: 0,
+          searchWords: [],
+          timeEpochMs: 1686142519756,
+          timeEpochNs: '1686142519756641000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_id1',
+          uniqueLabels: {
+            counter: '38141',
+            label: 'val2',
+          },
+        },
+        {
+          dataFrame: frames[0],
+          rowId: 'id2',
+          datasourceType: undefined,
+          entry: 'line2',
+          entryFieldIndex: 4,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38143',
+            label: 'val2',
+          },
+          logLevel: 'debug',
+          raw: 'line2',
+          rowIndex: 1,
+          searchWords: [],
+          timeEpochMs: 1686142520411,
+          timeEpochNs: '1686142520411000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:20-06:00',
+          timeLocal: '2023-06-07 06:55:20',
+          timeUtc: '2023-06-07 12:55:20',
+          uid: 'A_id2',
+          uniqueLabels: {
+            counter: '38143',
+            label: 'val2',
+          },
+        },
+        {
+          dataFrame: frames[0],
+          rowId: 'id3',
+          datasourceType: undefined,
+          entry: 'line3',
+          entryFieldIndex: 4,
+          hasAnsi: false,
+          hasUnescapedContent: false,
+          labels: {
+            counter: '38142',
+            label: 'val3',
+          },
+          logLevel: 'error',
+          raw: 'line3',
+          rowIndex: 2,
+          searchWords: [],
+          timeEpochMs: 1686142519997,
+          timeEpochNs: '1686142519997000000',
+          timeFromNow: 'mock:dateTimeFormatTimeAgo:2023-06-07T06:55:19-06:00',
+          timeLocal: '2023-06-07 06:55:19',
+          timeUtc: '2023-06-07 12:55:19',
+          uid: 'A_id3',
+          uniqueLabels: {
+            counter: '38142',
+            label: 'val3',
+          },
+        },
+      ],
+    };
+
+    expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
+  });
+
   it('should parse old Loki-style (grafana8.x) frames ( multi-frame )', () => {
     const frames: DataFrame[] = [
       {


### PR DESCRIPTION
added a new test for parsing a dataplane-compliant logs dataframe.
no other changes.