### PR TITLE
Config: Add [aws][external_id] to ini files

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -826,6 +826,9 @@ assume_role_enabled = true
 # Specify max no of pages to be returned by the ListMetricPages API
 list_metrics_page_limit = 500
 
+# Experimental, for use in Grafana Cloud only. Please do not set.
+external_id = 
+
 #################################### Azure ###############################
 [azure]
 # Azure cloud environment where Grafana is hosted

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -775,6 +775,12 @@
 # If true, assume role will be enabled for all AWS authentication providers that are specified in aws_auth_providers
 ; assume_role_enabled = true
 
+# Specify max no of pages to be returned by the ListMetricPages API
+; list_metrics_page_limit = 500
+
+# Experimental, for use in Grafana Cloud only. Please do not set.
+; external_id = 
+
 #################################### Azure ###############################
 [azure]
 # Azure cloud environment where Grafana is hosted


### PR DESCRIPTION
**What is this feature?**

Adds mention of [aws][external_id] to ini files. This is an experimental flag only relevant to Hosted Grafana, but we want mention of it to alleviate the risk of introducing conflicts. 