### PR TITLE
logs: log-details: updated test for more complete mock data

### DIFF
--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import React from 'react';
 
-import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme } from '@grafana/data';
+import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme, FieldType } from '@grafana/data';
 
 import { LogDetails, Props } from './LogDetails';
 import { createLogRow } from './__mocks__/logRow';
@@ -82,6 +82,7 @@ describe('LogDetails', () => {
     const entry = 'traceId=1234 msg="some message"';
     const dataFrame = new MutableDataFrame({
       fields: [
+        { name: 'timestamp', config: {}, type: FieldType.time, values: [1] },
         { name: 'entry', values: [entry] },
         // As we have traceId in message already this will shadow it.
         {


### PR DESCRIPTION
unit-test-only change.

i update a mock logs-dataframe to be more real: id did not contain a timestamp field, so i added a timestamp field to it.

(i need better mocked data for an another PR, coming separately, but wanted to keep this one simple and easy to review)