### PR TITLE
Alerting: Use the default time range of the panel in screenshots

### DIFF
--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -1,6 +1,7 @@
 package dashboards
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -46,6 +47,38 @@ type Dashboard struct {
 
 	Title string
 	Data  *simplejson.Json
+}
+
+type TimeRange struct {
+	From string
+	To   string
+}
+
+func (d *Dashboard) GetTimeRange() (*TimeRange, error) {
+	if d.Data == nil {
+		return nil, errors.New("dashboard data is missing")
+	}
+	timeField, ok := d.Data.CheckGet("time")
+	if !ok {
+		return nil, errors.New("dashboard data is missing time field")
+	}
+	fromField, ok := timeField.CheckGet("from")
+	if !ok {
+		return nil, errors.New("time field is missing from")
+	}
+	from, err := fromField.String()
+	if err != nil {
+		return nil, fmt.Errorf("from field is not a string: %w", err)
+	}
+	toField, ok := timeField.CheckGet("to")
+	if !ok {
+		return nil, errors.New("time field is missing to")
+	}
+	to, err := toField.String()
+	if err != nil {
+		return nil, fmt.Errorf("to field is not a string: %w", err)
+	}
+	return &TimeRange{From: from, To: to}, nil
 }
 
 func (d *Dashboard) SetID(id int64) {

--- a/pkg/services/ngalert/image/service_test.go
+++ b/pkg/services/ngalert/image/service_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/imguploader"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/screenshot"
@@ -25,36 +28,43 @@ func TestScreenshotImageService(t *testing.T) {
 
 	var (
 		cache       = NewMockCacheService(ctrl)
+		dbs         = dashboards.NewFakeDashboardService(t)
 		images      = store.NewFakeImageStore(t)
 		limiter     = screenshot.NoOpRateLimiter{}
 		screenshots = screenshot.NewMockScreenshotService(ctrl)
 		uploads     = imguploader.NewMockImageUploader(ctrl)
 	)
 
-	s := NewScreenshotImageService(cache, &limiter, log.NewNopLogger(), screenshots, 5*time.Second, images,
+	s := NewScreenshotImageService(cache, dbs, &limiter, log.NewNopLogger(), screenshots, 5*time.Second, images,
 		NewUploadingService(uploads, prometheus.NewRegistry()))
 
 	ctx := context.Background()
 
 	t.Run("image is taken, uploaded, saved to database and cached", func(t *testing.T) {
-		// assert that the cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "oyh1kYgaJwM=").Return(models.Image{}, false)
+		// cache is checked for an existing image
+		cache.EXPECT().Get(gomock.Any(), "EBfkKS/dJKg=").Return(models.Image{}, false)
 
-		// assert that a screenshot is taken
+		// dashboard is retrieved from the dashboard service to set the time range
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "foo"}).
+			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+
+		// screenshot is taken
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "foo",
 			PanelID:      1,
+			From:         "now-5m",
+			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(&screenshot.Screenshot{
 			Path: "foo.png",
 		}, nil)
 
-		// assert that the screenshot is made into an image and uploaded
+		// screenshot is made into an image and uploaded
 		uploads.EXPECT().Upload(gomock.Any(), "foo.png").
 			Return("https://example.com/foo.png", nil)
 
-		// assert that the image is saved into the database
+		// expected image saved to the database
 		expected := models.Image{
 			ID:    1,
 			Token: "foo",
@@ -62,8 +72,8 @@ func TestScreenshotImageService(t *testing.T) {
 			URL:   "https://example.com/foo.png",
 		}
 
-		// assert that the image is saved into the cache
-		cache.EXPECT().Set(gomock.Any(), "oyh1kYgaJwM=", expected).Return(nil)
+		// image is written to the cache
+		cache.EXPECT().Set(gomock.Any(), "EBfkKS/dJKg=", expected).Return(nil)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -75,32 +85,38 @@ func TestScreenshotImageService(t *testing.T) {
 	})
 
 	t.Run("image is taken, upload return error, saved to database without URL and cached", func(t *testing.T) {
-		// assert that the cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "yszV9tgmKAo=").Return(models.Image{}, false)
+		// cache is checked for an existing image
+		cache.EXPECT().Get(gomock.Any(), "SJFXw2sGMe8=").Return(models.Image{}, false)
 
-		// assert that a screenshot is taken
+		// dashboard is retrieved from the dashboard service to set the time range
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "bar"}).
+			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+
+		// screenshot is taken
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "bar",
 			PanelID:      1,
+			From:         "now-5m",
+			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(&screenshot.Screenshot{
 			Path: "bar.png",
 		}, nil)
 
-		// the screenshot is made into an image and uploaded, but the upload returns an error
+		// screenshot is made into an image and uploaded but the upload returns an error
 		uploads.EXPECT().Upload(gomock.Any(), "bar.png").
 			Return("", errors.New("failed to upload bar.png"))
 
-		// and then saved into the database, but without a URL
+		// image is saved to the database without a URL
 		expected := models.Image{
 			ID:    2,
 			Token: "bar",
 			Path:  "bar.png",
 		}
 
-		// assert that the image is saved into the cache, but without a URL
-		cache.EXPECT().Set(gomock.Any(), "yszV9tgmKAo=", expected).Return(nil)
+		// image is written to the cache without a URL
+		cache.EXPECT().Set(gomock.Any(), "SJFXw2sGMe8=", expected).Return(nil)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -114,8 +130,12 @@ func TestScreenshotImageService(t *testing.T) {
 	t.Run("image is returned from cache", func(t *testing.T) {
 		expected := models.Image{Path: "baz.png", URL: "https://example.com/baz.png"}
 
-		// assert that the cache is checked for an existing image and it is returned
-		cache.EXPECT().Get(gomock.Any(), "he399rFDBPI=").Return(expected, true)
+		// dashboard is retrieved from the dashboard service to set the time range
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "baz"}).
+			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+
+		// cache is checked for an existing image and it is returned
+		cache.EXPECT().Get(gomock.Any(), "qKS1yydWvqc=").Return(expected, true)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -127,14 +147,20 @@ func TestScreenshotImageService(t *testing.T) {
 	})
 
 	t.Run("error is returned when timeout is exceeded", func(t *testing.T) {
-		// assert that the cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "TTHub8HUe2U=").Return(models.Image{}, false)
+		// cache is checked for an existing image
+		cache.EXPECT().Get(gomock.Any(), "lSt00jwKht4=").Return(models.Image{}, false)
 
-		// assert that when the timeout is exceeded an error is returned
+		// dashboard is retrieved from the dashboard service to set the time range
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "qux"}).
+			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+
+		// when the timeout is exceeded an error is returned
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "qux",
 			PanelID:      1,
+			From:         "now-5m",
+			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(nil, context.DeadlineExceeded)
 
@@ -145,5 +171,63 @@ func TestScreenshotImageService(t *testing.T) {
 			PanelID:      util.Pointer(int64(1))})
 		assert.EqualError(t, err, "context deadline exceeded")
 		assert.Nil(t, image)
+	})
+
+	t.Run("dashboard not found returns error", func(t *testing.T) {
+		// return ErrDashboardNotFound for unknown dashboard
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "quux"}).
+			Return(nil, dashboards.ErrDashboardNotFound)
+
+		image, err := s.NewImage(ctx, &models.AlertRule{
+			OrgID:        1,
+			UID:          "quux",
+			DashboardUID: util.Pointer("quux"),
+			PanelID:      util.Pointer(int64(1))})
+		assert.EqualError(t, err, "Dashboard not found")
+		assert.Nil(t, image)
+	})
+
+	t.Run("dashboard with missing time range uses default", func(t *testing.T) {
+		// cache is checked for an existing image
+		cache.EXPECT().Get(gomock.Any(), "ae76t6+Elrs=").Return(models.Image{}, false)
+
+		// dashboard is retrieved from the dashboard service but with missing time range
+		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "corge"}).
+			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{}`))}, nil)
+
+		// screenshot is taken
+		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
+			OrgID:        1,
+			DashboardUID: "corge",
+			PanelID:      1,
+			From:         screenshot.DefaultFrom,
+			To:           screenshot.DefaultTo,
+			Timeout:      5 * time.Second,
+		}).Return(&screenshot.Screenshot{
+			Path: "corge.png",
+		}, nil)
+
+		// screenshot is made into an image and uploaded
+		uploads.EXPECT().Upload(gomock.Any(), "corge.png").
+			Return("https://example.com/corge.png", nil)
+
+		// image is saved to the database without a URL
+		expected := models.Image{
+			ID:    3,
+			Token: "corge",
+			Path:  "corge.png",
+			URL:   "https://example.com/corge.png",
+		}
+
+		// image is written to the cache without a URL
+		cache.EXPECT().Set(gomock.Any(), "ae76t6+Elrs=", expected).Return(nil)
+
+		image, err := s.NewImage(ctx, &models.AlertRule{
+			OrgID:        1,
+			UID:          "corge",
+			DashboardUID: util.Pointer("corge"),
+			PanelID:      util.Pointer(int64(1))})
+		require.NoError(t, err)
+		assert.Equal(t, expected, *image)
 	})
 }

--- a/pkg/services/ngalert/image/service_test.go
+++ b/pkg/services/ngalert/image/service_test.go
@@ -9,13 +9,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/imguploader"
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/screenshot"
@@ -28,33 +25,26 @@ func TestScreenshotImageService(t *testing.T) {
 
 	var (
 		cache       = NewMockCacheService(ctrl)
-		dbs         = dashboards.NewFakeDashboardService(t)
 		images      = store.NewFakeImageStore(t)
 		limiter     = screenshot.NoOpRateLimiter{}
 		screenshots = screenshot.NewMockScreenshotService(ctrl)
 		uploads     = imguploader.NewMockImageUploader(ctrl)
 	)
 
-	s := NewScreenshotImageService(cache, dbs, &limiter, log.NewNopLogger(), screenshots, 5*time.Second, images,
+	s := NewScreenshotImageService(cache, &limiter, log.NewNopLogger(), screenshots, 5*time.Second, images,
 		NewUploadingService(uploads, prometheus.NewRegistry()))
 
 	ctx := context.Background()
 
 	t.Run("image is taken, uploaded, saved to database and cached", func(t *testing.T) {
 		// cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "EBfkKS/dJKg=").Return(models.Image{}, false)
-
-		// dashboard is retrieved from the dashboard service to set the time range
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "foo"}).
-			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+		cache.EXPECT().Get(gomock.Any(), "oyh1kYgaJwM=").Return(models.Image{}, false)
 
 		// screenshot is taken
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "foo",
 			PanelID:      1,
-			From:         "now-5m",
-			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(&screenshot.Screenshot{
 			Path: "foo.png",
@@ -73,7 +63,7 @@ func TestScreenshotImageService(t *testing.T) {
 		}
 
 		// image is written to the cache
-		cache.EXPECT().Set(gomock.Any(), "EBfkKS/dJKg=", expected).Return(nil)
+		cache.EXPECT().Set(gomock.Any(), "oyh1kYgaJwM=", expected).Return(nil)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -86,19 +76,13 @@ func TestScreenshotImageService(t *testing.T) {
 
 	t.Run("image is taken, upload return error, saved to database without URL and cached", func(t *testing.T) {
 		// cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "SJFXw2sGMe8=").Return(models.Image{}, false)
-
-		// dashboard is retrieved from the dashboard service to set the time range
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "bar"}).
-			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+		cache.EXPECT().Get(gomock.Any(), "yszV9tgmKAo=").Return(models.Image{}, false)
 
 		// screenshot is taken
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "bar",
 			PanelID:      1,
-			From:         "now-5m",
-			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(&screenshot.Screenshot{
 			Path: "bar.png",
@@ -116,7 +100,7 @@ func TestScreenshotImageService(t *testing.T) {
 		}
 
 		// image is written to the cache without a URL
-		cache.EXPECT().Set(gomock.Any(), "SJFXw2sGMe8=", expected).Return(nil)
+		cache.EXPECT().Set(gomock.Any(), "yszV9tgmKAo=", expected).Return(nil)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -130,12 +114,8 @@ func TestScreenshotImageService(t *testing.T) {
 	t.Run("image is returned from cache", func(t *testing.T) {
 		expected := models.Image{Path: "baz.png", URL: "https://example.com/baz.png"}
 
-		// dashboard is retrieved from the dashboard service to set the time range
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "baz"}).
-			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
-
 		// cache is checked for an existing image and it is returned
-		cache.EXPECT().Get(gomock.Any(), "qKS1yydWvqc=").Return(expected, true)
+		cache.EXPECT().Get(gomock.Any(), "he399rFDBPI=").Return(expected, true)
 
 		image, err := s.NewImage(ctx, &models.AlertRule{
 			OrgID:        1,
@@ -148,19 +128,13 @@ func TestScreenshotImageService(t *testing.T) {
 
 	t.Run("error is returned when timeout is exceeded", func(t *testing.T) {
 		// cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "lSt00jwKht4=").Return(models.Image{}, false)
-
-		// dashboard is retrieved from the dashboard service to set the time range
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "qux"}).
-			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{"time":{"from":"now-5m","to":"now"}}`))}, nil)
+		cache.EXPECT().Get(gomock.Any(), "TTHub8HUe2U=").Return(models.Image{}, false)
 
 		// when the timeout is exceeded an error is returned
 		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
 			OrgID:        1,
 			DashboardUID: "qux",
 			PanelID:      1,
