### PR TITLE
Mention that header name in JWT configuration should be specified always

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -40,6 +40,10 @@ enabled = true
 header_name = X-JWT-Assertion
 ```
 
+{{% admonition type="warning" %}}
+header name should be specified even if only URL login is used, otherwise, the JWT token in the URL will be ignored.
+{{% /admonition %}}
+
 ## Configure login claim
 
 To identify the user, some of the claims needs to be selected as a login info. The subject claim called `"sub"` is mandatory and needs to identify the principal that is the subject of the JWT.


### PR DESCRIPTION
**What is this feature?**

Because it is not clear from the documentation that you have to specify JWT header name if you want to JWT auth. works at all.

**Why do we need this feature?**

Save many hours of debugging why your JWT in URL is ignored.

**Who is this feature for?**

For those who uses JWT auth with URL login but does not use any header for JWT.

Please check that:
- [x ] It works as expected from a user's perspective.
- [x ] If this is a pre-GA feature, it is behind a feature toggle.
- [x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
