### PR TITLE
Docs:  added alias to main data sources page

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - data-sources/
   - overview/
+  - ./features/datasources/
 labels:
   products:
     - cloud


### PR DESCRIPTION
Addresses 403 forbidden error for the following;

https://grafana.com/docs/grafana/latest/features/datasources/
