### PR TITLE
[v10.0.x] Dashboard: New Datasource picker link is keyboard accessible

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
+import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { usePopper } from 'react-popper';
@@ -70,54 +71,24 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
     ...restProps
   } = props;
 
+  const styles = useStyles2((theme: GrafanaTheme2) => getStylesDropdown(theme, props));
   const [isOpen, setOpen] = useState(false);
   const [inputHasFocus, setInputHasFocus] = useState(false);
-  const [markerElement, setMarkerElement] = useState<HTMLInputElement | null>();
-  const [selectorElement, setSelectorElement] = useState<HTMLDivElement | null>();
   const [filterTerm, setFilterTerm] = useState<string>('');
-  const openDropdown = () => {
-    reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.OPEN_DROPDOWN });
-    setOpen(true);
-    markerElement?.focus();
-  };
+  const { onKeyDown, keyboardEvents } = useKeyNavigationListener();
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Used to position the popper correctly and to bring back the focus when navigating from footer to input
+  const [markerElement, setMarkerElement] = useState<HTMLInputElement | null>();
+  // Used to position the popper correctly
+  const [selectorElement, setSelectorElement] = useState<HTMLDivElement | null>();
+  // Used to move the focus to the footer when tabbing from the input
+  const [footerRef, setFooterRef] = useState<HTMLElement | null>();
   const currentDataSourceInstanceSettings = useDatasource(current);
+  const grafanaDS = useDatasource('-- Grafana --');
   const currentValue = Boolean(!current && noDefault) ? undefined : currentDataSourceInstanceSettings;
   const prefixIcon =
     filterTerm && isOpen ? <DataSourceLogoPlaceHolder /> : <DataSourceLogo dataSource={currentValue} />;
-
-  const { onKeyDown, keyboardEvents } = useKeyNavigationListener();
-
-  useEffect(() => {
-    const sub = keyboardEvents.subscribe({
-      next: (keyEvent) => {
-        switch (keyEvent?.code) {
-          case 'ArrowDown': {
-            openDropdown();
-            keyEvent.preventDefault();
-            break;
-          }
-          case 'ArrowUp':
-            openDropdown();
-            keyEvent.preventDefault();
-            break;
-          case 'Escape':
-            onClose();
-            markerElement?.focus();
-            keyEvent.preventDefault();
-        }
-      },
-    });
-    return () => sub.unsubscribe();
-  });
-  const grafanaDS = useDatasource('-- Grafana --');
-
-  const onClickAddCSV = () => {
-    if (!grafanaDS) {
-      return;
-    }
-
-    onChange(grafanaDS, [defaultFileUploadQuery]);
-  };
 
   const popper = usePopper(markerElement, selectorElement, {
     placement: 'bottom-start',
@@ -136,9 +107,9 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
   const onClose = useCallback(() => {
     setFilterTerm('');
     setOpen(false);
-  }, [setOpen]);
+    markerElement?.focus();
+  }, [setOpen, markerElement]);
 
-  const ref = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(
     {
       onClose: onClose,
@@ -150,9 +121,72 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
     },
     ref
   );
-  const { dialogProps } = useDialog({}, ref);
+  const { dialogProps } = useDialog(
+    {
+      'aria-label': 'Opened data source picker list',
+    },
+    ref
+  );
 
