### PR TITLE
Add example of using LLMs via @grafana/experimental and LLM app plugin

### DIFF
--- a/conf/provisioning/datasources/robust-perception.yaml
+++ b/conf/provisioning/datasources/robust-perception.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Robust Perception
+    uid: robustperception
+    type: prometheus
+    access: proxy
+    url: http://demo.robustperception.io:9090
+    isDefault: true
+

--- a/conf/provisioning/plugins/grafana-llm-app.yaml
+++ b/conf/provisioning/plugins/grafana-llm-app.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+apps:
+  - type: grafana-llm-app
+    jsonData:
+      openAIUrl: https://api.openai.com
+      openAIOrganizationID: org-RXrPv8fY9rahdyxaw5fhwxub
+    secureJsonData:
+      openAIKey: $OPENAI_API_KEY

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "@grafana/aws-sdk": "0.0.47",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f",
+    "@grafana/experimental": "grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59",
     "@grafana/faro-core": "1.1.2",
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "@grafana/aws-sdk": "0.0.47",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59",
+    "@grafana/experimental": "1.7.0",
     "@grafana/faro-core": "1.1.2",
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "@grafana/aws-sdk": "0.0.47",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "1.6.1",
+    "@grafana/experimental": "grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f",
     "@grafana/faro-core": "1.1.2",
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderExplained.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderExplained.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useAsync } from 'react-use';
 
-import { Stack } from '@grafana/experimental';
+import { Stack, llms } from '@grafana/experimental';
+import { Spinner } from '@grafana/ui';
 
 import promqlGrammar from '../../promql';
 import { promQueryModeller } from '../PromQueryModeller';