-			From:         "now-5m",
-			To:           "now",
 			Timeout:      5 * time.Second,
 		}).Return(nil, context.DeadlineExceeded)
 
@@ -171,63 +145,5 @@ func TestScreenshotImageService(t *testing.T) {
 			PanelID:      util.Pointer(int64(1))})
 		assert.EqualError(t, err, "context deadline exceeded")
 		assert.Nil(t, image)
-	})
-
-	t.Run("dashboard not found returns error", func(t *testing.T) {
-		// return ErrDashboardNotFound for unknown dashboard
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "quux"}).
-			Return(nil, dashboards.ErrDashboardNotFound)
-
-		image, err := s.NewImage(ctx, &models.AlertRule{
-			OrgID:        1,
-			UID:          "quux",
-			DashboardUID: util.Pointer("quux"),
-			PanelID:      util.Pointer(int64(1))})
-		assert.EqualError(t, err, "Dashboard not found")
-		assert.Nil(t, image)
-	})
-
-	t.Run("dashboard with missing time range uses default", func(t *testing.T) {
-		// cache is checked for an existing image
-		cache.EXPECT().Get(gomock.Any(), "ae76t6+Elrs=").Return(models.Image{}, false)
-
-		// dashboard is retrieved from the dashboard service but with missing time range
-		dbs.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{OrgID: 1, UID: "corge"}).
-			Return(&dashboards.Dashboard{Data: simplejson.MustJson([]byte(`{}`))}, nil)
-
-		// screenshot is taken
-		screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
-			OrgID:        1,
-			DashboardUID: "corge",
-			PanelID:      1,
-			From:         screenshot.DefaultFrom,
-			To:           screenshot.DefaultTo,
-			Timeout:      5 * time.Second,
-		}).Return(&screenshot.Screenshot{
-			Path: "corge.png",
-		}, nil)
-
-		// screenshot is made into an image and uploaded
-		uploads.EXPECT().Upload(gomock.Any(), "corge.png").
-			Return("https://example.com/corge.png", nil)
-
-		// image is saved to the database without a URL
-		expected := models.Image{
-			ID:    3,
-			Token: "corge",
-			Path:  "corge.png",
-			URL:   "https://example.com/corge.png",
-		}
-
-		// image is written to the cache without a URL
-		cache.EXPECT().Set(gomock.Any(), "ae76t6+Elrs=", expected).Return(nil)
-
-		image, err := s.NewImage(ctx, &models.AlertRule{
-			OrgID:        1,
-			UID:          "corge",
-			DashboardUID: util.Pointer("corge"),
-			PanelID:      util.Pointer(int64(1))})
-		require.NoError(t, err)
-		assert.Equal(t, expected, *image)
 	})
 }

