### PR TITLE
Prometheus: Add flag for sigv4 width update in auth component

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -25,6 +25,10 @@ export const ConfigEditor = (props: Props) => {
 
   const prometheusConfigOverhaulAuth = config.featureToggles.prometheusConfigOverhaulAuth;
 
+  if (prometheusConfigOverhaulAuth) {
+    // passed to the SigV4 component(aws-sdk-react) to display custom width
+    props.options.jsonData.inExperimentalAuthComponent = true;
+  }
   // use ref so this is evaluated only first time it renders and the select does not disappear suddenly.
   const showAccessOptions = useRef(props.options.access === 'direct');
 

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -27,7 +27,8 @@ export const ConfigEditor = (props: Props) => {
 
   if (prometheusConfigOverhaulAuth) {
     // passed to the SigV4 component(aws-sdk-react) to display custom width
-    props.options.jsonData.inExperimentalAuthComponent = true;
+    // @ts-ignore (REMOVE THIS ONCE THE react-aws-sdk CHANGE HAS BEEN MADE TO UPDATE THE INTERFACE)
+    props.inExperimentalAuthComponent = true;
   }
   // use ref so this is evaluated only first time it renders and the select does not disappear suddenly.
   const showAccessOptions = useRef(props.options.access === 'direct');

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -46,7 +46,6 @@ export interface PromOptions extends DataSourceJsonData {
   incrementalQueryOverlapWindow?: string;
   disableRecordingRules?: boolean;
   sigV4Auth?: boolean;
-  inExperimentalAuthComponent?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -46,6 +46,7 @@ export interface PromOptions extends DataSourceJsonData {
   incrementalQueryOverlapWindow?: string;
   disableRecordingRules?: boolean;
   sigV4Auth?: boolean;
+  inExperimentalAuthComponent?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {


### PR DESCRIPTION
**What is this feature?**
This change passes a flag to the SigV4 auth to change the width when it is inside the new experimental auth component. 

See here for pictures of the width and the change in the aws-sdk-react repository https://github.com/grafana/grafana-aws-sdk-react/pull/52

**Why do we need this feature?**
The Prometheus config has been overhauled (merged under feature toggle in v10.1.x) with the new auth component. The SigV4 component needs a flag to update the input widths to fit inside the new auth component. 

**Who is this feature for?**
Users of the Prometheus config who use the SigV4 auth.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
