### PR TITLE
logs: log-details: handle dataplane-compliant dataframes

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -667,7 +667,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
               <div className={styles.logRows} data-testid="logRowsTable">
                 {/* Width should be full width minus logsnavigation and padding */}
                 <LogsTable
-                  rows={logRows}
                   logsSortOrder={this.state.logsSortOrder}
                   range={this.props.range}
                   splitOpen={this.props.splitOpen}

--- a/public/app/features/explore/Logs/LogsTable.test.tsx
+++ b/public/app/features/explore/Logs/LogsTable.test.tsx
@@ -1,15 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 
-import {
-  FieldType,
-  LogLevel,
-  LogRowModel,
-  LogsSortOrder,
-  MutableDataFrame,
-  standardTransformersRegistry,
-  toUtc,
-} from '@grafana/data';
+import { FieldType, LogRowModel, LogsSortOrder, standardTransformersRegistry, toUtc } from '@grafana/data';
 import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
 import { config } from '@grafana/runtime';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
@@ -68,7 +60,6 @@ describe('LogsTable', () => {
     };
     return (
       <LogsTable
-        rows={[makeLog({})]}
         logsSortOrder={LogsSortOrder.Descending}
         splitOpen={() => undefined}
         timeZone={'utc'}
@@ -140,26 +131,3 @@ describe('LogsTable', () => {
     });
   });
 });
