### PR TITLE
[v9.2.x] Bug: Compare `semver` digits for frontend packages config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,6 +244,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.23
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/armon/go-radix v1.0.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/blugelabs/bluge v0.1.9
 	github.com/blugelabs/bluge_segment_api v0.2.0
 	github.com/dlmiddlecote/sqlstats v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -437,7 +437,9 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=
 github.com/blevesearch/go-porterstemmer v1.0.3/go.mod h1:angGc5Ht+k2xhJdZi511LtmxuEf0OVpvUUNrwmM1P7M=

--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
 )
@@ -22,7 +23,16 @@ func GetConfig(c *cli.Context, metadata config.Metadata) (config.Config, config.
 		if err != nil {
 			return config.Config{}, "", err
 		}
-		if metadata.GrafanaVersion != packageJSONVersion {
+		semverGrafanaVersion, err := semver.Parse(metadata.GrafanaVersion)
+		if err != nil {
+			return config.Config{}, "", err
+		}
+		semverPackageJSONVersion, err := semver.Parse(packageJSONVersion)
+		if err != nil {
+			return config.Config{}, "", err
+		}
+		// Check if the semver digits of the tag are not equal
+		if semverGrafanaVersion.FinalizeVersion() != semverPackageJSONVersion.FinalizeVersion() {
 			return config.Config{}, "", cli.Exit(fmt.Errorf("package.json version and input tag version differ %s != %s.\nPlease update package.json", packageJSONVersion, metadata.GrafanaVersion), 1)
 		}
 	}

--- a/pkg/build/frontend/config_test.go
+++ b/pkg/build/frontend/config_test.go
@@ -3,7 +3,6 @@ package frontend
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"os"
 	"testing"
 
@@ -41,6 +40,13 @@ func TestGetConfig(t *testing.T) {
 		},
 		{
 			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, "", flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
+			name:               "custom tag, package.json doesn't match",
+			packageJsonVersion: "10.0.0",
+			metadata:           config.Metadata{GrafanaVersion: "10.0.0-abcd123pre", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},
+			wantErr:            false,
+		},
+		{
+			ctx:                cli.NewContext(app, setFlags(t, jobs, githubToken, "", flag.NewFlagSet("flagSet", flag.ContinueOnError)), nil),
 			name:               "package.json doesn't match tag",
 			packageJsonVersion: "10.1.0",
 			metadata:           config.Metadata{GrafanaVersion: "10.0.0", ReleaseMode: config.ReleaseMode{Mode: config.TagMode}},
@@ -68,7 +74,6 @@ func TestGetConfig(t *testing.T) {
 
 			got, _, err := GetConfig(tt.ctx, tt.metadata)
 			if !tt.wantErr {
-				fmt.Println(got.PackageVersion + " : " + tt.metadata.GrafanaVersion)
 				require.Equal(t, got.PackageVersion, tt.metadata.GrafanaVersion)
 			}
 


### PR DESCRIPTION
Backport 5f8ace33fb99dc375cb2bce697d5540e5812b469 from #71829

---

**What is this feature?**

For tag events, we compare frontend packages version taken from `package.json` with the `DRONE_TAG`. We want those two versions to be identical in order no to build the wrong frontend packages for the wrong release.
For custom releases (releases with a prerelease suffix) we only want to check the semver digits since we don't publish frontend packages for custom releases.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
