### PR TITLE
Sandbox: Set the `style` attribute of all `Element` child to be a live target

### DIFF
--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -79,13 +79,9 @@ export function isDomElement(obj: unknown): obj is Element {
  * This is necessary for plugins working with style attributes to work in Chrome
  */
 export function markDomElementStyleAsALiveTarget(el: Element) {
-  if (
-    // only HTMLElement's (extends Element) have a style attribute
-    el instanceof HTMLElement &&
-    // do not define it twice
-    !Object.hasOwn(el.style, SANDBOX_LIVE_VALUE)
-  ) {
-    Reflect.defineProperty(el.style, SANDBOX_LIVE_VALUE, {});
+  const style = Reflect.get(el, 'style');
+  if (!Object.hasOwn(style, SANDBOX_LIVE_VALUE)) {
+    Reflect.defineProperty(style, SANDBOX_LIVE_VALUE, {});
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

it expands the current logic to set `style` as a live target inside the sandbox to all Element children and not only HTMLElement
**Why do we need this feature?**

Elements such as `SVG` have a style attribute but don't inherit from HTMLElement which generated visual bugs in styles SVG elements.

**Who is this feature for?**

Plugins running inside the frontend sandbox
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
