### PR TITLE
CommandPalette: Remove parent search and fuzzy search for pages

### DIFF
--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -237,11 +237,9 @@ function useUfuzzy(): uFuzzy {
 
   if (!ref.current) {
     ref.current = new uFuzzy({
-      intraMode: 1,
-      intraIns: 1,
-      intraSub: 1,
-      intraTrn: 1,
-      intraDel: 1,
+      // See https://github.com/leeoniya/uFuzzy#options
+      intraMode: 0, // don't allow for typos/extra letters
+      intraIns: 0, // require each term in the search to appear exactly
     });
   }
 

--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -186,9 +186,7 @@ function useInternalMatches(filtered: ActionImpl[], search: string): Match[] {
       return throttledFiltered.map((action) => ({ score: 0, action }));
     }
 
-    const haystack = throttledFiltered.map(({ name, keywords }) =>
-      `${name} ${keywords ?? ''}`.toLowerCase()
-    );
+    const haystack = throttledFiltered.map(({ name, keywords }) => `${name} ${keywords ?? ''}`.toLowerCase());
 
     const results: Match[] = [];
 

--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -186,8 +186,8 @@ function useInternalMatches(filtered: ActionImpl[], search: string): Match[] {
       return throttledFiltered.map((action) => ({ score: 0, action }));
     }
 
-    const haystack = throttledFiltered.map(({ name, keywords, subtitle }) =>
-      `${name} ${keywords ?? ''} ${subtitle ?? ''}`.toLowerCase()
+    const haystack = throttledFiltered.map(({ name, keywords }) =>
+      `${name} ${keywords ?? ''}`.toLowerCase()
     );
 
     const results: Match[] = [];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Improved searching for pages in command palette.
- Remove searching on parent
- Changed fuzzy matching to be more strict 
 
These changes only affect pages, not dashboard searching

**Why do we need this feature?**

To leave more space for correct dashboard matching. Also more consistent with dashboard search.

**Who is this feature for?**

Users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #71265

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
