### PR TITLE
UserSync: Avoid UpdateLastSeenAt with invalid user ids

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -136,9 +136,13 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, identity *authn.Identit
 
 	namespace, id := identity.NamespacedID()
 
-	if id <= 0 || (namespace != authn.NamespaceUser && namespace != authn.NamespaceServiceAccount) {
-		// skip sync
-		return nil
+	// do not sync invalid users
+	if id <= 0 {
+		return nil // skip sync
+	}
+
+	if namespace != authn.NamespaceUser && namespace != authn.NamespaceServiceAccount {
+		return nil // skip sync
 	}
 
 	go func(userID int64) {

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -136,7 +136,7 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, identity *authn.Identit
 
 	namespace, id := identity.NamespacedID()
 
-	if namespace != authn.NamespaceUser && namespace != authn.NamespaceServiceAccount {
+	if id <= 0 || (namespace != authn.NamespaceUser && namespace != authn.NamespaceServiceAccount) {
 		// skip sync
 		return nil
 	}

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -26,6 +26,7 @@ var (
 	ErrProtectedUser     = errors.New("cannot adopt protected user")
 	ErrNoUniqueID        = errors.New("identifying id not found")
 	ErrLastSeenUpToDate  = errors.New("last seen is already up to date")
+	ErrUpdateInvalidID   = errors.New("unable to update invalid id")
 )
 
 type User struct {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -369,7 +369,7 @@ func (ss *sqlStore) ChangePassword(ctx context.Context, cmd *user.ChangeUserPass
 
 func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
 	if cmd.UserID <= 0 {
-		return nil
+		return user.ErrNoUniqueID
 	}
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -369,7 +369,7 @@ func (ss *sqlStore) ChangePassword(ctx context.Context, cmd *user.ChangeUserPass
 
 func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
 	if cmd.UserID <= 0 {
-		return user.ErrNoUniqueID
+		return user.ErrUpdateInvalidID
 	}
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -424,6 +424,8 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 			} else {
 				sess.SQL(rawSQL+"WHERE u.email=?", query.Email)
 			}
+		default:
+			return user.ErrNoUniqueID
 		}
 		has, err := sess.Get(&signedInUser)
 		if err != nil {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -368,6 +368,9 @@ func (ss *sqlStore) ChangePassword(ctx context.Context, cmd *user.ChangeUserPass
 }
 
 func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
+	if cmd.UserID <= 0 {
+		return nil
+	}
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{
 			ID:         cmd.UserID,

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -382,6 +382,15 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		result, err := userStore.GetSignedInUser(context.Background(), query)
 		require.NoError(t, err)
 		require.Equal(t, result.Email, "user1@test.com")
+
+		// Throw errors for invalid user IDs
+		for _, userID := range []int64{-1, 0} {
+			_, err = userStore.GetSignedInUser(context.Background(),
+				&user.GetSignedInUserQuery{
+					OrgID:  users[1].OrgID,
+					UserID: userID}) // zero
+			require.Error(t, err)
+		}
 	})
 
 	t.Run("update user", func(t *testing.T) {

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -349,8 +349,15 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	})
 
 	t.Run("update last seen at", func(t *testing.T) {
-		err := userStore.UpdateLastSeenAt(context.Background(), &user.UpdateUserLastSeenAtCommand{})
+		err := userStore.UpdateLastSeenAt(context.Background(), &user.UpdateUserLastSeenAtCommand{
+			UserID: 10, // Requires UserID
+		})
 		require.NoError(t, err)
+
+		err = userStore.UpdateLastSeenAt(context.Background(), &user.UpdateUserLastSeenAtCommand{
+			UserID: -1,
+		})
+		require.Error(t, err)
 	})
 
 	t.Run("get signed in user", func(t *testing.T) {


### PR DESCRIPTION
This changes the `UpdateLastSeenAt` logic so we only write it for valid users.  This avoids an error when using grafana with the image renderer that creates identities with a userId:0