### PR TITLE
Logs: Improved keyboard accessibility of log rows menu

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -203,6 +203,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           onClick={this.toggleDetails}
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
+          onFocus={this.onMouseEnter}
         >
           {showDuplicates && (
             <td className={styles.logsRowDuplicates}>
@@ -241,6 +242,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               onUnpinLine={this.props.onUnpinLine}
               pinned={this.props.pinned}
               mouseIsOver={this.state.mouseIsOver}
+              onBlur={this.onMouseLeave}
             />
           ) : (
             <LogRowMessage
@@ -256,6 +258,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               onUnpinLine={this.props.onUnpinLine}
               pinned={this.props.pinned}
               mouseIsOver={this.state.mouseIsOver}
+              onBlur={this.onMouseLeave}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -203,6 +203,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           onClick={this.toggleDetails}
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
+          /**
+           * For better accessibility support, we listen to the onFocus event here (to display the LogRowMenuCell), and
+           * to onBlur event in the LogRowMenuCell (to hide it). This way, the LogRowMenuCell is displayed when the user navigates
+           * using the keyboard.
+           */
           onFocus={this.onMouseEnter}
         >
           {showDuplicates && (

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useCallback } from 'react';
+import React, { FocusEvent, SyntheticEvent, useCallback } from 'react';
 
 import { LogRowModel } from '@grafana/data';
 import { ClipboardButton, IconButton } from '@grafana/ui';
@@ -16,6 +16,7 @@ interface Props {
   pinned?: boolean;
   styles: LogRowStyles;
   mouseIsOver: boolean;
+  onBlur?: () => void;
 }
 
 export const LogRowMenuCell = React.memo(
@@ -30,6 +31,7 @@ export const LogRowMenuCell = React.memo(
     showContextToggle,
     styles,
     mouseIsOver,
+    onBlur,
   }: Props) => {
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
     const onLogRowClick = useCallback((e: SyntheticEvent) => {
@@ -42,11 +44,19 @@ export const LogRowMenuCell = React.memo(
       },
       [onOpenContext, row]
     );
+    const handleBlur = useCallback(
+      (e: FocusEvent) => {
+        if (!e.currentTarget.contains(e.relatedTarget) && onBlur) {
+          onBlur();
+        }
+      },
+      [onBlur]
+    );
     const getLogText = useCallback(() => logText, [logText]);
     return (
       // TODO: fix keyboard a11y
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick}>
+      <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick} onBlur={handleBlur}>
         {pinned && !mouseIsOver && (
           <IconButton
             className={styles.unPinButton}
@@ -56,6 +66,7 @@ export const LogRowMenuCell = React.memo(
             tooltip="Unpin line"
             tooltipPlacement="top"
             aria-label="Unpin line"
+            tabIndex={0}
           />
         )}
         {mouseIsOver && (
@@ -68,6 +79,7 @@ export const LogRowMenuCell = React.memo(
                 tooltip="Show context"
                 tooltipPlacement="top"
                 aria-label="Show context"
+                tabIndex={0}
               />
             )}
             <ClipboardButton
@@ -79,6 +91,7 @@ export const LogRowMenuCell = React.memo(
               getText={getLogText}
               tooltip="Copy to clipboard"
               tooltipPlacement="top"
+              tabIndex={0}
             />
             {pinned && onUnpinLine && (
               <IconButton
@@ -89,6 +102,7 @@ export const LogRowMenuCell = React.memo(
                 tooltip="Unpin line"
                 tooltipPlacement="top"
                 aria-label="Unpin line"
+                tabIndex={0}
               />
             )}
             {!pinned && onPinLine && (
@@ -100,6 +114,7 @@ export const LogRowMenuCell = React.memo(
                 tooltip="Pin line"
                 tooltipPlacement="top"
                 aria-label="Pin line"
+                tabIndex={0}
               />
             )}
             {onPermalinkClick && row.rowId !== undefined && row.uid && (
@@ -110,6 +125,7 @@ export const LogRowMenuCell = React.memo(
                 size="md"
                 name="share-alt"
                 onClick={() => onPermalinkClick(row)}
+                tabIndex={0}
               />
             )}
           </>

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -44,6 +44,10 @@ export const LogRowMenuCell = React.memo(
       },
       [onOpenContext, row]
     );
+    /**
+     * For better accessibility support, we listen to the onBlur event here (to hide this component), and
+     * to onFocus in LogRow (to show this component).
+     */
     const handleBlur = useCallback(
       (e: FocusEvent) => {
         if (!e.currentTarget.contains(e.relatedTarget) && onBlur) {
@@ -54,7 +58,7 @@ export const LogRowMenuCell = React.memo(
     );
     const getLogText = useCallback(() => logText, [logText]);
     return (
-      // TODO: fix keyboard a11y
+      // We keep this click listener here to prevent the row from being selected when clicking on the menu.
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick} onBlur={handleBlur}>
         {pinned && !mouseIsOver && (

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -16,7 +16,7 @@ interface Props {
   pinned?: boolean;
   styles: LogRowStyles;
   mouseIsOver: boolean;
-  onBlur?: () => void;
+  onBlur: () => void;
 }
 
 export const LogRowMenuCell = React.memo(

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -19,6 +19,7 @@ const setup = (propOverrides?: Partial<ComponentProps<typeof LogRowMessage>>, ro
     app: CoreApp.Explore,
     styles,
     mouseIsOver: true,
+    onBlur: jest.fn(),
     ...(propOverrides || {}),
   };
 

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -22,6 +22,7 @@ interface Props {
   pinned?: boolean;
   styles: LogRowStyles;
   mouseIsOver: boolean;
+  onBlur?: () => void;
 }
 
 interface LogMessageProps {
@@ -75,10 +76,11 @@ export const LogRowMessage = React.memo((props: Props) => {
     onPinLine,
     pinned,
     mouseIsOver,
+    onBlur,
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
+  const shouldShowMenu = useMemo(() => mouseIsOver || pinned || true, [mouseIsOver, pinned]);
   return (
     <>
       {
@@ -105,6 +107,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             pinned={pinned}
             styles={styles}
             mouseIsOver={mouseIsOver}
+            onBlur={onBlur}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -22,7 +22,7 @@ interface Props {
   pinned?: boolean;
   styles: LogRowStyles;
   mouseIsOver: boolean;
-  onBlur?: () => void;
+  onBlur: () => void;
 }
 
 interface LogMessageProps {

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.test.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.test.tsx
@@ -21,6 +21,7 @@ const setup = (propOverrides: Partial<Props> = {}, detectedFields = ['place', 'p
     styles,
     detectedFields,
     mouseIsOver: true,
+    onBlur: jest.fn(),
     ...propOverrides,
   };
 

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -20,6 +20,7 @@ export interface Props {
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
   mouseIsOver: boolean;
+  onBlur?: () => void;
 }
 
 export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
@@ -65,8 +66,8 @@ export const LogRowMessageDisplayedFields = React.memo((props: Props) => {
             row={row}
             styles={styles}
             pinned={pinned}
-            {...rest}
             mouseIsOver={mouseIsOver}
+            {...rest}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -20,7 +20,7 @@ export interface Props {
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
   mouseIsOver: boolean;
-  onBlur?: () => void;
+  onBlur: () => void;
 }
 
 export const LogRowMessageDisplayedFields = React.memo((props: Props) => {


### PR DESCRIPTION
This PR improves the keyboard navigation of log lines by adding listeners to the `onFocus` and `onBlur` events on each log row.

- We listen to `onFocus` in the log row component to detect when a user navigates and focuses on it, and we display the log men.
- The user continues navigating using the keyboard, so to hide the log menu we listen to the `onBlur` event in the log menu, which is the last element we render on each row.

Demo:

https://github.com/grafana/grafana/assets/1069378/45e4bfa0-81bd-444f-9cbb-319812833a18

**Which issue(s) does this PR fix?**:

This was discovered while working on https://github.com/grafana/grafana/issues/70981 . The conclusion after reviewing the code is that:
- The onClick event in the span is not meant for interactions, but rather to prevent event propagations. See https://github.com/grafana/grafana/issues/70981#issuecomment-1660511534
- We're using this opportunity to add missing a11y support to the log row menu.

Closes https://github.com/grafana/grafana/issues/70981

**Special notes for your reviewer:**

Using any logging data source:
- Query for logs.
- Navigate the logs using the keyboard.
- Expected: you should be able to access and use the log row menu using the keyboard.
- Navigate the logs using the mouse, everything should work as usual.