### PR TITLE
FolderPicker interaction reporting

### DIFF
--- a/public/app/core/components/Select/OldFolderPicker.tsx
+++ b/public/app/core/components/Select/OldFolderPicker.tsx
@@ -97,7 +97,7 @@ export function OldFolderPicker(props: Props) {
       const resultsAfterMapAndFilter = mapSearchHitsToOptions(searchHits, filter);
       const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter;
 
-      reportInteraction('folder_picker_search_results_loaded', {
+      reportInteraction('grafana_folder_picker_results_loaded', {
         results: options.length,
         searchTermLength: query.length,
         enableCreateNew: Boolean(enableCreateNew),

--- a/public/app/core/components/Select/OldFolderPicker.tsx
+++ b/public/app/core/components/Select/OldFolderPicker.tsx
@@ -5,7 +5,7 @@ import { useAsync } from 'react-use';
 
 import { AppEvents, SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { useStyles2, ActionMeta, Input, InputActionMeta, AsyncVirtualizedSelect } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
@@ -55,6 +55,7 @@ export interface Props {
   /** The id of the search input. Use this to set a matching label with htmlFor */
   inputId?: string;
 }
+
 export type SelectedFolder = SelectableValue<string>;
 const VALUE_FOR_ADD = '-10';
 
@@ -95,6 +96,12 @@ export function OldFolderPicker(props: Props) {
       const searchHits = await searchFolders(query, permissionLevel, searchQueryType);
       const resultsAfterMapAndFilter = mapSearchHitsToOptions(searchHits, filter);
       const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter;
+
+      reportInteraction('folder_picker_search_results_loaded', {
+        results: options.length,
+        searchTermLength: query.length,
+        enableCreateNew: Boolean(enableCreateNew),
+      });
 
       const hasAccess =
         contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor) ||
@@ -224,18 +231,22 @@ export function OldFolderPicker(props: Props) {
   const createNewFolder = useCallback(
     async (folderName: string) => {
       if (folderWarning?.warningCondition(folderName)) {
+        reportInteraction('grafana_folder_picker_folder_created', { status: 'failed_condition' });
         return false;
       }
+
       const newFolder = await createFolder({ title: folderName });
       let folder: SelectableValue<string> = { value: '', label: 'Not created' };
 
       if (newFolder.uid) {
+        reportInteraction('grafana_folder_picker_folder_created', { status: 'success' });
         appEvents.emit(AppEvents.alertSuccess, ['Folder Created', 'OK']);
         folder = { value: newFolder.uid, label: newFolder.title };
 
         setFolder(newFolder);
         onFolderChange(folder, { action: 'create-option', option: folder });
       } else {
+        reportInteraction('grafana_folder_picker_folder_created', { status: 'failed' });
         appEvents.emit(AppEvents.alertError, ['Folder could not be created']);
       }
 
@@ -311,7 +322,6 @@ export function OldFolderPicker(props: Props) {
         <FolderWarningWhenCreating />
         <div className={styles.newFolder}>Press enter to create the new folder.</div>
         <Input
-          aria-label={'aria-label'}
           width={30}
           autoFocus={true}
           value={newFolderValue}


### PR DESCRIPTION
**What is this feature?**

Adds some interaction reporting (analytics) to FolderPicker. Specifically, the following events are reported:

 - `grafana_folder_picker_results_loaded` sent when the picker is opened and results are loaded. It is also triggered on the initial open. With the properties:
    - `results`: the number of folders returned
    - `searchTermLength`: the number of characters in the search term. Will be 0 for the initial load of the folder picker
    - `enableCreateNew`: boolean for whether the folder picker has been configured to enable users to create new users
 - `grafana_folder_picker_folder_created` sent for various events when user creates a folder, with properties
    - `status: 'failed_condition'`: when the consumer prevents the folder from being created. Only used by alerting to check the name of the folder
    - `status: 'success'`: when the folder was successfully created
    - `status: 'failed'`: when the folder failed to create for whatever unspecified reason

I think that's the only useful interactions to measure? Any other suggestions?

I think we can use the page url property that's automatically sent to determine where the folder picker is used if we want to drill into the data more.

**Why do we need this feature?**

To better understand how folder picker is used

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65745

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
