### PR TITLE
DS Picker: Ignore capitalization when sorting dropdown list

### DIFF
--- a/public/app/features/datasources/components/picker/utils.test.ts
+++ b/public/app/features/datasources/components/picker/utils.test.ts
@@ -32,15 +32,27 @@ describe('isDataSourceMatch', () => {
 describe('getDataSouceCompareFn', () => {
   const dataSources = [
     { uid: 'c', name: 'c', meta: { builtIn: false } },
+    { uid: 'D', name: 'D', meta: { builtIn: false } },
     { uid: 'a', name: 'a', meta: { builtIn: true } },
     { uid: 'b', name: 'b', meta: { builtIn: false } },
   ] as DataSourceInstanceSettings[];
+
+  it('sorts data sources alphabetically ignoring captitalization', () => {
+    dataSources.sort(getDataSourceCompareFn(undefined, [], []));
+    expect(dataSources).toEqual([
+      { uid: 'b', name: 'b', meta: { builtIn: false } },
+      { uid: 'c', name: 'c', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
+      { uid: 'a', name: 'a', meta: { builtIn: true } },
+    ] as DataSourceInstanceSettings[]);
+  });
 
   it('sorts built in datasources last and other data sources alphabetically', () => {
     dataSources.sort(getDataSourceCompareFn(undefined, [], []));
     expect(dataSources).toEqual([
       { uid: 'b', name: 'b', meta: { builtIn: false } },
       { uid: 'c', name: 'c', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'a', name: 'a', meta: { builtIn: true } },
     ] as DataSourceInstanceSettings[]);
   });
@@ -50,6 +62,7 @@ describe('getDataSouceCompareFn', () => {
     expect(dataSources).toEqual([
       { uid: 'c', name: 'c', meta: { builtIn: false } },
       { uid: 'b', name: 'b', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'a', name: 'a', meta: { builtIn: true } },
     ] as DataSourceInstanceSettings[]);
   });
@@ -60,6 +73,7 @@ describe('getDataSouceCompareFn', () => {
       { uid: 'a', name: 'a', meta: { builtIn: true } },
       { uid: 'c', name: 'c', meta: { builtIn: false } },
       { uid: 'b', name: 'b', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
     ] as DataSourceInstanceSettings[]);
   });
 
@@ -68,6 +82,7 @@ describe('getDataSouceCompareFn', () => {
     expect(dataSources).toEqual([
       { uid: 'b', name: 'b', meta: { builtIn: false } },
       { uid: 'c', name: 'c', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'a', name: 'a', meta: { builtIn: true } },
     ] as DataSourceInstanceSettings[]);
   });
@@ -78,7 +93,7 @@ describe('getDataSouceCompareFn', () => {
       { uid: 'b', name: 'b', meta: { builtIn: false } },
       { uid: 'c', name: 'c', meta: { builtIn: false } },
       { uid: 'e', name: 'e', meta: { builtIn: false } },
-      { uid: 'd', name: 'd', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'f', name: 'f', meta: { builtIn: false } },
     ] as DataSourceInstanceSettings[];
 
@@ -87,7 +102,7 @@ describe('getDataSouceCompareFn', () => {
       { uid: 'c', name: 'c', meta: { builtIn: false } },
       { uid: 'e', name: 'e', meta: { builtIn: false } },
       { uid: 'b', name: 'b', meta: { builtIn: false } },
-      { uid: 'd', name: 'd', meta: { builtIn: false } },
+      { uid: 'D', name: 'D', meta: { builtIn: false } },
       { uid: 'f', name: 'f', meta: { builtIn: false } },
       { uid: 'a', name: 'a', meta: { builtIn: true } },
     ] as DataSourceInstanceSettings[]);

--- a/public/app/features/datasources/components/picker/utils.ts
+++ b/public/app/features/datasources/components/picker/utils.ts
@@ -44,6 +44,9 @@ export function getDataSourceCompareFn(
   dataSourceVariablesIDs: string[]
 ) {
   const cmpDataSources = (a: DataSourceInstanceSettings, b: DataSourceInstanceSettings) => {
+    const nameA = a.name.toUpperCase();
+    const nameB = b.name.toUpperCase();
+
     // Sort the current ds before everything else.
     if (current && isDataSourceMatch(a, current)) {
       return -1;
@@ -68,8 +71,6 @@ export function getDataSourceCompareFn(
       return -1;
     } else if (bIsVariable && !aIsVariable) {
       return 1;
-    } else if (bIsVariable && aIsVariable) {
-      return a.name < b.name ? -1 : 1;
     }
 
     // Sort built in DataSources to the bottom and alphabetically by name.
@@ -77,12 +78,10 @@ export function getDataSourceCompareFn(
       return 1;
     } else if (b.meta.builtIn && !a.meta.builtIn) {
       return -1;
-    } else if (a.meta.builtIn && b.meta.builtIn) {
-      return a.name < b.name ? -1 : 1;
     }
 
     // Sort the rest alphabetically by name.
-    return a.name < b.name ? -1 : 1;
+    return nameA < nameB ? -1 : 1;
   };
 
   return cmpDataSources;


### PR DESCRIPTION
**What is this feature?**

Sorting doesn't take into account names starting with uppercase.

|Before|After|
|-|-|
<img width="587" alt="Captura de pantalla 2023-08-01 a las 12 17 10" src="https://github.com/grafana/grafana/assets/5699976/ce7ea03e-1477-4174-9ab3-24d16baf114d">|<img width="599" alt="Captura de pantalla 2023-08-01 a las 11 57 45" src="https://github.com/grafana/grafana/assets/5699976/ee4ff47f-e224-47f9-927b-3ba8c3f48fd3">


**Why do we need this feature?**

Otherwise, the sorting is wrong and it is confusing for the users

**Who is this feature for?**

Every product implementing DS picker

**Which issue(s) does this PR fix?**:

Fixes #72628 


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
