### PR TITLE
Auth: Don't show LDAP CTA card

### DIFF
--- a/public/app/features/auth-config/AuthConfigPage.tsx
+++ b/public/app/features/auth-config/AuthConfigPage.tsx
@@ -48,7 +48,7 @@ export const AuthConfigPageUnconnected = ({ providerStatuses, isLoading, loadSet
     (p) => providerStatuses[p.id]?.configured && !providerStatuses[p.id]?.enabled
   );
   const availableProviders = authProviders.filter(
-    (p) => !providerStatuses[p.id]?.enabled && !providerStatuses[p.id]?.configured
+    (p) => !providerStatuses[p.id]?.enabled && !providerStatuses[p.id]?.configured && !providerStatuses[p.id]?.hide
   );
   const firstAvailableProvider = availableProviders?.length ? availableProviders[0] : null;
 

--- a/public/app/types/configAuth.ts
+++ b/public/app/types/configAuth.ts
@@ -12,6 +12,7 @@ export interface AuthProviderStatus {
   enabled: boolean;
   configured: boolean;
   configFoundInIniFile?: boolean;
+  hide?: boolean;
 }
 
 export interface SettingsError {


### PR DESCRIPTION
**What is this feature?**

This PR fixes showing CTA card for LDAP in case if SAML is configured but not enabled and LDAP is not enabled.

**Why do we need this feature?**

We do not have UI for configuring new LDAP auth, so when it's not enabled, CTA card leads to non-existing page.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

