### PR TITLE
[v9.3.x] CI: use the base64 key in the windows installer steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2954,7 +2954,7 @@ steps:
   - publish-linux-packages-rpm
   environment:
     GCP_KEY:
-      from_secret: gcp_grafanauploads
+      from_secret: gcp_grafanauploads_base64
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
@@ -4489,6 +4489,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 307a779804ff68b6ef47b079c4bf7f2ebe00d55f64c89f17e5a895d916772c65
+hmac: fbb21199e6dbd37d9932d516804cbead6d1f2164f456b520cdba873dea2e108d
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1150,7 +1150,7 @@ def publish_grafanacom_step(ver_mode):
         ],
         "environment": {
             "GRAFANA_COM_API_KEY": from_secret("grafana_api_key"),
-            "GCP_KEY": from_secret(gcp_grafanauploads),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
         },
         "commands": [
             cmd,


### PR DESCRIPTION
Backport 0c2b2219bb7ad4496b0dac6614b2a0f8116771e0 from #72372