### PR TITLE
Retrieve and use Tempo version

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -125,7 +125,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       this._request('/api/status/buildinfo').pipe(
         map((response) => response),
         catchError((error) => {
-          console.log('Failure in retrieving build information', error.data.message);
+          console.error('Failure in retrieving build information', error.data.message);
           return of({ error, data: {} });
         })
       )

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -166,8 +166,14 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     try {
       return semver.gte(actualVersion, featuresToTempoVersion[featureName]);
     } catch {
-      // An error could still happen if Tempo is running locally. In that case, the version is not a
-      // semantic version and instead it is in the form `<branch>-<revision>` (e.g., `main-12bdeff`).
+      // An error could happen if Tempo is running locally. In that case, the version is not a semantic version
+      // and instead it is in the form `<branch>-<revision>`, possibly with a `-WIP` suffix (e.g., `main-12bdeff-WIP`).
+      // Thus, if the version is in the form `<branch>-<revision>`, assume that we are on the most updated
+      // Tempo version and thus any feature should be considered enabled
+      if (/^.*-[a-zA-Z0-9_]{7}(-WIP)?$/.test(actualVersion)) {
+        return true;
+      }
+
       console.error(`Cannot compare ${actualVersion} and ${featuresToTempoVersion[featureName]}`);
       return false;
     }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -193,7 +193,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     } catch {
       // This could happen if the Tempo version is from development (in that case the version is, e.g., `main-12bdeff`)
       console.log(`Cannot compare ${actualVersion} and ${featuresToTempoVersion[featureName]}`);
-      return false
+      return false;
     }
   }
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -336,7 +336,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             streaming: config.featureToggles.traceQLStreaming,
           });
 
-          if (config.featureToggles.traceQLStreaming) {
+          if (config.featureToggles.traceQLStreaming && this.isFeatureAvailable(FeatureName.streaming)) {
             subQueries.push(this.handleStreamingSearch(options, traceqlSearchTargets, queryValue));
           } else {
             subQueries.push(

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -506,7 +506,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
     return super.query(traceRequest).pipe(
       map((response) => {
-        console.log(response);
         if (response.error) {
           return response;
         }
@@ -569,8 +568,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     const url = `${this.instanceSettings.url}${apiUrl}${params.length ? `?${params}` : ''}`;
     const req = { ...options, url };
 
-    //eslint-disable-next-line
-    // debugger;
     return getBackendSrv().fetch(req);
   }
 


### PR DESCRIPTION
**What is this feature?**
Retrieve the version of the Tempo instance running on the backend of the user by calling the new dedicated endpoint, `/api/status/buildinfo`, and store it in the Grafana `TempoDatasource` object.

**Why do we need this feature?**
To be able to selectively show or hide features in the frontend, depending of whether the running Tempo instance support them or not.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/67660
