### PR TITLE
Fix setting oauthPassThru flag

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -82,35 +82,32 @@ export const DataSourceHttpSettings = (props: HttpSettingsProps) => {
   const theme = useTheme2();
   let urlTooltip;
 
-  useEffect(() => {
-    // Azure Authentication doesn't work correctly when Forward OAuth Identity is enabled.
-    // The Authorization header that has been set by the ApplyAzureAuth middleware gets overwritten
-    // with the Authorization header set by the OAuthTokenMiddleware.
-    const isAzureAuthEnabled =
-      (azureAuthSettings?.azureAuthSupported && azureAuthSettings.getAzureAuthEnabled(dataSourceConfig)) || false;
-    setAzureAuthEnabled(isAzureAuthEnabled);
-    if (isAzureAuthEnabled) {
-      const tmpOauthPassThru =
-        dataSourceConfig.jsonData.oauthPassThru !== undefined ? dataSourceConfig.jsonData.oauthPassThru : false;
-      onChange({
-        ...dataSourceConfig,
-        jsonData: {
-          ...dataSourceConfig.jsonData,
-          oauthPassThru: isAzureAuthEnabled ? false : tmpOauthPassThru,
-        },
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [azureAuthSettings]);
-
   const onSettingsChange = useCallback(
     (change: Partial<typeof dataSourceConfig>) => {
+      // Azure Authentication doesn't work correctly when Forward OAuth Identity is enabled.
+      // The Authorization header that has been set by the ApplyAzureAuth middleware gets overwritten
+      // with the Authorization header set by the OAuthTokenMiddleware.
+      const isAzureAuthEnabled =
+        (azureAuthSettings?.azureAuthSupported && azureAuthSettings.getAzureAuthEnabled(dataSourceConfig)) || false;
+      setAzureAuthEnabled(isAzureAuthEnabled);
+      if (isAzureAuthEnabled) {
+        const tmpOauthPassThru =
+          dataSourceConfig.jsonData.oauthPassThru !== undefined ? dataSourceConfig.jsonData.oauthPassThru : false;
+        change = {
+          ...change,
+          jsonData: {
+            ...dataSourceConfig.jsonData,
+            oauthPassThru: isAzureAuthEnabled ? false : tmpOauthPassThru,
+          },
+        };
+      }
+
       onChange({
         ...dataSourceConfig,
         ...change,
       });
     },
-    [dataSourceConfig, onChange]
+    [azureAuthSettings, dataSourceConfig, onChange]
   );
 
   switch (dataSourceConfig.access) {

--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -89,15 +89,17 @@ export const DataSourceHttpSettings = (props: HttpSettingsProps) => {
     const isAzureAuthEnabled =
       (azureAuthSettings?.azureAuthSupported && azureAuthSettings.getAzureAuthEnabled(dataSourceConfig)) || false;
     setAzureAuthEnabled(isAzureAuthEnabled);
-    const tmpOauthPassThru =
-      dataSourceConfig.jsonData.oauthPassThru !== undefined ? dataSourceConfig.jsonData.oauthPassThru : false;
-    onChange({
-      ...dataSourceConfig,
-      jsonData: {
-        ...dataSourceConfig.jsonData,
-        oauthPassThru: isAzureAuthEnabled ? false : tmpOauthPassThru,
-      },
-    });
+    if (isAzureAuthEnabled) {
+      const tmpOauthPassThru =
+        dataSourceConfig.jsonData.oauthPassThru !== undefined ? dataSourceConfig.jsonData.oauthPassThru : false;
+      onChange({
+        ...dataSourceConfig,
+        jsonData: {
+          ...dataSourceConfig.jsonData,
+          oauthPassThru: isAzureAuthEnabled ? false : tmpOauthPassThru,
+        },
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [azureAuthSettings]);
 


### PR DESCRIPTION
**What is this feature?**

UI broken after setting an alert manager data source to receive Grafana alerts. This Pr is addressing that issue by setting the `oauthPassThru` flag more robust way. 

Fixes https://github.com/grafana/grafana/issues/72469

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
