### PR TITLE
Sandbox: Redirect calls to window.location to window.locationSandbox

### DIFF
--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -58,12 +58,12 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     const response = await fetch('public/' + meta.module + '.js');
     let pluginCode = await response.text();
     pluginCode = patchPluginSourceMap(meta, pluginCode);
-    pluginCode = patchPluginAPIs(meta, pluginCode);
+    pluginCode = patchPluginAPIs(pluginCode);
     return pluginCode;
   }
 }
 
-function patchPluginAPIs(_: PluginMeta, pluginCode: string): string {
+function patchPluginAPIs(pluginCode: string): string {
   return pluginCode.replace(/window\.location/gi, 'window.locationSandbox');
 }
 

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -58,8 +58,13 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     const response = await fetch('public/' + meta.module + '.js');
     let pluginCode = await response.text();
     pluginCode = patchPluginSourceMap(meta, pluginCode);
+    pluginCode = patchPluginAPIs(meta, pluginCode);
     return pluginCode;
   }
+}
+
+function patchPluginAPIs(_: PluginMeta, pluginCode: string): string {
+  return pluginCode.replace(/window\.location/gi, 'window.locationSandbox');
 }
 
 /**

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -74,6 +74,10 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<unknown>
       liveTargetCallback: isLiveTarget,
       // endowments are custom variables we make available to plugins in their window object
       endowments: Object.getOwnPropertyDescriptors({
+        // window.location is unforgeable, we make the location available via endowments
+        // when the plugin code is loaded, the sandbox replaces the window.location with
+        // window.locationSandbox. In the future this can be a proxy
+        locationSandbox: window.location,
         // Plugins builds use the AMD module system. Their code consists
         // of a single function call to `define()` that internally contains all the plugin code.
         // This is that `define` function the plugin will call.

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -76,7 +76,8 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<unknown>
       endowments: Object.getOwnPropertyDescriptors({
         // window.location is unforgeable, we make the location available via endowments
         // when the plugin code is loaded, the sandbox replaces the window.location with
-        // window.locationSandbox. In the future this can be a proxy
+        // window.locationSandbox. In the future `window.location` could be a proxy if we
+        // want to intercept calls to it.
         locationSandbox: window.location,
         // Plugins builds use the AMD module system. Their code consists
         // of a single function call to `define()` that internally contains all the plugin code.


### PR DESCRIPTION
**What is this feature?**

Provides a mechanism for plugins using `window.location` to work inside the sandbox.

**Why do we need this feature?**

`window.location` is an javascript unforgeable and can't be captured via distortions. If a plugin tries to do any code that modified the `window.location` the operation will be applied to the underlying iframe instead of the main window as it is intended.

The only way to patch this behaviour is to patch the sourcecode itself to call a different API.

This PR replaces calls to `window.location` to `window.locationSandbox` which is the window.location object itself. `window.location` doesn't leak objects or APIs we don't want the plugins to use.

#### Q. What if plugins use `location` directly instead of `window.location`?

The read-only attributes of location are accessible, the problem only occurs with write attributes and methods. If a plugin is not using the full `window.location` for these write calls then it won't work as expected. Patching calls to `location.*` is a risky practice since only parsing and AST will reveal if that `location` variable is in fact `window.location` and parsing an AST will take too much time and will create a performance impact in plugin loading.

**Who is this feature for?**

Plugins running inside the sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/72269

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
