### PR TITLE
Alerting: New alert rule from explore

### DIFF
--- a/public/app/features/alerting/unified/components/explore/NewAlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/explore/NewAlertRuleForm.tsx
@@ -1,0 +1,86 @@
+import React, { type ReactElement, useEffect } from 'react';
+
+import { locationService, reportInteraction } from '@grafana/runtime';
+import { Alert, Button, Field, Form, Input, Modal } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { getExploreItemSelector } from 'app/features/explore/state/selectors';
+import { AccessControlAction, useSelector } from 'app/types';
+
+import { RuleFormValues } from '../../types/rule-form';
+import { exploreToRuleFormValues } from '../../utils/rule-form';
+import { createUrl } from '../../utils/url';
+
+type FormDTO = {
+  name: string;
+};
+
+function getNewAlertRuleURL(queryData: Partial<RuleFormValues>) {
+  const returnTo = window.location.href;
+  const defaults = JSON.stringify(queryData);
+
+  return createUrl('/alerting/new/alerting', {
+    returnTo,
+    defaults,
+  });
+}
+
+interface Props {
+  exploreId: string;
+  onClose: () => void;
+}
+
+export function NewAlertRuleFromExploreForm(props: Props): ReactElement {
+  const { exploreId, onClose } = props;
+  const exploreItem = useSelector(getExploreItemSelector(exploreId))!;
+
+  useEffect(() => {
+    reportInteraction('add_to_new_alertrule');
+  }, []);
+
+  // TODO better error handling here?
+  const canCreateAlertRule =
+    contextSrv.hasAccess(AccessControlAction.AlertingRuleCreate, contextSrv.isEditor) ||
+    contextSrv.hasAccess(AccessControlAction.AlertingRuleExternalWrite, contextSrv.isEditor);
+  if (!canCreateAlertRule) {
+    return (
+      <Alert title={'Insufficient permissions'} severity="error">
+        You have insufficient permissions for this action.
+      </Alert>
+    );
+  }
+
+  const onSubmit = async (data: FormDTO) => {
+    reportInteraction('add_to_new_alertrule_submit', {
+      queries: exploreItem.queries.length,
+    });
+
+    onClose();
+
+    const alertRuleFormData = await exploreToRuleFormValues(exploreItem, data.name);
+
+    const goTo = getNewAlertRuleURL(alertRuleFormData);
+    locationService.push(goTo);
+  };
+
+  // TODO maybe check if name is already taken? This would only work when we add more input / select elements.
+  // Do we want to add more stuff here like namespace / group selection?
+  return (
+    <Form onSubmit={onSubmit} defaultValues={{ name: '' }}>
+      {({ register, errors }) => (
+        <>
+          <Field label="Name" invalid={Boolean(errors.name)} error={'Name is required'}>
+            <Input placeholder="Alert rule name" {...register('name', { required: true })} />
+          </Field>
+          <Modal.ButtonRow>
+            <Button type="reset" onClick={onClose} fill="outline" variant="secondary">
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" icon="plus">
+              Create new alert rule
+            </Button>
+          </Modal.ButtonRow>
+        </>
+      )}
+    </Form>
+  );
+}

--- a/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
+++ b/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { PluginExtensionPoints, type PluginExtensionLinkConfig } from '@grafana/data';
 import { contextSrv } from 'app/core/core';
+import { NewAlertRuleFromExploreForm } from 'app/features/alerting/unified/components/explore/NewAlertRuleForm';
 import { AccessControlAction } from 'app/types';
 
 import { createExtensionLinkConfig, logWarning } from '../../plugins/extensions/utils';
@@ -20,8 +21,8 @@ export function getExploreExtensionConfigs(): PluginExtensionLinkConfig[] {
         icon: 'apps',
         configure: () => {
           const canAddPanelToDashboard =
-            contextSrv.hasAccess(AccessControlAction.DashboardsCreate, contextSrv.isEditor) ||
-            contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor);
+            contextSrv.hasAccess(AccessControlAction.AlertingRuleCreate, contextSrv.isEditor) ||
+            contextSrv.hasAccess(AccessControlAction.AlertingRuleExternalWrite, contextSrv.isEditor);
 
           // hide option if user has insufficient permissions
           if (!canAddPanelToDashboard) {
@@ -34,6 +35,33 @@ export function getExploreExtensionConfigs(): PluginExtensionLinkConfig[] {
           openModal({
             title: getAddToDashboardTitle(),
             body: ({ onDismiss }) => <AddToDashboardForm onClose={onDismiss!} exploreId={context?.exploreId!} />,
+          });
+        },
+      }),
+      createExtensionLinkConfig<PluginExtensionExploreContext>({
+        title: 'New alert rule',
+        description: 'Use the query and panel from explore and create/add it to a new alert rule',
+        extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
+        icon: 'bell',
+        configure: () => {
+          const canCreateNewAlertRule = contextSrv.hasAccess(
+            AccessControlAction.AlertingRuleCreate,
+            contextSrv.isEditor
+          );
+
+          // hide option if user has insufficient permissions
+          if (!canCreateNewAlertRule) {
+            return undefined;
+          }
+
+          return {};
+        },
+        onClick: (_, { context, openModal }) => {
+          openModal({
+            title: 'Create new alert rule',
+            body: ({ onDismiss }) => (
+              <NewAlertRuleFromExploreForm onClose={onDismiss!} exploreId={context?.exploreId!} />
+            ),
           });
         },
       }),


### PR DESCRIPTION
This PR adds the ability to create a new alert rule from the explore view.

Currently a WIP, needs a bunch of refactoring and some code needs to be shuffled around to minimize the maintenance burden for the explore team and to maximize the alerting team's autonomy.

Setting this to _draft_ state for now.

https://github.com/grafana/grafana/assets/868844/44a30dc4-a485-4f28-beff-09ae8c82f506


