### PR TITLE
codeowners: reassing mysql/postgres

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -190,14 +190,14 @@
 /devenv/docker/blocks/mssql_arm64/ @grafana/grafana-bi-squad
 /devenv/docker/blocks/mssql_tests/ @grafana/grafana-bi-squad
 /devenv/docker/blocks/mssql_tls/ @grafana/grafana-bi-squad
-/devenv/docker/blocks/mysql/ @grafana/grafana-bi-squad
-/devenv/docker/blocks/mysql_exporter/ @grafana/grafana-bi-squad
-/devenv/docker/blocks/mysql_opendata/ @grafana/grafana-bi-squad
-/devenv/docker/blocks/mysql_tests/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/mysql/ @grafana/oss-big-tent
+/devenv/docker/blocks/mysql_exporter/ @grafana/oss-big-tent
+/devenv/docker/blocks/mysql_opendata/ @grafana/oss-big-tent
+/devenv/docker/blocks/mysql_tests/ @grafana/oss-big-tent
 /devenv/docker/blocks/opentsdb/ @grafana/observability-metrics
 /devenv/docker/blocks/phlare/ @grafana/observability-traces-and-profiling
-/devenv/docker/blocks/postgres/ @grafana/grafana-bi-squad
-/devenv/docker/blocks/postgres_tests/ @grafana/grafana-bi-squad
+/devenv/docker/blocks/postgres/ @grafana/oss-big-tent
+/devenv/docker/blocks/postgres_tests/ @grafana/oss-big-tent
 /devenv/docker/blocks/prometheus/ @grafana/observability-metrics
 /devenv/docker/blocks/prometheus_random_data/ @grafana/observability-metrics
 /devenv/docker/blocks/pyroscope/ @grafana/observability-traces-and-profiling
@@ -254,8 +254,8 @@
 /pkg/tsdb/parca/ @grafana/observability-traces-and-profiling
 
 # BI backend code
-/pkg/tsdb/mysql/ @grafana/grafana-bi-squad
-/pkg/tsdb/postgres/ @grafana/grafana-bi-squad
+/pkg/tsdb/mysql/ @grafana/oss-big-tent
+/pkg/tsdb/postgres/ @grafana/oss-big-tent
 /pkg/tsdb/mssql/ @grafana/grafana-bi-squad
 
 # Database migrations
@@ -524,9 +524,9 @@ lerna.json @grafana/frontend-ops
 /public/app/plugins/datasource/loki/ @grafana/observability-logs
 /public/app/plugins/datasource/mixed/ @grafana/dashboards-squad
 /public/app/plugins/datasource/mssql/ @grafana/grafana-bi-squad
-/public/app/plugins/datasource/mysql/ @grafana/grafana-bi-squad
+/public/app/plugins/datasource/mysql/ @grafana/oss-big-tent
 /public/app/plugins/datasource/opentsdb/ @grafana/observability-metrics
-/public/app/plugins/datasource/postgres/ @grafana/grafana-bi-squad
+/public/app/plugins/datasource/postgres/ @grafana/oss-big-tent
 /public/app/plugins/datasource/prometheus/ @grafana/observability-metrics
 /public/app/plugins/datasource/cloud-monitoring/ @grafana/partner-datasources
 /public/app/plugins/datasource/zipkin/ @grafana/observability-traces-and-profiling


### PR DESCRIPTION
the mysql and postgres datasources are now going to be maintaned by the oss-big-tent squad.

(part of https://github.com/grafana/grafana/issues/72755)