### PR TITLE
Dashboard: Variables Dropdown - Fix Flickering on Refresh

### DIFF
--- a/public/app/features/variables/pickers/shared/VariableLink.tsx
+++ b/public/app/features/variables/pickers/shared/VariableLink.tsx
@@ -89,7 +89,7 @@ const LoadingIndicator = ({ onCancel }: Pick<Props, 'onCancel'>) => {
       <Icon
         className="spin-clockwise"
         name="sync"
-        size="xs"
+        size="sm"
         onClick={onClick}
         aria-label={selectors.components.LoadingIndicator.icon}
       />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix different icon sizes in same component to avoid flickering on state change.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #70323

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.

related code:

the size of angle-down icon is "sm" 

https://github.com/grafana/grafana/blob/66ccc600fb3e9635bf5c75e627b4d0008a80a782/public/app/features/variables/pickers/shared/VariableLink.tsx#L60

the size of spin-clockwise icon (display when loading) is "xs" 

https://github.com/grafana/grafana/blob/d710507bc5c91e97950737889c7855bbddf36491/public/app/features/variables/pickers/shared/VariableLink.tsx#L89-L95

