### PR TITLE
ci: split ephemeral instances action and run only the grafana build workflow in a larger runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -633,7 +633,8 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/publish-kinds-release.yml @grafana/grafana-as-code
 /.github/workflows/verify-kinds.yml @grafana/grafana-as-code
 /.github/workflows/dashboards-issue-add-label.yml @grafana/dashboards-squad
-/.github/workflows/ephemeral-instances.yml @grafana/grafana-operator-experience-squad
+/.github/workflows/ephemeral-instances-pr-comment.yml @grafana/grafana-operator-experience-squad
+/.github/workflows/ephemeral-instances-pr-opened-closed.yml @grafana/grafana-operator-experience-squad
 
 
 # Generated files not requiring owner approval

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -1,0 +1,51 @@
+name: 'Ephemeral instances: PR comment'
+on:
+  issue_comment:
+    types: [created]
+jobs:      
+  handle-pull-request-event:
+    if: github.event.sender.type == 'User' && 
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy-to-hg')
+    runs-on: 
+      labels: ubuntu-latest-8-cores
+    continue-on-error: true
+    steps:        
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.20'
+
+      - name: Generate a GitHub app installation token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.EI_APP_ID }}
+          private_key: ${{ secrets.EI_APP_PRIVATE_KEY }}
+
+      - name: Checkout ephemeral instances repository
+        uses: actions/checkout@v3  
+        with:
+          repository: grafana/ephemeral-grafana-instances-github-action
+          token: ${{ steps.generate_token.outputs.token }}
+          ref: main
+          path: ephemeral
+        
+      - name: Run action
+        env:
+          GITHUB_EVENT: ${{ toJson(github.event)}}
+        run: |
+          GRAFANA_VERSION=10.1.0
+
+          cd $GITHUB_WORKSPACE/ephemeral/src
+          go run . \
+            -GITHUB_TOKEN="${{ steps.generate_token.outputs.token }}" \
+            -GITHUB_EVENT="$GITHUB_EVENT" \
+            -GITHUB_TRIGGERING_ACTOR="${{ github.triggering_actor }}" \
+            -GCOM_HOST="${{ secrets.EI_GCOM_HOST }}" \
+            -GCOM_TOKEN="${{ secrets.EI_GCOM_TOKEN }}" \
+            -HOSTED_GRAFANA_IMAGE_TAG="$GRAFANA_VERSION-ephemeral-${{ github.triggering_actor }}-$(uuidgen)" \
+            -REGISTRY="${{ secrets.EI_EPHEMERAL_INSTANCES_REGISTRY }}" \
+            -GRAFANA_VERSION="$GRAFANA_VERSION" \
+            -GCP_SERVICE_ACCOUNT_KEY_BASE64="${{ secrets.EI_GCP_SERVICE_ACCOUNT_KEY_BASE64 }}" \
+            -EPHEMERAL_ORG_ID="${{ secrets.EI_EPHEMERAL_ORG_ID }}" || true

--- a/.github/workflows/ephemeral-instances-pr-opened-closed.yml
+++ b/.github/workflows/ephemeral-instances-pr-opened-closed.yml
@@ -1,14 +1,10 @@
-name: 'Ephemeral instances action'
+name: 'Ephemeral instances: PR opened/closed'
 on:
-  issue_comment:
-    types: [created]
   pull_request:
       types: [opened, reopened, closed]
 jobs:      
   handle-pull-request-event:
-    if: github.event.sender.type == 'User'
-    runs-on: 
-      labels: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:        
       - name: Setup Go
@@ -44,7 +40,7 @@ jobs:
             -GITHUB_TRIGGERING_ACTOR="${{ github.triggering_actor }}" \
             -GCOM_HOST="${{ secrets.EI_GCOM_HOST }}" \
             -GCOM_TOKEN="${{ secrets.EI_GCOM_TOKEN }}" \
-            -HOSTED_GRAFANA_IMAGE_TAG="$GRAFANA_VERSION-ephemeral-grafana-${{ github.triggering_actor }}-${{ github.run_number }}-${{ github.run_attempt }}" \
+            -HOSTED_GRAFANA_IMAGE_TAG="$GRAFANA_VERSION-ephemeral-${{ github.triggering_actor }}-$(uuidgen)" \
             -REGISTRY="${{ secrets.EI_EPHEMERAL_INSTANCES_REGISTRY }}" \
             -GRAFANA_VERSION="$GRAFANA_VERSION" \
             -GCP_SERVICE_ACCOUNT_KEY_BASE64="${{ secrets.EI_GCP_SERVICE_ACCOUNT_KEY_BASE64 }}" \


### PR DESCRIPTION
See https://github.com/grafana/grafana-enterprise/pull/5449 for an explanation