### PR TITLE
Traces: Enable showing trace ids

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -88,7 +88,6 @@ Experimental features might be changed or removed without prior notice.
 | `showDashboardValidationWarnings`           | Show warnings when dashboards do not validate against the schema                                             |
 | `mysqlAnsiQuotes`                           | Use double quotes to escape keyword in a MySQL query                                                         |
 | `nestedFolderPicker`                        | Enables the still in-development new folder picker to support nested folders                                 |
-| `showTraceId`                               | Show trace ids for requests                                                                                  |
 | `alertingBacktesting`                       | Rule backtesting API for alerting                                                                            |
 | `editPanelCSVDragAndDrop`                   | Enables drag and drop for CSV and Excel files                                                                |
 | `lokiQuerySplitting`                        | Split large interval queries into subqueries with smaller time intervals                                     |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -55,7 +55,6 @@ export interface FeatureToggles {
   nestedFolders?: boolean;
   nestedFolderPicker?: boolean;
   accessTokenExpirationCheck?: boolean;
-  showTraceId?: boolean;
   emptyDashboardPage?: boolean;
   disablePrometheusExemplarSampling?: boolean;
   alertingBacktesting?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -252,12 +252,6 @@ var (
 			Owner:       grafanaAuthnzSquad,
 		},
 		{
-			Name:        "showTraceId",
-			Description: "Show trace ids for requests",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaObservabilityLogsSquad,
-		},
-		{
 			Name:         "emptyDashboardPage",
 			Description:  "Enable the redesigned user interface of a dashboard page that includes no panels",
 			Stage:        FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -36,7 +36,6 @@ accessControlOnCall,preview,@grafana/grafana-authnz-team,false,false,false,false
 nestedFolders,preview,@grafana/backend-platform,false,false,false,false
 nestedFolderPicker,experimental,@grafana/grafana-frontend-platform,false,false,false,false
 accessTokenExpirationCheck,GA,@grafana/grafana-authnz-team,false,false,false,false
-showTraceId,experimental,@grafana/observability-logs,false,false,false,false
 emptyDashboardPage,GA,@grafana/dashboards-squad,false,false,false,true
 disablePrometheusExemplarSampling,GA,@grafana/observability-metrics,false,false,false,false
 alertingBacktesting,experimental,@grafana/alerting-squad,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -155,10 +155,6 @@ const (
 	// Enable OAuth access_token expiration check and token refresh using the refresh_token
 	FlagAccessTokenExpirationCheck = "accessTokenExpirationCheck"
 
-	// FlagShowTraceId
-	// Show trace ids for requests
-	FlagShowTraceId = "showTraceId"
-
 	// FlagEmptyDashboardPage
 	// Enable the redesigned user interface of a dashboard page that includes no panels
 	FlagEmptyDashboardPage = "emptyDashboardPage"

--- a/public/app/features/inspector/InspectErrorTab.tsx
+++ b/public/app/features/inspector/InspectErrorTab.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { DataQueryError } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Alert, JSONFormatter } from '@grafana/ui';
 
 interface InspectErrorTabProps {

--- a/public/app/features/inspector/InspectErrorTab.tsx
+++ b/public/app/features/inspector/InspectErrorTab.tsx
@@ -37,7 +37,7 @@ function renderError(error: DataQueryError) {
         <>
           {error.status && <>Status: {error.status}. Message: </>}
           {msg}
-          {config.featureToggles.showTraceId && error.traceId != null && (
+          {error.traceId != null && (
             <>
               <br />
               (Trace ID: {error.traceId})

--- a/public/app/features/inspector/InspectStatsTab.tsx
+++ b/public/app/features/inspector/InspectStatsTab.tsx
@@ -67,9 +67,7 @@ export const InspectStatsTab = ({ data, timeZone }: InspectStatsTabProps) => {
     <div aria-label={selectors.components.PanelInspector.Stats.content} className={containerStyles}>
       <InspectStatsTable timeZone={timeZone} name={statsTableName} stats={stats} />
       <InspectStatsTable timeZone={timeZone} name={dataStatsTableName} stats={dataStats} />
-      {config.featureToggles.showTraceId && (
-        <InspectStatsTraceIdsTable name={traceIdsStatsTableName} traceIds={data.traceIds ?? []} />
-      )}
+      <InspectStatsTraceIdsTable name={traceIdsStatsTableName} traceIds={data.traceIds ?? []} />
     </div>
   );
 };

--- a/public/app/features/inspector/InspectStatsTab.tsx
+++ b/public/app/features/inspector/InspectStatsTab.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { PanelData, QueryResultMetaStat, TimeZone } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 
 import { InspectStatsTable } from './InspectStatsTable';

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Icon, useStyles2 } from '@grafana/ui';
 
 export interface Props {

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -21,7 +21,7 @@ export function QueryErrorAlert({ error }: Props) {
       </div>
       <div className={styles.message}>
         {message}
-        {config.featureToggles.showTraceId && error.traceId != null && (
+        {error.traceId != null && (
           <>
             <br /> <span>(Trace ID: {error.traceId})</span>
           </>


### PR DESCRIPTION
this feature was behind the experimental `showTraceId` feature flag until now, now we are removing the feature toggle and enabling it by default.

how to test:
to have grafana-backend generatea traceids, add something like this to the grafana config file:
```
[tracing.opentelemetry.jaeger]
address = http://localhost:1234
propagation = jaeger
```

note, nothing has to run at the specified address (`localhost:1234`) in this case, to be able to test the change.
1. run a query that does not fail, like a loki query or prometheus query. after you run it, open the query inspector, go to the stats-tab, scroll to the bottom, and verify that the traceId is shown there.
2. run a query, for example a loki or prometheus query, and make a syntax error in it. for example this loki query : `{a="42"} haha`
    - verify that the traceid is added to the end of the arriving error message
    - go to the query inspector's `error` tab, and verify that you can see the traceid at the end of the error message here too.
    - go to the query inspector's `stats` tab, scroll to the bottom, and verify that you can see the traceid here too.