### PR TITLE
Doc's: Add google support for team sync

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-team-sync.md
+++ b/docs/sources/setup-grafana/configure-security/configure-team-sync.md
@@ -31,6 +31,7 @@ This mechanism allows Grafana to remove an existing synchronized user from a tea
 - [Azure AD]({{< relref "./configure-authentication/azuread#team-sync-enterprise-only" >}})
 - [GitHub OAuth]({{< relref "./configure-authentication/github#configure-team-synchronization" >}})
 - [GitLab OAuth]({{< relref "./configure-authentication/gitlab#configure-team-synchronization" >}})
+- [Google OAuth]({{< relref "./configure-authentication/google#configure-team-sync-for-google-oauth" >}})
 - [LDAP]({{< relref "./configure-authentication/enhanced-ldap#ldap-group-synchronization-for-teams" >}})
 - [Okta]({{< relref "./configure-authentication/okta#configure-team-synchronization-enterprise-only" >}})
 - [SAML]({{< relref "./configure-authentication/saml#configure-team-sync" >}})


### PR DESCRIPTION
**What is this feature?**

This feature adds Google as a supported team sync providers list.

**Why do we need this feature?**

It was missing.

**Who is this feature for?**

Everyone who enjoys the docs.

**Which issue(s) does this PR fix?**:

- bug bash

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
