### PR TITLE
Chore: Use GITHUB_TOKEN in pr-commands instead of grot token

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -23,5 +23,5 @@ jobs:
         uses: ./actions/commands
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-commands


### PR DESCRIPTION
Migrate away from the @grafanabot token in pr-commands.yml Github Actions. 

I'm not totally sure what permissions this action requires, so I hope this will be enough?