### PR TITLE
Prometheus: PoC add rate_interval_ms as rate range in prometheus

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -31,6 +31,7 @@ const NS_IN_MS = 1000000;
 const RATE_RANGES: CompletionItem[] = [
   { label: '$__interval', sortValue: '$__interval' },
   { label: '$__range', sortValue: '$__range' },
+  { label: '$__range', sortValue: '$__range' },
   { label: '1m', sortValue: '00:01:00' },
   { label: '5m', sortValue: '00:05:00' },
   { label: '10m', sortValue: '00:10:00' },

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -1,5 +1,5 @@
 import { escapeLabelValueInExactSelector } from '../../../language_utils';
-import { FUNCTIONS } from '../../../promql';
+import { FUNCTIONS, RATE_RANGES } from '../../../promql';
 
 import type { Situation, Label } from './situation';
 import { NeverCaseError } from './util';
@@ -57,20 +57,10 @@ async function getAllFunctionsAndMetricNamesCompletions(dataProvider: DataProvid
   return [...FUNCTION_COMPLETIONS, ...metricNames];
 }
 
-const DURATION_COMPLETIONS: Completion[] = [
-  '$__interval',
-  '$__range',
-  '$__rate_interval',
-  '1m',
-  '5m',
-  '10m',
-  '30m',
-  '1h',
-  '1d',
-].map((text) => ({
+const DURATION_COMPLETIONS: Completion[] = RATE_RANGES.map((text) => ({
   type: 'DURATION',
-  label: text,
-  insertText: text,
+  label: text.label,
+  insertText: text.label,
 }));
 
 async function getAllHistoryCompletions(dataProvider: DataProvider): Promise<Completion[]> {

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -7,6 +7,7 @@ import { CompletionItem } from '@grafana/ui';
 export const RATE_RANGES: CompletionItem[] = [
   { label: '$__interval', sortValue: '$__interval' },
   { label: '$__rate_interval', sortValue: '$__rate_interval' },
+  { label: '$__rate_interval_ms', sortValue: '$__rate_interval_ms' },
   { label: '$__range', sortValue: '$__range' },
   { label: '1m', sortValue: '00:01:00' },
   { label: '5m', sortValue: '00:05:00' },


### PR DESCRIPTION
**What is this feature?**
Taking a look at using `rate_interval_ms` in the frontend as a rate range
