### PR TITLE
feat(alerting): add config toggle for email theme

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -890,6 +890,8 @@ startTLS_policy =
 welcome_email_on_sign_up = false
 templates_pattern = emails/*.html, emails/*.txt
 content_types = text/html
+# Either "dark" or "light". Is currently only supported by the alert E-Mail.
+theme = dark
 
 #################################### Logging ##########################
 [log]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -843,6 +843,8 @@
 ;welcome_email_on_sign_up = false
 ;templates_pattern = emails/*.html, emails/*.txt
 ;content_types = text/html
+# Either "dark" or "light". Is currently only supported by the alert E-Mail.
+;theme = dark
 
 #################################### Logging ##########################
 [log]

--- a/pkg/setting/setting_smtp.go
+++ b/pkg/setting/setting_smtp.go
@@ -1,6 +1,9 @@
 package setting
 
-import "github.com/grafana/grafana/pkg/util"
+import (
+	"github.com/grafana/grafana/pkg/util"
+	"gopkg.in/ini.v1"
+)
 
 type SmtpSettings struct {
 	Enabled        bool
@@ -18,7 +21,13 @@ type SmtpSettings struct {
 	SendWelcomeEmailOnSignUp bool
 	TemplatesPatterns        []string
 	ContentTypes             []string
+	Theme                    string
 }
+
+const (
+	darkTheme  = "dark"
+	lightTheme = "light"
+)
 
 func (cfg *Cfg) readSmtpSettings() {
 	sec := cfg.Raw.Section("smtp")
@@ -38,4 +47,13 @@ func (cfg *Cfg) readSmtpSettings() {
 	cfg.Smtp.SendWelcomeEmailOnSignUp = emails.Key("welcome_email_on_sign_up").MustBool(false)
 	cfg.Smtp.TemplatesPatterns = util.SplitString(emails.Key("templates_pattern").MustString("emails/*.html, emails/*.txt"))
 	cfg.Smtp.ContentTypes = util.SplitString(emails.Key("content_types").MustString("text/html"))
+	cfg.Smtp.Theme = emailTheme(emails)
+}
+
+func emailTheme(emails *ini.Section) string {
+	emailTheme := emails.Key("theme").MustString(darkTheme)
+	if emailTheme != darkTheme && emailTheme != lightTheme {
+		return darkTheme
+	}
+	return emailTheme
 }

--- a/pkg/setting/setting_smtp_test.go
+++ b/pkg/setting/setting_smtp_test.go
@@ -1,0 +1,46 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+)
+
+func TestEmailTheme(t *testing.T) {
+	testCases := []struct {
+		name          string
+		iniContent    string
+		expectedTheme string
+	}{
+		{
+			name:          "default theme when no theme provided",
+			iniContent:    "",
+			expectedTheme: darkTheme,
+		},
+		{
+			name:          "default theme when invalid theme provided",
+			iniContent:    "[emails]\ntheme=red",
+			expectedTheme: darkTheme,
+		},
+		{
+			name:          "light theme when light theme provided",
+			iniContent:    "[emails]\ntheme=light",
+			expectedTheme: lightTheme,
+		},
+		{
+			name:          "dark theme when dark theme provided",
+			iniContent:    "[emails]\ntheme=dark",
+			expectedTheme: darkTheme,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, _ := ini.Load([]byte(tc.iniContent))
+			emailSection := cfg.Section("emails")
+			actualTheme := emailTheme(emailSection)
+			require.Equal(t, tc.expectedTheme, actualTheme)
+		})
+	}
+}


### PR DESCRIPTION
This adds the feature toggle for email themes, which can later also be extended to other emails to unify the theming.