### PR TITLE
RBAC: hide the empty basic role from the org role picker

### DIFF
--- a/public/app/features/admin/OrgRolePicker.tsx
+++ b/public/app/features/admin/OrgRolePicker.tsx
@@ -13,7 +13,8 @@ interface Props {
   width?: number | 'auto';
 }
 
-const options = Object.keys(OrgRole).map((key) => ({ label: key, value: key }));
+const basicRoles = Object.values(OrgRole).filter((r) => r !== OrgRole.None);
+const options = basicRoles.map((r) => ({ label: r, value: r }));
 
 export function OrgRolePicker({ value, onChange, 'aria-label': ariaLabel, inputId, autoFocus, ...restProps }: Props) {
   return (


### PR DESCRIPTION
**What is this feature?**

Hides `None` role from the org role picker (the OSS role picker).

Empty basic roles were introduced in https://github.com/grafana/grafana/pull/64694, but we forgot to hide them for the OSS role picker.

**Why do we need this feature?**

Empty basic roles are not ready for external use yet.