### PR TITLE
Loki Query Splitting: Ignore empty queries like hidden queries

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -216,7 +216,7 @@ function querySupportsSplitting(query: LokiQuery) {
 }
 
 export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
-  const queries = request.targets.filter((query) => !query.hide);
+  const queries = request.targets.filter((query) => !query.hide).filter((query) => query.expr);
   const [nonSplittingQueries, normalQueries] = partition(queries, (query) => !querySupportsSplitting(query));
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));
 


### PR DESCRIPTION
This PR fixes a situation where having an empty query in Explore will cause other queries to not execute. The fix was omitting empty queries from the groups that we pass to the query splitting code.

There's no reason to execute an empty query, and the behavior with a single empty query is to not execute, so we're following that pattern.

Added a regression test for this scenario.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/67547
Fixes https://github.com/grafana/grafana/issues/72304

**Special notes for your reviewer:**

Verify that:
- Single and multiple queries can run without issues.
- The bug is fixed.
- Results can be cleared up by running an empty query.