### PR TITLE
Chore: Remove pfs.GrafanaPlugin from schemas

### DIFF
--- a/.github/workflows/scripts/kinds/verify-kinds.go
+++ b/.github/workflows/scripts/kinds/verify-kinds.go
@@ -85,12 +85,6 @@ func main() {
 	}
 
 	for _, pp := range corelist.New(nil) {
-		// ElasticSearch composable kind causes the CUE evaluator to hand
-		// see https://github.com/grafana/grafana/pull/68034#discussion_r1187800059
-		if pp.Properties.Id == "elasticsearch" {
-			continue
-		}
-
 		for _, kind := range pp.ComposableKinds {
 			if len(kindArgs) > 0 && !contains(kindArgs, kind.Name()) {
 				continue

--- a/pkg/plugins/pfs/pfs.go
+++ b/pkg/plugins/pfs/pfs.go
@@ -196,13 +196,7 @@ func ParsePluginFS(fsys fs.FS, rt *thema.Runtime) (ParsedPlugin, error) {
 	})
 	bi.Files = append(bi.Files, f)
 
-	gpi := ctx.BuildInstance(bi)
-	// Temporary hack while we figure out what in the elasticsearch lineage turns
-	// this into an endless loop in thema, and why unifying twice is anything other
-	// than a total no-op.
-	if pp.Properties.Id != "elasticsearch" {
-		gpi = gpi.Unify(gpv)
-	}
+	gpi := ctx.BuildInstance(bi).Unify(gpv)
 	if gpi.Err() != nil {
 		return ParsedPlugin{}, errors.Wrap(errors.Promote(ErrInvalidGrafanaPluginInstance, pp.Properties.Id), gpi.Err())
 	}

--- a/public/app/plugins/datasource/azuremonitor/dataquery.cue
+++ b/public/app/plugins/datasource/azuremonitor/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	common "github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "merged"

--- a/public/app/plugins/datasource/cloud-monitoring/dataquery.cue
+++ b/public/app/plugins/datasource/cloud-monitoring/dataquery.cue
@@ -16,10 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "merged"

--- a/public/app/plugins/datasource/cloudwatch/dataquery.cue
+++ b/public/app/plugins/datasource/cloudwatch/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	common "github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/elasticsearch/dataquery.cue
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/loki/dataquery.cue
+++ b/public/app/plugins/datasource/loki/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/parca/dataquery.cue
+++ b/public/app/plugins/datasource/parca/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/prometheus/dataquery.cue
+++ b/public/app/plugins/datasource/prometheus/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	common "github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/tempo/dataquery.cue
+++ b/public/app/plugins/datasource/tempo/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/datasource/testdata/dataquery.cue
+++ b/public/app/plugins/datasource/testdata/dataquery.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
 	maturity: "experimental"

--- a/public/app/plugins/panel/debug/panelcfg.cue
+++ b/public/app/plugins/panel/debug/panelcfg.cue
@@ -14,14 +14,6 @@
 
 package grafanaplugin
 
-import (
-	// "github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
-)
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
-
 composableKinds: PanelCfg: {
 	maturity: "experimental"
 

--- a/public/app/plugins/panel/xychart/panelcfg.cue
+++ b/public/app/plugins/panel/xychart/panelcfg.cue
@@ -16,11 +16,7 @@ package grafanaplugin
 
 import (
 	"github.com/grafana/grafana/packages/grafana-schema/src/common"
-	"github.com/grafana/grafana/pkg/plugins/pfs"
 )
-
-// This file (with its sibling .cue files) implements pfs.GrafanaPlugin
-pfs.GrafanaPlugin
 
 composableKinds: PanelCfg: {
 	maturity: "experimental"


### PR DESCRIPTION
Looks like that we were unifying `pfs.GrafanaPlugin` twice. One in the schemas and other one in this [line](public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.gen.ts), making the generation slower.

`elasticsearch` unify works again since [this thema change](https://github.com/grafana/thema/pull/177)