### PR TITLE
InfluxDB: Fix setting retention policy on visual query editor

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
@@ -55,7 +55,7 @@ export const VisualInfluxQLEditor = (props: Props): JSX.Element => {
   const { retentionPolicies } = useRetentionPolicies(datasource);
 
   useEffect(() => {
-    if (!policy) {
+    if (!policy && retentionPolicies.length > 0) {
       props.onChange({
         ...query,
         policy: retentionPolicies[0],


### PR DESCRIPTION
**What is this feature?**

Fixes `useEffect` hook that is causes infinite loop when there is no retention policy fetch response


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
