### PR TITLE
AuthN: Lock down manual role updates for users synced through Grafana Com portal

### DIFF
--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -133,7 +133,7 @@ func IsProviderEnabled(cfg *setting.Cfg, authModule string) bool {
 	case GithubAuthModule:
 		return cfg.GitHubAuthEnabled
 	case GrafanaComAuthModule:
-		return cfg.GrafanaComAuthEnabled
+		return cfg.GrafanaComAuthEnabled || cfg.GrafanaNetAuthEnabled
 	case GenericOAuthModule:
 		return cfg.GenericOAuthAuthEnabled
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -494,6 +494,9 @@ type Cfg struct {
 	// skip the org roles coming from GrafanaCom
 	GrafanaComSkipOrgRoleSync bool
 
+	// Grafana.com Auth enabled through [auth.grafananet] config section
+	GrafanaNetAuthEnabled bool
+
 	// Geomap base layer config
 	GeomapDefaultBaseLayerConfig map[string]interface{}
 	GeomapEnableCustomBaseLayers bool
@@ -1452,6 +1455,11 @@ func readAuthGrafanaComSettings(cfg *Cfg) {
 	cfg.GrafanaComSkipOrgRoleSync = sec.Key("skip_org_role_sync").MustBool(false)
 }
 
+func readAuthGrafanaNetSettings(cfg *Cfg) {
+	sec := cfg.SectionWithEnvOverrides("auth.grafananet")
+	cfg.GrafanaNetAuthEnabled = sec.Key("enabled").MustBool(false)
+}
+
 func readAuthGithubSettings(cfg *Cfg) {
 	sec := cfg.SectionWithEnvOverrides("auth.github")
 	cfg.GitHubAuthEnabled = sec.Key("enabled").MustBool(false)
@@ -1559,6 +1567,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	// GrafanaCom
 	readAuthGrafanaComSettings(cfg)
+	readAuthGrafanaNetSettings(cfg)
 
 	// Github
 	readAuthGithubSettings(cfg)


### PR DESCRIPTION
**What is this feature?**

Make sure that roles can't be manually updated for users synced through GCom.

Looks like for HG instances we enable GCom provider in `[auth.grafananet]` config section and not `[auth.grafana_com]` config section. However, we only looked at `[auth.grafana_com]` config section when checking if GCom auth is enabled, and therefore correctly reported that it is not enabled and that users synced through GCom auth are not externally synced.

**Why do we need this feature?**

Users roles should either be updated manually or synced through the auth provider, we want to avoid the mix of both.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-authnz-team/issues/247

**Special notes for your reviewer:**

Note that we'll roll this change out behind a feature toggle (https://github.com/grafana/grafana/pull/72202), so that we can gradually introduce this to hosted Grafana users.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
