### PR TITLE
Only run workflows if they might be able to work

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -6,7 +6,22 @@ on:
       - closed
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' && secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,9 @@ on:
   schedule:
     - cron: '0 4 * * 6'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -7,7 +7,22 @@ on:
 concurrency:
   group: issue-commands-${{ github.event.issue.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.ISSUE_COMMANDS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/dashboards-issue-add-label.yml
+++ b/.github/workflows/dashboards-issue-add-label.yml
@@ -13,7 +13,22 @@ env:
 concurrency:
   group: issue-label-when-in-project-${{ github.event.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.ISSUE_COMMANDS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: log in

--- a/.github/workflows/dashboards-issue-add-label.yml
+++ b/.github/workflows/dashboards-issue-add-label.yml
@@ -2,14 +2,14 @@ name: When an issue changes and it's part of the dashboards project, add the das
 on:
   issues:
     types: [opened, closed, edited, reopened, assigned, unassigned, labeled, unlabeled]
-      
+
 env:
   GITHUB_TOKEN: ${{ secrets.ISSUE_COMMANDS_TOKEN }}
   ORGANIZATION: ${{ github.repository_owner }}
   REPO: ${{ github.event.repository.name }}
   TARGET_PROJECT: 202
   LABEL_IDs: "LA_kwDOAOaWjc8AAAABT38U-A"
-    
+
 concurrency:
   group: issue-label-when-in-project-${{ github.event.number }}
 jobs:
@@ -35,7 +35,7 @@ jobs:
                 }
               }
             }' -f org=$ORGANIZATION -f repo=$REPO > projects_data.json
-          
+
             echo 'IN_TARGET_PROJ='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.TARGET_PROJECT }}) | .project != null' projects_data.json) >> $GITHUB_ENV
             echo 'ITEM_ID='$(jq '.data.repository.issue.id' projects_data.json) >> $GITHUB_ENV
       - name: Set up label array

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -136,7 +136,7 @@ jobs:
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEVITATE_WEBHOOK_URL }}
-        HAS_SECRETS: ${{ (github.repository == "grafana/grafana" || secrets.SLACK_LEVITATE_WEBHOOK_URL != '') || '' }}
+        HAS_SECRETS: ${{ (github.repository == 'grafana/grafana' || secrets.SLACK_LEVITATE_WEBHOOK_URL != '') || '' }}
 
     # Add the label
     - name: Add "levitate breaking change" label

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -15,6 +15,10 @@ jobs:
     env:
       ARTIFACT_NAME: 'levitate' # The name of the artifact that we would like to download
       ARTIFACT_FOLDER: '${{ github.workspace }}/tmp' # The name of the folder where we will download the artifact to
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v3
@@ -119,7 +123,7 @@ jobs:
     # Posts a notification to Slack if a PR has a breaking change and it did not have a breaking change before
     - name: Post to Slack
       id: slack
-      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: slackapi/slack-github-action@v1.24.0
       with:
         payload: |
@@ -132,6 +136,7 @@ jobs:
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEVITATE_WEBHOOK_URL }}
+        HAS_SECRETS: ${{ (github.repository == "grafana/grafana" || secrets.SLACK_LEVITATE_WEBHOOK_URL != '') || '' }}
 
     # Add the label
     - name: Add "levitate breaking change" label

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -3,8 +3,30 @@ on:
   issue_comment:
     types: [created]
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.EI_APP_ID != '' &&
+                        secrets.EI_APP_PRIVATE_KEY != '' &&
+                        secrets.EI_GCOM_HOST != '' &&
+                        secrets.EI_GCOM_TOKEN != '' &&
+                        secrets.EI_EPHEMERAL_INSTANCES_REGISTRY != '' &&
+                        secrets.EI_GCP_SERVICE_ACCOUNT_KEY_BASE64 != '' &&
+                        secrets.EI_EPHEMERAL_ORG_ID != ''
+                        ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   handle-pull-request-event:
-    if: github.event.sender.type == 'User' && 
+    needs: config
+    if: needs.config.outputs.has-secrets &&
+        github.event.sender.type == 'User' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/deploy-to-hg')
     runs-on:

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -2,15 +2,15 @@ name: 'Ephemeral instances: PR comment'
 on:
   issue_comment:
     types: [created]
