### PR TITLE
InfluxDB: Fix handling flux response with no time and value column

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0 // @grafana/plugins-platform-backend
 	github.com/hashicorp/go-plugin v1.4.9 // @grafana/plugins-platform-backend
 	github.com/hashicorp/go-version v1.6.0 // @grafana/backend-platform
-	github.com/influxdata/influxdb-client-go/v2 v2.6.0 // @grafana/observability-metrics
+	github.com/influxdata/influxdb-client-go/v2 v2.12.3 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // @grafana/grafana-app-platform-squad
 	github.com/jmespath/go-jmespath v0.4.0 // @grafana/backend-platform
 	github.com/json-iterator/go v1.1.12 // @grafana/backend-platform

--- a/go.sum
+++ b/go.sum
@@ -1954,6 +1954,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb-client-go/v2 v2.6.0 h1:bIOaGTgvvv1Na2hG+nIvqyv7PK2UiU2WrJN1ck1ykyM=
 github.com/influxdata/influxdb-client-go/v2 v2.6.0/go.mod h1:Y/0W1+TZir7ypoQZYd2IrnVOKB3Tq6oegAQeSVN/+EU=
+github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0IpXeMSkY/uJa/O/vC4=
+github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=

--- a/pkg/tsdb/influxdb/flux/executor_test.go
+++ b/pkg/tsdb/influxdb/flux/executor_test.go
@@ -305,3 +305,13 @@ func TestTimestampFirst(t *testing.T) {
 	require.Equal(t, "Time", dr.Frames[0].Fields[0].Name)
 	require.Equal(t, "Value", dr.Frames[0].Fields[1].Name)
 }
+
+func TestWithoutTimeColumn(t *testing.T) {
+	dr := verifyGoldenResponse(t, "without-time-column")
+	require.Len(t, dr.Frames, 5)
+	// we make sure the timestamp-column is the first column
+	// in the dataframe, even if it was not the first column
+	// in the csv.
+	require.Equal(t, "cpu", dr.Frames[0].Fields[0].Name)
+	require.Equal(t, "host", dr.Frames[0].Fields[1].Name)
+}

--- a/pkg/tsdb/influxdb/flux/testdata/without-time-column.csv
+++ b/pkg/tsdb/influxdb/flux/testdata/without-time-column.csv
@@ -1,0 +1,14 @@
+#datatype,string,long,string,string
+#group,false,false,true,true
+#default,last,,,
+,result,table,cpu,host
+,,0,cpu-total,cc59eb40ad0f
+,,0,cpu-total,cc59eb40ad0f
+,,1,cpu0,cc59eb40ad0f
+,,1,cpu0,cc59eb40ad0f
+,,2,cpu1,cc59eb40ad0f
+,,3,cpu2,cc59eb40ad0f
+,,3,cpu2,cc59eb40ad0f
+,,4,cpu3,cc59eb40ad0f
+,,4,cpu3,cc59eb40ad0f
+

