### PR TITLE
Nested folders: Fix search query for empty self-contained permissions

### DIFF
--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -179,12 +179,10 @@ func (f *accessControlDashboardPermissionFilter) buildClauses() {
 						f.addRecQry(recQueryName, permSelector.String(), permSelectorArgs)
 						builder.WriteString(fmt.Sprintf("WHERE d.uid IN (SELECT uid FROM %s)", recQueryName))
 					default:
-						if len(permSelectorArgs) > 0 {
-							nestedFoldersSelectors, nestedFoldersArgs := nestedFoldersSelectors(permSelector.String(), permSelectorArgs, "folder_id", "id")
-							builder.WriteRune('(')
-							builder.WriteString(nestedFoldersSelectors)
-							args = append(args, nestedFoldersArgs...)
-						}
+						nestedFoldersSelectors, nestedFoldersArgs := nestedFoldersSelectors(permSelector.String(), permSelectorArgs, "folder_id", "id")
+						builder.WriteRune('(')
+						builder.WriteString(nestedFoldersSelectors)
+						args = append(args, nestedFoldersArgs...)
 					}
 				} else {
 					builder.WriteString("(dashboard.folder_id IN (SELECT d.id FROM dashboard as d ")

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -175,11 +175,9 @@ func (f *accessControlDashboardPermissionFilter) buildClauses() {
 					switch f.recursiveQueriesAreSupported {
 					case true:
 						builder.WriteString("(dashboard.folder_id IN (SELECT d.id FROM dashboard as d ")
-						if len(permSelectorArgs) > 0 {
-							recQueryName := fmt.Sprintf("RecQry%d", len(f.recQueries))
-							f.addRecQry(recQueryName, permSelector.String(), permSelectorArgs)
-							builder.WriteString(fmt.Sprintf("WHERE d.uid IN (SELECT uid FROM %s)", recQueryName))
-						}
+						recQueryName := fmt.Sprintf("RecQry%d", len(f.recQueries))
+						f.addRecQry(recQueryName, permSelector.String(), permSelectorArgs)
+						builder.WriteString(fmt.Sprintf("WHERE d.uid IN (SELECT uid FROM %s)", recQueryName))
 					default:
 						if len(permSelectorArgs) > 0 {
 							nestedFoldersSelectors, nestedFoldersArgs := nestedFoldersSelectors(permSelector.String(), permSelectorArgs, "folder_id", "id")

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -356,6 +356,24 @@ func TestIntegration_DashboardNestedPermissionFilter(t *testing.T) {
 		features       featuremgmt.FeatureToggles
 	}{
 		{
+			desc:           "Should not be able to view dashboards under inherited folders with no permissions if nested folders are enabled",
+			queryType:      searchstore.TypeDashboard,
+			permission:     dashboards.PERMISSION_VIEW,
+			permissions:    nil,
+			features:       featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders),
+			expectedResult: nil,
+		},
+		{
+			desc:       "Should be able to view dashboards under inherited folders with wildcard scope if nested folders are enabled",
+			queryType:  searchstore.TypeDashboard,
+			permission: dashboards.PERMISSION_VIEW,
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
+			},
+			features:       featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders),
+			expectedResult: []string{"dashboard under parent folder", "dashboard under subfolder"},
+		},
+		{
 			desc:       "Should be able to view dashboards under inherited folders if nested folders are enabled",
 			queryType:  searchstore.TypeDashboard,
 			permission: dashboards.PERMISSION_VIEW,
@@ -461,6 +479,24 @@ func TestIntegration_DashboardNestedPermissionFilter_WithSelfContainedPermission
 		expectedResult          []string
 		features                featuremgmt.FeatureToggles
 	}{
+		{
+			desc:                    "Should not be able to view dashboards under inherited folders with no permissions if nested folders are enabled",
+			queryType:               searchstore.TypeDashboard,
+			permission:              dashboards.PERMISSION_VIEW,
+			signedInUserPermissions: nil,
+			features:                featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders),
+			expectedResult:          nil,
+		},
+		{
+			desc:       "Should be able to view dashboards under inherited folders with wildcard scope if nested folders are enabled",
+			queryType:  searchstore.TypeDashboard,
+			permission: dashboards.PERMISSION_VIEW,
+			signedInUserPermissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
+			},
+			features:       featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders),
+			expectedResult: []string{"dashboard under parent folder", "dashboard under subfolder"},
+		},
 		{
 			desc:       "Should be able to view dashboards under inherited folders if nested folders are enabled",
 			queryType:  searchstore.TypeDashboard,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

#70749 added support for self-contained permissions in the `accessControlDashboardPermissionFilter`.
In the default case (nested folders off), we [check](https://github.com/grafana/grafana/blob/3652ecc7a62243e17b5837cc5d55ed05aca705ce/pkg/services/sqlstore/permissions/dashboard.go#L257) if there are any self-contained permissions at all.
However, we didn't do the same if nested folders are on, as a result most backend would fail (only SQLite was forgiving) with:
```
WITH RECURSIVE RecQry0 AS (
                        SELECT uid, parent_uid, org_id FROM folder WHERE uid IN ()
                        UNION ALL SELECT f.uid, f.parent_uid, f.org_id FROM folder f
INNER JOIN RecQry0 r ON f.parent_uid = r.uid and f.org_id = r.org_id
SELECT title FROM dashboard WHERE ((1 = 0) OR
(dashboard.folder_id IN (SELECT d.id FROM dashboard as d WHERE d.uid IN (SELECT uid FROM RecQry0)) AND NOT dashboard.is_folder))
```

I have discovered this while working on #72388

**Why do we need this feature?**

This fix introduces some additional tests catching this case and add the missing checks (when nested folders are on)

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
