### PR TITLE
Cloudwatch Logs: Set Alerting timeout to datasource config's logsTimeout (#72611)

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -81,7 +81,6 @@ func newExecutor(im instancemgmt.InstanceManager, cfg *setting.Cfg, sessions Ses
 	}
 
 	e.resourceHandler = httpadapter.New(e.newResourceMux())
-
 	return e
 }
 
@@ -118,8 +117,6 @@ type cloudWatchExecutor struct {
 	regionCache sync.Map
 
 	resourceHandler backend.CallResourceHandler
-	// can be reduced to shorten tests
-	logsTimeoutDefault time.Duration
 }
 
 func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx backend.PluginContext, region string) (models.RequestContext, error) {

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -55,7 +55,7 @@ var logger = log.New("tsdb.cloudwatch")
 func ProvideService(cfg *setting.Cfg, httpClientProvider httpclient.Provider, features featuremgmt.FeatureToggles) *CloudWatchService {
 	logger.Debug("Initializing")
 
-	// logs timeout deafult is 30 minutes, the same as timeout in frontend logs query
+	// logs timeout default is 30 minutes, the same as timeout in frontend logs query
 	// note: for alerting queries, the context will be cancelled before that unless evaluation_timeout_seconds in defaults.ini is increased (default: 30s)
 	defaultLogsTimeout := time.Minute * 30
 

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -46,7 +46,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 			return nil, err
 		}
 
-		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery, time.Duration(instance.Settings.LogsTimeout.Duration))
+		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery, instance.Settings.LogsTimeout.Duration)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 		if isTerminated(*res.Status) {
 			return res, err
 		}
-		if time.Duration(attemptCount) * time.Second >= logsTimeout {
+		if time.Duration(attemptCount)*time.Second >= logsTimeout {
 			return res, fmt.Errorf("time to fetch query results exceeded logs timeout")
 		}
 

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -46,7 +46,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 			return nil, err
 		}
 
-		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery, instance.Settings.LogsTimeout)
+		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery, time.Duration(instance.Settings.LogsTimeout.Duration))
 		if err != nil {
 			return nil, err
 		}
@@ -80,7 +80,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 }
 
 func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
-	queryContext backend.DataQuery, logsQuery models.LogsQuery, logsTimeout models.Duration) (*cloudwatchlogs.GetQueryResultsOutput, error) {
+	queryContext backend.DataQuery, logsQuery models.LogsQuery, logsTimeout time.Duration) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 		if isTerminated(*res.Status) {
 			return res, err
 		}
-		if (time.Duration(attemptCount) * time.Second) >= time.Duration(logsTimeout) {
+		if time.Duration(attemptCount) * time.Second >= logsTimeout {
 			return res, fmt.Errorf("time to fetch query results exceeded logs timeout")
 		}
 

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -314,7 +314,7 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		}, nil)
 		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Running")}, nil)
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{LogsTimeout: models.Duration(time.Millisecond)}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{LogsTimeout: models.Duration{time.Millisecond}}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -334,9 +334,7 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 			},
 		})
 		assert.Error(t, err)
-
 		cli.AssertNumberOfCalls(t, "GetQueryResultsWithContext", 1)
-
 	})
 	t.Run("when logsTimeout setting is defined, the polling period will be set to that variable", func(t *testing.T) {
 		cli = &mockLogsSyncClient{}
@@ -365,9 +363,6 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 			},
 		})
 		assert.Error(t, err)
-
 		cli.AssertNumberOfCalls(t, "GetQueryResultsWithContext", 1)
-
 	})
-
 }

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -307,4 +307,67 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, []*data.Field{expectedLogFieldFromSecondCall}, respB.Frames[0].Fields)
 	})
