### PR TITLE
Alerting: Fix state manager to not keep datasource_uid and ref_id labels in state after Error

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2240,6 +2240,88 @@ func TestProcessEvalResults(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "classic condition, execution Error as Error (alerting -> query error -> alerting)",
+			alertRule: &models.AlertRule{
+				OrgID:        1,
+				Title:        "test_title",
+				UID:          "test_alert_rule_uid",
+				NamespaceUID: "test_namespace_uid",
+				Annotations:  map[string]string{},
+				Labels:       map[string]string{"label": "test"},
+				Data: []models.AlertQuery{
+					{
+						RefID:         "A",
+						DatasourceUID: "test-datasource-uid",
+					},
+				},
+				IntervalSeconds: 10,
+				ExecErrState:    models.ErrorErrState,
+			},
+			expectedAnnotations: 2,
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+					eval.Result{
+						Instance:           data.Labels{},
+						State:              eval.Error,
+						Error:              expr.MakeQueryError("A", "test-datasource-uid", errors.New("this is an error")),
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+					eval.Result{
+						Instance:           data.Labels{},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid"],["alertname","test_title"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid"],["alertname","test_title"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"datasource_uid":               "test-datasource-uid", // this is the bug
+						"ref_id":                       "A",                   // this is the bug
+					},
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime,
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(10 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(110 * time.Second),
+					LastEvaluationTime: evaluationTime.Add(20 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2292,8 +2292,6 @@ func TestProcessEvalResults(t *testing.T) {
 						"__alert_rule_uid__":           "test_alert_rule_uid",
 						"alertname":                    "test_title",
 						"label":                        "test",
-						"datasource_uid":               "test-datasource-uid", // this is the bug
-						"ref_id":                       "A",                   // this is the bug
 					},
 					Values: make(map[string]float64),
 					State:  eval.Alerting,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR fixes a bug in the state manager that is described in https://github.com/grafana/grafana/issues/71467. It updates the state manager to clean up the labels sneaked after the cacheID was calculated. I added safety to remove only if the result does not contain these labels.

This is a temporary change to remediate the problem and will be changed in https://github.com/grafana/grafana/pull/68142

<details><summary>Before</summary>

https://github.com/grafana/grafana/assets/25988953/587410ac-f1e1-4bd9-8312-24428326ad6b

</details>

<details><summary>After</summary>

https://github.com/grafana/grafana/assets/25988953/b20212e4-3994-4f05-857d-af15139fa6cc

</details>


**Why do we need this feature?**
This happens only in the case when the result does not have any labels, usually when the rule uses the classic condition. The normal evaluation uses labels from the rule only. When an error happens, the error result does not have labels either, and therefore it is matched to the normal state instead of being a new state (in multi-dimensional alerts when each normal result contains labels). The state manager adds extra labels __after the state identifier is calculated__. Therefore, this makes the normal result match the state that contains the extra labels, and therefore the extra labels (datasource_uid and ref_id) never go away from the state.


**Who is this feature for?**
Those who use classic condition and execution of Error as an error.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/71467

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
