### PR TITLE
refactor: add wrap for small screen widths

### DIFF
--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -115,7 +115,7 @@ function ModalButtonRow({ leftItems, children }: { leftItems?: React.ReactNode; 
 
   return (
     <div className={styles.modalButtonRow}>
-      <HorizontalGroup justify="flex-end" spacing="md">
+      <HorizontalGroup justify="flex-end" spacing="md" wrap={true}>
         {children}
       </HorizontalGroup>
     </div>


### PR DESCRIPTION
**What is this feature?**

Wrap buttons in case of small screen width.

**Why do we need this feature?**

If there are several buttons some of them are hidden.

**Who is this feature for?**

Every user being confronted with a Modal in Grafana using a device with a small screen.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/66371

**Special notes for your reviewer:**

I'm aware of the fact that the alignment of the buttons is off. If you want me to adjust this it will not be possible to use the HorizontalGroup that we currently use. The change would require a customised styling.

Before:
<img width="321" alt="Screenshot 2023-07-17 at 15 52 15" src="https://github.com/grafana/grafana/assets/48948963/c787d019-8e8d-458e-bf82-f35d49b67c13">
<img width="322" alt="Screenshot 2023-07-17 at 15 51 07" src="https://github.com/grafana/grafana/assets/48948963/e5f450f2-3582-452c-97db-dae9cda19697">

After:
<img width="321" alt="Screenshot 2023-07-18 at 17 04 21" src="https://github.com/grafana/grafana/assets/48948963/06da0e25-6e4f-4090-89cd-2f8607dd26fe">
<img width="318" alt="Screenshot 2023-07-18 at 17 03 43" src="https://github.com/grafana/grafana/assets/48948963/ffd431f4-8346-423b-b597-64f1b59c4eda">
