### PR TITLE
NestedFolderPicker: Allow for excluding certain uids

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -34,11 +34,12 @@ interface NestedFolderPickerProps {
   // TODO: think properly (and pragmatically) about how to communicate moving to general folder,
   // vs removing selection (if possible?)
   onChange?: (folder: FolderChange) => void;
+  excludedUids?: string[];
 }
 
 const EXCLUDED_KINDS = ['empty-folder' as const, 'dashboard' as const];
 
-export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps) {
+export function NestedFolderPicker({ value, onChange, excludedUids = [] }: NestedFolderPickerProps) {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
   const selectedFolder = useGetFolderQuery(value || skipToken);
@@ -137,10 +138,18 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
         items: searchResults.items ?? [],
       };
 
-      return createFlatTree(undefined, searchCollection, childrenCollections, {}, 0, EXCLUDED_KINDS);
+      return createFlatTree(undefined, searchCollection, childrenCollections, {}, 0, EXCLUDED_KINDS, excludedUids);
     }
 
-    let flatTree = createFlatTree(undefined, rootCollection, childrenCollections, folderOpenState, 0, EXCLUDED_KINDS);
+    let flatTree = createFlatTree(
+      undefined,
+      rootCollection,
+      childrenCollections,
+      folderOpenState,
+      0,
+      EXCLUDED_KINDS,
+      excludedUids
+    );
 
     // Increase the level of each item to 'make way' for the fake root Dashboards item
     for (const item of flatTree) {
@@ -163,7 +172,7 @@ export function NestedFolderPicker({ value, onChange }: NestedFolderPickerProps)
     }
 
     return flatTree;
-  }, [search, searchState.value, rootCollection, childrenCollections, folderOpenState]);
+  }, [search, searchState.value, rootCollection, childrenCollections, folderOpenState, excludedUids]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -34,12 +34,12 @@ interface NestedFolderPickerProps {
   // TODO: think properly (and pragmatically) about how to communicate moving to general folder,
   // vs removing selection (if possible?)
   onChange?: (folder: FolderChange) => void;
-  excludedUids?: string[];
+  excludeUIDs?: string[];
 }
 
 const EXCLUDED_KINDS = ['empty-folder' as const, 'dashboard' as const];
 
-export function NestedFolderPicker({ value, onChange, excludedUids = [] }: NestedFolderPickerProps) {
+export function NestedFolderPicker({ value, onChange, excludeUIDs = [] }: NestedFolderPickerProps) {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
   const selectedFolder = useGetFolderQuery(value || skipToken);
@@ -138,7 +138,7 @@ export function NestedFolderPicker({ value, onChange, excludedUids = [] }: Neste
         items: searchResults.items ?? [],
       };
 
-      return createFlatTree(undefined, searchCollection, childrenCollections, {}, 0, EXCLUDED_KINDS, excludedUids);
+      return createFlatTree(undefined, searchCollection, childrenCollections, {}, 0, EXCLUDED_KINDS, excludeUIDs);
     }
 
     let flatTree = createFlatTree(
@@ -148,7 +148,7 @@ export function NestedFolderPicker({ value, onChange, excludedUids = [] }: Neste
       folderOpenState,
       0,
       EXCLUDED_KINDS,
-      excludedUids
+      excludeUIDs
     );
 
     // Increase the level of each item to 'make way' for the fake root Dashboards item
@@ -172,7 +172,7 @@ export function NestedFolderPicker({ value, onChange, excludedUids = [] }: Neste
     }
 
     return flatTree;
-  }, [search, searchState.value, rootCollection, childrenCollections, folderOpenState, excludedUids]);
+  }, [search, searchState.value, rootCollection, childrenCollections, folderOpenState, excludeUIDs]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {

--- a/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
@@ -61,7 +61,7 @@ export const MoveModal = ({ onConfirm, onDismiss, selectedItems, ...props }: Pro
 
       <Field label={t('browse-dashboards.action.move-modal-field-label', 'Folder name')}>
         {config.featureToggles.nestedFolderPicker ? (
-          <NestedFolderPicker value={moveTarget} onChange={handleFolderChange} />
+          <NestedFolderPicker value={moveTarget} onChange={handleFolderChange} excludedUids={selectedFolders} />
         ) : (
           <FolderPicker allowEmpty onChange={handleFolderChange} />
         )}

--- a/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
@@ -61,7 +61,7 @@ export const MoveModal = ({ onConfirm, onDismiss, selectedItems, ...props }: Pro
 
       <Field label={t('browse-dashboards.action.move-modal-field-label', 'Folder name')}>
         {config.featureToggles.nestedFolderPicker ? (
-          <NestedFolderPicker value={moveTarget} onChange={handleFolderChange} excludedUids={selectedFolders} />
+          <NestedFolderPicker value={moveTarget} onChange={handleFolderChange} excludeUIDs={selectedFolders} />
         ) : (
           <FolderPicker allowEmpty onChange={handleFolderChange} />
         )}

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -144,10 +144,11 @@ export function createFlatTree(
   childrenByUID: BrowseDashboardsState['childrenByParentUID'],
   openFolders: Record<string, boolean>,
   level = 0,
-  excludeKinds: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']> = []
+  excludeKinds: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']> = [],
+  excludedUids: string[] = []
 ): DashboardsTreeItem[] {
   function mapItem(item: DashboardViewItem, parentUID: string | undefined, level: number): DashboardsTreeItem[] {
-    if (excludeKinds.includes(item.kind)) {
+    if (excludeKinds.includes(item.kind) || excludedUids.includes(item.uid)) {
       return [];
     }
 
@@ -157,7 +158,8 @@ export function createFlatTree(
       childrenByUID,
       openFolders,
       level + 1,
-      excludeKinds
+      excludeKinds,
+      excludedUids
     );
 
     const isOpen = Boolean(openFolders[item.uid]);

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -145,10 +145,10 @@ export function createFlatTree(
   openFolders: Record<string, boolean>,
   level = 0,
   excludeKinds: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']> = [],
-  excludedUids: string[] = []
+  excludeUIDs: string[] = []
 ): DashboardsTreeItem[] {
   function mapItem(item: DashboardViewItem, parentUID: string | undefined, level: number): DashboardsTreeItem[] {
-    if (excludeKinds.includes(item.kind) || excludedUids.includes(item.uid)) {
+    if (excludeKinds.includes(item.kind) || excludeUIDs.includes(item.uid)) {
       return [];
     }
 
@@ -159,7 +159,7 @@ export function createFlatTree(
       openFolders,
       level + 1,
       excludeKinds,
-      excludedUids
+      excludeUIDs
     );
 
     const isOpen = Boolean(openFolders[item.uid]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- exposes a new prop, `excludeUIDs` on `NestedFolderPicker`
- this can be used to exclude certain folder uids (and all their children) from `NestedFolderPicker`

**Why do we need this feature?**

- to prevent moving a folder to itself (or a child)

**Who is this feature for?**

- anyone using nested folders

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/72007

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
