### PR TITLE
LogParser: safely stringify field value

### DIFF
--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -86,6 +86,11 @@ export const getDataframeFields = memoizeOne(
 );
 
 function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
+  // field that has empty value (we want to keep 0 or empty string)
+  if (field.values[row.rowIndex] == null) {
+    return true;
+  }
+
   // hidden field, remove
   if (field.config.custom?.hidden) {
     return true;
@@ -94,11 +99,6 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   // field with data-links, keep
   if ((field.config.links ?? []).length > 0) {
     return false;
-  }
-
-  // field that has empty value (we want to keep 0 or empty string)
-  if (field.values[row.rowIndex] == null) {
-    return true;
   }
 
   // the remaining checks use knowledge of how we parse logs-dataframes

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -1,6 +1,7 @@
 import memoizeOne from 'memoize-one';
 
 import { DataFrame, Field, FieldType, LinkModel, LogRowModel } from '@grafana/data';
+import { safeStringifyValue } from 'app/core/utils/explore';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
 export type FieldDef = {
@@ -69,9 +70,14 @@ export const getDataframeFields = memoizeOne(
       .filter((field, index) => !shouldRemoveField(field, index, row))
       .map((field) => {
         const links = getFieldLinks ? getFieldLinks(field, row.rowIndex, row.dataFrame) : [];
+        const fieldVal = field.values[row.rowIndex];
+        const outputVal =
+          typeof fieldVal === 'string' || typeof fieldVal === 'number'
+            ? fieldVal.toString()
+            : safeStringifyValue(fieldVal);
         return {
           keys: [field.name],
-          values: [field.values[row.rowIndex].toString()],
+          values: [outputVal],
           links: links,
           fieldIndex: field.index,
         };


### PR DESCRIPTION
We were calling `anything.toString()` and anything could be null. This is fixed in the current main, so I'm implementing the same code.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/6780

**Special notes for your reviewer:**

Force the field value to be null, open log details, it should not trigger an error with this fix.