### PR TITLE
[v9.5.x] Alerting: No longer silence paused alerts during legacy migration

### DIFF
--- a/docs/sources/alerting/migrating-alerts/migrating-legacy-alerts.md
+++ b/docs/sources/alerting/migrating-alerts/migrating-legacy-alerts.md
@@ -41,4 +41,3 @@ longer supported. We refer to these as [Differences]({{< relref "#differences" >
 ## Limitations
 
 1. Since `Hipchat` and `Sensu` notification channels are no longer supported, legacy alerts associated with these channels are not automatically migrated to Grafana Alerting. Assign the legacy alerts to a supported notification channel so that you continue to receive notifications for those alerts.
-   Silences (expiring after one year) are created for all paused dashboard alerts.

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -152,10 +152,6 @@ func (m *migration) makeAlertRule(l log.Logger, cond condition, da dashAlert, fo
 	n, v := getLabelForSilenceMatching(ar.UID)
 	ar.Labels[n] = v
 
-	if err := m.addSilence(da, ar); err != nil {
-		m.mg.Logger.Error("alert migration error: failed to create silence", "rule_name", ar.Title, "err", err)
-	}
-
 	if err := m.addErrorSilence(da, ar); err != nil {
 		m.mg.Logger.Error("alert migration error: failed to create silence for Error", "rule_name", ar.Title, "err", err)
 	}


### PR DESCRIPTION
Backport 8c6cdf51fce181f35c22707c0ee962b91238b8c0 from #71596

Manual backport reason:

The docs for migrating from legacy alerting has changed position since v9.5.x. Just made the change in the correct file.

---

Now that we have [alert pausing in UA](https://github.com/grafana/grafana/pull/60734) and [paused legacy alerts are migrated](https://github.com/grafana/grafana/pull/62798) to paused UA alert rules, we no longer need to silence them during migration.

[Docs](https://grafana.com/docs/grafana/v10.0/alerting/set-up/migrating-alerts/) updated to remove text: `Silences (expiring after one year) are created for all paused dashboard alerts.`

Fixes #71595

**Special notes for your reviewer:**

Backporting is technically optional here, but backporting simple legacy migration changes as far back as possible is best to improve migration experience without requiring instance upgrades.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
