### PR TITLE
Updated Syntax in Alerting Docs

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -73,7 +73,7 @@ Here are some tips on how to create an effective alert management set up for you
 
 **Which type of Alerting do you want to use?**
 
-- Choose between Grafana-managed Alerting or Grafana Mimir or Loki-managed Alerting; or both.
+- Choose between Grafana-managed Alerting, Grafana Mimir or Loki-managed Alerting; or a combination of them all.
 
 **How do you want to organize your alerts and notifications?**
 


### PR DESCRIPTION
Updating syntax for the choices of alerts - as there are 3 options, rather than 'both' would suggest a combination of them all... 

Additionally, updated syntax to remove the number of 'or's

**What is this feature?**
Update of syntax in docs

**Why do we need this feature?**
Syntax for clearer understanding of options 

**Who is this feature for?**

