### PR TITLE
fix: remove redundant renderChart definition in BigValueLayout compon…

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -263,10 +263,6 @@ export class WideNoChartLayout extends BigValueLayout {
     return styles;
   }
 
-  renderChart(): JSX.Element | null {
-    return null;
-  }
-
   getPanelStyles() {
     const panelStyles = super.getPanelStyles();
     panelStyles.alignItems = 'center';
@@ -430,10 +426,6 @@ export class StackedWithNoChartLayout extends BigValueLayout {
     styles.flexDirection = 'column';
     styles.flexGrow = 1;
     return styles;
-  }
-
-  renderChart(): JSX.Element | null {
-    return null;
   }
 
   getPanelStyles() {


### PR DESCRIPTION

no-backport

remove redundant renderChart definition in BigValueLayout component of grafana-ui