+
+	t.Run("when logsTimeout setting isn't defined, the polling period will be set to default value defined in cloudwatch executor", func(t *testing.T) {
+		cli = &mockLogsSyncClient{}
+		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Running")}, nil)
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures(), time.Millisecond)
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+                        "queryMode":    "Logs",
+                        "expression": "query string for A"
+                    }`),
+				},
+			},
+		})
+		assert.Error(t, err)
+
+		cli.AssertNumberOfCalls(t, "GetQueryResultsWithContext", 1)
+
+	})
+	t.Run("when logsTimeout setting is defined, the polling period will be set to that variable", func(t *testing.T) {
+		cli = &mockLogsSyncClient{}
+		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Running")}, nil)
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{LogsTimeout: "1ms"}}, nil
+		})
+
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+                        "queryMode":    "Logs",
+                        "expression": "query string for A"
+                    }`),
+				},
+			},
+		})
+		assert.Error(t, err)
+
+		cli.AssertNumberOfCalls(t, "GetQueryResultsWithContext", 1)
+
+	})
+
 }

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -314,7 +314,7 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		}, nil)
 		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Running")}, nil)
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{LogsTimeout: models.Duration{time.Millisecond}}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{LogsTimeout: models.Duration{Duration: time.Millisecond}}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -14,8 +14,8 @@ type Duration struct {
 }
 type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
-	Namespace               string        `json:"customMetricsNamespaces"`
-	SecureSocksProxyEnabled bool          `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
+	Namespace               string   `json:"customMetricsNamespaces"`
+	SecureSocksProxyEnabled bool     `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
 	LogsTimeout             Duration `json:"logsTimeout"`
 }
 

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -9,8 +9,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-type Duration time.Duration
-
+type Duration struct {
+	time.Duration
+}
 type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
 	Namespace               string        `json:"customMetricsNamespaces"`
@@ -36,8 +37,8 @@ func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWat
 
 	// logs timeout default is 30 minutes, the same as timeout in frontend logs query
 	// note: for alerting queries, the context will be cancelled before that unless evaluation_timeout_seconds in defaults.ini is increased (default: 30s)
