### PR TITLE
Tempo: If no search tag then do not query API for tag values

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.test.tsx
@@ -128,7 +128,7 @@ describe('SearchField', () => {
     };
     const { container } = renderSearchField(updateFilter, filter, ['tag1', 'tag22', 'tag33']);
 
-    const select = await container.querySelector(`input[aria-label="select test1 tag"]`);
+    const select = container.querySelector(`input[aria-label="select test1 tag"]`);
     expect(select).not.toBeNull();
     expect(select).toBeInTheDocument();
     if (select) {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -60,7 +60,7 @@ const SearchField = ({
 
   const updateOptions = async () => {
     try {
-      return await languageProvider.getOptionsV2(scopedTag);
+      return filter.tag ? await languageProvider.getOptionsV2(scopedTag) : [];
     } catch (error) {
       // Display message if Tempo is connected but search 404's
       if (isFetchError(error) && error?.status === 404) {


### PR DESCRIPTION
**What is this feature?**

If there is not a tag, then there is no need to query the API to get the tag values for an undefined tag.

**Why do we need this feature?**

Prevents a superfluous API request to search/tag/span.**undefined**/values.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

<img width="1156" alt="Screenshot 2023-07-28 at 15 10 47" src="https://github.com/grafana/grafana/assets/90795735/3922fda1-8067-4cf6-b704-4a86928bad4e">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
