### PR TITLE
NestedFolders: Select style for closed nested folder picker

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/css';
 import React, { useCallback, useId, useMemo, useState } from 'react';
-import Skeleton from 'react-loading-skeleton';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { useAsync } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, Icon, Input, LoadingBar, useStyles2 } from '@grafana/ui';
-import { Text } from '@grafana/ui/src/components/Text/Text';
-import { t, Trans } from 'app/core/internationalization';
+import { Alert, Icon, Input, LoadingBar, useStyles2 } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 import { skipToken, useGetFolderQuery } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { PAGE_SIZE } from 'app/features/browse-dashboards/api/services';
 import {
@@ -208,6 +206,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
       <Input
         ref={setTriggerRef}
         autoFocus
+        prefix={<Icon name="folder" />}
         placeholder={label ?? t('browse-dashboards.folder-picker.search-placeholder', 'Search folders')}
         value={search}
         className={styles.search}

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -26,6 +26,7 @@ import { DashboardViewItem } from 'app/features/search/types';
 import { useDispatch, useSelector } from 'app/types/store';
 
 import { getDOMId, NestedFolderList } from './NestedFolderList';
+import Trigger from './Trigger';
 import { useTreeInteractions } from './hooks';
 import { FolderChange, FolderUID } from './types';
 
@@ -198,22 +199,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
 
   if (!visible) {
     return (
-      <Button
-        autoFocus={autoFocusButton}
-        className={styles.button}
-        variant="secondary"
-        icon={value !== undefined ? 'folder' : undefined}
-        ref={setTriggerRef}
-        aria-label={label ? `Select folder: ${label} currently selected` : undefined}
-      >
-        {selectedFolder.isLoading ? (
-          <Skeleton width={100} />
-        ) : (
-          <Text truncate>
-            {label ?? <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>}
-          </Text>
-        )}
-      </Button>
+      <Trigger label={label} isLoading={selectedFolder.isLoading} autoFocus={autoFocusButton} ref={setTriggerRef} />
     );
   }
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -197,7 +197,19 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
 
   if (!visible) {
     return (
-      <Trigger label={label} isLoading={selectedFolder.isLoading} autoFocus={autoFocusButton} ref={setTriggerRef} />
+      <Trigger
+        label={label}
+        isLoading={selectedFolder.isLoading}
+        autoFocus={autoFocusButton}
+        ref={setTriggerRef}
+        aria-label={
+          label
+            ? t('browse-dashboards.folder-picker.accessible-label', 'Select folder: {{ label }} currently selected', {
+                label,
+              })
+            : undefined
+        }
+      />
     );
   }
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -206,7 +206,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
       <Input
         ref={setTriggerRef}
         autoFocus
-        prefix={<Icon name="folder" />}
+        prefix={label ? <Icon name="folder" /> : null}
         placeholder={label ?? t('browse-dashboards.folder-picker.search-placeholder', 'Search folders')}
         value={search}
         className={styles.search}

--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -1,0 +1,86 @@
+import { css } from '@emotion/css';
+import React, { forwardRef, ReactNode, ButtonHTMLAttributes } from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Icon, getInputStyles } from '@grafana/ui';
+import { Text } from '@grafana/ui/src/components/Text/Text';
+import { focusCss } from '@grafana/ui/src/themes/mixins';
+import { Trans } from 'app/core/internationalization';
+
+interface TriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading: boolean;
+  label?: ReactNode;
+}
+
+function Trigger({ isLoading, label, ...rest }: TriggerProps, ref: React.ForwardedRef<HTMLButtonElement>) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.inputWrapper}>
+        {label ? (
+          <div className={styles.prefix}>
+            <Icon name="folder" />
+          </div>
+        ) : undefined}
+
+        <button className={styles.fakeInput} {...rest} ref={ref}>
+          {isLoading ? (
+            <Skeleton width={100} />
+          ) : (
+            <Text as="span" truncate>
+              {label ?? <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>}
+            </Text>
+          )}
+        </button>
+
+        <div className={styles.suffix}>
+          <Icon name="angle-down" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default forwardRef(Trigger);
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const baseStyles = getInputStyles({ theme });
+
+  return {
+    wrapper: baseStyles.wrapper,
+    inputWrapper: baseStyles.inputWrapper,
+    prefix: css([
+      baseStyles.prefix,
+      {
+        pointerEvents: 'none',
+        color: theme.colors.text.primary,
+      },
+    ]),
+    suffix: css([
+      baseStyles.suffix,
+      {
+        pointerEvents: 'none',
+      },
+    ]),
+    fakeInput: css([
+      baseStyles.input,
+      {
+        textAlign: 'left',
+        paddingLeft: 28,
+
+        // We want the focus styles to appear only when tabbing through, not when clicking the button
+        // (and when focus is restored after command palette closes)
+        '&:focus': {
+          outline: 'unset',
+          boxShadow: 'unset',
+        },
+
+        '&:focus-visible': css`
+          ${focusCss(theme)}
+        `,
+      },
+    ]),
+  };
+};