-  const styles = useStyles2((theme: GrafanaTheme2) => getStylesDropdown(theme, props));
+  function openDropdown() {
+    reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.OPEN_DROPDOWN });
+    setOpen(true);
+    markerElement?.focus();
+  }
+
+  function onClickAddCSV() {
+    if (!grafanaDS) {
+      return;
+    }
+
+    onChange(grafanaDS, [defaultFileUploadQuery]);
+  }
+
+  function onKeyDownInput(keyEvent: React.KeyboardEvent<HTMLInputElement>) {
+    // From the input, it navigates to the footer
+    if (keyEvent.key === 'Tab' && !keyEvent.shiftKey && isOpen) {
+      keyEvent.preventDefault();
+      footerRef?.focus();
+    }
+    // From the input, if we navigate back, it closes the dropdown
+    if (keyEvent.key === 'Tab' && keyEvent.shiftKey && isOpen) {
+      onClose();
+    }
+    onKeyDown(keyEvent);
+  }
+
+  function onNavigateOutsiteFooter(e: React.KeyboardEvent<HTMLButtonElement>) {
+    // When navigating back, the dropdown keeps open and the input element is focused.
+    if (e.shiftKey) {
+      e.preventDefault();
+      markerElement?.focus();
+      // When navigating forward, the dropdown closes and and the element next to the input element is focused.
+    } else {
+      onClose();
+    }
+  }
+
+  useEffect(() => {
+    const sub = keyboardEvents.subscribe({
+      next: (keyEvent) => {
+        switch (keyEvent?.code) {
+          case 'ArrowDown':
+            openDropdown();
+            keyEvent.preventDefault();
+            break;
+          case 'ArrowUp':
+            openDropdown();
+            keyEvent.preventDefault();
+            break;
+          case 'Escape':
+            onClose();
+            keyEvent.preventDefault();
+            break;
+        }
+      },
+    });
+    return () => sub.unsubscribe();
+  });
 
   return (
     <div className={styles.container} data-testid={selectors.components.DataSourcePicker.container}>
@@ -166,15 +200,13 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
           prefix={currentValue ? prefixIcon : undefined}
           suffix={<Icon name={isOpen ? 'search' : 'angle-down'} />}
           placeholder={hideTextValue ? '' : dataSourceLabel(currentValue) || placeholder}
-          onClick={openDropdown}
           onFocus={() => {
             setInputHasFocus(true);
           }}
           onBlur={() => {
             setInputHasFocus(false);
-            onClose();
           }}
-          onKeyDown={onKeyDown}
+          onKeyDown={onKeyDownInput}
           value={filterTerm}
           onChange={(e) => {
             openDropdown();
@@ -187,29 +219,24 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
       {isOpen ? (
         <Portal>
           <div {...underlayProps} />
-          <div
-            ref={ref}
-            {...overlayProps}
-            {...dialogProps}
-            onMouseDown={(e) => {
-              e.preventDefault(); /** Need to prevent default here to stop onMouseDown to trigger onBlur of the input element */
-            }}
-          >
+          <div ref={ref} {...overlayProps} {...dialogProps}>
             <PickerContent
-              keyboardEvents={keyboardEvents}
+              {...restProps}
+              {...popper.attributes.popper}
+              style={popper.styles.popper}
+              ref={setSelectorElement}
+              footerRef={setFooterRef}
+              current={currentValue}
               filterTerm={filterTerm}
+              keyboardEvents={keyboardEvents}
               onChange={(ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => {
                 onClose();
                 onChange(ds, defaultQueries);
               }}
               onClose={onClose}
-              current={currentValue}
-              style={popper.styles.popper}
-              ref={setSelectorElement}
               onClickAddCSV={onClickAddCSV}
-              {...restProps}
               onDismiss={onClose}
-              {...popper.attributes.popper}
+              onNavigateOutsiteFooter={onNavigateOutsiteFooter}
             />
           </div>
         </Portal>
@@ -244,10 +271,13 @@ export interface PickerContentProps extends DataSourceDropdownProps {
   filterTerm?: string;
   onClose: () => void;
   onDismiss: () => void;
+  footerRef: (element: HTMLElement | null) => void;
+  onNavigateOutsiteFooter: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
 }
 
 const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((props, ref) => {
-  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter, uploadFile } = props;
+  const { filterTerm, onChange, onClose, onClickAddCSV, current, filter } = props;
+
   const changeCallback = useCallback(
     (ds: DataSourceInstanceSettings) => {
       onChange(ds);
@@ -281,50 +311,14 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
           }
         ></DataSourceList>
       </CustomScrollbar>
-      <div className={styles.footer}>
-        <ModalsController>
-          {({ showModal, hideModal }) => (
-            <Button
-              size="sm"
-              variant="secondary"
-              fill="text"
-              onClick={() => {
-                onClose();
-                showModal(DataSourceModal, {
-                  reportedInteractionFrom: 'ds_picker',
-                  tracing: props.tracing,
-                  dashboard: props.dashboard,
-                  mixed: props.mixed,
-                  metrics: props.metrics,
-                  type: props.type,
-                  annotations: props.annotations,
-                  variables: props.variables,
-                  alerting: props.alerting,
-                  pluginId: props.pluginId,
-                  logs: props.logs,
-                  filter: props.filter,
-                  uploadFile: props.uploadFile,
-                  current: props.current,
-                  onDismiss: hideModal,
-                  onChange: (ds, defaultQueries) => {
-                    onChange(ds, defaultQueries);
-                    hideModal();
-                  },
-                });
-                reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.OPEN_ADVANCED_DS_PICKER });
-              }}
-            >
-              Open advanced data source picker
-              <Icon name="arrow-right" />
-            </Button>
-          )}
-        </ModalsController>
-        {uploadFile && config.featureToggles.editPanelCSVDragAndDrop && (
-          <Button variant="secondary" size="sm" onClick={clickAddCSVCallback}>
-            Add csv or spreadsheet
-          </Button>
-        )}
-      </div>
+      <FocusScope>
+        <Footer
+          {...props}
+          onClickAddCSV={clickAddCSVCallback}
+          onChange={changeCallback}
+          onNavigateOutsiteFooter={props.onNavigateOutsiteFooter}
+        />
+      </FocusScope>
     </div>
   );
 });
@@ -345,6 +339,87 @@ function getStylesPickerContent(theme: GrafanaTheme2) {
     dataSourceList: css`
       flex: 1;
     `,
+    footer: css`
+      flex: 0;
+      display: flex;
+      flex-direction: row-reverse;
+      justify-content: space-between;
+      padding: ${theme.spacing(1.5)};
+      border-top: 1px solid ${theme.colors.border.weak};
+      background-color: ${theme.colors.background.secondary};
+    `,
+  };
+}
+
+export interface FooterProps extends PickerContentProps {}
+
+function Footer({ onClose, onChange, onClickAddCSV, ...props }: FooterProps) {
+  const styles = useStyles2(getStylesFooter);
+  const isUploadFileEnabled = props.uploadFile && config.featureToggles.editPanelCSVDragAndDrop;
+
+  const onKeyDownLastButton = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Tab') {
+      props.onNavigateOutsiteFooter(e);
+    }
+  };
+  const onKeyDownFirstButton = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Tab' && e.shiftKey) {
+      props.onNavigateOutsiteFooter(e);
+    }
+  };
+
+  return (
+    <div className={styles.footer}>
+      <ModalsController>
+        {({ showModal, hideModal }) => (
+          <Button
+            size="sm"
+            variant="secondary"
+            fill="text"
+            onClick={() => {
+              onClose();
+              showModal(DataSourceModal, {
+                reportedInteractionFrom: 'ds_picker',
+                tracing: props.tracing,
+                dashboard: props.dashboard,
+                mixed: props.mixed,
+                metrics: props.metrics,
+                type: props.type,
+                annotations: props.annotations,
+                variables: props.variables,
+                alerting: props.alerting,
+                pluginId: props.pluginId,
+                logs: props.logs,
+                filter: props.filter,
+                uploadFile: props.uploadFile,
+                current: props.current,
+                onDismiss: hideModal,
+                onChange: (ds, defaultQueries) => {
+                  onChange(ds, defaultQueries);
+                  hideModal();
+                },
+              });
+              reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.OPEN_ADVANCED_DS_PICKER });
+            }}
+            ref={props.footerRef}
+            onKeyDown={isUploadFileEnabled ? onKeyDownFirstButton : onKeyDownLastButton}
+          >
+            Open advanced data source picker
+            <Icon name="arrow-right" />
+          </Button>
+        )}
+      </ModalsController>
+      {isUploadFileEnabled && (
+        <Button variant="secondary" size="sm" onClick={onClickAddCSV} onKeyDown={onKeyDownLastButton}>
+          Add csv or spreadsheet
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function getStylesFooter(theme: GrafanaTheme2) {
+  return {
     footer: css`
       flex: 0;
       display: flex;


### PR DESCRIPTION
Backport cae68b955bfdf9997a5ce072df19ec4d30b2298c from #72134

---

**What is this feature?**

This should allow the user to tab their way from the input of the Datasource picker to the buttons underneath the list of available datasources in its dropdown.

**Why do we need this feature?**

Keyboard accessibility for the dropdown of the datasource picker.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/69109

**Special notes for your reviewer:**

<!--
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
-->