### PR TITLE
Data Sources: Remove Admin/Data sources page in favour of Connections/Data sources

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -4,7 +4,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/correlations"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
@@ -17,16 +16,6 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 	hasGlobalAccess := ac.HasGlobalAccess(s.accessControl, s.accesscontrolService, c)
 	orgsAccessEvaluator := ac.EvalPermission(ac.ActionOrgsRead)
 	authConfigUIAvailable := s.license.FeatureEnabled("saml")
-
-	if hasAccess(datasources.ConfigurationPageAccess) {
-		configNodes = append(configNodes, &navtree.NavLink{
-			Text:     "Data sources",
-			Icon:     "database",
-			SubTitle: "Add and configure data sources",
-			Id:       "datasources",
-			Url:      s.cfg.AppSubURL + "/datasources",
-		})
-	}
 
 	// FIXME: while we don't have a permissions for listing plugins the legacy check has to stay as a default
 	if pluginaccesscontrol.ReqCanAdminPlugins(s.cfg)(c) || hasAccess(pluginaccesscontrol.AdminAccessEvaluator) {

--- a/public/app/features/connections/pages/DataSourceDashboardsPage.tsx
+++ b/public/app/features/connections/pages/DataSourceDashboardsPage.tsx
@@ -3,16 +3,15 @@ import { useParams } from 'react-router-dom';
 
 import { Page } from 'app/core/components/Page/Page';
 import { DataSourceDashboards } from 'app/features/datasources/components/DataSourceDashboards';
-import { useDataSourceSettingsNav } from 'app/features/datasources/state';
+
+import { useDataSourceSettingsNav } from '../hooks/useDataSourceSettingsNav';
 
 export function DataSourceDashboardsPage() {
   const { uid } = useParams<{ uid: string }>();
-  const params = new URLSearchParams(location.search);
-  const pageId = params.get('page');
-  const nav = useDataSourceSettingsNav(uid, pageId);
+  const { navId, pageNav } = useDataSourceSettingsNav();
 
   return (
-    <Page navId="connections-datasources" pageNav={nav.main}>
+    <Page navId={navId} pageNav={pageNav}>
       <Page.Contents>
         <DataSourceDashboards uid={uid} />
       </Page.Contents>

--- a/public/app/features/connections/pages/DataSourceDashboardsPage.tsx
+++ b/public/app/features/connections/pages/DataSourceDashboardsPage.tsx
@@ -12,7 +12,7 @@ export function DataSourceDashboardsPage() {
   const nav = useDataSourceSettingsNav(uid, pageId);
 
   return (
-    <Page navId="connections-your-connections-datasources" pageNav={nav.main}>
+    <Page navId="connections-datasources" pageNav={nav.main}>
       <Page.Contents>
         <DataSourceDashboards uid={uid} />
       </Page.Contents>

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -1,8 +1,9 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, PluginType, locationUtil } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 
 import { CatalogPlugin, PluginIconName, PluginListDisplayMode } from '../types';
 
@@ -21,8 +22,13 @@ export function PluginListItem({ plugin, pathName, displayMode = PluginListDispl
   const styles = useStyles2(getStyles);
   const isList = displayMode === PluginListDisplayMode.List;
 
+  const href =
+    plugin.type === PluginType.datasource
+      ? locationUtil.assureBaseUrl(`${CONNECTIONS_ROUTES.DataSources}/${plugin.id}`)
+      : `${pathName}/${plugin.id}`;
+
   return (
-    <a href={`${pathName}/${plugin.id}`} className={cx(styles.container, { [styles.list]: isList })}>
+    <a href={href} className={cx(styles.container, { [styles.list]: isList })}>
       <PluginLogo src={plugin.info.logos.small} className={styles.pluginLogo} height={LOGO_SIZE} alt="" />
       <h2 className={cx(styles.name, 'plugin-name')}>{plugin.name}</h2>
       <div className={cx(styles.content, 'plugin-content')}>

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -1,9 +1,8 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2, PluginType, locationUtil } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
-import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 
 import { CatalogPlugin, PluginIconName, PluginListDisplayMode } from '../types';
 
@@ -22,13 +21,8 @@ export function PluginListItem({ plugin, pathName, displayMode = PluginListDispl
   const styles = useStyles2(getStyles);
   const isList = displayMode === PluginListDisplayMode.List;
 
-  const href =
-    plugin.type === PluginType.datasource
-      ? locationUtil.assureBaseUrl(`${CONNECTIONS_ROUTES.DataSources}/${plugin.id}`)
-      : `${pathName}/${plugin.id}`;
-
   return (
-    <a href={href} className={cx(styles.container, { [styles.list]: isList })}>
+    <a href={`${pathName}/${plugin.id}`} className={cx(styles.container, { [styles.list]: isList })}>
       <PluginLogo src={plugin.info.logos.small} className={styles.pluginLogo} height={LOGO_SIZE} alt="" />
       <h2 className={cx(styles.name, 'plugin-name')}>{plugin.name}</h2>
       <div className={cx(styles.content, 'plugin-content')}>

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -10,6 +10,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import UserAdminPage from 'app/features/admin/UserAdminPage';
 import LdapPage from 'app/features/admin/ldap/LdapPage';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/routes';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
@@ -105,9 +106,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: DATASOURCES_ROUTES.List,
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "DataSourcesListPage"*/ 'app/features/datasources/pages/DataSourcesListPage')
-      ),
+      component: () => <Redirect to={CONNECTIONS_ROUTES.DataSources} />,
     },
     {
       path: DATASOURCES_ROUTES.Edit,

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -116,11 +116,8 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: DATASOURCES_ROUTES.Dashboards,
-      component: SafeDynamicImport(
-        () =>
-          import(
-            /* webpackChunkName: "DataSourceDashboards"*/ 'app/features/datasources/pages/DataSourceDashboardsPage'
-          )
+      component: (props: RouteComponentProps<{ uid: string }>) => (
+        <Redirect to={CONNECTIONS_ROUTES.DataSourcesDashboards.replace(':uid', props.match.params.uid)} />
       ),
     },
     {

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect } from 'react-router-dom';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
 
 import { isTruthy } from '@grafana/data';
 import { LoginPage } from 'app/core/components/Login/LoginPage';
@@ -110,8 +110,8 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: DATASOURCES_ROUTES.Edit,
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "EditDataSourcePage"*/ '../features/datasources/pages/EditDataSourcePage')
+      component: (props: RouteComponentProps<{ uid: string }>) => (
+        <Redirect to={CONNECTIONS_ROUTES.DataSourcesEdit.replace(':uid', props.match.params.uid)} />
       ),
     },
     {

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -125,9 +125,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: DATASOURCES_ROUTES.New,
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NewDataSourcePage"*/ '../features/datasources/pages/NewDataSourcePage')
-      ),
+      component: () => <Redirect to={CONNECTIONS_ROUTES.DataSourcesNew} />,
     },
     {
       path: '/datasources/correlations',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR removes the **Admin/Data sources** page and introduces a redirection to the **Connections/Data sources** page.
The same is true for
- New datasource page (datasources/new)
- Edit datasource page (datasources/edit)
- Datasource dashboards page (datasources/edit/:uid/dashboards)

I didn't set up a redirect for the datasources details page, because we would have to redirect from `plugins/:id`, but it's not only data sources that are served at that URL. So we would have to detect if that ID is of a data source, and then redirect, which feels a little bit twisted.

Demo:
[Screencast from 2023-07-17 11-13-11.webm](https://github.com/grafana/grafana/assets/13637610/ef9b5513-4375-4384-991a-b298e9567004)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/cloud-onboarding/issues/4008

**Special notes for your reviewer:**
I informed the docs team about this change. I'm not sure about the status of this on their side, though.

There is something wrong with the navigation around the datasource dashboards page. In fact, it is already broken on `main`: https://github.com/grafana/grafana/issues/71843
I tried to fix it, but couldn't.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
