### PR TITLE
[v10.1.x] Auth: Lock down Grafana admin role updates if the role is externally synced

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -68,6 +68,11 @@ func (hs *HTTPServer) getUserUserProfile(c *contextmodel.ReqContext, userID int6
 		userProfile.AuthLabels = append(userProfile.AuthLabels, authLabel)
 		userProfile.IsExternal = true
 		userProfile.IsExternallySynced = login.IsExternallySynced(hs.Cfg, authInfo.AuthModule)
+		oAuthAndAllowAssignGrafanaAdmin := false
+		if oauthInfo := hs.SocialService.GetOAuthInfoProvider(strings.TrimPrefix(authInfo.AuthModule, "oauth_")); oauthInfo != nil {
+			oAuthAndAllowAssignGrafanaAdmin = oauthInfo.AllowAssignGrafanaAdmin
+		}
+		userProfile.IsGrafanaAdminExternallySynced = login.IsGrafanaAdminExternallySynced(hs.Cfg, authInfo.AuthModule, oAuthAndAllowAssignGrafanaAdmin)
 	}
 
 	userProfile.AccessControl = hs.getAccessControlMetadata(c, c.OrgID, "global.users:id:", strconv.FormatInt(userID, 10))

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/login/socialtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -214,6 +216,125 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		assert.Equal(t, 2, respJSON.Get("page").MustInt())
 		assert.Equal(t, 10, respJSON.Get("perPage").MustInt())
 	}, mock)
