### PR TITLE
NestedFolderPicker: Fix forms being submitted when opening folder picker 

### DIFF
--- a/public/app/core/components/NestedFolderPicker/Trigger.tsx
+++ b/public/app/core/components/NestedFolderPicker/Trigger.tsx
@@ -25,7 +25,12 @@ function Trigger({ isLoading, label, ...rest }: TriggerProps, ref: React.Forward
           </div>
         ) : undefined}
 
-        <button className={cx(styles.fakeInput, label ? styles.hasPrefix : undefined)} {...rest} ref={ref}>
+        <button
+          type="button"
+          className={cx(styles.fakeInput, label ? styles.hasPrefix : undefined)}
+          {...rest}
+          ref={ref}
+        >
           {isLoading ? (
             <Skeleton width={100} />
           ) : label ? (


### PR DESCRIPTION
There's an issue where the Dashboard save form will immediately submit when opening the nested folder picker.

This is due to not specifying `type=button`, and it defaulting to a submit button.