### PR TITLE
Alerting: Add more clear error to migration when rule cannot be parsed

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/dash_alert.go
+++ b/pkg/services/sqlstore/migrations/ualert/dash_alert.go
@@ -55,7 +55,8 @@ func (m *migration) slurpDashAlerts() ([]dashAlert, error) {
 	for i := range dashAlerts {
 		err = json.Unmarshal(dashAlerts[i].Settings, &dashAlerts[i].ParsedSettings)
 		if err != nil {
-			return nil, err
+			da := dashAlerts[i]
+			return nil, fmt.Errorf("failed to parse alert rule id %d, name '%s': %w", da.Id, da.Name, err)
 		}
 	}
 

--- a/pkg/services/sqlstore/migrations/ualert/dash_alert.go
+++ b/pkg/services/sqlstore/migrations/ualert/dash_alert.go
@@ -56,7 +56,7 @@ func (m *migration) slurpDashAlerts() ([]dashAlert, error) {
 		err = json.Unmarshal(dashAlerts[i].Settings, &dashAlerts[i].ParsedSettings)
 		if err != nil {
 			da := dashAlerts[i]
-			return nil, fmt.Errorf("failed to parse alert rule id %d, name '%s': %w", da.Id, da.Name, err)
+			return nil, fmt.Errorf("failed to parse alert rule ID:%d, name:'%s', orgID:%d: %w", da.Id, da.Name, da.OrgId, err)
 		}
 	}
 


### PR DESCRIPTION
Just adds some context to an error of parsing the legacy rule during migration

Fixes https://github.com/grafana/grafana/issues/65097