### PR TITLE
Loki/Elasticsearch: Migrate HTTP settings to Connection, Auth, and Advanced settings

### DIFF
--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -8,7 +8,7 @@ const addDataSource = () => {
       'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
-      e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');
+      e2e().get('#connection-url').type('http://loki-url:3100');
     },
   });
 };

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -9,7 +9,7 @@ const addDataSource = () => {
       'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
-      e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');
+      e2e().get('#connection-url').type('http://loki-url:3100');
     },
   });
 };

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
@@ -15,7 +15,9 @@ describe('ConfigEditor', () => {
     render(<ConfigEditor onOptionsChange={() => {}} options={createDefaultConfigOptions()} />);
 
     // Check DataSourceHttpSettings are rendered
-    expect(screen.getByRole('heading', { name: 'HTTP' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Connection' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Authentication' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Advanced HTTP settings' })).toBeInTheDocument();
 
     // Check ElasticDetails are rendered
     expect(screen.getByText('Elasticsearch details')).toBeInTheDocument();

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -33,8 +33,6 @@ export const ConfigEditor = (props: Props) => {
     }
   }, [onOptionsChange, options]);
 
-  config.sigV4AuthEnabled = true;
-
   const authProps = convertLegacyAuthProps({
     config: options,
     onChange: onOptionsChange,

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import { css } from '@emotion/css';
+import React, { useEffect } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
@@ -10,7 +11,7 @@ import {
   convertLegacyAuthProps,
   DataSourceDescription,
 } from '@grafana/experimental';
-import { Alert, DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
+import { Alert, SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 import { config } from 'app/core/config';
 
@@ -47,11 +48,6 @@ export const ConfigEditor = (props: Props) => {
         component: <SIGV4ConnectionConfig {...props} />,
       },
     ];
-    authProps.onAuthMethodSelect = (method) => {
-      authProps.onAuthMethodSelect(method);
-      options.jsonData.sigV4Auth = method === 'custom-sigv4';
-      onOptionsChange(options);
-    };
     authProps.selectedMethod = options.jsonData.sigV4Auth ? 'custom-sigv4' : authProps.selectedMethod;
   }
 
@@ -70,7 +66,15 @@ export const ConfigEditor = (props: Props) => {
       <Divider />
       <ConnectionSettings config={options} onChange={onOptionsChange} />
       <Divider />
-      <Auth {...authProps} />
+      <div className={options.jsonData.sigV4Auth ? styles.sigV4authContainer : ''}>
+        <Auth
+          {...authProps}
+          onAuthMethodSelect={(method) => {
+            options.jsonData.sigV4Auth = method === 'custom-sigv4';
+            authProps.onAuthMethodSelect(method);
+          }}
+        />
+      </div>
       <Divider />
       <ConfigSection
         title="Additional settings"
@@ -110,4 +114,12 @@ export const ConfigEditor = (props: Props) => {
       </ConfigSection>
     </>
   );
+};
+
+const styles = {
+  sigV4authContainer: css`
+    & > div {
+      max-width: 100%;
+    }
+  `,
 };

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -64,6 +64,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   dataLinks?: DataLinkConfig[];
   includeFrozen?: boolean;
   index?: string;
+  sigV4Auth?: boolean;
 }
 
 export type QueryType = 'metrics' | 'logs' | 'raw_data' | 'raw_document';

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
@@ -15,7 +15,9 @@ describe('ConfigEditor', () => {
 
   it('should render the right sections', () => {
     render(<ConfigEditor onOptionsChange={() => {}} options={createDefaultConfigOptions()} />);
-    expect(screen.getByRole('heading', { name: 'HTTP' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Connection' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Authentication' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Advanced HTTP settings' })).toBeInTheDocument();
     expect(screen.getByText('Maximum lines')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Derived fields' })).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -10,7 +10,7 @@ import {
   AdvancedHttpSettings,
 } from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
+import { SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 
 import { LokiOptions } from '../types';

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,9 +1,16 @@
 import React, { useCallback } from 'react';
 
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
+import {
+  ConfigSection,
+  DataSourceDescription,
+  ConnectionSettings,
+  Auth,
+  convertLegacyAuthProps,
+  AdvancedHttpSettings,
+} from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 
 import { LokiOptions } from '../types';
@@ -48,25 +55,27 @@ export const ConfigEditor = (props: Props) => {
         docsLink="https://grafana.com/docs/grafana/latest/datasources/loki"
         hasRequiredFields={false}
       />
-
       <Divider />
-
-      <DataSourceHttpSettings
-        defaultUrl={'http://localhost:3100'}
-        dataSourceConfig={options}
-        showAccessOptions={false}
-        onChange={onOptionsChange}
-        secureSocksDSProxyEnabled={config.secureSocksDSProxyEnabled}
+      <ConnectionSettings config={options} onChange={onOptionsChange} />
+      <Divider />
+      <Auth
+        {...convertLegacyAuthProps({
+          config: options,
+          onChange: onOptionsChange,
+        })}
       />
-
       <Divider />
-
       <ConfigSection
         title="Additional settings"
         description="Additional settings are optional settings that can be configured for more control over your data source."
         isCollapsible={true}
         isInitiallyOpen
       >
+        <AdvancedHttpSettings config={options} onChange={onOptionsChange} />
+        <Divider hideLine />
+        {config.secureSocksDSProxyEnabled && (
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+        )}
         <AlertingSettings options={options} onOptionsChange={onOptionsChange} />
         <Divider hideLine />
         <QuerySettings


### PR DESCRIPTION
This PR migrates the upper part of the data sources configuration pages, to be split among the Connection, Auth, and Advanced settings.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65294
Part of https://github.com/grafana/grafana/issues/67383

**Special notes for your reviewer:**

Loki:

![imagen](https://github.com/grafana/grafana/assets/1069378/9a13548b-40a9-4dad-8cab-e300e906e187)

Elasticsearch with SigV4 demo:

![imagen](https://github.com/grafana/grafana/assets/1069378/779e2ce2-3fab-43e7-a278-ba2fc67face2)

We need to double check that options are persisted in the same way as before the migration.