### PR TITLE
Explore: Do not update URL when time range changes to absolute

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -45,7 +45,6 @@ export class KeybindingSrv {
       this.bind('g e', this.goToExplore);
       this.bind('g a', this.openAlerting);
       this.bind('g p', this.goToProfile);
-      this.bind('t a', this.makeAbsoluteTime);
       this.bind('esc', this.exit);
       this.bindGlobalEsc();
     }
@@ -106,10 +105,6 @@ export class KeybindingSrv {
 
   private goToExplore() {
     this.locationService.push('/explore');
-  }
-
-  private makeAbsoluteTime() {
-    appEvents.publish(new AbsoluteTimeEvent());
   }
 
   private showHelpModal() {
@@ -190,6 +185,10 @@ export class KeybindingSrv {
   }
 
   setupTimeRangeBindings(updateUrl = true) {
+    this.bind('t a', () => {
+      appEvents.publish(new AbsoluteTimeEvent({ updateUrl }));
+    });
+
     this.bind('t z', () => {
       appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
     });

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -46,8 +46,8 @@ export class TimeSrv {
       this.shiftTime(e.payload.direction, e.payload.updateUrl);
     });
 
-    appEvents.subscribe(AbsoluteTimeEvent, () => {
-      this.makeAbsoluteTime();
+    appEvents.subscribe(AbsoluteTimeEvent, (e) => {
+      this.makeAbsoluteTime(e.payload.updateUrl);
     });
 
     document.addEventListener('visibilitychange', () => {
@@ -364,14 +364,9 @@ export class TimeSrv {
     );
   }
 
-  makeAbsoluteTime() {
-    const params = locationService.getSearch();
-    if (params.get('left')) {
-      return; // explore handles this;
-    }
-
+  makeAbsoluteTime(updateUrl: boolean) {
     const { from, to } = this.timeRange();
-    this.setTime({ from, to }, true);
+    this.setTime({ from, to }, updateUrl);
   }
 
   // isRefreshOutsideThreshold function calculates the difference between last refresh and now

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -160,7 +160,11 @@ export class ShiftTimeEvent extends BusEventWithPayload<ShiftTimeEventPayload> {
   static type = 'shift-time';
 }
 
-export class AbsoluteTimeEvent extends BusEventBase {
+interface AbsoluteTimeEventPayload {
+  updateUrl: boolean;
+}
+
+export class AbsoluteTimeEvent extends BusEventWithPayload<AbsoluteTimeEventPayload> {
   static type = 'absolute-time';
 }
 


### PR DESCRIPTION
Fixes: #72435

I've changed the way the `AbsoluteTimeRangeEvent` is handled to make it consistent with other time-related keyboard shortcuts. This allows Explore to pass a flag preventing URL from updating.
