### PR TITLE
[v10.0.x] AzureMonitor: revert Variable Editor region changes

### DIFF
--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -269,10 +269,14 @@ e2e.scenario({
       subscription: '$subscription',
       resourceGroup: '$resourceGroups',
     });
+    addAzureMonitorVariable('region', AzureQueryType.LocationsQuery, false, {
+      subscription: '$subscription',
+    });
     addAzureMonitorVariable('resource', AzureQueryType.ResourceNamesQuery, false, {
       subscription: '$subscription',
       resourceGroup: '$resourceGroups',
       namespace: '$namespace',
+      region: '$region',
     });
     e2e.pages.Dashboard.SubMenu.submenuItemLabels('subscription').click();
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts('grafanalabs-datasources-dev').click();
@@ -286,6 +290,8 @@ e2e.scenario({
       .parent()
       .find('input')
       .type('microsoft.storage/storageaccounts{downArrow}{enter}');
+    e2e.pages.Dashboard.SubMenu.submenuItemLabels('region').parent().find('button').click();
+    e2e.pages.Dashboard.SubMenu.submenuItemLabels('region').parent().find('input').type('uk south{downArrow}{enter}');
     e2e.pages.Dashboard.SubMenu.submenuItemLabels('resource').parent().find('button').click();
     e2e.pages.Dashboard.SubMenu.submenuItemLabels('resource')
       .parent()
@@ -300,6 +306,7 @@ e2e.scenario({
         e2eSelectors.queryEditor.resourcePicker.advanced.subscription.input().find('input').type('$subscription');
         e2eSelectors.queryEditor.resourcePicker.advanced.resourceGroup.input().find('input').type('$resourceGroups');
         e2eSelectors.queryEditor.resourcePicker.advanced.namespace.input().find('input').type('$namespaces');
+        e2eSelectors.queryEditor.resourcePicker.advanced.region.input().find('input').type('$region');
         e2eSelectors.queryEditor.resourcePicker.advanced.resource.input().find('input').type('$resource');
         e2eSelectors.queryEditor.resourcePicker.apply.button().click();
         e2eSelectors.queryEditor.metricsQueryEditor.metricName.input().find('input').type('Transactions{enter}');

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx
@@ -258,10 +258,12 @@ describe('VariableEditor:', () => {
       await waitFor(() => expect(screen.getByText('Logs')).toBeInTheDocument());
       await selectAndRerender('select query type', 'Resource Names', onChange, rerender);
       await selectAndRerender('select subscription', 'Primary Subscription', onChange, rerender);
+      await selectAndRerender('select region', 'North Europe', onChange, rerender);
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({
           queryType: AzureQueryType.ResourceNamesQuery,
           subscription: 'sub',
+          region: 'northeurope',
           refId: 'A',
         })
       );
@@ -318,6 +320,22 @@ describe('VariableEditor:', () => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({
           queryType: AzureQueryType.WorkspacesQuery,
+          subscription: 'sub',
+          refId: 'A',
+        })
+      );
+    });
+
+    it('should run the query if requesting regions', async () => {
+      const onChange = jest.fn();
+      const { rerender } = render(<VariableEditor {...defaultProps} onChange={onChange} />);
+      // wait for initial load
+      await waitFor(() => expect(screen.getByText('Logs')).toBeInTheDocument());
+      await selectAndRerender('select query type', 'Regions', onChange, rerender);
+      await selectAndRerender('select subscription', 'Primary Subscription', onChange, rerender);
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryType: AzureQueryType.LocationsQuery,
           subscription: 'sub',
           refId: 'A',
         })

--- a/public/app/plugins/datasource/azuremonitor/variables.ts
+++ b/public/app/plugins/datasource/azuremonitor/variables.ts
@@ -109,6 +109,17 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
               };
             }
             return { data: [] };
+          case AzureQueryType.LocationsQuery:
+            if (queryObj.subscription && this.hasValue(queryObj.subscription)) {
+              const locationMap = await this.datasource.azureMonitorDatasource.getLocations([queryObj.subscription]);
+              const res: Array<{ text: string; value: string }> = [];
+              locationMap.forEach((loc) => {
+                res.push({ text: loc.displayName, value: loc.name });
+              });
+              return {
+                data: res?.length ? [toDataFrame(res)] : [],
+              };
+            }
           default:
             request.targets[0] = queryObj;
             const queryResp = await lastValueFrom(this.datasource.query(request));


### PR DESCRIPTION
Backport 51b199e9866d7daae5102026b393d9022e6eed53 from #72306

---

Reverts a portion of #71886 since we still want regions for filtering in the Variable Editor.