### PR TITLE
Dashboard: Add support for Tempo query variables

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4298,22 +4298,24 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/tempo/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Do not use any type assertions.", "10"],
       [0, 0, 0, "Do not use any type assertions.", "11"],
       [0, 0, 0, "Do not use any type assertions.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
+      [0, 0, 0, "Do not use any type assertions.", "13"],
+      [0, 0, 0, "Do not use any type assertions.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
     ],
     "public/app/plugins/datasource/tempo/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -39,7 +39,6 @@ describe('TempoVariableQueryEditor', () => {
     expect(onChange).toHaveBeenCalledWith({
       type: TempoVariableQueryType.LabelNames,
       label: '',
-      stream: undefined,
       refId,
     });
   });
@@ -63,7 +62,6 @@ describe('TempoVariableQueryEditor', () => {
     expect(onChange).toHaveBeenCalledWith({
       type: TempoVariableQueryType.LabelValues,
       label: 'luna',
-      stream: undefined,
       refId,
     });
   });

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+
+import { TemplateSrv } from '@grafana/runtime';
+
+import {
+  TempoVariableQuery,
+  TempoVariableQueryEditor,
+  TempoVariableQueryEditorProps,
+  TempoVariableQueryType,
+} from './VariableQueryEditor';
+import { createTempoDatasource } from './mocks';
+
+const refId = 'TempoDatasourceVariableQueryEditor-VariableQuery';
+
+describe('TempoVariableQueryEditor', () => {
+  let props: TempoVariableQueryEditorProps;
+  let onChange: (value: TempoVariableQuery) => void;
+
+  beforeEach(() => {
+    props = {
+      datasource: createTempoDatasource({} as unknown as TemplateSrv),
+      query: { type: 0, refId: 'test' },
+      onChange: (_: TempoVariableQuery) => {},
+    };
+
+    onChange = jest.fn();
+  });
+
+  test('Allows to create a Label names variable', async () => {
+    expect(onChange).not.toHaveBeenCalled();
+    render(<TempoVariableQueryEditor {...props} onChange={onChange} />);
+
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label names');
+    await userEvent.click(document.body);
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: TempoVariableQueryType.LabelNames,
+      label: '',
+      stream: undefined,
+      refId,
+    });
+  });
+
+  test('Allows to create a Label values variable', async () => {
+    jest.spyOn(props.datasource, 'labelNamesQuery').mockResolvedValue([
+      {
+        text: 'moon',
+      },
+      {
+        text: 'luna',
+      },
+    ]);
+    expect(onChange).not.toHaveBeenCalled();
+    render(<TempoVariableQueryEditor {...props} onChange={onChange} />);
+
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
+    await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
+    await userEvent.click(document.body);
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: TempoVariableQueryType.LabelValues,
+      label: 'luna',
+      stream: undefined,
+      refId,
+    });
+  });
+});

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -48,7 +48,6 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
       onChange({
         type: newType.value,
         label,
-        stream: undefined,
         refId,
       });
     }

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -93,7 +93,6 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
             value={{ label, value: label }}
             options={labelOptions}
             width={16}
-            allowCustomValue
           />
         </InlineField>
       )}

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -96,6 +96,7 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
               value={{ label, value: label }}
               options={labelOptions}
               width={32}
