### PR TITLE
loki: tests: better nanosecond representation

### DIFF
--- a/public/app/plugins/datasource/loki/sortDataFrame.test.ts
+++ b/public/app/plugins/datasource/loki/sortDataFrame.test.ts
@@ -10,6 +10,7 @@ const inputFrame: DataFrame = {
       type: FieldType.time,
       config: {},
       values: [1005, 1001, 1003, 1002, 1003],
+      nanos: [0, 0, 5, 0, 0],
     },
     {
       name: 'value',

--- a/public/app/plugins/datasource/loki/sortDataFrame.test.ts
+++ b/public/app/plugins/datasource/loki/sortDataFrame.test.ts
@@ -9,7 +9,7 @@ const inputFrame: DataFrame = {
       name: 'time',
       type: FieldType.time,
       config: {},
-      values: [1005, 1001, 1004, 1002, 1003],
+      values: [1005, 1001, 1003, 1002, 1003],
     },
     {
       name: 'value',
@@ -21,7 +21,7 @@ const inputFrame: DataFrame = {
       name: 'tsNs',
       type: FieldType.time,
       config: {},
-      values: [`1005000000`, `1001000000`, `1004000000`, `1002000000`, `1003000000`],
+      values: [`1005000000`, `1001000000`, `1003000005`, `1002000000`, `1003000000`],
     },
   ],
   length: 5,
@@ -35,9 +35,9 @@ describe('loki sortDataFrame', () => {
     const lineValues = sortedFrame.fields[1].values;
     const tsNsValues = sortedFrame.fields[2].values;
 
-    expect(timeValues).toEqual([1001, 1002, 1003, 1004, 1005]);
+    expect(timeValues).toEqual([1001, 1002, 1003, 1003, 1005]);
     expect(lineValues).toEqual(['line1', 'line2', 'line3', 'line4', 'line5']);
-    expect(tsNsValues).toEqual([`1001000000`, `1002000000`, `1003000000`, `1004000000`, `1005000000`]);
+    expect(tsNsValues).toEqual([`1001000000`, `1002000000`, `1003000000`, `1003000005`, `1005000000`]);
   });
   it('sorts a dataframe descending', () => {
     const sortedFrame = sortDataFrameByTime(inputFrame, SortDirection.Descending);
@@ -46,8 +46,8 @@ describe('loki sortDataFrame', () => {
     const lineValues = sortedFrame.fields[1].values;
     const tsNsValues = sortedFrame.fields[2].values;
 
-    expect(timeValues).toEqual([1005, 1004, 1003, 1002, 1001]);
+    expect(timeValues).toEqual([1005, 1003, 1003, 1002, 1001]);
     expect(lineValues).toEqual(['line5', 'line4', 'line3', 'line2', 'line1']);
-    expect(tsNsValues).toEqual([`1005000000`, `1004000000`, `1003000000`, `1002000000`, `1001000000`]);
+    expect(tsNsValues).toEqual([`1005000000`, `1003000005`, `1003000000`, `1002000000`, `1001000000`]);
   });
 });


### PR DESCRIPTION
i modified a unit test to be better for a future PR:
1. i added the `nanos` attribute. this is not used in the current version, but it is always generated by the "real" loki plugin
2. i adjusted the timestamps to have some that differ only in the nanoseconds, to really test that it sorts correctly even at only nanosecond-differences.