### PR TITLE
Revert "Tooltip: Set tooltip of active panel to front of zIndex"

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useMountedState } from 'react-use';
 import uPlot from 'uplot';
@@ -13,12 +12,11 @@ import {
   formattedValueToString,
   getDisplayProcessor,
   getFieldDisplayName,
-  GrafanaTheme2,
   TimeZone,
 } from '@grafana/data';
 import { TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
-import { useStyles2, useTheme2 } from '../../../themes/ThemeContext';
+import { useTheme2 } from '../../../themes/ThemeContext';
 import { Portal } from '../../Portal/Portal';
 import { SeriesTable, SeriesTableRowProps, VizTooltipContainer } from '../../VizTooltip';
 import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
@@ -274,10 +272,8 @@ export const TooltipPlugin = ({
     tooltip = renderTooltip(otherProps.data, focusedSeriesIdx, focusedPointIdx);
   }
 
-  const style = useStyles2(getStyles);
-
   return (
-    <Portal className={isActive ? style.tooltipWrapper : undefined}>
+    <Portal>
       {tooltip && coords && (
         <VizTooltipContainer position={{ x: coords.x, y: coords.y }} offset={{ x: TOOLTIP_OFFSET, y: TOOLTIP_OFFSET }}>
           {tooltip}
@@ -325,9 +321,3 @@ export function positionTooltip(u: uPlot, bbox: DOMRect) {
 
   return { x, y };
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  tooltipWrapper: css`
-    z-index: ${theme.zIndex.portal + 1} !important;
-  `,
-});


### PR DESCRIPTION
Reverts grafana/grafana#70747

Slight break of build using emotion CSS string literals rather than object syntax.