### PR TITLE
Fix remove renderchart define

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -263,10 +263,6 @@ export class WideNoChartLayout extends BigValueLayout {
     return styles;
   }
 
-  renderChart(): JSX.Element | null {
-    return null;
-  }
-
   getPanelStyles() {
     const panelStyles = super.getPanelStyles();
     panelStyles.alignItems = 'center';
@@ -430,10 +426,6 @@ export class StackedWithNoChartLayout extends BigValueLayout {
     styles.flexDirection = 'column';
     styles.flexGrow = 1;
     return styles;
-  }
-
-  renderChart(): JSX.Element | null {
-    return null;
   }
 
   getPanelStyles() {

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -208,6 +208,7 @@ export abstract class BigValueLayout {
       </div>
     );
   }
+  
   getChartStyles(): CSSProperties {
     return {
       position: 'absolute',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

remove redundant renderChart definition in BigValueLayout component of grafana-ui

**Why do we need this feature?**

Avoiding call errors that prevent rendering

**Who is this feature for?**

developer

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
