### PR TITLE
Chore: Use GITHUB_TOKEN in issue-labeled instead of grot token

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           username: ${{ github.event.issue.user.login }}
           team: "${{ env.TEAM }}"
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Send Slack notification"
         if: ${{ (env.CHANNEL != 'null') && ((steps.checkUserMember.outputs.isTeamMember == 'false') || (env.TEAM != 'null')) }}


### PR DESCRIPTION
Migrate away from the @grafanabot token in issue-labeled.yml Github Actions.

I'm not totally sure what permissions this action requires, so I hope this will be enough?
