### PR TITLE
[v10.0.x] Alerting: Fix contact point testing with secure settings

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
-	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 type UnknownReceiverError struct {
@@ -166,22 +167,12 @@ func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Cont
 		}
 	}
 
-	// First, we encrypt the new or updated secure settings. Then, we load the existing secure settings from the database
-	// and add back any that weren't updated.
-	// We perform these steps in this order to ensure the hash of the secure settings remains stable when no secure
-	// settings were modified.
-	if err := config.EncryptConfig(func(ctx context.Context, payload []byte) ([]byte, error) {
-		return moa.Crypto.Encrypt(ctx, payload, secrets.WithoutScope())
-	}); err != nil {
+	if err := moa.Crypto.ProcessSecureSettings(ctx, org, config.AlertmanagerConfig.Receivers); err != nil {
 		return fmt.Errorf("failed to post process Alertmanager configuration: %w", err)
 	}
 
-	if err := moa.Crypto.LoadSecureSettings(ctx, org, config.AlertmanagerConfig.Receivers); err != nil {
-		return err
-	}
-
-	if err := config.AssignMissingConfigUIDs(); err != nil {
-		return fmt.Errorf("failed to post process Alertmanager configuration: %w", err)
+	if err := assignReceiverConfigsUIDs(config.AlertmanagerConfig.Receivers); err != nil {
+		return fmt.Errorf("failed to assign missing uids: %w", err)
 	}
 
 	am, err := moa.AlertmanagerFor(org)
@@ -198,6 +189,43 @@ func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Cont
 	}
 
 	return nil
+}
+
+// assignReceiverConfigsUIDs assigns missing UUIDs to receiver configs.
+func assignReceiverConfigsUIDs(c []*definitions.PostableApiReceiver) error {
+	seenUIDs := make(map[string]struct{})
+	// encrypt secure settings for storing them in DB
+	for _, r := range c {
+		switch r.Type() {
+		case definitions.GrafanaReceiverType:
+			for _, gr := range r.PostableGrafanaReceivers.GrafanaManagedReceivers {
+				if gr.UID == "" {
+					retries := 5
+					for i := 0; i < retries; i++ {
+						gen := util.GenerateShortUID()
+						_, ok := seenUIDs[gen]
+						if !ok {
+							gr.UID = gen
+							break
+						}
+					}
+					if gr.UID == "" {
+						return fmt.Errorf("all %d attempts to generate UID for receiver have failed; please retry", retries)
+					}
+				}
+				seenUIDs[gr.UID] = struct{}{}
+			}
+		default:
+		}
+	}
+	return nil
+}
+
+type provisioningStore interface {
+	GetProvenance(ctx context.Context, o models.Provisionable, org int64) (models.Provenance, error)
+	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
+	SetProvenance(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) error
+	DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error
 }
 
 func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config definitions.GettableUserConfig, org int64) (definitions.GettableUserConfig, error) {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/secrets"
@@ -32,7 +31,7 @@ var (
 
 type MultiOrgAlertmanager struct {
 	Crypto    Crypto
-	ProvStore provisioning.ProvisioningStore
+	ProvStore provisioningStore
 
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]*Alertmanager
@@ -55,7 +54,7 @@ type MultiOrgAlertmanager struct {
 }
 
 func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgStore store.OrgStore,
-	kvStore kvstore.KVStore, provStore provisioning.ProvisioningStore, decryptFn alertingNotify.GetDecryptedValueFn,
+	kvStore kvstore.KVStore, provStore provisioningStore, decryptFn alertingNotify.GetDecryptedValueFn,
 	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -285,7 +285,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 		_ = postRequest(t, u, amConfig, http.StatusAccepted) // nolint
 
 		// Get am config with UID and without secureSettings
-		resp := getRequest(t, u, http.StatusOK)
+		resp := getRequest(t, u, http.StatusOK) // nolint
 		b, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		config, err := notifier.Load(b)


### PR DESCRIPTION
Backport d31d17510976292779884a37cc5b65ada96db9fa from #72235

Conflict was on the two testing changes as they are not necessary in 10.0.x:

- [pkg/services/ngalert/api/api_provisioning_test.go](https://github.com/grafana/grafana/pull/72235/files#diff-b9cc20a0dbe734a282ee91edb9740d8b3828b840dcf515f16f55d371226e2968)
- [pkg/services/ngalert/provisioning/contactpoints_test.go](https://github.com/grafana/grafana/pull/72235/files#diff-f9ce385fc55e9d7f8183076d7f6c7aa8b23022e4ad3893ea3636e6064c4ed422)

---

Fix error when attempting to test a contact point with existing, saved secure settings.

Removes double encryption of secure settings during contact point testing and code duplication that helped cause the drift between alertmanager and test endpoint. Also adds integration tests to cover the regression.

Note: `provisioningStore` is created to prevent a cycle and the unnecessary dependency.