### PR TITLE
Admin: Add redirect notice for datasources to admin landing page

### DIFF
--- a/public/app/core/components/NavLandingPage/NavLandingPage.test.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.test.tsx
@@ -39,7 +39,7 @@ describe('NavLandingPage', () => {
     ],
   };
 
-  const setup = () => {
+  const setup = (showHeader = false) => {
     config.bootData.navTree = [
       {
         text: mockSectionTitle,
@@ -50,9 +50,10 @@ describe('NavLandingPage', () => {
       },
     ];
 
+    const header = showHeader ? <h3>Custom Header</h3> : undefined;
     return render(
       <TestProvider>
-        <NavLandingPage navId={mockId} />
+        <NavLandingPage navId={mockId} header={header} />
       </TestProvider>
     );
   };
@@ -77,5 +78,10 @@ describe('NavLandingPage', () => {
     setup();
     expect(screen.getByText(mockChild1.subTitle)).toBeInTheDocument();
     expect(screen.getByText(mockChild2.subTitle)).toBeInTheDocument();
+  });
+
+  it('renders the custom header when supplied', () => {
+    setup(true);
+    expect(screen.getByRole('heading', { name: 'Custom Header' })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -10,9 +10,10 @@ import { NavLandingPageCard } from './NavLandingPageCard';
 
 interface Props {
   navId: string;
+  header?: React.ReactNode;
 }
 
-export function NavLandingPage({ navId }: Props) {
+export function NavLandingPage({ navId, header }: Props) {
   const { node } = useNavModel(navId);
   const styles = useStyles2(getStyles);
   const children = node.children?.filter((child) => !child.hideFromTabs);
@@ -21,6 +22,7 @@ export function NavLandingPage({ navId }: Props) {
     <Page navId={node.id}>
       <Page.Contents>
         <div className={styles.content}>
+          {header}
           {children && children.length > 0 && (
             <section className={styles.grid}>
               {children?.map((child) => (

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -27,7 +27,7 @@ export function ConnectionsRedirectNotice() {
     <Alert severity="warning" title="">
       <div className={styles.alertContent}>
         <p className={styles.alertParagraph}>
-          Data sources have a new home! You can discover new data sources or manage existing ones in the new Connections
+          Data sources have a new home! You can discover new data sources or manage existing ones in the Connections
           page, accessible from the main menu.
         </p>
         <LinkButton aria-label="Link to Connections" icon="arrow-right" href={ROUTES.DataSources} fill="text">

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
@@ -22,9 +22,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 export function ConnectionsRedirectNotice() {
   const styles = useStyles2(getStyles);
+  const [showNotice, setShowNotice] = useState(true);
 
-  return (
-    <Alert severity="warning" title="">
+  return showNotice ? (
+    <Alert severity="warning" title="" onRemove={() => setShowNotice(false)}>
       <div className={styles.alertContent}>
         <p className={styles.alertParagraph}>
           Data sources have a new home! You can discover new data sources or manage existing ones in the Connections
@@ -35,5 +36,7 @@ export function ConnectionsRedirectNotice() {
         </LinkButton>
       </div>
     </Alert>
+  ) : (
+    <></>
   );
 }

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -25,7 +25,7 @@ export function ConnectionsRedirectNotice() {
   const [showNotice, setShowNotice] = useState(true);
 
   return showNotice ? (
-    <Alert severity="warning" title="" onRemove={() => setShowNotice(false)}>
+    <Alert severity="info" title="" onRemove={() => setShowNotice(false)}>
       <div className={styles.alertContent}>
         <p className={styles.alertParagraph}>
           Data sources have a new home! You can discover new data sources or manage existing ones in the Connections

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -10,6 +10,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import UserAdminPage from 'app/features/admin/UserAdminPage';
 import LdapPage from 'app/features/admin/ldap/LdapPage';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
+import { ConnectionsRedirectNotice } from 'app/features/connections/components/ConnectionsRedirectNotice';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/routes';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
@@ -309,7 +310,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/admin',
-      component: () => <NavLandingPage navId="cfg" />,
+      component: () => <NavLandingPage navId="cfg" header={<ConnectionsRedirectNotice />} />,
     },
     {
       path: '/admin/access',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

With the recent removal of the Admin/Data sources page ([PR](https://github.com/grafana/grafana/pull/72102)) we started hearing concerns ([1](https://github.com/grafana/grafana/pull/72102#discussion_r1274636864), [2](https://raintank-corp.slack.com/archives/C034LMXLXQU/p1690878898332439)) that users who are used to navigate to the Admin/Data sources page will be confused that that nav entry is gone.
This PR gives some guidance to help these users by adding a banner on top of the Admin landing page.

![image](https://github.com/grafana/grafana/assets/13637610/75de3326-3a1c-415f-b71c-7af24b29e32a)

**Who is this feature for?**

Users who would automatically navigate to Admin/Data sources.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/cloud-onboarding/issues/4008

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
