### PR TITLE
[v10.0.x] Add canonical URLs to all alerting pages

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - about-alerting/
   - unified-alerting/alerting/
+canonical: https://grafana.com/docs/grafana/latest/alerting/
 description: Intro to key benefits and features of Grafana Alerting
 labels:
   products:

--- a/docs/sources/alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/alerting-rules/_index.md
@@ -4,6 +4,7 @@ aliases:
   - rules/
   - unified-alerting/alerting-rules/
   - ./create-alerts/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/
 description: Configure alerting
 labels:
   products:

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../unified-alerting/alerting-rules/create-grafana-managed-rule/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/
 description: Create Grafana managed alert rule
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -2,6 +2,7 @@
 aliases:
   - ../unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule/
   - ../unified-alerting/alerting-rules/create-mimir-loki-managed-recording-rule/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-mimir-loki-managed-recording-rule/
 description: Create Grafana Mimir or Loki managed recording rule
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -3,6 +3,7 @@ aliases:
   - ../unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule/
   - ../unified-alerting/alerting-rules/create-mimir-loki-managed-recording-rule/
   - ../unified-alerting/alerting-rules/create-mimir-loki-managed-rule/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-mimir-loki-managed-rule/
 description: Create Grafana Mimir or Loki managed alerting rule
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/create-notification-policy.md
+++ b/docs/sources/alerting/alerting-rules/create-notification-policy.md
@@ -3,6 +3,7 @@ aliases:
   - ../notifications/
   - ../old-alerting/notifications/
   - ../unified-alerting/notifications/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-notification-policy/
 description: Notification policies
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/edit-mimir-loki-namespace-group.md
+++ b/docs/sources/alerting/alerting-rules/edit-mimir-loki-namespace-group.md
@@ -2,6 +2,7 @@
 aliases:
   - ../unified-alerting/alerting-rules/edit-cortex-loki-namespace-group/
   - ../unified-alerting/alerting-rules/edit-mimir-loki-namespace-group/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/edit-mimir-loki-namespace-group/
 description: Edit Grafana Mimir or Loki rule groups and namespaces
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/manage-contact-points/_index.md
+++ b/docs/sources/alerting/alerting-rules/manage-contact-points/_index.md
@@ -6,6 +6,7 @@ aliases:
   - ../../contact-points/test-contact-point/
   - ../create-contact-point/
   - alerting/manage-notifications/manage-contact-points/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/manage-contact-points/
 description: How to manage your contact points
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/manage-contact-points/configure-integrations.md
+++ b/docs/sources/alerting/alerting-rules/manage-contact-points/configure-integrations.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - alerting/manage-notifications/manage-contact-points/configure-integrations/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/manage-contact-points/configure-integrations/
 description: Configure integrations
 keywords:
   - Grafana

--- a/docs/sources/alerting/alerting-rules/manage-contact-points/webhook-notifier.md
+++ b/docs/sources/alerting/alerting-rules/manage-contact-points/webhook-notifier.md
@@ -3,6 +3,7 @@ aliases:
   - ../contact-points/notifiers/webhook-notifier/
   - ../fundamentals/contact-points/webhook-notifier/
   - alerting/manage-notifications/manage-contact-points/webhook-notifier/
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/manage-contact-points/webhook-notifier/
 description: Configure the webhook notifier for notifications
 keywords:
   - grafana

--- a/docs/sources/alerting/difference-old-new.md
+++ b/docs/sources/alerting/difference-old-new.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - unified-alerting/difference-old-new/
+canonical: https://grafana.com/docs/grafana/latest/alerting/difference-old-new/
 description: What's New with Grafana alerts
 draft: true
 keywords:

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - metrics/
   - unified-alerting/fundamentals/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/
 description: Intro to the key concepts in Alerting and how it works
 labels:
   products:

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/
 description: About Grafana alert rules
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/alert-instances.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/alert-instances.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/alert-instances/
 description: Learn about Grafana alert instances
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/alert-rule-types/
 description: Learn about the different alert rule types
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
@@ -3,6 +3,7 @@ aliases:
   - ../../contact-points/message-templating/
   - ../../message-templating/
   - ../../unified-alerting/message-templating/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/message-templating/
 description: Notification templating
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/organising-alerts.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/organising-alerts.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/organising-alerts/
 description: Learn how to organize alert rules
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/
 description: Introduction to queries and conditions
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/rule-evaluation/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/rule-evaluation/
 description: Introduction to alert rule evaluation
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alert-rules/state-and-health.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/state-and-health.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../unified-alerting/alerting-rules/state-and-health/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/state-and-health/
 description: State and Health of alerting rules
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/alertmanager.md
@@ -4,6 +4,7 @@ aliases:
   - ../metrics/
   - ../unified-alerting/fundamentals/alertmanager/
   - alerting/manage-notifications/alertmanager/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/alertmanager/
 description: Intro to the different Alertmanagers
 labels:
   products:

