### PR TITLE
Dashboards: Add megawatt hour (MWh) unit

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -227,6 +227,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Watt-hour per Kilogram (Wh/kg)', id: 'watthperkg', fn: SIPrefix('Wh/kg') },
       { name: 'Kilowatt-hour (kWh)', id: 'kwatth', fn: SIPrefix('Wh', 1) },
       { name: 'Kilowatt-min (kWm)', id: 'kwattm', fn: SIPrefix('W-Min', 1) },
+      { name: 'Megawatt-hour (mWh)', id: 'mwatth', fn: SIPrefix('Wh', 2) },
       { name: 'Ampere-hour (Ah)', id: 'amph', fn: SIPrefix('Ah') },
       { name: 'Kiloampere-hour (kAh)', id: 'kamph', fn: SIPrefix('Ah', 1) },
       { name: 'Milliampere-hour (mAh)', id: 'mamph', fn: SIPrefix('Ah', -1) },

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -227,7 +227,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Watt-hour per Kilogram (Wh/kg)', id: 'watthperkg', fn: SIPrefix('Wh/kg') },
       { name: 'Kilowatt-hour (kWh)', id: 'kwatth', fn: SIPrefix('Wh', 1) },
       { name: 'Kilowatt-min (kWm)', id: 'kwattm', fn: SIPrefix('W-Min', 1) },
-      { name: 'Megawatt-hour (mWh)', id: 'mwatth', fn: SIPrefix('Wh', 2) },
+      { name: 'Megawatt-hour (MWh)', id: 'mwatth', fn: SIPrefix('Wh', 2) },
       { name: 'Ampere-hour (Ah)', id: 'amph', fn: SIPrefix('Ah') },
       { name: 'Kiloampere-hour (kAh)', id: 'kamph', fn: SIPrefix('Ah', 1) },
       { name: 'Milliampere-hour (mAh)', id: 'mamph', fn: SIPrefix('Ah', -1) },


### PR DESCRIPTION
**What is this feature?**

This PR adds the Megawatt Hour (MWh) unit to the dashboard editor. We currently have Wh and kWh:

![CleanShot 2023-08-02 at 15 42 16@2x](https://github.com/grafana/grafana/assets/37156449/32c5ec7a-b7ce-49c3-9a1a-f0967f93fde7)

**Why do we need this feature?**

community superuser and Grafana Champion @gpinkos is building some awesome dashboards for play.grafana.org that monitor the US energy grids. Having a MWh option would be ideal for formatting.

**Who is this feature for?**

grafana lovers, data-nerds, etc

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
