### PR TITLE
Docs: Add CloudWatch Logs Monaco query editor to what's new in 10.1

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v10-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-1.md
@@ -178,7 +178,7 @@ The Metrics Explorer is a new feature to enhance metric browsing in the Promethe
 
 _Experimental in all editions of Grafana_
 
-The CloudWatch Logs query editor is moving from being a Slate-based editor to a Monaco-based editor. This new Monaco-based editor will provide improved syntax highlighting, and auto-completion. Enable the `cloudWatchLogsMonacoEditor` feature toggle to use the Monaco-based query editor.
+The CloudWatch Logs query editor is moving from being a Slate-based editor to a Monaco-based editor. This new Monaco-based editor will provide improved syntax highlighting, and auto-completion. Enable the `cloudWatchLogsMonacoEditor` feature toggle to use the Monaco-based query editor. If you’re using Grafana Cloud and would like to enable this feature, please contact customer support.
 
 ## Explore
 

--- a/docs/sources/whatsnew/whats-new-in-v10-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-1.md
@@ -172,6 +172,14 @@ The Metrics Explorer is a new feature to enhance metric browsing in the Promethe
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-1-metrics-explorer.png" max-width="750px" caption="Metrics explorer" >}}
 
+### CloudWatch Logs Monaco query editor
+
+<!-- Isabella Siu, Kevin Yu -->
+
+_Experimental in all editions of Grafana_
+
+The CloudWatch Logs query editor is moving from being a Slate-based editor to a Monaco-based editor. This new Monaco-based editor will provide improved syntax highlighting, and auto-completion. Enable the `cloudWatchLogsMonacoEditor` feature toggle to use the Monaco-based query editor.
+
 ## Explore
 
 ### Elasticsearch logs sample


### PR DESCRIPTION
**What is this feature?**

What's new documentation for CloudWatch Logs' new Monaco-based query editor in 10.1. The PR for it is here https://github.com/grafana/grafana/pull/71799.