### PR TITLE
docs: add What's new next for Cloud

### DIFF
--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -1,0 +1,29 @@
+---
+description: Feature and improvement highlights for Grafana Cloud
+keywords:
+  - grafana
+  - new
+  - documentation
+  - cloud
+  - release notes
+labels:
+  products:
+    - cloud
+title: What's new in Grafana Cloud
+weight: -37
+---
+
+# What’s new in Grafana Cloud
+
+Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana Cloud.
+
+<!-- Template below
+## Feature
+<!-- Name of contributor commented out -->
+<!-- Availability in OSS and Enterprise (for later) commented out -->
+<!-- [Generally available | Available in private/public preview | Experimental] in Grafana [Cloud Free | Cloud Pro | Cloud Advanced | Cloud]
+Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
+{{% admonition type="note" %}}
+You must use relative references when linking to docs within the Grafana repo. Please do not use absolute URLs. For more information about relrefs, refer to [Links and references](/docs/writers-toolkit/writing-guide/references/).
+{{% /admonition %}}
+-->


### PR DESCRIPTION
This page is where engineers can add What's new items for Cloud. It will be published in Cloud, but not in Grafana in this form. Eventually a copy of this page will be made in Grafana for the next release What's new.