### PR TITLE
Chore: use GITHUB_TOKEN in breaking changes workflow instead of grot …

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Levitate / Detect breaking changes"]
     types: [completed]
 
+permissions:
+  pull-requests: write
+
 jobs:
   notify:
     name: Report
@@ -35,7 +38,7 @@ jobs:
               run_id: runId,
           });
           const artifact = artifacts.data.artifacts.find(a => a.name === artifactName);
-        
+
           if (!artifact) {
               throw new Error(`Could not find artifact ${ artifactName } in workflow (${ runId })`);
           }
@@ -49,11 +52,11 @@ jobs:
 
           fs.mkdirSync(artifactFolder, { recursive: true });
           fs.writeFileSync(`${ artifactFolder }/${ artifactName }.zip`, Buffer.from(download.data));
-        
+
     # Unzip artifact
     - name: Unzip artifact
       run: unzip "${ARTIFACT_FOLDER}/${ARTIFACT_NAME}.zip" -d "${ARTIFACT_FOLDER}"
-    
+
      # Parse the artifact and register fields as step output variables
       # (All fields in the JSON will be available as ${{ steps.levitate-run.outputs.<field-name> }}
     - name: Parsing levitate result
@@ -137,7 +140,7 @@ jobs:
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
-        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           await github.rest.issues.addLabels({
             issue_number: process.env.PR_NUMBER,
@@ -153,7 +156,7 @@ jobs:
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
-        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           await github.rest.issues.removeLabel({
             issue_number: process.env.PR_NUMBER,
@@ -171,7 +174,7 @@ jobs:
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
-        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           await github.rest.pulls.requestReviewers({
             pull_number: process.env.PR_NUMBER,
@@ -188,7 +191,7 @@ jobs:
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
-        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           await github.rest.pulls.removeRequestedReviewers({
             pull_number: process.env.PR_NUMBER,


### PR DESCRIPTION
Switches to the GITHUB_TOKEN for the breaking changes workflow, instead of @grafanabot personal access token.

This improves reliability by not having the workflow's rate limit shared with other applications.