### PR TITLE
Devenv: add exemplar to self-instrumentation

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -63,6 +63,9 @@ datasources:
       alertmanagerUid: gdev-alertmanager
       prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
       prometheusVersion: 2.40.0
+      exemplarTraceIdDestinations:
+      - name: traceID
+        datasourceUid: gdev-tempo
     secureJsonData:
       basicAuthPassword: admin #https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables
 

--- a/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
+++ b/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
@@ -6,6 +6,7 @@
       - "host.docker.internal:host-gateway"
     command: >
       --enable-feature=remote-write-receiver
+      --enable-feature=exemplar-storage
       --config.file=/etc/prometheus/prometheus.yml
       --storage.tsdb.path=/prometheus
     volumes:


### PR DESCRIPTION
Adding exemplar support to the self-instrumentation devenv

For quick testing, the metric "grafana_http_request_duration_seconds_bucket" has exemplar enable and receive dozens of events per interaction with Grafana UI