### PR TITLE
Plugins: Add termination stage to plugin loader pipeline

### DIFF
--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -498,12 +498,12 @@ func (f *FakeInitializer) Initialize(ctx context.Context, ps []*plugins.Plugin) 
 }
 
 type FakeTerminator struct {
-	TerminateFunc func(ctx context.Context, uid string) error
+	TerminateFunc func(ctx context.Context, pluginID string) error
 }
 
-func (f *FakeTerminator) Terminate(ctx context.Context, uid string) error {
+func (f *FakeTerminator) Terminate(ctx context.Context, pluginID string) error {
 	if f.TerminateFunc != nil {
-		return f.TerminateFunc(ctx, uid)
+		return f.TerminateFunc(ctx, pluginID)
 	}
 	return nil
 }

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -496,3 +496,14 @@ func (f *FakeInitializer) Initialize(ctx context.Context, ps []*plugins.Plugin) 
 	}
 	return []*plugins.Plugin{}, nil
 }
+
+type FakeTerminator struct {
+	TerminateFunc func(ctx context.Context, uid string) error
+}
+
+func (f *FakeTerminator) Terminate(ctx context.Context, uid string) error {
+	if f.TerminateFunc != nil {
+		return f.TerminateFunc(ctx, uid)
+	}
+	return nil
+}

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/bootstrap"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/discovery"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/initialization"
+	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/termination"
 	"github.com/grafana/grafana/pkg/plugins/manager/process"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
