### PR TITLE
logs: context: various scrolling-fixes

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -461,6 +461,13 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       return;
     }
 
+    // if the newly loaded content is part of the initial load of `above` and `below`,
+    // we scroll to center, to keep the chosen log-row centered
+    if (loadCountRef.current.above <= 1 && loadCountRef.current.below <= 1) {
+      scrollToCenter();
+      return;
+    }
+
     const prevScrollHeight = prevScrollHeightRef.current;
     const currentHeight = scrollE.scrollHeight;
     prevScrollHeightRef.current = currentHeight;

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -363,16 +363,33 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
       const newBelow = logsSortOrder === LogsSortOrder.Ascending ? older : newer;
 
       if (currentGen === generationRef.current) {
-        setContext((c) => ({
-          above: {
-            rows: sortLogRows([...newAbove, ...c.above.rows], logsSortOrder),
-            loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
-          },
-          below: {
-            rows: sortLogRows([...c.below.rows, ...newBelow], logsSortOrder),
-            loadingState: newRows.length === 0 ? LoadingState.Done : LoadingState.NotStarted,
-          },
-        }));
+        setContext((c) => {
+          // we should only modify the row-arrays if necessary
+          const sortedNewAbove =
+            newAbove.length > 0 ? sortLogRows([...newAbove, ...c.above.rows], logsSortOrder) : c.above.rows;
+          const sortedNewBelow =
+            newBelow.length > 0 ? sortLogRows([...c.below.rows, ...newBelow], logsSortOrder) : c.below.rows;
+          return {
+            above: {
+              rows: sortedNewAbove,
+              loadingState:
+                place === 'above'
+                  ? newRows.length === 0
+                    ? LoadingState.Done
+                    : LoadingState.NotStarted
+                  : c.above.loadingState,
+            },
+            below: {
+              rows: sortedNewBelow,
+              loadingState:
+                place === 'below'
+                  ? newRows.length === 0
+                    ? LoadingState.Done
+                    : LoadingState.NotStarted
+                  : c.below.loadingState,
+            },
+          };
+        });
       }
     } catch {
       setSection(place, (section) => ({

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -279,6 +279,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
   const updateResults = async () => {
     await updateContextQuery();
     setContext(makeEmptyContext());
+    loadCountRef.current = { above: 0, below: 0 };
     generationRef.current += 1; // results from currently running loadMore calls will be ignored
   };
 


### PR DESCRIPTION
there are various fixes to the logs-context behavior, i'll describe the changes from top to bottom:

1. we reset the load-counter when the logs-context-ui changes. this will help us to better tracking the scrolling events (because when the logs-context-ui changes, we reload the whole logs-part)
2. the way we updated the "above" & "below" arrays when data was loaded had problems:
    - the `LoadingState` for both `above` & `below` was updated to the same value, regardless of what was happening
    - we always generated new `above` and `below` arrays, even if they did not change. this is a problem, because certain `useEffect` calls are triggered based on changes to these arrays, and they should not get triggered when the arrays do no tchange.
3. explicitly scroll-to-center, when the initial load-data events end. this will make it more reliable to always center on the chosen log-line at the beginning


how to test:
1. open the browser-dev-tools,  the `network` part. this will be used to verify how many ajax requests run
1. open logs-context with Loki ( we need Loki to be able to test logs-ui-changes)
2. verify that the chosen log-line is in the center (vertically)
3. verify that only 2 ajax requests ran (so, not 3 or more)
4.  scroll to the top, make sure it still loads so that the log-lines visually do not change position
5. repeat [4] for the bottom
6. change  the loki query, and do a "blur" event.
7. verify that the data loads, and the source log-line is centered