### PR TITLE
LogRow: ensure scrollIntoView is called only once with shortlinks

### DIFF
--- a/public/app/features/logs/components/LogRow.test.tsx
+++ b/public/app/features/logs/components/LogRow.test.tsx
@@ -66,6 +66,7 @@ describe('LogRow', () => {
         logRowUid: 'log-row-id',
         datasourceType: 'unknown',
       });
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
     });
 
     it('highlights row with same permalink-id', () => {
@@ -104,10 +105,17 @@ describe('LogRow', () => {
       expect(scrollIntoView).toHaveBeenCalled();
     });
 
-    it('not calls `scrollIntoView` if permalink does not match', () => {
+    it('does not call `scrollIntoView` if permalink does not match', () => {
       const scrollIntoView = jest.fn();
       setup({ permalinkedRowId: 'wrong-log-row-id', scrollIntoView });
       expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('calls `scrollIntoView` once', async () => {
+      const scrollIntoView = jest.fn();
+      setup({ permalinkedRowId: 'log-row-id', scrollIntoView });
+      await userEvent.hover(screen.getByText('test123'));
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -143,11 +143,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       return;
     }
 
-    // at this point this row is the permalinked row, so we need to scroll to it and highlight it if possible.
-    if (this.logLineRef.current && scrollIntoView) {
-      scrollIntoView(this.logLineRef.current);
-    }
     if (!this.state.highlightBackround) {
+      // at this point this row is the permalinked row, so we need to scroll to it and highlight it if possible.
+      if (this.logLineRef.current && scrollIntoView) {
+        scrollIntoView(this.logLineRef.current);
+      }
       reportInteraction('grafana_explore_logs_permalink_opened', {
         datasourceType: row.datasourceType ?? 'unknown',
         logRowUid: row.uid,


### PR DESCRIPTION
In `LogRow`, `scrollToLogRow` is being called after every component update, so it was incorrectly scrolling to the log line when, for example, the user moved the mouse over the log line, which currently causes a state change.

With this fix, `scrollIntoView` will only be called once and not with every other update.

**Special notes for your reviewer:**

Added a test case that fails in the current main but doesn't after these changes:

![imagen](https://github.com/grafana/grafana/assets/1069378/0ad51d7b-be5d-4519-bdb8-373d34cc2976)

To reproduce:
- Create a shortlink url.
- Navigate to it.
- Expected: you should be scrolled into the linked log line.
- Move the mouse over the log line or do other actions.
- You should not be scrolled to the log line again.