### PR TITLE
Alerting: Add exported constructor for panelKey

### DIFF
--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -57,14 +57,19 @@ type PanelKey struct {
 	panelID int64
 }
 
+func NewPanelKey(orgID int64, dashUID string, panelID int64) PanelKey {
+	return PanelKey{
+		orgID:   orgID,
+		dashUID: dashUID,
+		panelID: panelID,
+	}
+}
+
 // PanelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
 func parsePanelKey(rule history_model.RuleMeta, logger log.Logger) *PanelKey {
 	if rule.DashboardUID != "" {
-		return &PanelKey{
-			orgID:   rule.OrgID,
-			dashUID: rule.DashboardUID,
-			panelID: rule.PanelID,
-		}
+		key := NewPanelKey(rule.OrgID, rule.DashboardUID, rule.PanelID)
+		return &key
 	}
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

This is a tiny PR that makes it so the exported type `PanelKey` can be constructed in other packages.
Right now the fields are unexported, and the only method to obtain an instance is also unexported.

I went for this approach rather than exporting the fields because it adds some enforcement around what fields are required. It does not make sense to have a panel key without one of these three fields.

A valid alternate approach is to just export the fields. Please let me know if you'd prefer that!

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