-	if instance.LogsTimeout == 0 {
-		instance.LogsTimeout = Duration(30 * time.Minute)
+	if instance.LogsTimeout.Duration == 0 {
+		instance.LogsTimeout = Duration{30 * time.Minute}
 	}
 
 	instance.AccessKey = config.DecryptedSecureJSONData["accessKey"]
@@ -56,13 +57,13 @@ func (duration *Duration) UnmarshalJSON(b []byte) error {
 
 	switch value := unmarshalledJson.(type) {
 	case float64:
-		*duration = Duration(time.Duration(value))
+		*duration = Duration{time.Duration(value)}
 	case string:
 		dur, err := time.ParseDuration(value)
 		if err != nil {
 			return err
 		}
-		*duration = Duration(dur)
+		*duration = Duration{dur}
 	default:
 		return fmt.Errorf("invalid duration: %#v", unmarshalledJson)
 	}

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -12,6 +12,7 @@ type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
 	Namespace               string `json:"customMetricsNamespaces"`
 	SecureSocksProxyEnabled bool   `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
+	LogsTimeout             string `json:"logsTimeout"`
 }
 
 func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWatchSettings, error) {

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -3,16 +3,19 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+type Duration time.Duration
+
 type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
-	Namespace               string `json:"customMetricsNamespaces"`
-	SecureSocksProxyEnabled bool   `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
-	LogsTimeout             string `json:"logsTimeout"`
+	Namespace               string        `json:"customMetricsNamespaces"`
+	SecureSocksProxyEnabled bool          `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
+	LogsTimeout             Duration `json:"logsTimeout"`
 }
 
 func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWatchSettings, error) {
@@ -31,8 +34,39 @@ func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWat
 		instance.Profile = config.Database
 	}
 
+
+	// logs timeout default is 30 minutes, the same as timeout in frontend logs query
+	// note: for alerting queries, the context will be cancelled before that unless evaluation_timeout_seconds in defaults.ini is increased (default: 30s)
+	if instance.LogsTimeout == 0 {
+		instance.LogsTimeout = Duration(30 * time.Minute)
+	}
+
 	instance.AccessKey = config.DecryptedSecureJSONData["accessKey"]
 	instance.SecretKey = config.DecryptedSecureJSONData["secretKey"]
 
 	return instance, nil
+}
+
+func (duration *Duration) UnmarshalJSON(b []byte) error {
+	var unmarshalledJson interface{}
+
+	err := json.Unmarshal(b, &unmarshalledJson)
+	if err != nil {
+		return err
+	}
+
+	switch value := unmarshalledJson.(type) {
+	case float64:
+		*duration = Duration(time.Duration(value))
+	case string:
+		dur, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*duration = Duration(dur)
+	default:
+		return fmt.Errorf("invalid duration: %#v", unmarshalledJson)
+	}
+
+	return nil
 }

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -34,7 +34,6 @@ func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWat
 		instance.Profile = config.Database
 	}
 
-
 	// logs timeout default is 30 minutes, the same as timeout in frontend logs query
 	// note: for alerting queries, the context will be cancelled before that unless evaluation_timeout_seconds in defaults.ini is increased (default: 30s)
 	if instance.LogsTimeout == 0 {

--- a/pkg/tsdb/cloudwatch/models/settings_test.go
+++ b/pkg/tsdb/cloudwatch/models/settings_test.go
@@ -105,7 +105,7 @@ func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
 
 		s, err := LoadCloudWatchSettings(settings)
 		require.NoError(t, err)
-		assert.Equal(t, time.Minute * 30, s.LogsTimeout.Duration)
+		assert.Equal(t, time.Minute*30, s.LogsTimeout.Duration)
 	})
 	t.Run("Should correctly parse logsTimeout duration string", func(t *testing.T) {
 		settings := backend.DataSourceInstanceSettings{
@@ -123,7 +123,7 @@ func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
 
 		s, err := LoadCloudWatchSettings(settings)
 		require.NoError(t, err)
-		assert.Equal(t, time.Minute * 10, s.LogsTimeout.Duration)
+		assert.Equal(t, time.Minute*10, s.LogsTimeout.Duration)
 	})
 	t.Run("Should correctly parse logsTimeout string with float number", func(t *testing.T) {
 		settings := backend.DataSourceInstanceSettings{

--- a/pkg/tsdb/cloudwatch/models/settings_test.go
+++ b/pkg/tsdb/cloudwatch/models/settings_test.go
@@ -11,6 +11,24 @@ import (
 )
 
 func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
+	t.Run("Should return error for invalid json", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": fluffles^.^,
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"logsTimeout": "10m"
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		_, err := LoadCloudWatchSettings(settings)
+
+		assert.Error(t, err)
+	})
 	t.Run("Should parse keys query type", func(t *testing.T) {
 		settings := backend.DataSourceInstanceSettings{
 			ID: 33,
@@ -87,9 +105,9 @@ func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
 
 		s, err := LoadCloudWatchSettings(settings)
 		require.NoError(t, err)
-		assert.Equal(t, Duration(time.Minute * 30), s.LogsTimeout)
+		assert.Equal(t, time.Minute * 30, s.LogsTimeout.Duration)
 	})
-	t.Run("Should correctly parse logsTimeout json field", func(t *testing.T) {
+	t.Run("Should correctly parse logsTimeout duration string", func(t *testing.T) {
 		settings := backend.DataSourceInstanceSettings{
 			ID: 33,
 			JSONData: []byte(`{
@@ -105,6 +123,76 @@ func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
 
 		s, err := LoadCloudWatchSettings(settings)
 		require.NoError(t, err)
-		assert.Equal(t, Duration(time.Minute * 10), s.LogsTimeout)
+		assert.Equal(t, time.Minute * 10, s.LogsTimeout.Duration)
+	})
+	t.Run("Should correctly parse logsTimeout string with float number", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "arn",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"logsTimeout": "1.5s"
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		s, err := LoadCloudWatchSettings(settings)
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(1500000000), s.LogsTimeout.Duration)
+	})
+	t.Run("Should correctly parse logsTimeout duration in nanoseconds", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "arn",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"logsTimeout": 1500000000
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		s, err := LoadCloudWatchSettings(settings)
+		require.NoError(t, err)
+		assert.Equal(t, 1500*time.Millisecond, s.LogsTimeout.Duration)
+	})
+	t.Run("Should throw error if logsTimeout is an invalid duration format", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "arn",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"logsTimeout": "10mm"
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		_, err := LoadCloudWatchSettings(settings)
+		require.Error(t, err)
+	})
+	t.Run("Should throw error if logsTimeout is an invalid type", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "arn",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"logsTimeout": true
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		_, err := LoadCloudWatchSettings(settings)
+		require.Error(t, err)
 	})
 }

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -74,9 +74,9 @@ export const ConfigEditor = (props: Props) => {
       <h3 className="page-heading">CloudWatch Logs</h3>
       <div className="gf-form-group">
         <InlineField
-          label="Retry Timeout"
+          label="Query Result Timeout"
           labelWidth={28}
-          tooltip='Cloudwatch Logs allows for a maximum of 30 concurrent queries. If Grafana hits a concurrent max query error from Cloudwatch Logs it will auto-retry requesting a query for up to 30min. This retry timeout strategy is configurable. Must be a valid duration string, such as "15m" "30s" "2000ms" etc.'
+          tooltip='Grafana will poll for Cloudwatch Logs query results every second until Done status is returned from AWS or timeout is exceeded, in which case Grafana will return an error. The default period is 30 minutes. Note: For Alerting, the timeout defined in the config file will take precedence. Must be a valid duration string, such as "15m" "30s" "2000ms" etc.'
           invalid={Boolean(logsTimeoutError)}
         >
           <Input


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When getting results for CW Logs queries, the client needs to get the ID of the query first, then periodically poll the results with GetQueryResults. The Status of the query we get from AWS is "Running". Once the request resolves with Status "Done", it will contain complete results. More info [here](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetQueryResults.html)

In CloudwatchLogsQueryRunner for dashboards and explore, there is a timeout set in the ConfigEditor (default: 30 minutes) to retry query results for Cloudwatch Logs queries with GetQueryResults. 

After [some users](https://github.com/grafana/grafana/issues/63305#issuecomment-1553881446) noticed they were getting `"failed to query data: fetching of query results exceeded max number of attempts"` errors in their alerts, we decided to make this option configurable (only for alerts). However, in the process we discovered that the 30 minute configuration wasn't being used on the BE for alert queries. Instead, CW datasource plugin polled the results for 8 seconds maximum, which might be too short for some queries. 

So instead of making this configurable, we decided to first use this setting from ConfigEditor and make it 30 minutes. 
**Note that this means that some queries will timeout with the alerting runner's error "context cancelled", since the default value when running queries in this context is 30s (https://github.com/grafana/grafana/blob/main/conf/defaults.ini#L1207) but this can be increased per instance and doesn't need any change in the code**

The next step in improving this flow will be to not poll the results every second, but to instead do something like in [async-query-data](https://github.com/grafana/grafana-async-query-data-js/blob/main/src/requestLooper.ts), which will increase wait time with every request that returns still "Running".
After this, we could implement a query option input that will give the user more control over how often the results are polled per-query, but it might not be necessary after ☝🏻

Some additional things in this PR: 

1. Made the tooltip in ConfigEditor more clear that this is not a retry after error, but a retry after "not yet done" response. 
2. Defined the default 30 minute timeout in executor struct, in order to be able to pass a shorter timeout for tests (otherwise the test with default value would run for 30 min 👀)
3. Moved the comment about logs queries closer to where the requests for GetQueryResults were happening (from datasource.go to log_sync_query.go, since I felt it was easy to miss where it was. Lmk if there's a better place.


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/63305

**Special notes for your reviewer:**
When this is merged, I will comment [here](https://github.com/grafana/grafana/issues/63305) and [here](https://github.com/grafana/support-escalations/issues/6135) to inform the user and customer support about the change.
TODO: Add to what's new

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
