### PR TITLE
Grafana-ui: always apply target='_blank' and rel='noreferrer' on TextLink

### DIFF
--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -53,7 +53,7 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
     const externalIcon = icon || 'external-link-alt';
 
     return external ? (
-      <a href={validUrl} ref={ref} target="_blank" rel="noreferrer" {...rest} className={styles}>
+      <a href={validUrl} ref={ref} {...rest} target="_blank" rel="noreferrer" className={styles}>
         {children}
         <Icon size={svgSizes[variant] || 'md'} name={externalIcon} />
       </a>


### PR DESCRIPTION
**What is this feature?**

Reorders the props to always override `target` and `rel` with the right values, even if the user set an specific value for any of them.

**Why do we need this feature?**

To avoid users overriding the values of `target` and `rel`.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

Fixes #

Related to this [TextLink comment](https://github.com/grafana/grafana/pull/69330#discussion_r1267752344).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
