### PR TITLE
Chore: Update levitate workflow to not check for old grot token

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -141,11 +141,10 @@ jobs:
 
     # Add the label
     - name: Add "levitate breaking change" label
-      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
+      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
-        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -158,11 +157,10 @@ jobs:
 
     # Remove label (no more breaking changes)
     - name: Remove "levitate breaking change" label
-      if: steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
+      if: steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 && steps.levitate-run.outputs.shouldSkip != 'true'
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
-        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -177,11 +175,10 @@ jobs:
     # This is very weird, the actual request goes through (comes back with a 201), but does not assign the team.
     # Related issue: https://github.com/renovatebot/renovate/issues/1908
     - name: Add "grafana/plugins-platform-frontend" as a reviewer
-      if: steps.levitate-run.outputs.exit_code && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
+      if: steps.levitate-run.outputs.exit_code && steps.levitate-run.outputs.shouldSkip != 'true'
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
-        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -195,11 +192,10 @@ jobs:
 
     # Remove reviewers (no more breaking changes)
     - name: Remove "grafana/plugins-platform-frontend" from the list of reviewers
-      if: steps.levitate-run.outputs.exit_code == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
+      if: steps.levitate-run.outputs.exit_code == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
-        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |


### PR DESCRIPTION
Since https://github.com/grafana/grafana/pull/63164 was raised, we've changed a bunch of actions to prefer using the default `GITHUB_TOKEN` secret over the old `GH_BOT_ACCESS_TOKEN` grot user token.

