### PR TITLE
Chore: Fix pr-checks not having enough permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,13 +13,17 @@ on:
     types:
       - milestoned
       - demilestoned
+
 concurrency:
   group: pr-checks-${{ github.event.number }}
+
+permissions:
+  checks: write
+  actions: write
+  contents: read
+
 jobs:
   main:
-    permissions:
-      actions: write
-      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,7 @@ permissions:
   checks: write
   actions: write
   contents: read
+  pull-requests: read
 
 jobs:
   main:


### PR DESCRIPTION
Fixes regression from https://github.com/grafana/grafana/pull/72503 where pr-checks did not have enough permissions to report on statuses.

I suspect the other actions that use grafana/grafana-github-actions might be failing with not enough permissions, but unsure right now.