### PR TITLE
WIP: rework of PR 70954

### DIFF
--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -51,35 +51,6 @@ describe('logParser', () => {
       expect(fields.find((field) => field.keys[0] === 'labels')).not.toBe(undefined);
     });
 
-    it('should not filter out field with labels name and other type and datalinks', () => {
-      const logRow = createLogRow({
-        entryFieldIndex: 10,
-        dataFrame: new MutableDataFrame({
-          refId: 'A',
-          fields: [
-            testLineField,
-            testStringField,
-            {
-              name: 'labels',
-              type: FieldType.other,
-              config: {
-                links: [
-                  {
-                    title: 'test1',
-                    url: 'url1',
-                  },
-                ],
-              },
-              values: [{ place: 'luna', source: 'data' }],
-            },
-          ],
-        }),
-      });
-      const fields = getAllFields(logRow);
-      expect(fields.length).toBe(2);
-      expect(fields.find((field) => field.keys[0] === 'labels')).not.toBe(undefined);
-    });
-
     it('should filter out field with id name', () => {
       const logRow = createLogRow({
         entryFieldIndex: 10,

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -86,23 +86,6 @@ export const getDataframeFields = memoizeOne(
 );
 
 function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
-  // field that has empty value (we want to keep 0 or empty string)
-  if (field.values[row.rowIndex] == null) {
-    return true;
-  }
-
-  // hidden field, remove
-  if (field.config.custom?.hidden) {
-    return true;
-  }
-
-  // field with data-links, keep
-  if ((field.config.links ?? []).length > 0) {
-    return false;
-  }
-
-  // the remaining checks use knowledge of how we parse logs-dataframes
-
   // Remove field if it is:
   // "labels" field that is in Loki used to store all labels
   if (field.name === 'labels' && field.type === FieldType.other) {
@@ -127,5 +110,13 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
     return true;
   }
 
+  // hidden field
+  if (field.config.custom?.hidden) {
+    return true;
+  }
+  // field that has empty value (we want to keep 0 or empty string)
+  if (field.values[row.rowIndex] == null) {
+    return true;
+  }
   return false;
 }


### PR DESCRIPTION
the fix in https://github.com/grafana/grafana/pull/70901 got backported into v10.0.x in https://github.com/grafana/grafana/pull/70954 .

but the fix also attempted to cleanup the code, which is fine for the main-branch merge, but probably not good for a backport-PR.

what this PR does is:
- reverts the changes to `logParser.ts`
- applies a more minimal bug-fix to `logParser.ts`
- keeps most of the unit-test-changes from main, so that they still verify that the bug-fix works


the diff in this PR does not show the intent well, but if you run this:
```
git diff v10.0.2 origin/gabor/rework-70954 -- public/app/features/logs/components/logParser.ts
```

so, we want to see the changes to `logParser.ts` between the tag `v10.0.2` (previous release), and the-branch-of-this-PR, it shows this output:
```diff
diff --git a/public/app/features/logs/components/logParser.ts b/public/app/features/logs/components/logParser.ts
index 5950bb14c2..f2ec40fba0 100644
--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -1,6 +1,7 @@
 import memoizeOne from 'memoize-one';

 import { DataFrame, Field, FieldType, LinkModel, LogRowModel } from '@grafana/data';
+import { safeStringifyValue } from 'app/core/utils/explore';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';

 export type FieldDef = {
@@ -69,9 +70,14 @@ export const getDataframeFields = memoizeOne(
       .filter((field, index) => !shouldRemoveField(field, index, row))
       .map((field) => {
         const links = getFieldLinks ? getFieldLinks(field, row.rowIndex, row.dataFrame) : [];
+        const fieldVal = field.values[row.rowIndex];
+        const outputVal =
+          typeof fieldVal === 'string' || typeof fieldVal === 'number'
+            ? fieldVal.toString()
+            : safeStringifyValue(fieldVal);
         return {
           keys: [field.name],
-          values: [field.values[row.rowIndex].toString()],
+          values: [outputVal],
           links: links,
           fieldIndex: field.index,
         };
@@ -97,6 +103,13 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   ) {
     return true;
   }
+
+  // first string-field is the log-line
+  const firstStringFieldIndex = row.dataFrame.fields.findIndex((f) => f.type === FieldType.string);
+  if (firstStringFieldIndex === index) {
+    return true;
+  }
+
   // hidden field
   if (field.config.custom?.hidden) {
     return true;
```

(i do not know how to make a github link that shows this 😄 )