### PR TITLE
A11y: Added aria-label to ColorPicker component

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx
@@ -35,13 +35,12 @@ export const colorPickerFactory = <T extends ColorPickerProps>(
     pickerTriggerRef = createRef<any>();
 
     render() {
-      const { theme, children, onChange } = this.props;
+      const { theme, children, onChange, color } = this.props;
       const styles = getStyles(theme);
       const popoverElement = React.createElement(popover, {
         ...{ ...this.props, children: null },
         onChange,
       });
-
       return (
         <PopoverController content={popoverElement} hideAfter={300}>
           {(showPopper, hidePopper, popperProps) => {
@@ -72,7 +71,8 @@ export const colorPickerFactory = <T extends ColorPickerProps>(
                     ref={this.pickerTriggerRef}
                     onClick={showPopper}
                     onMouseLeave={hidePopper}
-                    color={theme.visualization.getColorByName(this.props.color || '#000000')}
+                    color={theme.visualization.getColorByName(color || '#000000')}
+                    aria-label={color}
                   />
                 )}
               </>

--- a/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
@@ -29,12 +29,17 @@ export const ColorSwatch = React.forwardRef<HTMLDivElement, Props>(
     const { isFocusVisible, focusProps } = useFocusRing();
     const styles = getStyles(theme, variant, color, isFocusVisible, isSelected);
     const hasLabel = !!label;
-    const colorLabel = `${ariaLabel || label} color`;
+    const colorLabel = ariaLabel || label;
 
     return (
       <div ref={ref} className={styles.wrapper} data-testid={selectors.components.ColorSwatch.name} {...otherProps}>
         {hasLabel && <span className={styles.label}>{label}</span>}
-        <button className={styles.swatch} {...focusProps} aria-label={colorLabel} type="button" />
+        <button
+          className={styles.swatch}
+          {...focusProps}
+          aria-label={colorLabel ? `${colorLabel} color` : 'Pick color'}
+          type="button"
+        />
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorSwatch.tsx
@@ -28,7 +28,7 @@ export const ColorSwatch = React.forwardRef<HTMLDivElement, Props>(
     const theme = useTheme2();
     const { isFocusVisible, focusProps } = useFocusRing();
     const styles = getStyles(theme, variant, color, isFocusVisible, isSelected);
-    const hasLabel = !!label;
+    const hasLabel = !label;
     const colorLabel = ariaLabel || label;
 
     return (
@@ -37,7 +37,7 @@ export const ColorSwatch = React.forwardRef<HTMLDivElement, Props>(
         <button
           className={styles.swatch}
           {...focusProps}
-          aria-label={colorLabel ? `${colorLabel} color` : 'Pick color'}
+          aria-label={hasLabel ? `${colorLabel} color` : 'Pick a color'}
           type="button"
         />
       </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Added `aria-label` to ColorPicker component.

**Why do we need this feature?**

To ensure visually impaired and cognitive users who depend on screen reader can navigate Grafana.

**Who is this feature for?**

Visually impaired and cognitive users who depend on screen reader

**Which issue(s) does this PR fix?**: 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #65851

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
