### PR TITLE
Update all links that have destinations outside of /docs/grafana/latest/datasources/ to use `docs/reference` shortcode

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -22,28 +22,28 @@ Each data source comes with a _query editor_,
 which formulates custom queries according to the source's structure.
 After you add and configure a data source, you can use it as an input for many operations, including:
 
-- Query the data with [Explore]({{< relref "../explore" >}}).
-- Visualize it in [panels]({{< relref "../panels-visualizations" >}}).
-- Create rules for [alerts]({{< relref "../alerting" >}}).
+- Query the data with [Explore][explore].
+- Visualize it in [panels][panels].
+- Create rules for [alerts][alerts].
 
 This documentation describes how to manage data sources in general,
 and how to configure or query the built-in data sources.
 For other data sources, refer to the list of [datasource plugins](/grafana/plugins/).
-To develop a custom plugin, refer to [Build a plugin]({{< relref "../developers/plugins/" >}}).
+To develop a custom plugin, refer to [Build a plugin][build-a-plugin].
 
 ## Manage data sources
 
-Only users with the [organization administrator role]({{< relref "../administration/roles-and-permissions#organization-roles" >}}) can add or remove data sources.
+Only users with the [organization administrator role][organization-roles] can add or remove data sources.
 To access data source management tools in Grafana as an administrator, navigate to **Configuration > Data Sources** in the Grafana sidebar.
 
-For details on data source management, including instructions on how to add data sources and configure user permissions for queries, refer to the [administration documentation]({{< relref "../administration/data-source-management" >}}).
+For details on data source management, including instructions on how to add data sources and configure user permissions for queries, refer to the [administration documentation][data-source-management].
 
 ## Use query editors
 
 {{< figure src="/static/img/docs/queries/influxdb-query-editor-7-2.png" class="docs-image--no-shadow" max-width="1000px" caption="The InfluxDB query editor" >}}
 
 Each data source's **query editor** provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
-You use a data source's query editor when you create queries in [dashboard panels]({{< relref "../panels-visualizations/query-transform-data" >}}) or [Explore]({{< relref "../explore/" >}}).
+You use a data source's query editor when you create queries in [dashboard panels][query-transform-data] or [Explore][explore].
 
 Because of the differences between query languages, each data source query editor looks and functions differently.
 Depending on your data source, the query editor might provide auto-completion features, metric names, variable suggestions, or a visual query-building interface.
@@ -70,20 +70,43 @@ Grafana includes three special data sources:
 
 These built-in core data sources are also included in the Grafana documentation:
 
