### PR TITLE
Chore: Use GITHUB_TOKEN in stale instead of grot token

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          repo-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before a stale Issue or Pull Request is closed.
           # Set to -1 to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
           days-before-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION


Migrate away from the @grafanabot token in stale.yml Github Actions.

I'm not totally sure what permissions this action requires, so I hope this will be enough?
