### PR TITLE
Docs update: /docs/sources/developers/http_api/user.md

### DIFF
--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -200,7 +200,7 @@ See note in the [introduction]({{< ref "#user-api" >}}) for an explanation.
 GET /api/users/lookup?loginOrEmail=user@mygraf.com HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+Authorization: Basic YWRtaW46YWRtaW4=
 ```
 
 **Example Request using the username as option**:


### PR DESCRIPTION
Dear back-end squad

In [this issue ](https://github.com/grafana/grafana/issues/72103#issuecomment-1651711145) created by a member from the Grafana community, it was reported that there seems to be a mistake in the example provided in [this doc ](https://grafana.com/docs/grafana/latest/developers/http_api/user/#get-single-user-by-usernamelogin-or-email)

![image](https://github.com/grafana/grafana/assets/45235678/16839387-11d3-4696-9292-382d1ecfba0e)

Note the highlighted texts says that the auth method should be Basic Auth., but that in the sample code you can see `Bearer` instead.
In fact, if you use the Bearer auth method, the API will return the following error:

``` json
{
    "accessErrorId": "ACE2612978684",
    "message": "You'll need additional permissions to perform this action. Permissions needed: users:read",
    "title": "Access denied"
}
```
fixes https://github.com/grafana/grafana/issues/72103


