### PR TITLE
SSE: Warn on dropped items in Union in Math Operation

### DIFF
--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -256,7 +256,7 @@ func (e *State) union(aResults, bResults Results, biNode *parse.BinaryNode) []*U
 			return unions
 		}
 	}
-	
+
 	for iA, a := range aResults.Values {
 		for iB, b := range bResults.Values {
 			var labels data.Labels
@@ -596,18 +596,18 @@ func (e *State) walkFunc(node *parse.FuncNode) (Results, error) {
 	return res, nil
 }
 
-func (s *State) addDropNotices(r *Results) {
+func (e *State) addDropNotices(r *Results) {
 	nT := strings.Builder{}
 
-	if s.DropCount > 0 && len(r.Values) > 0 {
+	if e.DropCount > 0 && len(r.Values) > 0 {
 		itemsPerNodeLimit := 5 // Limit on dropped items shown per each node in the binary node
 
-		nT.WriteString(fmt.Sprintf("%v items dropped from union(s)", s.DropCount))
-		if len(s.Drops) > 0 {
+		nT.WriteString(fmt.Sprintf("%v items dropped from union(s)", e.DropCount))
+		if len(e.Drops) > 0 {
 			nT.WriteString(": ")
 
 			biNodeDropCount := 0
-			for biNodeText, biNodeDrops := range s.Drops {
+			for biNodeText, biNodeDrops := range e.Drops {
 				nT.WriteString(fmt.Sprintf(`["%s": `, biNodeText))
 
 				nodeCount := 0

--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -65,31 +65,50 @@ func (e *Expr) executeState(s *State) (r Results, err error) {
 	defer errRecover(&err, s)
 	r, err = s.walk(e.Tree.Root)
 	nT := strings.Builder{}
-	if s.DropCount > 0 && len(r.Values) > 0 {
-		nT.WriteString(fmt.Sprintf("%v items dropped from union(s)", s.DropCount))
 
+	if s.DropCount > 0 && len(r.Values) > 0 {
 		itemsPerNodeLimit := 5 // Limit on dropped items shown per each node in the binary node
+
+		nT.WriteString(fmt.Sprintf("%v items dropped from union(s)", s.DropCount))
 		if len(s.Drops) > 0 {
 			nT.WriteString(": ")
+
+			biNodeDropCount := 0
 			for biNodeText, biNodeDrops := range s.Drops {
 				nT.WriteString(fmt.Sprintf(`["%s": `, biNodeText))
 
+				nodeCount := 0
 				for inputNode, droppedItems := range biNodeDrops {
 					nT.WriteString(fmt.Sprintf("(%s: ", inputNode))
-					
+
 					itemCount := 0
 					for _, item := range droppedItems {
 						nT.WriteString(fmt.Sprintf("{%s}", item))
-						nT.WriteString(")")
-						
+
 						itemCount++
 						if itemCount == itemsPerNodeLimit {
 							nT.WriteString(fmt.Sprintf("...%v more...", len(droppedItems)-itemsPerNodeLimit))
 							break
 						}
+						if itemCount < len(droppedItems) {
+							nT.WriteString(" ")
+						}
+					}
+
+					nT.WriteString(")")
+
+					nodeCount++
+					if nodeCount < len(biNodeDrops) {
+						nT.WriteString(" ")
 					}
 				}
+
 				nT.WriteString("]")
+
+				biNodeDropCount++
+				if biNodeDropCount < len(biNodeDrops) {
+					nT.WriteString(" ")
+				}
 			}
 		}
 

--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -216,21 +216,22 @@ func (e *State) union(aResults, bResults Results, biNode *parse.BinaryNode) []*U
 	collectDrops := func() {
 		check := func(v string, matchArray []bool, r *Results) {
 			for i, b := range matchArray {
-				if !b {
-					if e.Drops == nil {
-						e.Drops = make(map[string]map[string][]data.Labels)
-					}
-					if e.Drops[biNode.String()] == nil {
-						e.Drops[biNode.String()] = make(map[string][]data.Labels)
-					}
-
-					if r.Values[i].Type() == parse.TypeNoData {
-						continue
-					}
-
-					e.DropCount++
-					e.Drops[biNode.String()][v] = append(e.Drops[biNode.String()][v], r.Values[i].GetLabels())
+				if b {
+					continue
 				}
+				if e.Drops == nil {
+					e.Drops = make(map[string]map[string][]data.Labels)
+				}
+				if e.Drops[biNode.String()] == nil {
+					e.Drops[biNode.String()] = make(map[string][]data.Labels)
+				}
+
+				if r.Values[i].Type() == parse.TypeNoData {
+					continue
+				}
+
+				e.DropCount++
+				e.Drops[biNode.String()][v] = append(e.Drops[biNode.String()][v], r.Values[i].GetLabels())
 			}
 		}
 		check(aVar, aMatched, &aResults)

--- a/pkg/expr/mathexp/exp_nan_null_val_test.go
+++ b/pkg/expr/mathexp/exp_nan_null_val_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -491,21 +492,21 @@ func TestNoData(t *testing.T) {
 					res, err := e.Execute("", makeVars(NewNoData(), NewNoData()), tracing.NewFakeTracer())
 					require.NoError(t, err)
 					require.Len(t, res.Values, 1)
-					require.Equal(t, NewNoData(), res.Values[0])
+					require.Equal(t, parse.TypeNoData, res.Values[0].Type())
 				})
 
 				t.Run("$A=nodata, $B=series", func(t *testing.T) {
 					res, err := e.Execute("", makeVars(NewNoData(), series), tracing.NewFakeTracer())
 					require.NoError(t, err)
 					require.Len(t, res.Values, 1)
-					require.Equal(t, NewNoData(), res.Values[0])
+					require.Equal(t, parse.TypeNoData, res.Values[0].Type())
 				})
 
 				t.Run("$A=series, $B=nodata", func(t *testing.T) {
 					res, err := e.Execute("", makeVars(NewNoData(), series), tracing.NewFakeTracer())
 					require.NoError(t, err)
 					require.Len(t, res.Values, 1)
-					require.Equal(t, NewNoData(), res.Values[0])
+					require.Equal(t, parse.TypeNoData, res.Values[0].Type())
 				})
 			}
 		})

--- a/pkg/expr/mathexp/parse/node.go
+++ b/pkg/expr/mathexp/parse/node.go
@@ -77,6 +77,8 @@ func (t NodeType) String() string {
 		return "NodeString"
 	case NodeNumber:
 		return "NodeNumber"
+	case NodeVar:
+		return "NodeVar"
 	default:
 		return "NodeUnknown"
 	}

--- a/pkg/expr/mathexp/union_test.go
+++ b/pkg/expr/mathexp/union_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -293,7 +294,8 @@ func Test_union(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			unions := union(tt.aResults, tt.bResults)
+			fakeNode := &parse.BinaryNode{Args: [2]parse.Node{&parse.VarNode{}, &parse.VarNode{}}}
+			unions := (&State{}).union(tt.aResults, tt.bResults, fakeNode)
 			tt.unionsAre(t, tt.unions, unions)
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

Unions in SSE operations currently drop items when doing a binary operation (e.g. $A + $B) from either A or B when there isn't a label "match" between them.

This is confusing, so to aid in this, we warn and display the count of items that where dropped, and which items they were.

![image](https://github.com/grafana/grafana/assets/1692624/c122125d-f244-4c9d-a0ca-2edffc7ca84a)

![image](https://github.com/grafana/grafana/assets/1692624/64c5e7d1-4721-4c4b-82b9-814d5707d19c)


Fixes #

**Special notes for your reviewer:**

Design wise, we really need to revisit "Union". In short, Math should probably have a dropdown that changes what happens with a binary operation (e.g. `$a OP $b`) in terms of union/join set operations based on labels. So this is more in the direction of "Informational based on the currently (and only mode)" so as not to create a future problem when tackling this in a broader sense. 

The output format is pretty dense. The way it works is from Left to Right, so - `((A union B) union C)`. So things can be dropped between union of A and B, as well as between the result of of the the union between A and B then having a Union with C. To put it another way, with `$A + $B + $C`, if there is a match between A and C, but not between A and B, the item will be dropped.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
