### PR TITLE
Alerting: Improve performance of matching captures

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -303,14 +303,19 @@ type NumberValueCapture struct {
 
 func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.QueryDataResponse) ExecutionResults {
 	// captures contains the values of all instant queries and expressions for each dimension
-	captures := make(map[data.Fingerprint][]NumberValueCapture, len(execResp.Responses))
+	captures := make(map[string]map[data.Fingerprint]NumberValueCapture)
 	captureFn := func(refID string, labels data.Labels, value *float64) {
+		m := captures[refID]
+		if m == nil {
+			m = make(map[data.Fingerprint]NumberValueCapture)
+		}
 		fp := labels.Fingerprint()
-		captures[fp] = append(captures[fp], NumberValueCapture{
+		m[fp] = NumberValueCapture{
 			Var:    refID,
 			Value:  value,
 			Labels: labels.Copy(),
-		})
+		}
+		captures[refID] = m
 	}
 
 	// datasourceUIDsForRefIDs is a short-lived lookup table of RefID to DatasourceUID
@@ -382,24 +387,23 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 			theseLabels := frame.Fields[0].Labels
 			fp := theseLabels.Fingerprint()
 
-			// First look for a capture whose labels are an exact match
-			if groupedCaps, ok := captures[fp]; ok {
-				if frame.Meta.Custom == nil {
-					frame.Meta.Custom = []NumberValueCapture{}
-				}
-				frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), groupedCaps...)
-			} else {
-				// If no exact match was found, look for captures whose labels are either subsets
-				// or supersets
-				for _, groupedCaps := range captures {
-					if len(groupedCaps) > 0 {
-						firstCap := groupedCaps[0]
+			for _, fps := range captures {
+				// First look for a capture whose labels are an exact match
+				if v, ok := fps[fp]; ok {
+					if frame.Meta.Custom == nil {
+						frame.Meta.Custom = []NumberValueCapture{}
+					}
+					frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
+				} else {
+					// If no exact match was found, look for captures whose labels are either subsets
+					// or supersets
+					for _, v := range fps {
 						// matching labels are equal labels, or when one set of labels includes the labels of the other.
-						if theseLabels.Equals(firstCap.Labels) || theseLabels.Contains(firstCap.Labels) || firstCap.Labels.Contains(theseLabels) {
+						if theseLabels.Equals(v.Labels) || theseLabels.Contains(v.Labels) || v.Labels.Contains(theseLabels) {
 							if frame.Meta.Custom == nil {
 								frame.Meta.Custom = []NumberValueCapture{}
 							}
-							frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), groupedCaps...)
+							frame.Meta.Custom = append(frame.Meta.Custom.([]NumberValueCapture), v)
 						}
 					}
 				}

--- a/pkg/services/ngalert/eval/eval_bench_test.go
+++ b/pkg/services/ngalert/eval/eval_bench_test.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/util"
 	"strconv"
 	"testing"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func BenchmarkEvaluate(b *testing.B) {

--- a/pkg/services/ngalert/eval/eval_bench_test.go
+++ b/pkg/services/ngalert/eval/eval_bench_test.go
@@ -1,0 +1,59 @@
+package eval
+
+import (
+	"context"
+	"github.com/grafana/grafana/pkg/util"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func BenchmarkEvaluate(b *testing.B) {
+	var dataResp backend.QueryDataResponse
+	seedDataResponse(&dataResp, 10000)
+	var evaluator ConditionEvaluator = &conditionEvaluator{
+		expressionService: &fakeExpressionService{
+			hook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {
+				return &dataResp, nil
+			},
+		},
+		condition: models.Condition{
+			Condition: "B",
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		_, err := evaluator.Evaluate(context.Background(), time.Now())
+		if err != nil {
+			b.Fatalf("Unexpected error: %s", err)
+		}
+	}
+}
+
+func seedDataResponse(r *backend.QueryDataResponse, n int) {
+	resps := make(backend.Responses, n)
+	for i := 0; i < n; i++ {
+		labels := data.Labels{
+			"foo": strconv.Itoa(i),
+			"bar": strconv.Itoa(i + 1),
+		}
+		a, b := resps["A"], resps["B"]
+		a.Frames = append(a.Frames, &data.Frame{
+			Fields: data.Fields{
+				data.NewField("Time", labels, []time.Time{time.Now()}),
+				data.NewField("Value", labels, []*float64{util.Pointer(1.0)}),
+			},
+		})
+		b.Frames = append(b.Frames, &data.Frame{
+			Fields: data.Fields{
+				data.NewField("Value", labels, []*float64{util.Pointer(1.0)}),
+			},
+		})
+		resps["A"], resps["B"] = a, b
+	}
+	r.Responses = resps
+}


### PR DESCRIPTION
**What is this feature?**

This commit updates `eval.go` to improve the performance of matching captures in the general case. In some cases we have reduced the runtime of the function from 10s of minutes to a couple 100ms. In the case where no capture matches the exact labels, we revert to the current subset/superset match, but with a reduced search space due to grouping captures.

**Benchmarks**

All benchmarks are show as before and after benchmarks.

**100 alerts**

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	   35728	    997875 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	46.346s
```

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	  199930	    180568 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	38.337s
```

**500 alerts**

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	    1627	  22169211 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	38.737s
```

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	   40276	    911248 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	46.170s
```

**5000 alerts**

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	      16	2133231219 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	36.677s
```

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	    3922	   9225236 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	37.556s
```

**10,000 alerts**

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	       4	8555365688 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	68.640s
```

```
go test -bench=. -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/eval
BenchmarkEvaluate-8   	    1882	  18879993 ns/op
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/eval	37.919s
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
