### PR TITLE
Loki / Prometheus: Fix query builder select component in safari

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
@@ -133,51 +133,37 @@ export function OperationEditor({
     }
   }
 
-  const isInvalid = (isDragging: boolean) => {
-    if (isDragging) {
-      return undefined;
-    }
-
-    return isConflicting ? true : undefined;
-  };
-
   return (
     <Draggable draggableId={`operation-${index}`} index={index}>
-      {(provided, snapshot) => (
-        <InlineField
-          error={'You have conflicting label filters'}
-          invalid={isInvalid(snapshot.isDragging)}
-          className={cx(styles.error, styles.cardWrapper)}
+      {(provided) => (
+        <div
+          className={cx(
+            styles.card,
+            (shouldFlash || highlight) && styles.cardHighlight,
+            isConflicting && styles.cardError
+          )}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          data-testid={`operations.${index}.wrapper`}
         >
-          <div
-            className={cx(
-              styles.card,
-              (shouldFlash || highlight) && styles.cardHighlight,
-              isConflicting && styles.cardError
-            )}
-            ref={provided.innerRef}
-            {...provided.draggableProps}
-            data-testid={`operations.${index}.wrapper`}
-          >
-            <OperationHeader
-              operation={operation}
-              dragHandleProps={provided.dragHandleProps}
-              def={def}
-              index={index}
-              onChange={onChange}
-              onRemove={onRemove}
-              queryModeller={queryModeller}
-            />
-            <div className={styles.body}>{operationElements}</div>
-            {restParam}
-            {index < query.operations.length - 1 && (
-              <div className={styles.arrow}>
-                <div className={styles.arrowLine} />
-                <div className={styles.arrowArrow} />
-              </div>
-            )}
-          </div>
-        </InlineField>
+          <OperationHeader
+            operation={operation}
+            dragHandleProps={provided.dragHandleProps}
+            def={def}
+            index={index}
+            onChange={onChange}
+            onRemove={onRemove}
+            queryModeller={queryModeller}
+          />
+          <div className={styles.body}>{operationElements}</div>
+          {restParam}
+          {index < query.operations.length - 1 && (
+            <div className={styles.arrow}>
+              <div className={styles.arrowLine} />
+              <div className={styles.arrowArrow} />
+            </div>
+          )}
+        </div>
       )}
     </Draggable>
   );

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
@@ -4,7 +4,7 @@ import { Draggable } from 'react-beautiful-dnd';
 
 import { DataSourceApi, GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Icon, InlineField, Tooltip, useTheme2 } from '@grafana/ui';
+import { Button, Icon, Tooltip, useTheme2 } from '@grafana/ui';
 import { isConflictingFilter } from 'app/plugins/datasource/loki/querybuilder/operationUtils';
 import { LokiOperationId } from 'app/plugins/datasource/loki/querybuilder/types';
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
@@ -4,7 +4,7 @@ import { Draggable } from 'react-beautiful-dnd';
 
 import { DataSourceApi, GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Icon, Tooltip, useTheme2 } from '@grafana/ui';
+import { Button, Icon, InlineField, Tooltip, useTheme2 } from '@grafana/ui';
 import { isConflictingFilter } from 'app/plugins/datasource/loki/querybuilder/operationUtils';
 import { LokiOperationId } from 'app/plugins/datasource/loki/querybuilder/types';
 
@@ -133,37 +133,51 @@ export function OperationEditor({
     }
   }
 
+  const isInvalid = (isDragging: boolean) => {
+    if (isDragging) {
+      return undefined;
+    }
+
+    return isConflicting ? true : undefined;
+  };
+
   return (
     <Draggable draggableId={`operation-${index}`} index={index}>
-      {(provided) => (
-        <div
-          className={cx(
-            styles.card,
-            (shouldFlash || highlight) && styles.cardHighlight,
-            isConflicting && styles.cardError
-          )}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          data-testid={`operations.${index}.wrapper`}
+      {(provided, snapshot) => (
+        <InlineField
+          error={'You have conflicting label filters'}
+          invalid={isInvalid(snapshot.isDragging)}
+          className={cx(styles.error, styles.cardWrapper)}
         >
-          <OperationHeader
-            operation={operation}
-            dragHandleProps={provided.dragHandleProps}
-            def={def}
-            index={index}
-            onChange={onChange}
-            onRemove={onRemove}
-            queryModeller={queryModeller}
-          />
-          <div className={styles.body}>{operationElements}</div>
-          {restParam}
-          {index < query.operations.length - 1 && (
-            <div className={styles.arrow}>
-              <div className={styles.arrowLine} />
-              <div className={styles.arrowArrow} />
-            </div>
-          )}
-        </div>
+          <div
+            className={cx(
+              styles.card,
+              (shouldFlash || highlight) && styles.cardHighlight,
+              isConflicting && styles.cardError
+            )}
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            data-testid={`operations.${index}.wrapper`}
+          >
+            <OperationHeader
+              operation={operation}
+              dragHandleProps={provided.dragHandleProps}
+              def={def}
+              index={index}
+              onChange={onChange}
+              onRemove={onRemove}
+              queryModeller={queryModeller}
+            />
+            <div className={styles.body}>{operationElements}</div>
+            {restParam}
+            {index < query.operations.length - 1 && (
+              <div className={styles.arrow}>
+                <div className={styles.arrowLine} />
+                <div className={styles.arrowArrow} />
+              </div>
+            )}
+          </div>
+        </InlineField>
       )}
     </Draggable>
   );
@@ -240,8 +254,6 @@ const getStyles = (theme: GrafanaTheme2, isConflicting: boolean) => {
     card: css({
       background: theme.colors.background.primary,
       border: `1px solid ${theme.colors.border.medium}`,
-      display: 'flex',
-      flexDirection: 'column',
       cursor: 'grab',
       borderRadius: theme.shape.borderRadius(1),
       position: 'relative',

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
@@ -192,7 +192,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexWrap: 'wrap',
       gap: theme.spacing(2),
-      paddingBottom: theme.spacing(1),
     }),
     addButton: css({
       label: 'addButton',

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
@@ -192,6 +192,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexWrap: 'wrap',
       gap: theme.spacing(2),
+      paddingBottom: theme.spacing(1),
     }),
     addButton: css({
       label: 'addButton',


### PR DESCRIPTION
this pr fixes the behaviour shown in the linked escalation.

**How to test:**
1. follow the steps in this video to reproduce (**you must be using safari**): https://github.com/grafana/support-escalations/issues/6771#issuecomment-1640359381

2. confirm that this bug no longer exists and you can add aggregations without errors.


**Side effects of this fix:**

as you can see from the screenshots, the is a slight spacing difference between the labels and inputs of the query cards

Before & After:

 
![ss-before](https://github.com/grafana/grafana/assets/34524710/89d323b2-1a32-4779-ab9f-a803650d4c8d)

![ss-after](https://github.com/grafana/grafana/assets/34524710/8359d1c4-53f2-42bd-b804-659258a69ffd)



**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/support-escalations/issues/6771

