### PR TITLE
Tests: add MariaDB container stack for integration tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -865,6 +865,18 @@ services:
   volumes:
   - name: mysql80
     path: /var/lib/mysql
+- commands:
+  - docker-entrypoint.sh mariadbd
+  environment:
+    MARIADB_DATABASE: grafana_tests
+    MARIADB_PASSWORD: password
+    MARIADB_ROOT_PASSWORD: rootpass
+    MARIADB_USER: grafana
+  image: mariadb:10.11
+  name: mariadb1011
+  volumes:
+  - name: mariadb1011
+    path: /var/lib/mysql
 - environment: {}
   image: redis:6.2.11-alpine
   name: redis

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -138,7 +138,7 @@ Running the backend tests on Windows currently needs some tweaking, so use the b
 go run build.go test
 ```
 
-### Run SQLLite, PostgreSQL and MySQL integration tests
+### Run SQLLite, PostgreSQL and MySQL or MariaDB integration tests
 
 By default grafana runs SQLite, to run test with SQLite
 
@@ -146,7 +146,7 @@ By default grafana runs SQLite, to run test with SQLite
 go test -covermode=atomic -tags=integration ./pkg/...
 ```
 
-To run PostgreSQL and MySQL integration tests locally, you need to start the docker blocks for MySQL and/or PostgreSQL test data sources by running `make devenv sources=mysql_tests,postgres_tests`. When your test data sources are running, you can execute integration tests by running:
+To run PostgreSQL and MySQL or MariaDB integration tests locally, you need to start the docker blocks for PostgreSQL and/or MySQL or MariaDB test data sources by running `make devenv sources=mysql_tests|mariadb_tests,postgres_tests` (you can not run MySQL and MariaDB test simultaneously since they use the same port `localhost:3306`). When your test data sources are running, you can execute integration tests by running:
 
 ```bash
 make test-go-integration-mysql

--- a/devenv/docker/blocks/mariadb_tests/.env
+++ b/devenv/docker/blocks/mariadb_tests/.env
@@ -1,0 +1,1 @@
+mariadb_version=10.11

--- a/devenv/docker/blocks/mariadb_tests/Dockerfile
+++ b/devenv/docker/blocks/mariadb_tests/Dockerfile
@@ -1,0 +1,4 @@
+ARG mariadb_version=10.11
+FROM mariadb:${mariadb_version}
+COPY setup.sql /docker-entrypoint-initdb.d
+CMD ["mariadbd"]

--- a/devenv/docker/blocks/mariadb_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/mariadb_tests/docker-compose.yaml
@@ -1,0 +1,14 @@
+  mysqltests:
+    build:
+      context: docker/blocks/mariadb_tests
+      args:
+        - mariadb_version=${mariadb_version}
+    platform: linux/amd64
+    environment:
+      MARIADB_ROOT_PASSWORD: rootpass
+      MARIADB_DATABASE: grafana_tests
+      MARIADB_USER: grafana
+      MARIADB_PASSWORD: password
+    ports:
+      - "3306:3306"
+    tmpfs: /var/lib/mysql:rw

--- a/devenv/docker/blocks/mariadb_tests/setup.sql
+++ b/devenv/docker/blocks/mariadb_tests/setup.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE grafana_ds_tests;
+GRANT ALL PRIVILEGES ON grafana_ds_tests.* TO 'grafana';


### PR DESCRIPTION
WIP

**What is this feature?**

- add necessary container stack to be able to run integration tests against MariaDB;
- add CI steps for testing MariaDB LTS versions.

**Why do we need this feature?**

MariaDB is the default relational DB on some Linux distribution and evolves now differently from MySQL. It's important to keep and test compatibility with Grafana.

**Who is this feature for?**

People that choose MariaDB as the DB for installing Grafana.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
