### PR TITLE
PluginExtensions: Increased extension limit per plugin

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -282,7 +282,7 @@ export function getPanelMenu(
   const { extensions } = getPluginLinkExtensions({
     extensionPointId: PluginExtensionPoints.DashboardPanelMenu,
     context: createExtensionContext(panel, dashboard),
-    limitPerPlugin: 2,
+    limitPerPlugin: 3,
   });
 
   if (extensions.length > 0 && !panel.isEditing) {

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -120,6 +120,7 @@ function useExtensionLinks(context: PluginExtensionExploreContext): PluginExtens
     const { extensions } = getPluginLinkExtensions({
       extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
       context: context,
+      limitPerPlugin: 3,
     });
 
     return extensions;


### PR DESCRIPTION
**What is this feature?**
In the following PRs (https://github.com/grafana/grafana/pull/71074, https://github.com/grafana/grafana/pull/72194) we introduced categories for plugins which will group the menu items.

With that in place we can also increase the number of extensions allowed to be registered by a single plugin since they will be structured in a better way.

**Who is this feature for?**
plugin developers

**Which issue(s) does this PR fix?**:
n/a

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
