### PR TITLE
Docs: add alias to data sources index file 9.4

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - data-sources/
   - overview/
+  - ./features/datasources/
 cascade:
   labels:
     products:


### PR DESCRIPTION
Addresses 403 forbidden error for the following;

https://grafana.com/docs/grafana/latest/features/datasources/
