### PR TITLE
[v9.4.x] docs: add docker commands for enabling alpha layers

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -345,6 +345,12 @@ To enable the Night / Day layer, set `enable_alpha` to `true` in your configurat
 enable_alpha = true
 ```
 
+To enable the Photos layer using Docker, run the following command:
+
+```
+docker run -p 3000:3000 -e "GF_PANELS_ENABLE_ALPHA=true" grafana/grafana:<VERSION>
+```
+
 ### Options
 
 - **Show** toggles time source from panel time range
@@ -369,6 +375,12 @@ To enable the Photos layer, set `enable_alpha` to `true` in your configuration f
 ```
 [panels]
 enable_alpha = true
+```
+
+To enable the Photos layer using Docker, run the following command:
+
+```
+docker run -p 3000:3000 -e "GF_PANELS_ENABLE_ALPHA=true" grafana/grafana:<VERSION>
 ```
 
 ### Options


### PR DESCRIPTION
Backport ef0de1af32c7bf8f7b03a0317769f0ffd56bb46f from #71897

---

Adding this for Route and Photos layers in 10.0 and 9.5
Adding for Photos and Night/Day layer in 9.4