-
-const makeLog = (overrides: Partial<LogRowModel>): LogRowModel => {
-  const uid = overrides.uid || '1';
-  const entry = `log message ${uid}`;
-  return {
-    uid,
-    entryFieldIndex: 0,
-    rowIndex: 0,
-    dataFrame: new MutableDataFrame(),
-    logLevel: LogLevel.debug,
-    entry,
-    hasAnsi: false,
-    hasUnescapedContent: false,
-    labels: {},
-    raw: entry,
-    timeFromNow: '',
-    timeEpochMs: 1,
-    timeEpochNs: '1000000',
-    timeLocal: '',
-    timeUtc: '',
-    ...overrides,
-  };
-};

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -6,7 +6,6 @@ import {
   applyFieldOverrides,
   DataFrame,
   Field,
-  LogRowModel,
   LogsSortOrder,
   sortDataFrame,
   SplitOpen,
@@ -16,7 +15,7 @@ import {
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Table } from '@grafana/ui';
-import { shouldRemoveField } from 'app/features/logs/components/logParser';
+import { separateVisibleFields } from 'app/features/logs/components/logParser';
 import { parseLogsFrame } from 'app/features/logs/logsFrame';
 
 import { getFieldLinksForExplore } from '../utils/links';
@@ -28,7 +27,6 @@ interface Props {
   splitOpen: SplitOpen;
   range: TimeRange;
   logsSortOrder: LogsSortOrder;
-  rows: LogRowModel[];
 }
 
 const getTableHeight = memoizeOne((dataFrames: DataFrame[] | undefined) => {
@@ -40,7 +38,7 @@ const getTableHeight = memoizeOne((dataFrames: DataFrame[] | undefined) => {
 });
 
 export const LogsTable: React.FunctionComponent<Props> = (props) => {
-  const { timeZone, splitOpen, range, logsSortOrder, width, logsFrames, rows } = props;
+  const { timeZone, splitOpen, range, logsSortOrder, width, logsFrames } = props;
 
   const [tableFrame, setTableFrame] = useState<DataFrame | undefined>(undefined);
 
@@ -129,18 +127,17 @@ export const LogsTable: React.FunctionComponent<Props> = (props) => {
         });
 
       // remove fields that should not be displayed
-      dataFrame.fields.forEach((field: Field, index: number) => {
-        const row = rows[0]; // we just take the first row as the relevant row
-        if (shouldRemoveField(field, index, row, false, false)) {
-          transformations.push({
-            id: 'organize',
-            options: {
-              excludeByName: {
-                [field.name]: true,
-              },
+
+      const hiddenFields = separateVisibleFields(dataFrame, { keepBody: true, keepTimestamp: true }).hidden;
+      hiddenFields.forEach((field: Field, index: number) => {
+        transformations.push({
+          id: 'organize',
+          options: {
+            excludeByName: {
+              [field.name]: true,
             },
-          });
-        }
+          },
+        });
       });
       if (transformations.length > 0) {
         const [transformedDataFrame] = await lastValueFrom(transformDataFrame(transformations, [dataFrame]));
@@ -150,7 +147,7 @@ export const LogsTable: React.FunctionComponent<Props> = (props) => {
       }
     };
     prepare();
-  }, [prepareTableFrame, logsFrames, logsSortOrder, rows]);
+  }, [prepareTableFrame, logsFrames, logsSortOrder]);
 
   if (!tableFrame) {
     return null;

--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -1,4 +1,4 @@
-import { FieldType, MutableDataFrame } from '@grafana/data';
+import { DataFrame, DataFrameType, Field, FieldType, LogRowModel, MutableDataFrame } from '@grafana/data';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
 import { createLogRow } from './__mocks__/logRow';
@@ -198,6 +198,211 @@ describe('logParser', () => {
       const fields = getAllFields(logRow);
       expect(fields.length).toBe(1);
       expect(fields.find((field) => field.keys[0] === testStringField.name)).not.toBe(undefined);
+    });
+
+    describe('dataplane frames', () => {
+      const makeLogRow = (fields: Field[], entryFieldIndex: number): LogRowModel =>
+        createLogRow({
+          entryFieldIndex,
+          rowIndex: 0,
+          dataFrame: {
+            refId: 'A',
+            fields,
+            length: fields[0]?.values.length,
+            meta: {
+              type: DataFrameType.LogLines,
+            },
+          },
+        });
+
+      const expectHasField = (defs: FieldDef[], name: string): void => {
+        expect(defs.find((field) => field.keys[0] === name)).not.toBe(undefined);
+      };
+
+      it('should filter out fields with data links that have a nullish value', () => {
+        const createScenario = (value: unknown) =>
+          makeLogRow(
+            [
+              testTimeField,
+              testLineField,
+              {
+                name: 'link',
+                type: FieldType.string,
+                config: {
+                  links: [
+                    {
+                      title: 'link1',
+                      url: 'https://example.com',
+                    },
+                  ],
+                },
+                values: [value],
+              },
+            ],
+            1
+          );
+
+        expect(getAllFields(createScenario(null))).toHaveLength(0);
+        expect(getAllFields(createScenario(undefined))).toHaveLength(0);
+        expect(getAllFields(createScenario(''))).toHaveLength(1);
+        expect(getAllFields(createScenario('test'))).toHaveLength(1);
+        // technically this is a field-type-string, but i will add more
+        // falsy-values, just to be sure
+        expect(getAllFields(createScenario(false))).toHaveLength(1);
+        expect(getAllFields(createScenario(NaN))).toHaveLength(1);
+        expect(getAllFields(createScenario(0))).toHaveLength(1);
+        expect(getAllFields(createScenario(-0))).toHaveLength(1);
+      });
+
+      it('should filter out system-fields without data-links, but should keep severity', () => {
+        const row = makeLogRow(
+          [
+            testTimeField,
+            testLineField,
+            {
+              config: {},
+              name: 'id',
+              type: FieldType.string,
+              values: ['id1'],
+            },
+            {
+              config: {},
+              name: 'attributes',
+              type: FieldType.other,
+              values: [{ a: 1, b: 2 }],
+            },
+            {
+              config: {},
+              name: 'severity',
+              type: FieldType.string,
+              values: ['info'],
+            },
+            testStringField,
+          ],
+          1
+        );
+
+        const output = getAllFields(row);
+
+        expect(output).toHaveLength(2);
+        expectHasField(output, 'test_field_string');
+        expectHasField(output, 'severity');
+      });
+
+      it('should keep system fields with data-links', () => {
+        const links = [
+          {
+            title: 'link1',
+            url: 'https://example.com',
+          },
+        ];
+
+        const row = makeLogRow(
+          [
+            {
+              ...testTimeField,
+              config: { links },
+            },
+            {
+              ...testLineField,
+              config: { links },
+            },
+            {
+              config: { links },
+              name: 'id',
+              type: FieldType.string,
+              values: ['id1'],
+            },
+            {
+              config: { links },
+              name: 'attributes',
+              type: FieldType.other,
+              values: [{ a: 1, b: 2 }],
+            },
+            {
+              config: { links },
+              name: 'severity',
+              type: FieldType.string,
+              values: ['info'],
+            },
+          ],
+          1
+        );
+
+        const output = getAllFields(row);
+
+        expect(output).toHaveLength(5);
+        expectHasField(output, 'timestamp');
+        expectHasField(output, 'body');
+        expectHasField(output, 'id');
+        expectHasField(output, 'attributes');
+        expectHasField(output, 'severity');
+      });
+
+      it('should filter out config-hidden fields', () => {
+        const row = makeLogRow(
+          [
+            testTimeField,
+            testLineField,
+            {
+              ...testStringField,
+              config: {
+                custom: {
+                  hidden: true,
+                },
+              },
+            },
+          ],
+          1
+        );
+
+        const output = getAllFields(row);
+
+        expect(output).toHaveLength(0);
+      });
+
+      it('should filter out fields with null values', () => {
+        const row = makeLogRow(
+          [
+            testTimeField,
+            testLineField,
+            {
+              // null-value
+              config: {},
+              type: FieldType.string,
+              name: 'test1',
+              values: [null],
+            },
+            {
+              // null-value and data-link
+              config: {
+                links: [
+                  {
+                    title: 'link1',
+                    url: 'https://example.com',
+                  },
+                ],
+              },
+              type: FieldType.string,
+              name: 'test2',
+              values: [null],
+            },
+            {
+              // normal value
+              config: {},
+              type: FieldType.string,
+              name: 'test3',
+              values: ['testvalue'],
+            },
+          ],
+          1
+        );
+
+        const output = getAllFields(row);
+
+        expect(output).toHaveLength(1);
+        expectHasField(output, 'test3');
+      });
     });
   });
 

--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -1,4 +1,4 @@
-import { DataFrame, DataFrameType, Field, FieldType, LogRowModel, MutableDataFrame } from '@grafana/data';
+import { DataFrameType, Field, FieldType, LogRowModel, MutableDataFrame } from '@grafana/data';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
 import { createLogRow } from './__mocks__/logRow';


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/71029)

