### PR TITLE
Docs:  fixed incorrect TLS entry for mysql data source

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -155,7 +155,7 @@ datasources:
     user: grafana
     jsonData:
       tlsAuth: true
-      skipTLSVerify: true
+      tlsSkipVerify: true
       database: grafana
       maxOpenConns: 100 # Grafana v5.4+
       maxIdleConns: 100 # Grafana v5.4+


### PR DESCRIPTION
Addresses the following issue reported by a customer:

https://github.com/grafana/grafana/issues/72237