@@ -20,8 +22,44 @@ export const PromQueryBuilderExplained = React.memo<Props>(({ query }) => {
   const visQuery = buildVisualQueryFromString(query || '').query;
   const lang = { grammar: promqlGrammar, name: 'promql' };
 
+  const [llmReply, setLLMReply] = useState('');
+
+  const { value } = useAsync(async () => {
+    // Check if the LLM plugin is enabled and configured.
+    // If not, we won't be able to make requests, so return early.
+    const enabled = await llms.openai.enabled();
+    if (!enabled) {
+      return { enabled };
+    }
+
+    llms.openai
+      .streamChatCompletions({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an expert in the Prometheus query language PromQL. Explain the purpose of the following Prometheus query.',
+          },
+          { role: 'user', content: query },
+        ],
+      })
+      .pipe(
+        // Accumulate the stream content into a stream of strings, where each
+        // element contains the accumulated message so far.
+        llms.openai.accumulateContent()
+      )
+      .subscribe(setLLMReply);
+    return { enabled };
+  }, [query]);
+
   return (
     <Stack gap={0.5} direction="column">
+      {value?.enabled && (
+        <OperationExplainedBox title="Query summary">
+          {llmReply === '' ? <Spinner /> : <pre>{llmReply}</pre>}
+        </OperationExplainedBox>
+      )}
       <OperationExplainedBox
         stepNumber={1}
         title={<RawQuery query={`${visQuery.metric} ${promQueryModeller.renderLabels(visQuery.labels)}`} lang={lang} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,25 +3786,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/experimental@grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59":
-  version: 1.6.2
-  resolution: "@grafana/experimental@https://github.com/grafana/grafana-experimental.git#commit=44c73c843136cea876b620c127d6d5c76bdcde59"
-  dependencies:
-    "@types/uuid": ^8.3.3
-    uuid: ^8.3.2
-  peerDependencies:
-    "@emotion/css": 11.1.3
-    "@grafana/data": ^10.0.0
-    "@grafana/runtime": ^10.0.0
-    "@grafana/ui": ^10.0.0
-    react: 17.0.2
-    react-dom: 17.0.2
-    react-select: ^5.2.1
-    rxjs: 7.8.0
-  checksum: 8d3c8c65aab227ebba0d234de1faf530c29a255e66a4b8ede8163beac6fc325a18d5b340d3bf9882320377a0073a2697c9f3786c0057260f674d87f9b03a1034
-  languageName: node
-  linkType: hard
-
 "@grafana/experimental@npm:1.1.0":
   version: 1.1.0
   resolution: "@grafana/experimental@npm:1.1.0"
@@ -3820,6 +3801,25 @@ __metadata:
     react-dom: 17.0.2
     react-select: ^5.2.1
   checksum: 821be35785cfdfb64402cf30c8125cdb2b64ac913f5131931afbd3244f31faeccb900e6be431e145a085536ee91a64d4bced5f8a1e067f77201868321722b26d
+  languageName: node
+  linkType: hard
+
+"@grafana/experimental@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@grafana/experimental@npm:1.7.0"
+  dependencies:
+    "@types/uuid": ^8.3.3
+    uuid: ^8.3.2
+  peerDependencies:
+    "@emotion/css": 11.1.3
+    "@grafana/data": ^10.0.0
+    "@grafana/runtime": ^10.0.0
+    "@grafana/ui": ^10.0.0
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-select: ^5.2.1
+    rxjs: 7.8.0
+  checksum: f418072aab298bf5fa4b80d59593f10c62e77347e346cc5f669bdee1de2626fdd9f3d999da55a3079ccf6c6df979fc82e8e4d2e3d3bff2e66e49a0c38b8b80a0
   languageName: node
   linkType: hard
 
@@ -19275,7 +19275,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 6.0.0
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules"
-    "@grafana/experimental": "grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59"
+    "@grafana/experimental": 1.7.0
     "@grafana/faro-core": 1.1.2
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,9 +3786,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/experimental@grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f":
+"@grafana/experimental@grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59":
   version: 1.6.2
-  resolution: "@grafana/experimental@https://github.com/grafana/grafana-experimental.git#commit=664c67d1070e50e7c176036b2b93df2ea7ca987f"
+  resolution: "@grafana/experimental@https://github.com/grafana/grafana-experimental.git#commit=44c73c843136cea876b620c127d6d5c76bdcde59"
   dependencies:
     "@types/uuid": ^8.3.3
     uuid: ^8.3.2
@@ -3801,7 +3801,7 @@ __metadata:
     react-dom: 17.0.2
     react-select: ^5.2.1
     rxjs: 7.8.0
-  checksum: 6192500050a87b75cd65bb03f6ce045bfccc930f55655b57acbeb3e984edea11d151546f97f4b4c7a1d5d5f8a234d63fe795d0062861dd9ce8f678b0d527e5e5
+  checksum: 8d3c8c65aab227ebba0d234de1faf530c29a255e66a4b8ede8163beac6fc325a18d5b340d3bf9882320377a0073a2697c9f3786c0057260f674d87f9b03a1034
   languageName: node
   linkType: hard
 
@@ -19275,7 +19275,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 6.0.0
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules"
-    "@grafana/experimental": "grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f"
+    "@grafana/experimental": "grafana/grafana-experimental#44c73c843136cea876b620c127d6d5c76bdcde59"
     "@grafana/faro-core": 1.1.2
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,6 +3786,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana/experimental@grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f":
+  version: 1.6.2
+  resolution: "@grafana/experimental@https://github.com/grafana/grafana-experimental.git#commit=664c67d1070e50e7c176036b2b93df2ea7ca987f"
+  dependencies:
+    "@types/uuid": ^8.3.3
+    uuid: ^8.3.2
+  peerDependencies:
+    "@emotion/css": 11.1.3
+    "@grafana/data": ^10.0.0
+    "@grafana/runtime": ^10.0.0
+    "@grafana/ui": ^10.0.0
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-select: ^5.2.1
+    rxjs: 7.8.0
+  checksum: 6192500050a87b75cd65bb03f6ce045bfccc930f55655b57acbeb3e984edea11d151546f97f4b4c7a1d5d5f8a234d63fe795d0062861dd9ce8f678b0d527e5e5
+  languageName: node
+  linkType: hard
+
 "@grafana/experimental@npm:1.1.0":
   version: 1.1.0
   resolution: "@grafana/experimental@npm:1.1.0"
@@ -3801,24 +3820,6 @@ __metadata:
     react-dom: 17.0.2
     react-select: ^5.2.1
   checksum: 821be35785cfdfb64402cf30c8125cdb2b64ac913f5131931afbd3244f31faeccb900e6be431e145a085536ee91a64d4bced5f8a1e067f77201868321722b26d
-  languageName: node
-  linkType: hard
-
-"@grafana/experimental@npm:1.6.1":
-  version: 1.6.1
-  resolution: "@grafana/experimental@npm:1.6.1"
-  dependencies:
-    "@types/uuid": ^8.3.3
-    uuid: ^8.3.2
-  peerDependencies:
-    "@emotion/css": 11.1.3
-    "@grafana/data": ^9.2.0
-    "@grafana/runtime": ^9.2.0
-    "@grafana/ui": ^9.2.0
-    react: 17.0.2
-    react-dom: 17.0.2
-    react-select: ^5.2.1
-  checksum: 64c32bc9e3bf96c88fbe9522c53e13e4cbc3848ff83df2b1b76735ad5cf9e1775b31094d1298c4bc6a8c75dbcac015eedb14dd9269f492f296c240c58c9916e7
   languageName: node
   linkType: hard
 
@@ -19274,7 +19275,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 6.0.0
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules"
-    "@grafana/experimental": 1.6.1
+    "@grafana/experimental": "grafana/grafana-experimental#664c67d1070e50e7c176036b2b93df2ea7ca987f"
     "@grafana/faro-core": 1.1.2
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1


### PR DESCRIPTION
This PR is meant to serve as an example of adding a small LLM-powered feature
to Grafana's frontend using the APIs available in @grafana/experimental and
the OpenAI proxy provided by the `grafana-llm-app` app plugin.

It's not meant to be merged, but I'm hoping it will help people who would
like to use LLMs in our upcoming hackathon.

https://github.com/grafana/grafana/assets/5464991/9237eef5-c809-4b03-91c9-2004908a73ee

---

<details>
<summary>Testing TL;DR</summary>
<pre>
git clone git@github.com:grafana/grafana -b llm-api-example
cd grafana
yarn && yarn dev
go run ./pkg/cmd/grafana cli --pluginUrl https://storage.googleapis.com/grafana-llm-app/grafana-llm-app-0.1.0.zip --pluginsDir data/plugins plugins install grafana-llm-app
make run
</pre>
Then head to [this Explore link](http://localhost:3000/explore?panes=%7B%22osU%22:%7B%22datasource%22:%22robustperception%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%20%28job%29%20%28go_goroutines%7Binstance%3D~%5C%22demo.do.%2A%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22robustperception%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1).
</details>

To test it out, you'll need to first install the grafana-llm-app plugin:

```
go run ./pkg/cmd/grafana cli --pluginUrl https://storage.googleapis.com/grafana-llm-app/grafana-llm-app-0.1.0.zip --pluginsDir data/plugins plugins install grafana-llm-app
```

and the `OPENAI_API_KEY` environment variable set to a valid OpenAI API key.

Then `make run` will install the LLM plugin when starting Grafana's backend.

You should now be able to see a new section when clicking 'Explain' on a
Prometheus code editor query, which contains a streamed explanation of
the query from an LLM. (It's pretty terrible UX, but it's only an example!)

E.g. [this example Explore page](http://localhost:3000/explore?panes=%7B%22osU%22:%7B%22datasource%22:%22robustperception%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%20%28job%29%20%28go_goroutines%7Binstance%3D~%5C%22demo.do.%2A%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22robustperception%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1).
 
---

The PR itself does three main things:

1. bump the version of @grafana/experimental to a pre-release, git version
   that includes the LLM APIs (this will be released more officially soon,
   so I'll keep this PR updated)
2. adds an example provisioning file for the `grafana-llm-app` plugin,
   which configures the OpenAI API key
3. adds some logic to the `PromQueryBuilderExplained` component to call the LLM
   and display the output if the LLM plugin is enabled and configured.
