### PR TITLE
[Docs v9.4x] Manual backport - Update _index.md (#72068)

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -22,12 +22,7 @@ While an image is being rendered, the PNG image is temporarily written to the fi
 
 A background job runs every 10 minutes and removes temporary images. You can configure how long an image should be stored before being removed by configuring the [temp_data_lifetime]({{< relref "../configure-grafana/#temp_data_lifetime" >}}) setting.
 
-<<<<<<< HEAD
-You can also render a PNG by clicking the dropdown arrow next to a panel title, then clicking **Share > Direct link rendered image**.
-=======
 You can also render a PNG by hovering over the panel to display the actions menu in the top right corner, and then clicking **Share > Direct link rendered image** in the Link tab.
-
-> > > > > > > b88a321ad2 (Update \_index.md (#72068))
 
 ## Alerting and render limits
 
@@ -85,12 +80,7 @@ AUTH_TOKEN=-
 }
 ```
 
-<<<<<<< HEAD
-See the [Grafana configuration]({{< relref "../configure-grafana/#renderer_token" >}}) for how to configure the token in Grafana.
-=======
 See [Grafana configuration]({{< relref "../configure-grafana#renderer_token" >}}) for how to configure the token in Grafana.
-
-> > > > > > > b88a321ad2 (Update \_index.md (#72068))
 
 ### Rendering mode
 

--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -22,7 +22,12 @@ While an image is being rendered, the PNG image is temporarily written to the fi
 
 A background job runs every 10 minutes and removes temporary images. You can configure how long an image should be stored before being removed by configuring the [temp_data_lifetime]({{< relref "../configure-grafana/#temp_data_lifetime" >}}) setting.
 
+<<<<<<< HEAD
 You can also render a PNG by clicking the dropdown arrow next to a panel title, then clicking **Share > Direct link rendered image**.
+=======
+You can also render a PNG by hovering over the panel to display the actions menu in the top right corner, and then clicking **Share > Direct link rendered image** in the Link tab.
+
+> > > > > > > b88a321ad2 (Update \_index.md (#72068))
 
 ## Alerting and render limits
 
@@ -32,7 +37,7 @@ Alert notifications can include images, but rendering many images at the same ti
 
 > **Note:** Starting from Grafana v7.0.0, all PhantomJS support has been removed. Please use the Grafana Image Renderer plugin or remote rendering service.
 
-To install the plugin, refer to the [Grafana Image Renderer Installation instructions](https://grafana.com/grafana/plugins/grafana-image-renderer#installation).
+To install the plugin, refer to the [Grafana Image Renderer Installation instructions](/grafana/plugins/grafana-image-renderer/?tab=installation#installation).
 
 ## Configuration
 
@@ -80,7 +85,12 @@ AUTH_TOKEN=-
 }
 ```
 
+<<<<<<< HEAD
 See the [Grafana configuration]({{< relref "../configure-grafana/#renderer_token" >}}) for how to configure the token in Grafana.
+=======
+See [Grafana configuration]({{< relref "../configure-grafana#renderer_token" >}}) for how to configure the token in Grafana.
+
+> > > > > > > b88a321ad2 (Update \_index.md (#72068))
 
 ### Rendering mode
 
@@ -320,7 +330,7 @@ CHROME_BIN="/usr/bin/chromium-browser"
 
 #### Start browser with additional arguments
 
-Additional arguments to pass to the headless browser instance. Defaults are `--no-sandbox,--disable-gpu`. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/) and the list of flags used as defaults by Puppeteer can be found [there](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts#L172). Multiple arguments is separated with comma-character.
+Additional arguments to pass to the headless browser instance. Defaults are `--no-sandbox,--disable-gpu`. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/) and the list of flags used as defaults by Puppeteer can be found [there](https://cri.dev/posts/2020-04-04-Full-list-of-Chromium-Puppeteer-flags/). Multiple arguments is separated with comma-character.
 
 ```bash
 RENDERING_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-accelerated-2d-canvas,--disable-gpu,--window-size=1280x758


### PR DESCRIPTION
* Update _index.md

Edits to the "Set up image rendering" doc.

1. First section, "Set up Image Rendering," last paragraph: "You can also render a PNG by clicking hovering..." -- I removed "clicking" from that sentence.

2. "Alerting and Render Limits" section, link for "concurrent_render_limit" takes you to the page but not the section. This seems to be the case for all section links on this "Configure Grafana" page. I'm not sure how to fix it but switched from a relative link to a full path to see if that would help.

3. "Install Grafana Image Renderer Plugin," the link goes to the plugin overview page instead of the installation page. I tried adding the full path to see if that would go to the installation tab.

4. "Configuration" section, the same as the second edit I made, the first link, "Grafana configuration file," goes to the page but not the section link. I switched the relative path to a full path to see if it would work.

5. "Security" section, the very last sentence has the same Grafana configuration page link that goes to the correct page but not the correct section, "Grafana configuration" for the renderer token section. Same as previous ones, I switched out the relative path for the full path.

6. "Start browser with additional arguments," the second link in the first paragraph that goes to Puppeteer list of Chromium flags went to a 404 page. I couldn't figure out where they had moved it so I found a different site with a list of default flags and used that link instead.

* corrects links

* updates links

* fixes anchor link

---------

Co-authored-by: Chris Moyer <chris.moyer@grafana.com>
(cherry picked from commit b88a321ad29dfaa5e1faa9d4f645fba8bc4dc737)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
