### PR TITLE
Tracing: New images in trace-integration docs

### DIFF
--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -304,7 +304,7 @@ If the file has multiple traces, Grafana visualizes its first trace.
 
 ## Span Filters
 
-![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters.png)
+![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters-v10-1.png)
 
 Using span filters, you can filter your spans in the trace timeline viewer. The more filters you add, the more specific are the filtered spans.
 
@@ -314,6 +314,8 @@ You can add one or more of the following filters:
 - Span name
 - Duration
 - Tags (which include tags, process tags, and log fields)
+
+To only show the spans you have matched, you can press the `Show matches only` toggle.
 
 ## Link to a trace ID from logs
 

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -370,7 +370,7 @@ To open a query in Tempo with the span name of that row automatically set in the
 
 ## Span Filters
 
-![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters.png)
+![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters-v10-1.png)
 
 Using span filters, you can filter your spans in the trace timeline viewer. The more filters you add, the more specific are the filtered spans.
 
@@ -380,6 +380,8 @@ You can add one or more of the following filters:
 - Span name
 - Duration
 - Tags (which include tags, process tags, and log fields)
+
+To only show the spans you have matched, you can press the `Show matches only` toggle.
 
 ## Link to a trace ID from logs
 

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -273,7 +273,7 @@ If the file has multiple traces, Grafana visualizes its first trace.
 
 ## Span Filters
 
-![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters.png)
+![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters-v10-1.png)
 
 Using span filters, you can filter your spans in the trace timeline viewer. The more filters you add, the more specific are the filtered spans.
 
@@ -283,6 +283,8 @@ You can add one or more of the following filters:
 - Span name
 - Duration
 - Tags (which include tags, process tags, and log fields)
+
+To only show the spans you have matched, you can press the `Show matches only` toggle.
 
 ## Link to a trace ID from logs
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -41,11 +41,11 @@ For information on querying each data source, refer to their documentation:
 
 This section explains the elements of the Trace View.
 
-{{< figure src="/static/img/docs/explore/explore-trace-view-full-8-0.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view" >}}
 
 ### Header
 
-{{< figure src="/static/img/docs/v70/explore-trace-view-header.png" class="docs-image--no-shadow" max-width= "750px" caption="Screenshot of the trace view header" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-header.png" class="docs-image--no-shadow" max-width= "750px" caption="Screenshot of the trace view header" >}}
 
 - Header title: Shows the name of the root span and trace ID.
 - Search: Highlights spans containing the searched text.
@@ -53,7 +53,7 @@ This section explains the elements of the Trace View.
 
 ### Minimap
 
-{{< figure src="/static/img/docs/v70/explore-trace-view-minimap.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view minimap" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-minimap.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view minimap" >}}
 
 Shows condensed view or the trace timeline. Drag your mouse over the minimap to zoom into smaller time range. Zooming will also update the main timeline, so it is easy to see shorter spans. Hovering over the minimap, when zoomed, will show Reset Selection button which resets the zoom.
 
@@ -74,7 +74,7 @@ To only show the spans you have matched, you can press the `Show matches only` t
 
 ### Timeline
 
-{{< figure src="/static/img/docs/v70/explore-trace-view-timeline.png" class="docs-image--no-shadow" max-width= "900px"  caption="Screenshot of the trace view timeline" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-timeline.png" class="docs-image--no-shadow" max-width= "900px"  caption="Screenshot of the trace view timeline" >}}
 
 Shows list of spans within the trace. Each span row consists of these components:
 
@@ -87,7 +87,7 @@ Clicking anywhere on the span row shows span details.
 
 ### Span details
 
-{{< figure src="/static/img/docs/v70/explore-trace-view-span-details.png" class="docs-image--no-shadow" max-width= "900px"  caption="Screenshot of the trace view span details" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-span-details.png" class="docs-image--no-shadow" max-width= "900px"  caption="Screenshot of the trace view span details" >}}
 
 - Operation name.
 - Span metadata.
@@ -103,7 +103,7 @@ Available in Grafana 7.4 and later versions.
 
 You can navigate from a span in a trace view directly to logs relevant for that span. This feature is available for Tempo, Jaeger, and Zipkin data sources. Refer to their [relevant documentation](/docs/grafana/latest/datasources/tempo/#trace-to-logs) for configuration instructions.
 
-{{< figure src="/static/img/docs/explore/trace-to-log-7-4.png" class="docs-image--no-shadow" max-width= "600px"  caption="Screenshot of the trace view in Explore with icon next to the spans" >}}
+{{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-trace-to-logs.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view in Explore with icon next to the spans" >}}
 
 Click the document icon to open a split view in Explore with the configured data source and query relevant logs for the span.
 
@@ -119,7 +119,7 @@ You can navigate from a span in a trace view directly to metrics relevant for th
 
 You can optionally expand the node graph for the displayed trace. Depending on the data source, this can show spans of the trace as nodes in the graph, or as some additional context like service graph based on the current trace.
 
-![Node graph](/static/img/docs/explore/explore-trace-view-node-graph-8-0.png 'Node graph')
+{{< figure src="/media/docs/tempo/screenshot-grafana-node-graph.png" class="docs-image--no-shadow" max-width= "900px"  caption="Screenshot of the node graph" >}}
 
 ## Service Graph
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -59,7 +59,7 @@ Shows condensed view or the trace timeline. Drag your mouse over the minimap to 
 
 ### Span Filters
 
-![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters.png)
+![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters-v10-1.png)
 
 Using span filters, you can filter your spans in the trace timeline viewer. The more filters you add, the more specific are the filtered spans.
 
@@ -69,6 +69,8 @@ You can add one or more of the following filters:
 - Span name
 - Duration
 - Tags (which include tags, process tags, and log fields)
+
+To only show the spans you have matched, you can press the `Show matches only` toggle.
 
 ### Timeline
 


### PR DESCRIPTION
**What is this feature?**

Adds new images for span filtering and the trace view header with updates to older trace view images.

**Why do we need this feature?**

Up to date images.

**Who is this feature for?**

Docs users.

**Special notes for your reviewer:**

![screenshot-grafana-trace-view-trace-to-logs](https://github.com/grafana/grafana/assets/90795735/74c5b11f-c54f-480e-a04f-695df3c9f2b8)



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