-jobs:      
+jobs:
   handle-pull-request-event:
     if: github.event.sender.type == 'User' && 
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/deploy-to-hg')
-    runs-on: 
+    runs-on:
       labels: ubuntu-latest-8-cores
     continue-on-error: true
-    steps:        
+    steps:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -24,13 +24,13 @@ jobs:
           private_key: ${{ secrets.EI_APP_PRIVATE_KEY }}
 
       - name: Checkout ephemeral instances repository
-        uses: actions/checkout@v3  
+        uses: actions/checkout@v3
         with:
           repository: grafana/ephemeral-grafana-instances-github-action
           token: ${{ steps.generate_token.outputs.token }}
           ref: main
           path: ephemeral
-        
+
       - name: Run action
         env:
           GITHUB_EVENT: ${{ toJson(github.event)}}

--- a/.github/workflows/ephemeral-instances-pr-opened-closed.yml
+++ b/.github/workflows/ephemeral-instances-pr-opened-closed.yml
@@ -6,7 +6,7 @@ jobs:
   handle-pull-request-event:
     runs-on: ubuntu-latest
     continue-on-error: true
-    steps:        
+    steps:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -20,13 +20,13 @@ jobs:
           private_key: ${{ secrets.EI_APP_PRIVATE_KEY }}
 
       - name: Checkout ephemeral instances repository
-        uses: actions/checkout@v3  
+        uses: actions/checkout@v3
         with:
           repository: grafana/ephemeral-grafana-instances-github-action
           token: ${{ steps.generate_token.outputs.token }}
           ref: main
           path: ephemeral
-        
+
       - name: Run action
         env:
           GITHUB_EVENT: ${{ toJson(github.event)}}

--- a/.github/workflows/ephemeral-instances-pr-opened-closed.yml
+++ b/.github/workflows/ephemeral-instances-pr-opened-closed.yml
@@ -2,8 +2,30 @@ name: 'Ephemeral instances: PR opened/closed'
 on:
   pull_request:
       types: [opened, reopened, closed]
-jobs:      
+jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.EI_APP_ID != '' &&
+                        secrets.EI_APP_PRIVATE_KEY != '' &&
+                        secrets.EI_GCOM_HOST != '' &&
+                        secrets.EI_GCOM_TOKEN != '' &&
+                        secrets.EI_EPHEMERAL_INSTANCES_REGISTRY != '' &&
+                        secrets.EI_GCP_SERVICE_ACCOUNT_KEY_BASE64 != '' &&
+                        secrets.EI_EPHEMERAL_ORG_ID != ''
+                        ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   handle-pull-request-event:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -5,21 +5,35 @@ on:
     types: [opened, closed, edited, reopened, assigned, unassigned, labeled, unlabeled]
     labels:
       - 'type/epic'
-      
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_PROJECTS_ACCESS_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_BOT_PROJECTS_ACCESS_TOKEN }}
   ORGANIZATION: ${{ github.repository_owner }}
   REPO: ${{ github.event.repository.name }}
   PARENT_PROJECT: 304
   CHILD_PROJECT_1: 78
   CHILD_PROJECT_2: 111
   CHILD_PROJECT_3: 202
-    
+
 concurrency:
   group: issue-add-to-parent-project-${{ github.event.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GH_BOT_PROJECTS_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
-    if: contains(github.event.issue.labels.*.name, 'type/epic')
+    needs: config
+    if: needs.config.outputs.has-secrets && contains(github.event.issue.labels.*.name, 'type/epic')
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue is in child or parent projects
@@ -46,7 +60,7 @@ jobs:
                 }
               }
             }' -f org=$ORGANIZATION -f repo=$REPO > projects_data.json
