### PR TITLE
loki: logs-context: handle sorting for dataplane frames

### DIFF
--- a/public/app/plugins/datasource/loki/sortDataFrame.test.ts
+++ b/public/app/plugins/datasource/loki/sortDataFrame.test.ts
@@ -1,8 +1,8 @@
-import { DataFrame, FieldType } from '@grafana/data';
+import { DataFrame, DataFrameType, FieldType } from '@grafana/data';
 
 import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
 
-const inputFrame: DataFrame = {
+const classicFrame: DataFrame = {
   refId: 'A',
   fields: [
     {
@@ -28,27 +28,126 @@ const inputFrame: DataFrame = {
   length: 5,
 };
 
-describe('loki sortDataFrame', () => {
+const dataPlaneFrame1: DataFrame = {
+  refId: 'A',
+  meta: {
+    type: DataFrameType.LogLines,
+  },
+  fields: [
+    {
+      name: 'timestamp',
+      type: FieldType.time,
+      config: {},
+      values: [1005, 1001, 1004, 1002, 1003],
+    },
+    {
+      name: 'body',
+      type: FieldType.string,
+      config: {},
+      values: ['line5', 'line1', 'line4', 'line2', 'line3'],
+    },
+  ],
+  length: 5,
+};
+
+const dataPlaneFrame2: DataFrame = {
+  refId: 'A',
+  meta: {
+    type: DataFrameType.LogLines,
+  },
+  fields: [
+    {
+      name: 'timestamp',
+      type: FieldType.time,
+      config: {},
+      values: [1000, 1000, 1000, 1000, 1000],
+      nanos: [5, 1, 4, 2, 3],
+    },
+    {
+      name: 'body',
+      type: FieldType.string,
+      config: {},
+      values: ['line5', 'line1', 'line4', 'line2', 'line3'],
+    },
+  ],
+  length: 5,
+};
+
+describe('loki sortDataFrame classic', () => {
   it('sorts a dataframe ascending', () => {
-    const sortedFrame = sortDataFrameByTime(inputFrame, SortDirection.Ascending);
+    const sortedFrame = sortDataFrameByTime(classicFrame, SortDirection.Ascending);
     expect(sortedFrame.length).toBe(5);
     const timeValues = sortedFrame.fields[0].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
     const lineValues = sortedFrame.fields[1].values;
     const tsNsValues = sortedFrame.fields[2].values;
 
     expect(timeValues).toEqual([1001, 1002, 1003, 1003, 1005]);
+    expect(timeNanos).toEqual([0, 0, 0, 5, 0]);
     expect(lineValues).toEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
     expect(tsNsValues).toEqual([`1001000000`, `1002000000`, `1003000000`, `1003000005`, `1005000000`]);
   });
   it('sorts a dataframe descending', () => {
-    const sortedFrame = sortDataFrameByTime(inputFrame, SortDirection.Descending);
+    const sortedFrame = sortDataFrameByTime(classicFrame, SortDirection.Descending);
     expect(sortedFrame.length).toBe(5);
     const timeValues = sortedFrame.fields[0].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
     const lineValues = sortedFrame.fields[1].values;
     const tsNsValues = sortedFrame.fields[2].values;
 
     expect(timeValues).toEqual([1005, 1003, 1003, 1002, 1001]);
+    expect(timeNanos).toEqual([0, 5, 0, 0, 0]);
     expect(lineValues).toEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
     expect(tsNsValues).toEqual([`1005000000`, `1003000005`, `1003000000`, `1002000000`, `1001000000`]);
+  });
+});
+
+describe('loki sortDataFrame dataplane without timefield-nanos', () => {
+  it('sorts a dataframe ascending', () => {
+    const sortedFrame = sortDataFrameByTime(dataPlaneFrame1, SortDirection.Ascending);
+    expect(sortedFrame.length).toBe(5);
+    const timeValues = sortedFrame.fields[0].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
+    const lineValues = sortedFrame.fields[1].values;
+
+    expect(timeValues).toEqual([1001, 1002, 1003, 1004, 1005]);
+    expect(timeNanos).toBe(undefined);
+    expect(lineValues).toEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
+  });
+  it('sorts a dataframe descending', () => {
+    const sortedFrame = sortDataFrameByTime(dataPlaneFrame1, SortDirection.Descending);
+    expect(sortedFrame.length).toBe(5);
+    const timeValues = sortedFrame.fields[0].values;
+    const lineValues = sortedFrame.fields[1].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
+
+    expect(timeValues).toEqual([1005, 1004, 1003, 1002, 1001]);
+    expect(timeNanos).toBe(undefined);
+    expect(lineValues).toEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
+  });
+});
+
+describe('loki sortDataFrame dataplane with timefield-nanos', () => {
+  it('sorts a dataframe ascending', () => {
+    const sortedFrame = sortDataFrameByTime(dataPlaneFrame2, SortDirection.Ascending);
+    expect(sortedFrame.length).toBe(5);
+    const timeValues = sortedFrame.fields[0].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
+    const lineValues = sortedFrame.fields[1].values;
+
+    expect(timeValues).toEqual([1000, 1000, 1000, 1000, 1000]);
+    expect(timeNanos).toEqual([1, 2, 3, 4, 5]);
+    expect(lineValues).toEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
+  });
+  it('sorts a dataframe descending', () => {
+    const sortedFrame = sortDataFrameByTime(dataPlaneFrame2, SortDirection.Descending);
+    expect(sortedFrame.length).toBe(5);
+    const timeValues = sortedFrame.fields[0].values;
+    const timeNanos = sortedFrame.fields[0].nanos;
+    const lineValues = sortedFrame.fields[1].values;
+
+    expect(timeValues).toEqual([1000, 1000, 1000, 1000, 1000]);
+    expect(timeNanos).toEqual([5, 4, 3, 2, 1]);
+    expect(lineValues).toEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
   });
 });


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/72419)

when you open the logs-context on loki logs, the loki datasource:
1. fetches data from the database
2. sorts the data correctly (ascending or descending)

we want to do [2] with nanosecond precision, and traditionally our timestamp-fields contained numbers that were milliseconds-since-1970-jan-1, so this always needed some extra work.

the Loki dataframes contain a field named `tsNs`, which contains numbers-as-strings, which are nanoseconds-since-1970-jan-1 (needs to be stored as string because javascript cannot handle such large numbers well).

so the code uses the `tsNs` field to sort.

problem is, we added the feature toggle `lokiLogsDataplane`, that makes loki emit dataplane-compliant dataframes. those do not have the `tsNs` field.

so now, if you use the `lokiLogsDataplane` feature toggle, the code will crash at:
https://github.com/grafana/grafana/blob/722f787eaa888757da911f9bdf6ffd5228179357/public/app/plugins/datasource/loki/sortDataFrame.ts#L58-L60

but we can solve this problem.  you see, since some time the timestamp-fields were extended to properly store the nanosecond info. the way this work is that next to the usual `.value` attribute, they have an optional `.nanos` attribute, that is an array of "missing nanosecond precision" as numbers between `0` and `999999`.
so, for example:
-  in the `tsNs` approach, in the `tsNs` field:
    - `field.value[index]  = 1690533783837272321`
- in the modern approach, in the timestamp field:
    - `field.value[index]  = 1690533783837`
    - `field.nanos[index] = 272321`
basically, the `tsNs` value is "split" between `.value` and `.nanos`.

so, we can use this for the `lokiLogsDataplane` dataframes. but what about normal loki dataframes?
turns out, even those contain the `.nanos` attribute correctly. so, technically, in normal loki dataframes the nanosecond info is twice: in TsNs, and in timestamp.nanos.
this means that we can simply switch from using `tsNs` to sort to use `timestamp+nanos` to sort, in both normal loki dataframes and in dataplane loki dataframes.

this is what the PR is doing.
you can see in the unit-tests, that there is a test for normal-loki dataframe, and two tests for dataplane-loki dataframe.


how to test:
1. run loki, go to explore, open logs-context
2. verify that you see logs above and below the log-line, and that there are no errors in the javascript console.
3. enable the `lokiLogsDataplane` feature toggle, and repeat the steps [1] and [2]