### PR TITLE
Authn: client token rotation schedule

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -213,14 +213,6 @@ export class ContextSrv {
       // get the time token is going to expire
       let expires = this.getSessionExpiry();
 
-      // if expires is 0 we run rotation now and reschedule the job
-      // this can happen if user was signed in before upgrade
-      // after a successful rotation the expiry cookie will be present
-      if (expires === 0) {
-        this.rotateToken().then();
-        return;
-      }
-
       // because this job is scheduled for every tab we have open that shares a session we try
       // to distribute the scheduling of the job. For now this can be between 1 and 20 seconds
       const expiresWithDistribution = expires - Math.floor(Math.random() * (20 - 1) + 1);
@@ -252,25 +244,8 @@ export class ContextSrv {
       return false;
     }
 
-    const params = new URLSearchParams(window.location.search);
-
-    // skip if this is a render request
-    if (!!params.get('render')) {
-      return false;
-    }
-
-    // skip if we are using auth_token in url
-    if (!!params.get('auth_token')) {
-      return false;
-    }
-
-    // skip if the user has been authenticated by authproxy and does not have a login token
-    if (this.user.authenticatedBy === 'authproxy' && !config.auth.AuthProxyEnableLoginToken) {
-      return false;
-    }
-
-    // skip if the user has been authenticated by JWT auth
-    if (this.user.authenticatedBy === 'jwt') {
+    let expires = this.getSessionExpiry();
+    if (expires === 0) {
       return false;
     }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -242,6 +242,10 @@ export class ContextSrv {
       return false;
     }
 
+    // skip if there is no no session to rotate
+    // if a user has a session but not yet a session expiry cookie, can happen during upgrade
+    // from an older version of grafana we never schedule the job and the fallback logic
+    // in backend_srv will take care of rotations.
     if (this.getSessionExpiry() === 0) {
       return false;
     }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -242,8 +242,7 @@ export class ContextSrv {
       return false;
     }
 
-    let expires = this.getSessionExpiry();
-    if (expires === 0) {
+    if (this.getSessionExpiry() === 0) {
       return false;
     }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -242,10 +242,11 @@ export class ContextSrv {
       return false;
     }
 
-    // skip if there is no no session to rotate
+    // skip if there is no session to rotate
     // if a user has a session but not yet a session expiry cookie, can happen during upgrade
-    // from an older version of grafana we never schedule the job and the fallback logic
-    // in backend_srv will take care of rotations.
+    // from an older version of grafana, we never schedule the job and the fallback logic
+    // in backend_srv will take care of rotations until first rotation has been made and
+    // page has been reloaded.
     if (this.getSessionExpiry() === 0) {
       return false;
     }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -91,9 +91,7 @@ export class ContextSrv {
     this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
     this.minRefreshInterval = config.minRefreshInterval;
 
-    if (this.canScheduleRotation()) {
-      this.scheduleTokenRotationJob();
-    }
+    this.scheduleTokenRotationJob();
   }
 
   async fetchUserPermissions() {


### PR DESCRIPTION
**What is this feature?**
When scheduling client side token rotation we have handled a bunch of edge cases

* https://github.com/grafana/grafana/pull/68709
* https://github.com/grafana/grafana/pull/71073
* https://github.com/grafana/grafana/pull/72496

Instead we can check the presence of a session expiry and only schedule the job if we have a expiry time for our session.

If a user ha a session but the expiry cookie is not present the fallback logic will handle rotation of tokens and the scheduling will only kick in after a rotation has happened and the page is reloaded.

Tested:
* Auth proxy with and without `login_token_enabled`
* JWT and url_token
* Anonymous user

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
