### PR TITLE
CI: Move github-release workflow to new action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -605,7 +605,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/detect-breaking-changes-* @grafana/plugins-platform-frontend
 /.github/workflows/doc-validator.yml @grafana/docs-tooling
 /.github/workflows/epic-add-to-platform-ux-parent-project.yml @meanmina
-/.github/workflows/github-release.yml @torkelo
+/.github/workflows/github-release.yml @grafana/grafana-delivery
 /.github/workflows/issue-labeled.yml @armandgrillet
 /.github/workflows/issue-opened.yml @grafana/grafana-community-support
 /.github/workflows/metrics-collector.yml @torkelo

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -5,26 +5,22 @@ on:
       version:
         required: true
         description: Needs to match, exactly, the name of a milestone (NO v prefix)
+      latest:
+        required: false
+        description: Mark this release as latest (`1`) or not (`0`, default)
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@v3
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
-          ref: main
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
       - name: "Generate token"
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-      - name: Run github release action
-        uses: ./actions/github-release
+      - name: Create GitHub release (manually invoked)
+        uses: grafana/grafana-github-actions-go/github-release@main
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          version: ${{ inputs.version }}
+          metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}


### PR DESCRIPTION
This moves the current github-release workflow over to a new action implementation to support some more scenarios. Tested in a private repository and the sandbox.

I also took the opportunity to update the CODEOWNERS since delivery is more or less exclusively using that workflow.

Follow-up to https://github.com/grafana/grafana-github-actions-go/pull/53