### PR TITLE
chore: refactor SecretMigrationProviderImpl as a dskit module

### DIFF
--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -13,6 +13,8 @@ const (
 	HTTPServer string = "http-server"
 	// Provisioning sets up Grafana with preconfigured datasources, dashboards, etc.
 	Provisioning string = "provisioning"
+	// SecretMigrator handles all database migrations for Grafana
+	SecretMigrator string = "secret-migrator"
 )
 
 // dependencyMap defines Module Targets => Dependencies
@@ -22,5 +24,5 @@ var dependencyMap = map[string][]string{
 	CertGenerator:    {},
 	GrafanaAPIServer: {CertGenerator},
 
-	All: {Provisioning, HTTPServer, BackgroundServices},
+	All: {Provisioning, SecretMigrator, HTTPServer, BackgroundServices},
 }

--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -13,16 +13,16 @@ const (
 	HTTPServer string = "http-server"
 	// Provisioning sets up Grafana with preconfigured datasources, dashboards, etc.
 	Provisioning string = "provisioning"
-	// SecretMigrator handles all database migrations for Grafana
+	// SecretMigrator handles legacy secrets migrations
 	SecretMigrator string = "secret-migrator"
 )
 
 // dependencyMap defines Module Targets => Dependencies
 var dependencyMap = map[string][]string{
 	BackgroundServices: {Provisioning, HTTPServer},
+	CertGenerator:      {},
+	GrafanaAPIServer:   {CertGenerator},
+	Provisioning:       {SecretMigrator},
 
-	CertGenerator:    {},
-	GrafanaAPIServer: {CertGenerator},
-
-	All: {Provisioning, SecretMigrator, HTTPServer, BackgroundServices},
+	All: {BackgroundServices},
 }

--- a/pkg/modules/registry/registry.go
+++ b/pkg/modules/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/server/backgroundsvcs"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/grafana-apiserver"
 	"github.com/grafana/grafana/pkg/services/provisioning"
+	"github.com/grafana/grafana/pkg/services/secrets/kvstore/migrations"
 )
 
 type Registry interface{}
@@ -26,6 +27,7 @@ func ProvideRegistry(
 	certGenerator certgenerator.ServiceInterface,
 	httpServer *api.HTTPServer,
 	provisioningService *provisioning.ProvisioningServiceImpl,
+	secretsMigrator *migrations.SecretMigrationProviderImpl,
 ) *registry {
 	return newRegistry(
 		log.New("modules.registry"),
@@ -35,6 +37,7 @@ func ProvideRegistry(
 		certGenerator,
 		httpServer,
 		provisioningService,
+		secretsMigrator,
 	)
 }
 

--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -28,7 +28,6 @@ import (
 	publicdashboardsmetric "github.com/grafana/grafana/pkg/services/publicdashboards/metric"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/searchV2"
-	secretsMigrations "github.com/grafana/grafana/pkg/services/secrets/kvstore/migrations"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	samanager "github.com/grafana/grafana/pkg/services/serviceaccounts/manager"
@@ -48,7 +47,7 @@ func ProvideBackgroundServiceRegistry(
 	pluginsUpdateChecker *updatechecker.PluginsService, metrics *metrics.InternalMetricsService,
 	secretsService *secretsManager.SecretsService, remoteCache *remotecache.RemoteCache, StorageService store.StorageService, searchService searchV2.SearchService, entityEventsService store.EntityEventsService,
 	saService *samanager.ServiceAccountsService, authInfoService *authinfoservice.Implementation,
-	grpcServerProvider grpcserver.Provider, secretMigrationProvider secretsMigrations.SecretMigrationProvider, loginAttemptService *loginattemptimpl.Service,
+	grpcServerProvider grpcserver.Provider, loginAttemptService *loginattemptimpl.Service,
 	bundleService *supportbundlesimpl.Service,
 	publicDashboardsMetric *publicdashboardsmetric.Service,
 	keyRetriever *dynamic.KeyRetriever,
@@ -84,7 +83,6 @@ func ProvideBackgroundServiceRegistry(
 		saService,
 		authInfoService,
 		processManager,
-		secretMigrationProvider,
 		loginAttemptService,
 		bundleService,
 		publicDashboardsMetric,

--- a/pkg/services/secrets/kvstore/migrations/migrator.go
+++ b/pkg/services/secrets/kvstore/migrations/migrator.go
@@ -66,19 +66,12 @@ func ProvideSecretMigrationProvider(
 		migrateFromPluginService: migrateFromPluginService,
 	}
 
-	s.BasicService = services.NewBasicService(s.start, s.running, nil).WithName(modules.SecretMigrator)
+	s.BasicService = services.NewIdleService(s.start, nil).WithName(modules.SecretMigrator)
 	return s
 }
 
 func (s *SecretMigrationProviderImpl) start(ctx context.Context) error {
 	return s.Migrate(ctx)
-}
-
-// Migrate() logs errors, but does not return them, so we just block until the
-// context is done.
-func (s *SecretMigrationProviderImpl) running(ctx context.Context) error {
-	<-ctx.Done()
-	return nil
 }
 
 // Migrate Run migration services. This will block until all services have exited.


### PR DESCRIPTION
This wraps the legacy secrets migration service (`SecretMigrationProviderImpl`) as a `dskit` module. 

I've tested the functionality locally, and this looks good in hosted grafana.
For the local test, I deleted the local database, checked out grafana at 8.5.x & provisioned all the datasources from devenv. Then I could see the legacy secrets in the datasources table:

<img width="690" alt="Screenshot 2023-07-20 at 8 25 28 AM" src="https://github.com/grafana/grafana/assets/6210214/a5e6a87d-39cb-475a-9312-efd4088e5e4f">

Then, checked this branch back out and ran again:
```
DEBUG[07-20|08:36:35] Starting secret migration service        logger=secret.migration service=*migrations.DataSourceSecretMigrationService
DEBUG[07-20|08:36:35] secret migration status is               logger=secret.migration
DEBUG[07-20|08:36:35] performing secret migration              logger=secret.migration needs migration=false needs compatibility=true
```

The secrets table (which didn't exist in 8.5) was created and populated, and the secure_json_data in the datasources field is encrypted:

<img width="782" alt="Screenshot 2023-07-20 at 8 41 42 AM" src="https://github.com/grafana/grafana/assets/6210214/7dde84c9-c699-474e-99df-e41ca0798483">

🎉 

------
There was another option: I could have made the `SecretMigrationProviderImpl` service [a dskit `Manager`](https://github.com/grafana/dskit/blob/c30720760c5d23eef733a3e7e299e8247e438a24/services/manager.go#L34), and made all the sub-services (`DataSourceSecretMigrationService`, `MigrateToPluginService`, `MigrateFromPluginService`) modules served by that manager. 

I did not try that out for a couple of reasons: 
- it represents a bigger paradigm shift, and we're still getting accustomed to `dskit` modules in general
- it felt unnecessarily heavyweight/complex given that the sub-services aren't long running ones; this is more of a task runner. 

We can always revisit this later if there's reason to (or I can revisit _now_ if anyone sees a benefit from doing so!)