### PR TITLE
CI: Upgrade peter-evans/create-pull-request from `v3` to `v5`

### DIFF
--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           make -C pkg/services/ngalert/api/tooling post.json api.json
       - name: Open Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update alerting swagger spec"


### PR DESCRIPTION
**What is this feature?**

Fix node12 deprecation warning

**Why do we need this feature?**

GitHub will remove node12 support

**Who is this feature for?**

CI: .github/workflows/alerting-swagger-gen.yml

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
