### PR TITLE
Docs: Add backup docs

### DIFF
--- a/docs/sources/administration/backup/index.md
+++ b/docs/sources/administration/backup/index.md
@@ -1,0 +1,76 @@
+---
+description: Describes backing up a locally provisioned Grafana instance.
+keywords:
+  - grafana
+  - backup
+labels:
+  products:
+    - enterprise
+    - oss
+title: Back up Grafana
+weight: 600
+---
+
+# Back Up Grafana
+
+To back up a local Grafana deployment, you need to consider three aspects: configuration, plugin data, and Grafana data.
+
+## Backing Up Configuration
+
+You will need to copy any configuration files that you have modified in your Grafana deployment.  Copy the files from the configuration location to your backup repository.
+
+### Config File Locations
+
+- Default configuration from `$WORKING_DIR/conf/defaults.ini`
+- Custom configuration from `$WORKING_DIR/conf/custom.ini`
+
+{{% admonition type="note" %}}
+If you have installed Grafana using the `deb` or `rpm`
+packages, then your configuration file is located at
+`/etc/grafana/grafana.ini`. This path is specified in the Grafana
+init.d script using `--config` file parameter.
+{{% /admonition %}}
+
+## Backing Up Plugin Data
+
+Installing plugins in Grafana creates a folder per plugin with its associated files and data.  You will need to copy all files and folders recursively from this location to your backup repository.
+
+### Plugin Data Locations
+
+- Default location for plugins in a binary or source install is `$WORKING_DIR/data/plugins`
+- Default location for plugins in a `deb` or `rpm` package is `/var/lib/grafana/plugins`
+
+{{% admonition type="note" %}}
+If you have installed Grafana using the `deb` or `rpm`
+packages, then your plugins are located at
+`/var/lib/grafana/plugins` by default. This path is specified in the Grafana
+init.d script using `--config` file parameter.
+{{% /admonition %}}
+
+## Backing Up Database
+
+Dashboard and user data is stored in the Grafana database.  Depending on the database you are using you might need to use different tools to back this data up.
+
+### SQLite
+
+The default Grafana database is SQLite, which stores its data in a single file on disk.  To back this up, copy the SQLite database file to your backup repository.
+
+{{% admonition type="note" %}}
+You should shut down your Grafana service before backing up the SQLite database to preserve data integrity.
+{{% /admonition %}}
+
+#### SQLite Database Locations
+
+- Default location for SQLite data in a binary or source install is `$WORKING_DIR/data/grafana.db`
+- Default location for SQLite data in a `deb` or `rpm` package is `/var/lib/grafana/grafana.db`
+
+{{% admonition type="note" %}}
+If you have installed Grafana using the `deb` or `rpm`
+packages, then your SQLite database is located at
+`/var/lib/grafana/grafana.db` by default. This path is specified in the Grafana
+init.d script using `--config` file parameter.
+{{% /admonition %}}
+
+### MySQL/MariaDB or PostgreSQL
+
+Refer to your database documentation for backing up the Grafana database from these tools.


### PR DESCRIPTION
**What is this feature?**

This adds documentation for how to back up a Grafana deployment.

**Why do we need this feature?**

I've been asked several times for advice on how to back up Grafana.  Having this in the docs could help other people with the same question.

**Who is this feature for?**

Grafana administrators who are deploying Grafana locally.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
