### PR TITLE
Secrets: Add user_auth.o_auth_id_token column to migrator

### DIFF
--- a/pkg/services/secrets/migrator/migrator.go
+++ b/pkg/services/secrets/migrator/migrator.go
@@ -39,6 +39,7 @@ func ProvideSecretsMigrator(
 		b64Secret{simpleSecret: simpleSecret{tableName: "user_auth", columnName: "o_auth_access_token"}, encoding: base64.StdEncoding},
 		b64Secret{simpleSecret: simpleSecret{tableName: "user_auth", columnName: "o_auth_refresh_token"}, encoding: base64.StdEncoding},
 		b64Secret{simpleSecret: simpleSecret{tableName: "user_auth", columnName: "o_auth_token_type"}, encoding: base64.StdEncoding},
+		b64Secret{simpleSecret: simpleSecret{tableName: "user_auth", columnName: "o_auth_id_token"}, encoding: base64.StdEncoding},
 		b64Secret{simpleSecret: simpleSecret{tableName: "secrets", columnName: "value"}, hasUpdatedColumn: true, encoding: base64.RawStdEncoding},
 		jsonSecret{tableName: "data_source"},
 		jsonSecret{tableName: "plugin_setting"},


### PR DESCRIPTION
**What is this feature?**

It adds a new column (`user_auth.o_auth_id_token`) into the `secrets.Migrator`.

**Why do we need this feature?**

Because that database column contains secrets (encrypted data), thus needs to be listed on the `secrets.Migrator`, otherwise, any [operational work](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-database-encryption/#operational-work) could leave this database column contents inconsistent.

Please, find more details [here](https://docs.google.com/document/d/1diQV6DGXPaiwrkoDk1Cf4tDiionOrGaJ9NLNJMjrB4I/edit).