@@ -27,6 +28,7 @@ type Loader struct {
 	discovery   discovery.Discoverer
 	bootstrap   bootstrap.Bootstrapper
 	initializer initialization.Initializer
+	termination termination.Terminator
 
 	processManager          process.Service
 	pluginRegistry          registry.Service
@@ -45,15 +47,17 @@ type Loader struct {
 func ProvideService(cfg *config.Cfg, authorizer plugins.PluginLoaderAuthorizer,
 	pluginRegistry registry.Service, roleRegistry plugins.RoleRegistry, assetPath *assetpath.Service,
 	angularInspector angularinspector.Inspector, externalServiceRegistry oauth.ExternalServiceRegistry,
-	discovery discovery.Discoverer, bootstrap bootstrap.Bootstrapper, initializer initialization.Initializer) *Loader {
+	discovery discovery.Discoverer, bootstrap bootstrap.Bootstrapper, initializer initialization.Initializer,
+	termination termination.Terminator) *Loader {
 	return New(cfg, authorizer, pluginRegistry, process.NewManager(pluginRegistry), roleRegistry, assetPath,
-		angularInspector, externalServiceRegistry, discovery, bootstrap, initializer)
+		angularInspector, externalServiceRegistry, discovery, bootstrap, initializer, termination)
 }
 
 func New(cfg *config.Cfg, authorizer plugins.PluginLoaderAuthorizer, pluginRegistry registry.Service,
 	processManager process.Service, roleRegistry plugins.RoleRegistry, assetPath *assetpath.Service,
 	angularInspector angularinspector.Inspector, externalServiceRegistry oauth.ExternalServiceRegistry,
-	discovery discovery.Discoverer, bootstrap bootstrap.Bootstrapper, initializer initialization.Initializer) *Loader {
+	discovery discovery.Discoverer, bootstrap bootstrap.Bootstrapper, initializer initialization.Initializer,
+	termination termination.Terminator) *Loader {
 	return &Loader{
 		pluginRegistry:          pluginRegistry,
 		signatureValidator:      signature.NewValidator(authorizer),
@@ -68,6 +72,7 @@ func New(cfg *config.Cfg, authorizer plugins.PluginLoaderAuthorizer, pluginRegis
 		discovery:               discovery,
 		bootstrap:               bootstrap,
 		initializer:             initializer,
+		termination:             termination,
 	}
 }
 
@@ -178,40 +183,7 @@ func (l *Loader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins
 }
 
 func (l *Loader) Unload(ctx context.Context, pluginID string) error {
-	plugin, exists := l.pluginRegistry.Plugin(ctx, pluginID)
-	if !exists {
-		return plugins.ErrPluginNotInstalled
-	}
-
-	if plugin.IsCorePlugin() || plugin.IsBundledPlugin() {
-		return plugins.ErrUninstallCorePlugin
-	}
-
-	if err := l.unload(ctx, plugin); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (l *Loader) unload(ctx context.Context, p *plugins.Plugin) error {
-	l.log.Debug("Stopping plugin process", "pluginId", p.ID)
-
-	if err := l.processManager.Stop(ctx, p.ID); err != nil {
-		return err
-	}
-
-	if err := l.pluginRegistry.Remove(ctx, p.ID); err != nil {
-		return err
-	}
-	l.log.Debug("Plugin unregistered", "pluginId", p.ID)
-
-	if remover, ok := p.FS.(plugins.FSRemover); ok {
-		if err := remover.Remove(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return l.termination.Terminate(ctx, pluginID)
 }
 
 func (l *Loader) PluginErrors() []*plugins.Error {

--- a/pkg/plugins/manager/pipeline/bootstrap/bootstrap.go
+++ b/pkg/plugins/manager/pipeline/bootstrap/bootstrap.go
@@ -65,6 +65,10 @@ func (b *Bootstrap) Bootstrap(ctx context.Context, src plugins.PluginSource, fou
 		return nil, err
 	}
 
+	if len(b.decorateSteps) == 0 {
+		return ps, nil
+	}
+
 	for _, p := range ps {
 		for _, decorator := range b.decorateSteps {
 			p, err = decorator(ctx, p)

--- a/pkg/plugins/manager/pipeline/bootstrap/doc.go
+++ b/pkg/plugins/manager/pipeline/bootstrap/doc.go
@@ -1,4 +1,4 @@
-// Package bootstrap defines the second stage of the plugin loader pipeline.
+// Package bootstrap defines the Bootstrap stage of the plugin loader pipeline.
 //
 // The Bootstrap stage must implement the Bootstrapper interface.
 // - Bootstrap(ctx context.Context, src plugins.PluginSource, bundles []*plugins.FoundBundle) ([]*plugins.Plugin, error)

--- a/pkg/plugins/manager/pipeline/discovery/doc.go
+++ b/pkg/plugins/manager/pipeline/discovery/doc.go
@@ -1,4 +1,4 @@
-// Package discovery defines the first stage of the plugin loader pipeline.
+// Package discovery defines the Discovery stage of the plugin loader pipeline.
 
 // The Discovery stage must implement the Discoverer interface.
 // - Discover(ctx context.Context, src plugins.PluginSource) ([]*plugins.FoundBundle, error)

--- a/pkg/plugins/manager/pipeline/doc.go
+++ b/pkg/plugins/manager/pipeline/doc.go
@@ -5,7 +5,7 @@
 // 	 Discovery: Find plugins (e.g. from disk, remote, etc.), and [optionally] filter the results based on some criteria.
 // 	 Bootstrap: Create the plugins found in the discovery stage and enrich them with metadata.
 // 	 Verification: Verify the plugins based on some criteria (e.g. signature validation, angular detection, etc.)
-// 	 Initialization: Initialize the plugin for use (e.g. register with Grafana, etc.)
-// 	 Post-Initialization: Perform any post-initialization tasks (e.g. start the backend process, declare RBAC roles etc.)
+// 	 Initialization: Initialize the plugin for use (e.g. register with Grafana, start the backend process, declare RBAC roles etc.)
+// - Termination: Terminate the plugin (e.g. stop the backend process, cleanup, etc.)
 
 package pipeline

--- a/pkg/plugins/manager/pipeline/initialization/doc.go
+++ b/pkg/plugins/manager/pipeline/initialization/doc.go
@@ -1,4 +1,4 @@
-// Package initialization defines the fourth stage of the plugin loader pipeline.
+// Package initialization defines the Initialization stage of the plugin loader pipeline.
 //
 // The Initialization stage must implement the Initializer interface.
 // - Initialize(ctx context.Context, ps []*plugins.Plugin) ([]*plugins.Plugin, error)

--- a/pkg/plugins/manager/pipeline/initialization/steps.go
+++ b/pkg/plugins/manager/pipeline/initialization/steps.go
@@ -22,8 +22,8 @@ type BackendClientInit struct {
 	log             log.Logger
 }
 
-// NewBackendClientInitStep returns a new InitializeFunc for registering a backend plugin process.
-func NewBackendClientInitStep(envVarProvider envvars.Provider,
+// BackendClientInitStep returns a new InitializeFunc for registering a backend plugin process.
+func BackendClientInitStep(envVarProvider envvars.Provider,
 	backendProvider plugins.BackendFactoryProvider) InitializeFunc {
 	return newBackendProcessRegistration(envVarProvider, backendProvider).Initialize
 }
@@ -64,8 +64,8 @@ type PluginRegistration struct {
 	log            log.Logger
 }
 
-// NewPluginRegistrationStep returns a new InitializeFunc for registering a plugin with the plugin registry.
-func NewPluginRegistrationStep(pluginRegistry registry.Service) InitializeFunc {
+// PluginRegistrationStep returns a new InitializeFunc for registering a plugin with the plugin registry.
+func PluginRegistrationStep(pluginRegistry registry.Service) InitializeFunc {
 	return newPluginRegistration(pluginRegistry).Initialize
 }
 

--- a/pkg/plugins/manager/pipeline/initialization/steps_test.go
+++ b/pkg/plugins/manager/pipeline/initialization/steps_test.go
@@ -28,7 +28,7 @@ func TestInitializer_Initialize(t *testing.T) {
 			Class: plugins.ClassCore,
 		}
 
-		stepFunc := NewBackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
+		stepFunc := BackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
 
 		var err error
 		p, err = stepFunc(context.Background(), p)
@@ -52,7 +52,7 @@ func TestInitializer_Initialize(t *testing.T) {
 			Class: plugins.ClassExternal,
 		}
 
-		stepFunc := NewBackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
+		stepFunc := BackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
 
 		var err error
 		p, err = stepFunc(context.Background(), p)
@@ -76,7 +76,7 @@ func TestInitializer_Initialize(t *testing.T) {
 			Class: plugins.ClassExternal,
 		}
 
-		stepFunc := NewBackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
+		stepFunc := BackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{plugin: p})
 
 		var err error
 		p, err = stepFunc(context.Background(), p)
@@ -94,7 +94,7 @@ func TestInitializer_Initialize(t *testing.T) {
 			},
 		}
 
-		i := NewBackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{
+		i := BackendClientInitStep(&fakeEnvVarsProvider{}, &fakeBackendProvider{
 			plugin: p,
 		})
 

--- a/pkg/plugins/manager/pipeline/termination/doc.go
+++ b/pkg/plugins/manager/pipeline/termination/doc.go
@@ -1,0 +1,5 @@
+// Package termination defines the Termination stage of the plugin loader pipeline.
+//
+// The Termination stage must implement the Terminator interface.
+// - Terminate(ctx context.Context, uid string) error
+package termination

--- a/pkg/plugins/manager/pipeline/termination/doc.go
+++ b/pkg/plugins/manager/pipeline/termination/doc.go
@@ -1,5 +1,5 @@
 // Package termination defines the Termination stage of the plugin loader pipeline.
 //
 // The Termination stage must implement the Terminator interface.
-// - Terminate(ctx context.Context, uid string) error
+// - Terminate(ctx context.Context, pluginID string) error
 package termination

--- a/pkg/plugins/manager/pipeline/termination/steps.go
+++ b/pkg/plugins/manager/pipeline/termination/steps.go
@@ -66,10 +66,7 @@ func newBackendProcessTerminator(processManager process.Service) *BackendProcess
 func (t *BackendProcessTerminator) Terminate(ctx context.Context, p *plugins.Plugin) error {
 	t.log.Debug("Stopping plugin process", "pluginId", p.ID)
 
-	if err := t.processManager.Stop(ctx, p.ID); err != nil {
-		return err
-	}
-	return nil
+	return t.processManager.Stop(ctx, p.ID)
 }
 
 // Deregister implements a TerminateFunc for removing a plugin from the plugin registry.

--- a/pkg/plugins/manager/pipeline/termination/steps.go
+++ b/pkg/plugins/manager/pipeline/termination/steps.go
@@ -28,8 +28,8 @@ func newTerminablePluginResolver(pluginRegistry registry.Service) *TerminablePlu
 }
 
 // Resolve returns a plugin that can be terminated.
-func (r *TerminablePluginResolver) Resolve(ctx context.Context, uid string) (*plugins.Plugin, error) {
-	p, exists := r.pluginRegistry.Plugin(ctx, uid)
+func (r *TerminablePluginResolver) Resolve(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
+	p, exists := r.pluginRegistry.Plugin(ctx, pluginID)
 	if !exists {
 		return nil, plugins.ErrPluginNotInstalled
 	}

--- a/pkg/plugins/manager/pipeline/termination/steps.go
+++ b/pkg/plugins/manager/pipeline/termination/steps.go
@@ -1,0 +1,110 @@
+package termination
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/log"
+	"github.com/grafana/grafana/pkg/plugins/manager/process"
+	"github.com/grafana/grafana/pkg/plugins/manager/registry"
+)
+
+// TerminablePluginResolver implements a ResolveFunc for resolving a plugin that can be terminated.
+type TerminablePluginResolver struct {
+	pluginRegistry registry.Service
+	log            log.Logger
+}
+
+// TerminablePluginResolverStep returns a new ResolveFunc for resolving a plugin that can be terminated.
+func TerminablePluginResolverStep(pluginRegistry registry.Service) ResolveFunc {
+	return newTerminablePluginResolver(pluginRegistry).Resolve
+}
+
+func newTerminablePluginResolver(pluginRegistry registry.Service) *TerminablePluginResolver {
+	return &TerminablePluginResolver{
+		pluginRegistry: pluginRegistry,
+		log:            log.New("plugins.resolver"),
+	}
+}
+
+// Resolve returns a plugin that can be terminated.
+func (r *TerminablePluginResolver) Resolve(ctx context.Context, uid string) (*plugins.Plugin, error) {
+	p, exists := r.pluginRegistry.Plugin(ctx, uid)
+	if !exists {
+		return nil, plugins.ErrPluginNotInstalled
+	}
+
+	// core plugins and bundled plugins cannot be terminated
+	if p.IsCorePlugin() || p.IsBundledPlugin() {
+		return nil, plugins.ErrUninstallCorePlugin
+	}
+
+	return p, nil
+}
+
+// BackendProcessTerminator implements a TerminateFunc for stopping a backend plugin process.
+//
+// It uses the process.Service to stop the backend plugin process.
+type BackendProcessTerminator struct {
+	processManager process.Service
+	log            log.Logger
+}
+
+// BackendProcessTerminatorStep returns a new TerminateFunc for stopping a backend plugin process.
+func BackendProcessTerminatorStep(processManager process.Service) TerminateFunc {
+	return newBackendProcessTerminator(processManager).Terminate
+}
+
+func newBackendProcessTerminator(processManager process.Service) *BackendProcessTerminator {
+	return &BackendProcessTerminator{
+		processManager: processManager,
+		log:            log.New("plugins.backend.termination"),
+	}
+}
+
+// Terminate stops a backend plugin process.
+func (t *BackendProcessTerminator) Terminate(ctx context.Context, p *plugins.Plugin) error {
+	t.log.Debug("Stopping plugin process", "pluginId", p.ID)
+
+	if err := t.processManager.Stop(ctx, p.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Deregister implements a TerminateFunc for removing a plugin from the plugin registry.
+type Deregister struct {
+	pluginRegistry registry.Service
+	log            log.Logger
+}
+
+// DeregisterStep returns a new TerminateFunc for removing a plugin from the plugin registry.
+func DeregisterStep(pluginRegistry registry.Service) TerminateFunc {
+	return newDeregister(pluginRegistry).Deregister
+}
+
+func newDeregister(pluginRegistry registry.Service) *Deregister {
+	return &Deregister{
+		pluginRegistry: pluginRegistry,
+		log:            log.New("plugins.deregister"),
+	}
+}
+
+// Deregister removes a plugin from the plugin registry.
+func (d *Deregister) Deregister(ctx context.Context, p *plugins.Plugin) error {
+	if err := d.pluginRegistry.Remove(ctx, p.ID); err != nil {
+		return err
+	}
+	d.log.Debug("Plugin unregistered", "pluginId", p.ID)
+	return nil
+}
+
+// FSRemoval implements a TerminateFunc for removing plugin files from the filesystem.
+func FSRemoval(_ context.Context, p *plugins.Plugin) error {
+	if remover, ok := p.FS.(plugins.FSRemover); ok {
+		if err := remover.Remove(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -1,0 +1,67 @@
+package termination
+
+import (
+	"context"
+	"errors"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/plugins/log"
+)
+
+// Terminator is responsible for the Termination stage of the plugin loader pipeline.
+type Terminator interface {
+	Terminate(ctx context.Context, uid string) error
+}
+
+// ResolveFunc is the function used for the Resolve step of the Termination stage.
+type ResolveFunc func(ctx context.Context, uid string) (*plugins.Plugin, error)
+
+// TerminateFunc is the function used for the Terminate step of the Termination stage.
+type TerminateFunc func(ctx context.Context, p *plugins.Plugin) error
+
+type Terminate struct {
+	cfg            *config.Cfg
+	resolveStep    ResolveFunc
+	terminateSteps []TerminateFunc
+	log            log.Logger
+}
+
+type Opts struct {
+	ResolveFunc    ResolveFunc
+	TerminateFuncs []TerminateFunc
+}
+
+// New returns a new Termination stage.
+func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
+	// without a resolve function, we can't do anything so return an error
+	if opts.ResolveFunc == nil && opts.TerminateFuncs != nil {
+		return nil, errors.New("resolve function is required")
+	}
+
+	if opts.TerminateFuncs == nil {
+		opts.TerminateFuncs = []TerminateFunc{}
+	}
+
+	return &Terminate{
+		cfg:            cfg,
+		resolveStep:    opts.ResolveFunc,
+		terminateSteps: opts.TerminateFuncs,
+		log:            log.New("plugins.initialization"),
+	}, nil
+}
+
+// Terminate will execute the Terminate steps of the Termination stage.
+func (t *Terminate) Terminate(ctx context.Context, uid string) error {
+	p, err := t.resolveStep(ctx, uid)
+	if err != nil {
+		return err
+	}
+
+	for _, terminate := range t.terminateSteps {
+		if err = terminate(ctx, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -47,7 +47,7 @@ func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
 		cfg:            cfg,
 		resolveStep:    opts.ResolveFunc,
 		terminateSteps: opts.TerminateFuncs,
-		log:            log.New("plugins.initialization"),
+		log:            log.New("plugins.termination"),
 	}, nil
 }
 

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -11,11 +11,11 @@ import (
 
 // Terminator is responsible for the Termination stage of the plugin loader pipeline.
 type Terminator interface {
-	Terminate(ctx context.Context, uid string) error
+	Terminate(ctx context.Context, pluginID string) error
 }
 
 // ResolveFunc is the function used for the Resolve step of the Termination stage.
-type ResolveFunc func(ctx context.Context, uid string) (*plugins.Plugin, error)
+type ResolveFunc func(ctx context.Context, pluginID string) (*plugins.Plugin, error)
 
 // TerminateFunc is the function used for the Terminate step of the Termination stage.
 type TerminateFunc func(ctx context.Context, p *plugins.Plugin) error
@@ -52,8 +52,8 @@ func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
 }
 
 // Terminate will execute the Terminate steps of the Termination stage.
-func (t *Terminate) Terminate(ctx context.Context, uid string) error {
-	p, err := t.resolveStep(ctx, uid)
+func (t *Terminate) Terminate(ctx context.Context, pluginID string) error {
+	p, err := t.resolveStep(ctx, pluginID)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/pluginsintegration/loader/loader.go
+++ b/pkg/services/pluginsintegration/loader/loader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/bootstrap"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/discovery"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/initialization"
+	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/termination"
 	"github.com/grafana/grafana/pkg/plugins/manager/process"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/oauth"
@@ -27,10 +28,11 @@ func ProvideService(cfg *config.Cfg, authorizer plugins.PluginLoaderAuthorizer, 
 	pluginRegistry registry.Service, roleRegistry plugins.RoleRegistry, assetPath *assetpath.Service,
 	angularInspector angularinspector.Inspector, externalServiceRegistry oauth.ExternalServiceRegistry,
 	discovery discovery.Discoverer, bootstrap bootstrap.Bootstrapper, initializer initialization.Initializer,
+	termination termination.Terminator,
 ) *Loader {
 	return &Loader{
 		loader: pluginsLoader.New(cfg, authorizer, pluginRegistry, processManager, roleRegistry, assetPath,
-			angularInspector, externalServiceRegistry, discovery, bootstrap, initializer),
+			angularInspector, externalServiceRegistry, discovery, bootstrap, initializer, termination),
 	}
 }
 

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/bootstrap"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/discovery"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/initialization"
+	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/termination"
 	"github.com/grafana/grafana/pkg/plugins/manager/process"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
@@ -69,6 +70,8 @@ var WireSet = wire.NewSet(
 	wire.Bind(new(bootstrap.Bootstrapper), new(*bootstrap.Bootstrap)),
 	pipeline.ProvideInitializationStage,
 	wire.Bind(new(initialization.Initializer), new(*initialization.Initialize)),
+	pipeline.ProvideTerminationStage,
+	wire.Bind(new(termination.Terminator), new(*termination.Terminate)),
 
 	angularpatternsstore.ProvideService,
 	angulardetectorsprovider.ProvideDynamic,


### PR DESCRIPTION
**What is this feature?**

Continues the migration of the plugin loader to the pipeline pattern.

**Why do we need this feature?**

To continue the refactoring of the plugin loader to improve its API.

**Who is this feature for?**

Plugins Platform

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #

**Special notes for your reviewer:**
-->
Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
