### PR TITLE
Transformations: fix bug in seriesToRowsTransformer when a timeserie …

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -29,6 +29,7 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
           return data;
         }
 
+        data = data.filter((frame) => frame.length > 0);
         if (!isTimeSeriesFrames(data)) {
           return data;
         }
@@ -45,6 +46,8 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
 
         for (let frameIndex = 0; frameIndex < data.length; frameIndex++) {
           const frame = data[frameIndex];
+
+          console.log('frame ref id: ', frame.refId);
 
           for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {
             const field = frame.fields[fieldIndex];

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -47,8 +47,6 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
         for (let frameIndex = 0; frameIndex < data.length; frameIndex++) {
           const frame = data[frameIndex];
 
-          console.log('frame ref id: ', frame.refId);
-
           for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {
             const field = frame.fields[fieldIndex];
 


### PR DESCRIPTION
In the seriesToRowsTransformer, when a timeseries of one of the queries is empty, it is considered invalid and the data is returned as is.

Before checking if timeseries are valid with `isTimeSeriesFrames()`, we should filter out empty timeseries and continue with the transformation with the non empty timeseries