### PR TITLE
Bug: Compare `semver` digits for frontend packages config

### DIFF
--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -2,8 +2,8 @@ package frontend
 
 import (
 	"fmt"
-	"github.com/blang/semver/v4"
 
+	"github.com/blang/semver/v4"
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
 )

--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"fmt"
+	"github.com/blang/semver/v4"
 
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
@@ -22,7 +23,16 @@ func GetConfig(c *cli.Context, metadata config.Metadata) (config.Config, config.
 		if err != nil {
 			return config.Config{}, "", err
 		}
-		if metadata.GrafanaVersion != packageJSONVersion {
+		semverGrafanaVersion, err := semver.Parse(metadata.GrafanaVersion)
+		if err != nil {
+			return config.Config{}, "", err
+		}
+		semverPackageJSONVersion, err := semver.Parse(packageJSONVersion)
+		if err != nil {
+			return config.Config{}, "", err
+		}
+		// Check if the semver digits of the tag are not equal
+		if semverGrafanaVersion.FinalizeVersion() != semverPackageJSONVersion.FinalizeVersion() {
 			return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json", packageJSONVersion, metadata.GrafanaVersion), 1)
 		}
 	}

--- a/pkg/build/frontend/config_test.go
+++ b/pkg/build/frontend/config_test.go
@@ -45,6 +45,13 @@ func TestGetConfig(t *testing.T) {
 		},
 		{
 			ctx:                cli.NewContext(app, setFlags(t, flag.NewFlagSet("flagSet", flag.ContinueOnError), flagObj{name: jobs, value: "2"}, flagObj{name: githubToken, value: "token"}), nil),
+			name:               "custom tag, package.json doesn't match",
+			packageJsonVersion: "10.0.0",
+			metadata:           config.Metadata{GrafanaVersion: "10.0.0-abcd123pre", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},
+			wantErr:            false,
+		},
+		{
+			ctx:                cli.NewContext(app, setFlags(t, flag.NewFlagSet("flagSet", flag.ContinueOnError), flagObj{name: jobs, value: "2"}, flagObj{name: githubToken, value: "token"}), nil),
 			name:               "package.json doesn't match tag",
 			packageJsonVersion: "10.1.0",
 			metadata:           config.Metadata{GrafanaVersion: "10.0.0", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},


### PR DESCRIPTION
**What is this feature?**

For tag events, we compare frontend packages version taken from `package.json` with the `DRONE_TAG`. We want those two versions to be identical in order no to build the wrong frontend packages for the wrong release.
For custom releases (releases with a prerelease suffix) we only want to check the semver digits since we don't publish frontend packages for custom releases.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
