### PR TITLE
Tempo: Only add option to values dropdown if there is a value

### DIFF
--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -121,11 +121,15 @@ export default class TempoLanguageProvider extends LanguageProvider {
     const response = await this.request(`/api/v2/search/tag/${tag}/values`);
     let options: Array<SelectableValue<string>> = [];
     if (response && response.tagValues) {
-      options = response.tagValues.map((v: { type: string; value: string }) => ({
-        type: v.type,
-        value: v.value,
-        label: v.value,
-      }));
+      response.tagValues.forEach((v: { type: string; value?: string }) => {
+        if (v.value) {
+          options.push({
+            type: v.type,
+            value: v.value,
+            label: v.value,
+          });
+        }
+      });
     }
     return options;
   }


### PR DESCRIPTION
**What is this feature?**

Only add option to values dropdown if there is a value.

**Why do we need this feature?**

Prevents adding options to tag value dropdown if there is not a value. Otherwise it adds an empty option.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

We should also probably let someone on the Tempo squad know we can get responses returned from the API where only the type is provided and not the value which we need for the dropdown.

<img width="467" alt="Screenshot 2023-07-28 at 15 47 16" src="https://github.com/grafana/grafana/assets/90795735/bf31f83d-3050-4106-a9f5-4b73b9478a26">
<img width="989" alt="Screenshot 2023-07-28 at 15 40 36" src="https://github.com/grafana/grafana/assets/90795735/276374c0-dff2-4812-8266-96aee4cb8ca3">


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
