### PR TITLE
Chore: Upgrade Go to 1.21rc3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -74,13 +74,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-starlark .
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-starlark
 trigger:
   event:
@@ -127,13 +127,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -153,7 +153,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - yarn run ci:test-frontend
@@ -161,7 +161,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   event:
@@ -215,7 +215,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -224,7 +224,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -234,7 +234,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-frontend
 - commands:
   - |-
@@ -248,7 +248,7 @@ steps:
   - yarn run i18n:compile
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-i18n
 trigger:
   event:
@@ -302,7 +302,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -313,7 +313,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -322,7 +322,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -330,19 +330,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -350,7 +350,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   event:
@@ -399,7 +399,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -419,12 +419,12 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -433,12 +433,12 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: lint-backend
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
   failure: ignore
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: validate-modfile
 trigger:
   event:
@@ -494,7 +494,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -503,7 +503,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -511,18 +511,18 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -545,7 +545,7 @@ steps:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: trigger-test-release
   when:
     branch: main
@@ -573,7 +573,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -582,7 +582,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -593,7 +593,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -601,7 +601,7 @@ steps:
   - compile-build-cmd
   - yarn-install
   environment: null
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/build package --jobs 8 --edition oss
@@ -612,7 +612,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -625,7 +625,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -728,7 +728,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -739,7 +739,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -890,7 +890,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -903,7 +903,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -916,7 +916,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -924,13 +924,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -947,7 +947,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -964,7 +964,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql57
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-5.7-integration-tests
 - commands:
   - apt-get update
@@ -981,7 +981,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -991,7 +991,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -1001,7 +1001,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   event:
@@ -1056,7 +1056,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - |-
@@ -1068,7 +1068,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1076,7 +1076,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1091,7 +1091,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 trigger:
   event:
@@ -1131,13 +1131,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: shellcheck
 trigger:
   event:
@@ -1226,14 +1226,14 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1243,7 +1243,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1252,20 +1252,20 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - if [ -z ${GO_PACKAGES} ]; then echo 'missing GO_PACKAGES'; false; fi
   - go test -v -run=^$ -benchmem -timeout=1h -count=8 -bench=. ${GO_PACKAGES}
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: sqlite-benchmark-integration-tests
 - commands:
   - if [ -z ${GO_PACKAGES} ]; then echo 'missing GO_PACKAGES'; false; fi
@@ -1276,7 +1276,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-benchmark-integration-tests
 - commands:
   - if [ -z ${GO_PACKAGES} ]; then echo 'missing GO_PACKAGES'; false; fi
@@ -1286,7 +1286,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql57
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-5.7-benchmark-integration-tests
 - commands:
   - if [ -z ${GO_PACKAGES} ]; then echo 'missing GO_PACKAGES'; false; fi
@@ -1296,7 +1296,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-8.0-benchmark-integration-tests
 trigger:
   event:
@@ -1341,7 +1341,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - |-
@@ -1353,7 +1353,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1361,7 +1361,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1376,7 +1376,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 trigger:
   branch: main
@@ -1425,13 +1425,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -1439,7 +1439,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   branch: main
@@ -1481,7 +1481,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -1491,7 +1491,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-frontend
 - commands:
   - |-
@@ -1505,7 +1505,7 @@ steps:
   - yarn run i18n:compile
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-i18n
 trigger:
   branch: main
@@ -1549,7 +1549,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1558,7 +1558,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1566,19 +1566,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -1586,7 +1586,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   branch: main
@@ -1630,12 +1630,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -1644,12 +1644,12 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: lint-backend
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
   failure: ignore
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: validate-modfile
 - commands:
   - ./bin/build verify-drone
@@ -1705,7 +1705,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1714,7 +1714,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1722,25 +1722,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -1749,7 +1749,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -1760,7 +1760,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1770,7 +1770,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1788,7 +1788,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1801,7 +1801,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1904,7 +1904,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -1915,7 +1915,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1959,7 +1959,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: publish-frontend-metrics
   when:
     repo:
@@ -2052,7 +2052,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: release-canary-npm-packages
   when:
     paths:
@@ -2175,7 +2175,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -2188,7 +2188,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2196,13 +2196,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -2219,7 +2219,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2236,7 +2236,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql57
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-5.7-integration-tests
 - commands:
   - apt-get update
@@ -2253,7 +2253,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2263,7 +2263,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2273,7 +2273,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   branch: main
@@ -2485,13 +2485,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build whatsnew-checker
   depends_on:
   - compile-build-cmd
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: whats-new-checker
 trigger:
   event:
@@ -2541,32 +2541,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -2575,7 +2575,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -2584,7 +2584,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -2594,7 +2594,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss  --sign $${DRONE_TAG}
@@ -2612,14 +2612,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -2658,7 +2658,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2735,7 +2735,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     event:
@@ -2794,7 +2794,7 @@ steps:
       from_secret: gcp_upload_artifacts_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: store-npm-packages
 trigger:
   event:
