### PR TITLE
Enrich DataRequestEvent MetaAnalytics with varName

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -522,6 +522,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
+  variableName?: string; // When the query is made by a dashboard-variable
   dashboardUID?: string;
   publicDashboardAccessToken?: string;
 

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -505,6 +505,16 @@ export interface DataQueryError {
   type?: DataQueryErrorType;
 }
 
+/**
+ * Describes the origin of the data request.
+ *
+ * @public
+ */
+export interface DataRequestOrigin {
+  type: 'panel' | 'variable';
+  reference: string;
+}
+
 export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   requestId: string; // Used to identify results and optionally cancel the request in backendSrv
 
@@ -521,8 +531,11 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   queryCachingTTL?: number | null;
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
+  /**
+   * @deprecated use origin instead
+   */
   panelId?: number;
-  variableName?: string; // When the query is made by a dashboard-variable
+  origin?: DataRequestOrigin;
   dashboardUID?: string;
   publicDashboardAccessToken?: string;
 

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -29,6 +29,7 @@ export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceUid: string;
   datasourceType: string;
   panelId?: number;
+  variableName?: string;
   panelName?: string;
   duration: number;
   error?: string;

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -1,4 +1,4 @@
-import { CoreApp } from '@grafana/data';
+import { CoreApp, DataRequestOrigin } from '@grafana/data';
 
 import { EchoEvent, EchoEventType } from '../services/EchoSrv';
 
@@ -28,12 +28,15 @@ export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceId: number;
   datasourceUid: string;
   datasourceType: string;
+  /**
+   * @deprecated use origin instead
+   */
   panelId?: number;
-  variableName?: string;
   panelName?: string;
   duration: number;
   error?: string;
   dataSize?: number;
+  origin?: DataRequestOrigin;
 }
 
 /**

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -108,7 +108,10 @@ function getTestDataForVariable(requestApp: string, series: DataFrame[] = []): P
   return {
     request: {
       app: requestApp,
-      variableName: 'variable_name',
+      origin: {
+        type: 'variable',
+        reference: 'variable_name',
+      },
       startTime: now.unix(),
       endTime: now.add(1, 's').unix(),
     } as DataQueryRequest,
@@ -156,7 +159,10 @@ describe('emitDataRequestEvent - from a dashboard variable', () => {
         datasourceUid: datasource.uid,
         datasourceType: datasource.type,
         source: 'dashboard',
-        variableName: 'variable_name',
+        origin: {
+          type: 'variable',
+          reference: 'variable_name',
+        },
         dashboardUid: 'test', // from dashboard srv
         dataSize: 0,
         duration: 1,

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -65,6 +65,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
     const totalQueries = Object.keys(queryCacheStatus).length;
     const cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
 
+    eventData.variableName = data.request!.variableName;
     eventData.panelId = data.request!.panelId;
     eventData.totalQueries = totalQueries;
     eventData.cachedQueries = cachedQueries;

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -65,8 +65,8 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
     const totalQueries = Object.keys(queryCacheStatus).length;
     const cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
 
-    eventData.variableName = data.request!.variableName;
     eventData.panelId = data.request!.panelId;
+    eventData.origin = data.request!.origin;
     eventData.totalQueries = totalQueries;
     eventData.cachedQueries = cachedQueries;
 

--- a/public/app/features/variables/query/VariableQueryRunner.test.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.test.ts
@@ -119,6 +119,12 @@ describe('VariableQueryRunner', () => {
           expect(queryRunners.getRunnerForDatasource).toHaveBeenCalledTimes(1);
           expect(queryRunner.getTarget).toHaveBeenCalledTimes(1);
           expect(queryRunner.runRequest).toHaveBeenCalledTimes(1);
+          expect(queryRunner.runRequest).toBeCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              variableName: 'query',
+            })
+          );
           expect(datasource.metricFindQuery).not.toHaveBeenCalled();
 
           // updateVariableOptions and validateVariableSelectionState

--- a/public/app/features/variables/query/VariableQueryRunner.test.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.test.ts
@@ -122,7 +122,10 @@ describe('VariableQueryRunner', () => {
           expect(queryRunner.runRequest).toBeCalledWith(
             expect.anything(),
             expect.objectContaining({
-              variableName: 'query',
+              origin: {
+                type: 'variable',
+                reference: 'query',
+              },
             })
           );
           expect(datasource.metricFindQuery).not.toHaveBeenCalled();

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -184,6 +184,7 @@ export class VariableQueryRunner {
       app: CoreApp.Dashboard,
       requestId: uuidv4(),
       timezone: '',
+      variableName: variable.name,
       range,
       interval: '',
       intervalMs: 0,

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -184,7 +184,10 @@ export class VariableQueryRunner {
       app: CoreApp.Dashboard,
       requestId: uuidv4(),
       timezone: '',
-      variableName: variable.name,
+      origin: {
+        type: 'variable',
+        reference: variable.name,
+      },
       range,
       interval: '',
       intervalMs: 0,


### PR DESCRIPTION
DataRequestEvents often come from Panels, but they can also come from
Dashboard Variables that have type "Query".
These events are logged via reportMetaAnalytics. For Panels they are
logged with a `panelId` field present. But for Dashboard Variables
there is no identifier logged, so it's hard to see both:
- Where the data-request was made from (ie. that it came from a dashboard variable at all, and)
- Which dashboard-variable made the data-request

I'd like to add this logging, in order to aid debugging of slow
data-requests coming from dashboard variables. Dashboard-variables can
have more complexity than Panels, because there are different
query-types available which each hit a different Prometheus API endpoint
(in the case of the Prom datasource). As a result, queries can be slow
due to:
- Making a bad choice of query-type for the shape of your data, or
- A regression in one of the Prom API endpoints, for example
   `/label/[label-key]/values`

Having this additional logging would help with debugging these in
general.

These logs are available to all GrafanaCloud customers via the
`grafanacloud-[instance-slug]-usage-insights` Loki datasource, so this
should help our customers too.

See this screenshot of what I'm describing:
![image](https://github.com/grafana/grafana/assets/2903904/af81b672-07be-48b4-9e61-04b7746ab892)