+              allowCustomValue
             />
           </InlineField>
         </InlineFieldRow>

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+
+import { DataQuery, SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+
+import { TempoDatasource } from './datasource';
+
+export enum TempoVariableQueryType {
+  LabelNames,
+  LabelValues,
+}
+
+export interface TempoVariableQuery extends DataQuery {
+  type: TempoVariableQueryType;
+  label?: string;
+  stream?: string;
+}
+
+const variableOptions = [
+  { label: 'Label names', value: TempoVariableQueryType.LabelNames },
+  { label: 'Label values', value: TempoVariableQueryType.LabelValues },
+];
+
+const refId = 'TempoDatasourceVariableQueryEditor-VariableQuery';
+
+export type TempoVariableQueryEditorProps = {
+  onChange: (value: TempoVariableQuery) => void;
+  query: TempoVariableQuery;
+  datasource: TempoDatasource;
+};
+
+export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoVariableQueryEditorProps) => {
+  const [label, setLabel] = useState(query.label || '');
+  const [type, setType] = useState<number | undefined>(query.type);
+  const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
+
+  useEffect(() => {
+    if (type === TempoVariableQueryType.LabelValues) {
+      datasource.labelNamesQuery().then((labelNames: Array<{ text: string }>) => {
+        setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
+      });
+    }
+  }, [datasource, query, type]);
+
+  const onQueryTypeChange = (newType: SelectableValue<TempoVariableQueryType>) => {
+    setType(newType.value);
+    if (newType.value !== undefined) {
+      onChange({
+        type: newType.value,
+        label,
+        stream: undefined,
+        refId,
+      });
+    }
+  };
+
+  const onLabelChange = (newLabel: SelectableValue<string>) => {
+    const newLabelValue = newLabel.value || '';
+    setLabel(newLabelValue);
+    if (type !== undefined) {
+      onChange({
+        type,
+        label: newLabelValue,
+        stream: undefined,
+        refId,
+      });
+    }
+  };
+
+  const handleBlur = () => {
+    if (type !== undefined) {
+      onChange({ type, label, stream: undefined, refId });
+    }
+  };
+
+  return (
+    <InlineFieldRow>
+      <InlineField label="Query type" labelWidth={20}>
+        <Select
+          aria-label="Query type"
+          onChange={onQueryTypeChange}
+          onBlur={handleBlur}
+          value={type}
+          options={variableOptions}
+          width={16}
+        />
+      </InlineField>
+      {type === TempoVariableQueryType.LabelValues && (
+        <InlineField label="Label" labelWidth={20}>
+          <Select
+            aria-label="Label"
+            onChange={onLabelChange}
+            onBlur={handleBlur}
+            value={{ label, value: label }}
+            options={labelOptions}
+            width={16}
+            allowCustomValue
+          />
+        </InlineField>
+      )}
+    </InlineFieldRow>
+  );
+};

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -86,8 +86,9 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
           />
         </InlineField>
       </InlineFieldRow>
-      <InlineFieldRow>
-        {type === TempoVariableQueryType.LabelValues && (
+
+      {type === TempoVariableQueryType.LabelValues && (
+        <InlineFieldRow>
           <InlineField label="Label" labelWidth={20}>
             <Select
               aria-label="Label"
@@ -98,8 +99,8 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
               width={32}
             />
           </InlineField>
-        )}
-      </InlineFieldRow>
+        </InlineFieldRow>
+      )}
     </>
   );
 };

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -73,29 +73,33 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
   };
 
   return (
-    <InlineFieldRow>
-      <InlineField label="Query type" labelWidth={20}>
-        <Select
-          aria-label="Query type"
-          onChange={onQueryTypeChange}
-          onBlur={handleBlur}
-          value={type}
-          options={variableOptions}
-          width={16}
-        />
-      </InlineField>
-      {type === TempoVariableQueryType.LabelValues && (
-        <InlineField label="Label" labelWidth={20}>
+    <>
+      <InlineFieldRow>
+        <InlineField label="Query type" labelWidth={20}>
           <Select
-            aria-label="Label"
-            onChange={onLabelChange}
+            aria-label="Query type"
+            onChange={onQueryTypeChange}
             onBlur={handleBlur}
-            value={{ label, value: label }}
-            options={labelOptions}
-            width={16}
+            value={type}
+            options={variableOptions}
+            width={32}
           />
         </InlineField>
-      )}
-    </InlineFieldRow>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        {type === TempoVariableQueryType.LabelValues && (
+          <InlineField label="Label" labelWidth={20}>
+            <Select
+              aria-label="Label"
+              onChange={onLabelChange}
+              onBlur={handleBlur}
+              value={{ label, value: label }}
+              options={labelOptions}
+              width={32}
+            />
+          </InlineField>
+        )}
+      </InlineFieldRow>
+    </>
   );
 };

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.tsx
@@ -60,7 +60,6 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
       onChange({
         type,
         label: newLabelValue,
-        stream: undefined,
         refId,
       });
     }
