### PR TITLE
Prometheus: Add support for day_of_year

### DIFF
--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -239,6 +239,13 @@ export const FUNCTIONS = [
       'Returns the day of the week for each of the given times in UTC. Returned values are from 0 to 6, where 0 means Sunday etc.',
   },
   {
+    insertText: 'day_of_year',
+    label: 'day_of_year',
+    detail: 'day_of_year(v=vector(time()) instant-vector)',
+    documentation:
+      'Returns the day of the year for each of the given times in UTC. Returned values are from 1 to 365 for non-leap years, and 1 to 366 in leap years.',
+  },
+  {
     insertText: 'days_in_month',
     label: 'days_in_month',
     detail: 'days_in_month(v=vector(time()) instant-vector)',

--- a/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
@@ -165,6 +165,10 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       category: PromVisualQueryOperationCategory.Time,
     }),
     createFunction({
+      id: PromOperationId.DayOfYear,
+      category: PromVisualQueryOperationCategory.Time,
+    }),
+    createFunction({
       id: PromOperationId.DaysInMonth,
       category: PromVisualQueryOperationCategory.Time,
     }),

--- a/public/app/plugins/datasource/prometheus/querybuilder/types.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/types.ts
@@ -53,6 +53,7 @@ export enum PromOperationId {
   CountValues = 'count_values',
   DayOfMonth = 'day_of_month',
   DayOfWeek = 'day_of_week',
+  DayOfYear = 'day_of_year',
   DaysInMonth = 'days_in_month',
   Deg = 'deg',
   Delta = 'delta',


### PR DESCRIPTION
**What is this feature?**
Adding support for day_of_year 

**Why do we need this feature?**
Grafana should support all functionality available in Prometheus.
https://prometheus.io/docs/prometheus/latest/querying/functions/#day_of_year

**Who is this feature for?**
Folks writing Prometheus queries in Grafana

**Which issue(s) does this PR fix?**:
Fixes # https://github.com/grafana/grafana/issues/72402

<img width="1709" alt="image" src="https://github.com/grafana/grafana/assets/109082771/874f9613-89c9-4cce-af8b-36f6cdc9c565">

<img width="368" alt="image" src="https://github.com/grafana/grafana/assets/109082771/aadc3b3e-ddac-4457-831b-698ef77f8c1a">

<img width="1020" alt="image" src="https://github.com/grafana/grafana/assets/109082771/a959a065-7222-42be-a4bb-056404468ca1">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
