### PR TITLE
[v10.0.x] CI: use the base64 key in the windows installer steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3023,7 +3023,7 @@ steps:
   - publish-linux-packages-rpm
   environment:
     GCP_KEY:
-      from_secret: gcp_grafanauploads
+      from_secret: gcp_grafanauploads_base64
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
@@ -4612,6 +4612,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: fcf3c6f58b564b3ca60bb9ba1d5c9e6dd167f2661e591f3c37c0f32a3ec9df3e
+hmac: 3667a0151d11fbabfc3d6e07a704363d852a9134e33b20b94345d044f5ddeb88
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1160,7 +1160,7 @@ def publish_grafanacom_step(ver_mode):
         ],
         "environment": {
             "GRAFANA_COM_API_KEY": from_secret("grafana_api_key"),
-            "GCP_KEY": from_secret(gcp_grafanauploads),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
         },
         "commands": [
             cmd,


### PR DESCRIPTION
Backport 0c2b2219bb7ad4496b0dac6614b2a0f8116771e0 from #72372