### PR TITLE
logs: improved unit tests

### DIFF
--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -6,12 +6,18 @@ import { getAllFields, createLogLineLinks, FieldDef } from './logParser';
 
 describe('logParser', () => {
   describe('getAllFields', () => {
-    it('should filter out field with labels name and other type', () => {
+    it('should filter out field with labels name old-loki-style frame', () => {
       const logRow = createLogRow({
-        entryFieldIndex: 10,
+        entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+          },
           refId: 'A',
           fields: [
+            testTimeField,
             testLineField,
             testStringField,
             {
@@ -29,12 +35,13 @@ describe('logParser', () => {
       expect(fields.find((field) => field.keys[0] === 'labels')).toBe(undefined);
     });
 
-    it('should not filter out field with labels name and string type', () => {
+    it('should not filter out field with labels name in not-old-loki-style frame', () => {
       const logRow = createLogRow({
-        entryFieldIndex: 10,
+        entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
           refId: 'A',
           fields: [
+            testTimeField,
             testLineField,
             testStringField,
             {
@@ -53,10 +60,11 @@ describe('logParser', () => {
 
     it('should not filter out field with labels name and other type and datalinks', () => {
       const logRow = createLogRow({
-        entryFieldIndex: 10,
+        entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
           refId: 'A',
           fields: [
+            testTimeField,
             testLineField,
             testStringField,
             {
@@ -82,10 +90,11 @@ describe('logParser', () => {
 
     it('should filter out field with id name', () => {
       const logRow = createLogRow({
-        entryFieldIndex: 10,
+        entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
           refId: 'A',
           fields: [
+            testTimeField,
             testLineField,
             testStringField,
             {
@@ -139,10 +148,10 @@ describe('logParser', () => {
 
     it('should not filter out field with string values', () => {
       const logRow = createLogRow({
-        entryFieldIndex: 10,
+        entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
           refId: 'A',
-          fields: [testLineField, { ...testStringField }],
+          fields: [testTimeField, testLineField, { ...testStringField }],
         }),
       });
 
@@ -213,6 +222,13 @@ describe('logParser', () => {
     });
   });
 });
+
+const testTimeField = {
+  name: 'timestamp',
+  type: FieldType.time,
+  config: {},
+  values: [1],
+};
 
 const testLineField = {
   name: 'body',

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -222,10 +222,16 @@ describe('checkLogsError()', () => {
 describe('logRowsToReadableJson', () => {
   const testRow: LogRowModel = {
     rowIndex: 0,
-    entryFieldIndex: 0,
+    entryFieldIndex: 1,
     dataFrame: {
       length: 1,
       fields: [
+        {
+          name: 'timestamp',
+          type: FieldType.time,
+          config: {},
+          values: [1],
+        },
         {
           name: 'body',
           type: FieldType.string,
@@ -253,6 +259,12 @@ describe('logRowsToReadableJson', () => {
     length: 1,
     fields: [
       {
+        name: 'timestamp',
+        type: FieldType.time,
+        config: {},
+        values: [1],
+      },
+      {
         name: 'body',
         type: FieldType.string,
         config: {},
@@ -268,7 +280,7 @@ describe('logRowsToReadableJson', () => {
   };
   const testRow2: LogRowModel = {
     rowIndex: 0,
-    entryFieldIndex: -1,
+    entryFieldIndex: 1,
     dataFrame: testDf,
     entry: 'test entry',
     hasAnsi: false,


### PR DESCRIPTION
changes to unit tests, nothing else:
- some logs-related unit tests got updated to contain "closer to real" test-data
- some logs-related tests had minor changes about what exactly should they test


(i am working on changes to `logParser.ts`. usually in tests we only mock as much data-structure as we need, and when my changes to `logParser.ts` will happen, i need more complete mocked objects. so i chose to update the tests first. they still pass)