### PR TITLE
Plugins: Add elementId attribute to angular_deprecation_docs_clicked interaction

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -109,6 +109,7 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
             pluginId={plugin.meta.id}
             pluginType={plugin.meta.type}
             angularSupportEnabled={config?.angularSupportEnabled}
+            interactionElementId="panel-options"
           />
         )}
         <div className={styles.formRow}>

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -82,6 +82,7 @@ export function PluginDetailsPage({
               pluginId={plugin.id}
               pluginType={plugin.type}
               showPluginDetailsLink={false}
+              interactionElementId="plugin-details-page"
             />
           )}
           <PluginDetailsSignature plugin={plugin} className={styles.alert} />

--- a/public/app/features/plugins/angularDeprecation/AngularDeprecationPluginNotice.test.tsx
+++ b/public/app/features/plugins/angularDeprecation/AngularDeprecationPluginNotice.test.tsx
@@ -89,12 +89,13 @@ describe('AngularDeprecationPluginNotice', () => {
   });
 
   it('reports interaction when clicking on the link', async () => {
-    render(<AngularDeprecationPluginNotice pluginId="test-id" />);
+    render(<AngularDeprecationPluginNotice pluginId="test-id" interactionElementId="some-identifier" />);
     const c = 'Read our deprecation notice and migration advice.';
     expect(screen.getByText(c)).toBeInTheDocument();
     await userEvent.click(screen.getByText(c));
     expect(reportInteraction).toHaveBeenCalledWith('angular_deprecation_docs_clicked', {
       pluginId: 'test-id',
+      elementId: 'some-identifier',
     });
   });
 });

--- a/public/app/features/plugins/angularDeprecation/AngularDeprecationPluginNotice.tsx
+++ b/public/app/features/plugins/angularDeprecation/AngularDeprecationPluginNotice.tsx
@@ -12,6 +12,8 @@ type Props = {
 
   angularSupportEnabled?: boolean;
   showPluginDetailsLink?: boolean;
+
+  interactionElementId?: string;
 };
 
 function deprecationMessage(pluginType?: string, angularSupportEnabled?: boolean): string {
@@ -42,8 +44,17 @@ function deprecationMessage(pluginType?: string, angularSupportEnabled?: boolean
 // An Alert showing information about Angular deprecation notice.
 // If the plugin does not use Angular (!plugin.angularDetected), it returns null.
 export function AngularDeprecationPluginNotice(props: Props): React.ReactElement | null {
-  const { className, angularSupportEnabled, pluginId, pluginType, showPluginDetailsLink } = props;
+  const { className, angularSupportEnabled, pluginId, pluginType, showPluginDetailsLink, interactionElementId } = props;
   const [dismissed, setDismissed] = useState(false);
+
+  const interactionAttributes: Record<string, string> = {};
+  if (pluginId) {
+    interactionAttributes.pluginId = pluginId;
+  }
+  if (interactionElementId) {
+    interactionAttributes.elementId = interactionElementId;
+  }
+
   return dismissed ? null : (
     <Alert severity="warning" title="Angular plugin" className={className} onRemove={() => setDismissed(true)}>
       <p>{deprecationMessage(pluginType, angularSupportEnabled)}</p>
@@ -56,9 +67,7 @@ export function AngularDeprecationPluginNotice(props: Props): React.ReactElement
               target="_blank"
               rel="noreferrer"
               onClick={() => {
-                reportInteraction('angular_deprecation_docs_clicked', {
-                  pluginId,
-                });
+                reportInteraction('angular_deprecation_docs_clicked', interactionAttributes);
               }}
             >
               Read our deprecation notice and migration advice.

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -261,6 +261,7 @@ export class QueryGroup extends PureComponent<Props, State> {
             pluginType={PluginType.datasource}
             angularSupportEnabled={config?.angularSupportEnabled}
             showPluginDetailsLink={true}
+            interactionElementId="datasource-query"
           />
         )}
       </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds `elementId` attribute to `angular_deprecation_docs_clicked` interaction.

**Why do we need this feature?**

To distinguish which link is clicked as it can be from:

- Panel options
- Datasource options
- Plugin details page
- Dashboard (PR not merged yet)

**Who is this feature for?**

Grafana Labs.

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #
-->

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
