### PR TITLE
Proxy: Set the proxy information in Grafana for Graphite

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -492,6 +492,14 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 		if val, exists, err := s.DecryptedValue(ctx, ds, "secureSocksProxyPassword"); err == nil && exists {
 			proxyOpts.Auth.Password = val
 		}
+
+		proxyOpts.Timeouts = &sdkproxy.DefaultTimeoutOptions
+		if val, err := ds.JsonData.Get("timeout").Float64(); err == nil {
+			proxyOpts.Timeouts.Timeout = time.Duration(val) * time.Second
+		}
+		if val, err := ds.JsonData.Get("keepAlive").Float64(); err == nil {
+			proxyOpts.Timeouts.KeepAlive = time.Duration(val) * time.Second
+		}
 	}
 	opts.ProxyOptions = proxyOpts
 

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -483,25 +483,27 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 		}
 	}
 
-	proxyOpts := &sdkproxy.Options{}
 	if ds.JsonData != nil && ds.JsonData.Get("enableSecureSocksProxy").MustBool(false) {
-		proxyOpts.Enabled = true
-		proxyOpts.Auth = &sdkproxy.AuthOptions{
-			Username: ds.JsonData.Get("secureSocksProxyUsername").MustString(ds.UID),
+		proxyOpts := &sdkproxy.Options{
+			Enabled: true,
+			Auth: &sdkproxy.AuthOptions{
+				Username: ds.JsonData.Get("secureSocksProxyUsername").MustString(ds.UID),
+			},
+			Timeouts: &sdkproxy.DefaultTimeoutOptions,
 		}
+
 		if val, exists, err := s.DecryptedValue(ctx, ds, "secureSocksProxyPassword"); err == nil && exists {
 			proxyOpts.Auth.Password = val
 		}
-
-		proxyOpts.Timeouts = &sdkproxy.DefaultTimeoutOptions
 		if val, err := ds.JsonData.Get("timeout").Float64(); err == nil {
 			proxyOpts.Timeouts.Timeout = time.Duration(val) * time.Second
 		}
 		if val, err := ds.JsonData.Get("keepAlive").Float64(); err == nil {
 			proxyOpts.Timeouts.KeepAlive = time.Duration(val) * time.Second
 		}
+
+		opts.ProxyOptions = proxyOpts
 	}
-	opts.ProxyOptions = proxyOpts
 
 	if ds.JsonData != nil && ds.JsonData.Get("sigV4Auth").MustBool(false) && setting.SigV4AuthEnabled {
 		opts.SigV4 = &sdkhttpclient.SigV4Config{

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -481,6 +482,16 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 			Password: password,
 		}
 	}
+
+	proxyOpts := &proxy.Options{}
+	if ds.JsonData != nil && ds.JsonData.Get("enableSecureSocksProxy").MustBool(false) {
+		proxyOpts.Enabled = true
+		proxyOpts.Auth = &proxy.AuthOptions{
+			Username: ds.JsonData.Get("secureSocksProxyUsername").MustString(ds.UID),
+			Password: ds.JsonData.Get("secureSocksProxyPassword").MustString(""),
+		}
+	}
+	opts.ProxyOptions = proxyOpts
 
 	if ds.JsonData != nil && ds.JsonData.Get("sigV4Auth").MustBool(false) && setting.SigV4AuthEnabled {
 		opts.SigV4 = &sdkhttpclient.SigV4Config{

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -848,6 +848,80 @@ func TestService_GetHttpTransport(t *testing.T) {
 	})
 }
 
+func TestService_getProxySettings(t *testing.T) {
+	sqlStore := db.InitTestDB(t)
+	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
+	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))
+	quotaService := quotatest.New(false, nil)
+	dsService, err := ProvideService(sqlStore, secretsService, secretsStore, &setting.Cfg{}, featuremgmt.WithFeatures(), acmock.New(), acmock.NewMockedPermissionsService(), quotaService)
+	require.NoError(t, err)
+
+	t.Run("Should default to disabled", func(t *testing.T) {
+		ds := datasources.DataSource{
+			ID:    1,
+			OrgID: 1,
+			UID:   "uid",
+			Name:  "graphite",
+			URL:   "http://test:8001",
+			Type:  "Graphite",
+		}
+
+		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		require.NoError(t, err)
+		require.False(t, opts.ProxyOptions.Enabled)
+	})
+
+	t.Run("Username should default to datasource UID", func(t *testing.T) {
+		sjson := simplejson.New()
+		sjson.Set("enableSecureSocksProxy", true)
+		ds := datasources.DataSource{
+			ID:       1,
+			OrgID:    1,
+			UID:      "uid",
+			Name:     "graphite",
+			URL:      "http://test:8001",
+			Type:     "Graphite",
+			JsonData: sjson,
+		}
+
+		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		require.NoError(t, err)
+		require.True(t, opts.ProxyOptions.Enabled)
+		require.Equal(t, opts.ProxyOptions.Auth.Username, ds.UID)
+	})
+
+	t.Run("Can override username and password", func(t *testing.T) {
+		sjson := simplejson.New()
+		pass := "testpass"
+		user := "testuser"
+		sjson.Set("enableSecureSocksProxy", true)
+		sjson.Set("secureSocksProxyUsername", user)
+		ds := datasources.DataSource{
+			ID:       1,
+			OrgID:    1,
+			UID:      "uid",
+			Name:     "graphite",
+			URL:      "http://test:8001",
+			Type:     "Graphite",
+			JsonData: sjson,
+		}
+
+		secureJsonData, err := json.Marshal(map[string]string{
+			"secureSocksProxyPassword": pass,
+		})
+		require.NoError(t, err)
+
+		err = secretsStore.Set(context.Background(), ds.OrgID, ds.Name, secretskvs.DataSourceSecretType, string(secureJsonData))
+		require.NoError(t, err)
+
+		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		require.NoError(t, err)
+		require.True(t, opts.ProxyOptions.Enabled)
+		require.Equal(t, opts.ProxyOptions.Auth.Username, user)
+		require.Equal(t, opts.ProxyOptions.Auth.Password, pass)
+	})
+}
+
 func TestService_getTimeout(t *testing.T) {
 	cfg := &setting.Cfg{}
 	originalTimeout := sdkhttpclient.DefaultTimeoutOptions.Timeout

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -868,7 +868,7 @@ func TestService_getProxySettings(t *testing.T) {
 
 		opts, err := dsService.httpClientOptions(context.Background(), &ds)
 		require.NoError(t, err)
-		require.False(t, opts.ProxyOptions.Enabled)
+		require.Nil(t, opts.ProxyOptions)
 	})
 
 	t.Run("Username should default to datasource UID", func(t *testing.T) {

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -890,12 +890,14 @@ func TestService_getProxySettings(t *testing.T) {
 		require.Equal(t, opts.ProxyOptions.Auth.Username, ds.UID)
 	})
 
-	t.Run("Can override username and password", func(t *testing.T) {
+	t.Run("Can override options", func(t *testing.T) {
 		sjson := simplejson.New()
 		pass := "testpass"
 		user := "testuser"
 		sjson.Set("enableSecureSocksProxy", true)
 		sjson.Set("secureSocksProxyUsername", user)
+		sjson.Set("timeout", 10)
+		sjson.Set("keepAlive", 5)
 		ds := datasources.DataSource{
 			ID:       1,
 			OrgID:    1,
@@ -919,6 +921,8 @@ func TestService_getProxySettings(t *testing.T) {
 		require.True(t, opts.ProxyOptions.Enabled)
 		require.Equal(t, opts.ProxyOptions.Auth.Username, user)
 		require.Equal(t, opts.ProxyOptions.Auth.Password, pass)
+		require.Equal(t, opts.ProxyOptions.Timeouts.Timeout, 10*time.Second)
+		require.Equal(t, opts.ProxyOptions.Timeouts.KeepAlive, 5*time.Second)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

In Grafana 10.1, the secure socks proxy code was moved to use the Grafana Plugin SDK ([PR](https://github.com/grafana/grafana/pull/71616/)). This caused Graphite to fail to set up the proxy because the Graphite code does not use the sdk to parse the http client options, so the proxy was assumed to be disabled on every Graphite datasource.

This PR adds parsing of the proxy options to `httpClientOptions` to restore proxy functionality with Graphite.

**Why do we need this feature?**

The secure socks proxy is broken for Graphite in 10.1


Fixes https://github.com/grafana/hosted-grafana/issues/4462