### PR TITLE
Alerting: Add exported getters for PanelKey fields

### DIFF
--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -74,6 +74,18 @@ func parsePanelKey(rule history_model.RuleMeta, logger log.Logger) *PanelKey {
 	return nil
 }
 
+func (p PanelKey) OrgID() int64 {
+	return p.orgID
+}
+
+func (p PanelKey) DashUID() string {
+	return p.dashUID
+}
+
+func (p PanelKey) PanelID() int64 {
+	return p.panelID
+}
+
 func mergeLabels(base, into data.Labels) data.Labels {
 	for k, v := range into {
 		base[k] = v


### PR DESCRIPTION
**What is this feature?**

Adds structured getters for PanelKey fields. The constructor is exported, but nothing is readable. >.>

**Why do we need this feature?**

So type can be used effectively in external packages

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
