### PR TITLE
Alerting: Add dashboardUID and panelID query parameters for loki state history

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -29,6 +29,8 @@ func (srv *HistorySrv) RouteQueryStateHistory(c *contextmodel.ReqContext) respon
 	to := c.QueryInt64("to")
 	limit := c.QueryInt("limit")
 	ruleUID := c.Query("ruleUID")
+	dashUID := c.Query("dashboardUID")
+	panelID := c.QueryInt64("panelID")
 
 	labels := make(map[string]string)
 	for k, v := range c.Req.URL.Query() {
@@ -40,6 +42,8 @@ func (srv *HistorySrv) RouteQueryStateHistory(c *contextmodel.ReqContext) respon
 	query := models.HistoryQuery{
 		RuleUID:      ruleUID,
 		OrgID:        c.OrgID,
+		DashboardUID: dashUID,
+		PanelID:      panelID,
 		SignedInUser: c.SignedInUser,
 		From:         time.Unix(from, 0),
 		To:           time.Unix(to, 0),

--- a/pkg/services/ngalert/models/history.go
+++ b/pkg/services/ngalert/models/history.go
@@ -10,6 +10,8 @@ import (
 type HistoryQuery struct {
 	RuleUID      string
 	OrgID        int64
+	DashboardUID string
+	PanelID      int64
 	Labels       map[string]string
 	From         time.Time
 	To           time.Time

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -377,6 +377,12 @@ func buildLogQuery(query models.HistoryQuery) (string, error) {
 	if query.RuleUID != "" {
 		logQL = fmt.Sprintf("%s | ruleUID=%q", logQL, query.RuleUID)
 	}
+	if query.DashboardUID != "" {
+		logQL = fmt.Sprintf("%s | dashboardUID=%q", logQL, query.DashboardUID)
+	}
+	if query.PanelID != 0 {
+		logQL = fmt.Sprintf("%s | panelID=%d", logQL, query.PanelID)
+	}
 
 	labelFilters := ""
 	labelKeys := make([]string, 0, len(query.Labels))
@@ -394,5 +400,8 @@ func buildLogQuery(query models.HistoryQuery) (string, error) {
 }
 
 func queryHasLogFilters(query models.HistoryQuery) bool {
-	return query.RuleUID != "" || len(query.Labels) > 0
+	return query.RuleUID != "" ||
+		query.DashboardUID != "" ||
+		query.PanelID != 0 ||
+		len(query.Labels) > 0
 }

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -238,6 +238,22 @@ func TestRemoteLokiBackend(t *testing.T) {
 				exp: `{orgID="123",from="state-history"} | json | ruleUID="rule-uid"`,
 			},
 			{
+				name: "filters dashboardUID in log line",
+				query: models.HistoryQuery{
+					OrgID:        123,
+					DashboardUID: "dash-uid",
+				},
+				exp: `{orgID="123",from="state-history"} | json | dashboardUID="dash-uid"`,
+			},
+			{
+				name: "filters panelID in log line",
+				query: models.HistoryQuery{
+					OrgID:   123,
+					PanelID: 456,
+				},
+				exp: `{orgID="123",from="state-history"} | json | panelID=456`,
+			},
+			{
 				name: "filters instance labels in log line",
 				query: models.HistoryQuery{
 					OrgID: 123,


### PR DESCRIPTION
**What is this feature?**

Allows state history to be queried by dashboardUID and panelID.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
