### PR TITLE
Geomap: Promote route + photos layer to beta, promote geojson layer to stable

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -12,7 +12,6 @@ import {
   MapLayerRegistryItem,
   MapLayerOptions,
   GrafanaTheme2,
-  PluginState,
   EventBus,
 } from '@grafana/data';
 import { ComparisonOperation } from '@grafana/schema';

--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -66,7 +66,6 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
   name: 'GeoJSON',
   description: 'Load static data from a geojson file',
   isBaseMap: false,
-  state: PluginState.beta,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/data/photosLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/photosLayer.tsx
@@ -69,7 +69,7 @@ export const photosLayer: MapLayerRegistryItem<PhotoConfig> = {
   isBaseMap: false,
   showLocation: true,
   hideOpacity: true,
-  state: PluginState.alpha,
+  state: PluginState.beta,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -69,7 +69,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
   description: 'Render data points as a route',
   isBaseMap: false,
   showLocation: true,
-  state: PluginState.alpha,
+  state: PluginState.beta,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/registry.ts
+++ b/public/app/plugins/panel/geomap/layers/registry.ts
@@ -57,33 +57,44 @@ interface RegistrySelectInfo {
 }
 
 function getLayersSelection(items: Array<MapLayerRegistryItem<any>>, current?: string): RegistrySelectInfo {
-  const res: RegistrySelectInfo = { options: [], current: [] };
+  const registry: RegistrySelectInfo = { options: [], current: [] };
   const alpha: Array<SelectableValue<string>> = [];
+
   for (const layer of items) {
-    const opt: SelectableValue<string> = { label: layer.name, value: layer.id, description: layer.description };
-    if (layer.state === PluginState.alpha) {
-      if (!hasAlphaPanels) {
-        continue;
-      }
-      opt.label = `${layer.name} (Alpha)`;
-      opt.icon = 'bolt';
-      alpha.push(opt);
-    } else {
-      res.options.push(opt);
+    const option: SelectableValue<string> = { label: layer.name, value: layer.id, description: layer.description };
+
+    switch (layer.state) {
+      case PluginState.alpha:
+        if (!hasAlphaPanels) {
+          break;
+        }
+        option.label = `${layer.name} (Alpha)`;
+        option.icon = 'bolt';
+        alpha.push(option);
+        break;
+      case PluginState.beta:
+        option.label = `${layer.name} (Beta)`;
+      default:
+        registry.options.push(option);
     }
+
     if (layer.id === current) {
-      res.current.push(opt);
+      registry.current.push(option);
     }
   }
-  for (const p of alpha) {
-    res.options.push(p);
+
+  // Position alpha layers at the end of the layers list
+  for (const layer of alpha) {
+    registry.options.push(layer);
   }
-  return res;
+
+  return registry;
 }
 
 export function getLayersOptions(basemap: boolean, current?: string): RegistrySelectInfo {
   if (basemap) {
     return getLayersSelection([defaultBaseLayer, ...basemapLayers], current);
   }
+
   return getLayersSelection([...dataLayers, ...basemapLayers], current);
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/71801

Promote the route and photos layer to beta state - which allows them to be generally discoverable by users without needing to enable alpha features.

Also, promote the geojson layer to "stable" as it has been in use for a long time.

Beta layers will exist along side other stable layer types, while alpha layers are always listed at the very end of the layers list.

<img width="449" alt="Screenshot 2023-07-24 at 4 24 56 PM" src="https://github.com/grafana/grafana/assets/22381771/b1f68931-1463-458d-93bd-73d78b0b17c6">