@@ -2840,13 +2840,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -2854,7 +2854,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   event:
@@ -2896,7 +2896,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2905,7 +2905,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2913,19 +2913,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -2933,7 +2933,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   event:
@@ -3047,7 +3047,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -3143,7 +3143,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
@@ -3212,12 +3212,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - ./bin/build artifacts npm retrieve --tag ${DRONE_TAG}
@@ -3241,7 +3241,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: release-npm-packages
 trigger:
   event:
@@ -3277,7 +3277,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -3697,32 +3697,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -3731,7 +3731,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -3742,7 +3742,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -3752,7 +3752,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3770,14 +3770,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -3816,7 +3816,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3893,7 +3893,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -3977,13 +3977,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -3991,7 +3991,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   ref:
@@ -4027,7 +4027,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4036,7 +4036,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4044,19 +4044,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -4064,7 +4064,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   ref:
@@ -4148,7 +4148,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4156,13 +4156,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -4179,7 +4179,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4196,7 +4196,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql57
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-5.7-integration-tests
 - commands:
   - apt-get update
@@ -4213,7 +4213,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4223,7 +4223,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4233,7 +4233,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4381,7 +4381,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4389,13 +4389,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -4412,7 +4412,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4429,7 +4429,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql57
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-5.7-integration-tests
 - commands:
   - apt-get update
@@ -4446,7 +4446,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql80
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-8.0-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4456,7 +4456,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4466,7 +4466,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   event:
@@ -4720,11 +4720,11 @@ platform:
 steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5-go1.21rc3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.17.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.6
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.21rc3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
@@ -4742,11 +4742,11 @@ steps:
   name: scan-unknown-low-medium-vulnerabilities
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5-go1.21rc3
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.17.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.6
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.21rc3
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
@@ -4789,7 +4789,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss
@@ -4970,6 +4970,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: b3a378789d0a84f8eedd22567d2ce7609cc9c079bdd58ea8e71d0d9456c423e8
+hmac: 37a352d2ac1a7150f6b0dba10275987c2945ca06af754b98de08ffc90265450a
 
 ...

--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set go version
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: '1.21rc3'
       - name: Build swagger
         run: |
           make -C pkg/services/ngalert/api/tooling post.json api.json

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       name: Set go version
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.21rc3'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set go version
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.21rc3'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish-kinds-next.yml
+++ b/.github/workflows/publish-kinds-next.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
         with:
-          go-version: '1.20.6'
+          go-version: '1.21rc3'
 
       - name: "Verify kinds"
         run: go run .github/workflows/scripts/kinds/verify-kinds.go

--- a/.github/workflows/publish-kinds-release.yml
+++ b/.github/workflows/publish-kinds-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
         with:
-          go-version: '1.20.6'
+          go-version: '1.21rc3'
 
       - name: "Verify kinds"
         run: go run .github/workflows/scripts/kinds/verify-kinds.go

--- a/.github/workflows/verify-kinds.yml
+++ b/.github/workflows/verify-kinds.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Setup Go"
         uses: "actions/setup-go@v4"
         with:
-          go-version: '1.20.6'
+          go-version: '1.21rc3'
 
       - name: "Verify kinds"
         run: go run .github/workflows/scripts/kinds/verify-kinds.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=alpine:3.17
 ARG JS_IMAGE=node:18-alpine3.17
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.20.6-alpine3.17
+ARG GO_IMAGE=golang:1.21rc3-alpine3.17
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
-	--build-arg GO_IMAGE=golang:1.20.6 \
+	--build-arg GO_IMAGE=golang:1.21rc3 \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (LTS into 2024) in order to ensure binary compatibility with older glibc's.
 FROM debian:buster-20220822
 
-ENV GOVERSION=1.20.6 \
+ENV GOVERSION=1.21rc3 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=18.12.0-1nodesource1 \

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -4,11 +4,11 @@ This module contains all the docker images that are used to build test and publi
 
 images = {
     "cloudsdk_image": "google/cloud-sdk:431.0.0",
-    "build_image": "grafana/build-container:1.7.5",
+    "build_image": "grafana/build-container:1.7.5-go1.21rc3",
     "publish_image": "grafana/grafana-ci-deploy:1.3.3",
     "alpine_image": "alpine:3.17.1",
     "curl_image": "byrnedo/alpine-curl:0.1.8",
-    "go_image": "golang:1.20.6",
+    "go_image": "golang:1.21rc3",
     "plugins_slack_image": "plugins/slack",
     "postgres_alpine_image": "postgres:12.3-alpine",
     "mysql5_image": "mysql:5.7.39",


### PR DESCRIPTION
Updates Grafana's Go version to 1.21rc3.