### PR TITLE
Use new NestedFolderPicker in SaveDashboardAsForm

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -6,17 +6,40 @@ import { NestedFolderPicker, NestedFolderPickerProps } from '../NestedFolderPick
 
 import { OldFolderPicker } from './OldFolderPicker';
 
+interface FolderPickerProps extends NestedFolderPickerProps {
+  // These props are only used by the old folder picker, and should be removed when old picker is removed
+
+  /** @deprecated */
+  initialTitle?: string;
+
+  /** @deprecated */
+  dashboardId?: number | string;
+
+  /** @deprecated */
+  enableCreateNew?: boolean;
+}
+
 // Temporary wrapper component to switch between the NestedFolderPicker and the old flat
 // FolderPicker depending on feature flags
-export function FolderPicker(props: NestedFolderPickerProps) {
+export function FolderPicker(props: FolderPickerProps) {
   const nestedEnabled = config.featureToggles.nestedFolders && config.featureToggles.nestedFolderPicker;
-  return nestedEnabled ? <NestedFolderPicker {...props} /> : <OldFolderPickerWrapper {...props} />;
+  const { initialTitle, dashboardId, enableCreateNew, ...newFolderPickerProps } = props;
+
+  return nestedEnabled ? <NestedFolderPicker {...newFolderPickerProps} /> : <OldFolderPickerWrapper {...props} />;
 }
 
 // Converts new NestedFolderPicker props to old non-nested folder picker props
 // Seperate component so the hooks aren't created if not used
-function OldFolderPickerWrapper({ value, showRootFolder, onChange }: NestedFolderPickerProps) {
+function OldFolderPickerWrapper({
+  value,
+  showRootFolder,
+  onChange,
+  initialTitle,
+  dashboardId,
+  enableCreateNew,
+}: FolderPickerProps) {
   const [initialFolderUID] = useState(value);
+
   const handleOnChange = useCallback(
     (newFolder: { title: string; uid: string }) => {
       if (onChange) {
@@ -26,5 +49,14 @@ function OldFolderPickerWrapper({ value, showRootFolder, onChange }: NestedFolde
     [onChange]
   );
 
-  return <OldFolderPicker onChange={handleOnChange} initialFolderUid={initialFolderUID} showRoot={showRootFolder} />;
+  return (
+    <OldFolderPicker
+      onChange={handleOnChange}
+      showRoot={showRootFolder}
+      initialFolderUid={initialFolderUID}
+      initialTitle={initialTitle}
+      dashboardId={dashboardId}
+      enableCreateNew={enableCreateNew}
+    />
+  );
 }

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import { config } from '@grafana/runtime';
 import { Button, Input, Switch, Form, Field, InputControl, HorizontalGroup } from '@grafana/ui';
-import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
-import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
+import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { validationSrv } from 'app/features/manage-dashboards/services/ValidationSrv';
 
@@ -110,23 +108,17 @@ export const SaveDashboardAsForm = ({
           </Field>
           <Field label="Folder">
             <InputControl
-              render={({ field: { ref, ...field } }) =>
-                config.featureToggles.nestedFolderPicker ? (
-                  <NestedFolderPicker
-                    {...field}
-                    onChange={(uid: string, title: string) => field.onChange({ uid, title })}
-                    value={field.value?.uid}
-                  />
-                ) : (
-                  <OldFolderPicker
-                    {...field}
-                    dashboardId={dashboard.id}
-                    initialFolderUid={dashboard.meta.folderUid}
-                    initialTitle={dashboard.meta.folderTitle}
-                    enableCreateNew
-                  />
-                )
-              }
+              render={({ field: { ref, ...field } }) => (
+                <FolderPicker
+                  {...field}
+                  onChange={(uid: string, title: string) => field.onChange({ uid, title })}
+                  value={field.value?.uid}
+                  // Old folder picker fields
+                  initialTitle={dashboard.meta.folderTitle}
+                  dashboardId={dashboard.id}
+                  enableCreateNew
+                />
+              )}
               control={control}
               name="$folder"
             />


### PR DESCRIPTION
**What is this feature?**

 - Switches to the new FolderPicker component in SaveDashboardAsForm which switches between NestedFolderPicker and OldFolderPicker depending on feature flags
 - Adds some new props to the wrapper FolderPicker to help with the transition.
 
![5667_2023-07-24-11-55_firefox](https://github.com/grafana/grafana/assets/46142/0bdff144-e4c1-43ab-91cc-7fc72c04c982)

