### PR TITLE
POC: Admission hooks implemented in an example plugin with communication from Grafana over gRPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -323,7 +323,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ecordell/optgen v0.0.6 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -616,6 +616,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -135,11 +135,11 @@ func (s *service) start(ctx context.Context) error {
 	o.RecommendedOptions.Admission.Plugins = admission.NewPlugins()
 	grafanaAdmission.RegisterDenyByName(o.RecommendedOptions.Admission.Plugins)
 	grafanaAdmission.RegisterAddDefaultFields(o.RecommendedOptions.Admission.Plugins)
-	grafanaAdmission.RegisterGrpcCalloutPluginValidate(o.RecommendedOptions.Admission.Plugins, s.pluginsClient)
+	grafanaAdmission.RegisterGrpcCalloutAdmissionInPlugin(o.RecommendedOptions.Admission.Plugins, s.pluginsClient)
 
-	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutPluginValidate}
+	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutAdmissionInPlugin}
 	o.RecommendedOptions.Admission.DisablePlugins = append([]string{}, o.RecommendedOptions.Admission.EnablePlugins...)
-	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutPluginValidate}
+	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutAdmissionInPlugin}
 
 	// Get the util to get the paths to pre-generated certs
 	certUtil := certgenerator.CertUtil{

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -3,6 +3,8 @@ package grafanaapiserver
 import (
 	"context"
 	"crypto/x509"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugincontext"
 	"net"
 	"os"
 	"path"
@@ -67,19 +69,24 @@ type service struct {
 
 	restOptionsGetter func(runtime.Codec) genericregistry.RESTOptionsGetter
 
+	pluginsClient plugins.Client
+	pCtxProvider  *plugincontext.Provider
+
 	handler   web.Handler
 	dataPath  string
 	stopCh    chan struct{}
 	stoppedCh chan error
 }
 
-func ProvideService(cfg *setting.Cfg, rr routing.RouteRegister, restOptionsGetter func(runtime.Codec) genericregistry.RESTOptionsGetter) (*service, error) {
+func ProvideService(cfg *setting.Cfg, rr routing.RouteRegister, restOptionsGetter func(runtime.Codec) genericregistry.RESTOptionsGetter, pluginsClient plugins.Client, pCtxProvider *plugincontext.Provider) (*service, error) {
 	s := &service{
 		rr:       rr,
 		dataPath: path.Join(cfg.DataPath, "k8s"),
 		stopCh:   make(chan struct{}),
 
 		restOptionsGetter: restOptionsGetter,
+		pluginsClient:     pluginsClient,
+		pCtxProvider:      pCtxProvider,
 	}
 
 	s.BasicService = services.NewBasicService(s.start, s.running, nil).WithName(modules.GrafanaAPIServer)
@@ -130,9 +137,11 @@ func (s *service) start(ctx context.Context) error {
 	o.RecommendedOptions.Admission.Plugins = admission.NewPlugins()
 	grafanaAdmission.RegisterDenyByName(o.RecommendedOptions.Admission.Plugins)
 	grafanaAdmission.RegisterAddDefaultFields(o.RecommendedOptions.Admission.Plugins)
-	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields}
+	grafanaAdmission.RegisterGrpcCalloutPluginValidate(o.RecommendedOptions.Admission.Plugins, s.pluginsClient, s.pCtxProvider)
+
+	o.RecommendedOptions.Admission.RecommendedPluginOrder = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutPluginValidate}
 	o.RecommendedOptions.Admission.DisablePlugins = append([]string{}, o.RecommendedOptions.Admission.EnablePlugins...)
-	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields}
+	o.RecommendedOptions.Admission.EnablePlugins = []string{grafanaAdmission.PluginNameDenyByName, grafanaAdmission.PluginNameAddDefaultFields, grafanaAdmission.PluginNameGrpcCalloutPluginValidate}
 
 	// Get the util to get the paths to pre-generated certs
 	certUtil := certgenerator.CertUtil{

--- a/pkg/services/k8s/apiserver/admission/grpc_callout_plugin_validate.go
+++ b/pkg/services/k8s/apiserver/admission/grpc_callout_plugin_validate.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"fmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugincontext"
+	"io"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const PluginNameGrpcCalloutPluginValidate = "GrpcCalloutPluginValidate"
+
+var (
+	_ backend.CallResourceResponseSender = &grpcCalloutPluginValidate{}
+)
+
+// Register registers a plugin
+func RegisterGrpcCalloutPluginValidate(plugins *admission.Plugins, pluginsClient plugins.Client, pCtxProvider *plugincontext.Provider) {
+	plugins.Register(PluginNameGrpcCalloutPluginValidate, func(config io.Reader) (admission.Interface, error) {
+		return NewGrpcCalloutPluginValidate(pluginsClient, pCtxProvider), nil
+	})
+}
+
+// example of admission plugin that will deny any resource with name "deny"
+type grpcCalloutPluginValidate struct {
+	pluginsClient plugins.Client
+	pCtxProvider  *plugincontext.Provider
+}
+
+var _ admission.ValidationInterface = grpcCalloutPluginValidate{}
+
+func (g grpcCalloutPluginValidate) Send(response *backend.CallResourceResponse) error {
+	fmt.Printf("Backend response is: +%v", response)
+	return nil
+}
+
+// Validate makes an admission decision based on the request attributes.  It is NOT allowed to mutate.
+func (g grpcCalloutPluginValidate) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error) {
+	// kind := a.GetKind()
+	if true { // kind.Group == "charandas.example.com" && kind.Kind == "TestObject"
+		g.pluginsClient.CallResource(ctx, &backend.CallResourceRequest{
+			Path:   "/k8s/admission/mutation",
+			Method: "GET",
+			PluginContext: backend.PluginContext{
+				OrgID:                      0,
+				PluginID:                   "charandas-callbackadmissionexample-app",
+				User:                       nil,
+				AppInstanceSettings:        nil,
+				DataSourceInstanceSettings: nil,
+			},
+		}, g)
+	}
+
+	return nil
+}
+
+// Handles returns true if this admission controller can handle the given operation
+// where operation can be one of CREATE, UPDATE, DELETE, or CONNECT
+func (grpcCalloutPluginValidate) Handles(operation admission.Operation) bool {
+	return true
+}
+
+// NewGrpcCalloutPluginValidate creates an always deny admission handler
+func NewGrpcCalloutPluginValidate(pluginsClient plugins.Client, pCtxProvider *plugincontext.Provider) admission.Interface {
+	return &grpcCalloutPluginValidate{
+		pluginsClient: pluginsClient,
+		pCtxProvider:  pCtxProvider,
+	}
+}

--- a/pkg/services/k8s/apiserver/restoptionsgetter.go
+++ b/pkg/services/k8s/apiserver/restoptionsgetter.go
@@ -51,6 +51,8 @@ func ProvideRESTOptionsGetter(cfg *setting.Cfg, features featuremgmt.FeatureTogg
 }
 
 func (f *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
+	// NOTE: since entitystorage depends on a kindsys.Core for the moment to extract info such as Name, MachineName
+	// and my test plugin resource doesn't have an equivalent, opting for filestorage
 	if resource.Resource == "grafanaresourcedefinitions" || resource.Resource == "testobjects" {
 		return f.fallback.GetRESTOptions(resource)
 	}

--- a/pkg/services/k8s/apiserver/restoptionsgetter.go
+++ b/pkg/services/k8s/apiserver/restoptionsgetter.go
@@ -51,7 +51,7 @@ func ProvideRESTOptionsGetter(cfg *setting.Cfg, features featuremgmt.FeatureTogg
 }
 
 func (f *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
-	if resource.Resource == "grafanaresourcedefinitions" {
+	if resource.Resource == "grafanaresourcedefinitions" || resource.Resource == "testobjects" {
 		return f.fallback.GetRESTOptions(resource)
 	}
 
@@ -88,6 +88,7 @@ func (f *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (gener
 		) (storage.Interface, factory.DestroyFunc, error) {
 			var dualWrite DualWriter
 			var found kindsys.Core
+
 			kinds := f.registry.All()
 			for _, k := range kinds {
 				if k.Props().Common().PluralMachineName == config.GroupResource.Resource {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Shows how a possible implementation of plugins handling their own mutation and admission logic over gRPC resource handler could look like.

While K8s admission constructs such as AdmissionRequest and AdmissionResponse are used as payloads, its important to note that since we aren't pulling most of the stock K8s code dealing with admission webhooks, instead resorting to more building-block level AdmissionPlugins, that we indeed need to look at these responses coming back over gRPC and handle updates to (or validation of) objects ourselves in the `Admit` and `Validate` functions of respective interfaces that admission plugins work with.

Corresponding plugin on my personal repo: https://github.com/charandas/charandas-callbackadmissionexample-app/blob/main/pkg/plugin/resources.go

![grafana-plugin-admission-over-grpc](https://github.com/grafana/grafana/assets/542168/e98c369c-14e7-477b-8d16-2e2870360892)

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
