### PR TITLE
A11Y: SelectOptionGroup component fix lint rule about element interactions

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
@@ -24,7 +24,9 @@ const getSelectOptionGroupStyles = stylesFactory((theme: GrafanaTheme2) => {
   return {
     header: css({
       display: 'flex',
-      justifyContent: 'space-between',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      justifyItems: 'center',
       cursor: 'pointer',
       padding: '7px 10px',
       width: '100%',
@@ -35,7 +37,7 @@ const getSelectOptionGroupStyles = stylesFactory((theme: GrafanaTheme2) => {
       },
     }),
     label: css({
-      flexGrow: 0,
+      flexGrow: 1,
     }),
     icon: css({
       paddingRight: '2px',

--- a/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
@@ -24,9 +24,7 @@ const getSelectOptionGroupStyles = stylesFactory((theme: GrafanaTheme2) => {
   return {
     header: css({
       display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      justifyItems: 'center',
+      justifyContent: 'space-between',
       cursor: 'pointer',
       padding: '7px 10px',
       width: '100%',
@@ -37,7 +35,7 @@ const getSelectOptionGroupStyles = stylesFactory((theme: GrafanaTheme2) => {
       },
     }),
     label: css({
-      flexGrow: 1,
+      flexGrow: 0,
     }),
     icon: css({
       paddingRight: '2px',
@@ -81,11 +79,11 @@ class UnthemedSelectOptionGroup extends PureComponent<ExtendedGroupProps, State>
 
     return (
       <div>
-        {/* TODO: fix keyboard a11y */}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div className={styles.header} onClick={this.onToggleChildren}>
+        {/*React Select doesn't support focusable option group headers, this will be skipped when using
+      the keyboard */}
+        <div className={styles.header} onClick={this.onToggleChildren} role="presentation">
           <span className={styles.label}>{label}</span>
-          <Icon className={styles.icon} name={expanded ? 'angle-up' : 'angle-down'} />{' '}
+          <Icon className={styles.icon} name={expanded ? 'angle-up' : 'angle-down'} />
         </div>
         {expanded && children}
       </div>


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixed the lint rule about element interaction. `jsx-a11y/no-static-element-interactions `

**Why do we need this feature?**

To improve accessibility.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70963

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