--- a/docs/sources/alerting/fundamentals/annotation-label/_index.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - ../alerting-rules/alert-annotation-label/
   - ../unified-alerting/alerting-rules/alert-annotation-label/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/
 description: Annotations and labels for alerting
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/how-to-use-labels/
 description: Learn about labels and label matchers in alerting
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/labels-and-label-matchers/
 description: Learn about labels and label matchers in alerting
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation/
 description: Learn about templating of labels and annotations
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/contact-points/index.md
+++ b/docs/sources/alerting/fundamentals/contact-points/index.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana/latest/alerting/contact-points/
   - /docs/grafana/latest/alerting/unified-alerting/contact-points/
   - /docs/grafana/latest/alerting/fundamentals/contact-points/contact-point-types/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/contact-points/
 description: Create or edit contact point
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/data-source-alerting.md
+++ b/docs/sources/alerting/fundamentals/data-source-alerting.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/data-source-alerting/
 description: Data sources in Grafana Alerting
 labels:
   products:

--- a/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
@@ -2,6 +2,7 @@
 aliases:
   - ../metrics/
   - ../unified-alerting/fundamentals/evaluate-grafana-alerts/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/evaluate-grafana-alerts/
 description: How to alert on numeric data
 labels:
   products:

--- a/docs/sources/alerting/fundamentals/high-availability/_index.md
+++ b/docs/sources/alerting/fundamentals/high-availability/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - ../high-availability/
   - ../unified-alerting/high-availability/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/high-availability/
 description: High availability
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/notification-policies/_index.md
+++ b/docs/sources/alerting/fundamentals/notification-policies/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notification-policies/
 description: Introduction to notifications Policies
 keywords:
   - grafana

--- a/docs/sources/alerting/fundamentals/notification-policies/notifications.md
+++ b/docs/sources/alerting/fundamentals/notification-policies/notifications.md
@@ -2,6 +2,7 @@
 aliases:
   - ../notifications/
   - alerting/manage-notifications/create-notification-policy/
+canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notification-policies/notifications/
 description: Notification policies
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/
 description: Manage alert notifications
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/create-silence.md
+++ b/docs/sources/alerting/manage-notifications/create-silence.md
@@ -5,6 +5,7 @@ aliases:
   - ../silences/linking-to-silence-form/
   - ../silences/remove-silence/
   - ../unified-alerting/silences/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/create-silence/
 description: Add silence alert notification
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/declare-incident-from-alert.md
+++ b/docs/sources/alerting/manage-notifications/declare-incident-from-alert.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - alerting/alerting-rules/declare-incident-from-alert/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/declare-incident-from-alert/
 description: Declare an incident from a firing alert
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/images-in-notifications/
 description: How to use images in notifications
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -2,6 +2,7 @@
 aliases:
   - ../notifications/mute-timings/
   - ../unified-alerting/notifications/mute-timings/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/mute-timings/
 description: Mute timings
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/
 description: How to customize your notifications using templating
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/create-notification-templates/
 description: How to create notification templates
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/template-notifications/reference.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/reference.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/reference/
 description: Reference for templating notifications
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/use-notification-templates/
 description: Use notification templates in contact points
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/using-go-templating-language/
 description: Use Go's templating language in notifications
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/view-alert-groups.md
+++ b/docs/sources/alerting/manage-notifications/view-alert-groups.md
@@ -5,6 +5,7 @@ aliases:
   - ../alert-groups/filter-alerts/
   - ../alert-groups/view-alert-grouping/
   - ../unified-alerting/alert-groups/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/view-alert-groups/
 description: Alert groups
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/view-alert-rules.md
+++ b/docs/sources/alerting/manage-notifications/view-alert-rules.md
@@ -3,6 +3,7 @@ aliases:
   - ../unified-alerting/alerting-rules/rule-list/
   - ../view-alert-rules/
   - rule-list/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/view-alert-rules/
 description: Manage alerting rules
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/view-notification-errors.md
+++ b/docs/sources/alerting/manage-notifications/view-notification-errors.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/view-notification-errors/
 description: View notification errors to find out why they weren't sent or received
 keywords:
   - grafana

