### PR TITLE
Alerting: Exclude expression refIDs from NoData state

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -442,7 +442,10 @@ func datasourceUIDsToRefIDs(refIDsToDatasourceUIDs map[string]string) map[string
 	// for each Datasource UID we can append them all to a slice and then
 	// sort them once
 	refIDs := make([]string, 0, len(refIDsToDatasourceUIDs))
-	for refID := range refIDsToDatasourceUIDs {
+	for refID, datasourceUid := range refIDsToDatasourceUIDs {
+		if expr.NodeTypeFromDatasourceUID(datasourceUid) != expr.TypeDatasourceNode {
+			continue
+		} // TODO think about ML node NO-Data... perhaps report original datasource.
 		refIDs = append(refIDs, refID)
 	}
 	sort.Strings(refIDs)

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -324,8 +324,6 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 	for _, next := range c.Data {
 		datasourceUIDsForRefIDs[next.RefID] = next.DatasourceUID
 	}
-	// datasourceExprUID is a special DatasourceUID for expressions
-	datasourceExprUID := strconv.FormatInt(expr.DatasourceID, 10)
 
 	result := ExecutionResults{Results: make(map[string]data.Frames)}
 	for refID, res := range execResp.Responses {
@@ -347,7 +345,7 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 			hasNoFrames := len(res.Frames) == 0
 			hasNoFields := len(res.Frames) == 1 && len(res.Frames[0].Fields) == 0
 			if hasNoFrames || hasNoFields {
-				if s, ok := datasourceUIDsForRefIDs[refID]; ok && s != datasourceExprUID {
+				if s, ok := datasourceUIDsForRefIDs[refID]; ok && expr.NodeTypeFromDatasourceUID(s) == expr.TypeDatasourceNode { // TODO perhaps extract datasource UID from ML expression too.
 					result.NoData[refID] = s
 				}
 			}
@@ -442,10 +440,7 @@ func datasourceUIDsToRefIDs(refIDsToDatasourceUIDs map[string]string) map[string
 	// for each Datasource UID we can append them all to a slice and then
 	// sort them once
 	refIDs := make([]string, 0, len(refIDsToDatasourceUIDs))
-	for refID, datasourceUid := range refIDsToDatasourceUIDs {
-		if expr.NodeTypeFromDatasourceUID(datasourceUid) != expr.TypeDatasourceNode {
-			continue
-		} // TODO think about ML node NO-Data... perhaps report original datasource.
+	for refID := range refIDsToDatasourceUIDs {
 		refIDs = append(refIDs, refID)
 	}
 	sort.Strings(refIDs)

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -354,6 +354,21 @@ func TestEvaluateExecutionResultsNoData(t *testing.T) {
 		require.ElementsMatch(t, []string{"1", "2"}, datasourceUIDs)
 		require.ElementsMatch(t, []string{"A,B", "C"}, refIDs)
 	})
+
+	t.Run("should ignore expression ref-ids", func(t *testing.T) {
+		results := ExecutionResults{
+			NoData: map[string]string{
+				"A":  "ce7e897f-81e5-4be6-9636-a7f26eaf576b",
+				"B1": expr.DatasourceType,
+				"B2": expr.OldDatasourceUID,
+				"C":  expr.MLDatasourceUID,
+			},
+		}
+		v := evaluateExecutionResult(results, time.Time{})
+		require.Len(t, v, 1)
+		require.Equal(t, data.Labels{"datasource_uid": "ce7e897f-81e5-4be6-9636-a7f26eaf576b", "ref_id": "A"}, v[0].Instance)
+		require.Equal(t, NoData, v[0].State)
+	})
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -354,21 +354,6 @@ func TestEvaluateExecutionResultsNoData(t *testing.T) {
 		require.ElementsMatch(t, []string{"1", "2"}, datasourceUIDs)
 		require.ElementsMatch(t, []string{"A,B", "C"}, refIDs)
 	})
-
-	t.Run("should ignore expression ref-ids", func(t *testing.T) {
-		results := ExecutionResults{
-			NoData: map[string]string{
-				"A":  "ce7e897f-81e5-4be6-9636-a7f26eaf576b",
-				"B1": expr.DatasourceType,
-				"B2": expr.OldDatasourceUID,
-				"C":  expr.MLDatasourceUID,
-			},
-		}
-		v := evaluateExecutionResult(results, time.Time{})
-		require.Len(t, v, 1)
-		require.Equal(t, data.Labels{"datasource_uid": "ce7e897f-81e5-4be6-9636-a7f26eaf576b", "ref_id": "A"}, v[0].Instance)
-		require.Equal(t, NoData, v[0].State)
-	})
 }
 
 func TestValidate(t *testing.T) {
@@ -577,11 +562,23 @@ func TestEvaluate(t *testing.T) {
 			Data: []models.AlertQuery{{
 				RefID:         "A",
 				DatasourceUID: "test",
+			}, {
+				RefID:         "B",
+				DatasourceUID: expr.DatasourceUID,
+			}, {
+				RefID:         "C",
+				DatasourceUID: expr.OldDatasourceUID,
+			}, {
+				RefID:         "D",
+				DatasourceUID: expr.MLDatasourceUID,
 			}},
 		},
 		resp: backend.QueryDataResponse{
 			Responses: backend.Responses{
 				"A": {Frames: nil},
+				"B": {Frames: []*data.Frame{{Fields: nil}}},
+				"C": {Frames: nil},
+				"D": {Frames: []*data.Frame{{Fields: nil}}},
 			},
 		},
 		expected: Results{{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes alerting evaluator to not include expression RefID to NoData result

**Why do we need this feature?**
This removes an extra state that mentions refID of expressions when no data result is executed as NoData state.

<details><summary>Example</summary>

![firefox_kUGehpZzsH](https://github.com/grafana/grafana/assets/25988953/e1e95c47-7b66-42db-b990-87ca459a764a)

</details>

**Who is this feature for?**
Those who configure execution of NoData as NoData.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71993

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
