### PR TITLE
Fix typos in Loki template variable tests

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -42,10 +42,10 @@ describe('LokiVariableQueryEditor', () => {
 
     expect(onChange).not.toHaveBeenCalled();
 
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label names');
 
     expect(onChange).toHaveBeenCalledWith({
-      type: LokiVariableQueryType.LabelValues,
+      type: LokiVariableQueryType.LabelNames,
       label: '',
       stream: '',
       refId,


### PR DESCRIPTION
Fix some typos I detected by chance in Loki's tests.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
