### PR TITLE
Clarify necessary rediss scheme for TLS with redis caching

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -488,7 +488,7 @@ Disabling the maximum is not recommended in production environments.
 
 ### url
 
-The full Redis URL of your Redis server. For example: `redis://username:password@localhost:6379`. To enable TLS, use the `redis` scheme.
+The full Redis URL of your Redis server. For example: `redis://username:password@localhost:6379`. To enable TLS, use the `rediss` scheme.
 
 The default is `"redis://localhost:6379"`.
 
@@ -502,7 +502,7 @@ If you have specify `cluster`, the value for `url` is ignored.
 {{% /admonition %}}
 
 {{% admonition type="note" %}}
-You can enable TLS for cluster mode using the `redis` scheme in Grafana Enterprise v8.5 and later versions.
+You can enable TLS for cluster mode using the `rediss` scheme in Grafana Enterprise v8.5 and later versions.
 {{% /admonition %}}
 
 ### prefix


### PR DESCRIPTION
To enable TLS with Redis you must use the `rediss` scheme, not the `redis` scheme. This is documented here: https://www.iana.org/assignments/uri-schemes/prov/rediss