### PR TITLE
Alerting: Sort NumberCaptureValues in EvaluationString

### DIFF
--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -43,20 +44,20 @@ func extractEvalString(frame *data.Frame) (s string) {
 	}
 
 	if captures, ok := frame.Meta.Custom.([]NumberValueCapture); ok {
+		// Sort captures in ascending order of "Var" so we can assert in tests
+		sort.Slice(captures, func(i, j int) bool {
+			return captures[i].Var < captures[j].Var
+		})
 		sb := strings.Builder{}
-
 		for i, capture := range captures {
 			sb.WriteString("[ ")
 			sb.WriteString(fmt.Sprintf("var='%s' ", capture.Var))
 			sb.WriteString(fmt.Sprintf("labels={%s} ", capture.Labels))
-
 			valString := "null"
 			if capture.Value != nil {
 				valString = fmt.Sprintf("%v", *capture.Value)
 			}
-
 			sb.WriteString(fmt.Sprintf("value=%v ", valString))
-
 			sb.WriteString("]")
 			if i < len(captures)-1 {
 				sb.WriteString(", ")
@@ -64,7 +65,6 @@ func extractEvalString(frame *data.Frame) (s string) {
 		}
 		return sb.String()
 	}
-
 	return ""
 }
 

--- a/pkg/services/ngalert/eval/extract_md_test.go
+++ b/pkg/services/ngalert/eval/extract_md_test.go
@@ -40,6 +40,14 @@ func TestExtractEvalString(t *testing.T) {
 			}, util.Pointer(1.0), withRefID("A")),
 			outString: `[ var='A0' metric='Test' labels={host=foo} value=32.3 ], [ var='A1' metric='Test' labels={host=baz} value=10 ], [ var='A2' metric='TestA' labels={host=zip} value=11 ]`,
 		},
+		{
+			desc: "Captures are sorted in ascending order of var",
+			inFrame: newMetaFrame([]NumberValueCapture{
+				{Var: "B", Labels: data.Labels{"host": "foo"}, Value: util.Pointer(1.0)},
+				{Var: "A", Labels: data.Labels{"host": "foo"}, Value: util.Pointer(10.0)},
+			}, util.Pointer(1.0)),
+			outString: `[ var='A' labels={host=foo} value=10 ], [ var='B' labels={host=foo} value=1 ]`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This commit changes extractEvalString to sort NumberCaptureValues in ascending order of Var before building the output string. This means that users will see EvaluationString in a consistent order, but also make it possible to assert its output in tests.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
