### PR TITLE
Auth: lock down Grafana admin sync for SAML

### DIFF
--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -125,6 +125,8 @@ func IsGrafanaAdminExternallySynced(cfg *setting.Cfg, authModule string, oAuthAn
 	switch authModule {
 	case JWTModule:
 		return cfg.JWTAuthAllowAssignGrafanaAdmin
+	case SAMLAuthModule:
+		return cfg.SAMLRoleValuesGrafanaAdmin != ""
 	case LDAPAuthModule:
 		return true
 	default:

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -517,8 +517,9 @@ type Cfg struct {
 	SecureSocksDSProxy SecureSocksDSProxySettings
 
 	// SAML Auth
-	SAMLAuthEnabled     bool
-	SAMLSkipOrgRoleSync bool
+	SAMLAuthEnabled            bool
+	SAMLSkipOrgRoleSync        bool
+	SAMLRoleValuesGrafanaAdmin string
 
 	// Okta OAuth
 	OktaAuthEnabled     bool
@@ -1263,6 +1264,7 @@ func (cfg *Cfg) readSAMLConfig() {
 	samlSec := cfg.Raw.Section("auth.saml")
 	cfg.SAMLAuthEnabled = samlSec.Key("enabled").MustBool(false)
 	cfg.SAMLSkipOrgRoleSync = samlSec.Key("skip_org_role_sync").MustBool(false)
+	cfg.SAMLRoleValuesGrafanaAdmin = samlSec.Key("role_values_grafana_admin").MustString("")
 }
 
 func (cfg *Cfg) readLDAPConfig() {


### PR DESCRIPTION
**What is this feature?**

Locking down manual Grafana Admin role updates for SAML users if Grafana Admin role is synced through SAML (when `role_values_grafana_admin` is set).

**Why do we need this feature?**

We locked down manual Grafana Admin role updates in https://github.com/grafana/grafana/pull/72677, but forgot to do it for SAML.