### PR TITLE
Chore: Use Github App credentials for pr-commands.yml workflow

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -19,9 +19,15 @@ jobs:
           ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_PEM }}
       - name: Run Commands
         uses: ./actions/commands
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ steps.generate_token.outputs.token }}
           configPath: pr-commands


### PR DESCRIPTION
The [grafana-pr-automation](https://github.com/apps/grafana-pr-automation) Github App was created so the pr-commands workflow can run with the required permissions.