### PR TITLE
Chore: Rename addById to addByUID

### DIFF
--- a/public/app/features/playlist/PlaylistForm.tsx
+++ b/public/app/features/playlist/PlaylistForm.tsx
@@ -24,7 +24,7 @@ export const PlaylistForm = ({ onSubmit, playlist }: Props) => {
     return () => getGrafanaSearcher().tags({ kind: ['dashboard'] });
   }, []);
 
-  const { items, addById, addByTag, deleteItem, moveItem } = usePlaylistItems(propItems);
+  const { items, addByUID, addByTag, deleteItem, moveItem } = usePlaylistItems(propItems);
 
   const doSubmit = (list: Playlist) => {
     setSaving(true);
@@ -63,7 +63,7 @@ export const PlaylistForm = ({ onSubmit, playlist }: Props) => {
                 <h3 className="page-headering">Add dashboards</h3>
 
                 <Field label="Add by title">
-                  <DashboardPicker id="dashboard-picker" onChange={addById} key={items.length} />
+                  <DashboardPicker id="dashboard-picker" onChange={addByUID} key={items.length} />
                 </Field>
 
                 <Field label="Add by tag">

--- a/public/app/features/playlist/usePlaylistItems.tsx
+++ b/public/app/features/playlist/usePlaylistItems.tsx
@@ -19,7 +19,7 @@ export function usePlaylistItems(playlistItems?: PlaylistItem[]) {
     }
   }, [items]);
 
-  const addById = useCallback(
+  const addByUID = useCallback(
     (dashboard?: DashboardPickerDTO) => {
       if (!dashboard) {
         return;
@@ -74,5 +74,5 @@ export function usePlaylistItems(playlistItems?: PlaylistItem[]) {
     [items]
   );
 
-  return { items, addById, addByTag, deleteItem, moveItem };
+  return { items, addByUID, addByTag, deleteItem, moveItem };
 }


### PR DESCRIPTION
Just renames this function to make it extra clear that it no longer uses Dashboard ID

Part of https://github.com/grafana/grafana/issues/48850 