### PR TITLE
NestedFolders: Rename FolderPicker to OldFolderPicker

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1550,7 +1550,7 @@ exports[`better eslint`] = {
     "public/app/core/components/QueryOperationRow/QueryOperationAction.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
-    "public/app/core/components/Select/FolderPicker.tsx:5381": [
+    "public/app/core/components/Select/OldFolderPicker.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
     "public/app/core/components/TagFilter/TagFilter.tsx:5381": [

--- a/public/app/angular/angular_wrappers.ts
+++ b/public/app/angular/angular_wrappers.ts
@@ -11,7 +11,7 @@ import {
   UnitPicker,
 } from '@grafana/ui';
 import { react2AngularDirective } from 'app/angular/react2angular';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import { TimePickerSettings } from 'app/features/dashboard/components/DashboardSettings/TimePickerSettings';
 import { QueryEditor as CloudMonitoringQueryEditor } from 'app/plugins/datasource/cloud-monitoring/components/QueryEditor';
 
@@ -119,7 +119,7 @@ export function registerAngularDirectives() {
     'showForwardOAuthIdentityOption',
     ['onChange', { watchDepth: 'reference', wrapApply: true }],
   ]);
-  react2AngularDirective('folderPicker', FolderPicker, [
+  react2AngularDirective('folderPicker', OldFolderPicker, [
     'labelClass',
     'rootName',
     'enableCreateNew',

--- a/public/app/core/components/Select/OldFolderPicker.test.tsx
+++ b/public/app/core/components/Select/OldFolderPicker.test.tsx
@@ -9,9 +9,9 @@ import * as api from 'app/features/manage-dashboards/state/actions';
 
 import { DashboardSearchHit } from '../../../features/search/types';
 
-import { FolderPicker, getInitialValues } from './FolderPicker';
+import { OldFolderPicker, getInitialValues } from './OldFolderPicker';
 
-describe('FolderPicker', () => {
+describe('OldFolderPicker', () => {
   it('should render', async () => {
     jest
       .spyOn(api, 'searchFolders')
@@ -20,7 +20,7 @@ describe('FolderPicker', () => {
         { title: 'Dash 2', uid: 'wfTJJL5Wz' } as DashboardSearchHit,
       ]);
 
-    render(<FolderPicker onChange={jest.fn()} />);
+    render(<OldFolderPicker onChange={jest.fn()} />);
     expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
   });
 
@@ -33,7 +33,7 @@ describe('FolderPicker', () => {
         { title: 'Dash 3', uid: '7MeksYbmk' } as DashboardSearchHit,
       ]);
 
-    render(<FolderPicker onChange={jest.fn()} filter={(hits) => hits.filter((h) => h.uid !== 'wfTJJL5Wz')} />);
+    render(<OldFolderPicker onChange={jest.fn()} filter={(hits) => hits.filter((h) => h.uid !== 'wfTJJL5Wz')} />);
 
     const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
     selectEvent.openMenu(pickerContainer);
@@ -59,7 +59,7 @@ describe('FolderPicker', () => {
 
     const create = jest.spyOn(api, 'createFolder').mockResolvedValue(newFolder);
 
-    render(<FolderPicker onChange={onChangeFn} enableCreateNew={true} allowEmpty={true} />);
+    render(<OldFolderPicker onChange={onChangeFn} enableCreateNew={true} allowEmpty={true} />);
     expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText('Select a folder'), newFolder.title);
@@ -87,7 +87,7 @@ describe('FolderPicker', () => {
     jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(true);
 
     const onChangeFn = jest.fn();
-    render(<FolderPicker onChange={onChangeFn} />);
+    render(<OldFolderPicker onChange={onChangeFn} />);
     expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
     const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
     selectEvent.openMenu(pickerContainer);
@@ -108,7 +108,7 @@ describe('FolderPicker', () => {
     jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(true);
 
     const onChangeFn = jest.fn();
-    render(<FolderPicker onChange={onChangeFn} showRoot={false} />);
+    render(<OldFolderPicker onChange={onChangeFn} showRoot={false} />);
     expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
     const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
     selectEvent.openMenu(pickerContainer);
@@ -129,7 +129,7 @@ describe('FolderPicker', () => {
     jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(false);
 
     const onChangeFn = jest.fn();
-    render(<FolderPicker onChange={onChangeFn} />);
+    render(<OldFolderPicker onChange={onChangeFn} />);
     expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
     const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
     selectEvent.openMenu(pickerContainer);
@@ -150,7 +150,7 @@ describe('FolderPicker', () => {
     });
     jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(false);
     const onChangeFn = jest.fn();
-    render(<FolderPicker onChange={onChangeFn} />);
+    render(<OldFolderPicker onChange={onChangeFn} />);
 
     const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
     await userEvent.type(pickerContainer, 'Test');

--- a/public/app/core/components/Select/OldFolderPicker.tsx
+++ b/public/app/core/components/Select/OldFolderPicker.tsx
@@ -58,7 +58,7 @@ export interface Props {
 export type SelectedFolder = SelectableValue<string>;
 const VALUE_FOR_ADD = '-10';
 
-export function FolderPicker(props: Props) {
+export function OldFolderPicker(props: Props) {
   const {
     dashboardId,
     allowEmpty,

--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
-import { FolderPicker, Props as FolderPickerProps } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker, Props as FolderPickerProps } from 'app/core/components/Select/OldFolderPicker';
 import { PermissionLevelString, SearchQueryType } from 'app/types';
 
-import { FolderWarning, CustomAdd } from '../../../../../core/components/Select/FolderPicker';
+import { FolderWarning, CustomAdd } from '../../../../../core/components/Select/OldFolderPicker';
 
 export interface Folder {
   title: string;
@@ -48,7 +48,7 @@ export function RuleFolderPicker(props: RuleFolderPickerProps) {
   };
 
   return (
-    <FolderPicker
+    <OldFolderPicker
       showRoot={false}
       rootName=""
       allowEmpty={true}

--- a/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.tsx
@@ -6,7 +6,7 @@ import { Alert, Button, Field, Modal } from '@grafana/ui';
 import { Text } from '@grafana/ui/src/unstable';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
 import { FolderChange } from 'app/core/components/NestedFolderPicker/types';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import { t, Trans } from 'app/core/internationalization';
 
 import { DashboardTreeSelection } from '../../types';
@@ -63,7 +63,7 @@ export const MoveModal = ({ onConfirm, onDismiss, selectedItems, ...props }: Pro
         {config.featureToggles.nestedFolderPicker ? (
           <NestedFolderPicker value={moveTarget} onChange={handleFolderChange} excludeUIDs={selectedFolders} />
         ) : (
-          <FolderPicker allowEmpty onChange={handleFolderChange} />
+          <OldFolderPicker allowEmpty onChange={handleFolderChange} />
         )}
       </Field>
 

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -7,7 +7,7 @@ import { CollapsableSection, Field, Input, RadioButtonGroup, TagsInput } from '@
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
 import { FolderChange } from 'app/core/components/NestedFolderPicker/types';
 import { Page } from 'app/core/components/Page/Page';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import { updateTimeZoneDashboard, updateWeekStartDashboard } from 'app/features/dashboard/state/actions';
 
 import { DeleteDashboardButton } from '../DeleteDashboard/DeleteDashboardButton';
@@ -112,7 +112,7 @@ export function GeneralSettingsUnconnected({
             {config.featureToggles.nestedFolderPicker ? (
               <NestedFolderPicker value={dashboard.meta.folderUid} onChange={onFolderChange} />
             ) : (
-              <FolderPicker
+              <OldFolderPicker
                 inputId="dashboard-folder-input"
                 initialTitle={dashboard.meta.folderTitle}
                 initialFolderUid={dashboard.meta.folderUid}

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { config } from '@grafana/runtime';
 import { Button, Input, Switch, Form, Field, InputControl, HorizontalGroup } from '@grafana/ui';
 import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { validationSrv } from 'app/features/manage-dashboards/services/ValidationSrv';
 
@@ -114,7 +114,7 @@ export const SaveDashboardAsForm = ({
                 config.featureToggles.nestedFolderPicker ? (
                   <NestedFolderPicker {...field} value={field.value?.uid} />
                 ) : (
-                  <FolderPicker
+                  <OldFolderPicker
                     {...field}
                     dashboardId={dashboard.id}
                     initialFolderUid={dashboard.meta.folderUid}

--- a/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
@@ -3,7 +3,7 @@ import { useAsync, useDebounce } from 'react-use';
 
 import { isFetchError } from '@grafana/runtime';
 import { Button, Field, Input, Modal } from '@grafana/ui';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import { t, Trans } from 'app/core/internationalization';
 
 import { PanelModel } from '../../../dashboard/state';
@@ -71,7 +71,7 @@ export const AddLibraryPanelContents = ({ panel, initialFolderUid, onDismiss }: 
           'Library panel permissions are derived from the folder permissions'
         )}
       >
-        <FolderPicker
+        <OldFolderPicker
           onChange={({ uid }) => setFolderUid(uid)}
           initialFolderUid={initialFolderUid}
           inputId="share-panel-library-panel-folder-picker"

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -14,7 +14,7 @@ import {
   InputControl,
   Legend,
 } from '@grafana/ui';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 
 import {
   DashboardInput,
@@ -82,7 +82,7 @@ export const ImportDashboardForm = ({
       <Field label="Folder">
         <InputControl
           render={({ field: { ref, ...field } }) => (
-            <FolderPicker {...field} enableCreateNew initialFolderUid={initialFolderUid} />
+            <OldFolderPicker {...field} enableCreateNew initialFolderUid={initialFolderUid} />
           )}
           name="folder"
           control={control}

--- a/public/app/features/search/page/components/ManageActions.test.tsx
+++ b/public/app/features/search/page/components/ManageActions.test.tsx
@@ -14,7 +14,7 @@ jest.mock('app/core/services/context_srv', () => ({
   },
 }));
 
-jest.mock('app/core/components/Select/FolderPicker', () => {
+jest.mock('app/core/components/Select/OldFolderPicker', () => {
   return {
     FolderPicker: () => null,
   };

--- a/public/app/features/search/page/components/ManageActions.test.tsx
+++ b/public/app/features/search/page/components/ManageActions.test.tsx
@@ -16,7 +16,7 @@ jest.mock('app/core/services/context_srv', () => ({
 
 jest.mock('app/core/components/Select/OldFolderPicker', () => {
   return {
-    FolderPicker: () => null,
+    OldFolderPicker: () => null,
   };
 });
 

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, HorizontalGroup, Modal, useStyles2 } from '@grafana/ui';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import config from 'app/core/config';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { moveDashboards, moveFolders } from 'app/features/manage-dashboards/state/actions';
@@ -125,7 +125,7 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
 
           <p>Move {thingsMoving} to:</p>
 
-          <FolderPicker allowEmpty={true} enableCreateNew={false} onChange={handleFolderChange} />
+          <OldFolderPicker allowEmpty={true} enableCreateNew={false} onChange={handleFolderChange} />
         </div>
 
         <HorizontalGroup justify="flex-end">

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PanelPlugin } from '@grafana/data';
 import { config, DataSourcePicker } from '@grafana/runtime';
 import { TagsInput } from '@grafana/ui';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import {
   ALL_FOLDER,
   GENERAL_FOLDER,
@@ -275,7 +275,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       defaultValue: null,
       editor: function RenderFolderPicker(props) {
         return (
-          <FolderPicker
+          <OldFolderPicker
             enableReset={true}
             showRoot={false}
             allowEmpty={true}


### PR DESCRIPTION
Renames the existing FolderPicker to OldFolderPicker.

A subsequent PR will introduce a new component that switches between the old folder picker and new nested folder picker depending on feature flags.

Part of https://github.com/grafana/grafana/issues/65745 