+}
+
+func Test_GetUserByID(t *testing.T) {
+	testcases := []struct {
+		name                         string
+		authModule                   string
+		allowAssignGrafanaAdmin      bool
+		authEnabled                  bool
+		skipOrgRoleSync              bool
+		expectedIsGrafanaAdminSynced bool
+	}{
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced OAuth user if Grafana Admin role is not synced",
+			authModule:                   login.GenericOAuthModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      false,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced OAuth user if OAuth provider is not enabled",
+			authModule:                   login.GenericOAuthModule,
+			authEnabled:                  false,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced OAuth user if org roles are not being synced",
+			authModule:                   login.GenericOAuthModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              true,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = true for an externally synced OAuth user",
+			authModule:                   login.GenericOAuthModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: true,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced JWT user if Grafana Admin role is not synced",
+			authModule:                   login.JWTModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      false,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced JWT user if JWT provider is not enabled",
+			authModule:                   login.JWTModule,
+			authEnabled:                  false,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = false for an externally synced JWT user if org roles are not being synced",
+			authModule:                   login.JWTModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              true,
+			expectedIsGrafanaAdminSynced: false,
+		},
+		{
+			name:                         "Should return IsGrafanaAdminExternallySynced = true for an externally synced JWT user",
+			authModule:                   login.JWTModule,
+			authEnabled:                  true,
+			allowAssignGrafanaAdmin:      true,
+			skipOrgRoleSync:              false,
+			expectedIsGrafanaAdminSynced: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			userAuth := &login.UserAuth{AuthModule: tc.authModule}
+			authInfoService := &logintest.AuthInfoServiceFake{ExpectedUserAuth: userAuth}
+			socialService := &socialtest.FakeSocialService{}
+			userService := &usertest.FakeUserService{ExpectedUserProfileDTO: &user.UserProfileDTO{}}
+			cfg := setting.NewCfg()
+
+			switch tc.authModule {
+			case login.GenericOAuthModule:
+				socialService.ExpectedAuthInfoProvider = &social.OAuthInfo{AllowAssignGrafanaAdmin: tc.allowAssignGrafanaAdmin, Enabled: tc.authEnabled}
+				cfg.GenericOAuthAuthEnabled = tc.authEnabled
+				cfg.GenericOAuthSkipOrgRoleSync = tc.skipOrgRoleSync
+			case login.JWTModule:
+				cfg.JWTAuthEnabled = tc.authEnabled
+				cfg.JWTAuthSkipOrgRoleSync = tc.skipOrgRoleSync
+				cfg.JWTAuthAllowAssignGrafanaAdmin = tc.allowAssignGrafanaAdmin
+			}
+
+			hs := &HTTPServer{
+				Cfg:             cfg,
+				authInfoService: authInfoService,
+				SocialService:   socialService,
+				userService:     userService,
+			}
+
+			sc := setupScenarioContext(t, "/api/users/1")
+			sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+				sc.context = c
+				return hs.GetUserByID(c)
+			})
+
+			sc.m.Get("/api/users/:id", sc.defaultHandler)
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+			var resp user.UserProfileDTO
+			require.Equal(t, http.StatusOK, sc.resp.Code)
+			err := json.Unmarshal(sc.resp.Body.Bytes(), &resp)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedIsGrafanaAdminSynced, resp.IsGrafanaAdminExternallySynced)
+		})
+	}
 }
 
 func TestHTTPServer_UpdateUser(t *testing.T) {

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -114,6 +114,24 @@ func IsExternallySynced(cfg *setting.Cfg, authModule string) bool {
 	return true
 }
 
+// IsGrafanaAdminExternallySynced returns true if Grafana server admin role is being managed by an external auth provider, and false otherwise.
+// Grafana admin role sync is available for JWT, OAuth providers and LDAP.
+// For JWT and OAuth providers there is an additional config option `allow_assign_grafana_admin` that has to be enabled for Grafana Admin role to be synced.
+func IsGrafanaAdminExternallySynced(cfg *setting.Cfg, authModule string, oAuthAndAllowAssignGrafanaAdmin bool) bool {
+	if !IsExternallySynced(cfg, authModule) {
+		return false
+	}
+
+	switch authModule {
+	case JWTModule:
+		return cfg.JWTAuthAllowAssignGrafanaAdmin
+	case LDAPAuthModule:
+		return true
+	default:
+		return oAuthAndAllowAssignGrafanaAdmin
+	}
+}
+
 func IsProviderEnabled(cfg *setting.Cfg, authModule string) bool {
 	switch authModule {
 	case SAMLAuthModule:

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -142,21 +142,22 @@ type GetUserProfileQuery struct {
 }
 
 type UserProfileDTO struct {
-	ID                 int64           `json:"id"`
-	Email              string          `json:"email"`
-	Name               string          `json:"name"`
-	Login              string          `json:"login"`
-	Theme              string          `json:"theme"`
-	OrgID              int64           `json:"orgId,omitempty"`
-	IsGrafanaAdmin     bool            `json:"isGrafanaAdmin"`
-	IsDisabled         bool            `json:"isDisabled"`
-	IsExternal         bool            `json:"isExternal"`
-	IsExternallySynced bool            `json:"isExternallySynced"`
-	AuthLabels         []string        `json:"authLabels"`
-	UpdatedAt          time.Time       `json:"updatedAt"`
-	CreatedAt          time.Time       `json:"createdAt"`
-	AvatarURL          string          `json:"avatarUrl"`
-	AccessControl      map[string]bool `json:"accessControl,omitempty"`
+	ID                             int64           `json:"id"`
+	Email                          string          `json:"email"`
+	Name                           string          `json:"name"`
+	Login                          string          `json:"login"`
+	Theme                          string          `json:"theme"`
+	OrgID                          int64           `json:"orgId,omitempty"`
+	IsGrafanaAdmin                 bool            `json:"isGrafanaAdmin"`
+	IsDisabled                     bool            `json:"isDisabled"`
+	IsExternal                     bool            `json:"isExternal"`
+	IsExternallySynced             bool            `json:"isExternallySynced"`
+	IsGrafanaAdminExternallySynced bool            `json:"isGrafanaAdminExternallySynced"`
+	AuthLabels                     []string        `json:"authLabels"`
+	UpdatedAt                      time.Time       `json:"updatedAt"`
+	CreatedAt                      time.Time       `json:"createdAt"`
+	AvatarURL                      string          `json:"avatarUrl"`
+	AccessControl                  map[string]bool `json:"accessControl,omitempty"`
 }
 
 // implement Conversion interface to define custom field mapping (xorm feature)

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -130,7 +130,11 @@ export class UserAdminPage extends PureComponent<Props> {
               {isLDAPUser && isUserSynced && featureEnabled('ldapsync') && ldapSyncInfo && canReadLDAPStatus && (
                 <UserLdapSyncInfo ldapSyncInfo={ldapSyncInfo} user={user} onUserSync={this.onUserSync} />
               )}
-              <UserPermissions isGrafanaAdmin={user.isGrafanaAdmin} onGrafanaAdminChange={this.onGrafanaAdminChange} />
+              <UserPermissions
+                isGrafanaAdmin={user.isGrafanaAdmin}
+                isExternalUser={user?.isGrafanaAdminExternallySynced}
+                onGrafanaAdminChange={this.onGrafanaAdminChange}
+              />
             </>
           )}
 

--- a/public/app/features/admin/UserPermissions.tsx
+++ b/public/app/features/admin/UserPermissions.tsx
@@ -6,6 +6,7 @@ import { AccessControlAction } from 'app/types';
 
 interface Props {
   isGrafanaAdmin: boolean;
+  isExternalUser?: boolean;
 
   onGrafanaAdminChange: (isGrafanaAdmin: boolean) => void;
 }
@@ -15,7 +16,7 @@ const adminOptions = [
   { label: 'No', value: false },
 ];
 
-export function UserPermissions({ isGrafanaAdmin, onGrafanaAdminChange }: Props) {
+export function UserPermissions({ isGrafanaAdmin, isExternalUser, onGrafanaAdminChange }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [currentAdminOption, setCurrentAdminOption] = useState(isGrafanaAdmin);
 
@@ -28,7 +29,7 @@ export function UserPermissions({ isGrafanaAdmin, onGrafanaAdminChange }: Props)
 
   const handleGrafanaAdminChange = () => onGrafanaAdminChange(currentAdminOption);
 
-  const canChangePermissions = contextSrv.hasPermission(AccessControlAction.UsersPermissionsUpdate);
+  const canChangePermissions = contextSrv.hasPermission(AccessControlAction.UsersPermissionsUpdate) && !isExternalUser;
 
   return (
     <>

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -48,6 +48,7 @@ export interface UserDTO extends WithAccessControlMetadata {
   teams?: Unit[];
   orgs?: Unit[];
   isExternallySynced?: boolean;
+  isGrafanaAdminExternallySynced?: boolean;
 }
 
 export interface Invitee {


### PR DESCRIPTION
Backport d3b481dac87aaeae26195bbedfd80ed33a1cebed from #72677

---

**What is this feature?**

Roles should either be manually updated or externally synced. If they are externally synced, we lock manual role updates.

**Why do we need this feature?**

For clearer and more secure role management.

**Who is this feature for?**

Anyone who uses external auth providers to sync user's roles.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
