### PR TITLE
AzureMonitor: Check to see if response is nil to prevent panic

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -268,7 +268,7 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Warn("Failed to close response body", "err", err)
+			logger.Warn("failed to close response body", "err", err)
 		}
 	}()
 
@@ -284,7 +284,7 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	var data types.SubscriptionsResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", fmt.Errorf("Failed to unmarshal subscription detail response. error: %s, status: %s, body: %s", err, res.Status, string(body))
+		return "", fmt.Errorf("failed to unmarshal subscription detail response. error: %s, status: %s, body: %s", err, res.Status, string(body))
 	}
 
 	return data.DisplayName, nil
@@ -326,7 +326,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Warn("Failed to close response body", "err", err)
+			logger.Warn("failed to close response body", "err", err)
 		}
 	}()
 
@@ -359,8 +359,8 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 func (e *AzureMonitorDatasource) createRequest(ctx context.Context, logger log.Logger, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		logger.Debug("Failed to create request", "error", err)
-		return nil, fmt.Errorf("%v: %w", "Failed to create request", err)
+		logger.Debug("failed to create request", "error", err)
+		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -381,7 +381,7 @@ func (e *AzureMonitorDatasource) unmarshalResponse(logger log.Logger, res *http.
 	var data types.AzureMonitorResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		logger.Debug("Failed to unmarshal AzureMonitor response", "error", err, "status", res.Status, "body", string(body))
+		logger.Debug("failed to unmarshal AzureMonitor response", "error", err, "status", res.Status, "body", string(body))
 		return types.AzureMonitorResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -266,6 +266,10 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	if err != nil {
 		logger.Warn("failed to request subscription details: %s", err)
 	}
+	if res == nil {
+		logger.Warn("failed to request subscription details", "err", "no response received from client")
+		return ""
+	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			logger.Warn("Failed to close response body", "err", err)

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -344,8 +344,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 
 	subscription, err := e.retrieveSubscriptionDetails(cli, ctx, logger, tracer, query.Subscription, dsInfo.Routes["Azure Monitor"].URL, dsInfo.DatasourceID, dsInfo.OrgID)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		logger.Warn(err.Error())
 	}
 
 	dataResponse.Frames, err = e.parseResponse(data, query, azurePortalUrl, subscription)


### PR DESCRIPTION
This will prevent panics from happening when there is no response. 
https://github.com/grafana/support-escalations/issues/6911