### PR TITLE
InfluxDB: Fix fetching retention policies after manually entering a non-existent retention policy

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
@@ -133,12 +133,7 @@ export const VisualInfluxQLEditor = (props: Props): JSX.Element => {
         <FromSection
           policy={policy}
           measurement={measurement}
-          getPolicyOptions={() =>
-            withTemplateVariableOptions(
-              allTagKeys.then(() => getAllPolicies(datasource)),
-              wrapPure
-            )
-          }
+          getPolicyOptions={() => withTemplateVariableOptions(getAllPolicies(datasource), wrapPure)}
           getMeasurementOptions={(filter) =>
             withTemplateVariableOptions(
               allTagKeys.then((keys) =>


### PR DESCRIPTION
**What is this feature?**

When a user enters a non-existent retention policy and then tries to see other options again it doesn't load the options.
This PR is fixing this bug.

**Who is this feature for?**

InfluxDB Users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/72563

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
