### PR TITLE
Chore: Influxdb variable type cleanup

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4045,40 +4045,30 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/plugins/datasource/influxdb/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Do not use any type assertions.", "12"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "19"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "20"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "21"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "23"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "24"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "25"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "26"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "27"],
-      [0, 0, 0, "Do not use any type assertions.", "28"]
+      [0, 0, 0, "Do not use any type assertions.", "18"]
     ],
     "public/app/plugins/datasource/influxdb/influx_query_model.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4143,8 +4133,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "16"]
     ],
     "public/app/plugins/datasource/influxdb/response_parser.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4171,9 +4160,7 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/influxdb/specs/mocks.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/datasource/jaeger/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 
 import {
   DataSourcePluginOptionsEditorProps,
+  DataSourceSettings,
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceOption,
@@ -23,7 +24,7 @@ import {
 import { config } from 'app/core/config';
 
 import { BROWSER_MODE_DISABLED_MESSAGE } from '../../../constants';
-import { InfluxOptions, InfluxSecureJsonData, InfluxVersion } from '../../../types';
+import { InfluxOptions, InfluxOptionsV1, InfluxSecureJsonData, InfluxVersion } from '../../../types';
 
 const { Input, SecretFormField } = LegacyForms;
 
@@ -76,7 +77,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
   onVersionChanged = (selected: SelectableValue<InfluxVersion>) => {
     const { options, onOptionsChange } = this.props;
 
-    const copy: any = {
+    const copy: DataSourceSettings<InfluxOptionsV1, {}> = {
       ...options,
       jsonData: {
         ...options.jsonData,
@@ -89,11 +90,12 @@ export class ConfigEditor extends PureComponent<Props, State> {
       copy.jsonData.httpMode = 'POST';
 
       // Remove old 1x configs
-      delete copy.user;
-      delete copy.database;
-    }
+      const { user, database, ...rest } = copy;
 
-    onOptionsChange(copy);
+      onOptionsChange(rest as DataSourceSettings<InfluxOptions, {}>);
+    } else {
+      onOptionsChange(copy);
+    }
   };
 
   renderInflux2x() {

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/hooks/useRetentionPolicies.test.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/hooks/useRetentionPolicies.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 
+import { FetchResponse } from '@grafana/runtime/src';
 import config from 'app/core/config';
 
 import { getMockDS, getMockDSInstanceSettings, mockBackendService } from '../../../../../specs/mocks';
@@ -24,7 +25,17 @@ describe('useRetentionPolicies', () => {
   });
 });
 
-const response = {
+const response: FetchResponse = {
+  config: {
+    url: 'mock-response-url',
+  },
+  headers: new Headers(),
+  ok: false,
+  redirected: false,
+  status: 0,
+  statusText: '',
+  type: 'basic',
+  url: '',
   data: {
     results: {
       metadataQuery: {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -10,9 +10,11 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   dateMath,
+  DateTime,
   FieldType,
   MetricFindValue,
   QueryResultMeta,
+  RawTimeRange,
   ScopedVars,
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
@@ -235,7 +237,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return true;
   }
 
-  applyTemplateVariables(query: InfluxQuery, scopedVars: ScopedVars): Record<string, any> {
+  applyTemplateVariables(query: InfluxQuery, scopedVars: ScopedVars): InfluxQuery {
     // We want to interpolate these variables on backend
     const { __interval, __interval_ms, ...rest } = scopedVars || {};
 
@@ -253,7 +255,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return query;
   }
 
-  targetContainsTemplate(target: any) {
+  targetContainsTemplate(target: InfluxQuery) {
     // for flux-mode we just take target.query,
     // for influxql-mode we use InfluxQueryModel to create the text-representation
     const queryText = this.isFlux ? target.query : buildRawQuery(target);
@@ -298,10 +300,10 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
     if (query.select) {
       expandedQuery.select = query.select.map((selects) => {
-        return selects.map((select: any) => {
+        return selects.map((select) => {
           return {
             ...select,
-            params: select.params?.map((param: any) => {
+            params: select.params?.map((param) => {
               return this.templateSrv.replace(param.toString(), undefined, 'regex');
             }),
           };
@@ -355,7 +357,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         super.query({
           ...options, // includes 'range'
           targets: [target],
-        } as DataQueryRequest)
+        })
       ).then((rsp) => {
         if (rsp.data?.length) {
           return frameToMetricFindValue(rsp.data[0]);
@@ -381,29 +383,32 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   // Used in public/app/features/variables/adhoc/picker/AdHocFilterKey.tsx::fetchFilterKeys
-  getTagKeys(options: any = {}) {
+  getTagKeys(options: InfluxQuery) {
     const query = buildMetadataQuery({
       type: 'TAG_KEYS',
       templateService: this.templateSrv,
       database: this.database,
-      measurement: options.measurement || '',
+      measurement: options.measurement ?? '',
       tags: [],
     });
     return this.metricFindQuery(query, options);
   }
 
-  getTagValues(options: any = {}) {
+  getTagValues(options: InfluxQuery) {
     const query = buildMetadataQuery({
       type: 'TAG_VALUES',
       templateService: this.templateSrv,
       database: this.database,
       withKey: options.key,
-      measurement: options.measurement || '',
+      measurement: options.measurement ?? '',
       tags: [],
     });
     return this.metricFindQuery(query, options);
   }
 
+  /**
+   * @deprecated
+   */
   _seriesQuery(query: string, options?: any) {
     if (!query) {
       return of({ results: [] });
@@ -417,6 +422,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return this._influxRequest(this.httpMode, '/query', { q: query, epoch: 'ms' }, options);
   }
 
+  /**
+   * @deprecated
+   */
   serializeParams(params: any) {
     if (!params) {
       return '';
@@ -424,17 +432,20 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
     return reduce(
       params,
-      (memo, value, key) => {
+      (memo: string[], value, key) => {
         if (value === null || value === undefined) {
           return memo;
         }
         memo.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
         return memo;
       },
-      [] as string[]
+      []
     ).join('&');
   }
 
+  /**
+   * @deprecated
+   */
   _influxRequest(method: string, url: string, data: any, options?: any) {
     const currentUrl = this.urls.shift()!;
     this.urls.push(currentUrl);
@@ -520,6 +531,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       );
   }
 
+  /**
+   * @deprecated
+   */
   handleErrors(err: any) {
     const error: DataQueryError = {
       message:
@@ -545,14 +559,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return error;
   }
 
-  getTimeFilter(options: any) {
+  getTimeFilter(options: { rangeRaw: RawTimeRange; timezone: string }) {
     const from = this.getInfluxTime(options.rangeRaw.from, false, options.timezone);
     const until = this.getInfluxTime(options.rangeRaw.to, true, options.timezone);
 
     return 'time >= ' + from + ' and time <= ' + until;
   }
 
-  getInfluxTime(date: any, roundUp: any, timezone: any) {
+  getInfluxTime(date: DateTime | string, roundUp: any, timezone: any) {
+    let outPutDate;
     if (isString(date)) {
       if (date === 'now') {
         return 'now()';
@@ -564,7 +579,11 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         const unit = parts[2];
         return 'now() - ' + amount + unit;
       }
-      date = dateMath.parse(date, roundUp, timezone);
+      outPutDate = dateMath.parse(date, roundUp, timezone);
+      if (!outPutDate) {
+        throw new Error('unable to parse date');
+      }
+      date = outPutDate;
     }
 
     return date.valueOf() + 'ms';
@@ -578,6 +597,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
   /**
    * The unchanged pre 7.1 query implementation
+   * @deprecated
    */
   classicQuery(options: any): Observable<DataQueryResponse> {
     let timeFilter = this.getTimeFilter(options);

--- a/public/app/plugins/datasource/influxdb/query_part.ts
+++ b/public/app/plugins/datasource/influxdb/query_part.ts
@@ -1,6 +1,6 @@
-import { map, clone } from 'lodash';
+import { clone, map } from 'lodash';
 
-import { QueryPartDef, QueryPart, functionRenderer, suffixRenderer } from 'app/features/alerting/state/query_part';
+import { functionRenderer, QueryPart, QueryPartDef, suffixRenderer } from 'app/features/alerting/state/query_part';
 
 const index: any[] = [];
 const categories: any = {
@@ -33,7 +33,7 @@ function aliasRenderer(part: { params: string[] }, innerExpr: string) {
   return innerExpr + ' AS ' + '"' + part.params[0] + '"';
 }
 
-function fieldRenderer(part: { params: string[] }, innerExpr: any) {
+function fieldRenderer(part: { params: string[] }) {
   const param = part.params[0];
 
   if (param === '*') {

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -354,6 +354,9 @@ describe('InfluxDataSource', () => {
           interpolationVar: { text: text, value: text },
           interpolationVar2: { text: 'interpolationText2', value: 'interpolationText2' },
         });
+        if (!query.tags?.length) {
+          throw new Error('Tags are not defined');
+        }
         const value = query.tags[0].value;
         const scopedVars = 'interpolationText|interpolationText2';
         expect(value).toBe(scopedVars);

--- a/public/app/plugins/datasource/influxdb/specs/mocks.ts
+++ b/public/app/plugins/datasource/influxdb/specs/mocks.ts
@@ -15,8 +15,8 @@ export const templateSrvStub = {
   replace: replaceMock,
 } as unknown as TemplateSrv;
 
-export function mockBackendService(response: any) {
-  const fetchMock = jest.fn().mockReturnValue(of(response as FetchResponse));
+export function mockBackendService(response: FetchResponse) {
+  const fetchMock = jest.fn().mockReturnValue(of(response));
   const origBackendSrv = getBackendSrv();
   setBackendSrv({
     ...origBackendSrv,

--- a/public/app/plugins/datasource/influxdb/types.ts
+++ b/public/app/plugins/datasource/influxdb/types.ts
@@ -19,6 +19,14 @@ export interface InfluxOptions extends DataSourceJsonData {
   maxSeries?: number;
 }
 
+/**
+ * @deprecated
+ */
+export interface InfluxOptionsV1 extends InfluxOptions {
+  user?: string;
+  database?: string;
+}
+
 export interface InfluxSecureJsonData {
   // For Flux
   token?: string;


### PR DESCRIPTION
**What is this feature?**

Defining more types instead of `any`
Based on @gtk-grafana 's work here: https://github.com/grafana/grafana/pull/70025



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
