### PR TITLE
Docs: Fix URL encoding @ Keycloak logout example

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
@@ -137,7 +137,7 @@ To enable Single Logout, you need to add the following option to the configurati
 
 ```ini
 [auth]
-signout_redirect_url = https://<PROVIDER_DOMAIN>/auth/realms/<REALM_NAME>/protocol/openid-connect/logout?redirect_uri=https%3A%2F%2<GRAFANA_DOMAIN>%2Flogin
+signout_redirect_url = https://<PROVIDER_DOMAIN>/auth/realms/<REALM_NAME>/protocol/openid-connect/logout?redirect_uri=https%3A%2F%2F<GRAFANA_DOMAIN>%2Flogin
 ```
 
 As an example, `<PROVIDER_DOMAIN>` can be `keycloak-demo.grafana.org`,


### PR DESCRIPTION
**What is this feature?**

This is a fix for the single logout configuration suggested in the docs for Keycloak integration.

**Why do we need this feature?**

If the user copies the suggestion and replaces only `<GRAFANA_DOMAIN>`, Keycloak silently fails to logout without any tips on what's wrong.

**Who is this feature for?**

Everyone following the docs to integrate Grafana with Keycloak.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

First (and very simple) contribution, I hope I've provided all needed info. (: