### PR TITLE
grafana-data: handle reordering of field.nanos

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -8,6 +8,7 @@ import {
   guessFieldTypes,
   isDataFrame,
   isTableData,
+  reverseDataFrame,
   sortDataFrame,
   toDataFrame,
   toLegacyResponseData,
@@ -360,19 +361,45 @@ describe('sorted DataFrame', () => {
       { name: 'fist', type: FieldType.time, values: [1, 2, 3] },
       { name: 'second', type: FieldType.string, values: ['a', 'b', 'c'] },
       { name: 'third', type: FieldType.number, values: [2000, 3000, 1000] },
+      { name: 'fourth', type: FieldType.time, values: [1, 2, 3], nanos: [10, 20, 30] },
     ],
   });
   it('Should sort numbers', () => {
     const sorted = sortDataFrame(frame, 0, true);
     expect(sorted.length).toEqual(3);
     expect(sorted.fields[0].values).toEqual([3, 2, 1]);
+    expect(sorted.fields[0].nanos).toBeUndefined();
     expect(sorted.fields[1].values).toEqual(['c', 'b', 'a']);
+    expect(sorted.fields[1].nanos).toBeUndefined();
+    expect(sorted.fields[3].values).toEqual([3, 2, 1]);
+    expect(sorted.fields[3].nanos).toEqual([30, 20, 10]);
   });
 
   it('Should sort strings', () => {
     const sorted = sortDataFrame(frame, 1, true);
     expect(sorted.length).toEqual(3);
     expect(sorted.fields[0].values).toEqual([3, 2, 1]);
+    expect(sorted.fields[0].nanos).toBeUndefined();
     expect(sorted.fields[1].values).toEqual(['c', 'b', 'a']);
+    expect(sorted.fields[1].nanos).toBeUndefined();
+    expect(sorted.fields[3].values).toEqual([3, 2, 1]);
+    expect(sorted.fields[3].nanos).toEqual([30, 20, 10]);
+  });
+});
+
+describe('reverse DataFrame', () => {
+  const frame = toDataFrame({
+    fields: [
+      { name: 'fist', type: FieldType.time, values: [1, 2, 3], nanos: [10, 20, 30] },
+      { name: 'third', type: FieldType.string, values: ['a', 'b', 'c'] },
+    ],
+  });
+  it('should reverse dataframe', () => {
+    const rev = reverseDataFrame(frame);
+    expect(rev.length).toEqual(3);
+    expect(rev.fields[0].values).toEqual([3, 2, 1]);
+    expect(rev.fields[0].nanos).toEqual([30, 20, 10]);
+    expect(rev.fields[1].values).toEqual(['c', 'b', 'a']);
+    expect(rev.fields[1].nanos).toBeUndefined();
   });
 });

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -431,23 +431,19 @@ export function sortDataFrame(data: DataFrame, sortIndex?: number, reverse = fal
   return {
     ...data,
     fields: data.fields.map((f) => {
-      return {
+      const newF = {
         ...f,
         values: f.values.map((v, i) => f.values[index[i]]),
-        nanos: f.nanos?.map((n, i, nanos) => nanos[index[i]]),
       };
+
+      // only add .nanos if it exists
+      const { nanos } = f;
+      if (nanos !== undefined) {
+        newF.nanos = nanos.map((n, i) => nanos[index[i]]);
+      }
+      return newF;
     }),
   };
-}
-
-function reverseNanos(nanos?: number[]): number[] | undefined {
-  if (nanos === undefined) {
-    return undefined;
-  }
-
-  const revNanos = [...nanos];
-  revNanos.reverse();
-  return revNanos;
 }
 
 /**
@@ -460,11 +456,19 @@ export function reverseDataFrame(data: DataFrame): DataFrame {
       const values = [...f.values];
       values.reverse();
 
-      return {
+      const newF = {
         ...f,
         values,
-        nanos: reverseNanos(f.nanos),
       };
+
+      // only add .nanos if it exists
+      const { nanos } = f;
+      if (nanos !== undefined) {
+        const revNanos = [...nanos];
+        revNanos.reverse();
+        newF.nanos = revNanos;
+      }
+      return newF;
     }),
   };
 }

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -434,9 +434,20 @@ export function sortDataFrame(data: DataFrame, sortIndex?: number, reverse = fal
       return {
         ...f,
         values: f.values.map((v, i) => f.values[index[i]]),
+        nanos: f.nanos?.map((n, i, nanos) => nanos[index[i]]),
       };
     }),
   };
+}
+
+function reverseNanos(nanos?: number[]): number[] | undefined {
+  if (nanos === undefined) {
+    return undefined;
+  }
+
+  const revNanos = [...nanos];
+  revNanos.reverse();
+  return revNanos;
 }
 
 /**
@@ -448,9 +459,11 @@ export function reverseDataFrame(data: DataFrame): DataFrame {
     fields: data.fields.map((f) => {
       const values = [...f.values];
       values.reverse();
+
       return {
         ...f,
         values,
+        nanos: reverseNanos(f.nanos),
       };
     }),
   };


### PR DESCRIPTION
(partially handles https://github.com/grafana/grafana/issues/72285)

timestamp fields can have an optional `.nanos` attribute that contains nanosecond-precision-adjustments. (see https://github.com/grafana/grafana/pull/64529 )

when we reorder a dataframe field, we need to apply the reorder not just to `.values` but to `.nanos` too.

this PR does that.


(NOTE: i made sure that teh `.nanos` attribute is only added if it existed on the original field, otherwise we add `nanos: undefined` everywhere.. but this makes the diff a bit larger)