@@ -68,7 +67,7 @@ export const TempoVariableQueryEditor = ({ onChange, query, datasource }: TempoV
 
   const handleBlur = () => {
     if (type !== undefined) {
-      onChange({ type, label, stream: undefined, refId });
+      onChange({ type, label, refId });
     }
   };
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -18,6 +18,7 @@ import { BackendDataSourceResponse, FetchResponse, setBackendSrv, setDataSourceS
 import { BarGaugeDisplayMode, TableCellDisplayMode } from '@grafana/schema';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
+import { TempoVariableQueryType } from './VariableQueryEditor';
 import { TraceqlSearchScope } from './dataquery.gen';
 import {
   DEFAULT_LIMIT,
@@ -32,6 +33,7 @@ import {
 } from './datasource';
 import mockJson from './mockJsonResponse.json';
 import mockServiceGraph from './mockServiceGraph.json';
+import { createMetadataRequest, createTempoDatasource } from './mocks';
 import { TempoJsonData, TempoQuery } from './types';
 
 let mockObservable: () => Observable<any>;
@@ -766,6 +768,57 @@ describe('Tempo service graph view', () => {
         datasourceName: 'Tempo',
       },
     });
+  });
+});
+
+describe('label names', () => {
+  let datasource: TempoDatasource;
+
+  beforeEach(() => {
+    datasource = createTempoDatasource();
+    jest
+      .spyOn(datasource, 'metadataRequest')
+      .mockImplementation(createMetadataRequest({ data: { tagNames: ['label1', 'label2'] } }));
+  });
+
+  it('get label names', async () => {
+    // label_names()
+    const response = await datasource.executeVariableQuery({ refId: 'test', type: TempoVariableQueryType.LabelNames });
+
+    expect(response).toEqual([{ text: 'label1' }, { text: 'label2' }]);
+  });
+});
+
+describe('get label values', () => {
+  let datasource: TempoDatasource;
+
+  beforeEach(() => {
+    datasource = createTempoDatasource();
+    jest
+      .spyOn(datasource, 'metadataRequest')
+      .mockImplementation(createMetadataRequest({ data: { tagValues: ['value1', 'value2'] } }));
+  });
+
+  it('get label values for given label', async () => {
+    // label_values("label")
+    const response = await datasource.executeVariableQuery({
+      refId: 'test',
+      type: TempoVariableQueryType.LabelValues,
+      label: 'label',
+    });
+
+    expect(response).toEqual([{ text: 'value1' }, { text: 'value2' }]);
+  });
+
+  it('do not raise error when label is not set', async () => {
+    // label_values()
+    const response = await datasource.executeVariableQuery({
+      refId: 'test',
+      type: TempoVariableQueryType.LabelValues,
+      label: undefined,
+    });
+
+    expect(response).toEqual([]);
   });
 });
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -771,7 +771,7 @@ describe('Tempo service graph view', () => {
   });
 });
 
