### PR TITLE
Administration: Feature toggle for feature toggle admin page

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -127,6 +127,7 @@ Experimental features might be changed or removed without prior notice.
 | `mlExpressions`                             | Enable support for Machine Learning in server-side expressions                                               |
 | `disableTraceQLStreaming`                   | Disables the option to stream the response of TraceQL queries of the Tempo data source                       |
 | `grafanaAPIServer`                          | Enable Kubernetes API Server for Grafana resources                                                           |
+| `featureToggleAdminPage`                    | Enable admin page for managing feature toggles from the Grafana front-end                                    |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -114,4 +114,5 @@ export interface FeatureToggles {
   mlExpressions?: boolean;
   disableTraceQLStreaming?: boolean;
   grafanaAPIServer?: boolean;
+  featureToggleAdminPage?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -654,5 +654,13 @@ var (
 			FrontendOnly: false,
 			Owner:        grafanaAppPlatformSquad,
 		},
+		{
+			Name:            "featureToggleAdminPage",
+			Description:     "Enable admin page for managing feature toggles from the Grafana front-end",
+			Stage:           FeatureStageExperimental,
+			FrontendOnly:    false,
+			Owner:           grafanaOperatorExperienceSquad,
+			RequiresRestart: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -95,3 +95,4 @@ transformationsRedesign,experimental,@grafana/observability-metrics,false,false,
 mlExpressions,experimental,@grafana/alerting-squad,false,false,false,false
 disableTraceQLStreaming,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
 grafanaAPIServer,experimental,@grafana/grafana-app-platform-squad,false,false,false,false
+featureToggleAdminPage,experimental,@grafana/grafana-operator-experience-squad,false,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -390,4 +390,8 @@ const (
 	// FlagGrafanaAPIServer
 	// Enable Kubernetes API Server for Grafana resources
 	FlagGrafanaAPIServer = "grafanaAPIServer"
+
+	// FlagFeatureToggleAdminPage
+	// Enable admin page for managing feature toggles from the Grafana front-end
+	FlagFeatureToggleAdminPage = "featureToggleAdminPage"
 )


### PR DESCRIPTION
**What is this feature?**

This is a feature toggle to enable the feature toggle admin page in the Grafana frontend.

**Why do we need this feature?**

So we can safely develop the new feature toggle admin page without affecting users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71590

**Special notes for your reviewer:**

[FRR](https://docs.google.com/document/d/1RklGLWciDLYvR4jekf-GmnCXBIpkjg1DQjZKYzkCJ-8)

