### PR TITLE
Chore: Bump devenv postgres blocks version to 11.20

### DIFF
--- a/devenv/docker/blocks/postgres/.env
+++ b/devenv/docker/blocks/postgres/.env
@@ -1,1 +1,1 @@
-postgres_version=10.15
+postgres_version=11.20

--- a/devenv/docker/blocks/postgres_tests/.env
+++ b/devenv/docker/blocks/postgres_tests/.env
@@ -1,1 +1,1 @@
-postgres_version=10.15
+postgres_version=11.20

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,4 +1,4 @@
-ARG postgres_version=10.15
+ARG postgres_version=11.20
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/


### PR DESCRIPTION
The lowest supported postgres version is 11.20 (previous 10.23 is unsupported since November 2022). Since PostgreSQL 11 has a new LLVM JIT built-in it might result in better performance. So, let's upgrade!