### PR TITLE
information about where to put yaml files for provisioning alerting resources

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -20,7 +20,7 @@ weight: 100
 
 ## Create and manage alerting resources using file provisioning
 
-Provision your alerting resources using files from disk. When you start Grafana, the data from these files is created in your Grafana system. Grafana adds any new resources you created, updates any that you changed, and deletes old ones.
+Provision your alerting resources using files from the `alerting` folder inside your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning). When you start Grafana, the data from these files is created in your Grafana system. Grafana adds any new resources you created, updates any that you changed, and deletes old ones.
 
 Arrange your files in a directory in a way that best suits your use case. For example, you can choose a team-based layout where every team has its own file, you can have one big file for all your teams; or you can have one file per resource type.
 
@@ -47,8 +47,9 @@ Create or delete alert rules in your Grafana instance(s).
 
    If you do not delete the alert rule, it will clash with the provisioned alert rule once uploaded.
 
-Here is an example of a configuration file for creating alert rules.
+Here is an example of a configuration file for creating alert rules. You can name this file whatever you want, but it must be inside the `alerting` subfolder of your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning). 
 
+📄 `my_provisioning_dir/alerting/alert_rules.yaml`
 ```yaml
 # config file version
 apiVersion: 1
@@ -121,6 +122,8 @@ groups:
 
 Here is an example of a configuration file for deleting alert rules.
 
+
+📄 `my_provisioning_dir/alerting/delete_old_alert_rules.yaml`
 ```yaml
 # config file version
 apiVersion: 1
@@ -145,8 +148,10 @@ Create or delete contact points in your Grafana instance(s).
 
 1. Ensure that your files are in the right directory on the node running the Grafana server, so that they deploy alongside your Grafana instance(s).
 
-Here is an example of a configuration file for creating contact points.
+Here is an example of a configuration file for creating contact points. You can name this file whatever you want, but it must be inside the `alerting` subfolder of your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning).
 
+
+📄 `my_provisioning_dir/alerting/my_contact_points.yaml`
 ```yaml
 # config file version
 apiVersion: 1
@@ -504,8 +509,10 @@ Create or reset the notification policy tree in your Grafana instance(s).
 
 4. Ensure that your files are in the right directory on the node running the Grafana server, so that they deploy alongside your Grafana instance(s).
 
-Here is an example of a configuration file for creating notification policies.
+Here is an example of a configuration file for creating notification policiies. You can name this file whatever you want, but it must be inside the `alerting` subfolder of your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning).
 
+
+📄 `my_provisioning_dir/alerting/foo_notification_policies.yaml`
 ```yaml
 # config file version
 apiVersion: 1
@@ -594,8 +601,10 @@ Create or delete templates in your Grafana instance(s).
 
 2. Add the file(s) to your GitOps workflow, so that they deploy alongside your Grafana instance(s).
 
-Here is an example of a configuration file for creating templates.
+Here is an example of a configuration file for creating templates. You can name this file whatever you want, but it must be inside the `alerting` subfolder of your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning).
 
+
+📄 `my_provisioning_dir/alerting/foo_notification_policies.yaml`
 ```yaml
 # config file version
 apiVersion: 1
@@ -634,7 +643,10 @@ Create or delete mute timings in your Grafana instance(s).
 
 1. Add the file(s) to your GitOps workflow, so that they deploy alongside your Grafana instance(s).
 
-Here is an example of a configuration file for creating mute timings.
+Here is an example of a configuration file for creating mute timings. You can name this file whatever you want, but it must be inside the `alerting` subfolder of your [configured `provisioning` directory](/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md#paths.provisioning).
+
+
+📄 `my_provisioning_dir/alerting/mute_timings.yaml`
 
 ```yaml
 # config file version

--- a/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
+++ b/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
@@ -46,7 +46,7 @@ Grafana supports configuration as code through _provisioning_. The resources tha
 - [Data sources](/docs/grafana/latest/administration/provisioning/#datasources)
 - [Alert notification channels](/docs/grafana/latest/administration/provisioning/#alert-notification-channels)
 
-## Set the provisioning directory
+## <a name="paths.provisioning"></a>Set the provisioning directory
 
 Before you can start provisioning resources, Grafana needs to know where to find the _provisioning directory_. The provisioning directory contains configuration files that are applied whenever Grafana starts and continuously updated while running.
 
@@ -70,6 +70,10 @@ provisioning/
   dashboards/
     <yaml files>
   notifiers/
+    <yaml files>
+  plugins/
+    <yaml files>
+  alerting/
     <yaml files>
 ```
 


### PR DESCRIPTION
**What is this feature?**

add the information to the documentation which explains where to put yaml files to provision alerting resources

**Why do we need this feature?**

because right now the only place to learn where to put these files is the [source code `pkg/services/provisioning/provisioning.go#L273`](https://github.com/grafana/grafana/blob/d280fedb3f537581d14f6e6227c7c2aa667ea106/pkg/services/provisioning/provisioning.go#L273)

**Who is this feature for?**

People who are trying to provision alert resources


