### PR TITLE
logs: better unit tests

### DIFF
--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -163,7 +163,7 @@ describe('logParser', () => {
         entryFieldIndex: 10,
         dataFrame: new MutableDataFrame({
           refId: 'A',
-          fields: [{ ...testField }],
+          fields: [testTimeField, testLineField, { ...testField }],
         }),
       });
 
@@ -177,7 +177,7 @@ describe('logParser', () => {
         entryFieldIndex: 10,
         dataFrame: new MutableDataFrame({
           refId: 'A',
-          fields: [{ ...testFieldWithNullValue }],
+          fields: [testTimeField, testLineField, { ...testFieldWithNullValue }],
         }),
       });
 


### PR DESCRIPTION
some of the unit-tests use mocked dataframes, and i am changing them to be a little closer to "real" dataframes: they should have a timestamp-field and a logline-field). 

(this is needed for a future PR)