### PR TITLE
A11y: Fixed keyboard accessibility in Tooltip Component

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/Popover.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Popover.tsx
@@ -23,7 +23,7 @@ const transitionStyles: { [key: string]: object } = {
 
 export type RenderPopperArrowFn = (props: { arrowProps: PopperArrowProps; placement: string }) => JSX.Element;
 
-interface Props extends Omit<React.HTMLAttributes<HTMLElement>, 'content'> {
+interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> {
   show: boolean;
   placement?: Placement;
   content: PopoverContent;
@@ -34,18 +34,8 @@ interface Props extends Omit<React.HTMLAttributes<HTMLElement>, 'content'> {
 
 class Popover extends PureComponent<Props> {
   render() {
-    const {
-      content,
-      show,
-      placement,
-      onMouseEnter,
-      onMouseLeave,
-      className,
-      wrapperClassName,
-      renderArrow,
-      referenceElement,
-      onKeyDown,
-    } = this.props;
+    const { content, show, placement, className, wrapperClassName, renderArrow, referenceElement, ...rest } =
+      this.props;
 
     return (
       <Manager>
@@ -66,11 +56,7 @@ class Popover extends PureComponent<Props> {
                 >
                   {({ ref, style, placement, arrowProps, update }) => {
                     return (
-                      <button
-                        aria-describedby="tooltip"
-                        onMouseEnter={onMouseEnter}
-                        onMouseLeave={onMouseLeave}
-                        onKeyDown={onKeyDown}
+                      <div
                         ref={ref}
                         style={{
                           ...style,
@@ -79,6 +65,7 @@ class Popover extends PureComponent<Props> {
                         }}
                         data-placement={placement}
                         className={`${wrapperClassName}`}
+                        {...rest}
                       >
                         <div className={className}>
                           {typeof content === 'string' && content}
@@ -93,7 +80,7 @@ class Popover extends PureComponent<Props> {
                               placement,
                             })}
                         </div>
-                      </button>
+                      </div>
                     );
                   }}
                 </ReactPopper>

--- a/packages/grafana-ui/src/components/Tooltip/Popover.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Popover.tsx
@@ -23,7 +23,7 @@ const transitionStyles: { [key: string]: object } = {
 
 export type RenderPopperArrowFn = (props: { arrowProps: PopperArrowProps; placement: string }) => JSX.Element;
 
-interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> {
+interface Props extends Omit<React.HTMLAttributes<HTMLElement>, 'content'> {
   show: boolean;
   placement?: Placement;
   content: PopoverContent;
@@ -66,9 +66,8 @@ class Popover extends PureComponent<Props> {
                 >
                   {({ ref, style, placement, arrowProps, update }) => {
                     return (
-                      // TODO: fix keyboard a11y
-                      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-                      <div
+                      <button
+                        aria-describedby="tooltip"
                         onMouseEnter={onMouseEnter}
                         onMouseLeave={onMouseLeave}
                         onKeyDown={onKeyDown}
@@ -94,7 +93,7 @@ class Popover extends PureComponent<Props> {
                               placement,
                             })}
                         </div>
-                      </div>
+                      </button>
                     );
                   }}
                 </ReactPopper>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixed keyboard accessibility in Tooltip component.

**Why do we need this feature?**

To ensure the components are accessible.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70964

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
