### PR TITLE
PluginExtensions: Allow to specify unkown properties in override but they will be ignored

### DIFF
--- a/public/app/features/plugins/extensions/getPluginExtensions.test.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.ts
@@ -140,7 +140,7 @@ describe('getPluginExtensions()', () => {
       type: 'unknown-type',
       pluginId: 'another-plugin',
 
-      // Unkown properties
+      // Unknown properties
       testing: false,
 
       // The following props are allowed to override

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.ts
@@ -134,18 +134,30 @@ describe('getPluginExtensions()', () => {
     expect(extension.category).toBe('Machine Learning');
   });
 
-  test('should hide the extension if it tries to override not-allowed properties with the configure() function', () => {
+  test('should ignore not-allowed properties passed via the configure() function', () => {
     link2.configure = jest.fn().mockImplementation(() => ({
       // The following props are not allowed to override
       type: 'unknown-type',
       pluginId: 'another-plugin',
+
+      // Unkown properties
+      testing: false,
+
+      // The following props are allowed to override
+      title: 'test',
     }));
 
     const registry = createPluginExtensionRegistry([{ pluginId, extensionConfigs: [link2] }]);
     const { extensions } = getPluginExtensions({ registry, extensionPointId: extensionPoint2 });
+    const [extension] = extensions;
 
     expect(link2.configure).toHaveBeenCalledTimes(1);
-    expect(extensions).toHaveLength(0);
+    expect(extensions).toHaveLength(1);
+    expect(extension.title).toBe('test');
+    expect(extension.type).toBe('link');
+    expect(extension.pluginId).toBe('grafana-basic-app');
+    //@ts-ignore
+    expect(extension.testing).toBeUndefined();
   });
   test('should pass a read only context to the configure() function', () => {
     const context = { title: 'New title from the context!' };

--- a/public/app/features/plugins/extensions/getPluginExtensions.test.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.test.ts
@@ -134,7 +134,7 @@ describe('getPluginExtensions()', () => {
     expect(extension.category).toBe('Machine Learning');
   });
 
-  test('should ignore not-allowed properties passed via the configure() function', () => {
+  test('should ignore restricted properties passed via the configure() function', () => {
     link2.configure = jest.fn().mockImplementation(() => ({
       // The following props are not allowed to override
       type: 'unknown-type',

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -140,7 +140,7 @@ function getLinkExtensionOverrides(pluginId: string, config: PluginExtensionLink
 
     if (Object.keys(rest).length > 0) {
       logWarning(
-        `Extension "${config.title}", it trying to override not-allowed properties: ${Object.keys(rest).join(
+        `Extension "${config.title}", is trying to override not-allowed properties: ${Object.keys(rest).join(
           ', '
         )} which will be ignored.`
       );

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -139,10 +139,10 @@ function getLinkExtensionOverrides(pluginId: string, config: PluginExtensionLink
     assertStringProps({ title, description }, ['title', 'description']);
 
     if (Object.keys(rest).length > 0) {
-      throw new Error(
-        `Invalid extension "${config.title}". Trying to override not-allowed properties: ${Object.keys(rest).join(
+      logWarning(
+        `Extension "${config.title}", it trying to override not-allowed properties: ${Object.keys(rest).join(
           ', '
-        )}`
+        )} which will be ignored.`
       );
     }
 

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -140,7 +140,7 @@ function getLinkExtensionOverrides(pluginId: string, config: PluginExtensionLink
 
     if (Object.keys(rest).length > 0) {
       logWarning(
-        `Extension "${config.title}", is trying to override not-allowed properties: ${Object.keys(rest).join(
+        `Extension "${config.title}", is trying to override restricted properties: ${Object.keys(rest).join(
           ', '
         )} which will be ignored.`
       );


### PR DESCRIPTION
**What is this feature?**
When we added the category property (https://github.com/grafana/grafana/pull/71074) extensions got hidden in older versions of Grafana. This fix will prevent that from happening and instead log a warning and ignore unkown overrides.

**Why do we need this feature?**
So you can run "newer" versions of plugin extensions in older versions of Grafana.

**Who is this feature for?**
Plugin developers

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
