### PR TITLE
Chore: Fix pr-checks not having enough permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,6 +18,7 @@ concurrency:
   group: pr-checks-${{ github.event.number }}
 
 permissions:
+  statuses: write
   checks: write
   actions: write
   contents: read


### PR DESCRIPTION
Fixes regression from https://github.com/grafana/grafana/pull/72503 where pr-checks did not have enough permissions to report on statuses.

I suspect the other actions that use grafana/grafana-github-actions might be failing with not enough permissions, but unsure right now.