### PR TITLE
Logs: Fix ui getting stuck when removing fields

### DIFF
--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -2,6 +2,7 @@ import { screen, render, fireEvent } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 
 import { LogRowModel } from '@grafana/data';
+import config from 'app/core/config';
 
 import { LogDetailsRow } from './LogDetailsRow';
 
@@ -64,11 +65,22 @@ describe('LogDetailsRow', () => {
       setup();
       expect(screen.getAllByRole('button', { name: 'Filter out value' })).toHaveLength(1);
     });
-    it('should render remove filter button', async () => {
+    it('should render filter buttons when toggleLabelsInLogsUI false', async () => {
+      setup({
+        isFilterLabelActive: jest.fn().mockResolvedValue(true),
+      });
+      expect(screen.getByRole('button', { name: 'Filter for value' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Filter out value' })).toBeInTheDocument();
+    });
+
+    it('should render remove filter button when toggleLabelsInLogsUI true', async () => {
+      const defaultValue = config.featureToggles.toggleLabelsInLogsUI;
+      config.featureToggles.toggleLabelsInLogsUI = true;
       setup({
         isFilterLabelActive: jest.fn().mockResolvedValue(true),
       });
       expect(await screen.findByRole('button', { name: 'Remove filter' })).toBeInTheDocument();
+      config.featureToggles.toggleLabelsInLogsUI = defaultValue;
     });
   });
 

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -1,10 +1,10 @@
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 import memoizeOne from 'memoize-one';
-import React, { PureComponent, useState } from 'react';
+import React, { PureComponent, useEffect, useState } from 'react';
 
 import { CoreApp, Field, GrafanaTheme2, IconName, LinkModel, LogLabelStatsModel, LogRowModel } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { ClipboardButton, DataLinkButton, IconButton, Themeable2, withTheme2 } from '@grafana/ui';
 
 import { LogLabelStats } from './LogLabelStats';
@@ -274,10 +274,20 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
           <td className={style.logsDetailsIcon}>
             <div className={styles.buttonRow}>
               {hasFilteringFunctionality && (
-                <AsyncIconButton name="search-plus" onClick={this.filterLabel} isActive={this.isFilterLabelActive} />
-              )}
-              {hasFilteringFunctionality && (
-                <IconButton name="search-minus" tooltip="Filter out value" onClick={this.filterOutLabel} />
+                <>
+                  {config.featureToggles.toggleLabelsInLogsUI && (
+                    // If we are using the new label toggling, we want to use the async icon button
+                    <AsyncIconButton
+                      name="search-plus"
+                      onClick={this.filterLabel}
+                      isActive={this.isFilterLabelActive}
+                    />
+                  )}
+                  {!config.featureToggles.toggleLabelsInLogsUI && (
+                    <IconButton name="search-minus" onClick={this.filterLabel} tooltip="Filter for value" />
+                  )}
+                  <IconButton name="search-minus" tooltip="Filter out value" onClick={this.filterOutLabel} />
+                </>
               )}
               {!disableActions && displayedFields && toggleFieldButton}
               {!disableActions && (

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -284,7 +284,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
                     />
                   )}
                   {!config.featureToggles.toggleLabelsInLogsUI && (
-                    <IconButton name="search-minus" onClick={this.filterLabel} tooltip="Filter for value" />
+                    <IconButton name="search-plus" onClick={this.filterLabel} tooltip="Filter for value" />
                   )}
                   <IconButton name="search-minus" tooltip="Filter out value" onClick={this.filterOutLabel} />
                 </>

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 import memoizeOne from 'memoize-one';
-import React, { PureComponent, useEffect, useState } from 'react';
+import React, { PureComponent, useState } from 'react';
 
 import { CoreApp, Field, GrafanaTheme2, IconName, LinkModel, LogLabelStatsModel, LogRowModel } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';


### PR DESCRIPTION
How to reproduce is mentioned and showed also here: https://github.com/grafana/grafana/issues/72504: 
1. Click show this field instead of log line in log details
2. Click filter for or filter out some field
3. Click hide this field after filtering freezes the app

The issue is with `AsyncIconButton` that was introduced in and in https://github.com/grafana/grafana/pull/70328 and in  some specific cases (like the one described)  it causes  infinite loop . We should properly address the issue with `AsyncIconButton` in separate PR, but for the purposes of 10.1 release and to make fix as small as possible, we just won't use it unless experimental/WIP feature toggle `toggleLabelsInLogsUI` is enabled  and use `IconButton`.  

Fixes https://github.com/grafana/grafana/issues/72504