### PR TITLE
HTTP Client Metrics: Add datasource_type to datasource metrics

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -18,7 +18,7 @@ var (
 			Name:      "datasource_request_total",
 			Help:      "A counter for outgoing requests for a data source",
 		},
-		[]string{"datasource", "code", "method"},
+		[]string{"datasource", "datasource_type", "code", "method"},
 	)
 
 	datasourceRequestHistogram = promauto.NewHistogramVec(
@@ -27,7 +27,7 @@ var (
 			Name:      "datasource_request_duration_seconds",
 			Help:      "histogram of durations of outgoing data source requests sent from Grafana",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
-		}, []string{"datasource", "code", "method"},
+		}, []string{"datasource", "datasource_type", "code", "method"},
 	)
 
 	datasourceResponseHistogram = promauto.NewHistogramVec(
@@ -36,7 +36,7 @@ var (
 			Name:      "datasource_response_size_bytes",
 			Help:      "histogram of data source response sizes returned to Grafana",
 			Buckets:   []float64{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576},
-		}, []string{"datasource"},
+		}, []string{"datasource", "datasource_type"},
 	)
 
 	datasourceRequestsInFlight = promauto.NewGaugeVec(
@@ -45,7 +45,7 @@ var (
 			Name:      "datasource_request_in_flight",
 			Help:      "A gauge of outgoing data source requests currently being sent by Grafana",
 		},
-		[]string{"datasource"},
+		[]string{"datasource", "datasource_type"},
 	)
 )
 
@@ -71,18 +71,29 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 			return next
 		}
 
-		datasourceLabel := prometheus.Labels{"datasource": datasourceLabelName}
+		datasourceType, exists := opts.Labels["datasource_type"]
+		if !exists {
+			return next
+		}
+		datasourceLabelType, err := metricutil.SanitizeLabelName(datasourceType)
+		// if the datasource type cannot be turned into a prometheus
+		// label we will skip instrumenting these metrics.
+		if err != nil {
+			return next
+		}
 
-		return executeMiddlewareFunc(next, datasourceLabel)
+		labels := prometheus.Labels{"datasource": datasourceLabelName, "datasource_type": datasourceLabelType}
+
+		return executeMiddlewareFunc(next, labels)
 	})
 }
 
-func executeMiddleware(next http.RoundTripper, datasourceLabel prometheus.Labels) http.RoundTripper {
+func executeMiddleware(next http.RoundTripper, labels prometheus.Labels) http.RoundTripper {
 	return sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		requestCounter := datasourceRequestCounter.MustCurryWith(datasourceLabel)
-		requestHistogram := datasourceRequestHistogram.MustCurryWith(datasourceLabel)
-		requestInFlight := datasourceRequestsInFlight.With(datasourceLabel)
-		responseSizeHistogram := datasourceResponseHistogram.With(datasourceLabel)
+		requestCounter := datasourceRequestCounter.MustCurryWith(labels)
+		requestHistogram := datasourceRequestHistogram.MustCurryWith(labels)
+		requestInFlight := datasourceRequestsInFlight.With(labels)
+		responseSizeHistogram := datasourceResponseHistogram.With(labels)
 
 		res, err := promhttp.InstrumentRoundTripperDuration(requestHistogram,
 			promhttp.InstrumentRoundTripperCounter(requestCounter,


### PR DESCRIPTION
**What is this feature?**

This PR adds the `datasource_type` label to the datasource metrics to help identify how queries are doing for a specific datasource type, rather than just for a specific datasource..

**Why do we need this feature?**

We'd like to see how specific datasource types are doing

**Who is this feature for?**

Grafana developers & operators of grafana
