### PR TITLE
Prometheus: Add present_over_time syntax highlighting

### DIFF
--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -521,6 +521,12 @@ export const FUNCTIONS = [
     detail: 'last_over_time(range-vector)',
     documentation: 'The most recent point value in specified interval.',
   },
+  {
+    insertText: 'present_over_time',
+    label: 'present_over_time',
+    detail: 'present_over_time(range-vector)',
+    documentation: 'The value 1 for any series in the specified interval.',
+  },
 ];
 
 export const PROM_KEYWORDS = FUNCTIONS.map((keyword) => keyword.label);


### PR DESCRIPTION
to color "present_over_time" keyword for prometheus query

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

to color in blue the present_over_time keyword for prometheus


**Why do we need this feature?**

for completeness of the syntax and look and feel of formula builder
see prom functions doc
https://prometheus.io/docs/prometheus/latest/querying/functions/

**Who is this feature for?**

for the query builder UI

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/72299
Today "present_over_time" is not recognized by the query builder and stay in white.
This issue is happening in both grafana 9 and 10 code. 

**Special notes for your reviewer:**

ideally it should be also back ported to grafana 9 along with "last_over_time" which is also not yet in grafana 9.
Please check that:
- [X] It works as expected from a user's perspective.

