### PR TITLE
Tranformations: True OUTER JOIN in the join by field transformation used for tabular data 

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinByField.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.ts
@@ -8,8 +8,9 @@ import { DataTransformerID } from './ids';
 import { joinDataFrames } from './joinDataFrames';
 
 export enum JoinMode {
-  outer = 'outer',
+  outer = 'outer', // best for time series, non duplicated join on values
   inner = 'inner',
+  outerTabular = 'outerTabular', // best for tabular data where the join on value can be duplicated
 }
 
 export interface JoinByFieldOptions {

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
@@ -2,6 +2,8 @@ import { toDataFrame } from '../../dataframe/processDataFrame';
 import { getFieldDisplayName } from '../../field';
 import { DataFrame, FieldType } from '../../types/dataFrame';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
+import { fieldMatchers } from '../matchers';
+import { FieldMatcherID } from '../matchers/ids';
 
 import { calculateFieldTransformer } from './calculateField';
 import { JoinMode } from './joinByField';
@@ -28,6 +30,8 @@ describe('align frames', () => {
       ],
     });
 
+    // the following does not work for tabular joins where the joined on field value is duplicated
+    // the time will never have a dupicated time which is joined on
     it('should perform an outer join', () => {
       const out = joinDataFrames({ frames: [series1, series2] })!;
       expect(
@@ -123,6 +127,89 @@ describe('align frames', () => {
             "values": [
               "first",
               "third",
+            ],
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('join tabular data by chosen field', () => {
+    // join on gender where there are multiple values, duplicate values which can increase the rows
+
+    const tableData1 = toDataFrame({
+      fields: [
+        { name: 'gender', type: FieldType.string, values: ['MALE', 'MALE', 'MALE', 'FEMALE', 'FEMALE', 'FEMALE'] },
+        {
+          name: 'day',
+          type: FieldType.string,
+          values: ['Wednesday', 'Tuesday', 'Monday', 'Wednesday', 'Tuesday', 'Monday'],
+        },
+        { name: 'count', type: FieldType.number, values: [18, 72, 13, 17, 71, 7] },
+      ],
+    });
+    const tableData2 = toDataFrame({
+      fields: [
+        { name: 'gender', type: FieldType.string, values: ['MALE', 'FEMALE'] },
+        { name: 'count', type: FieldType.number, values: [103, 95] },
+      ],
+    });
+
+    it('should perform an outer join with duplicated values to join on', () => {
+      const out = joinDataFrames({
+        frames: [tableData1, tableData2],
+        joinBy: fieldMatchers.get(FieldMatcherID.byName).get('gender'),
+        mode: JoinMode.outerTabular,
+      })!;
+      expect(
+        out.fields.map((f) => ({
+          name: f.name,
+          values: f.values,
+        }))
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "name": "gender",
+            "values": [
+              "MALE",
+              "MALE",
+              "MALE",
+              "FEMALE",
+              "FEMALE",
+              "FEMALE",
+            ],
+          },
+          {
+            "name": "day",
+            "values": [
+              "Wednesday",
+              "Tuesday",
+              "Monday",
+              "Wednesday",
+              "Tuesday",
+              "Monday",
+            ],
+          },
+          {
+            "name": "count",
+            "values": [
+              18,
+              72,
+              13,
+              17,
+              71,
+              7,
+            ],
+          },
+          {
+            "name": "count",
+            "values": [
+              103,
+              103,
+              103,
+              95,
+              95,
+              95,
             ],
           },
         ]

--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -14,8 +14,19 @@ import { Select, InlineFieldRow, InlineField } from '@grafana/ui';
 import { useAllFieldNamesFromDataFrames } from '../utils';
 
 const modes = [
-  { value: JoinMode.outer, label: 'OUTER', description: 'Keep all rows from any table with a value' },
-  { value: JoinMode.inner, label: 'INNER', description: 'Drop rows that do not match a value in all tables' },
+  {
+    value: JoinMode.outer,
+    label: 'OUTER (TIME SERIES)',
+    description:
+      'Keep all rows from any table with a value. Join on distinct field values. Performant and best used for time series.',
+  },
+  {
+    value: JoinMode.outerTabular,
+    label: 'OUTER (TABULAR)',
+    description:
+      'Join on a field value with dupicated values. Non performant outer join best used for tabular(SQL like) data.',
+  },
+  { value: JoinMode.inner, label: 'INNER', description: 'Drop rows that do not match a value in all tables.' },
 ];
 
 export function SeriesToFieldsTransformerEditor({ input, options, onChange }: TransformerUIProps<JoinByFieldOptions>) {


### PR DESCRIPTION
**What is this feature?**
This implements a true outer join for tabular data where the value to join on has duplicated values in multiple rows. This also updates copy for the original outer join. The original outer join does not support this because it is optimized for time series where a time value is never duplicated.

- [ ] need to add docs

![Screenshot 2023-07-23 at 6 05 36 PM](https://github.com/grafana/grafana/assets/25674746/7e4b6c0a-4b3a-4a2f-8e7e-5b3c1569003f)

**Why do we need this feature?**
The original outer join does not support a join on a value that is duplicated. This change adds an option to the join by field to join on a field value that is duplicated and have the output correct.

For example
| gender  | day  |  count  |
|---|---|---|
|  MALE | Wednesday  | 18 |
|  MALE  | Tuesday  |  72  |
|  MALE | Monday | 13  |
|  FEMALE |  Wednesday |  17 |
|  FEMALE |  Tuesday |  71 |
|  FEMALE |  Monday |  7 |

can now be joined with 
| gender  | count  |
|---|---|
|  MALE | 103 |
|  FEMALE | 95  |

![Screenshot 2023-07-23 at 6 05 23 PM](https://github.com/grafana/grafana/assets/25674746/1d9cc968-0657-40ac-abd2-4842cf9e27c5)

![Screenshot 2023-07-23 at 5 59 24 PM](https://github.com/grafana/grafana/assets/25674746/25e60f9e-06d6-4838-9a4c-96d825ba40af)

**Who is this feature for?**
Users who want to join frames on a value that is duplicated.

**This addresses the following issues/escalations:**:
https://github.com/grafana/support-escalations/issues/5362
https://github.com/grafana/grafana/issues/66032

**Special notes for your reviewer:**
I used the mock data source to create tabular data. When the frame names are different for each query we run into problems but this seems to be something with the other join by field I think. I need more eyes on this.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