--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -4,8 +4,8 @@ import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Icon, getInputStyles } from '@grafana/ui';
-import { Text } from '@grafana/ui/src/components/Text/Text';
 import { focusCss } from '@grafana/ui/src/themes/mixins';
+import { Text } from '@grafana/ui/src/unstable';
 import { Trans } from 'app/core/internationalization';
 
 interface TriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { forwardRef, ReactNode, ButtonHTMLAttributes } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
@@ -25,7 +25,7 @@ function Trigger({ isLoading, label, ...rest }: TriggerProps, ref: React.Forward
           </div>
         ) : undefined}
 
-        <button className={styles.fakeInput} {...rest} ref={ref}>
+        <button className={cx(styles.fakeInput, label ? styles.hasPrefix : undefined)} {...rest} ref={ref}>
           {isLoading ? (
             <Skeleton width={100} />
           ) : (
@@ -51,6 +51,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrapper: baseStyles.wrapper,
     inputWrapper: baseStyles.inputWrapper,
+
     prefix: css([
       baseStyles.prefix,
       {
@@ -58,17 +59,20 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: theme.colors.text.primary,
       },
     ]),
+
     suffix: css([
       baseStyles.suffix,
       {
         pointerEvents: 'none',
       },
     ]),
+
     fakeInput: css([
       baseStyles.input,
       {
         textAlign: 'left',
-        paddingLeft: 28,
+
+        letterSpacing: 'normal',
 
         // We want the focus styles to appear only when tabbing through, not when clicking the button
         // (and when focus is restored after command palette closes)
@@ -82,5 +86,9 @@ const getStyles = (theme: GrafanaTheme2) => {
         `,
       },
     ]),
+
+    hasPrefix: css({
+      paddingLeft: 28,
+    }),
   };
 };

--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -29,11 +29,9 @@ function Trigger({ isLoading, label, ...rest }: TriggerProps, ref: React.Forward
           {isLoading ? (
             <Skeleton width={100} />
           ) : label ? (
-            <Text as="span" truncate>
-              {label}
-            </Text>
+            <Text truncate>{label}</Text>
           ) : (
-            <Text as="span" truncate color="secondary">
+            <Text truncate color="secondary">
               <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>
             </Text>
           )}

--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -28,9 +28,13 @@ function Trigger({ isLoading, label, ...rest }: TriggerProps, ref: React.Forward
         <button className={cx(styles.fakeInput, label ? styles.hasPrefix : undefined)} {...rest} ref={ref}>
           {isLoading ? (
             <Skeleton width={100} />
-          ) : (
+          ) : label ? (
             <Text as="span" truncate>
-              {label ?? <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>}
+              {label}
+            </Text>
+          ) : (
+            <Text as="span" truncate color="secondary">
+              <Trans i18nKey="browse-dashboards.folder-picker.button-label">Select folder</Trans>
             </Text>
           )}
         </button>

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -62,6 +62,7 @@
       "move": ""
     },
     "folder-picker": {
+      "accessible-label": "",
       "button-label": "",
       "empty-message": "",
       "error-title": "",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -62,6 +62,7 @@
       "move": "Move"
     },
     "folder-picker": {
+      "accessible-label": "Select folder: {{ label }} currently selected",
       "button-label": "Select folder",
       "empty-message": "No folders found",
       "error-title": "Error loading folders",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -67,6 +67,7 @@
       "move": ""
     },
     "folder-picker": {
+      "accessible-label": "",
       "button-label": "",
       "empty-message": "",
       "error-title": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -67,6 +67,7 @@
       "move": ""
     },
     "folder-picker": {
+      "accessible-label": "",
       "button-label": "",
       "empty-message": "",
       "error-title": "",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -62,6 +62,7 @@
       "move": "Mővę"
     },
     "folder-picker": {
+      "accessible-label": "Ŝęľęčŧ ƒőľđęř: {{ label }} čūřřęŉŧľy şęľęčŧęđ",
       "button-label": "Ŝęľęčŧ ƒőľđęř",
       "empty-message": "Ńő ƒőľđęřş ƒőūŉđ",
       "error-title": "Ēřřőř ľőäđįŉģ ƒőľđęřş",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -57,6 +57,7 @@
       "move": ""
     },
     "folder-picker": {
+      "accessible-label": "",
       "button-label": "",
       "empty-message": "",
       "error-title": "",


### PR DESCRIPTION
Make the closed/unexpanded nested folder picker look like a Select/Textbox.

![5675_2023-07-19-16-48_firefox](https://github.com/grafana/grafana/assets/46142/98818e8b-e7c9-4ab9-8998-26353b558887)

![5676_2023-07-19-16-48_firefox](https://github.com/grafana/grafana/assets/46142/ca69fe1f-7dc1-449f-9a0a-b2a6e9e377db)
