### PR TITLE
DataFrame: Add metadata for supporting time comparison windows

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -7,5 +7,10 @@ export * from './dimensions';
 export * from './ArrayDataFrame';
 export * from './DataFrameJSON';
 export * from './frameComparisons';
-export { anySeriesWithTimeField, isTimeSeriesFrame, isTimeSeriesFrames } from './utils';
+export {
+  anySeriesWithTimeField,
+  isTimeSeriesFrame,
+  isTimeSeriesFrames,
+  shiftComparisonFramesTimestamps,
+} from './utils';
 export { StreamingDataFrame, StreamingFrameAction, type StreamingFrameOptions } from './StreamingDataFrame';

--- a/packages/grafana-data/src/dataframe/utils.test.ts
+++ b/packages/grafana-data/src/dataframe/utils.test.ts
@@ -1,7 +1,8 @@
+import { dateTime } from '../datetime';
 import { FieldType } from '../types';
 
 import { toDataFrame } from './processDataFrame';
-import { anySeriesWithTimeField } from './utils';
+import { anySeriesWithTimeField, shiftComparisonFramesTimestamps } from './utils';
 
 describe('anySeriesWithTimeField', () => {
   describe('single frame', () => {
@@ -74,6 +75,106 @@ describe('anySeriesWithTimeField', () => {
         ],
       });
       expect(anySeriesWithTimeField([frameA, frameB])).toBeTruthy();
+    });
+  });
+
+  describe('shiftComparisonFramesTimestamps', () => {
+    it('should do nothing if time range does not exist on data frame metadata', () => {
+      const frameA = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+      const frameB = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'name', type: FieldType.string, values: ['a', 'b', 'c'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+
+      shiftComparisonFramesTimestamps([frameA, frameB]);
+      expect(frameA.fields[0].values).toEqual([100, 200, 300]);
+      expect(frameB.fields[0].values).toEqual([100, 200, 300]);
+    });
+
+    it('should do nothing if time range does not exist on first data frame metadata but exists on others', () => {
+      const frameA = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+      const frameB = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'name', type: FieldType.string, values: ['a', 'b', 'c'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+
+      frameB.meta = {
+        timeRange: {
+          from: dateTime(1690966348),
+          to: dateTime(1690966348),
+          raw: {
+            from: dateTime(1690966348),
+            to: dateTime(1690966348),
+          },
+        },
+      };
+
+      shiftComparisonFramesTimestamps([frameA, frameB]);
+      expect(frameA.fields[0].values).toEqual([100, 200, 300]);
+      expect(frameB.fields[0].values).toEqual([100, 200, 300]);
+    });
+
+    it('should shift comparison frames', () => {
+      const diff = 3600000; // 1h
+
+      const referenceFrame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1690966348, 1690966348 + diff / 2, 1690966348 + diff] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+
+      referenceFrame.meta = {
+        timeRange: {
+          from: dateTime(1690966348),
+          to: dateTime(1690966348 + diff),
+          raw: {
+            from: dateTime(1690966348),
+            to: dateTime(1690966348 + diff),
+          },
+        },
+      };
+
+      // Shifted by 1h
+      const shiftedFrame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1690966348 - diff, 1690966348 - diff / 2, 1690966348] },
+          { name: 'name', type: FieldType.string, values: ['a', 'b', 'c'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+
+      shiftedFrame.meta = {
+        timeRange: {
+          from: dateTime(1690966348 - diff),
+          to: dateTime(1690966348),
+          raw: {
+            from: dateTime(1690966348 - diff),
+            to: dateTime(1690966348),
+          },
+        },
+      };
+
+      shiftComparisonFramesTimestamps([referenceFrame, shiftedFrame]);
+
+      expect(referenceFrame.fields[0].values).toEqual([1690966348, 1690966348 + diff / 2, 1690966348 + diff]);
+      expect(shiftedFrame.fields[0].values).toEqual([1690966348, 1690966348 + diff / 2, 1690966348 + diff]);
     });
   });
 });

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -4,7 +4,7 @@ import { ApplyFieldOverrideOptions } from './fieldOverrides';
 import { DataTopic } from './query';
 import { DataTransformerConfig } from './transformations';
 
-import { PanelPluginDataSupport } from '.';
+import { PanelPluginDataSupport, TimeRange } from '.';
 
 export type KeyValue<T = any> = Record<string, T>;
 
@@ -101,6 +101,11 @@ export interface QueryResultMeta {
   limit?: number; // used by log models and loki
   json?: boolean; // used to keep track of old json doc values
   instant?: boolean;
+
+  /**
+   * Indicates a time range that the data source was queried with.
+   */
+  timeRange?: TimeRange;
 }
 
 export interface QueryResultMetaStat extends FieldConfig {

--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -1,4 +1,12 @@
-import { DataFrame, Field, FieldConfig, FieldType, outerJoinDataFrames, TimeRange } from '@grafana/data';
+import {
+  DataFrame,
+  Field,
+  FieldConfig,
+  FieldType,
+  outerJoinDataFrames,
+  shiftComparisonFramesTimestamps,
+  TimeRange,
+} from '@grafana/data';
 import {
   AxisPlacement,
   GraphDrawStyle,
@@ -52,6 +60,7 @@ function applySpanNullsThresholds(frame: DataFrame, refFieldName?: string | null
 
 export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) {
   let xField: Field;
+
   loop: for (let frame of frames) {
     for (let field of frame.fields) {
       if (dimFields.x(field, frame, frames)) {
@@ -60,6 +69,8 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
       }
     }
   }
+
+  shiftComparisonFramesTimestamps(frames);
 
   // apply null insertions at interval
   frames = frames.map((frame) => {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -13,6 +13,7 @@ import {
   outerJoinDataFrames,
   TimeZone,
   VizOrientation,
+  shiftComparisonFramesTimestamps,
 } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import {
@@ -362,6 +363,8 @@ export function prepareBarChartDisplayValues(
   if (!series?.length) {
     return { warn: 'No data in response' };
   }
+
+  shiftComparisonFramesTimestamps(series);
 
   cacheFieldDisplayNames(series);
 

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -9,6 +9,7 @@ import {
   GrafanaTheme2,
   LinkModel,
   outerJoinDataFrames,
+  shiftComparisonFramesTimestamps,
   ValueFormatter,
   ValueLinkConfig,
 } from '@grafana/data';
@@ -73,6 +74,8 @@ export function prepareHeatmapData(
   if (!frames?.length) {
     return {};
   }
+
+  shiftComparisonFramesTimestamps(frames);
 
   cacheFieldDisplayNames(frames);
 


### PR DESCRIPTION
This builds on top of exploration done in https://github.com/grafana/grafana/pull/71204 and https://github.com/grafana/grafana/pull/71129. This PR adds `timeRange` property to data frame metadata, to indicate what time range a query was executed with.

Spent some time talking with @leeoniya about this and we think the approach of providing not pre-shifted data frames from Scenes will be sensible going forward. The time comparison graphing support comes down to visualizations, and with this PR it is quite a minimal change to the panels in order to support rendering of compare series. The only thing required to do seems to be just shifting the compare series relative to reference (original time range) frame.

This PR assumes that queries run for a previous time period will be returned in data frames that follow the reference frame: `[referenceFrame, shiftedFrame1, shiftedFrame2,...]`. grafana/data exposes `shiftComparisonFramesTimestamps` utility function that is used by panels when they prepare data for rendering. This way, the changes required in panels are minimal.

@ryantxu  - I know you started exploring this territory- is this anyhow aligned with your approach?