### PR TITLE
Dashboard: Fixes dashboard setting Links overflow

### DIFF
--- a/public/app/features/dashboard/components/LinksSettings/LinkSettingsList.tsx
+++ b/public/app/features/dashboard/components/LinksSettings/LinkSettingsList.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { arrayUtils } from '@grafana/data';
-import { DeleteButton, HorizontalGroup, Icon, IconButton, TagList } from '@grafana/ui';
+import { DeleteButton, HorizontalGroup, Icon, IconButton, TagList, useStyles2 } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 
 import { DashboardModel, DashboardLink } from '../../state/DashboardModel';
@@ -14,6 +15,8 @@ type LinkSettingsListProps = {
 };
 
 export const LinkSettingsList = ({ dashboard, onNew, onEdit }: LinkSettingsListProps) => {
+  const styles = useStyles2(getStyles);
+
   const [links, setLinks] = useState(dashboard.links);
 
   const moveLink = (idx: number, direction: number) => {
@@ -69,8 +72,8 @@ export const LinkSettingsList = ({ dashboard, onNew, onEdit }: LinkSettingsListP
               </td>
               <td role="gridcell">
                 <HorizontalGroup>
-                  {link.title && <span>{link.title}</span>}
-                  {link.type === 'link' && <span>{link.url}</span>}
+                  {link.title && <span className={styles.titleWrapper}>{link.title}</span>}
+                  {link.type === 'link' && <span className={styles.urlWrapper}>{link.url}</span>}
                   {link.type === 'dashboards' && <TagList tags={link.tags ?? []} />}
                 </HorizontalGroup>
               </td>
@@ -100,3 +103,16 @@ export const LinkSettingsList = ({ dashboard, onNew, onEdit }: LinkSettingsListP
     </>
   );
 };
+
+const getStyles = () => ({
+  titleWrapper: css`
+    width: 20vw;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  `,
+  urlWrapper: css`
+    width: 40vw;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  `,
+});


### PR DESCRIPTION
What is this feature?
This PR fixes overflow issue seen in Links section of Dashboard setting. It has tried to control 
- text overflow in URL title
- text overflow in URL value

Which issue(s) does this PR fix?:
Fixes: https://github.com/grafana/grafana/issues/65399

Here is the ss of output after the PR.
<img width="1642" alt="Screenshot 2023-07-27 at 12 43 26" src="https://github.com/grafana/grafana/assets/34975245/417a6de9-6602-4a70-b51e-7a66864b6a2c">

