### PR TITLE
Alerting: Fix edit / view of webhook contact point when no authorization is set

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/util.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.test.ts
@@ -34,6 +34,11 @@ describe('normalizeFormValues', () => {
 
     expect(normalizeFormValues(config)).toEqual(createContactPoint({ bearer_token_file: 'file' }));
   });
+
+  it('should normalize even if authorization is not defined', () => {
+    const config = createContactPoint({});
+    expect(normalizeFormValues(config)).toEqual(createContactPoint({}));
+  });
 });
 
 function createContactPoint(httpConfig: DeprecatedAuthHTTPConfig | HTTPAuthConfig) {

--- a/public/app/features/alerting/unified/components/receivers/form/util.ts
+++ b/public/app/features/alerting/unified/components/receivers/form/util.ts
@@ -8,7 +8,7 @@ export interface DeprecatedAuthHTTPConfig {
 }
 
 export interface HTTPAuthConfig {
-  authorization: {
+  authorization?: {
     type: string;
     credentials?: string;
     credentials_file?: string;
@@ -42,8 +42,8 @@ function normalizeHTTPConfig(config: HTTPAuthConfig | DeprecatedAuthHTTPConfig):
 
   return {
     ...omit(config, 'authorization'),
-    bearer_token: config.authorization.credentials,
-    bearer_token_file: config.authorization.credentials_file,
+    bearer_token: config.authorization?.credentials,
+    bearer_token_file: config.authorization?.credentials_file,
   };
 }
 


### PR DESCRIPTION
The `authorization` configuration for a webhook is optional, it was incorrectly typed in https://github.com/grafana/grafana/commit/a91de30f99f992900a344dff628eeb3369416075 and thus causes a crash when a user tries to view a contact point that included a webhook configuration without the `authorization` property.