### PR TITLE
Prometheus: Fix heatmap query format

### DIFF
--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -266,6 +266,7 @@ export interface DataFrameDTO extends QueryResultBase {
 
 export interface FieldCalcs extends Record<string, any> {}
 
+/** @deprecated check data plane docs: https://grafana.github.io/dataplane **/
 export const TIME_SERIES_VALUE_FIELD_NAME = 'Value';
 export const TIME_SERIES_TIME_FIELD_NAME = 'Time';
 export const TIME_SERIES_METRIC_FIELD_NAME = 'Metric';

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -266,7 +266,7 @@ export interface DataFrameDTO extends QueryResultBase {
 
 export interface FieldCalcs extends Record<string, any> {}
 
-/** @deprecated check data plane docs: https://grafana.github.io/dataplane **/
+/** @deprecated check data plane docs: https://grafana.github.io/dataplane/heatmap **/
 export const TIME_SERIES_VALUE_FIELD_NAME = 'Value';
 export const TIME_SERIES_TIME_FIELD_NAME = 'Time';
 export const TIME_SERIES_METRIC_FIELD_NAME = 'Metric';

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -422,6 +422,65 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[0].fields[2].name).toEqual('2');
       expect(series.data[0].fields[3].name).toEqual('+Inf');
     });
+    it('results with dataplane heatmap format should be correctly transformed', () => {
+      const options = {
+        targets: [
+          {
+            format: 'heatmap',
+            refId: 'A',
+          },
+        ],
+      } as unknown as DataQueryRequest<PromQuery>;
+      const response = {
+        state: 'Done',
+        data: [
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                type: FieldType.number,
+                values: [10, 10, 0],
+                labels: { le: '1' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [30, 10, 40],
+                labels: { le: '+Inf' },
+              },
+            ],
+          }),
+          createDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
+              {
+                name: 'Value',
+                type: FieldType.number,
+                values: [20, 10, 30],
+                labels: { le: '2' },
+              },
+            ],
+          }),
+        ],
+      } as unknown as DataQueryResponse;
+
+      const series = transformV2(response, options, {});
+      expect(series.data[0].fields.length).toEqual(4);
+      expect(series.data[0].fields[1].values).toEqual([10, 10, 0]);
+      expect(series.data[0].fields[2].values).toEqual([10, 0, 30]);
+      expect(series.data[0].fields[3].values).toEqual([10, 0, 10]);
+      expect(series.data[0].fields[1].name).toEqual('1');
+      expect(series.data[0].fields[2].name).toEqual('2');
+      expect(series.data[0].fields[3].name).toEqual('+Inf');
+    });
 
     it('results with heatmap format from multiple queries should be correctly transformed', () => {
       const options = {

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -91,7 +91,6 @@ describe('Prometheus Result Transformer', () => {
         fields: [
           { name: 'Time', type: FieldType.time, values: [1, 2, 3] },
           {
-            name: 'Value',
             type: FieldType.number,
             values: [4, 5, 6],
             config: {
@@ -108,7 +107,6 @@ describe('Prometheus Result Transformer', () => {
         fields: [
           { name: 'Time', type: FieldType.time, values: [1, 2, 3] },
           {
-            name: 'Value',
             type: FieldType.number,
             values: [7, 8, 9],
             config: {
@@ -362,7 +360,7 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[1].meta?.preferredVisualisationType).toEqual('rawPrometheus' as PreferredVisualisationType);
     });
 
-    it('results with heatmap format should be correctly transformed', () => {
+    it('results with deprecated heatmap format should be correctly transformed', () => {
       const options = {
         targets: [
           {
@@ -422,7 +420,7 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[0].fields[2].name).toEqual('2');
       expect(series.data[0].fields[3].name).toEqual('+Inf');
     });
-    it('results with dataplane heatmap format should be correctly transformed', () => {
+    it('results with heatmap format should be correctly transformed', () => {
       const options = {
         targets: [
           {
@@ -450,7 +448,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40],
                 labels: { le: '+Inf' },
@@ -462,7 +459,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [20, 10, 30],
                 labels: { le: '2' },
@@ -503,7 +499,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [10, 10, 0],
                 labels: { le: '1' },
@@ -515,7 +510,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [20, 10, 30],
                 labels: { le: '2' },
@@ -527,7 +521,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40],
                 labels: { le: '+Inf' },
@@ -539,7 +532,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [10, 10, 0],
                 labels: { le: '1' },
@@ -551,7 +543,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [20, 10, 30],
                 labels: { le: '2' },
@@ -563,7 +554,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40],
                 labels: { le: '+Inf' },
@@ -598,7 +588,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [10, 10, 0],
                 labels: { le: '1', additionalProperty: '10' },
@@ -610,7 +599,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [20, 10, 30],
                 labels: { le: '2', additionalProperty: '10' },
@@ -622,7 +610,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40],
                 labels: { le: '+Inf', additionalProperty: '10' },
@@ -635,7 +622,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [0, 10, 10],
                 labels: { le: '1', additionalProperty: '20' },
@@ -647,7 +633,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [20, 10, 40],
                 labels: { le: '2', additionalProperty: '20' },
@@ -659,7 +644,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 60],
                 labels: { le: '+Inf', additionalProperty: '20' },
@@ -672,7 +656,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 30, 60],
                 labels: { le: '1', additionalProperty: '30' },
@@ -684,7 +667,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 40, 60],
                 labels: { le: '2', additionalProperty: '30' },
@@ -696,7 +678,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [40, 40, 60],
                 labels: { le: '+Inf', additionalProperty: '30' },
@@ -738,7 +719,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [10, 10, 0],
                 labels: { le: '1' },
@@ -756,7 +736,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4, 3, 2, 1] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40, 90, 14, 21],
                 labels: { le: '6' },
@@ -788,7 +767,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [10, 10, 0],
                 labels: { le: '1' },
@@ -806,7 +784,6 @@ describe('Prometheus Result Transformer', () => {
             fields: [
               { name: 'Time', type: FieldType.time, values: [6, 5, 4, 3, 2, 1] },
               {
-                name: 'Value',
                 type: FieldType.number,
                 values: [30, 10, 40, 90, 14, 21],
                 labels: { le: '6' },

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -121,7 +121,7 @@ export function transformV2(
   // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default
   heatmapResults.forEach((df) => {
     if (df.name == null) {
-      let f = df.fields[1];
+      let f = df.fields.find((f) => f.type === FieldType.number);
 
       if (f) {
         let le = f.labels?.le;

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -288,6 +288,7 @@ export function transform(
       preferredVisualisationType: transformOptions.query.instant ? 'rawPrometheus' : 'graph',
     },
   };
+
   const prometheusResult = response.data.data;
 
   if (isExemplarData(prometheusResult)) {
@@ -352,7 +353,8 @@ export function transform(
 
   // When format is heatmap use the already created data frames and transform it more
   if (options.format === 'heatmap') {
-    return mergeHeatmapFrames(transformToHistogramOverTime(dataFrame.sort(sortSeriesByLabel)));
+    const sortedFrames = dataFrame.sort(sortSeriesByLabel);
+    return mergeHeatmapFrames(transformToHistogramOverTime(sortedFrames));
   }
 
   // Return matrix or vector result as DataFrame[]
@@ -653,9 +655,10 @@ function transformToHistogramOverTime(seriesList: DataFrame[]) {
     le20    20  10  30    =>    10  0   30
     le30    30  10  35    =>    10  0   5
     */
+
   for (let i = seriesList.length - 1; i > 0; i--) {
-    const topSeries = seriesList[i].fields[1];
-    const bottomSeries = seriesList[i - 1].fields[1];
+    const topSeries = seriesList[i].fields.find((s) => s.type === FieldType.number);
+    const bottomSeries = seriesList[i - 1].fields.find((s) => s.type === FieldType.number);
     if (!topSeries || !bottomSeries) {
       throw new Error('Prometheus heatmap transform error: data should be a time series');
     }

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -288,7 +288,6 @@ export function transform(
       preferredVisualisationType: transformOptions.query.instant ? 'rawPrometheus' : 'graph',
     },
   };
-
   const prometheusResult = response.data.data;
 
   if (isExemplarData(prometheusResult)) {
@@ -353,8 +352,7 @@ export function transform(
 
   // When format is heatmap use the already created data frames and transform it more
   if (options.format === 'heatmap') {
-    const sortedFrames = dataFrame.sort(sortSeriesByLabel);
-    return mergeHeatmapFrames(transformToHistogramOverTime(sortedFrames));
+    return mergeHeatmapFrames(transformToHistogramOverTime(dataFrame.sort(sortSeriesByLabel)));
   }
 
   // Return matrix or vector result as DataFrame[]

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -150,7 +150,7 @@ export function transformV2(
     // Create a new grouping by iterating through the data frames...
     const heatmapResultsGroupedByValues = groupBy<DataFrame>(heatmapResultsGroup, (dataFrame) => {
       // Each data frame has `Time` and `Value` properties, we want to get the values
-      const values = dataFrame.fields[1];
+      const values = dataFrame.fields.find((field) => field.type === FieldType.number);
       // Specific functionality for special "le" quantile heatmap value, we know if this value exists, that we do not want to calculate the heatmap density across data frames from the same quartile
       if (values?.labels && HISTOGRAM_QUANTILE_LABEL_NAME in values.labels) {
         const { le, ...notLE } = values?.labels;

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -121,7 +121,7 @@ export function transformV2(
   // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default
   heatmapResults.forEach((df) => {
     if (df.name == null) {
-      let f = df.fields.find((f) => f.name === 'Value');
+      let f = df.fields[1];
 
       if (f) {
         let le = f.labels?.le;
@@ -150,7 +150,7 @@ export function transformV2(
     // Create a new grouping by iterating through the data frames...
     const heatmapResultsGroupedByValues = groupBy<DataFrame>(heatmapResultsGroup, (dataFrame) => {
       // Each data frame has `Time` and `Value` properties, we want to get the values
-      const values = dataFrame.fields.find((field) => field.name === TIME_SERIES_VALUE_FIELD_NAME);
+      const values = dataFrame.fields[1];
       // Specific functionality for special "le" quantile heatmap value, we know if this value exists, that we do not want to calculate the heatmap density across data frames from the same quartile
       if (values?.labels && HISTOGRAM_QUANTILE_LABEL_NAME in values.labels) {
         const { le, ...notLE } = values?.labels;
@@ -654,8 +654,8 @@ function transformToHistogramOverTime(seriesList: DataFrame[]) {
     le30    30  10  35    =>    10  0   5
     */
   for (let i = seriesList.length - 1; i > 0; i--) {
-    const topSeries = seriesList[i].fields.find((s) => s.name === TIME_SERIES_VALUE_FIELD_NAME);
-    const bottomSeries = seriesList[i - 1].fields.find((s) => s.name === TIME_SERIES_VALUE_FIELD_NAME);
+    const topSeries = seriesList[i].fields[1];
+    const bottomSeries = seriesList[i - 1].fields[1];
     if (!topSeries || !bottomSeries) {
       throw new Error('Prometheus heatmap transform error: data should be a time series');
     }


### PR DESCRIPTION
**What is this feature?**
Fixing issue in prometheus frontend which was not data plane compatible, and was causing the code to throw errors when looking for the old Field name of "Value", which was changed in https://github.com/grafana/grafana/pull/62694.

**Why do we need this feature?**
To fix visualizations that use prometheus heatmap format.

**Who is this feature for?**
Prometheus users


**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/71017

**Special notes for your reviewer:**
This seems to get the vizs up and running and everything looks as it did before the breaking changes were merged. There's still more bugs that I've missed, but hopefully not anymore that are introduced?

This has been tested with and without the prometheusDataplane flag enabled, this should work in both cases.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
