### PR TITLE
Loki: Run logs volume for query when switching from trace to logs

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1093,6 +1093,24 @@ describe('LokiDatasource', () => {
     });
 
     describe('logs volume', () => {
+      // The default queryType value is Range
+      it('returns logs volume for query with no queryType', () => {
+        expect(
+          ds.getSupplementaryQuery(
+            { type: SupplementaryQueryType.LogsVolume },
+            {
+              expr: '{label=value}',
+              refId: 'A',
+            }
+          )
+        ).toEqual({
+          expr: 'sum by (level) (count_over_time({label=value}[$__interval]))',
+          queryType: LokiQueryType.Range,
+          refId: 'log-volume-A',
+          supportingQueryType: SupportingQueryType.LogsVolume,
+        });
+      });
+
       it('returns logs volume query for range log query', () => {
         expect(
           ds.getSupplementaryQuery(

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -194,7 +194,7 @@ export class LokiDatasource
     switch (options.type) {
       case SupplementaryQueryType.LogsVolume:
         // it has to be a logs-producing range-query
-        isQuerySuitable = !!(query.expr && isLogsQuery(query.expr) && query.queryType === LokiQueryType.Range);
+        isQuerySuitable = !!(expr && isLogsQuery(expr) && normalizedQuery.queryType === LokiQueryType.Range);
         if (!isQuerySuitable) {
           return undefined;
         }
@@ -209,7 +209,7 @@ export class LokiDatasource
 
       case SupplementaryQueryType.LogsSample:
         // it has to be a metric query
-        isQuerySuitable = !!(query.expr && !isLogsQuery(query.expr));
+        isQuerySuitable = !!(expr && !isLogsQuery(expr));
         if (!isQuerySuitable) {
           return undefined;
         }


### PR DESCRIPTION
Discovered while @Elfo404 was investigating https://github.com/grafana/grafana/issues/72243. More info in https://raintank-corp.slack.com/archives/C03PMJLVC67/p1690283551281389. 

When Loki query is created somewhere else (e.g. in Tempo/Trace view) and no `queryType` is selected, we default to `Range`. We use `getNormalizedLokiQuery` function to do handle a logic. 

In `getSupplementaryQuery` that we use to evaluate if supplementary query (e.g, logs volume) should be run, we initially normalized query, but then didn't use  `queryType` from `normalizedQuery` to decide if logs volume should be run. 
This meant that queries with not queryType, even though they are Range queries, were filtered out and logs volume query was not executed. 

This PR fixes the issue and adds test. 