### PR TITLE
Pyroscope: Fix panic on query when symbol names are repeating

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -312,14 +312,14 @@ func treeToNestedSetDataFrame(tree *ProfileTree, unit string) *data.Frame {
 
 type EnumField struct {
 	field     *data.Field
-	valuesMap map[string]int64
-	counter   int64
+	valuesMap map[string]data.EnumItemIndex
+	counter   data.EnumItemIndex
 }
 
 func NewEnumField(name string, labels data.Labels) *EnumField {
 	return &EnumField{
 		field:     data.NewField(name, labels, []data.EnumItemIndex{}),
-		valuesMap: make(map[string]int64),
+		valuesMap: make(map[string]data.EnumItemIndex),
 	}
 }
 
@@ -328,7 +328,7 @@ func (e *EnumField) Append(value string) {
 		e.field.Append(valueIndex)
 	} else {
 		e.valuesMap[value] = e.counter
-		e.field.Append(data.EnumItemIndex(e.counter))
+		e.field.Append(e.counter)
 		e.counter++
 	}
 }

--- a/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
@@ -196,6 +196,7 @@ func Test_treeToNestedDataFrame(t *testing.T) {
 				},
 				{Value: 30, Level: 1, Self: 3, Name: "func2", Nodes: []*ProfileTree{
 					{Value: 15, Level: 2, Self: 4, Name: "func1:func3"},
+					{Value: 10, Level: 2, Self: 4, Name: "func1"},
 				}},
 			},
 		}
@@ -211,10 +212,10 @@ func Test_treeToNestedDataFrame(t *testing.T) {
 		}
 		require.Equal(t,
 			[]*data.Field{
-				data.NewField("level", nil, []int64{0, 1, 1, 2}),
-				data.NewField("value", nil, []int64{100, 40, 30, 15}).SetConfig(&data.FieldConfig{Unit: "short"}),
-				data.NewField("self", nil, []int64{1, 2, 3, 4}).SetConfig(&data.FieldConfig{Unit: "short"}),
-				data.NewField("label", nil, []data.EnumItemIndex{0, 1, 2, 3}).SetConfig(labelConfig),
+				data.NewField("level", nil, []int64{0, 1, 1, 2, 2}),
+				data.NewField("value", nil, []int64{100, 40, 30, 15, 10}).SetConfig(&data.FieldConfig{Unit: "short"}),
+				data.NewField("self", nil, []int64{1, 2, 3, 4, 4}).SetConfig(&data.FieldConfig{Unit: "short"}),
+				data.NewField("label", nil, []data.EnumItemIndex{0, 1, 2, 3, 1}).SetConfig(labelConfig),
 			}, frame.Fields)
 	})
 


### PR DESCRIPTION
The types of the map used for names enemu field was different form the field type after https://github.com/grafana/grafana/pull/72078.

This fixes the typings and changes the unit test to hit that branch of code.

Fixes #72187