--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -3,6 +3,7 @@ aliases:
   - ../fundamentals/state-and-health/
   - ../unified-alerting/alerting-rules/state-and-health/
   - ../view-state-health/
+canonical: https://grafana.com/docs/grafana/latest/alerting/manage-notifications/view-state-health/
 description: State and Health of alerting rules
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - unified-alerting/set-up/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/
 description: How to configure alerting features and integrations
 labels:
   products:

--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -1,4 +1,5 @@
 ---
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/configure-alert-state-history/
 description: Configure Alert State History
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../configure-alertmanager/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/configure-alertmanager/
 description: Configure Alertmanager
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - ../high-availability/enable-alerting-ha/
   - ../unified-alerting/high-availability/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/
 description: Enable alerting high availability
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/meta-monitoring/_index.md
+++ b/docs/sources/alerting/set-up/meta-monitoring/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - meta-monitoring/
   - alerting/meta-monitoring/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/meta-monitoring/
 description: Meta monitoring
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -4,6 +4,7 @@ aliases:
   - unified-alerting/
   - unified-alerting/difference-old-new/
   - alerting/migrating-alerts/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
 description: Upgrade Grafana alerts
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting-deprecation.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - alerting/legacy-alerting-deprecation/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting-deprecation/
 description: Legacy alerting deprecation notice
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/_index.md
@@ -4,6 +4,7 @@ aliases:
   - /docs/grafana-cloud/how-do-i/alerts/
   - /docs/grafana-cloud/legacy-alerting/
   - alerting/migrating-alerts/legacy-alerting/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/
 description: Legacy alerting
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/_index.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/
 description: Grafana Cloud Alerting
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/alertmanager.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/alertmanager.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/alertmanager/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/alertmanager/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/alertmanager/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/alertmanager/
 description: Alertmanager
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/create-edit-rules.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/create-edit-rules.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/create-edit-rules/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/create-edit-rules/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/create-edit-rules/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/create-edit-rules/
 description: Create and edit alert rules
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/namespaces-and-groups.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/namespaces-and-groups.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/namespaces-and-groups/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/namespaces-and-groups/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/namespaces-and-groups/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/namespaces-and-groups/
 description: Namespaces and rule groups
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/silences.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/silences.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/silences/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/silences/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/silences/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/silences/
 description: Silences
 labels:
   products:

--- a/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/view-filter-rules.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/view-filter-rules.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/view-filter-rules/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/view-filter-alerts/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/view-filter-rules/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/legacy-alerting/grafana-cloud-alerting/view-filter-rules/
 description: View and filter alert rules
 labels:
   products:

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -2,6 +2,7 @@
 aliases:
   - alerting-limitations/
   - alerting/performance-limitations/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/performance-limitations/
 description: Performance considerations and limitations
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../provision-alerting-resources/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/
 description: Provision alerting resources
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../provision-alerting-resources/file-provisioning/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/
 description: Create and manage resources using file provisioning
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../provision-alerting-resources/terraform-provisioning/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/
 description: Create and manage alerting resources using Terraform
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../provision-alerting-resources/view-provisioned-resources/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/view-provisioned-resources/
 description: View provisioned resources in Grafana
 keywords:
   - grafana

--- a/docs/sources/alerting/set-up/set-up-cloud/_index.md
+++ b/docs/sources/alerting/set-up/set-up-cloud/_index.md
@@ -8,6 +8,7 @@ aliases:
   - /docs/grafana-cloud/alerts/grafana-cloud-alerting/
   - /docs/grafana-cloud/how-do-i/grafana-cloud-alerting/
   - /docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/
+canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/set-up-cloud/
 description: How to configure Alerting for Cloud
 labels:
   products:


### PR DESCRIPTION
Backport 37ef4e940f79b6c81024db6863a6a264e71d8ed7 from #71830

---

Grafana Cloud documentation reuses this documentation.

Having duplicate pages can be detrimental to SEO and setting the canonical URL helps by letting search engines only index the canonical page.

We do not index /docs/grafana/next/ pages, only /docs/grafana/latest/, so there is no need to concern ourselves with how this canonical is managed across versions. Pages that are not "latest", automatically have their canonical set to "latest" by the website.

Only backporting to v10.0.x because I think the chance of conflict is low and the canonicals are only needed in current  and future "latest" docs.