### PR TITLE
Allow to pass a blob to core fetch function

### DIFF
--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -92,15 +92,16 @@ describe('isContentTypeApplicationJson', () => {
 
 describe('parseBody', () => {
   it.each`
-    options                  | isAppJson | expected
-    ${undefined}             | ${false}  | ${undefined}
-    ${undefined}             | ${true}   | ${undefined}
-    ${{ data: undefined }}   | ${false}  | ${undefined}
-    ${{ data: undefined }}   | ${true}   | ${undefined}
-    ${{ data: 'some data' }} | ${false}  | ${'some data'}
-    ${{ data: 'some data' }} | ${true}   | ${'some data'}
-    ${{ data: { id: '0' } }} | ${false}  | ${new URLSearchParams({ id: '0' })}
-    ${{ data: { id: '0' } }} | ${true}   | ${'{"id":"0"}'}
+    options                                         | isAppJson | expected
+    ${undefined}                                    | ${false}  | ${undefined}
+    ${undefined}                                    | ${true}   | ${undefined}
+    ${{ data: undefined }}                          | ${false}  | ${undefined}
+    ${{ data: undefined }}                          | ${true}   | ${undefined}
+    ${{ data: 'some data' }}                        | ${false}  | ${'some data'}
+    ${{ data: 'some data' }}                        | ${true}   | ${'some data'}
+    ${{ data: { id: '0' } }}                        | ${false}  | ${new URLSearchParams({ id: '0' })}
+    ${{ data: { id: '0' } }}                        | ${true}   | ${'{"id":"0"}'}
+    ${{ data: new Blob([new Uint8Array([1, 1])]) }} | ${false}  | ${new Blob([new Uint8Array([1, 1])])}
   `(
     "when called with options: '$options' and isAppJson: '$isAppJson' then the result should be '$expected'",
     ({ options, isAppJson, expected }) => {

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,4 +1,3 @@
-import { Blob } from 'buffer';
 import { omitBy } from 'lodash';
 
 import { deprecationWarning } from '@grafana/data';
@@ -90,7 +89,7 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
   if (!options.data || typeof options.data === 'string') {
     return options.data;
   }
-  if (options.data.constructor.name === 'Blob') {
+  if (options.data instanceof Blob) {
     return options.data;
   }
 

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,3 +1,4 @@
+import { Blob } from 'buffer';
 import { omitBy } from 'lodash';
 
 import { deprecationWarning } from '@grafana/data';
@@ -87,6 +88,9 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
   }
 
   if (!options.data || typeof options.data === 'string') {
+    return options.data;
+  }
+  if (options.data.constructor.name === 'Blob') {
     return options.data;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This allows to pass a Blob and not try to parse it when using the core fetch function which is used by plugins when communicating with backend service.

**Why do we need this feature?**

I have feature that needs to send protobuf encoded data and this is blocking.

**Who is this feature for?**

Mostly for developer using fetch.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
