### PR TITLE
Timeseries: Fix TooltipPlugin hooks warning

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -63,6 +63,8 @@ export const TooltipPlugin = ({
 
   const pluginId = `TooltipPlugin`;
 
+  const style = useStyles2(getStyles);
+
   // Debug logs
   useEffect(() => {
     pluginLog(pluginId, true, `Focused series: ${focusedSeriesIdx}, focused point: ${focusedPointIdx}`);
@@ -273,8 +275,6 @@ export const TooltipPlugin = ({
   } else {
     tooltip = renderTooltip(otherProps.data, focusedSeriesIdx, focusedPointIdx);
   }
-
-  const style = useStyles2(getStyles);
 
   return (
     <Portal className={isActive ? style.tooltipWrapper : undefined}>


### PR DESCRIPTION
This fixes the hooks order warning in TooltipPlugin introduced by https://github.com/grafana/grafana/pull/70747

Warning on hovering over panel

![Screenshot 2023-07-19 at 2 39 34 PM](https://github.com/grafana/grafana/assets/88068998/fc95b7b9-0367-4036-822b-c5b784fbb58f)



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
