### PR TITLE
BrowseDashboards: Enable new UI without nested folders

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -129,6 +129,7 @@ Experimental features might be changed or removed without prior notice.
 | `grafanaAPIServer`                          | Enable Kubernetes API Server for Grafana resources                                                                                                                                       |
 | `featureToggleAdminPage`                    | Enable admin page for managing feature toggles from the Grafana front-end                                                                                                                |
 | `awsAsyncQueryCaching`                      | Enable caching for async queries for Redshift and Athena. Requires that the `useCachingService` feature toggle is enabled and the datasource has caching and async query support enabled |
+| `newBrowseDashboards`                       | New browse/manage dashboards UI                                                                                                                                                          |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -116,4 +116,5 @@ export interface FeatureToggles {
   featureToggleAdminPage?: boolean;
   awsAsyncQueryCaching?: boolean;
   splitScopes?: boolean;
+  newBrowseDashboards?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -671,5 +671,12 @@ var (
 			Owner:           grafanaAuthnzSquad,
 			RequiresRestart: true,
 		},
+		{
+			Name:         "newBrowseDashboards",
+			Description:  "New browse/manage dashboards UI",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			FrontendOnly: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -97,3 +97,4 @@ grafanaAPIServer,experimental,@grafana/grafana-app-platform-squad,false,false,fa
 featureToggleAdminPage,experimental,@grafana/grafana-operator-experience-squad,false,false,true,false
 awsAsyncQueryCaching,experimental,@grafana/aws-datasources,false,false,false,false
 splitScopes,preview,@grafana/grafana-authnz-team,false,false,true,false
+newBrowseDashboards,experimental,@grafana/grafana-frontend-platform,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -398,4 +398,8 @@ const (
 	// FlagSplitScopes
 	// Support faster dashboard and folder search by splitting permission scopes into parts
 	FlagSplitScopes = "splitScopes"
+
+	// FlagNewBrowseDashboards
+	// New browse/manage dashboards UI
+	FlagNewBrowseDashboards = "newBrowseDashboards"
 )

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -4,12 +4,12 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Space } from '@grafana/experimental';
-import { config } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
 import { Trans, t } from 'app/core/internationalization';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { DescendantCount } from 'app/features/browse-dashboards/components/BrowseActions/DescendantCount';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 
 import { AddPermission } from './AddPermission';
 import { PermissionList } from './PermissionList';
@@ -140,7 +140,7 @@ export const Permissions = ({
     <div>
       {canSetPermissions && (
         <>
-          {config.featureToggles.nestedFolders && resource === 'folders' && (
+          {newBrowseDashboardsEnabled() && resource === 'folders' && (
             <>
               <Trans i18nKey="access-control.permissions.permissions-change-warning">
                 This will change permissions for this folder and all its descendants. In total, this will affect:

--- a/public/app/core/components/Select/OldFolderPicker.tsx
+++ b/public/app/core/components/Select/OldFolderPicker.tsx
@@ -5,11 +5,12 @@ import { useAsync } from 'react-use';
 
 import { AppEvents, SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import { useStyles2, ActionMeta, Input, InputActionMeta, AsyncVirtualizedSelect } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { createFolder, getFolderByUid, searchFolders } from 'app/features/manage-dashboards/state/actions';
 import { DashboardSearchHit } from 'app/features/search/types';
 import { AccessControlAction, PermissionLevelString, SearchQueryType } from 'app/types';
@@ -80,7 +81,7 @@ export function OldFolderPicker(props: Props) {
     folderWarning,
   } = props;
 
-  const rootName = rootNameProp ?? config.featureToggles.nestedFolders ? 'Dashboards' : 'General';
+  const rootName = rootNameProp ?? newBrowseDashboardsEnabled() ? 'Dashboards' : 'General';
 
   const [folder, setFolder] = useState<SelectedFolder | null>(null);
   const [isCreatingNew, setIsCreatingNew] = useState(false);

--- a/public/app/core/selectors/navModel.ts
+++ b/public/app/core/selectors/navModel.ts
@@ -1,5 +1,5 @@
 import { NavModel, NavModelItem, NavIndex } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { FOLDER_ID } from 'app/features/folders/state/navModel';
 
 import { HOME_NAV_ID } from '../reducers/navModel';
@@ -40,7 +40,7 @@ export const getNavModel = (navIndex: NavIndex, id: string, fallback?: NavModel,
 
 export function getRootSectionForNode(node: NavModelItem): NavModelItem {
   // Don't recurse fully up the folder tree when nested folders is enabled
-  if (config.featureToggles.nestedFolders && node.id === FOLDER_ID) {
+  if (newBrowseDashboardsEnabled() && node.id === FOLDER_ID) {
     return node;
   } else {
     return node.parentItem && node.parentItem.id !== HOME_NAV_ID ? getRootSectionForNode(node.parentItem) : node;

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -173,8 +173,8 @@ export const browseDashboardsAPI = createApi({
         };
 
         for (const folderCounts of results) {
-          totalCounts.folder += folderCounts.folder;
-          totalCounts.dashboard += folderCounts.dashboard;
+          totalCounts.folder += folderCounts.folder ?? 0;
+          totalCounts.dashboard += folderCounts.dashboard ?? 0;
           totalCounts.alertRule += folderCounts.alertrule ?? 0;
 
           // TODO enable these once the backend correctly returns them

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher, NestedFolderDTO } from 'app/features/search/service';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
@@ -12,6 +12,10 @@ export async function listFolders(
   page = 1,
   pageSize = PAGE_SIZE
 ): Promise<DashboardViewItem[]> {
+  if (parentUID && !config.featureToggles.nestedFolders) {
+    return [];
+  }
+
   const backendSrv = getBackendSrv();
 
   const folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', {

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -6,7 +6,20 @@ export function buildBreakdownString(
   libraryPanelCount: number,
   alertRuleCount: number
 ) {
+  console.log({
+    folderCount,
+    dashboardCount,
+    libraryPanelCount,
+    alertRuleCount,
+  });
+  console.log({
+    folderCount: folderCount ?? 0,
+    dashboardCount: dashboardCount ?? 0,
+    libraryPanelCount: libraryPanelCount ?? 0,
+    alertRuleCount: alertRuleCount ?? 0,
+  });
   const total = folderCount + dashboardCount + libraryPanelCount + alertRuleCount;
+
   const parts = [];
   if (folderCount) {
     parts.push(t('browse-dashboards.counts.folder', '{{count}} folder', { count: folderCount }));

--- a/public/app/features/browse-dashboards/featureFlag.ts
+++ b/public/app/features/browse-dashboards/featureFlag.ts
@@ -1,0 +1,5 @@
+import { config } from '@grafana/runtime';
+
+export function newBrowseDashboardsEnabled() {
+  return config.featureToggles.nestedFolders || config.featureToggles.newBrowseDashboards;
+}

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -1,12 +1,13 @@
 import { useAsyncFn } from 'react-use';
 
 import { locationUtil } from '@grafana/data';
-import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';
 import { useSaveDashboardMutation } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { saveDashboard as saveDashboardApiCall } from 'app/features/manage-dashboards/state/actions';
 import { useDispatch } from 'app/types';
@@ -20,7 +21,7 @@ const saveDashboard = async (
   dashboard: DashboardModel,
   saveDashboardRtkQuery: ReturnType<typeof useSaveDashboardMutation>[0]
 ) => {
-  if (config.featureToggles.nestedFolders) {
+  if (newBrowseDashboardsEnabled()) {
     const query = await saveDashboardRtkQuery({
       dashboard: saveModel,
       folderUid: options.folderUid ?? dashboard.meta.folderUid ?? saveModel.meta.folderUid,

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { createErrorNotification } from 'app/core/copy/appNotification';
 import { getKioskMode } from 'app/core/navigation/kiosk';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { PanelModel } from 'app/features/dashboard/state';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { getPageNavFromSlug, getRootContentNavModel } from 'app/features/storage/StorageFolderPage';

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -91,6 +91,8 @@ async function fetchDashboard(
         // only the folder API has information about ancestors
         // get parent folder (if it exists) and put it in the store
         // this will be used to populate the full breadcrumb trail
+        //
+        // Doesn't use newBrowseDashboardsEnabled() because this is only for actually nested folders
         if (config.featureToggles.nestedFolders && dashDTO.meta.folderUid) {
           await dispatch(getFolderByUid(dashDTO.meta.folderUid));
         }
@@ -114,6 +116,8 @@ async function fetchDashboard(
         // only the folder API has information about ancestors
         // get parent folder (if it exists) and put it in the store
         // this will be used to populate the full breadcrumb trail
+        //
+        // Doesn't use newBrowseDashboardsEnabled() because this is only for actually nested folders
         if (config.featureToggles.nestedFolders && args.urlFolderUid) {
           await dispatch(getFolderByUid(args.urlFolderUid));
         }

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -3,10 +3,11 @@ import React, { memo } from 'react';
 import { useAsync } from 'react-use';
 
 import { locationUtil, NavModelItem } from '@grafana/data';
-import { config, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import NewBrowseDashboardsPage from 'app/features/browse-dashboards/BrowseDashboardsPage';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { FolderDTO } from 'app/types';
 
 import { loadFolderPage } from '../loaders';
@@ -21,12 +22,13 @@ export interface DashboardListPageRouteParams {
 interface Props extends GrafanaRouteComponentProps<DashboardListPageRouteParams> {}
 
 export const DashboardListPageFeatureToggle = memo((props: Props) => {
-  if (config.featureToggles.nestedFolders) {
+  if (newBrowseDashboardsEnabled()) {
     return <NewBrowseDashboardsPage {...props} />;
   }
 
   return <DashboardListPage {...props} />;
 });
+
 DashboardListPageFeatureToggle.displayName = 'DashboardListPageFeatureToggle';
 
 const DashboardListPage = memo(({ match, location }: Props) => {

--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -5,10 +5,10 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { Observable } from 'rxjs';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { useStyles2, Spinner, Button } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { Trans } from 'app/core/internationalization';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { FolderDTO } from 'app/types';
 
 import { getGrafanaSearcher } from '../../service';
@@ -149,7 +149,7 @@ export const SearchView = ({ showManage, folderDTO, hidePseudoFolders, keyboardE
     folderDTO &&
     // With nested folders, SearchView doesn't know if it's fetched all children
     // of a folder so don't show empty state here.
-    !config.featureToggles.nestedFolders &&
+    !newBrowseDashboardsEnabled() &&
     !state.loading &&
     !state.result?.totalRows &&
     !stateManager.hasSearchFilters()

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -10,6 +10,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import UserAdminPage from 'app/features/admin/UserAdminPage';
 import LdapPage from 'app/features/admin/ldap/LdapPage';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
+import { newBrowseDashboardsEnabled } from 'app/features/browse-dashboards/featureFlag';
 import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/routes';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
@@ -153,7 +154,7 @@ export function getAppRoutes(): RouteDescriptor[] {
         () => import(/* webpackChunkName: "NewDashboardsFolder"*/ 'app/features/folders/components/NewDashboardsFolder')
       ),
     },
-    !config.featureToggles.nestedFolders && {
+    !newBrowseDashboardsEnabled() && {
       path: '/dashboards/f/:uid/:slug/permissions',
       component: config.rbacEnabled
         ? SafeDynamicImport(
@@ -476,7 +477,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     {
       path: '/dashboards/f/:uid/:slug/library-panels',
       component: SafeDynamicImport(
-        config.featureToggles.nestedFolders
+        newBrowseDashboardsEnabled()
           ? () =>
               import(
                 /* webpackChunkName: "FolderLibraryPanelsPage"*/ 'app/features/browse-dashboards/BrowseFolderLibraryPanelsPage'
@@ -490,7 +491,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       roles: () =>
         contextSrv.evaluatePermission(() => ['Viewer', 'Editor', 'Admin'], [AccessControlAction.AlertingRuleRead]),
       component: SafeDynamicImport(
-        config.featureToggles.nestedFolders
+        newBrowseDashboardsEnabled()
           ? () =>
               import(/* webpackChunkName: "FolderAlerting"*/ 'app/features/browse-dashboards/BrowseFolderAlertingPage')
           : () => import(/* webpackChunkName: "FolderAlerting"*/ 'app/features/folders/FolderAlerting')

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -35,9 +35,9 @@ export interface FolderState {
 }
 
 export interface DescendantCountDTO {
-  folder: number;
-  dashboard: number;
-  libraryPanel: number;
+  folder?: number;
+  dashboard?: number;
+  libraryPanel?: number;
   alertrule?: number;
 }
 

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "",
+      "cannot-move-folders": "",
       "delete-button": "",
       "delete-modal-text": "",
       "delete-modal-title": "",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "Cancel",
+      "cannot-move-folders": "Folders can not be moved",
       "delete-button": "Delete",
       "delete-modal-text": "This action will delete the following content:",
       "delete-modal-title": "Delete",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "",
+      "cannot-move-folders": "",
       "delete-button": "",
       "delete-modal-text": "",
       "delete-modal-title": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "",
+      "cannot-move-folders": "",
       "delete-button": "",
       "delete-modal-text": "",
       "delete-modal-title": "",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "Cäŉčęľ",
+      "cannot-move-folders": "Főľđęřş čäŉ ŉőŧ þę mővęđ",
       "delete-button": "Đęľęŧę",
       "delete-modal-text": "Ŧĥįş äčŧįőŉ ŵįľľ đęľęŧę ŧĥę ƒőľľőŵįŉģ čőŉŧęŉŧ:",
       "delete-modal-title": "Đęľęŧę",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -26,6 +26,7 @@
   "browse-dashboards": {
     "action": {
       "cancel-button": "",
+      "cannot-move-folders": "",
       "delete-button": "",
       "delete-modal-text": "",
       "delete-modal-title": "",


### PR DESCRIPTION
**What is this feature?**

This PR introduces a new `newBrowseDashboards` feature toggle and gates our new browse dashboards work behind that. The new UI will be enabled if _either_ the `nestedFolders` or `browseDashboards`feature flags are enabled.

A few changes to facilitate this:

 - Creates a `newBrowseDashboardsEnabled()` helper function to contain the above logic, and updates most usages of the `nestedFolders` feature flag to reference this instead
 - Disable the Move button if the user has selected folders (as there's nowhere to move folders to without nested folders) 
![image](https://github.com/grafana/grafana/assets/46142/dd4c6c5e-cd01-426b-aa7a-19fbbee5b840)
 - Don't allow folders to be deleted if they contain alert rules or library panels
   - Technically this isn't required (the old UI _says_ deleting a folder will delete alert rules, but then it fails if it contains alert rules)
![image](https://github.com/grafana/grafana/assets/46142/aeac626d-05a4-4424-ad41-69bdc1a6a853)



**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

TODO:

 - [x] Prevent attempting to move folders 
 - [x] Fix DescendantCounts showing "NaN items" (lol)
 - [x] Don't allow folders to be deleted if they contain anything other than dashboards
     - [ ] actually disable the delete modal
 - [ ] Prevent creating nested folders 