### PR TITLE
Tracing: Differentiate collector and agent better

### DIFF
--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -267,10 +267,14 @@ func splitCustomAttribs(s string) ([]attribute.KeyValue, error) {
 func (ots *Opentelemetry) initJaegerTracerProvider() (*tracesdk.TracerProvider, error) {
 	var ep jaeger.EndpointOption
 	// Create the Jaeger exporter: address can be either agent address (host:port) or collector URL
-	if host, port, err := net.SplitHostPort(ots.Address); err == nil {
-		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port), jaeger.WithMaxPacketSize(64000))
-	} else {
+	if strings.HasPrefix(ots.Address, "http://") || strings.HasPrefix(ots.Address, "https://") {
+		ots.log.Debug("using jaeger collector", "address", ots.Address)
 		ep = jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(ots.Address))
+	} else if host, port, err := net.SplitHostPort(ots.Address); err == nil {
+		ots.log.Debug("using jaeger agent", "host", host, "port", port)
+		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port))
+	} else {
+		return nil, fmt.Errorf("invalid tracer address: %s", ots.Address)
 	}
 	exp, err := jaeger.New(ep)
 	if err != nil {

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -272,7 +272,7 @@ func (ots *Opentelemetry) initJaegerTracerProvider() (*tracesdk.TracerProvider, 
 		ep = jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(ots.Address))
 	} else if host, port, err := net.SplitHostPort(ots.Address); err == nil {
 		ots.log.Debug("using jaeger agent", "host", host, "port", port)
-		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port))
+		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port), jaeger.WithMaxPacketSize(64000))
 	} else {
 		return nil, fmt.Errorf("invalid tracer address: %s", ots.Address)
 	}


### PR DESCRIPTION
This PR uses Jaeger collector for HTTP/HTTPS URLs and Agent for `host:port` notation (without a HTTP/HTTPS schema). It makes sense because Jaeger collector is only available for HTTP/HTTPS protocols and Agent uses UDP `host:port` only.

Previous code worked because usually people run Collector on a custom port, so `SplitHostPort` failed with an error. Now this HTTP/UDP check is more explicit with some logging added.

Fixes https://github.com/grafana/grafana/issues/71205