-            
+
             echo 'IN_PARENT_PROJ='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .project != null' projects_data.json) >> $GITHUB_ENV
             echo 'PARENT_PROJ_STATUS_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | select(.fieldValueByName != null) | .fieldValueByName.optionId' projects_data.json) >> $GITHUB_ENV
             echo 'ITEM_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .id' projects_data.json) >> $GITHUB_ENV
@@ -96,7 +110,7 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f issue=${{ github.event.issue.node_id }} --jq '.data.addProjectV2ItemById.item.id')"
- 
+
             echo 'ITEM_ID='$item_id >> $GITHUB_ENV
       - name: Set parent project status Done
         if: contains(env.CHILD_PROJ_STATUS, 'Done')
@@ -124,7 +138,7 @@ jobs:
                 projectId: $project
                 itemId: $item
                 fieldId: $status_field
-                value: { 
+                value: {
                   singleSelectOptionId: $status_value
                   }
               }) {

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -5,7 +5,22 @@ on:
     types: [labeled]
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.SLACK_WEBHOOK_URL != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   notify:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: "Download teams.yml to know which label is for which team"

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -16,7 +16,22 @@ on:
     types: [opened, closed]
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,9 @@ concurrency:
   group: pr-checks-${{ github.event.number }}
 jobs:
   main:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '**/*.go'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-codeql-analysis-javascript.yml
+++ b/.github/workflows/pr-codeql-analysis-javascript.yml
@@ -9,6 +9,9 @@ on:
       - '**/*.ts'
       - '**/*.tsx'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-codeql-analysis-python.yml
+++ b/.github/workflows/pr-codeql-analysis-python.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '**/*.py'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-commands-closed.yml
+++ b/.github/workflows/pr-commands-closed.yml
@@ -2,11 +2,13 @@ name: Run when PRs are closed
 on:
   pull_request:
     types:
-      - closed      
+      - closed
 concurrency:
   group: pr-commands-closed-${{ github.event.number }}
 jobs:
   close_job:
+    permissions:
+      pull-requests: write
     # this job will only run if the PR has been closed without being merged
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
@@ -15,4 +17,4 @@ jobs:
         echo PR #${{ github.event.number }} has been closed without being merged, removing milestone.
         gh pr edit ${{ github.event.number }} --milestone "" --repo $GITHUB_REPOSITORY
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -8,7 +8,25 @@ on:
 concurrency:
   group: pr-commands-${{ github.event.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_PR_AUTOMATION_APP_ID != '' &&
+                        secrets.GRAFANA_PR_AUTOMATION_APP_PEM != '' &&
+                        secrets.GRAFANA_MISC_STATS_API_KEY != ''
+                        ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/publish-kinds-next.yml
+++ b/.github/workflows/publish-kinds-next.yml
@@ -9,7 +9,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' &&secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-kinds-release.yml
+++ b/.github/workflows/publish-kinds-release.yml
@@ -11,7 +11,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' && secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: "github.repository == 'grafana/grafana'"
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: "github.repository == 'grafana/grafana'"
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/remove-milestone.yml
+++ b/.github/workflows/remove-milestone.yml
@@ -13,7 +13,24 @@ on:
         type: string
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' && secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,7 +12,26 @@ on:
         required: false
         default: "0"
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' &&
+                        secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '' &&
+                        secrets.GRAFANA_MISC_STATS_API_KEY != '' &&
+                        secrets.GRAFANABOT_FORUM_KEY != ''
+                        ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"


### PR DESCRIPTION
**What is this feature?**

Check for secrets in workflows that use secrets

**Why do we need this feature?**

Otherwise forks get lots of failures

**Who is this feature for?**

Contributors who aren't members of the grafana organization and thus need to use forks where github actions may run, and especially those who run those forks in organizations that are moderately concerned about security (and thus have restricted the github_token's default permissions)

**Which issue(s) does this PR fix?**:

Fixes #63163

**Special notes for your reviewer**:

This is a followup to #63164 as some workflows changed since it was written.
@armandgrillet 