### PR TITLE
Loki: Migrate HTTP settings to new components

### DIFF
--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -8,7 +8,7 @@ const addDataSource = () => {
       'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
-      e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');
+      e2e().get('#connection-url').type('http://loki-url:3100');
     },
   });
 };

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -9,7 +9,7 @@ const addDataSource = () => {
       'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
-      e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');
+      e2e().get('#connection-url').type('http://loki-url:3100');
     },
   });
 };

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
@@ -15,7 +15,9 @@ describe('ConfigEditor', () => {
 
   it('should render the right sections', () => {
     render(<ConfigEditor onOptionsChange={() => {}} options={createDefaultConfigOptions()} />);
-    expect(screen.getByRole('heading', { name: 'HTTP' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Connection' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Authentication' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Advanced HTTP settings' })).toBeInTheDocument();
     expect(screen.getByText('Maximum lines')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Derived fields' })).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -10,7 +10,7 @@ import {
   AdvancedHttpSettings,
 } from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
+import { SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 
 import { LokiOptions } from '../types';

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,9 +1,16 @@
 import React, { useCallback } from 'react';
 
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
+import {
+  ConfigSection,
+  DataSourceDescription,
+  ConnectionSettings,
+  Auth,
+  convertLegacyAuthProps,
+  AdvancedHttpSettings,
+} from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 
 import { LokiOptions } from '../types';
@@ -48,25 +55,27 @@ export const ConfigEditor = (props: Props) => {
         docsLink="https://grafana.com/docs/grafana/latest/datasources/loki"
         hasRequiredFields={false}
       />
-
       <Divider />
-
-      <DataSourceHttpSettings
-        defaultUrl={'http://localhost:3100'}
-        dataSourceConfig={options}
-        showAccessOptions={false}
-        onChange={onOptionsChange}
-        secureSocksDSProxyEnabled={config.secureSocksDSProxyEnabled}
+      <ConnectionSettings config={options} onChange={onOptionsChange} />
+      <Divider />
+      <Auth
+        {...convertLegacyAuthProps({
+          config: options,
+          onChange: onOptionsChange,
+        })}
       />
-
       <Divider />
-
       <ConfigSection
         title="Additional settings"
         description="Additional settings are optional settings that can be configured for more control over your data source."
         isCollapsible={true}
         isInitiallyOpen
       >
+        <AdvancedHttpSettings config={options} onChange={onOptionsChange} />
+        <Divider hideLine />
+        {config.secureSocksDSProxyEnabled && (
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+        )}
         <AlertingSettings options={options} onOptionsChange={onOptionsChange} />
         <Divider hideLine />
         <QuerySettings


### PR DESCRIPTION
This PR migrates the upper part of the data sources configuration pages, to be split among the Connection, Auth, and Advanced settings.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

How to test:
- Edit https://github.com/grafana/grafana/blob/main/devenv/datasources.yaml
- Add the following entries:
```
  - name: gdev-loki-basic-auth
    type: loki
    access: proxy
    url: http://localhost:3100
    editable: true
    basicAuth: true
    basicAuthUser: "user"
    jsonData:
    secureJsonData:
      basicAuthPassword: "pass"

  - name: gdev-loki-oauth-auth
    type: loki
    access: proxy
    url: http://localhost:3100
    editable: true
    basicAuth: false
    jsonData:
      oauthPassThru: true

  - name: gdev-loki-no-auth
    type: loki
    access: proxy
    url: http://localhost:3100
    editable: true
    basicAuth: false
    jsonData:
      serverName: "domain.example.com"
      tlsAuth: true
      tlsAuthWithCACert: true
      tlsSkipVerify: true
    secureJsonData: 
      tlsCACert: "--- BEGIN CERTIFICATE ---"
      tlsClientCert: "--- BEGIN CERTIFICATE ---"
      tlsClientKey: "--- RSA PRIVATE KEY CERTIFICATE ---"
```
- Run `setup.sh` and restart grafana.
- Look for each data source and you should see the expected options to be filled up.

![oauth new](https://github.com/grafana/grafana/assets/1069378/ab9b91da-ffeb-4dfe-9c00-f707efc1bd75)
![oauth old](https://github.com/grafana/grafana/assets/1069378/7e4f0fa8-18ea-477b-8108-62963b496a58)

--

![no-auth new](https://github.com/grafana/grafana/assets/1069378/b78a6f9f-8e2f-4a97-8856-b41ef782e1ab)
![no-auth old](https://github.com/grafana/grafana/assets/1069378/03033feb-ff14-46f5-bc52-acafe7ff16a6)

--

![basic old](https://github.com/grafana/grafana/assets/1069378/8f4bd373-4ede-4ba8-9038-adca6ac7b965)
![basic new](https://github.com/grafana/grafana/assets/1069378/c0e730f4-9772-4668-a5d8-61897c763dab)

