### PR TITLE
[v9.2.x] CI: use the base64 key in the windows installer steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2898,7 +2898,7 @@ steps:
   - publish-linux-packages-rpm
   environment:
     GCP_KEY:
-      from_secret: gcp_grafanauploads
+      from_secret: gcp_grafanauploads_base64
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
@@ -4403,6 +4403,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 08188da75c5aa81f098dd33ef464b761c886d0f7416b591747ea5b6ad2453949
+hmac: 474d45dba3a551fd41d59408c07839a33a68970e8e2eafee9d6123340e7315b9
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1150,7 +1150,7 @@ def publish_grafanacom_step(ver_mode):
         ],
         "environment": {
             "GRAFANA_COM_API_KEY": from_secret("grafana_api_key"),
-            "GCP_KEY": from_secret(gcp_grafanauploads),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
         },
         "commands": [
             cmd,


### PR DESCRIPTION
Backport 0c2b2219bb7ad4496b0dac6614b2a0f8116771e0 from #72372