-describe('label names', () => {
+describe('label names - v2 tags', () => {
   let datasource: TempoDatasource;
 
   beforeEach(() => {
@@ -779,7 +779,6 @@ describe('label names', () => {
     jest.spyOn(datasource, 'metadataRequest').mockImplementation(
       createMetadataRequest({
         data: {
-          tagNames: ['label1', 'label2'],
           scopes: [{ name: 'span', tags: ['label1', 'label2'] }],
         },
       })
@@ -794,7 +793,28 @@ describe('label names', () => {
   });
 });
 
-describe('get label values', () => {
+describe('label names - v1 tags', () => {
+  let datasource: TempoDatasource;
+
+  beforeEach(() => {
+    datasource = createTempoDatasource();
+    jest.spyOn(datasource, 'metadataRequest').mockImplementationOnce(() => {throw Error}).mockImplementation(
+      createMetadataRequest({
+        data: {
+          tagNames: ['label1', 'label2'],
+        },
+      })
+    );
+  });
+
+  it('get label names', async () => {
+    // label_names()
+    const response = await datasource.executeVariableQuery({ refId: 'test', type: TempoVariableQueryType.LabelNames });
+    expect(response).toEqual([{ text: 'label1' }, { text: 'label2' }, { text: 'status.code' }]);
+  });
+});
+
+describe('label values', () => {
   let datasource: TempoDatasource;
 
   beforeEach(() => {

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -852,7 +852,10 @@ describe('label values', () => {
       label: 'label',
     });
 
-    expect(response).toEqual([{ text: 'value1' }, { text: 'value2' }]);
+    expect(response).toEqual([
+      { text: { type: 'value1', value: 'value1', label: 'value1' } },
+      { text: { type: 'value2', value: 'value2', label: 'value2' } },
+    ]);
   });
 
   it('do not raise error when label is not set', async () => {

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -780,10 +780,7 @@ describe('label names', () => {
       createMetadataRequest({
         data: {
           tagNames: ['label1', 'label2'],
-          scopes: [
-            // @ts-ignore
-            { name: 'span', tags: ['label1', 'label2'] },
-          ],
+          scopes: [{ name: 'span', tags: ['label1', 'label2'] }],
         },
       })
     );
@@ -806,13 +803,11 @@ describe('get label values', () => {
       createMetadataRequest({
         data: {
           tagValues: [
-            // @ts-ignore
             {
               type: 'value1',
               value: 'value1',
               label: 'value1',
             },
-            // @ts-ignore
             {
               type: 'value2',
               value: 'value2',

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -798,13 +798,18 @@ describe('label names - v1 tags', () => {
 
   beforeEach(() => {
     datasource = createTempoDatasource();
-    jest.spyOn(datasource, 'metadataRequest').mockImplementationOnce(() => {throw Error}).mockImplementation(
-      createMetadataRequest({
-        data: {
-          tagNames: ['label1', 'label2'],
-        },
+    jest
+      .spyOn(datasource, 'metadataRequest')
+      .mockImplementationOnce(() => {
+        throw Error;
       })
-    );
+      .mockImplementation(
+        createMetadataRequest({
+          data: {
+            tagNames: ['label1', 'label2'],
+          },
+        })
+      );
   });
 
   it('get label names', async () => {

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -776,9 +776,17 @@ describe('label names', () => {
 
   beforeEach(() => {
     datasource = createTempoDatasource();
-    jest
-      .spyOn(datasource, 'metadataRequest')
-      .mockImplementation(createMetadataRequest({ data: { tagNames: ['label1', 'label2'] } }));
+    jest.spyOn(datasource, 'metadataRequest').mockImplementation(
+      createMetadataRequest({
+        data: {
+          tagNames: ['label1', 'label2'],
+          scopes: [
+            // @ts-ignore
+            { name: 'span', tags: ['label1', 'label2'] },
+          ],
+        },
+      })
+    );
   });
 
   it('get label names', async () => {
@@ -794,9 +802,26 @@ describe('get label values', () => {
 
   beforeEach(() => {
     datasource = createTempoDatasource();
-    jest
-      .spyOn(datasource, 'metadataRequest')
-      .mockImplementation(createMetadataRequest({ data: { tagValues: ['value1', 'value2'] } }));
+    jest.spyOn(datasource, 'metadataRequest').mockImplementation(
+      createMetadataRequest({
+        data: {
+          tagValues: [
+            // @ts-ignore
+            {
+              type: 'value1',
+              value: 'value1',
+              label: 'value1',
+            },
+            // @ts-ignore
+            {
+              type: 'value2',
+              value: 'value2',
+              label: 'value2',
+            },
+          ],
+        },
+      })
+    );
   });
 
   it('get label values for given label', async () => {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -142,11 +142,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
   async labelNamesQuery() {
     await this.languageProvider.fetchTags();
-
-    const tagsResource = this.languageProvider.getTags(TraceqlSearchScope.Resource);
-    const tagsSpan = this.languageProvider.getTags(TraceqlSearchScope.Span);
-    const tags = tagsResource.concat(tagsSpan);
-
+    const tags = this.languageProvider.getAutocompleteTags();
     return tags.filter((tag) => tag !== undefined).map((tag) => ({ text: tag })) as Array<{ text: string }>;
   }
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -155,6 +155,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     try {
       // Retrieve the scope of the tag
       // Example: given `http.status_code`, we want scope `span`
+      // Note that we ignore possible name clashes, e.g., `http.status_code` in both `span` and `resource`
       const scope: string | undefined = (this.languageProvider.tagsV2 || [])
         // flatten the Scope objects
         .flatMap((tagV2) => tagV2.tags.map((tag) => ({ scope: tagV2.name, name: tag })))

--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -129,7 +129,7 @@ export default class TempoLanguageProvider extends LanguageProvider {
     return options;
   }
 
-  async getOptionsV2(tag: string, query: string): Promise<Array<SelectableValue<string>>> {
+  async getOptionsV2(tag: string, query?: string): Promise<Array<SelectableValue<string>>> {
     const response = await this.request(`/api/v2/search/tag/${tag}/values`, query ? { q: query } : {});
     let options: Array<SelectableValue<string>> = [];
     if (response && response.tagValues) {

--- a/public/app/plugins/datasource/tempo/mocks.ts
+++ b/public/app/plugins/datasource/tempo/mocks.ts
@@ -64,5 +64,5 @@ export function createTempoDatasource(
 }
 
 export function createMetadataRequest(labelsAndValues: Record<string, Record<string, string[]>>) {
-  return async (url: string, params?: Record<string, string | number>) => labelsAndValues;
+  return async () => labelsAndValues;
 }

--- a/public/app/plugins/datasource/tempo/mocks.ts
+++ b/public/app/plugins/datasource/tempo/mocks.ts
@@ -1,0 +1,68 @@
+import { DataSourceInstanceSettings, PluginType, toUtc } from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
+
+import { TempoDatasource } from './datasource';
+import { TempoJsonData } from './types';
+
+const rawRange = {
+  from: toUtc('2018-04-25 10:00'),
+  to: toUtc('2018-04-25 11:00'),
+};
+
+const defaultTimeSrvMock = {
+  timeRange: jest.fn().mockReturnValue({
+    from: rawRange.from,
+    to: rawRange.to,
+    raw: rawRange,
+  }),
+};
+
+const defaultTemplateSrvMock = {
+  replace: (input: string) => input,
+};
+
+export function createTempoDatasource(
+  templateSrvMock: Partial<TemplateSrv> = defaultTemplateSrvMock,
+  settings: Partial<DataSourceInstanceSettings<TempoJsonData>> = {},
+  timeSrvStub = defaultTimeSrvMock
+): TempoDatasource {
+  const customSettings: DataSourceInstanceSettings<TempoJsonData> = {
+    url: 'myloggingurl',
+    id: 0,
+    uid: '',
+    type: '',
+    name: '',
+    meta: {
+      id: 'id',
+      name: 'name',
+      type: PluginType.datasource,
+      module: '',
+      baseUrl: '',
+      info: {
+        author: {
+          name: 'Test',
+        },
+        description: '',
+        links: [],
+        logos: {
+          large: '',
+          small: '',
+        },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    },
+    readOnly: false,
+    jsonData: {},
+    access: 'direct',
+    ...settings,
+  };
+
+  // @ts-expect-error
+  return new TempoDatasource(customSettings, templateSrvMock, timeSrvStub);
+}
+
+export function createMetadataRequest(labelsAndValues: Record<string, Record<string, string[]>>) {
+  return async (url: string, params?: Record<string, string | number>) => labelsAndValues;
+}

--- a/public/app/plugins/datasource/tempo/mocks.ts
+++ b/public/app/plugins/datasource/tempo/mocks.ts
@@ -63,6 +63,6 @@ export function createTempoDatasource(
   return new TempoDatasource(customSettings, templateSrvMock, timeSrvStub);
 }
 
-export function createMetadataRequest(labelsAndValues: Record<string, Record<string, string[]>>) {
+export function createMetadataRequest(labelsAndValues: Record<string, Record<string, unknown>>) {
   return async () => labelsAndValues;
 }

--- a/public/app/plugins/datasource/tempo/variables.test.ts
+++ b/public/app/plugins/datasource/tempo/variables.test.ts
@@ -15,10 +15,7 @@ describe('TempoVariableSupport', () => {
       createMetadataRequest({
         data: {
           tagNames: ['label1', 'label2'],
-          scopes: [
-            // @ts-ignore
-            { name: 'span', tags: ['label1', 'label2'] },
-          ],
+          scopes: [{ name: 'span', tags: ['label1', 'label2'] }],
         },
       })
     );

--- a/public/app/plugins/datasource/tempo/variables.test.ts
+++ b/public/app/plugins/datasource/tempo/variables.test.ts
@@ -11,9 +11,17 @@ describe('TempoVariableSupport', () => {
 
   beforeEach(() => {
     const datasource = createTempoDatasource();
-    jest
-      .spyOn(datasource, 'metadataRequest')
-      .mockImplementation(createMetadataRequest({ data: { tagNames: ['label1', 'label2'] } }));
+    jest.spyOn(datasource, 'metadataRequest').mockImplementation(
+      createMetadataRequest({
+        data: {
+          tagNames: ['label1', 'label2'],
+          scopes: [
+            // @ts-ignore
+            { name: 'span', tags: ['label1', 'label2'] },
+          ],
+        },
+      })
+    );
     TempoVariableSupportMock = new TempoVariableSupport(datasource);
   });
 

--- a/public/app/plugins/datasource/tempo/variables.test.ts
+++ b/public/app/plugins/datasource/tempo/variables.test.ts
@@ -1,0 +1,46 @@
+import { lastValueFrom } from 'rxjs';
+
+import { DataQueryRequest, TimeRange } from '@grafana/data';
+
+import { TempoVariableQuery } from './VariableQueryEditor';
+import { createMetadataRequest, createTempoDatasource } from './mocks';
+import { TempoVariableSupport } from './variables';
+
+describe('TempoVariableSupport', () => {
+  let TempoVariableSupportMock: TempoVariableSupport;
+
+  beforeEach(() => {
+    const datasource = createTempoDatasource();
+    jest
+      .spyOn(datasource, 'metadataRequest')
+      .mockImplementation(createMetadataRequest({ data: { tagNames: ['label1', 'label2'] } }));
+    TempoVariableSupportMock = new TempoVariableSupport(datasource);
+  });
+
+  it('should return label names for Tempo', async () => {
+    const response = TempoVariableSupportMock.query({
+      app: 'undefined',
+      startTime: 0,
+      requestId: '1',
+      interval: 'undefined',
+      scopedVars: {},
+      timezone: 'undefined',
+      type: 0,
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [
+        {
+          refId: 'A',
+          datasource: { uid: 'GRAFANA_DATASOURCE_NAME', type: 'sample' },
+          type: 0,
+        },
+      ],
+      panelId: 1,
+      publicDashboardAccessToken: '',
+      range: { from: new Date().toLocaleString(), to: new Date().toLocaleString() } as unknown as TimeRange,
+    } as DataQueryRequest<TempoVariableQuery>);
+
+    const data = (await lastValueFrom(response)).data;
+    expect(data).toEqual([{ text: 'label1' }, { text: 'label2' }]);
+  });
+});

--- a/public/app/plugins/datasource/tempo/variables.ts
+++ b/public/app/plugins/datasource/tempo/variables.ts
@@ -1,0 +1,25 @@
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { DataQueryRequest, DataQueryResponse, CustomVariableSupport } from '@grafana/data';
+
+import { TempoVariableQuery, TempoVariableQueryEditor } from './VariableQueryEditor';
+import { TempoDatasource } from './datasource';
+
+export class TempoVariableSupport extends CustomVariableSupport<TempoDatasource, TempoVariableQuery> {
+  editor = TempoVariableQueryEditor;
+
+  constructor(private datasource: TempoDatasource) {
+    super();
+    this.query = this.query.bind(this);
+  }
+
+  query(request: DataQueryRequest<TempoVariableQuery>): Observable<DataQueryResponse> {
+    if (!this.datasource) {
+      throw new Error('Datasource not initialized');
+    }
+
+    const result = this.datasource.executeVariableQuery(request.targets[0]);
+    return from(result).pipe(map((data) => ({ data })));
+  }
+}


### PR DESCRIPTION
**What is this feature?**
Add support for template variables (`Label names` and `Label values`) in Tempo, similarly to what is already available in Loki and Prometheus. [Quick demo](https://github.com/grafana/grafana/assets/135109076/7074728c-8bf4-4251-a27b-21bcb718e2f6).

**Why do we need this feature?**
It has been requested by a few customers and discussed with @09jvilla.

**Who is this feature for?**
Customers.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/72575
Fixes https://github.com/grafana/grafana/issues/70305
