### PR TITLE
Chore: Add AwaitHealthy to ModuleEngine and Server

### DIFF
--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Engine interface {
+	AwaitHealthy(context.Context) error
 	Init(context.Context) error
 	Run(context.Context) error
 	Shutdown(context.Context) error
@@ -57,6 +58,14 @@ func ProvideService(
 
 		features: features,
 	}
+}
+
+// AwaitHealthy waits for all registered modules to be healthy.
+func (m *service) AwaitHealthy(ctx context.Context) error {
+	if m.serviceManager == nil {
+		return fmt.Errorf("service manager has not been initialized")
+	}
+	return m.serviceManager.AwaitHealthy(ctx)
 }
 
 // Init initializes all registered modules.

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -63,7 +63,7 @@ func ProvideService(
 // AwaitHealthy waits for all registered modules to be healthy.
 func (m *service) AwaitHealthy(ctx context.Context) error {
 	if m.serviceManager == nil {
-		return fmt.Errorf("service manager has not been initialized")
+		return errors.New("service manager has not been initialized")
 	}
 	return m.serviceManager.AwaitHealthy(ctx)
 }

--- a/pkg/modules/util.go
+++ b/pkg/modules/util.go
@@ -27,9 +27,17 @@ func (m *MockModuleManager) RegisterInvisibleModule(name string, initFn func() (
 }
 
 type MockModuleEngine struct {
-	InitFunc     func(context.Context) error
-	RunFunc      func(context.Context) error
-	ShutdownFunc func(context.Context) error
+	AwaitHealthyFunc func(context.Context) error
+	InitFunc         func(context.Context) error
+	RunFunc          func(context.Context) error
+	ShutdownFunc     func(context.Context) error
+}
+
+func (m *MockModuleEngine) AwaitHealthy(ctx context.Context) error {
+	if m.AwaitHealthyFunc != nil {
+		return m.AwaitHealthyFunc(ctx)
+	}
+	return nil
 }
 
 func (m *MockModuleEngine) Init(ctx context.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,6 +112,11 @@ func (s *Server) init(ctx context.Context) error {
 	return s.roleRegistry.RegisterFixedRoles(ctx)
 }
 
+// AwaitHealthy waits for the server to become healthy.
+func (s *Server) AwaitHealthy(ctx context.Context) error {
+	return s.moduleService.AwaitHealthy(ctx)
+}
+
 // Run initializes and starts services. This will block until all services have
 // exited. To initiate shutdown, call the Shutdown method in another goroutine.
 func (s *Server) Run(ctx context.Context) error {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -71,6 +71,8 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 	})
 
 	// Wait for Grafana to be ready
+	err = env.Server.AwaitHealthy(ctx)
+	require.NoError(t, err)
 	addr := listener.Addr().String()
 	resp, err := http.Get(fmt.Sprintf("http://%s/api/health", addr))
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This allows integration tests to wait for all modules to be healthy before running.

**Why do we need this feature?**

These changes were originally part of #72123, and are needed to fix a race condition in integration tests.

**Who is this feature for?**

@grafana/grafana-app-platform-squad 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

part of https://github.com/grafana/grafana-enterprise/issues/5550
