### PR TITLE
Chore: Turn validate-modfile failure into blocking drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -437,7 +437,6 @@ steps:
   name: lint-backend
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  failure: ignore
   image: golang:1.20.6
   name: validate-modfile
 trigger:
@@ -1648,7 +1647,6 @@ steps:
   name: lint-backend
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
-  failure: ignore
   image: golang:1.20.6
   name: validate-modfile
 - commands:
@@ -4558,6 +4556,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 4dab5540224fa874ec46cb062c8b89730b7b42bb9237ec3f4c02b469786966cf
+hmac: f2b25e9786bc5dd27ea27d7ed8b9b88e001014bbdf5376c38556bafe5043b717
 
 ...

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace go.opentelemetry.io/otel/metric => go.opentelemetry.io/otel/metric v1.16
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0
 
 require (
-	cloud.google.com/go/storage v1.30.1 // @grafana/backend-platform
+	cloud.google.com/go/storage v1.30.1
 	cuelang.org/go v0.6.0-0.dev // @grafana/grafana-as-code
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // @grafana/backend-platform
 	github.com/Azure/go-autorest/autorest v0.11.28 // @grafana/backend-platform

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace go.opentelemetry.io/otel/metric => go.opentelemetry.io/otel/metric v1.16
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0
 
 require (
-	cloud.google.com/go/storage v1.30.1
+	cloud.google.com/go/storage v1.30.1 // @grafana/backend-platform
 	cuelang.org/go v0.6.0-0.dev // @grafana/grafana-as-code
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // @grafana/backend-platform
 	github.com/Azure/go-autorest/autorest v0.11.28 // @grafana/backend-platform

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -261,7 +261,6 @@ def validate_modfile_step():
     return {
         "name": "validate-modfile",
         "image": images["go_image"],
-        "failure": "ignore",
         "commands": [
             "go run scripts/modowners/modowners.go check go.mod",
         ],


### PR DESCRIPTION
If any dependency in go.mod doesn't have an assigned owner, validate-modfile will fail as a blocking step.

ref https://github.com/grafana/grafana-backend-platform-squad/issues/1