### PR TITLE
[v10.1.x] Auth: add a lock message for Grafana Admin role

### DIFF
--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -107,6 +107,8 @@ export class UserAdminPage extends PureComponent<Props> {
     const canReadSessions = contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList);
     const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
     const isUserSynced = !config.auth.DisableSyncLock && user?.isExternallySynced;
+    const authSource = user?.authLabels?.[0];
+    const lockMessage = authSource ? `Synced via ${authSource}` : '';
 
     const pageNav: NavModelItem = {
       text: user?.login ?? '',
@@ -133,6 +135,7 @@ export class UserAdminPage extends PureComponent<Props> {
               <UserPermissions
                 isGrafanaAdmin={user.isGrafanaAdmin}
                 isExternalUser={user?.isGrafanaAdminExternallySynced}
+                lockMessage={lockMessage}
                 onGrafanaAdminChange={this.onGrafanaAdminChange}
               />
             </>

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -488,7 +488,7 @@ interface ExternalUserTooltipProps {
   lockMessage?: string;
 }
 
-const ExternalUserTooltip = ({ lockMessage }: ExternalUserTooltipProps) => {
+export const ExternalUserTooltip = ({ lockMessage }: ExternalUserTooltipProps) => {
   const styles = useStyles2(getTooltipStyles);
 
   return (

--- a/public/app/features/admin/UserPermissions.tsx
+++ b/public/app/features/admin/UserPermissions.tsx
@@ -1,12 +1,16 @@
+import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
-import { ConfirmButton, RadioButtonGroup, Icon } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { ConfirmButton, RadioButtonGroup, Icon, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
+import { ExternalUserTooltip } from 'app/features/admin/UserOrgs';
 import { AccessControlAction } from 'app/types';
 
 interface Props {
   isGrafanaAdmin: boolean;
   isExternalUser?: boolean;
+  lockMessage?: string;
 
   onGrafanaAdminChange: (isGrafanaAdmin: boolean) => void;
 }
@@ -16,7 +20,7 @@ const adminOptions = [
   { label: 'No', value: false },
 ];
 
-export function UserPermissions({ isGrafanaAdmin, isExternalUser, onGrafanaAdminChange }: Props) {
+export function UserPermissions({ isGrafanaAdmin, isExternalUser, lockMessage, onGrafanaAdminChange }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [currentAdminOption, setCurrentAdminOption] = useState(isGrafanaAdmin);
 
@@ -30,6 +34,8 @@ export function UserPermissions({ isGrafanaAdmin, isExternalUser, onGrafanaAdmin
   const handleGrafanaAdminChange = () => onGrafanaAdminChange(currentAdminOption);
 
   const canChangePermissions = contextSrv.hasPermission(AccessControlAction.UsersPermissionsUpdate) && !isExternalUser;
+
+  const styles = useStyles2(getTooltipStyles);
 
   return (
     <>
@@ -71,6 +77,11 @@ export function UserPermissions({ isGrafanaAdmin, isExternalUser, onGrafanaAdmin
                       Change
                     </ConfirmButton>
                   )}
+                  {isExternalUser && (
+                    <div className={styles.lockMessageClass}>
+                      <ExternalUserTooltip lockMessage={lockMessage} />
+                    </div>
+                  )}
                 </td>
               </tr>
             </tbody>
@@ -80,3 +91,12 @@ export function UserPermissions({ isGrafanaAdmin, isExternalUser, onGrafanaAdmin
     </>
   );
 }
+
+const getTooltipStyles = (theme: GrafanaTheme2) => ({
+  lockMessageClass: css`
+    display: flex;
+    justify-content: flex-end;
+    font-style: italic;
+    margin-right: ${theme.spacing(0.6)};
+  `,
+});


### PR DESCRIPTION
Backport 1bf94058dbcbef0017f83a8fcad78355afcd9492 from #72724

---

**What is this feature?**

Adds a lock message if Grafana Admin role is externally synced. 

Before the change:
<img width="1130" alt="Screenshot 2023-08-02 at 11 09 18" src="https://github.com/grafana/grafana/assets/9482349/83721fcb-f07c-484e-b10e-b13660bcf84c">

After the change:
<img width="1109" alt="Screenshot 2023-08-02 at 11 01 04" src="https://github.com/grafana/grafana/assets/9482349/d4658728-3c2e-4ca1-9e05-d57024911892">

**Why do we need this feature?**

Grafana Admin role locking was introduced in https://github.com/grafana/grafana/pull/72677. It might be unclear to users why they can't change the Server Admin role, so this PR adds a message explaining why the role is locked.

**Who is this feature for?**

Anyone who uses external auth providers to sync Grafana server admin role.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
