### PR TITLE
SSE: (Instrumentation/Chore) Add datasource_type label to grafana_sse…

### DIFF
--- a/pkg/expr/metrics.go
+++ b/pkg/expr/metrics.go
@@ -23,7 +23,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Subsystem: metricsSubSystem,
 			Name:      "ds_queries_total",
 			Help:      "Number of datasource queries made via server side expression requests",
-		}, []string{"error", "dataplane"}),
+		}, []string{"error", "dataplane", "datasource_type"}),
 
 		// older (No Namespace or Subsystem)
 		expressionsQuerySummary: prometheus.NewSummaryVec(

--- a/pkg/expr/ml.go
+++ b/pkg/expr/ml.go
@@ -81,7 +81,7 @@ func (m *MLNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s *
 		}
 		logger.Debug("Data source queried", "responseType", responseType)
 		useDataplane := strings.HasPrefix("dataplane-", responseType)
-		s.metrics.dsRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane)).Inc()
+		s.metrics.dsRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane), mlPluginID).Inc()
 	}()
 
 	// Execute the command and provide callback function for sending a request via plugin API.

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -235,7 +235,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		}
 		logger.Debug("Data source queried", "responseType", responseType)
 		useDataplane := strings.HasPrefix(responseType, "dataplane-")
-		s.metrics.dsRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane)).Inc()
+		s.metrics.dsRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane), dn.datasource.Type).Inc()
 	}()
 
 	resp, err := s.dataService.QueryData(ctx, req)


### PR DESCRIPTION
**What is this feature?**

Adds "datasource_type" (a key used in other metrics it seems) to the `grafana_sse_ds_queries_total` metric.

**Why do we need this feature?**

See breakdown of datasources used with SSE.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