--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -92,6 +92,17 @@ func (s *HeadlessScreenshotService) Take(ctx context.Context, opts ScreenshotOpt
 		return nil, err
 	}
 
+	// If To and From have not been set then use the defaults for the panel
+	if opts.To == "" || opts.From == "" {
+		r, err := dashboard.GetTimeRange()
+		if err != nil {
+			s.instrumentError(err)
+			return nil, err
+		}
+		opts.To = r.To
+		opts.From = r.From
+	}
+
 	opts = opts.SetDefaults()
 
 	u := url.URL{}

--- a/pkg/services/screenshot/screenshot_test.go
+++ b/pkg/services/screenshot/screenshot_test.go
@@ -3,18 +3,19 @@ package screenshot
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestHeadlessScreenshotService(t *testing.T) {

--- a/pkg/services/screenshot/screenshot_test.go
+++ b/pkg/services/screenshot/screenshot_test.go
@@ -3,18 +3,18 @@ package screenshot
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/rendering"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestHeadlessScreenshotService(t *testing.T) {
@@ -25,55 +25,121 @@ func TestHeadlessScreenshotService(t *testing.T) {
 	r := rendering.NewMockService(c)
 	s := NewHeadlessScreenshotService(&d, r, prometheus.NewRegistry())
 
-	// a non-existent dashboard should return error
-	d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(nil, dashboards.ErrDashboardNotFound).Once()
-	ctx := context.Background()
-	opts := ScreenshotOptions{}
-	screenshot, err := s.Take(ctx, opts)
-	assert.EqualError(t, err, "Dashboard not found")
-	assert.Nil(t, screenshot)
+	t.Run("takes a screenshot", func(t *testing.T) {
+		qResult := &dashboards.Dashboard{ID: 1, UID: "foo", Slug: "bar", OrgID: 2, Data: simplejson.MustJson([]byte(`{"time":{"to":"now","from":"now-4h"}}`))}
+		d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(qResult, nil).Once()
 
-	// should take a screenshot
-	qResult := &dashboards.Dashboard{ID: 1, UID: "foo", Slug: "bar", OrgID: 2}
-	d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(qResult, nil)
+		renderOpts := rendering.Opts{
+			AuthOpts: rendering.AuthOpts{
+				OrgID:   2,
+				OrgRole: org.RoleAdmin,
+			},
+			ErrorOpts: rendering.ErrorOpts{
+				ErrorConcurrentLimitReached: true,
+				ErrorRenderUnavailable:      true,
+			},
+			TimeoutOpts: rendering.TimeoutOpts{
+				Timeout: DefaultTimeout,
+			},
+			Width:           DefaultWidth,
+			Height:          DefaultHeight,
+			Theme:           DefaultTheme,
+			Path:            "d-solo/foo/bar?from=now-6h&orgId=2&panelId=4&to=now-2h",
+			ConcurrentLimit: setting.AlertingRenderLimit,
+		}
 
-	renderOpts := rendering.Opts{
-		AuthOpts: rendering.AuthOpts{
-			OrgID:   2,
-			OrgRole: org.RoleAdmin,
-		},
-		ErrorOpts: rendering.ErrorOpts{
-			ErrorConcurrentLimitReached: true,
-			ErrorRenderUnavailable:      true,
-		},
-		TimeoutOpts: rendering.TimeoutOpts{
-			Timeout: DefaultTimeout,
-		},
-		Width:           DefaultWidth,
-		Height:          DefaultHeight,
-		Theme:           DefaultTheme,
-		Path:            "d-solo/foo/bar?from=now-6h&orgId=2&panelId=4&to=now-2h",
-		ConcurrentLimit: setting.AlertingRenderLimit,
-	}
+		ctx := context.Background()
+		opts := ScreenshotOptions{
+			DashboardUID: "foo",
+			PanelID:      4,
+			From:         "now-6h",
+			To:           "now-2h",
+		}
+		r.EXPECT().Render(ctx, renderOpts, nil).Return(&rendering.RenderResult{FilePath: "panel.png"}, nil)
+		screenshot, err := s.Take(ctx, opts)
+		require.NoError(t, err)
+		assert.Equal(t, Screenshot{Path: "panel.png"}, *screenshot)
+	})
 
-	opts.From = "now-6h"
-	opts.To = "now-2h"
-	opts.DashboardUID = "foo"
-	opts.PanelID = 4
-	r.EXPECT().
-		Render(ctx, renderOpts, nil).
-		Return(&rendering.RenderResult{FilePath: "panel.png"}, nil)
-	screenshot, err = s.Take(ctx, opts)
-	require.NoError(t, err)
-	assert.Equal(t, Screenshot{Path: "panel.png"}, *screenshot)
+	t.Run("missing To and From should use time range of the panel", func(t *testing.T) {
+		qResult := &dashboards.Dashboard{ID: 1, UID: "foo", Slug: "bar", OrgID: 2, Data: simplejson.MustJson([]byte(`{"time":{"to":"now","from":"now-4h"}}`))}
+		d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(qResult, nil).Once()
 
-	// a timeout should return error
-	r.EXPECT().
-		Render(ctx, renderOpts, nil).
-		Return(nil, rendering.ErrTimeout)
-	screenshot, err = s.Take(ctx, opts)
-	assert.EqualError(t, err, fmt.Sprintf("failed to take screenshot: %s", rendering.ErrTimeout))
-	assert.Nil(t, screenshot)
+		renderOpts := rendering.Opts{
+			AuthOpts: rendering.AuthOpts{
+				OrgID:   2,
+				OrgRole: org.RoleAdmin,
+			},
+			ErrorOpts: rendering.ErrorOpts{
+				ErrorConcurrentLimitReached: true,
+				ErrorRenderUnavailable:      true,
+			},
+			TimeoutOpts: rendering.TimeoutOpts{
+				Timeout: DefaultTimeout,
+			},
+			Width:           DefaultWidth,
+			Height:          DefaultHeight,
+			Theme:           DefaultTheme,
+			Path:            "d-solo/foo/bar?from=now-4h&orgId=2&panelId=4&to=now",
+			ConcurrentLimit: setting.AlertingRenderLimit,
+		}
+
+		ctx := context.Background()
+		opts := ScreenshotOptions{
+			DashboardUID: "foo",
+			PanelID:      4,
+		}
+		r.EXPECT().Render(ctx, renderOpts, nil).Return(&rendering.RenderResult{FilePath: "panel.png"}, nil)
+		screenshot, err := s.Take(ctx, opts)
+		require.NoError(t, err)
+		assert.Equal(t, Screenshot{Path: "panel.png"}, *screenshot)
+	})
+
+	t.Run("missing dashboard should return error", func(t *testing.T) {
+		// a non-existent dashboard should return error
+		d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(nil, dashboards.ErrDashboardNotFound).Once()
+		ctx := context.Background()
+		opts := ScreenshotOptions{}
+		screenshot, err := s.Take(ctx, opts)
+		assert.EqualError(t, err, "Dashboard not found")
+		assert.Nil(t, screenshot)
+	})
+
+	t.Run("timeout should return an error", func(t *testing.T) {
+		qResult := &dashboards.Dashboard{ID: 1, UID: "foo", Slug: "bar", OrgID: 2, Data: simplejson.MustJson([]byte(`{"time":{"to":"now","from":"now-4h"}}`))}
+		d.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(qResult, nil).Once()
+
+		renderOpts := rendering.Opts{
+			AuthOpts: rendering.AuthOpts{
+				OrgID:   2,
+				OrgRole: org.RoleAdmin,
+			},
+			ErrorOpts: rendering.ErrorOpts{
+				ErrorConcurrentLimitReached: true,
+				ErrorRenderUnavailable:      true,
+			},
+			TimeoutOpts: rendering.TimeoutOpts{
+				Timeout: DefaultTimeout,
+			},
+			Width:           DefaultWidth,
+			Height:          DefaultHeight,
+			Theme:           DefaultTheme,
+			Path:            "d-solo/foo/bar?from=now-4h&orgId=2&panelId=4&to=now",
+			ConcurrentLimit: setting.AlertingRenderLimit,
+		}
+
+		ctx := context.Background()
+		opts := ScreenshotOptions{
+			DashboardUID: "foo",
+			PanelID:      4,
+		}
+		r.EXPECT().
+			Render(ctx, renderOpts, nil).
+			Return(nil, rendering.ErrTimeout)
+		screenshot, err := s.Take(ctx, opts)
+		assert.EqualError(t, err, fmt.Sprintf("failed to take screenshot: %s", rendering.ErrTimeout))
+		assert.Nil(t, screenshot)
+	})
 }
 
 func TestNoOpScreenshotService(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This commit fixes a regression where screenshots were fixed to the last 1h. This changes screenshots to use the default time range of the panel.

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #63718

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
