### PR TITLE
Chore: Remove eval source maps to fix trusted types during dev

### DIFF
--- a/results.md
+++ b/results.md
@@ -1,0 +1,5 @@
+| Command | Mean [s] | Min [s] | Max [s] | Relative |
+|:---|---:|---:|---:|---:|
+| `yarn dev --env noTsCheck=1 useDevtool=eval-source-map` | 10.113 ± 0.093 | 9.957 | 10.294 | 1.00 |
+| `yarn dev --env noTsCheck=1 useDevtool=inline-source-map` | 11.048 ± 0.084 | 10.908 | 11.145 | 1.09 ± 0.01 |
+| `yarn dev --env noTsCheck=1 useDevtool=source-map` | 11.499 ± 0.542 | 10.933 | 12.645 | 1.14 ± 0.05 |

--- a/results.md
+++ b/results.md
@@ -1,5 +1,0 @@
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `yarn dev --env noTsCheck=1 useDevtool=eval-source-map` | 10.113 ± 0.093 | 9.957 | 10.294 | 1.00 |
-| `yarn dev --env noTsCheck=1 useDevtool=inline-source-map` | 11.048 ± 0.084 | 10.908 | 11.145 | 1.09 ± 0.01 |
-| `yarn dev --env noTsCheck=1 useDevtool=source-map` | 11.499 ± 0.542 | 10.933 | 12.645 | 1.14 ± 0.05 |

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -22,7 +22,7 @@ const esbuildOptions = {
 
 module.exports = (env = {}) => {
   return merge(common, {
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
     mode: 'development',
 
     entry: {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/67929 dev source maps were changed to fix a Firefox issue, however trusted types does not support `eval()`, so we must change sourcemaps to something else. This prevents e2e tests from being able to run locally.

Changing to `source-map` slows down fresh rebuild by about 1.5 seconds.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `yarn dev --env noTsCheck=1 useDevtool=eval-source-map` | 10.113 ± 0.093 | 9.957 | 10.294 | 1.00 |
| `yarn dev --env noTsCheck=1 useDevtool=inline-source-map` | 11.048 ± 0.084 | 10.908 | 11.145 | 1.09 ± 0.01 |
| `yarn dev --env noTsCheck=1 useDevtool=source-map` | 11.499 ± 0.542 | 10.933 | 12.645 | 1.14 ± 0.05 |

Fixes https://github.com/grafana/grafana/issues/71558
