### PR TITLE
Plugins Instrumentation: add exemplar to the plugin requests metrics

### DIFF
--- a/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
+++ b/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
@@ -6,6 +6,7 @@
       - "host.docker.internal:host-gateway"
     command: >
       --enable-feature=remote-write-receiver
+      --enable-feature=exemplar-storage
       --config.file=/etc/prometheus/prometheus.yml
       --storage.tsdb.path=/prometheus
     volumes:

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -4,7 +4,6 @@ package instrumentation
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -78,24 +77,23 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 
 	elapsed := time.Since(start)
 
-	logger := log.New("plugin.instrumentation").FromContext(ctx)
-	logger.Error(fmt.Sprintf("QueryData() traceID: %s", tracing.TraceIDFromContext(ctx, false)))
+	pluginRequestDurationWithLabels := pluginRequestDuration.WithLabelValues(pluginCtx.PluginID, endpoint, string(cfg.Target))
+	pluginRequestCounterWithLabels := pluginRequestCounter.WithLabelValues(pluginCtx.PluginID, endpoint, status, string(cfg.Target))
+	pluginRequestDurationSecondsWithLabels := PluginRequestDurationSeconds.WithLabelValues("grafana-backend", pluginCtx.PluginID, endpoint, status, string(cfg.Target))
 
-	// pluginRequestDuration.WithLabelValues(pluginCtx.PluginID, endpoint, string(cfg.Target)).Observe(float64(elapsed / time.Millisecond))
-
-	metric := pluginRequestDuration.WithLabelValues(pluginCtx.PluginID, endpoint, string(cfg.Target))
 	if traceID := tracing.TraceIDFromContext(ctx, true); traceID != "" {
-		logger.Error(fmt.Sprintf("observe with examplar: %s", traceID))
-		metric.(prometheus.ExemplarObserver).ObserveWithExemplar(
+		pluginRequestDurationWithLabels.(prometheus.ExemplarObserver).ObserveWithExemplar(
 			float64(elapsed/time.Millisecond), prometheus.Labels{"traceID": traceID},
 		)
+		pluginRequestCounterWithLabels.(prometheus.ExemplarAdder).AddWithExemplar(1, prometheus.Labels{"traceID": traceID})
+		pluginRequestDurationSecondsWithLabels.(prometheus.ExemplarObserver).ObserveWithExemplar(
+			elapsed.Seconds(), prometheus.Labels{"traceID": traceID},
+		)
 	} else {
-		metric.Observe(float64(elapsed / time.Millisecond))
+		pluginRequestDurationWithLabels.Observe(float64(elapsed / time.Millisecond))
+		pluginRequestCounterWithLabels.Inc()
+		pluginRequestDurationSecondsWithLabels.Observe(elapsed.Seconds())
 	}
-
-	pluginRequestCounter.WithLabelValues(pluginCtx.PluginID, endpoint, status, string(cfg.Target)).Inc()
-
-	PluginRequestDurationSeconds.WithLabelValues("grafana-backend", pluginCtx.PluginID, endpoint, status, string(cfg.Target)).Observe(elapsed.Seconds())
 
 	if cfg.LogDatasourceRequests {
 		logParams := []interface{}{

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -78,6 +78,9 @@ func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cf
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	logger := log.New("tsdb.prometheus").FromContext(ctx)
+	logger.Error(fmt.Sprintf("QueryData() traceID: %s", tracing.TraceIDFromContext(ctx, false)))
+
 	if len(req.Queries) == 0 {
 		err := fmt.Errorf("query contains no queries")
 		instrumentation.UpdateQueryDataMetrics(err, nil)

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -78,9 +78,6 @@ func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cf
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	logger := log.New("tsdb.prometheus").FromContext(ctx)
-	logger.Error(fmt.Sprintf("QueryData() traceID: %s", tracing.TraceIDFromContext(ctx, false)))
-
 	if len(req.Queries) == 0 {
 		err := fmt.Errorf("query contains no queries")
 		instrumentation.UpdateQueryDataMetrics(err, nil)


### PR DESCRIPTION
Add exemplar to the plugin requests metrics.

This will allow to go from the metrics to traces