### PR TITLE
Transformation: keep collapsed states

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { cx, css } from '@emotion/css';
 import React, { ChangeEvent } from 'react';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 import { Unsubscribable } from 'rxjs';
@@ -270,26 +270,30 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
   };
 
   renderTransformationEditors = () => {
-    const { data, transformations } = this.state;
+    const styles = getStyles(config.theme2);
+    const { data, transformations, showPicker } = this.state;
+    const hide = config.featureToggles.transformationsRedesign && showPicker;
 
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
-        <Droppable droppableId="transformations-list" direction="vertical">
-          {(provided) => {
-            return (
-              <div ref={provided.innerRef} {...provided.droppableProps}>
-                <TransformationOperationRows
-                  configs={transformations}
-                  data={data}
-                  onRemove={this.onTransformationRemove}
-                  onChange={this.onTransformationChange}
-                />
-                {provided.placeholder}
-              </div>
-            );
-          }}
-        </Droppable>
-      </DragDropContext>
+      <div className={cx({ [styles.hide]: hide })}>
+        <DragDropContext onDragEnd={this.onDragEnd}>
+          <Droppable droppableId="transformations-list" direction="vertical">
+            {(provided) => {
+              return (
+                <div ref={provided.innerRef} {...provided.droppableProps}>
+                  <TransformationOperationRows
+                    configs={transformations}
+                    data={data}
+                    onRemove={this.onTransformationRemove}
+                    onChange={this.onTransformationChange}
+                  />
+                  {provided.placeholder}
+                </div>
+              );
+            }}
+          </Droppable>
+        </DragDropContext>
+      </div>
     );
   };
 
@@ -529,7 +533,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
               />
             ) : null}
             {hasTransforms && config.featureToggles.transformationsRedesign && !this.state.showPicker && (
-              <div className={styles.listInformationLineWrapper}>
+              <div className={cx(styles.listInformationLineWrapper)}>
                 <span className={styles.listInformationLineText}>Transformations in use</span>{' '}
                 <Button
                   size="sm"
@@ -550,9 +554,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
                 />
               </div>
             )}
-            {hasTransforms &&
-              (!config.featureToggles.transformationsRedesign || !this.state.showPicker) &&
-              this.renderTransformationEditors()}
+            {hasTransforms && this.renderTransformationEditors()}
             {this.renderTransformsPicker()}
           </div>
         </Container>
@@ -587,6 +589,9 @@ function TransformationCard({ transform, onClick }: TransformationCardProps) {
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    hide: css`
+      display: none;
+    `,
     card: css`
       margin: 0;
       padding: ${theme.spacing(1)};

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -533,7 +533,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
               />
             ) : null}
             {hasTransforms && config.featureToggles.transformationsRedesign && !this.state.showPicker && (
-              <div className={cx(styles.listInformationLineWrapper)}>
+              <div className={styles.listInformationLineWrapper}>
                 <span className={styles.listInformationLineText}>Transformations in use</span>{' '}
                 <Button
                   size="sm"


### PR DESCRIPTION
This PR allows to keep the "collapsed/expanded" state of the list of configured transformations.
Instead of rendering/not rendering, the list, we show/hide it. So the state of the element is not destroyed while switching "screen" (list => picker => list)

https://raintank-corp.slack.com/archives/C02UC0KCSF4/p1690530679256659?thread_ts=1689613735.780749&cid=C02UC0KCSF4