### PR TITLE
Security: Authenticate to GCR for trivy scans

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4165,13 +4165,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4185,6 +4205,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4195,13 +4219,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4215,6 +4259,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4225,13 +4273,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4246,6 +4314,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4256,13 +4328,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4277,6 +4369,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4286,6 +4382,16 @@ platform:
   arch: amd64
   os: linux
 steps:
+- commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
@@ -4306,8 +4412,13 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5
@@ -4328,8 +4439,13 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 1 --severity HIGH,CRITICAL us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4343,6 +4459,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4374,6 +4494,10 @@ trigger:
   cron: grafana-com-nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 get:
   name: credentials.json
@@ -4543,7 +4667,13 @@ get:
 kind: secret
 name: delivery-bot-app-private-key
 ---
+get:
+  name: service-account
+  path: infra/data/ci/gcr-admin
+kind: secret
+name: gcr_credentials
+---
 kind: signature
-hmac: 303fb59b2da9a39e5bc46dcb962894895697c46477d0c94b2a65c290e87ea57e
+hmac: 5cc59ab45bc9b976cde32b144f61aae11517843d3e731d8bb1e2b619e0daad49
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4669,11 +4669,11 @@ name: delivery-bot-app-private-key
 ---
 get:
   name: service-account
-  path: infra/data/ci/gcr-admin
+  path: secret/data/common/gcr
 kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 5cc59ab45bc9b976cde32b144f61aae11517843d3e731d8bb1e2b619e0daad49
+hmac: 37c8cdea5d79479014c2bee1b93433549ba5f8d5f2eef4f599247312c661118c
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -28,7 +28,7 @@ def authenticate_gcr_step():
     return {
         "name": "authenticate-gcr",
         "image": "docker:dind",
-        "commands": ['echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io'],
+        "commands": ["echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io"],
         "environment": {
             "GCR_CREDENTIALS": from_secret("gcr_credentials"),
         },

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -24,6 +24,17 @@ def cronjobs():
         grafana_com_nightly_pipeline(),
     ]
 
+def authenticate_gcr_step():
+    return {
+        "name": "authenticate-gcr",
+        "image": "docker:dind",
+        "commands": ['echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io'],
+        "environment": {
+            "GCR_CREDENTIALS": from_secret("gcr_credentials"),
+        },
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+    }
+
 def cron_job_pipeline(cronName, name, steps):
     return {
         "kind": "pipeline",
@@ -41,6 +52,14 @@ def cron_job_pipeline(cronName, name, steps):
             "retries": 3,
         },
         "steps": steps,
+        "volumes": [
+            {
+                "name": "docker",
+                "host": {
+                    "path": "/var/run/docker.sock",
+                },
+            },
+        ],
     }
 
 def scan_docker_image_pipeline(tag):
@@ -58,6 +77,7 @@ def scan_docker_image_pipeline(tag):
         cronName = "nightly",
         name = "scan-" + docker_image + "-image",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image),
             scan_docker_image_high_critical_vulnerabilities_step(docker_image),
             slack_job_failed_step("grafana-backend-ops", docker_image),
@@ -75,6 +95,7 @@ def scan_build_test_publish_docker_image_pipeline():
         cronName = "nightly",
         name = "scan-build-test-and-publish-docker-images",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step("all"),
             scan_docker_image_high_critical_vulnerabilities_step("all"),
             slack_job_failed_step("grafana-backend-ops", "build-images"),
@@ -101,6 +122,8 @@ def scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image):
         "name": "scan-unknown-low-medium-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
@@ -123,6 +146,8 @@ def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
         "name": "scan-high-critical-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def slack_job_failed_step(channel, image):

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -148,4 +148,9 @@ def secrets():
             "infra/data/ci/grafana-release-eng/grafana-delivery-bot",
             "app-private-key",
         ),
+        vault_secret(
+            "gcr_credentials",
+            "infra/data/ci/gcr-admin",
+            "service-account",
+        ),
     ]

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -150,7 +150,7 @@ def secrets():
         ),
         vault_secret(
             "gcr_credentials",
-            "infra/data/ci/gcr-admin",
+            "secret/data/common/gcr",
             "service-account",
         ),
     ]


### PR DESCRIPTION
**What is this feature?**

Our nightly trivy scans fail for GCR images, because of the lack of authentication. This PR should fix this issue by authenticating to GCR using a service account secret. 

Small note - `http://us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest` needs dev SA authentication so it'll be excluded for now until we move it to `us.gcr.io/kubernetes-dev`.

Also updates `google/cloud-sdk`, to `444.0.0`. 