in the logs-visualization, when you open a log-row, we show details there... the things that get shown there are:
1. all the "labels"
2. any dataframe-fields that were not "consumed" by the logs-visualization (so, we do not show the `id` field, or the nanosecond-timestamp (`tsNs`) field etc.)


[2] is calculated in `logParser.ts`.

previously, it calculated this by "knowing" what to look for, so, for example, it looked for the first field with type=time, which is the timestamp-field, and for the first field with type=stirng, which is the log-line-field, etc.

but with the dataplane-format, the fields are "found" in a slightly different way (every field is found by name). 
so we have to add extra `IF`s to `logParser.ts`.

but there is a different approach.  we already have code that finds all the logs-dataframe-fields, for both old-formats and new-formats. it's in `logsFrame.ts`.

so, in this PR, we simply as `logsFrame.ts` to parse the dataframe, and give us all the fields it does not know how to handle, and that can form the base for [2]. there are some extra steps needed (for example, we want to see the log-level field anyway etc.).

until now the function that did it, called `shouldRemoveField`, worked on a single field, so, for example, if the log-details needed to show 10 fields, it was called 10 times. this was not efficient, so now we have a new function named `separateVisibleFields`, that returns two arrays-of-fields, one is what should be shonw, and one is what should be hidden.
(log-details consumed the to-be-shown array, the experimental logs-table-mode consumes the to-be-hidden array).

(note: i'm not too happy with the name `separateVisibleFields`, if you have a better idea, please let me know 👍 )

additionally, `separateVisibleFields`, only performs checks on the fields globally. it does not do checks on the field's value in a specific log-row (the `is-nullish` check).. that is performed separately. this is needed because the `logs-table-mode` use-case does not want the `is-nullish` check when deciding what table-columns to hide)


how to test:
Loki:
1. make sure you have a running elastic, and a running loki database. something like `make devenv sources=elastic,loki` should do the trick
2. make sure you have the `logsExploreTableVisualisation` feature-flag enabled (this stays enabled during the whole test)
3. go to explore, make a loki query. open log-details:
    - verify that it looks normal
    - verify that it does not show "system" fields, like "id" or "labels"
5. switch to table-mode, and verify that the table contains the same fields as the log-details previously, except that it also has the timestamp-column and the log-line column
6. now enable the feature-flag `lokiLogsDataplane`.
7. go to explore, make a loki query. open log-details
    - verify that it looks normal
    - verify that it does not show "system" fields, like "id" or "attributes"
9. switch to table-mode, and verify that the table contains the same fields as the log-details previously, except that it also has the timestamp-column and the log-line column
10. you can turn off the `lokiLogsDataplane` feature toggle now

Elastic:
1. go to explore, make an elastic query. open log-details:
    - verify that it looks normal
    - verify that it show the `level` field
2. switch to table-mode, and verify that the table contains the same fields as the log-details previously, except that it also has the timestamp-column and the log-line column