--- a/pkg/tsdb/influxdb/flux/testdata/without-time-column.golden.jsonc
+++ b/pkg/tsdb/influxdb/flux/testdata/without-time-column.golden.jsonc
@@ -1,0 +1,295 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +------------------------------------------+------------------------------------------+
+//  | Name: cpu                                | Name: host                               |
+//  | Labels: cpu=cpu-total, host=cc59eb40ad0f | Labels: cpu=cpu-total, host=cc59eb40ad0f |
+//  | Type: []*string                          | Type: []*string                          |
+//  +------------------------------------------+------------------------------------------+
+//  | cpu-total                                | cc59eb40ad0f                             |
+//  | cpu-total                                | cc59eb40ad0f                             |
+//  +------------------------------------------+------------------------------------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------------+-------------------------------------+
+//  | Name: cpu                           | Name: host                          |
+//  | Labels: cpu=cpu0, host=cc59eb40ad0f | Labels: cpu=cpu0, host=cc59eb40ad0f |
+//  | Type: []*string                     | Type: []*string                     |
+//  +-------------------------------------+-------------------------------------+
+//  | cpu0                                | cc59eb40ad0f                        |
+//  | cpu0                                | cc59eb40ad0f                        |
+//  +-------------------------------------+-------------------------------------+
+//  
+//  
+//  
+//  Frame[2] 
+//  Name: 
+//  Dimensions: 2 Fields by 1 Rows
+//  +-------------------------------------+-------------------------------------+
+//  | Name: cpu                           | Name: host                          |
+//  | Labels: cpu=cpu1, host=cc59eb40ad0f | Labels: cpu=cpu1, host=cc59eb40ad0f |
+//  | Type: []*string                     | Type: []*string                     |
+//  +-------------------------------------+-------------------------------------+
+//  | cpu1                                | cc59eb40ad0f                        |
+//  +-------------------------------------+-------------------------------------+
+//  
+//  
+//  
+//  Frame[3] 
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------------+-------------------------------------+
+//  | Name: cpu                           | Name: host                          |
+//  | Labels: cpu=cpu2, host=cc59eb40ad0f | Labels: cpu=cpu2, host=cc59eb40ad0f |
+//  | Type: []*string                     | Type: []*string                     |
+//  +-------------------------------------+-------------------------------------+
+//  | cpu2                                | cc59eb40ad0f                        |
+//  | cpu2                                | cc59eb40ad0f                        |
+//  +-------------------------------------+-------------------------------------+
+//  
+//  
+//  
+//  Frame[4] 
+//  Name: 
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------------+-------------------------------------+
+//  | Name: cpu                           | Name: host                          |
+//  | Labels: cpu=cpu3, host=cc59eb40ad0f | Labels: cpu=cpu3, host=cc59eb40ad0f |
+//  | Type: []*string                     | Type: []*string                     |
+//  +-------------------------------------+-------------------------------------+
+//  | cpu3                                | cc59eb40ad0f                        |
+//  | cpu3                                | cc59eb40ad0f                        |
+//  +-------------------------------------+-------------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "cpu",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu-total",
+              "host": "cc59eb40ad0f"
+            }
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu-total",
+              "host": "cc59eb40ad0f"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cpu-total",
+            "cpu-total"
+          ],
+          [
+            "cc59eb40ad0f",
+            "cc59eb40ad0f"
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "cpu",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu0",
+              "host": "cc59eb40ad0f"
+            }
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu0",
+              "host": "cc59eb40ad0f"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cpu0",
+            "cpu0"
+          ],
+          [
+            "cc59eb40ad0f",
+            "cc59eb40ad0f"
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "cpu",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu1",
+              "host": "cc59eb40ad0f"
+            }
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu1",
+              "host": "cc59eb40ad0f"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cpu1"
+          ],
+          [
+            "cc59eb40ad0f"
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "cpu",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu2",
+              "host": "cc59eb40ad0f"
+            }
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu2",
+              "host": "cc59eb40ad0f"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cpu2",
+            "cpu2"
+          ],
+          [
+            "cc59eb40ad0f",
+            "cc59eb40ad0f"
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "fields": [
+          {
+            "name": "cpu",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu3",
+              "host": "cc59eb40ad0f"
+            }
+          },
+          {
+            "name": "host",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            },
+            "labels": {
+              "cpu": "cpu3",
+              "host": "cc59eb40ad0f"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cpu3",
+            "cpu3"
+          ],
+          [
+            "cc59eb40ad0f",
+            "cc59eb40ad0f"
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What is this feature?**

When we query in a way where there is no time and value column in the response, the frame builder fails to create data frames. This PR is addressing it. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

InfluxDB Flux query users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71258

**Special notes for your reviewer:**

### How to test it?
- Spin up InfluxDB 2.x with devenv
- Create an Influxdb datasource that uses `Flux` as query language
- Go to explore and use that datasource
- Use the following query
```
from(bucket: "mybucket")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r["_measurement"] == "cpu")
  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)
  |> sort(columns: ["_time"], desc: true)
  |> keep(columns: ["cpu", "host"])
  |> yield(name: "last") 
```
- Observe that there is an error
- Switch to this branch
- Try again

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
