### PR TITLE
Alerting: Prevent showing View YAML button on new rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -227,15 +227,17 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
         </Button>
       ) : null}
 
-      <Button
-        variant="secondary"
-        type="button"
-        onClick={() => setShowEditYaml(true)}
-        disabled={submitState.loading}
-        size="sm"
-      >
-        {isCortexLokiOrRecordingRule(watch) ? 'Edit YAML' : 'View YAML'}
-      </Button>
+      {existing ? (
+        <Button
+          variant="secondary"
+          type="button"
+          onClick={() => setShowEditYaml(true)}
+          disabled={submitState.loading}
+          size="sm"
+        >
+          {isCortexLokiOrRecordingRule(watch) ? 'Edit YAML' : 'View YAML'}
+        </Button>
+      ) : null}
     </HorizontalGroup>
   );
 


### PR DESCRIPTION
**What is this feature?**

Prevents showing the View YAML button on new rules

**Why do we need this feature?**

Rules that are not saved don't have any configuration info to return yet.

**Who is this feature for?**

All users

<img width="1494" alt="image" src="https://github.com/grafana/grafana/assets/6271380/271558c0-38ad-40d6-9908-06189439c413">
