### PR TITLE
ClientTokenRotation: Don't rotate session cookie for authproxy

### DIFF
--- a/devenv/docker/blocks/auth/nginx_proxy/Dockerfile
+++ b/devenv/docker/blocks/auth/nginx_proxy/Dockerfile
@@ -1,4 +1,0 @@
-FROM nginx:1.19.3-alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY htpasswd /etc/nginx/htpasswd

--- a/devenv/docker/blocks/auth/nginx_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/nginx_proxy/docker-compose.yaml
@@ -5,5 +5,11 @@
 # root_url = %(protocol)s://%(domain)s:10080/grafana/
 
   nginxproxy:
-    build: docker/blocks/auth/nginx_proxy
-    network_mode: host
+    image: nginx:1.24-alpine
+    volumes:
+      - "./docker/blocks/auth/nginx_proxy/nginx.conf:/etc/nginx/nginx.conf"
+      - "./docker/blocks/auth/nginx_proxy/htpasswd:/etc/nginx/htpasswd"
+    ports:
+      - "8090:8090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
@@ -25,10 +25,10 @@ http {
       # user1: grafana and user2: grafana
       ################################################################
 
-      auth_basic "Restricted Content";
-      auth_basic_user_file /etc/nginx/htpasswd;
-      # Remove the authentication header meant for NGINX
-      proxy_set_header "Authorization" "";
+      # auth_basic "Restricted Content";
+      # auth_basic_user_file /etc/nginx/htpasswd;
+      # # Remove the authentication header meant for NGINX
+      # proxy_set_header "Authorization" "";
 
       ################################################################
       # To use the auth proxy header, set the following in custom.ini:
@@ -36,9 +36,10 @@ http {
       # enabled = true
       # header_name = X-WEBAUTH-USER
       # header_property = username
+      # enable_login_token = false
       ################################################################
 
-      proxy_set_header X-WEBAUTH-USER $remote_user;
+      # proxy_set_header X-WEBAUTH-USER $remote_user;
 
       proxy_pass http://host.docker.internal:3000/;
     }

--- a/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
@@ -25,10 +25,10 @@ http {
       # user1: grafana and user2: grafana
       ################################################################
 
-      # auth_basic "Restricted Content";
-      # auth_basic_user_file /etc/nginx/htpasswd;
-      # # Remove the authentication header meant for NGINX
-      # proxy_set_header "Authorization" "";
+      auth_basic "Restricted Content";
+      auth_basic_user_file /etc/nginx/htpasswd;
+      # Remove the authentication header meant for NGINX
+      proxy_set_header "Authorization" "";
 
       ################################################################
       # To use the auth proxy header, set the following in custom.ini:
@@ -39,7 +39,7 @@ http {
       # enable_login_token = false
       ################################################################
 
-      # proxy_set_header X-WEBAUTH-USER $remote_user;
+      proxy_set_header X-WEBAUTH-USER $remote_user;
 
       proxy_pass http://host.docker.internal:3000/;
     }

--- a/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy/nginx.conf
@@ -4,14 +4,20 @@ http {
   sendfile on;
 
   proxy_redirect     off;
-  proxy_set_header   Host $host;
+  proxy_set_header   Host $host:$server_port;
   proxy_set_header   X-Real-IP $remote_addr;
   proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header   X-Forwarded-Host $server_name;
 
   server {
-    listen 10080;
+    listen 8090;
 
+    ###############################################################
+    #  Location is under the sub path /grafana/. We need to update the
+    #  config.ini file accordingly.
+    #  [server]
+    #  root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+    ###############################################################
     location /grafana/ {
       ################################################################
       # Enable these settings to test with basic auth and an auth proxy header
@@ -19,8 +25,10 @@ http {
       # user1: grafana and user2: grafana
       ################################################################
 
-      # auth_basic "Restricted Content";
-      # auth_basic_user_file /etc/nginx/htpasswd;
+      auth_basic "Restricted Content";
+      auth_basic_user_file /etc/nginx/htpasswd;
+      # Remove the authentication header meant for NGINX
+      proxy_set_header "Authorization" "";
 
       ################################################################
       # To use the auth proxy header, set the following in custom.ini:
@@ -30,9 +38,9 @@ http {
       # header_property = username
       ################################################################
 
-      # proxy_set_header X-WEBAUTH-USER $remote_user;
+      proxy_set_header X-WEBAUTH-USER $remote_user;
 
-      proxy_pass http://localhost:3000/;
+      proxy_pass http://host.docker.internal:3000/;
     }
   }
 }

--- a/devenv/docker/blocks/auth/nginx_proxy/nginx_login_only.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy/nginx_login_only.conf
@@ -10,7 +10,7 @@ http {
   proxy_set_header   X-Forwarded-Host $server_name;
 
   server {
-    listen 10080;
+    listen 8090;
 
     location /grafana/ {
       ################################################################
@@ -26,17 +26,18 @@ http {
       # enabled = true
       # header_name = X-WEBAUTH-USER
       # header_property = username
+      # enable_login_token = true
       ################################################################
 
       location /grafana/login {
         auth_basic "Restricted Content";
         auth_basic_user_file /etc/nginx/htpasswd;
         proxy_set_header X-WEBAUTH-USER $remote_user;
-        proxy_pass http://localhost:3000/login;
+        proxy_pass http://host.docker.internal:3000/login;
       }
 
       proxy_set_header Authorization "";
-      proxy_pass http://localhost:3000/;
+      proxy_pass http://host.docker.internal:3000/;
     }
   }
 }

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -240,4 +240,5 @@ export interface AuthSettings {
   GoogleSkipOrgRoleSync?: boolean;
   GenericOAuthSkipOrgRoleSync?: boolean;
   DisableSyncLock?: boolean;
+  AuthProxyEnableLoginToken?: boolean;
 }

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -18,6 +18,7 @@ type FrontendSettingsAuthDTO struct {
 	GitLabSkipOrgRoleSync       bool `json:"GitLabSkipOrgRoleSync"`
 	OktaSkipOrgRoleSync         bool `json:"OktaSkipOrgRoleSync"`
 	DisableSyncLock             bool `json:"DisableSyncLock"`
+	AuthProxyEnableLoginToken   bool `json:"AuthProxyEnableLoginToken"`
 }
 
 type FrontendSettingsBuildInfoDTO struct {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -46,9 +46,9 @@ type CurrentUser struct {
 	Language                   string             `json:"language"`
 	HelpFlags1                 user.HelpFlags1    `json:"helpFlags1"`
 	HasEditPermissionInFolders bool               `json:"hasEditPermissionInFolders"`
+	AuthenticatedBy            string             `json:"authenticatedBy"`
 	Permissions                UserPermissionsMap `json:"permissions,omitempty"`
 	Analytics                  AnalyticsSettings  `json:"analytics"`
-	AuthenticatedBy            string             `json:"authenticatedBy"`
 }
 
 type AnalyticsSettings struct {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -48,6 +48,7 @@ type CurrentUser struct {
 	HasEditPermissionInFolders bool               `json:"hasEditPermissionInFolders"`
 	Permissions                UserPermissionsMap `json:"permissions,omitempty"`
 	Analytics                  AnalyticsSettings  `json:"analytics"`
+	AuthenticatedBy            string             `json:"authenticatedBy"`
 }
 
 type AnalyticsSettings struct {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -166,6 +166,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 			GitLabSkipOrgRoleSync:       hs.Cfg.GitLabSkipOrgRoleSync,
 			OktaSkipOrgRoleSync:         hs.Cfg.OktaSkipOrgRoleSync,
 			DisableSyncLock:             hs.Cfg.DisableSyncLock,
+			AuthProxyEnableLoginToken:   hs.Cfg.AuthProxyEnableLoginToken,
 		},
 
 		BuildInfo: dtos.FrontendSettingsBuildInfoDTO{

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -105,6 +105,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 			HelpFlags1:                 c.HelpFlags1,
 			HasEditPermissionInFolders: hasEditPerm,
 			Analytics:                  hs.buildUserAnalyticsSettings(c.Req.Context(), c.SignedInUser),
+			AuthenticatedBy:            c.SignedInUser.AuthenticatedBy,
 		},
 		Settings:                            settings,
 		ThemeType:                           theme.Type,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -265,7 +265,7 @@ export class ContextSrv {
     }
 
     // skip if the user has been authenticated by authproxy
-    if (this.user.authenticatedBy === 'authproxy') {
+    if (this.user.authenticatedBy === 'authproxy' && !config.auth.AuthProxyEnableLoginToken) {
       return false;
     }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -264,7 +264,7 @@ export class ContextSrv {
       return false;
     }
 
-    // skip if the user has been authenticated by authproxy
+    // skip if the user has been authenticated by authproxy and does not have a login token
     if (this.user.authenticatedBy === 'authproxy' && !config.auth.AuthProxyEnableLoginToken) {
       return false;
     }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -34,6 +34,7 @@ export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
   permissions?: UserPermission;
   analytics: AnalyticsSettings;
   fiscalYearStartMonth: number;
+  authenticatedBy: string;
 
   constructor() {
     this.id = 0;
@@ -59,6 +60,7 @@ export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
     this.analytics = {
       identifier: '',
     };
+    this.authenticatedBy = '';
 
     if (config.bootData.user) {
       extend(this, config.bootData.user);
@@ -259,6 +261,11 @@ export class ContextSrv {
 
     // skip if we are using auth_token in url
     if (!!params.get('auth_token')) {
+      return false;
+    }
+
+    // skip if the user has been authenticated by authproxy
+    if (this.user.authenticatedBy === 'authproxy') {
       return false;
     }
 

--- a/public/app/types/config.ts
+++ b/public/app/types/config.ts
@@ -6,4 +6,5 @@ import { CurrentUserDTO } from '@grafana/data';
 export interface CurrentUserInternal extends CurrentUserDTO {
   helpFlags1: number;
   hasEditPermissionInFolders: boolean;
+  authenticatedBy: string;
 }


### PR DESCRIPTION
**What is this feature?**

Prevent client side token rotation when authproxy is used.

**Why do we need this feature?**

With:
```ini
[auth.proxy]
enable_login_token = false
```

We have the current problem:
* When we authenticate using auth_proxy we don't get a session cookie
* When the frontend is loaded: we are asking for the session cookie rotation (through a scheduled job).
  * Note: For some auth mechanisms we skip the job (render or auth_token in param) [I assume it's because these auth mechanisms don't have a session cookie?]
* When we call the rotate endpoint going through our auth proxy, we don't have session cookie, so nothing to rotate, hence we get rejected.

With:
```ini
[auth.proxy]
enable_login_token = true
```
If the login endpoint is used before any other call, then we have no problem with client side rotation.
If the proxy does not first redirect to login, then no session cookie is created and we are in the same situation as above. But this is another problem, not tied to this PR.

**How to test this feature?**

To test authproxy **with** client side token rotation:

<details>
<summary>Expand.</summary>

Place in your config ini file:

```ini
[feature_toggles]
enable = clientTokenRotation

[server]
root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/

[auth.proxy]
enabled = true
header_name = X-WEBAUTH-USER
header_property = username
auto_sign_up = true
sync_ttl = 60
headers_encoded = false
enable_login_token = true
```

Run:
```bash
make devenv sources="auth/nginx_proxy"
```

Open a web browser and navigate to http://localhost:8090/grafana/login

</details>

To test client side token rotation **is not** called when `enable_login_token` is `false`:

<details>
<summary>Expand.</summary>

Place in your config ini file:

```ini
[feature_toggles]
enable = clientTokenRotation

[server]
root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/

[auth.proxy]
enabled = true
header_name = X-WEBAUTH-USER
header_property = username
auto_sign_up = true
sync_ttl = 60
headers_encoded = false
enable_login_token = false
```

Run:
```bash
make devenv sources="auth/nginx_proxy"
```

Open a web browser and navigate to http://localhost:8090/grafana/

</details>

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/grafana-authnz-team/issues/219

**Special notes for your reviewer:**

Known edge cases:
* If Grafana has `enable_login_token` `true` but the proxy does not redirect to the login page first, client side token rotation is going to fail.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
