### PR TITLE
[v10.0.x] Chore: Upgrade Go to 1.21rc3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -74,13 +74,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-starlark .
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-starlark
 trigger:
   event:
@@ -127,13 +127,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -153,7 +153,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - yarn run ci:test-frontend
@@ -161,7 +161,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   event:
@@ -215,7 +215,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -224,7 +224,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -235,7 +235,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-frontend
 trigger:
   event:
@@ -289,7 +289,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -300,7 +300,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -309,7 +309,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -317,19 +317,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -337,7 +337,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   event:
@@ -386,7 +386,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -406,12 +406,12 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -420,7 +420,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: lint-backend
 trigger:
   event:
@@ -476,7 +476,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -485,7 +485,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -493,18 +493,18 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -527,7 +527,7 @@ steps:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: trigger-test-release
   when:
     branch: main
@@ -555,7 +555,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -564,7 +564,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -575,7 +575,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -583,7 +583,7 @@ steps:
   - compile-build-cmd
   - yarn-install
   environment: null
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/build package --jobs 8 --edition oss
@@ -594,7 +594,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -607,7 +607,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -710,7 +710,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -721,7 +721,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -858,7 +858,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -871,7 +871,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -884,7 +884,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -892,13 +892,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -915,7 +915,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -932,7 +932,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -942,7 +942,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -952,7 +952,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   event:
@@ -1004,7 +1004,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - |-
@@ -1016,7 +1016,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1024,7 +1024,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1068,13 +1068,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: shellcheck
 trigger:
   event:
@@ -1115,7 +1115,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - |-
@@ -1127,7 +1127,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1135,7 +1135,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1188,13 +1188,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -1202,7 +1202,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   branch: main
@@ -1242,7 +1242,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -1253,7 +1253,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: lint-frontend
 trigger:
   branch: main
@@ -1295,7 +1295,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1304,7 +1304,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1312,19 +1312,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -1332,7 +1332,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   branch: main
@@ -1374,12 +1374,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -1388,7 +1388,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: lint-backend
 - commands:
   - ./bin/build verify-drone
@@ -1442,7 +1442,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1451,7 +1451,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1459,25 +1459,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -1486,7 +1486,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -1497,7 +1497,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1507,7 +1507,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1525,7 +1525,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1538,7 +1538,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1641,7 +1641,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -1652,7 +1652,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1696,7 +1696,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: publish-frontend-metrics
   when:
     repo:
@@ -1789,7 +1789,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: release-canary-npm-packages
   when:
     paths:
@@ -1896,7 +1896,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1909,7 +1909,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1917,13 +1917,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -1940,7 +1940,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1957,7 +1957,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -1967,7 +1967,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -1977,7 +1977,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   branch: main
@@ -2180,13 +2180,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build whatsnew-checker
   depends_on:
   - compile-build-cmd
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: whats-new-checker
 trigger:
   event:
@@ -2236,32 +2236,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -2270,7 +2270,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -2279,7 +2279,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -2289,7 +2289,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss  --sign $${DRONE_TAG}
@@ -2307,14 +2307,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -2353,7 +2353,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2430,7 +2430,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     event:
@@ -2489,7 +2489,7 @@ steps:
       from_secret: gcp_upload_artifacts_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: store-npm-packages
 trigger:
   event:
@@ -2535,13 +2535,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -2549,7 +2549,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   event:
@@ -2591,7 +2591,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2600,7 +2600,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2608,19 +2608,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -2628,7 +2628,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   event:
@@ -2742,7 +2742,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -2838,7 +2838,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
@@ -2907,12 +2907,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - ./bin/build artifacts npm retrieve --tag ${DRONE_TAG}
@@ -2936,7 +2936,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: release-npm-packages
 trigger:
   event:
@@ -2972,7 +2972,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -3392,32 +3392,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -3426,7 +3426,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss--build-id ${DRONE_BUILD_NUMBER}
@@ -3437,7 +3437,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -3447,7 +3447,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3465,14 +3465,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -3511,7 +3511,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3588,7 +3588,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: build-storybook
   when:
     paths:
@@ -3669,13 +3669,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -3683,7 +3683,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-frontend
 trigger:
   ref:
@@ -3719,7 +3719,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3728,7 +3728,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3736,19 +3736,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend
 - commands:
   - go test -count=1 -covermode=atomic -timeout=5m -run '^TestIntegration' $(find
@@ -3756,7 +3756,7 @@ steps:
     | grep -o '\(.*\)/' | sort -u)
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: test-backend-integration
 trigger:
   ref:
@@ -3826,7 +3826,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3834,13 +3834,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -3857,7 +3857,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3874,7 +3874,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -3884,7 +3884,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -3894,7 +3894,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4025,7 +4025,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -4033,13 +4033,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: wire-install
 - commands:
   - apt-get update
@@ -4056,7 +4056,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4073,7 +4073,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4083,7 +4083,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4093,7 +4093,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.5
+  image: grafana/build-container:1.7.5-go1.21rc3
   name: memcached-integration-tests
 trigger:
   event:
@@ -4344,11 +4344,11 @@ platform:
 steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5-go1.21rc3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.17.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.6
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.21rc3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
@@ -4366,11 +4366,11 @@ steps:
   name: scan-unknown-low-medium-vulnerabilities
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5-go1.21rc3
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.17.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.6
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.21rc3
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
@@ -4413,7 +4413,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.6
+  image: golang:1.21rc3
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss
@@ -4612,6 +4612,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: fcf3c6f58b564b3ca60bb9ba1d5c9e6dd167f2661e591f3c37c0f32a3ec9df3e
+hmac: 6c20857c86adad9a205e5980f07d39d1a52e85888040c0140bbc74e684312564
 
 ...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.6'
+        go-version: '1.21rc3'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.6'
+        go-version: '1.21rc3'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=alpine:3.17
 ARG JS_IMAGE=node:18-alpine3.17
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.20.6-alpine3.17
+ARG GO_IMAGE=golang:1.21rc3-alpine3.17
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
-	--build-arg GO_IMAGE=golang:1.20.6 \
+	--build-arg GO_IMAGE=golang:1.21rc3 \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (LTS into 2024) in order to ensure binary compatibility with older glibc's.
 FROM debian:buster-20220822
 
-ENV GOVERSION=1.20.6 \
+ENV GOVERSION=1.21rc3 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=18.12.0-1nodesource1 \

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -4,11 +4,11 @@ This module contains all the docker images that are used to build test and publi
 
 images = {
     "cloudsdk_image": "google/cloud-sdk:431.0.0",
-    "build_image": "grafana/build-container:1.7.5",
+    "build_image": "grafana/build-container:1.7.5-go1.21rc3",
     "publish_image": "grafana/grafana-ci-deploy:1.3.3",
     "alpine_image": "alpine:3.17.1",
     "curl_image": "byrnedo/alpine-curl:0.1.8",
-    "go_image": "golang:1.20.6",
+    "go_image": "golang:1.21rc3",
     "plugins_slack_image": "plugins/slack",
     "postgres_alpine_image": "postgres:12.3-alpine",
     "mysql5_image": "mysql:5.7.39",


### PR DESCRIPTION
Updates Grafana's Go version to 1.21rc3.