-- [Alertmanager]({{< relref "./alertmanager/" >}})
-- [AWS CloudWatch]({{< relref "./aws-cloudwatch/" >}})
-- [Azure Monitor]({{< relref "./azure-monitor/" >}})
-- [Elasticsearch]({{< relref "./elasticsearch/" >}})
-- [Google Cloud Monitoring]({{< relref "./google-cloud-monitoring/" >}})
-- [Graphite]({{< relref "./graphite/" >}})
-- [InfluxDB]({{< relref "./influxdb/" >}})
-- [Jaeger]({{< relref "./jaeger/" >}})
-- [Loki]({{< relref "./loki/" >}})
-- [Microsoft SQL Server (MSSQL)]({{< relref "./mssql/" >}})
-- [MySQL]({{< relref "./mysql/" >}})
-- [OpenTSDB]({{< relref "./opentsdb/" >}})
-- [PostgreSQL]({{< relref "./postgres/" >}})
-- [Prometheus]({{< relref "./prometheus/" >}})
-- [Tempo]({{< relref "./tempo/" >}})
-- [Testdata]({{< relref "./testdata/" >}})
-- [Zipkin]({{< relref "./zipkin/" >}})
+- [Alertmanager][({{< relref "./alertmanager" >}})
+- [AWS CloudWatch]({{< relref "./aws-cloudwatch" >}})
+- [Azure Monitor]({{< relref "./azure-monitor" >}})
+- [Elasticsearch]({{< relref "./elasticsearch" >}})
+- [Google Cloud Monitoring]({{< relref "./google-cloud-monitoring" >}})
+- [Graphite]({{< relref "./graphite" >}})
+- [InfluxDB]({{< relref "./influxdb" >}})
+- [Jaeger]({{< relref "./jaeger" >}})
+- [Loki]({{< relref "./loki" >}})
+- [Microsoft SQL Server (MSSQL)]({{< relref "./mssql" >}})
+- [MySQL]({{< relref "./mysql" >}})
+- [OpenTSDB]({{< relref "./opentsdb" >}})
+- [PostgreSQL]({{< relref "./postgres" >}})
+- [Prometheus]({{< relref "./prometheus" >}})
+- [Tempo]({{< relref "./tempo" >}})
+- [Testdata]({{< relref "./testdata" >}})
+- [Zipkin]({{< relref "./zipkin" >}})
+
+{{% docs/reference %}}
+[alerts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+[alerts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+
+[build-a-plugin]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins"
+[build-a-plugin]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[organization-roles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions#organization-roles"
+[organization-roles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions#organization-roles"
+
+[panels]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations"
+[panels]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -70,7 +70,7 @@ Grafana includes three special data sources:
 
 These built-in core data sources are also included in the Grafana documentation:
 
-- [Alertmanager][({{< relref "./alertmanager" >}})
+- [Alertmanager]({{< relref "./alertmanager" >}})
 - [AWS CloudWatch]({{< relref "./aws-cloudwatch" >}})
 - [Azure Monitor]({{< relref "./azure-monitor" >}})
 - [Elasticsearch]({{< relref "./elasticsearch" >}})

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -22,12 +22,12 @@ weight: 150
 # Alertmanager data source
 
 Grafana includes built-in support for Alertmanager implementations in Prometheus and Mimir.
-Once you add it as a data source, you can use the [Grafana Alerting UI](/docs/grafana/latest/alerting/) to manage silences, contact points, and notification policies.
+Once you add it as a data source, you can use the [Grafana Alerting UI][alerting] to manage silences, contact points, and notification policies.
 To switch between Grafana and any configured Alertmanager data sources, you can select your preference from a drop-down option in those databases' data source settings pages.
 
 ## Alertmanager implementations
 
-The data source supports [Prometheus](https://prometheus.io/) and [Grafana Mimir](https://grafana.com/docs/mimir/latest/) (default) implementations of Alertmanager.
+The data source supports [Prometheus](https://prometheus.io/) and [Grafana Mimir](/docs/mimir/latest/) (default) implementations of Alertmanager.
 You can specify the implementation in the data source's Settings page.
 When using Prometheus, contact points and notification policies are read-only in the Grafana Alerting UI, because it doesn't support updates to the configuration using HTTP API.
 
@@ -56,7 +56,7 @@ To configure basic settings for the data source, complete the following steps:
 ## Provision the Alertmanager data source
 
 You can provision Alertmanager data sources by updating Grafana's configuration files.
-For more information on provisioning, and common settings available, refer to the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}}).
+For more information on provisioning, and common settings available, refer to the [provisioning docs page][data-sources].
 
 Here is an example for provisioning the Alertmanager data source:
 
@@ -79,3 +79,11 @@ datasources:
     secureJsonData:
       basicAuthPassword: test_password
 ```
+
+{{% docs/reference %}}
+[alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+[alerting]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting"
+
+[data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+[data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -26,11 +26,11 @@ weight: 200
 Grafana ships with built-in support for Amazon CloudWatch.
 This topic describes queries, templates, variables, and other configuration specific to the CloudWatch data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [provision the data source]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system, and should [control pricing]({{< relref "#control-pricing" >}}) and [manage service quotas]({{< relref "#manage-service-quotas" >}}) accordingly.
+Administrators can also [provision the data source](#provision-the-data-source) with Grafana's provisioning system, and should [control pricing](#control-pricing) and [manage service quotas](#manage-service-quotas) accordingly.
 
-Once you've added the data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 {{% admonition type="note" %}}
 To troubleshoot issues while setting up the CloudWatch data source, check the `/var/log/grafana/grafana.log` file.
@@ -50,12 +50,12 @@ To troubleshoot issues while setting up the CloudWatch data source, check the `/
 A Grafana plugin's requests to AWS are made on behalf of an AWS Identity and Access Management (IAM) role or IAM user.
 The IAM user or IAM role must have the associated policies to perform certain API actions.
 
-For authentication options and configuration details, refer to [AWS authentication]({{< relref "./aws-authentication/" >}}).
+For authentication options and configuration details, refer to [AWS authentication]({{< relref "./aws-authentication" >}}).
 
 #### IAM policy examples
 
 To read CloudWatch metrics and EC2 tags, instances, regions, and alarms, you must grant Grafana permissions via IAM.
-You can attach these permissions to the IAM role or IAM user you configured in [AWS authentication]({{< relref "./aws-authentication/" >}}).
+You can attach these permissions to the IAM role or IAM user you configured in [AWS authentication]({{< relref "./aws-authentication" >}}).
 
 ##### Metrics-only permissions
 
@@ -217,7 +217,7 @@ The data source select contains only existing data source instances of type X-Ra
 To use this feature, you must already have an X-Ray data source configured.
 For details, see the [X-Ray data source docs](/grafana/plugins/grafana-x-ray-datasource/).
 
-To view the X-Ray link, select the log row in either the Explore view or dashboard [Logs panel]({{< relref "../../panels-visualizations/visualizations/logs" >}}) to view the log details section.
+To view the X-Ray link, select the log row in either the Explore view or dashboard [Logs panel][logs] to view the log details section.
 
 To log the `@xrayTraceId`, see the [AWS X-Ray documentation](https://docs.amazonaws.cn/en_us/xray/latest/devguide/xray-services.html).
 
@@ -227,7 +227,7 @@ To provide the field to Grafana, your log queries must also contain the `@xrayTr
 
 ### Configure the data source with grafana.ini
 
-The Grafana [configuration file]({{< relref "../../setup-grafana/configure-grafana#aws" >}}) includes an `AWS` section where you can configure data source options:
+The Grafana [configuration file][configure-grafana-aws] includes an `AWS` section where you can configure data source options:
 
 | Configuration option      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -238,7 +238,7 @@ The Grafana [configuration file]({{< relref "../../setup-grafana/configure-grafa
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning examples
 
@@ -302,7 +302,7 @@ datasources:
 
 The CloudWatch data source can query data from both CloudWatch metrics and CloudWatch Logs APIs, each with its own specialized query editor.
 
-For details, see the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, see the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -310,7 +310,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
 
 ## Import pre-configured dashboards
 
@@ -324,7 +324,7 @@ The CloudWatch data source ships with curated and pre-configured dashboards for 
 
 **To import curated dashboards:**
 
-1. Navigate to the data source's [configuration page]({{< relref "#configure-the-data-source" >}}).
+1. Navigate to the data source's [configuration page](#configure-the-data-source).
 1. Select the **Dashboards** tab.
 
    This displays the curated selection of importable dashboards.
@@ -355,7 +355,7 @@ filter @message like /Exception/
 If you receive an error like `input data must be a wide series but got ...` when trying to alert on a query, make sure that your query returns valid numeric data that can be output to a Time series panel.
 {{% /admonition %}}
 
-For more information on Grafana alerts, refer to [Alerting]({{< relref "../../alerting" >}}).
+For more information on Grafana alerts, refer to [Alerting][alerting].
 
 ## Control pricing
 
@@ -391,3 +391,26 @@ To use this feature, configure in the [AWS console under Cloudwatch Settings](ht
 ## CloudWatch Logs data protection
 
 CloudWatch Logs can safeguard data by using log group data protection policies. If you have data protection enabled for a log group, then any sensitive data that matches the data identifiers you've selected will be masked. In order to view masked data you will need to have the `logs:Unmask` IAM permission enabled. See the AWS documentation on how to [help protect sensitive log data with masking](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) to learn more about this.
+
+{{% docs/reference %}}
+[alerting]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting"
+[alerting]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting"
+
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-aws]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#aws"
+[configure-grafana-aws]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#aws"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[logs]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+[logs]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -28,11 +28,11 @@ All requests to AWS APIs are performed on the server side by the Grafana backend
 
 This topic has the following sections:
 
-- [Select an authentication method]({{< relref "#select-an-authentication-method" >}})
-- [Assume a role]({{< relref "#assume-a-role" >}})
-- [Use a custom endpoint]({{< relref "#use-a-custom-endpoint" >}})
-- [Use an AWS credentials file]({{< relref "#use-an-aws-credentials-file" >}})
-- [Use EKS IAM roles for service accounts]({{< relref "#use-eks-iam-roles-for-service-accounts" >}})
+- [Select an authentication method](#select-an-authentication-method)
+- [Assume a role](#assume-a-role)
+- [Use a custom endpoint](#use-a-custom-endpoint)
+- [Use an AWS credentials file](#use-an-aws-credentials-file)
+- [Use EKS IAM roles for service accounts](#use-eks-iam-roles-for-service-accounts)
 
 ## Select an authentication method
 
@@ -53,7 +53,7 @@ Open source Grafana enables the `AWS SDK Default`, `Credentials file`, and `Acce
   This option is enabled by default only in Amazon Managed Grafana.
 
 If necessary, you can enable or disable them if you have server configuration access.
-For more information, refer to the [`allowed_auth_providers` documentation]({{< relref "../../../setup-grafana/configure-grafana#allowed_auth_providers" >}}).
+For more information, refer to the [`allowed_auth_providers` documentation][configure-grafana-allowed-auth-providers].
 
 ## Assume a role
 
@@ -63,7 +63,7 @@ If this field is left blank, Grafana uses the provided credentials directly, and
 
 If this field isn't blank, Grafana uses the provided credentials to perform an [sts:AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) call.
 
-To disable this feature, refer to the [`assume_role_enabled` documentation]({{< relref "../../../setup-grafana/configure-grafana#assume_role_enabled" >}}).
+To disable this feature, refer to the [`assume_role_enabled` documentation][configure-grafana-assume-role-enabled].
 
 ### Use an external ID
 
@@ -110,3 +110,11 @@ securityContext:
   runAsUser: 472
   runAsGroup: 472
 ```
+
+{{% docs/reference %}}
+[configure-grafana-allowed-auth-providers]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#allowed_auth_providers"
+[configure-grafana-allowed-auth-providers]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#allowed_auth_providers"
+
+[configure-grafana-assume-role-enabled]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#assume_role_enabled"
+[configure-grafana-assume-role-enabled]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#assume_role_enabled"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -23,14 +23,14 @@ weight: 300
 # Amazon CloudWatch query editor
 
 This topic explains querying specific to the CloudWatch data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 The CloudWatch data source can query data from both CloudWatch metrics and CloudWatch Logs APIs, each with its own specialized query editor.
 
-- [CloudWatch metrics]({{< relref "#query-cloudwatch-metrics" >}})
-- [CloudWatch Logs]({{< relref "#query-cloudwatch-logs" >}})
+- [CloudWatch metrics](#query-cloudwatch-metrics)
+- [CloudWatch Logs](#query-cloudwatch-logs)
 
 {{< figure src="/static/img/docs/cloudwatch/cloudwatch-query-editor-api-modes-8.3.0.png" max-width="500px" class="docs-image--right" caption="CloudWatch API modes" >}}
 
@@ -40,8 +40,8 @@ Select which API to query by using the query mode switch on top of the editor.
 
 You can build two types of queries with the CloudWatch query editor:
 
-- [Metric Search]({{< relref "#create-a-metric-search-query" >}})
-- [Metric Query]({{< relref "#create-a-metric-insights-query" >}}), which uses the Metrics Insights feature
+- [Metric Search](#create-a-metric-search-query)
+- [Metric Query](#create-a-metric-insights-query), which uses the Metrics Insights feature
 
 ### Create a Metric Search query
 
@@ -51,7 +51,7 @@ If you enable `Match Exact`, you must also specify all dimensions of the metric 
 If `Match Exact` is disabled, you can specify any number of dimensions on which you'd like to filter.
 The data source returns up to 100 metrics matching your filter criteria.
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 #### Create dynamic queries with dimension wildcards
 
@@ -65,7 +65,7 @@ This can help you monitor metrics for AWS resources, like EC2 instances or conta
 When an auto-scaling event creates new instances, they automatically appear in the graph without you having to track the new instance IDs.
 This capability is currently limited to retrieving up to 100 metrics.
 
-You can expand the [Query inspector]({{< relref "../../../panels-visualizations/query-transform-data/#navigate-the-query-tab" >}}) button and click `Meta Data` to see the search expression that's automatically built to support wildcards.
+You can expand the [Query inspector][query-transform-data-navigate-the-query-tab] button and click `Meta Data` to see the search expression that's automatically built to support wildcards.
 
 To learn more about search expressions, refer to the [CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html).
 The search expression is defined by default in such a way that the queried metrics must match the defined dimension names exactly.
@@ -145,7 +145,7 @@ For details about the Metrics Insights syntax, refer to the [AWS reference docum
 
 For information about Metrics Insights limits, refer to the [AWS feature documentation](https://docs.aws.amazon.com/console/cloudwatch/metricsinsights).
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 #### Use Metrics Insights keywords
 
@@ -221,7 +221,7 @@ The logs query editor helps you write CloudWatch Logs Query Language queries acr
 1. Use the main input area to write your query in [CloudWatch Logs Query Language](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
 
 You can also write queries returning time series data by using the [`stats` command](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_Insights-Visualizing-Log-Data.html).
-When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), make sure you are in Metrics Explore mode.
+When making `stats` queries in [Explore][explore], make sure you are in Metrics Explore mode.
 
 {{< figure src="/static/img/docs/v70/explore-mode-switcher.png" max-width="500px" class="docs-image--right" caption="Explore mode switcher" >}}
 
@@ -235,7 +235,7 @@ To enable cross-account observability, complete the following steps:
 
 1. Go to the [Amazon CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
 
-1. Add [two API actions](/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
+1. Add [two API actions]({{< relref "../../aws-cloudwatch#cross-account-observability-permissions" >}}) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the `Logs` mode and the `Metric search` mode. Once you have it configured correctly, you'll see a "Monitoring account" badge displayed in the query editor header.
 
@@ -259,3 +259,14 @@ To view your query in the CloudWatch Logs Insights console, click the `CloudWatc
 If you're not logged in to the CloudWatch console, the link forwards you to the login page.
 
 The provided link is valid for any account, but displays the expected metrics only if you're logged in to the account that corresponds to the selected data source in Grafana.
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[query-transform-data-navigate-the-query-tab]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#navigate-the-query-tab"
+[query-transform-data-navigate-the-query-tab]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#navigate-the-query-tab"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/aws-cloudwatch/template-variables/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/template-variables/index.md
@@ -25,7 +25,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Use query variables
 
@@ -52,7 +52,7 @@ For details about the metrics CloudWatch provides, refer to the [CloudWatch docu
 ### Use variables in queries
 
 Use Grafana's variable syntax to include variables in queries.
-For details, refer to the [variable syntax documentation]({{< relref "../../../dashboards/variables/variable-syntax" >}}).
+For details, refer to the [variable syntax documentation][variable-syntax].
 
 ## Use ec2_instance_attribute
 
@@ -97,3 +97,14 @@ You can select any attribute that has a single value and isn't an object or arra
 
 You can select tags by prepending the tag name with `Tags.`.
 For example, select the tag `Name` by using `Tags.Name`.
+
+{{% docs/reference %}}
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variable-syntax]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+[variable-syntax]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -30,10 +30,10 @@ weight: 300
 Grafana ships with built-in support for Azure Monitor, the Azure service to maximize the availability and performance of applications and services in the Azure Cloud.
 This topic explains configuring and querying specific to the Azure Monitor data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
 
-Once you've added the Azure Monitor data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards" >}}) and use [Explore]({{< relref "../../explore" >}}).
+Once you've added the Azure Monitor data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 The Azure Monitor data source supports visualizing data from three Azure services:
 
@@ -61,7 +61,7 @@ The app registration you create must have the `Reader` role assigned on the subs
 For more information, refer to [Azure documentation for role assignments](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal?tabs=current).
 
 If you host Grafana in Azure, such as in App Service or Azure Virtual Machines, you can configure the Azure Monitor data source to use Managed Identity for secure authentication without entering credentials into Grafana.
-For details, refer to [Configuring using Managed Identity]({{< relref "#configuring-using-managed-identity" >}}).
+For details, refer to [Configuring using Managed Identity](#configuring-using-managed-identity).
 
 | Name                        | Description                                                                                                                                                                                                                                                                                           |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -75,7 +75,7 @@ For details, refer to [Configuring using Managed Identity]({{< relref "#configur
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning examples
 
@@ -130,7 +130,7 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
 **To enable managed identity for Grafana:**
 
-1. Set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server configuration]({{< relref "../../setup-grafana/configure-grafana/#azure" >}}).
+1. Set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure].
 
    ```ini
    [azure]
@@ -147,7 +147,7 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
 The Azure Monitor data source can query data from Azure Monitor Metrics and Logs, the Azure Resource Graph, and Application Insights Traces. Each source has its own specialized query editor.
 
-For details, see the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, see the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -155,7 +155,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
 
 ## Application Insights and Insights Analytics (removed))
 
@@ -164,3 +164,20 @@ Until Grafana v8.0, you could query the same Azure Application Insights data usi
 These queries were deprecated in Grafana v7.5. In Grafana v8.0, Application Insights and Insights Analytics were made read-only in favor of querying this data through Metrics and Logs. These query methods were completely removed in Grafana v9.0.
 
 If you're upgrading from a Grafana version prior to v9.0 and relied on Application Insights and Analytics queries, refer to the [Grafana v9.0 documentation](/docs/grafana/v9.0/datasources/azuremonitor/deprecated-application-insights/) for help migrating these queries to Metrics and Logs queries.
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-azure]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#azure"
+[configure-grafana-azure]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#azure"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/azure-monitor/query-editor/index.md
+++ b/docs/sources/datasources/azure-monitor/query-editor/index.md
@@ -26,16 +26,16 @@ weight: 300
 # Azure Monitor query editor
 
 This topic explains querying specific to the Azure Monitor data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 The Azure Monitor data source's query editor has three modes depending on which Azure service you want to query:
 
-- **Metrics** for [Azure Monitor Metrics]({{< relref "#query-azure-monitor-metrics" >}})
-- **Logs** for [Azure Monitor Logs]({{< relref "#query-azure-monitor-logs" >}})
-- [**Azure Resource Graph**]({{< relref "#query-azure-resource-graph" >}})
-- **Traces** for [Application Insights Traces]({{< relref "#query-application-insights-traces" >}})
+- **Metrics** for [Azure Monitor Metrics](#query-azure-monitor-metrics)
+- **Logs** for [Azure Monitor Logs](#query-azure-monitor-logs)
+- [**Azure Resource Graph**](#query-azure-resource-graph)
+- **Traces** for [Application Insights Traces](#query-application-insights-traces)
 
 ## Query Azure Monitor Metrics
 
@@ -74,7 +74,7 @@ Optionally, you can apply further aggregations or filter by dimensions.
 
 The available options change depending on what is relevant to the selected metric.
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 ### Format legend aliases
 
@@ -133,7 +133,7 @@ You can also perform complex analysis of Logs data by using KQL.
 
 1. Enter your KQL query.
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 ### Logs query examples
 
@@ -213,7 +213,7 @@ To help you write queries, you can use several Grafana macros in the `where` cla
 | `$__escapeMulti($myVar)`        | Escapes illegal characters in multi-value template variables.<br/>If `$myVar` has the values `'\\grafana-vm\Network(eth0)\Total','\\hello!'` as a string, use this to expand it to `@'\\grafana-vm\Network(eth0)\Total', @'\\hello!'`.<br/><br/>If using single-value variables, escape the variable inline instead: `@'\$myVar'`.                                                                                                                                                              |
 | `$__contains(colName, $myVar)`  | Expands multi-value template variables.<br/>If `$myVar` has the value `'value1','value2'`, use this to expand it to `colName in ('value1','value2')`.<br/><br/>If using the `All` option, check the `Include All Option` checkbox, and type the value `all` in the `Custom all value` field. If `$myVar` has the value `all`, the macro instead expands to `1 == 1`.<br/>For template variables with many options, this avoids building a large "where..in" clause, which improves performance. |
 
-Additionally, Grafana has the built-in [`$__interval` macro]({{< relref "../../../panels-visualizations/query-transform-data#query-options" >}}), which calculates an interval in seconds.
+Additionally, Grafana has the built-in [`$__interval` macro][query-transform-data-query-options], which calculates an interval in seconds.
 
 ## Query Azure Resource Graph
 
@@ -336,9 +336,17 @@ Selecting the trace format will filter events with the `trace` type.
 1. Specify event types to filter by.
 1. Specify event properties to filter by.
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 ## Working with large Azure resource data sets
 
 If a request exceeds the [maximum allowed value of records](https://docs.microsoft.com/en-us/azure/governance/resource-graph/concepts/work-with-data#paging-results), the result is paginated and only the first page of results are returned.
 You can use filters to reduce the amount of records returned under that value.
+
+{{% docs/reference %}}
+[query-transform-data-query-options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#query-options"
+[query-transform-data-query-options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#query-options"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/azure-monitor/template-variables/index.md
+++ b/docs/sources/datasources/azure-monitor/template-variables/index.md
@@ -31,7 +31,7 @@ Instead of hard-coding details such as resource group or resource name values in
 This helps you create more interactive, dynamic, and reusable dashboards.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Use query variables
 
@@ -81,3 +81,11 @@ It is possible to select multiple values for **Resource Groups** and **Resource 
 - Are of the same type (namespace).
 
 Also, note that if a template variable pointing to multiple resource groups or names is used in another template variable as a parameter (e.g. to retrieve metric names), only the first value will be used. This means that the combination of the first resource group and name selected should be valid.
+
+{{% docs/reference %}}
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -23,13 +23,13 @@ Grafana ships with built-in support for Elasticsearch.
 You can make many types of queries to visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events stored in Elasticsearch.
 
 This topic explains configuring and querying specific to the Elasticsearch data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the Elasticsearch data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore" >}}).
+Once you've added the Elasticsearch data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 ## Supported Elasticsearch versions
 
@@ -93,7 +93,7 @@ You can also override this setting in a dashboard panel under its data source op
 
 ### X-Pack enabled
 
-Toggle this to enable `X-Pack`-specific features and options, which provide the [query editor]({{< relref "./query-editor/" >}}) with additional aggregations, such as `Rate` and `Top Metrics`.
+Toggle this to enable `X-Pack`-specific features and options, which provide the [query editor]({{< relref "./query-editor" >}}) with additional aggregations, such as `Rate` and `Top Metrics`.
 
 #### Include frozen indices
 
@@ -105,7 +105,7 @@ Frozen indices are [deprecated in Elasticsearch](https://www.elastic.co/guide/en
 
 ### Logs
 
-You can optionally configure the two Logs parameters **Message field name** and **Level field name** to determine which fields the data source uses for log messages and log levels when visualizing logs in [Explore]({{< relref "../../explore/" >}}).
+You can optionally configure the two Logs parameters **Message field name** and **Level field name** to determine which fields the data source uses for log messages and log levels when visualizing logs in [Explore][explore].
 
 For example, if you're using a default setup of Filebeat for shipping logs to Elasticsearch, set:
 
@@ -139,17 +139,17 @@ For details on AWS SigV4, refer to the [AWS documentation](https://docs.aws.amaz
 Available in Grafana v7.3 and higher.
 {{% /admonition %}}
 
-To sign requests to your Amazon Elasticsearch Service domain, you can enable SigV4 in Grafana's [configuration]({{< relref "../../setup-grafana/configure-grafana/#sigv4_auth_enabled" >}}).
+To sign requests to your Amazon Elasticsearch Service domain, you can enable SigV4 in Grafana's [configuration][configure-grafana-sigv4-auth-enabled].
 
 Once AWS SigV4 is enabled, you can configure it on the Elasticsearch data source configuration page.
-For more information about AWS authentication options, refer to [AWS authentication]({{< relref "../aws-cloudwatch/aws-authentication/" >}}).
+For more information about AWS authentication options, refer to [AWS authentication]({{< relref "../aws-cloudwatch/aws-authentication" >}}).
 
 {{< figure src="/static/img/docs/v73/elasticsearch-sigv4-config-editor.png" max-width="500px" class="docs-image--no-shadow" caption="SigV4 configuration for AWS Elasticsearch Service" >}}
 
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 {{% admonition type="note" %}}
 The previously used `database` field has now been [deprecated](https://github.com/grafana/grafana/pull/58647).
@@ -201,7 +201,7 @@ datasources:
 
 You can select multiple metrics and group by multiple terms or filters when using the Elasticsearch query editor.
 
-For details, see the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, see the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -209,4 +209,24 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-sigv4-auth-enabled]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled"
+[configure-grafana-sigv4-auth-enabled]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana/#sigv4_auth_enabled"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -25,7 +25,7 @@ weight: 300
 {{< figure src="/static/img/docs/elasticsearch/query-editor-7-4.png" max-width="500px" class="docs-image--no-shadow" caption="Elasticsearch Query Editor" >}}
 
 This topic explains querying specific to the Elasticsearch data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Select and edit metrics
 
@@ -36,7 +36,7 @@ To expand the row to view and edit any available metric or group-by options, cli
 
 ## Use template variables
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 ## Name a time series
 
@@ -52,7 +52,6 @@ You can control the name for time series via the `Alias` input field.
 
 Some metric aggregations, such as _Moving Average_ and _Derivative_, are called **Pipeline** aggregations.
 Elasticsearch pipeline metrics must be based on another metric.
-
 Use the eye icon next to the metric to prevent metrics from appearing in the graph.
 This is useful for metrics you only have in the query for use in a pipeline metric.
 
@@ -72,3 +71,8 @@ If the query is [multi-field](https://www.elastic.co/guide/en/elasticsearch/refe
 
 Queries of `terms` have a 500-result limit by default.
 To set a custom limit, set the `size` property in your query.
+
+{{% docs/reference %}}
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -24,7 +24,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Choose a variable syntax
 
@@ -34,7 +34,7 @@ The Elasticsearch data source supports two variable syntaxes for use in the **Qu
 - `[[varname]]`, such as `hostname:[[hostname]]`
 
 When the _Multi-value_ or _Include all value_ options are enabled, Grafana converts the labels from plain text to a Lucene-compatible condition.
-For details, see the [Multi-value variables]({{< relref "../../../dashboards/variables/add-template-variables#multi-value-variables" >}}) documentation.
+For details, see the [Multi-value variables][add-template-variables-multi-value-variables] documentation.
 
 ## Use variables in queries
 
@@ -71,3 +71,14 @@ In the above example, a Lucene query filters documents based on the `hostname` p
 The example also uses a variable in the _Terms_ group by field input box, which you can use to quickly change how data is grouped.
 
 To view an example dashboard on Grafana Play, see the [Elasticsearch Templated Dashboard](https://play.grafana.org/d/z8OZC66nk/elasticsearch-8-2-0-sample-flight-data?orgId=1).
+
+{{% docs/reference %}}
+[add-template-variables-multi-value-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#multi-value-variables"
+[add-template-variables-multi-value-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#multi-value-variables"
+
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -33,10 +33,10 @@ This topic describes queries, templates, variables, and other configuration spec
 Before Grafana v7.1, Google Cloud Monitoring was referred to as Google Stackdriver.
 {{% /admonition %}}
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
 
-Once you've added the Google Cloud Monitoring data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) and apply [annotations]({{< relref "#annotations" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the Google Cloud Monitoring data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) and apply [annotations](#annotations) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 ## Configure the data source
 
@@ -61,19 +61,19 @@ To configure basic settings for the data source, complete the following steps:
 Before you can request data from Google Cloud Monitoring, you must configure authentication.
 All requests to Google APIs are performed on the server-side by the Grafana backend.
 
-For authentication options and configuration details, refer to [Google authentication]({{< relref "./google-authentication/" >}}).
+For authentication options and configuration details, refer to [Google authentication]({{< relref "./google-authentication" >}}).
 
 When configuring Google authentication, note these additional Google Cloud Monitoring-specific steps:
 
 #### Configure a GCP Service Account
 
-When you [create a Google Cloud Platform (GCP) Service Account and key file]({{< relref "./google-authentication/#create-a-gcp-service-account-and-key-file" >}}), the Service Account must have the **Monitoring Viewer** role (**Role > Select a role > Monitoring > Monitoring Viewer**):
+When you [create a Google Cloud Platform (GCP) Service Account and key file]({{< relref "./google-authentication#create-a-gcp-service-account-and-key-file" >}}), the Service Account must have the **Monitoring Viewer** role (**Role > Select a role > Monitoring > Monitoring Viewer**):
 
 {{< figure src="/static/img/docs/v71/cloudmonitoring_service_account_choose_role.png" max-width="600px" class="docs-image--no-shadow" caption="Choose role" >}}
 
 #### Grant the GCE Default Service Account scope
 
-If Grafana is running on a Google Compute Engine (GCE) virtual machine, then when you [Configure a GCE Default Service Account]({{< relref "./google-authentication/#configure-a-gce-default-service-account" >}}), you must also grant that Service Account access to the "Cloud Monitoring API" scope.
+If Grafana is running on a Google Compute Engine (GCE) virtual machine, then when you [Configure a GCE Default Service Account]({{< relref "./google-authentication#configure-a-gce-default-service-account" >}}), you must also grant that Service Account access to the "Cloud Monitoring API" scope.
 
 ### Enable necessary Google Cloud Platform APIs
 
@@ -91,7 +91,7 @@ Before you can request data from Google Cloud Monitoring, you must first enable 
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning examples
 
@@ -157,14 +157,14 @@ These curated dashboards are based on similar dashboards in the GCP dashboard sa
 
 **To import curated dashboards:**
 
-1. Navigate to the data source's [configuration page]({{< relref "#configure-the-data-source" >}}).
+1. Navigate to the data source's [configuration page](#configure-the-data-source).
 1. Select the **Dashboards** tab.
 
    This displays the curated selection of importable dashboards.
 
 1. Select **Import** for the dashboard to import.
 
-The dashboards include a [template variable]({{< relref "./template-variables/" >}}) populated with the projects accessible by the configured [Service Account]({{< relref "./google-authentication/" >}}) each time you load the dashboard.
+The dashboards include a [template variable]({{< relref "./template-variables" >}}) populated with the projects accessible by the configured [Service Account]({{< relref "./google-authentication" >}}) each time you load the dashboard.
 After Grafana loads the dashboard, you can select a project from the dropdown list.
 
 **To customize an imported dashboard:**
@@ -176,7 +176,7 @@ If you don't, upgrading Grafana can overwrite the customized dashboard with the 
 
 The Google Cloud Monitoring query editor helps you build two types of queries: **Metric** and **Service Level Objective (SLO)**.
 
-For details, refer to the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -184,4 +184,18 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
@@ -21,19 +21,19 @@ weight: 300
 # Google Cloud Monitoring query editor
 
 This topic explains querying specific to the Google Cloud Monitoring data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 The Google Cloud Monitoring query editor helps you build queries for two types of data, which both return time series data:
 
-- [Metrics]({{< relref "#query-metrics" >}})
+- [Metrics](#query-metrics)
 
-  You can also create [Monitoring Query Language (MQL)]({{< relref "#use-the-monitoring-query-language" >}}) queries.
+  You can also create [Monitoring Query Language (MQL)](#use-the-monitoring-query-language) queries.
 
-- [Service Level Objectives (SLO)]({{< relref "#query-service-level-objectives" >}})
+- [Service Level Objectives (SLO)](#query-service-level-objectives)
 
-You also use the query editor when you [annotate]({{< relref "#apply-annotations" >}}) visualizations.
+You also use the query editor when you [annotate](#apply-annotations) visualizations.
 
 ## Query metrics
 
@@ -119,7 +119,7 @@ You can align all data points received in a fixed length of time by applying an 
 #### Select an alignment function
 
 During alignment, all data points are received in a fixed interval.
-Within each interval, as defined by the [alignment period]({{< relref "#alignment-period" >}})), and for each time series, the data is aggregated into a single point.
+Within each interval, as defined by the [alignment period](#alignment-period)), and for each time series, the data is aggregated into a single point.
 The value of that point is determined by the type of alignment function you use.
 
 For more information on alignment functions, refer to [alignment metric selector](https://cloud.google.com/monitoring/charts/metrics-selector#alignment).
@@ -225,7 +225,7 @@ To understand basic MQL concepts, refer to [Introduction to Monitoring Query Lan
 
 ### Set alias patterns for MQL queries
 
-MQL queries use the same alias patterns as [metric queries]({{< relref "#set-alias-patterns" >}}).
+MQL queries use the same alias patterns as [metric queries](#set-alias-patterns).
 
 However, `{{metric.service}}` is not supported, and `{{metric.type}}` and `{{metric.name}}` show the time series key in the response.
 
@@ -272,13 +272,13 @@ The **Alias By** field helps you control the format of legend keys for SLO queri
 
 ### Alignment period and group-by time for SLO queries
 
-SLO queries use the same alignment period functionality as [metric queries]({{< relref "#define-the-alignment-period" >}}).
+SLO queries use the same alignment period functionality as [metric queries](#define-the-alignment-period).
 
 ## Apply annotations
 
 {{< figure src="/static/img/docs/google-cloud-monitoring/annotations-8-0.png" max-width= "400px" class="docs-image--right" >}}
 
-[Annotations]({{< relref "../../../dashboards/build-dashboards/annotate-visualizations" >}}) overlay rich event information on top of graphs.
+[Annotations][annotate-visualizations] overlay rich event information on top of graphs.
 You can add annotation queries in the Dashboard menu's Annotations view.
 
 Rendering annotations is expensive, and it's important to limit the number of rows returned.
@@ -303,3 +303,11 @@ Example result: `monitoring.googleapis.com/uptime_check/http_status has this val
 | `{{metric.service}}`     | Returns the service part.         | `{{metric.service}}`             | `compute`                                         |
 | `{{metric.label.xxx}}`   | Returns the metric label value.   | `{{metric.label.instance_name}}` | `grafana-1-prod`                                  |
 | `{{resource.label.xxx}}` | Returns the resource label value. | `{{resource.label.zone}}`        | `us-east1-b`                                      |
+
+{{% docs/reference %}}
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/google-cloud-monitoring/template-variables/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/template-variables/index.md
@@ -27,7 +27,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Use query variables
 
@@ -50,4 +50,15 @@ The Google Cloud Monitoring data source plugin provides the following **Query Ty
 ## Use variables in queries
 
 Use Grafana's variable syntax to include variables in queries.
-For details, refer to the [variable syntax documentation]({{< relref "../../../dashboards/variables/variable-syntax" >}}).
+For details, refer to the [variable syntax documentation][variable-syntax].
+
+{{% docs/reference %}}
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variable-syntax]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+[variable-syntax]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/grafana-pyroscope.md
+++ b/docs/sources/datasources/grafana-pyroscope.md
@@ -21,7 +21,7 @@ weight: 1150
 
 # Grafana Pyroscope data source
 
-Formerly Phlare data source, it supports both Phlare and Pyroscope, a horizontally scalable, highly-available, multi-tenant, OSS, continuous profiling aggregation systems. Add it as a data source, and you are ready to query your profiles in [Explore]({{< relref "../explore" >}}).
+Formerly Phlare data source, it supports both Phlare and Pyroscope, a horizontally scalable, highly-available, multi-tenant, OSS, continuous profiling aggregation systems. Add it as a data source, and you are ready to query your profiles in [Explore][explore].
 
 ## Configure the Grafana Pyroscope data source
 
@@ -67,13 +67,13 @@ Use the labels selector input to filter by labels. Phlare and Pyroscope uses sim
 
 Options section contains a switch for Query Type and Group by.
 
-Select a query type to return the profile data which can be shown in the [Flame Graph]({{< relref "../panels-visualizations/visualizations/flame-graph" >}}), metric data visualized in a graph, or both. You can only select both options in a dashboard, because panels allow only one visualization.
+Select a query type to return the profile data which can be shown in the [Flame Graph][flame-graph], metric data visualized in a graph, or both. You can only select both options in a dashboard, because panels allow only one visualization.
 
 Group by allows you to group metric data by a specified label. Without any Group by label, metric data is aggregated over all the labels into single time series. You can use multiple labels to group by. Group by has only an effect on the metric data and does not change the profile data results.
 
 ### Profiles query results
 
-Profiles can be visualized in a flame graph. See the [Flame Graph documentation]({{< relref "../panels-visualizations/visualizations/flame-graph" >}}) to learn about the visualization and its features.
+Profiles can be visualized in a flame graph. See the [Flame Graph documentation][flame-graph] to learn about the visualization and its features.
 
 ![Flame graph](/static/img/docs/phlare/flame-graph.png 'Flame graph')
 
@@ -89,7 +89,7 @@ This allows you to quickly see any spikes in the value of the scraped profiles a
 
 ## Provision the Grafana Pyroscope data source
 
-You can modify the Grafana configuration files to provision the Grafana Pyroscope data source. To learn more, and to view the available provisioning settings, see [provisioning documentation]({{< relref "../administration/provisioning/#datasources" >}}).
+You can modify the Grafana configuration files to provision the Grafana Pyroscope data source. To learn more, and to view the available provisioning settings, see [provisioning documentation][provisioning-data-sources].
 
 Here is an example config:
 
@@ -104,3 +104,14 @@ datasources:
       minStep: '15s'
       backendType: 'pyroscope'
 ```
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[flame-graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+[flame-graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/graphite/_index.md
+++ b/docs/sources/datasources/graphite/_index.md
@@ -22,10 +22,10 @@ weight: 600
 Grafana includes built-in support for Graphite.
 This topic explains options, variables, querying, and other features specific to the Graphite data source, which include its feature-rich query editor.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
 
-Once you've added the Graphite data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the Graphite data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 ## Configure the data source
 
@@ -45,7 +45,7 @@ To configure basic settings for the data source, complete the following steps:
    | **Name**                | Sets the name you use to refer to the data source in panels and queries.                                                             |
    | **Default**             | Sets whether the data source is pre-selected for new panels. You can set only one default data source per organization.              |
    | **URL**                 | Sets the HTTP protocol, IP, and port of your graphite-web or graphite-api installation.                                              |
-   | **Auth**                | For details, refer to [Configure Authentication]({{< relref "../../setup-grafana/configure-security/configure-authentication/" >}}). |
+   | **Auth**                | For details, refer to [Configure Authentication][configure-authentication]. |
    | **Basic Auth**          | Enables basic authentication to the data source.                                                                                     |
    | **User**                | Sets the user name for basic authentication.                                                                                         |
    | **Password**            | Sets the password for basic authentication.                                                                                          |
@@ -62,14 +62,14 @@ You can also configure settings specific to the Graphite data source:
 
 ### Integrate with Loki
 
-When you change the data source selection in [Explore]({{< relref "../../explore/" >}}), Graphite queries are converted to Loki queries.
+When you change the data source selection in [Explore][explore], Graphite queries are converted to Loki queries.
 Grafana extracts Loki label names and values from the Graphite queries according to mappings provided in the Graphite data source configuration.
 Queries using tags with `seriesByTags()` are also transformed without any additional setup.
 
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for lists of common configuration options and JSON data options, refer to [Provisioning data sources]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for lists of common configuration options and JSON data options, refer to [Provisioning data sources][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -91,7 +91,7 @@ Grafana includes a Graphite-specific query editor to help you build queries.
 The query editor helps you quickly navigate the metric space, add functions, and change function parameters.
 It can handle all types of Graphite queries, including complex nested queries through the use of query references.
 
-For details, refer to the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -99,9 +99,29 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
 
 ## Get Grafana metrics into Graphite
 
 Grafana exposes metrics for Graphite on the `/metrics` endpoint.
-For detailed instructions, refer to [Internal Grafana metrics]({{< relref "../../setup-grafana/set-up-grafana-monitoring" >}}).
+For detailed instructions, refer to [Internal Grafana metrics][internal-grafana-metrics].
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-authentication]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-security/configure-authentication"
+[configure-authentication]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-security/configure-authentication"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[internal-grafana-metrics]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+[internal-grafana-metrics]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/graphite/_index.md
+++ b/docs/sources/datasources/graphite/_index.md
@@ -40,18 +40,18 @@ To configure basic settings for the data source, complete the following steps:
 
 1. Set the data source's basic configuration options:
 
-   | Name                    | Description                                                                                                                          |
-   | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-   | **Name**                | Sets the name you use to refer to the data source in panels and queries.                                                             |
-   | **Default**             | Sets whether the data source is pre-selected for new panels. You can set only one default data source per organization.              |
-   | **URL**                 | Sets the HTTP protocol, IP, and port of your graphite-web or graphite-api installation.                                              |
-   | **Auth**                | For details, refer to [Configure Authentication][configure-authentication]. |
-   | **Basic Auth**          | Enables basic authentication to the data source.                                                                                     |
-   | **User**                | Sets the user name for basic authentication.                                                                                         |
-   | **Password**            | Sets the password for basic authentication.                                                                                          |
-   | **Custom HTTP Headers** | Click **Add header** to add a custom HTTP header.                                                                                    |
-   | **Header**              | Defines the custom header name.                                                                                                      |
-   | **Value**               | Defines the custom header value.                                                                                                     |
+   | Name                    | Description                                                                                                             |
+   | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+   | **Name**                | Sets the name you use to refer to the data source in panels and queries.                                                |
+   | **Default**             | Sets whether the data source is pre-selected for new panels. You can set only one default data source per organization. |
+   | **URL**                 | Sets the HTTP protocol, IP, and port of your graphite-web or graphite-api installation.                                 |
+   | **Auth**                | For details, refer to [Configure Authentication][configure-authentication].                                             |
+   | **Basic Auth**          | Enables basic authentication to the data source.                                                                        |
+   | **User**                | Sets the user name for basic authentication.                                                                            |
+   | **Password**            | Sets the password for basic authentication.                                                                             |
+   | **Custom HTTP Headers** | Click **Add header** to add a custom HTTP header.                                                                       |
+   | **Header**              | Defines the custom header name.                                                                                         |
+   | **Value**               | Defines the custom header value.                                                                                        |
 
 You can also configure settings specific to the Graphite data source:
 

--- a/docs/sources/datasources/graphite/query-editor/index.md
+++ b/docs/sources/datasources/graphite/query-editor/index.md
@@ -27,7 +27,7 @@ Grafana includes a Graphite-specific query editor to help you build queries.
 The query editor helps you quickly navigate the metric space, add functions, and change function parameters.
 It can handle all types of Graphite queries, including complex nested queries through the use of query references.
 
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## View the raw query
 
@@ -110,7 +110,7 @@ This is more efficient than adding a query for each time series, such as `cpu.pe
 
 ## Apply annotations
 
-[Annotations]({{< relref "../../../dashboards/build-dashboards/annotate-visualizations" >}}) overlay rich event information on top of graphs.
+[Annotations][annotate-visualizations] overlay rich event information on top of graphs.
 You can add annotation queries in the Dashboard menu's Annotations view.
 
 Graphite supports two ways to query annotations:
@@ -121,10 +121,21 @@ Graphite supports two ways to query annotations:
 ## Get Grafana metrics into Graphite
 
 Grafana exposes metrics for Graphite on the `/metrics` endpoint.
-For detailed instructions, refer to [Internal Grafana metrics]({{< relref "../../../setup-grafana/set-up-grafana-monitoring" >}}).
+For detailed instructions, refer to [Internal Grafana metrics][set-up-grafana-monitoring].
 
 ## Integration with Loki
 
 Graphite queries get converted to Loki queries when the data source selection changes in Explore. Loki label names and values are extracted from the Graphite queries according to mappings information provided in Graphite data source configuration. Queries using tags with `seriesByTags()` are also transformed without any additional setup.
 
 Refer to the Graphite data source settings for more details.
+
+{{% docs/reference %}}
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[set-up-grafana-monitoring]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+[set-up-grafana-monitoring]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/graphite/template-variables/index.md
+++ b/docs/sources/datasources/graphite/template-variables/index.md
@@ -24,7 +24,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Select a query type
 
@@ -68,7 +68,7 @@ Non-tag queries use the default glob formatting for multi-value variables.
 server=~${servers:regex}
 ```
 
-For more information, refer to [Advanced variable format options]({{< relref "../../../dashboards/variables/variable-syntax#advanced-variable-format-options" >}}).
+For more information, refer to [Advanced variable format options][variable-syntax-advanced-variable-format-options].
 
 ## Use other query variables
 
@@ -144,3 +144,14 @@ The Graphite data source supports two variable syntaxes for use in the **Query**
 ### Templated dashboard example
 
 To view an example templated dashboard, refer to [Graphite Templated Dashboard](https://play.grafana.org/dashboard/db/graphite-templated-nested).
+
+{{% docs/reference %}}
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -25,13 +25,13 @@ weight: 700
 {{< docs/shared "influxdb/intro.md" >}}
 
 Grafana includes built-in support for InfluxDB.
-This topic explains options, variables, querying, and other features specific to the InfluxDB data source, which include its [feature-rich code editor for queries and visual query builder]({{< relref "./query-editor/" >}}).
+This topic explains options, variables, querying, and other features specific to the InfluxDB data source, which include its [feature-rich code editor for queries and visual query builder]({{< relref "./query-editor" >}}).
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the InfluxDB data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the InfluxDB data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 ## Configure the data source
 
@@ -51,7 +51,7 @@ To configure basic settings for the data source, complete the following steps:
     | **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
     | **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
     | **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |
-    | **Min time interval** | _(Optional)_ Refer to [Min time interval]({{< relref "#configure-min-time-interval" >}}).                                                                                                                    |
+    | **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                    |
     | **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
 
 You can also configure settings specific to the InfluxDB data source. These options are described in the sections below.
@@ -123,7 +123,7 @@ Configure these options if you select the Flux query language:
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 {{% admonition type="note" %}}
 `database` [field is deprecated](https://github.com/grafana/grafana/pull/58647).
@@ -191,9 +191,9 @@ datasources:
 
 ## Query the data source
 
-The InfluxDB data source's query editor has two modes, InfluxQL and Flux, depending on your choice of query language in the [data source configuration]({{< relref "#configure-the-data-source" >}}):
+The InfluxDB data source's query editor has two modes, InfluxQL and Flux, depending on your choice of query language in the [data source configuration](#configure-the-data-source):
 
-For details, refer to the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -201,4 +201,18 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -51,7 +51,7 @@ To configure basic settings for the data source, complete the following steps:
     | **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
     | **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
     | **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |
-    | **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                    |
+    | **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                                     |
     | **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
 
 You can also configure settings specific to the InfluxDB data source. These options are described in the sections below.

--- a/docs/sources/datasources/influxdb/query-editor/index.md
+++ b/docs/sources/datasources/influxdb/query-editor/index.md
@@ -15,16 +15,16 @@ weight: 200
 # InfluxDB query editor
 
 This topic explains querying specific to the InfluxDB data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 The InfluxDB data source's query editor has two modes depending on your choice of query language in the [data source configuration]({{< relref "../#configure-the-data-source" >}}):
 
-- [InfluxQL]({{< relref "#influxql-query-editor" >}})
-- [Flux]({{< relref "#flux-query-editor" >}})
+- [InfluxQL](#influxql-query-editor)
+- [Flux](#flux-query-editor)
 
-You also use the query editor to retrieve [log data]({{< relref "#query-logs" >}}) and [annotate]({{< relref "#apply-annotations" >}}) visualizations.
+You also use the query editor to retrieve [log data](#query-logs) and [annotate](#apply-annotations) visualizations.
 
 ## InfluxQL query editor
 
@@ -161,11 +161,11 @@ from(bucket: "grafana")
   |> yield(name: "mean")
 ```
 
-To view the interpolated version of a query with the query inspector, refer to [Panel Inspector]({{< relref "../../../panels-visualizations/panel-inspector" >}}).
+To view the interpolated version of a query with the query inspector, refer to [Panel Inspector][panel-inspector].
 
 ## Query logs
 
-You can query and display log data from InfluxDB in [Explore]({{< relref "../../../explore" >}}) and with the [Logs panel]({{< relref "../../../panels-visualizations/visualizations/logs" >}}) for dashboards.
+You can query and display log data from InfluxDB in [Explore][explore] and with the [Logs panel][logs] for dashboards.
 
 Select the InfluxDB data source, then enter a query to display your logs.
 
@@ -184,7 +184,7 @@ To remove tag filters, click the first select, then choose **--remove filter--**
 
 ## Apply annotations
 
-[Annotations]({{< relref "../../../dashboards/build-dashboards/annotate-visualizations" >}}) overlay rich event information on top of graphs.
+[Annotations][annotate-visualizations] overlay rich event information on top of graphs.
 You can add annotation queries in the Dashboard menu's Annotations view.
 
 For InfluxDB, your query **must** include `WHERE $timeFilter`.
@@ -198,3 +198,20 @@ The **Tags** field's value can be a comma-separated string.
 ```sql
 SELECT title, description from events WHERE $timeFilter ORDER BY time ASC
 ```
+
+{{% docs/reference %}}
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[logs]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+[logs]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+
+[panel-inspector]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/panel-inspector"
+[panel-inspector]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/panel-inspector"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/influxdb/template-variables/index.md
+++ b/docs/sources/datasources/influxdb/template-variables/index.md
@@ -26,14 +26,14 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Use query variables
 
 If you add a query template variable, you can write an InfluxDB exploration (metadata) query.
 These queries can return results like measurement names, key names, or key values.
 
-For more information, refer to [Add query variable]({{< relref "../../../dashboards/variables/add-template-variables#add-a-query-variable" >}}).
+For more information, refer to [Add query variable][add-template-variables-adds-a-query-variable].
 
 For example, to create a variable that contains all values for tag `hostname`, specify a query like this in the query variable **Query**:
 
@@ -65,7 +65,7 @@ This helps you change group-by using the variable list at the top of the dashboa
 InfluxDB supports the special **Ad hoc filters** variable type.
 You can use this variable type to specify any number of key/value filters, and Grafana applies them automatically to all of your InfluxDB queries.
 
-For more information, refer to [Add ad hoc filters]({{< relref "../../../dashboards/variables/add-template-variables#add-ad-hoc-filters" >}}).
+For more information, refer to [Add ad hoc filters][add-template-variables-add-ad-hoc-filters].
 
 ## Choose a variable syntax
 
@@ -88,3 +88,17 @@ When you enable the **Multi-value** or **Include all value** options, Grafana co
 ### Templated dashboard example
 
 To view an example templated dashboard, refer to [InfluxDB Templated Dashboard](https://play.grafana.org/dashboard/db/influxdb-templated).
+
+{{% docs/reference %}}
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+
+[add-template-variables-adds-a-query-variable]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-a-query-variable"
+[add-template-variables-adds-a-query-variable]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-a-query-variable"
+
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -327,7 +327,7 @@ To configure this feature, see the [Derived fields]({{< relref "../loki#configur
 
 You can link to Jaeger traces from metrics in Prometheus data sources by configuring an exemplar.
 
-To configure this feature, see the [introduction to exemplars][expemplars] documentation.
+To configure this feature, see the [introduction to exemplars][exemplars] documentation.
 
 {{% docs/reference %}}
 [build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"

--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -22,13 +22,13 @@ weight: 800
 
 Grafana ships with built-in support for Jaeger, which provides open source, end-to-end distributed tracing. This topic explains configuration and queries specific to the Jaeger data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so your Grafana instance's users can create queries in the [query editor]({{< relref "#query-the-data-source" >}}) when the users [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the data source, you can [configure it](#configure-the-data-source) so your Grafana instance's users can create queries in the [query editor](#query-the-data-source) when the users [build dashboards][build-dashboards] and use [Explore][explore].
 
-You can also [upload a JSON trace file]({{< relref "#upload-a-json-trace-file" >}}), [link to a trace ID from logs]({{< relref "#link-to-a-trace-id-from-logs" >}}), and [link to a trace ID from metrics]({{< relref "#link-to-a-trace-id-from-metrics" >}}).
+You can also [upload a JSON trace file](#upload-a-json-trace-file), [link to a trace ID from logs](#link-to-a-trace-id-from-logs), and [link to a trace ID from metrics](#link-to-a-trace-id-from-metrics).
 
 ## Configure the data source
 
@@ -63,12 +63,12 @@ Available in Grafana v7.4 and higher.
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
 {{% /admonition %}}
 
-The **Trace to logs** setting configures the [trace to logs feature]({{< relref "../../explore/trace-integration" >}}) that is available when you integrate Grafana with Jaeger.
+The **Trace to logs** setting configures the [trace to logs feature][explore-trace-integration] that is available when you integrate Grafana with Jaeger.
 
 There are two ways to configure the trace to logs feature:
 
 - Use a simplified configuration with default query, or
-- Configure a custom query where you can use a [template language]({{< relref "../../dashboards/variables/variable-syntax">}}) to interpolate variables from the trace or span.
+- Configure a custom query where you can use a [template language][variable-syntax] to interpolate variables from the trace or span.
 
 #### Use a simple configuration
 
@@ -118,7 +118,7 @@ The following table describes the ways in which you can configure your trace to 
 ### Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle]({{< relref "../../setup-grafana/configure-grafana#feature_toggles" >}}).
+This feature is behind the `traceToMetrics` [feature toggle][configure-grafana-feature-toggles].
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
 {{% /admonition %}}
 
@@ -143,7 +143,7 @@ Each linked query consists of:
 
 ### Node Graph
 
-The **Node Graph** setting enables the [Node Graph visualization]({{< relref "../../panels-visualizations/visualizations/node-graph/" >}}), which is disabled by default.
+The **Node Graph** setting enables the [Node Graph visualization][node-graph], which is disabled by default.
 
 Once enabled, Grafana displays the Node Graph above the trace view.
 
@@ -162,7 +162,7 @@ You can choose one of three options:
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning and available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning#data-sources" >}}).
+For more information about provisioning and available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -213,10 +213,10 @@ datasources:
 
 ## Query the data source
 
-You can query and display traces from Jaeger via [Explore]({{< relref "../../explore" >}}).
+You can query and display traces from Jaeger via [Explore][explore].
 
 This topic explains configuration and queries specific to the Jaeger data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ### Query by search
 
@@ -327,4 +327,36 @@ To configure this feature, see the [Derived fields]({{< relref "../loki#configur
 
 You can link to Jaeger traces from metrics in Prometheus data sources by configuring an exemplar.
 
-To configure this feature, see the [introduction to exemplars]({{< relref "docs/grafana/latest/fundamentals/exemplars" >}}) documentation.
+To configure this feature, see the [introduction to exemplars][expemplars] documentation.
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-feature-toggles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+[configure-grafana-feature-toggles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[exemplars]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+[exemplars]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+
+[explore-trace-integration]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+[explore-trace-integration]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[node-graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+[node-graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[variable-syntax]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+[variable-syntax]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -34,11 +34,11 @@ The following guides will help you get started with Loki:
 
 ## Adding a data source
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management]
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the Loki data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}), use [Explore]({{< relref "../../explore/" >}}), and [annotate visualizations]({{< relref "./query-editor/#apply-annotations" >}}).
+Once you've added the Loki data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards], use [Explore][explore], and [annotate visualizations]({{< relref "./query-editor#apply-annotations" >}}).
 
 {{% admonition type="note" %}}
 To troubleshoot configuration and other issues, check the log file located at `/var/log/grafana/grafana.log` on Unix systems, or in `<grafana_install_dir>/data/log` on other platforms and manual installations.
@@ -47,7 +47,7 @@ To troubleshoot configuration and other issues, check the log file located at `/
 ## Provision the Loki data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 ### Provisioning examples
 
@@ -116,7 +116,7 @@ datasources:
 
 The Loki data source's query editor helps you create log and metric queries that use Loki's query language, [LogQL](/docs/loki/latest/logql/).
 
-For details, refer to the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -124,4 +124,21 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[logs-integration-labels-and-detected-fields]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore/logs-integration#labels-and-detected-fields"
+[logs-integration-labels-and-detected-fields]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore/logs-integration#labels-and-detected-fields"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -19,30 +19,30 @@ weight: 300
 
 # Loki query editor
 
-The Loki data source's query editor helps you create [log]({{< relref "#create-a-log-query" >}}) and [metric]({{< relref "#create-a-metric-query" >}}) queries that use Loki's query language, [LogQL](/docs/loki/latest/logql/).
+The Loki data source's query editor helps you create [log](#create-a-log-query) and [metric](#create-a-metric-query) queries that use Loki's query language, [LogQL](/docs/loki/latest/logql/).
 
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, refer to [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 The Loki query editor has two modes:
 
-- [Builder mode]({{< relref "#builder-mode" >}}), which provides a visual query designer.
-- [Code mode]({{< relref "#code-mode" >}}), which provides a feature-rich editor for writing queries.
+- [Builder mode](#builder-mode), which provides a visual query designer.
+- [Code mode](#code-mode), which provides a feature-rich editor for writing queries.
 
 To switch between the editor modes, select the corresponding **Builder** and **Code** tabs.
 
 To run a query, select **Run queries** located at the top of the editor.
 
 {{% admonition type="note" %}}
-To run Loki queries in [Explore]({{< relref "../../../explore/" >}}), select **Run query**.
+To run Loki queries in [Explore][explore], select **Run query**.
 {{% /admonition %}}
 
 Each mode is synchronized, so you can switch between them without losing your work, although there are some limitations. Builder mode doesn't support some complex queries.
 When you switch from Code mode to Builder mode with such a query, the editor displays a warning message that explains how you might lose parts of the query if you continue.
 You can then decide whether you still want to switch to Builder mode.
 
-You can also augment queries by using [template variables]({{< relref "./template-variables/" >}}).
+You can also augment queries by using [template variables]({{< relref "./template-variables" >}}).
 
 ## Toolbar elements
 
@@ -129,7 +129,7 @@ In same cases the query editor can detect which operations would be most appropr
 ## Code mode
 
 In **Code mode**, you can write complex queries using a text editor with autocompletion feature, syntax highlighting, and query validation.
-It also contains a [label browser]({{< relref "#label-browser" >}}) to further help you write queries.
+It also contains a [label browser](#label-browser) to further help you write queries.
 
 For more information about Loki's query language, refer to the [Loki documentation](/docs/loki/latest/logql/).
 
@@ -157,7 +157,7 @@ The following options are the same for both **Builder** and **Code** mode:
 ## Create a log query
 
 Loki log queries return the contents of the log lines.
-You can query and display log data from Loki via [Explore]({{< relref "../../../explore" >}}), and with the [Logs panel]({{< relref "../../../panels-visualizations/visualizations/logs" >}}) in dashboards.
+You can query and display log data from Loki via [Explore][explore], and with the [Logs panel][logs] in dashboards.
 
 To display the results of a log query, select the Loki data source, then enter a LogQL query.
 
@@ -175,7 +175,7 @@ To reset filters and use the initial log context query, click the `Revert to ini
 
 ### Tail live logs
 
-Loki supports live tailing of logs in real-time in [Explore]({{< relref "../../../explore" >}}).
+Loki supports live tailing of logs in real-time in [Explore][explore].
 
 Live tailing relies on two Websocket connections: one between the browser and Grafana server, and another between the Grafana server and Loki server.
 
@@ -241,9 +241,23 @@ For more information about metric queries, refer to the [Loki metric queries doc
 
 ## Apply annotations
 
-[Annotations]({{< relref "../../../dashboards/build-dashboards/annotate-visualizations" >}}) overlay rich event information on top of graphs.
+[Annotations][annotate-visualizations] overlay rich event information on top of graphs.
 You can add annotation queries in the Dashboard menu's Annotations view.
 
 You can use any non-metric Loki query as a source for annotations.
 Grafana automatically uses log content as annotation text and your log stream labels as tags.
 You don't need to create any additional mapping.
+
+{{% docs/reference %}}
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[logs]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+[logs]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/logs"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/loki/template-variables/index.md
+++ b/docs/sources/datasources/loki/template-variables/index.md
@@ -25,7 +25,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Use query variables
 
@@ -45,13 +45,13 @@ The form has these options:
 Loki supports the special **Ad hoc filters** variable type.
 You can use this variable type to specify any number of key/value filters, and Grafana applies them automatically to all of your Loki queries.
 
-For more information, refer to [Add ad hoc filters]({{< relref "../../../dashboards/variables/add-template-variables#add-ad-hoc-filters" >}}).
+For more information, refer to [Add ad hoc filters][add-template-variables-add-ad-hoc-filters].
 
 ## Use interval and range variables
 
 You can use some global built-in variables in query variables: `$__interval`, `$__interval_ms`, `$__range`, `$__range_s`, and `$__range_ms`.
 
-For more information, refer to [Global built-in variables]({{< relref "../../../dashboards/variables/add-template-variables#global-variables" >}}).
+For more information, refer to [Global built-in variables][add-template-variables-global-variables].
 
 ### Label Extraction and Indexing in Loki:
 
@@ -78,3 +78,17 @@ By effectively extracting and indexing labels, Loki enables users to perform com
 Utilizing Loki's indexed labels in combination with Grafana's template variables provides a powerful way to interactively explore and visualize log data. Template variables allow users to create dynamic queries, selecting and filtering logs based on various labels, such as job names, instance IDs, severity levels, or any other contextual information attached to the log entries.
 
 In conclusion, Loki's label extraction and indexing mechanisms are key components that contribute to its ability to handle vast amounts of log data efficiently. By making use of labels and template variables, users can easily gain valuable insights from their log data and troubleshoot issues effectively.
+
+{{% docs/reference %}}
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+
+[add-template-variables-global-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#global-variables"
+[add-template-variables-global-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#global-variables"
+
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/mssql/_index.md
+++ b/docs/sources/datasources/mssql/_index.md
@@ -27,11 +27,11 @@ You can query and visualize data from any Microsoft SQL Server 2005 or newer, in
 
 This topic explains configuration specific to the Microsoft SQL Server data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the Microsoft SQL Server data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the Microsoft SQL Server data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 ## Configure the data source
 
@@ -65,7 +65,7 @@ You can also configure settings specific to the Microsoft SQL Server data source
 
 ### Min time interval
 
-The **Min time interval** setting defines a lower limit for the [`$__interval`]({{< relref "../../dashboards/variables/add-template-variables#__interval" >}}) and [`$__interval_ms`]({{< relref "../../dashboards/variables/add-template-variables#__interval_ms" >}}) variables.
+The **Min time interval** setting defines a lower limit for the [`$__interval`][add-template-variables-interval] and [`$__interval_ms`][add-template-variables-interval_ms] variables.
 
 This value _must_ be formatted as a number followed by a valid time identifier:
 
@@ -114,7 +114,7 @@ We recommend that you use the latest available service pack for optimal compatib
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -142,7 +142,7 @@ datasources:
 
 You can create queries with the Microsoft SQL Server data source's query editor when editing a panel that uses a MS SQL data source.
 
-For details, refer to the [query editor documentation]({{< relref "./query-editor/" >}}).
+For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
 ## Use template variables
 
@@ -150,4 +150,24 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For details, see the [template variables documentation]({{< relref "./template-variables/" >}}).
+For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+{{% docs/reference %}}
+[add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+[add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+
+[add-template-variables-interval_ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+[add-template-variables-interval_ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/mssql/_index.md
+++ b/docs/sources/datasources/mssql/_index.md
@@ -153,11 +153,14 @@ Grafana refers to such variables as template variables.
 For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
 
 {{% docs/reference %}}
+
+<!-- prettier-ignore-start -->
+[add-template-variables-interval-ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+[add-template-variables-interval-ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+
 [add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
 [add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
-
-[add-template-variables-interval_ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
-[add-template-variables-interval_ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+<!-- prettier-ignore-end -->
 
 [build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
 [build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"

--- a/docs/sources/datasources/mssql/query-editor/index.md
+++ b/docs/sources/datasources/mssql/query-editor/index.md
@@ -25,14 +25,14 @@ weight: 300
 You can create queries with the Microsoft SQL Server data source's query editor when editing a panel that uses a MS SQL data source.
 
 This topic explains querying specific to the MS SQL data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Choose a query editing mode
 
 You can switch the query editor between two modes:
 
-- [Code mode]({{< relref "#code-mode" >}}), which provides a feature-rich editor for writing queries
-- [Builder mode]({{< relref "#builder-mode" >}}), which provides a visual query designer
+- [Code mode](#code-mode), which provides a feature-rich editor for writing queries
+- [Builder mode](#builder-mode), which provides a visual query designer
 
 To switch between the editor modes, select the corresponding **Builder** and **Code** tabs above the editor.
 
@@ -40,9 +40,9 @@ To run a query, select **Run query** located at the top right corner of the edit
 
 The query editor also provides:
 
-- [Macros]){{< relref "#use-macros" >}}
-- [Annotations]){{< relref "#apply-annotations" >}}
-- [Stored procedures]){{< relref "#use-stored-procedures" >}}
+- [Macros](#use-macros)
+- [Annotations](#apply-annotations)
+- [Stored procedures](#use-stored-procedures)
 
 ## Configure common options
 
@@ -57,7 +57,7 @@ To choose a response format, select either the **Table** or **Time series** form
 To use the time series format, you must name one of the MS SQL columns `time`.
 You can use time series queries, but not table queries, in alerting conditions.
 
-For details about using these formats, refer to [Use table queries]({{< relref "#use-table-queries" >}}) and [Use time series queries]({{< relref "#use-time-series-queries" >}}).
+For details about using these formats, refer to [Use table queries](#use-table-queries) and [Use time series queries](#use-time-series-queries).
 
 ## Code mode
 
@@ -166,7 +166,7 @@ To display the raw interpolated SQL string that the data source executed, click 
 
 ## Use table queries
 
-If the **Format** query option is set to **Table** for a [Table panel]{{< relref "../../../panels-visualizations/visualizations/table/" >}}, you can enter any type of SQL query.
+If the **Format** query option is set to **Table** for a [Table panel][table], you can enter any type of SQL query.
 The Table panel then displays the query results with whatever columns and rows are returned.
 
 **Example database table:**
@@ -227,7 +227,7 @@ The resulting table panel:
 If you set the **Format** setting in the query editor to **Time series**, then the query must have a column named `time` that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds.
 Result sets of time series queries must also be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../../../developers/plugins/introduction-to-plugin-development/data-frames#wide-format" >}}).
+A time series query result is returned in a [wide data frame format][data-frames-wide-format].
 Any column except time or of type string transforms into value fields in the data frame query result.
 Any string column transforms into field labels in the data frame query result.
 
@@ -237,7 +237,7 @@ For backward compatibility, there's an exception to the above rule for queries t
 Instead of transforming the `metric` column into field labels, it becomes the field name, and then the series name is formatted as the value of the `metric` column.
 See the example with the `metric` column below.
 
-To optionally customize the default series name formatting, refer to [Standard options definitions]({{< relref "../../../panels-visualizations/configure-standard-options#display-name" >}}).
+To optionally customize the default series name formatting, refer to [Standard options definitions][configure-standard-options-display-name].
 
 **Example with `metric` column:**
 
@@ -283,7 +283,7 @@ GROUP BY
 ORDER BY 1
 ```
 
-Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard options definitions]({{< relref "../../../panels-visualizations/configure-standard-options#display-name" >}}) display name value of `${__field.labels.hostname}`.
+Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard options definitions][configure-standard-options-display-name] display name value of `${__field.labels.hostname}`.
 
 Data frame result:
 
@@ -326,7 +326,7 @@ Data frame result:
 
 ## Apply annotations
 
-[Annotations]({{< relref "../../../dashboards/build-dashboards/annotate-visualizations" >}}) overlay rich event information on top of graphs.
+[Annotations][annotate-visualizations] overlay rich event information on top of graphs.
 You can add annotation queries in the Dashboard menu's Annotations view.
 
 **Columns:**
@@ -348,7 +348,7 @@ CREATE TABLE [events] (
 )
 ```
 
-We also use the database table defined in [Time series queries]({{< relref "#time-series-queries" >}}).
+We also use the database table defined in [Time series queries](#time-series-queries).
 
 **Example query using time column with epoch values:**
 
@@ -544,3 +544,20 @@ DECLARE
 
 EXEC dbo.sp_test_datetime @from, @to
 ```
+
+{{% docs/reference %}}
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[configure-standard-options-display-name]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+[configure-standard-options-display-name]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+
+[data-frames-wide-format]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+[data-frames-wide-format]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[table]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/table"
+[table]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/table"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/mssql/template-variables/index.md
+++ b/docs/sources/datasources/mssql/template-variables/index.md
@@ -27,7 +27,7 @@ Instead of hard-coding details such as server, application, and sensor names in 
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 Grafana refers to such variables as template variables.
 
-For an introduction to templating and template variables, refer to the [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}) documentation.
+For an introduction to templating and template variables, refer to the [Templating][variables] and [Add and manage variables][add-template-variables] documentation.
 
 ## Query variable
 
@@ -97,4 +97,15 @@ Grafana automatically creates a quoted, comma-separated string for multi-value v
 
 `${servers:csv}`
 
-Read more about variable formatting options in the [Variables]({{< relref "../../../dashboards/variables/variable-syntax#advanced-variable-format-options" >}}) documentation.
+Read more about variable formatting options in the [Variables][variable-syntax-advanced-variable-format-options] documentation.
+
+{{% docs/reference %}}
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -23,9 +23,9 @@ weight: 1000
 
 Grafana ships with a built-in MySQL data source plugin that allows you to query and visualize data from a MySQL compatible database.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
 ## Configure the data source
 
@@ -57,7 +57,7 @@ Administrators can also [configure the data source via YAML]({{< relref "#provis
 
 ### Min time interval
 
-The **Min time interval** setting defines a lower limit for the [`$__interval`]({{< relref "../../dashboards/variables/add-template-variables#__interval" >}}) and [`$__interval_ms`]({{< relref "../../dashboards/variables/add-template-variables#__interval_ms" >}}) variables.
+The **Min time interval** setting defines a lower limit for the [`$__interval`][add-template-variables-interval] and [`$__interval_ms`][add-template-variables-interval-ms] variables.
 
 This value _must_ be formatted as a number followed by a valid time identifier:
 
@@ -96,7 +96,7 @@ You can use wildcards (`*`) in place of database or table if you want to grant a
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning examples
 
@@ -174,7 +174,7 @@ datasources:
 The MySQL query builder is available when editing a panel using a MySQL data source.
 
 This topic explains querying specific to the MySQL data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../panels-visualizations/query-transform-data/" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 You can run the built query by pressing the `Run query` button in the top right corner of the editor.
 
@@ -297,11 +297,11 @@ The examples in this section query the following table:
 
 If the `Format as` query option is set to `Time Series` then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../../developers/plugins/introduction-to-plugin-development/data-frames#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format][data-frames-wide-format]. Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 
-To optionally customize the default series name formatting, refer to [Standard options definitions]({{< relref "../../panels-visualizations/configure-standard-options#display-name" >}}).
+To optionally customize the default series name formatting, refer to [Standard options definitions][configure-standard-options-display-name].
 
 **Example with `metric` column:**
 
@@ -344,7 +344,7 @@ GROUP BY time, hostname
 ORDER BY time
 ```
 
-Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [[Standard options definitions]({{< relref "../../panels-visualizations/configure-standard-options#display-name" >}}) display value of `${__field.labels.hostname}`.
+Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard options definitions][configure-standard-options-display-name] display value of `${__field.labels.hostname}`.
 
 Data frame result:
 
@@ -397,7 +397,7 @@ This feature is currently available in the nightly builds and will be included i
 
 Instead of hard-coding things like server, application and sensor name in your metric queries you can use variables in their place. Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data being displayed in your dashboard.
 
-Check out the [Templating]({{< relref "../../dashboards/variables" >}}) documentation for an introduction to the templating feature and the different types of template variables.
+Check out the [Templating][variables] documentation for an introduction to the templating feature and the different types of template variables.
 
 ### Query Variable
 
@@ -492,11 +492,11 @@ Grafana automatically creates a quoted, comma-separated string for multi-value v
 
 `${servers:csv}`
 
-Read more about variable formatting options in the [Variables]({{< relref "../../dashboards/variables/variable-syntax#advanced-variable-format-options" >}}) documentation.
+Read more about variable formatting options in the [Variables][variable-syntax-advanced-variable-format-options] documentation.
 
 ## Annotations
 
-[Annotations]({{< relref "../../dashboards/build-dashboards/annotate-visualizations" >}}) allow you to overlay rich event information on top of graphs. You add annotation queries via the Dashboard menu / Annotations view.
+[Annotations][annotate-visualizations] allow you to overlay rich event information on top of graphs. You add annotation queries via the Dashboard menu / Annotations view.
 
 **Example query using time column with epoch values:**
 
@@ -550,3 +550,35 @@ WHERE
 ## Alerting
 
 Time series queries should work in alerting conditions. Table formatted queries are not yet supported in alert rule conditions.
+
+{{% docs/reference %}}
+[add-template-variables-interval-ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+[add-template-variables-interval-ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+
+[add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+[add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[configure-standard-options-display-name]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+[configure-standard-options-display-name]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+
+[data-frames-wide-format]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+[data-frames-wide-format]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -552,11 +552,14 @@ WHERE
 Time series queries should work in alerting conditions. Table formatted queries are not yet supported in alert rule conditions.
 
 {{% docs/reference %}}
+
+<!-- prettier-ignore-start -->
 [add-template-variables-interval-ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
 [add-template-variables-interval-ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
 
 [add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
 [add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+<!-- prettier-ignore-end -->
 
 [annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
 [annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"

--- a/docs/sources/datasources/opentsdb/_index.md
+++ b/docs/sources/datasources/opentsdb/_index.md
@@ -23,9 +23,9 @@ weight: 1100
 Grafana ships with advanced support for OpenTSDB.
 This topic explains configuration, variables, querying, and other features specific to the OpenTSDB data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
 ## OpenTSDB settings
 
@@ -53,7 +53,7 @@ To configure basic settings for the data source, complete the following steps:
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -93,7 +93,7 @@ Instead of hard-coding things like server, application and sensor name in your m
 Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data
 being displayed in your dashboard.
 
-Check out the [Templating]({{< relref "../../dashboards/variables/" >}}) documentation for an introduction to the templating feature and the different
+Check out the [Templating][variables] documentation for an introduction to the templating feature and the different
 types of template variables.
 
 ### Query variable
@@ -127,3 +127,14 @@ Some examples are mentioned below to make nested template queries work successfu
 | `tag_values(cpu, hostname, env=$env, region=$region)` | Return tag values for cpu metric, selected env tag value, selected region tag value and tag key hostname |
 
 For details on OpenTSDB metric queries, check out the official [OpenTSDB documentation](http://opentsdb.net/docs/build/html/index.html)
+
+{{% docs/reference %}}
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/parca.md
+++ b/docs/sources/datasources/parca.md
@@ -19,7 +19,7 @@ weight: 1110
 
 # Parca data source
 
-Grafana ships with built-in support for Parca, a continuous profiling OSS database for analysis of CPU and memory usage, down to the line number and throughout time. Add it as a data source, and you are ready to query your profiles in [Explore]({{< relref "../explore" >}}).
+Grafana ships with built-in support for Parca, a continuous profiling OSS database for analysis of CPU and memory usage, down to the line number and throughout time. Add it as a data source, and you are ready to query your profiles in [Explore][explore].
 
 ## Configure the Parca data source
 
@@ -61,11 +61,11 @@ Use the labels selector input to filter by labels. Parca uses similar syntax to 
 
 ![Options section](/static/img/docs/parca/options-section.png 'Options section')
 
-Select a query type to return the profile data which can be shown in the [Flame Graph]({{< relref "../panels-visualizations/visualizations/flame-graph" >}}), metric data visualized in a graph, or both. You can only select both options in a dashboard, because panels allow only one visualization.
+Select a query type to return the profile data which can be shown in the [Flame Graph][flame-graph], metric data visualized in a graph, or both. You can only select both options in a dashboard, because panels allow only one visualization.
 
 ### Profiles query results
 
-Profiles can be visualized in a flame graph. See the [Flame Graph documentation]({{< relref "../panels-visualizations/visualizations/flame-graph" >}}) to learn about the visualization and its features.
+Profiles can be visualized in a flame graph. See the [Flame Graph documentation][flame-graph] to learn about the visualization and its features.
 
 ![Flame graph](/static/img/docs/parca/flame-graph.png 'Flame graph')
 
@@ -81,7 +81,7 @@ This allows you to quickly see any spikes in the value of the scraped profiles a
 
 ## Provision the Parca data source
 
-You can modify the Grafana configuration files to provision the Parca data source. To learn more, and to view the available provisioning settings, see [provisioning documentation]({{< relref "../administration/provisioning/#datasources" >}}).
+You can modify the Grafana configuration files to provision the Parca data source. To learn more, and to view the available provisioning settings, see [provisioning documentation][provisioning-data-sources].
 
 Here is an example config:
 
@@ -93,3 +93,14 @@ datasources:
     type: parca
     url: http://localhost:3100
 ```
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[flame-graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+[flame-graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/postgres/_index.md
+++ b/docs/sources/datasources/postgres/_index.md
@@ -21,9 +21,9 @@ weight: 1200
 
 Grafana ships with a built-in PostgreSQL data source plugin that allows you to query and visualize data from a PostgreSQL compatible database.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
 ## PostgreSQL settings
 
@@ -58,7 +58,7 @@ To configure basic settings for the data source, complete the following steps:
 
 ### Min time interval
 
-A lower limit for the [$__interval]({{< relref "../../dashboards/variables/add-template-variables/#__interval" >}}) and [$__interval_ms]({{< relref "../../dashboards/variables/add-template-variables/#__interval_ms" >}}) variables.
+A lower limit for the [$__interval][add-template-variables-interval] and [$__interval_ms][add-template-variables-interval-ms] variables.
 Recommended to be set to write frequency, for example `1m` if your data is written every minute.
 This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value **needs** to be formatted as a
 number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
@@ -129,7 +129,7 @@ By flipping the preview switch at the top of the editor, you can get a preview o
 
 ### Provision the data source
 
-It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning#datasources" >}}).
+It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -232,11 +232,11 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../../developers/plugins/introduction-to-plugin-development/data-frames#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format][data-frames-wide-format]. Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 
-To optionally customize the default series name formatting, refer to [Standard options definitions]({{< relref "../../panels-visualizations/configure-standard-options#display-name" >}}).
+To optionally customize the default series name formatting, refer to [Standard options definitions][configure-standard-options-display-name].
 
 **Example with `metric` column:**
 
@@ -278,7 +278,7 @@ GROUP BY time, hostname
 ORDER BY time
 ```
 
-Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard options definitions]({{< relref "../../panels-visualizations/configure-standard-options#display-name" >}}) display value of `${__field.labels.hostname}`.
+Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard options definitions][configure-standard-options-display-name] display value of `${__field.labels.hostname}`.
 
 Data frame result:
 
@@ -323,7 +323,7 @@ Data frame result:
 
 Instead of hard-coding things like server, application and sensor name in your metric queries you can use variables in their place. Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data being displayed in your dashboard.
 
-Refer to [Templates and variables]({{< relref "../../dashboards/variables" >}}) for an introduction to the templating feature and the different types of template variables.
+Refer to [Templates and variables][variables] for an introduction to the templating feature and the different types of template variables.
 
 ### Query variable
 
@@ -416,11 +416,11 @@ Grafana automatically creates a quoted, comma-separated string for multi-value v
 
 `${servers:csv}`
 
-Read more about variable formatting options in the [Variables]({{< relref "../../dashboards/variables/variable-syntax#advanced-variable-format-options" >}}) documentation.
+Read more about variable formatting options in the [Variables][variable-syntax-advanced-variable-format-options] documentation.
 
 ## Annotations
 
-[Annotations]({{< relref "../../dashboards/build-dashboards/annotate-visualizations" >}}) allow you to overlay rich event information on top of graphs. You add annotation queries via the Dashboard menu / Annotations view.
+[Annotations][annotate-visualizations] allow you to overlay rich event information on top of graphs. You add annotation queries via the Dashboard menu / Annotations view.
 
 **Example query using time column with epoch values:**
 
@@ -475,3 +475,32 @@ WHERE
 
 Time series queries should work in alerting conditions. Table formatted queries are not yet supported in alert rule
 conditions.
+
+{{% docs/reference %}}
+[add-template-variables-interval-ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+[add-template-variables-interval-ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
+
+[add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+[add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+
+[annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+[annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
+
+[configure-standard-options-display-name]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+[configure-standard-options-display-name]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#display-name"
+
+[data-frames-wide-format]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+[data-frames-wide-format]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/developers/plugins/introduction-to-plugin-development/data-frames#wide-format"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#datasources"
+
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+[variable-syntax-advanced-variable-format-options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax#advanced-variable-format-options"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/postgres/_index.md
+++ b/docs/sources/datasources/postgres/_index.md
@@ -58,7 +58,7 @@ To configure basic settings for the data source, complete the following steps:
 
 ### Min time interval
 
-A lower limit for the [$__interval][add-template-variables-interval] and [$__interval_ms][add-template-variables-interval-ms] variables.
+A lower limit for the [`$__interval`][add-template-variables-interval] and [`$__interval_ms`][add-template-variables-interval-ms] variables.
 Recommended to be set to write frequency, for example `1m` if your data is written every minute.
 This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value **needs** to be formatted as a
 number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
@@ -477,11 +477,14 @@ Time series queries should work in alerting conditions. Table formatted queries 
 conditions.
 
 {{% docs/reference %}}
+
+<!-- prettier-ignore-start -->
 [add-template-variables-interval-ms]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
 [add-template-variables-interval-ms]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval_ms"
 
 [add-template-variables-interval]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
 [add-template-variables-interval]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#__interval"
+<!-- prettier-ignore-end -->
 
 [annotate-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"
 [annotate-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/annotate-visualizations"

--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -19,22 +19,22 @@ weight: 1300
 
 # Prometheus data source
 
-Prometheus is an open-source database that uses an telemetry collector agent to scrape and store metrics used for monitoring and alerting. If you are just getting started with Prometheus, see [What is Prometheus?]({{< relref "../../fundamentals/intro-to-prometheus/" >}}).
+Prometheus is an open-source database that uses an telemetry collector agent to scrape and store metrics used for monitoring and alerting. If you are just getting started with Prometheus, see [What is Prometheus?][intro-to-prometheus].
 
 Grafana provides native support for Prometheus.
-For instructions on downloading Prometheus see [Get started with Grafana and Prometheus](/docs/grafana/latest/getting-started/get-started-grafana-prometheus/#get-started-with-grafana-and-prometheus).
+For instructions on downloading Prometheus see [Get started with Grafana and Prometheus][get-started-prometheus].
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
 Only users with the organization `administrator` role can add data sources and edit existing data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the Prometheus data source, you can [configure it](/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}), use [Explore]({{< relref "../../explore/" >}}), and [annotate visualizations]({{< relref "./query-editor/#apply-annotations" >}}).
+Once you've added the Prometheus data source, you can [configure it][configure-prometheus-data-source] so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor" >}}) when they [build dashboards][build-dashboards], use [Explore][explore], and [annotate visualizations]({{< relref "./query-editor#apply-annotations" >}}).
 
 The following guides will help you get started with the Prometheus data source:
 
-- [Configure the Prometheus data source](/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/)
-- [Prometheus query editor](/docs/grafana/latest/datasources/prometheus/query-editor/)
-- [Template variables](/docs/grafana/latest/datasources/prometheus/template-variables/)
+- [Configure the Prometheus data source][configure-prometheus-data-source]
+- [Prometheus query editor]({{< relref "./query-editor" >}})
+- [Template variables]({{< relref "./template-variables" >}})
 
 ## Prometheus API
 
@@ -48,7 +48,7 @@ For more information on how to query other Prometheus-compatible projects from G
 ## Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 {{% admonition type="note" %}}
 Once you have provisioned a data source you cannot edit it.
@@ -93,14 +93,14 @@ We also bundle a dashboard within Grafana so you can start viewing your metrics 
 
 **To import the bundled dashboard:**
 
-1. Navigate to the data source's [configuration page]({{< relref "#configure-the-data-source" >}}).
+1. Navigate to the data source's [configuration page](#configure-the-data-source).
 1. Select the **Dashboards** tab.
 
 This displays dashboards for Grafana and Prometheus.
 
 1. Select **Import** for the dashboard to import.
 
-For details about these metrics, refer to [Internal Grafana metrics]({{< relref "../../setup-grafana/set-up-grafana-monitoring/" >}}).
+For details about these metrics, refer to [Internal Grafana metrics][set-up-grafana-monitoring].
 
 ## Amazon Managed Service for Prometheus
 
@@ -124,7 +124,7 @@ If you run Grafana in an Amazon EKS cluster, follow the AWS guide to [Query usin
 
 The Prometheus data source works with Azure authentication. To configure Azure authentication see [Configure Azure Active Directory (AD) authentication](/docs/grafana/latest/datasources/azure-monitor/#configure-azure-active-directory-ad-authentication).
 
-In Grafana Enterprise, update the .ini configuration file: [Configure Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/). Depending on your setup, the .ini file is located [here](/docs/grafana/latest/setup-grafana/configure-grafana/#configuration-file-location).
+In Grafana Enterprise, update the .ini configuration file: [Configure Grafana][configure-grafana]. Depending on your setup, the .ini file is located [here][configure-grafana-configuration-file-location].
 Add the following setting in the **[auth]** section :
 
 ```bash
@@ -138,7 +138,7 @@ If you are using Azure authentication settings do not enable `Forward OAuth iden
 
 ## Exemplars
 
-Exemplars associate higher-cardinality metadata from a specific event with traditional time series data. See [Introduction to exemplars]({{< relref "../../fundamentals/exemplars/" >}}) in Prometheus documentation for detailed information on how they work.
+Exemplars associate higher-cardinality metadata from a specific event with traditional time series data. See [Introduction to exemplars][exemplars] in Prometheus documentation for detailed information on how they work.
 
 {{% admonition type="note" %}}
 Available in Prometheus v2.26 and higher with Grafana v7.4 and higher.
@@ -148,7 +148,7 @@ Grafana 7.4 and higher can show exemplars data alongside a metric both in Explor
 
 {{< figure src="/static/img/docs/v74/exemplars.png" class="docs-image--no-shadow" caption="Screenshot showing the detail window of an Exemplar" >}}
 
-See the Exemplars section in [Configure Prometheus data source](/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/).
+See the Exemplars section in [Configure Prometheus data source][configure-prometheus-data-source].
 
 {{< figure src="/static/img/docs/prometheus/exemplars-10-1.png" max-width="500px" class="docs-image--no-shadow" caption="Exemplars" >}}
 
@@ -164,3 +164,35 @@ Increasing the duration of the `incrementalQueryOverlapWindow` will increase the
 ## Recording Rules (beta)
 
 The Prometheus data source can be configured to disable recording rules under the data source configuration or provisioning file (under `disableRecordingRules` in jsonData).
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-configuration-file-location]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#configuration-file-location"
+[configure-grafana-configuration-file-location]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#configuration-file-location"
+
+[configure-grafana]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
+[configure-grafana]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana"
+
+[configure-prometheus-data-source]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/configure-prometheus-data-source"
+[configure-prometheus-data-source]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/configure-prometheus-data-source"
+
+[exemplars]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+[exemplars]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[get-started-prometheus]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/getting-started/get-started-grafana-prometheus#get-started-with-grafana-and-prometheus"
+[get-started-prometheus]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/getting-started/get-started-grafana-prometheus#get-started-with-grafana-and-prometheus"
+
+[intro-to-prometheus]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/intro-to-prometheus"
+[intro-to-prometheus]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/intro-to-prometheus"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[set-up-grafana-monitoring]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+[set-up-grafana-monitoring]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/set-up-grafana-monitoring"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -21,7 +21,7 @@ weight: 200
 
 Grafana ships with built-in support for Prometheus. If you are new to Prometheus the following documentation will help you get started working with Prometheus and Grafana:
 
-- [What is Prometheus?]({{< relref "../../fundamentals/intro-to-prometheus/" >}})
+- [What is Prometheus?][intro-to-prometheus]
 - [Prometheus data model](https://prometheus.io/docs/concepts/data_model/)
 - [Getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
 
@@ -99,7 +99,7 @@ Following are additional configuration options.
 
 ### Query editor
 
-- **Default editor** - Sets a default editor. Options are `Builder` or `Code`. For information on query editor types see [Prometheus query editor](/docs/grafana/latest/datasources/prometheus/query-editor/).
+- **Default editor** - Sets a default editor. Options are `Builder` or `Code`. For information on query editor types see [Prometheus query editor]({{< relref "./query-editor" >}}).
 
 - **Disable metrics lookup** - Toggle on to disable the metrics chooser and metric/label support in the query field's autocomplete. This helps if you have performance issues with large Prometheus instances.
 
@@ -119,11 +119,11 @@ Following are additional configuration options.
 
 ### Exemplars
 
-Support for exemplars is available only for the Prometheus data source. If this is your first time working with exemplars see [Introduction to exemplars]({{< relref "../../fundamentals/exemplars/" >}}). An exemplar is a specific trace representative of measurement taken in a given time interval.
+Support for exemplars is available only for the Prometheus data source. If this is your first time working with exemplars see [Introduction to exemplars][exemplars]. An exemplar is a specific trace representative of measurement taken in a given time interval.
 
 - **Internal link** - Toggle on to enable an internal link. When enabled, reveals the data source selector. Select the backend tracing data store for your exemplar data.
 
-- **URL** - _(Visible if you **disable** `Internal link`)_ Defines the external link's URL trace backend. You can interpolate the value from the field by using the [`${__value.raw}` macro]({{< relref "../..//panels-visualizations/configure-data-links/#value-variables" >}}).
+- **URL** - _(Visible if you **disable** `Internal link`)_ Defines the external link's URL trace backend. You can interpolate the value from the field by using the [`${__value.raw}` macro][configure-data-links-value-variables].
 
 - **Data source** - _(Visible if you **enable** `Internal link`)_ The data source the exemplar will navigate to.
 
@@ -132,3 +132,14 @@ Support for exemplars is available only for the Prometheus data source. If this 
 - **Label name** - The name of the field in the `labels` object used to obtain the traceID property.
 
 - **Remove exemplar link** - Click to remove existing links.
+
+{{% docs/reference %}}
+[configure-data-links-value-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-data-links#value-variables"
+[configure-data-links-value-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-data-links#value-variables"
+
+[exemplars]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+[exemplars]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+
+[intro-to-prometheus]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/intro-to-prometheus"
+[intro-to-prometheus]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/intro-to-prometheus"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -21,9 +21,9 @@ weight: 300
 
 Grafana provides a query editor for the Prometheus data source to create queries in PromQL. For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
 
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
-For options and functions common to all query editors, see [Query editors]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For options and functions common to all query editors, see [Query editors][query-transform-data].
 
 ## Choose a query editing mode
 
@@ -81,8 +81,8 @@ This setting supports the `$__interval` and `$__rate_interval` macros.
 Switch between the following format options:
 
 - **Time series** - The default time series format. See [Time series kind formats](https://grafana.github.io/dataplane/timeseries/) for information on time series data frames and how time and value fields are structured.
-- **Table** - This works only in a [Table panel]({{< relref "../../../panels-visualizations/visualizations/table" >}}).
-- **Heatmap** - Displays metrics of the Histogram type on a [Heatmap panel]({{< relref "../../../panels-visualizations/visualizations/heatmap" >}}) by converting cumulative histograms to regular ones and sorting the series by the bucket bound.
+- **Table** - This works only in a [Table panel][table].
+- **Heatmap** - Displays metrics of the Histogram type on a [Heatmap panel][heatmap] by converting cumulative histograms to regular ones and sorting the series by the bucket bound.
 
 ### Type
 
@@ -92,7 +92,7 @@ The **Type** setting sets the query type. These include:
 - **Range** - Returns a range vector consisting of a set of time series data containing a range of data points over time for each time series. You can choose lines, bars, points, stacked lines or stacked bars
 - **Instant** - Returns one data point per query and only the most recent point in the time range provided. The results can be shown in table format or as raw data. To depict instant query results in the time series panel, first add a field override, next add a property to the override named `Transform`, and finally select `Constant` from the **Transform** dropdown.
 
-For more information, refer to the [Time Series Transform option documentation]({{< relref "../../../panels-visualizations/visualizations/time-series#transform" >}}).
+For more information, refer to the [Time Series Transform option documentation][time-series-transform].
 
 {{% admonition type="note" %}}
 Grafana modifies the request dates for queries to align them with the dynamically calculated step.
@@ -101,7 +101,7 @@ This ensures a consistent display of metrics data, but it can result in a small 
 
 ### Exemplars
 
-Toggle **Exemplars** to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus. For more information see [Introduction to exemplars](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/).
+Toggle **Exemplars** to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus. For more information see [Introduction to exemplars][exemplars].
 
 {{% admonition type="note" %}}
 There is no option to add exemplars with an **Instant** query type.
@@ -197,7 +197,7 @@ Once you are satisfied with your query, click **Run query**.
 The user interface (UI) also lets you select metrics, labels, filters and operations.
 
 You can write complex queries using the text editor with autocompletion features and syntax highlighting.
-It also contains a [Metrics browser]({{< relref "#metrics-browser" >}}) to further help you write queries.
+It also contains a [Metrics browser](#metrics-browser) to further help you write queries.
 
 ### Use autocomplete
 
@@ -227,3 +227,20 @@ The values section has only one search field, and its filtering applies to all l
 For example, among your labels `app`, `job`, `job_name` only one might have the value you are looking for.
 
 Once you are satisfied with your query, click **Run query**.
+
+{{% docs/reference %}}
+[exemplars]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+[exemplars]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+
+[heatmap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
+[heatmap]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[table]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/table"
+[table]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/table"
+
+[time-series-transform]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series#transform"
+[time-series-transform]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series#transform"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/prometheus/template-variables/index.md
+++ b/docs/sources/datasources/prometheus/template-variables/index.md
@@ -23,7 +23,7 @@ weight: 400
 Instead of hard-coding details such as server, application, and sensor names in metric queries, you can use variables. Grafana refers to such variables as **template** variables.
 Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the data displayed in your dashboard.
 
-For an introduction to templating and template variables, see [Templating]({{< relref "../../../dashboards/variables" >}}) and [Add and manage variables]({{< relref "../../../dashboards/variables/add-template-variables" >}}).
+For an introduction to templating and template variables, see [Templating][variables] and [Add and manage variables][add-template-variables].
 
 ## Use query variables
 
@@ -64,7 +64,7 @@ The following selection options are available:
 ### Use interval and range variables
 
 You can use some global built-in variables in query variables, for example, `$__interval`, `$__interval_ms`, `$__range`, `$__range_s` and `$__range_ms`.
-For details, see [Global built-in variables]({{< relref "../../../dashboards/variables/add-template-variables#global-variables" >}}).
+For details, see [Global built-in variables][add-template-variables-global-variables].
 The `label_values` function doesn't support queries, so you can use these variables in conjunction with the `query_result` function to filter variable queries.
 
 Make sure to set the variable's `refresh` trigger to be `On Time Range Change` to get the correct instances when changing the time range on the dashboard.
@@ -132,5 +132,19 @@ If you've enabled the _Multi-value_ or _Include all value_ options, Grafana conv
 
 ## Use the ad hoc filters variable type
 
-Prometheus supports the special [ad hoc filters]({{< relref "../../../dashboards/variables/add-template-variables#add-ad-hoc-filters" >}}) variable type, which you can use to specify any number of label/value filters on the fly.
+Prometheus supports the special [ad hoc filters][add-template-variables-add-ad-hoc-filters] variable type, which you can use to specify any number of label/value filters on the fly.
 These filters are automatically applied to all your Prometheus queries.
+
+{{% docs/reference %}}
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+[add-template-variables-add-ad-hoc-filters]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#add-ad-hoc-filters"
+
+[add-template-variables-global-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#global-variables"
+[add-template-variables-global-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables#global-variables"
+
+[add-template-variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+[add-template-variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/add-template-variables"
+
+[variables]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[variables]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -22,13 +22,13 @@ weight: 1400
 
 Grafana ships with built-in support for [Tempo](https://grafana.com/docs/tempo/latest/), a high-volume, minimal-dependency trace storage, open-source tracing solution from Grafana Labs. This topic explains configuration and queries specific to the Tempo data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
-You can also [use the Service Graph]({{< relref "#use-the-service-graph" >}}) to view service relationships, [track RED metrics]({{< relref "#open-the-service-graph-view" >}}), [upload a JSON trace file]({{< relref "#upload-a-json-trace-file" >}}), [link to a trace ID from logs]({{< relref "#link-to-a-trace-id-from-logs" >}}), and [link to a trace ID from metrics]({{< relref "#link-to-a-trace-id-from-metrics" >}}).
+You can also [use the Service Graph](#use-the-service-graph) to view service relationships, [track RED metrics](#open-the-service-graph-view), [upload a JSON trace file](#upload-a-json-trace-file), [link to a trace ID from logs](#link-to-a-trace-id-from-logs), and [link to a trace ID from metrics](#link-to-a-trace-id-from-metrics).
 
 ## Configure the data source
 
@@ -63,12 +63,12 @@ Available in Grafana v7.4 and higher.
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
 {{% /admonition %}}
 
-The **Trace to logs** setting configures the [trace to logs feature]({{< relref "../../explore/trace-integration" >}}) that is available when you integrate Grafana with Tempo.
+The **Trace to logs** setting configures the [trace to logs feature][explore-trace-integration] that is available when you integrate Grafana with Tempo.
 
 There are two ways to configure the trace to logs feature:
 
 - Use a simplified configuration with default query, or
-- Configure a custom query where you can use a [template language]({{< relref "../../dashboards/variables/variable-syntax">}}) to interpolate variables from the trace or span.
+- Configure a custom query where you can use a [template language][variable-syntax] to interpolate variables from the trace or span.
 
 #### Use a simple configuration
 
@@ -118,7 +118,7 @@ The following table describes the ways in which you can configure your trace to 
 ### Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle]({{< relref "../../setup-grafana/configure-grafana#feature_toggles" >}}).
+This feature is behind the `traceToMetrics` [feature toggle][configure-grafana-feature-toggles].
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
 {{% /admonition %}}
 
@@ -147,11 +147,11 @@ The **Service Graph** setting configures the [Service Graph](/docs/tempo/latest/
 
 Configure the **Data source** setting to define in which Prometheus instance the Service Graph data is stored.
 
-To use the Service Graph, refer to the [Service Graph documentation]({{< relref "#use-the-service-graph" >}}).
+To use the Service Graph, refer to the [Service Graph documentation](#use-the-service-graph).
 
 ### Node Graph
 
-The **Node Graph** setting enables the [node graph visualization]({{< relref "../../panels-visualizations/visualizations/node-graph/" >}}), which is disabled by default.
+The **Node Graph** setting enables the [node graph visualization][node-graph], which is disabled by default.
 
 Once enabled, Grafana displays the node graph above the trace view.
 
@@ -195,7 +195,7 @@ You can choose one of three options:
 ### Provision the data source
 
 You can define and configure the Tempo data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning and available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
+For more information about provisioning and available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -248,7 +248,7 @@ datasources:
 
 ## Query the data source
 
-The Tempo data source's query editor helps you query and display traces from Tempo in [Explore]({{< relref "../../explore" >}}).
+The Tempo data source's query editor helps you query and display traces from Tempo in [Explore][explore].
 
 For details, refer to the [query editor documentation]({{< relref "./query-editor" >}}).
 
@@ -320,13 +320,13 @@ You use the Service Graph to detect performance issues; track increases in error
 
 1. [Configure Grafana Agent](/docs/tempo/latest/grafana-agent/service-graphs/#quickstart) or [Tempo or GET](/docs/tempo/latest/metrics-generator/service_graphs/#tempo) to generate Service Graph data.
 1. Link a Prometheus data source in the Tempo data source's [Service Graph](#configure-service-graph) settings.
-1. Navigate to [Explore]({{< relref "../../explore/" >}}).
+1. Navigate to [Explore][explore].
 1. Select the Tempo data source.
 1. Select the **Service Graph** query type.
 1. Run the query.
 1. _(Optional)_ Filter by service name.
 
-For details, refer to [Node Graph panel]({{< relref "../../panels-visualizations/visualizations/node-graph/" >}}).
+For details, refer to [Node Graph panel][node-graph].
 
 Each circle in the graph represents a service.
 To open a context menu with additional links for quick navigation to other relevant information, click a service.
@@ -353,7 +353,7 @@ For details, refer to the [Service Graph view documentation](/docs/tempo/latest/
 To open the Service Graph view:
 
 1. Link a Prometheus data source in the Tempo data source settings.
-1. Navigate to [Explore]({{< relref "../../explore/" >}}).
+1. Navigate to [Explore][explore].
 1. Select the Tempo data source.
 1. Select the **Service Graph** query type.
 1. Run the query.
@@ -393,4 +393,33 @@ To configure this feature, see the [Derived fields]({{< relref "../loki#configur
 
 You can link to Tempo traces from metrics in Prometheus data sources by configuring an exemplar.
 
-To configure this feature, see the [introduction to exemplars]({{< relref "docs/grafana/latest/fundamentals/exemplars" >}}) documentation.
+To configure this feature, see the [introduction to exemplars][exemplars] documentation.
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-feature-toggles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+[configure-grafana-feature-toggles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[exemplars]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+[exemplars]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/exemplars"
+
+[explore-trace-integration]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+[explore-trace-integration]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[node-graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+[node-graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[variable-syntax]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+[variable-syntax]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/tempo/query-editor/index.md
+++ b/docs/sources/datasources/tempo/query-editor/index.md
@@ -19,10 +19,10 @@ weight: 300
 
 # Tempo query editor
 
-The Tempo data source's query editor helps you query and display traces from Tempo in [Explore]({{< relref "../../../explore" >}}).
+The Tempo data source's query editor helps you query and display traces from Tempo in [Explore][explore].
 
 This topic explains configuration and queries specific to the Tempo data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ## Query by search
 
@@ -89,3 +89,11 @@ To find traces to visualize, you can use the [Loki query editor]({{< relref "../
 For results, you must configure [derived fields]({{< relref "../../loki#configure-derived-fields" >}}) in the Loki data source that point to this data source.
 
 {{< figure src="/static/img/docs/tempo/query-editor-search.png" class="docs-image--no-shadow" max-width="750px" caption="Screenshot of the Tempo query editor showing the Loki Search tab" >}}
+
+{{% docs/reference %}}
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -21,10 +21,10 @@ weight: 1500
 
 # TestData data source
 
-Grafana ships with a TestData data source, which creates simulated time series data for any [panel]({{< relref "../../panels-visualizations/" >}}).
+Grafana ships with a TestData data source, which creates simulated time series data for any [panel][panels-visualizations].
 You can use it to build your own fake and random time series data and render it in any panel, which helps you verify dashboard functionality since you can safely and easily share the data.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
 
 ## Configure the data source
@@ -93,7 +93,7 @@ TestData also provides an example dashboard.
 
 **To import the example dashboard:**
 
-1. Navigate to the data source's [configuration page]({{< relref "#configure-the-data-source" >}}).
+1. Navigate to the data source's [configuration page](#configure-the-data-source).
 1. Select the **Dashboards** tab.
 1. Select **Import** for the **Simple Streaming Example** dashboard.
 
@@ -106,3 +106,11 @@ If you don't, upgrading Grafana can overwrite the customized dashboard with the 
 
 If you report an issue on GitHub involving the use or rendering of time series data, we strongly recommend that you use this data source to replicate the issue.
 That makes it much easier for the developers to replicate and solve your issue.
+
+{{% docs/reference %}}
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[panels-visualizations]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations"
+[panels-visualizations]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations"
+{{% /docs/reference %}}

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -22,13 +22,13 @@ weight: 1600
 
 Grafana ships with built-in support for Zipkin, an open source, distributed tracing system. This topic explains configuration and queries specific to the Zipkin data source.
 
-For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
+For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management].
 Only users with the organization administrator role can add data sources.
-Administrators can also [configure the data source via YAML]({{< relref "#provision-the-data-source" >}}) with Grafana's provisioning system.
+Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the Zipkin data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "#query-the-data-source" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
+Once you've added the Zipkin data source, you can [configure it](#configure-the-data-source) so that your Grafana instance's users can create queries in its [query editor](#query-the-data-source) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
-You can also [upload a JSON trace file]({{< relref "#upload-a-json-trace-file" >}}), [link to a trace ID from logs]({{< relref "#link-to-a-trace-id-from-logs" >}}), and [link to a trace ID from metrics]({{< relref "#link-to-a-trace-id-from-metrics" >}}).
+You can also [upload a JSON trace file](#upload-a-json-trace-file), [link to a trace ID from logs](#link-to-a-trace-id-from-logs), and [link to a trace ID from metrics](#link-to-a-trace-id-from-metrics).
 
 ## Configure the data source
 
@@ -61,12 +61,12 @@ Available in Grafana v7.4 and higher.
 If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
 {{% /admonition %}}
 
-The **Trace to logs** setting configures the [trace to logs feature]({{< relref "../../explore/trace-integration" >}}) that is available when you integrate Grafana with Zipkin.
+The **Trace to logs** setting configures the [trace to logs feature][trace-integration] that is available when you integrate Grafana with Zipkin.
 
 There are two ways to configure the trace to logs feature:
 
 - Use a simplified configuration with default query, or
-- Configure a custom query where you can use a [template language]({{< relref "../../dashboards/variables/variable-syntax">}}) to interpolate variables from the trace or span.
+- Configure a custom query where you can use a [template language][variable-syntax] to interpolate variables from the trace or span.
 
 #### Use a simple configuration
 
@@ -116,8 +116,8 @@ The following table describes the ways in which you can configure your trace to 
 ### Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle]({{< relref "../../setup-grafana/configure-grafana#feature_toggles" >}}).
-If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
+This feature is behind the `traceToMetrics` [feature toggle][configure-grafana-feature-toggles].
+If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org/#support) to access this feature.
 {{% /admonition %}}
 
 The **Trace to metrics** setting configures the [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/) available when integrating Grafana with Zipkin.
@@ -141,7 +141,7 @@ Each linked query consists of:
 
 ### Node Graph
 
-The **Node Graph** setting enables the [Node Graph visualization]({{< relref "../../panels-visualizations/visualizations/node-graph/" >}}), which is disabled by default.
+The **Node Graph** setting enables the [Node Graph visualization][node-graph], which is disabled by default.
 
 Once enabled, Grafana displays the Node Graph after loading the trace view.
 
@@ -160,7 +160,7 @@ You can choose one of three options:
 ### Provision the data source
 
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
-For more information about provisioning and available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning#data-sources" >}}).
+For more information about provisioning and available configuration options, refer to [Provisioning Grafana][provisioning-data-sources].
 
 #### Provisioning example
 
@@ -211,10 +211,10 @@ datasources:
 
 ## Query the data source
 
-You can query and display traces from Zipkin via [Explore]({{< relref "../../explore/" >}}).
+You can query and display traces from Zipkin via [Explore][explore]
 
 This topic explains configuration and queries specific to the Zipkin data source.
-For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../../panels-visualizations/query-transform-data" >}}).
+For general documentation on querying data sources in Grafana, see [Query and transform data][query-transform-data].
 
 ### Query by trace ID
 
@@ -297,3 +297,32 @@ To configure this feature, see the [Derived fields]({{< relref "../loki#configur
 You can link to Zipkin traces from metrics in Prometheus data sources by configuring an exemplar.
 
 To configure this feature, see the [introduction to exemplars]({{< relref "docs/grafana/latest/fundamentals/exemplars" >}}) documentation.
+
+{{% docs/reference %}}
+[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+
+[configure-grafana-feature-toggles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+[configure-grafana-feature-toggles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+
+[data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+[data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
+
+[explore]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+[explore]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore"
+
+[node-graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+[node-graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+
+[provisioning-data-sources]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+[provisioning-data-sources]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/provisioning#data-sources"
+
+[query-transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+[query-transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data"
+
+[trace-integration]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+[trace-integration]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/explore/trace-integration"
+
+[variable-syntax]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+[variable-syntax]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/variables/variable-syntax"
+{{% /docs/reference %}}


### PR DESCRIPTION
Use of this shortcode means that links can resolve different depending on where the page is published.
At the moment, most links are configured to go back to Grafana documentation even if there might be a more appropriate Grafana Cloud destination.

All links have been replaced with `/docs/reference` style links. The link destination for any link label is determined when the page is built and checked with relrefs. There are no broken relrefs in the datasources docs when running `make docs` so I believe all the links are working as intended when it comes to Grafana docs.

Note that the Grafana Cloud content links to the "next" version of Grafana documentation. The `<GRAFANA VERSION>` variable is replaced with `next` in Grafana Cloud pages because we set `grafana_version: next` in the Grafana Cloud documentation front matter.
For the pages published in Grafana, `<GRAFANA VERSION>` is automatically replaced with the current version.

Additional changes:
1. When I saw a relref containing only an anchor, I replaced that with a raw Markdown anchor link. It saves some keypresses and the behavior is the same as Hugo does not check anchors exist during the build.

https://github.com/grafana/writers-toolkit/pull/282 documents the shortcode behavior in more detail.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
