### PR TITLE
Alerting: Create table and stores for alert_instance_data

### DIFF
--- a/pkg/services/ngalert/models/instance.go
+++ b/pkg/services/ngalert/models/instance.go
@@ -16,6 +16,13 @@ type AlertInstance struct {
 	LastEvalTime      time.Time
 }
 
+type AlertInstanceData struct {
+	OrgID     int64     `xorm:"org_id"`
+	RuleUID   string    `xorm:"rule_uid"`
+	Data      []byte    `xorm:"data"`
+	ExpiresAt time.Time `xorm:"expires_at"`
+}
+
 type AlertInstanceKey struct {
 	RuleOrgID  int64  `xorm:"rule_org_id"`
 	RuleUID    string `xorm:"rule_uid"`

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -16,6 +16,29 @@ type InstanceStore interface {
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error
 }
 
+// InstanceDataStore is an interface for storing the instance data for alert rules.
+// The store does assume the format of the data, other than it is a blob less
+// than 16MB.
+type InstanceDataStore interface {
+	// ListAlertInstanceData returns the instance data for all alert rules.
+	// It does not return expired instance data, as this should be deleted using
+	// DeleteExpiredAlertInstanceData.
+	ListAlertInstanceData(ctx context.Context, cmd *models.ListAlertInstancesQuery) ([]*models.AlertInstanceData, error)
+
+	// SaveAlertInstanceData saves instance data for the alert rule. The data
+	// should have an ExpiresAt time some time in the future, as expired
+	// instance data is not returned from the store. In most cases, a multiple
+	// of the evaluation interval is recommended.
+	SaveAlertInstanceData(ctx context.Context, data models.AlertInstanceData) error
+
+	// DeleteAlertInstanceData deletes the alert instance data. It returns
+	// true if the instance data was deleted, and false if it does not exist.
+	DeleteAlertInstanceData(ctx context.Context, key models.AlertRuleKey) (bool, error)
+
+	// DeleteExpiredAlertInstanceData deletes all expired instance data.
+	DeleteExpiredAlertInstanceData(ctx context.Context) (int64, error)
+}
+
 // RuleReader represents the ability to fetch alert rules.
 type RuleReader interface {
 	ListAlertRules(ctx context.Context, query *models.ListAlertRulesQuery) (models.RulesGroup, error)

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -2,9 +2,11 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -196,4 +198,72 @@ func (st DBstore) DeleteAlertInstancesByRule(ctx context.Context, key models.Ale
 		_, err := sess.Exec("DELETE FROM alert_instance WHERE rule_org_id = ? AND rule_uid = ?", key.OrgID, key.UID)
 		return err
 	})
+}
+
+func (st DBstore) ListAlertInstanceData(ctx context.Context, cmd *models.ListAlertInstancesQuery) (result []*models.AlertInstanceData, err error) {
+	err = st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		q := sess.Table("alert_instance_data").Where("expires_at > ?", time.Now())
+		if cmd.RuleOrgID > 0 {
+			q = q.And("org_id = ?", cmd.RuleOrgID)
+		}
+		if cmd.RuleUID != "" {
+			q = q.And("rule_uid = ?", cmd.RuleUID)
+		}
+		data := make([]*models.AlertInstanceData, 0)
+		if err := q.Find(&data); err != nil {
+			return err
+		}
+		result = data
+		return nil
+	})
+	return result, err
+}
+
+func (st DBstore) SaveAlertInstanceData(ctx context.Context, data models.AlertInstanceData) error {
+	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
+			"alert_instance_data",
+			[]string{"org_id", "rule_uid"},
+			[]string{"org_id", "rule_uid", "data", "expires_at"})
+		_, err := sess.SQL(upsertSQL, data.OrgID, data.RuleUID, data.Data, data.ExpiresAt).Query()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (st DBstore) DeleteAlertInstanceData(ctx context.Context, key models.AlertRuleKey) (bool, error) {
+	var (
+		res     sql.Result
+		deleted int64
+		err     error
+	)
+	if err = st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		res, err = sess.Exec("DELETE FROM alert_instance_data WHERE org_id = ? AND rule_uid = ?", key.OrgID, key.UID)
+		return err
+	}); err != nil {
+		return false, err
+	}
+	deleted, err = res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return deleted > 0, nil
+}
+
+func (st DBstore) DeleteExpiredAlertInstanceData(ctx context.Context) (int64, error) {
+	var (
+		res     sql.Result
+		deleted int64
+		err     error
+	)
+	if err = st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		res, err = sess.Exec("DELETE FROM alert_instance_data WHERE expires_at <= ?", time.Now())
+		return err
+	}); err != nil {
+		return -1, err
+	}
+	deleted, err = res.RowsAffected()
+	return deleted, err
 }

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -3,10 +3,10 @@ package store_test
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -53,6 +53,8 @@ func historicalTableMigrations(mg *migrator.Migrator) {
 	addAlertmanagerConfigHistoryMigrations(mg)
 
 	extractAlertmanagerConfigurationHistoryMigration(mg)
+
+	addAlertInstanceDataMigration(mg)
 }
 
 // addAlertDefinitionMigrations should not be modified.
@@ -189,6 +191,25 @@ func alertInstanceMigration(mg *migrator.Migrator) {
 		migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
 			Name: "current_reason", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: true,
 		}))
+}
+
+func addAlertInstanceDataMigration(mg *migrator.Migrator) {
+	alertInstanceData := migrator.Table{
+		Name: "alert_instance_data",
+		Columns: []*migrator.Column{
+			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "rule_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
+			{Name: "data", Type: migrator.DB_LongBlob, Nullable: false},
+			{Name: "expires_at", Type: migrator.DB_DateTime, Nullable: false},
+		},
+		PrimaryKeys: []string{"org_id", "rule_uid"},
+	}
+
+	mg.AddMigration("create alert_instance_data table", migrator.NewAddTableMigration(alertInstanceData))
+	mg.AddMigration("add index on expires_at column in alert_instance_data table", migrator.NewAddIndexMigration(alertInstanceData, &migrator.Index{
+		Cols: []string{"expires_at"},
+		Type: migrator.IndexType,
+	}))
 }
 
 func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64) {


### PR DESCRIPTION
**What is this feature?**

This pull request creates the table and stores for `alert_instance_data` from #72227.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
