### PR TITLE
Update start-restart-grafana.md

### DIFF
--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -181,6 +181,14 @@ To restart the Grafana server, complete the following steps:
 
 Restart methods differ depending on whether you installed Grafana using Homebrew or as standalone macOS binaries.
 
+### Start Grafana using Homebrew
+
+Use the [Homebrew](http://brew.sh/) start command:
+
+```bash
+brew services start grafana
+```
+
 ### Restart Grafana using Homebrew
 
 Use the [Homebrew](http://brew.sh/) restart command:

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -183,7 +183,7 @@ Restart methods differ depending on whether you installed Grafana using Homebrew
 
 ### Start Grafana using Homebrew
 
-Use the [Homebrew](http://brew.sh/) start command:
+To start Grafana using [Homebrew](http://brew.sh/), run the following start command:
 
 ```bash
 brew services start grafana


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/72309

Adds simple missing homebrew start command reference to MacOS instructions to maintain parallel structure with the rest of the page.