### PR TITLE
Frontend: Select component investigation PoC/hack

### DIFF
--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -47,12 +47,16 @@ export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | stri
   return useMemo(() => {
     return {
       ...resetSelectStyles(theme),
-      menuPortal: (base: any) => {
+      menuPortal: ({ left, top, bottom, position }: any) => {
+        console.log('menuPortal', { top, bottom, position, left });
+        // debugger;
         // Would like to correct top position when menu is placed bottom, but have props are not sent to this style function.
         // Only state is. https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Menu.tsx#L605
         return {
-          ...base,
-          zIndex: theme.zIndex.portal,
+          top,
+          position,
+          minWidth: '100%',
+          zIndex: theme.zIndex.dropdown,
         };
       },
       //These are required for the menu positioning to function


### PR DESCRIPTION
NOT TO BE MERGED, this is just demonstrating that safari keeps changing the left offset in the styles causing a re-render which is crashing dropdowns for Safari users in g10