### PR TITLE
Elasticsearch: HTTP settings migration

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
@@ -15,7 +15,9 @@ describe('ConfigEditor', () => {
     render(<ConfigEditor onOptionsChange={() => {}} options={createDefaultConfigOptions()} />);
 
     // Check DataSourceHttpSettings are rendered
-    expect(screen.getByRole('heading', { name: 'HTTP' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Connection' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Authentication' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Advanced HTTP settings' })).toBeInTheDocument();
 
     // Check ElasticDetails are rendered
     expect(screen.getByText('Elasticsearch details')).toBeInTheDocument();

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -33,8 +33,6 @@ export const ConfigEditor = (props: Props) => {
     }
   }, [onOptionsChange, options]);
 
-  config.sigV4AuthEnabled = true;
-
   const authProps = convertLegacyAuthProps({
     config: options,
     onChange: onOptionsChange,

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import { css } from '@emotion/css';
+import React, { useEffect } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
@@ -10,7 +11,7 @@ import {
   convertLegacyAuthProps,
   DataSourceDescription,
 } from '@grafana/experimental';
-import { Alert, DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
+import { Alert, SecureSocksProxySettings } from '@grafana/ui';
 import { Divider } from 'app/core/components/Divider';
 import { config } from 'app/core/config';
 
@@ -47,11 +48,6 @@ export const ConfigEditor = (props: Props) => {
         component: <SIGV4ConnectionConfig {...props} />,
       },
     ];
-    authProps.onAuthMethodSelect = (method) => {
-      authProps.onAuthMethodSelect(method);
-      options.jsonData.sigV4Auth = method === 'custom-sigv4';
-      onOptionsChange(options);
-    };
     authProps.selectedMethod = options.jsonData.sigV4Auth ? 'custom-sigv4' : authProps.selectedMethod;
   }
 
@@ -70,7 +66,15 @@ export const ConfigEditor = (props: Props) => {
       <Divider />
       <ConnectionSettings config={options} onChange={onOptionsChange} />
       <Divider />
-      <Auth {...authProps} />
+      <div className={options.jsonData.sigV4Auth ? styles.sigV4authContainer : ''}>
+        <Auth
+          {...authProps}
+          onAuthMethodSelect={(method) => {
+            options.jsonData.sigV4Auth = method === 'custom-sigv4';
+            authProps.onAuthMethodSelect(method);
+          }}
+        />
+      </div>
       <Divider />
       <ConfigSection
         title="Additional settings"
@@ -110,4 +114,12 @@ export const ConfigEditor = (props: Props) => {
       </ConfigSection>
     </>
   );
+};
+
+const styles = {
+  sigV4authContainer: css`
+    & > div {
+      max-width: 100%;
+    }
+  `,
 };

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -62,7 +62,7 @@ export const ConfigEditor = (props: Props) => {
         hasRequiredFields={false}
       />
       <Divider />
-      <ConnectionSettings config={options} onChange={onOptionsChange} />
+      <ConnectionSettings config={options} onChange={onOptionsChange} urlPlaceholder="http://localhost:9200" />
       <Divider />
       <div className={options.jsonData.sigV4Auth ? styles.sigV4authContainer : ''}>
         <Auth

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -74,6 +74,7 @@ export const ConfigEditor = (props: Props) => {
             jsonData: {
               ...options.jsonData,
               sigV4Auth: method === 'custom-sigv4',
+              oauthPassThru: method === AuthMethod.OAuthForward,
             },
           });
         }}

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import React, { useEffect } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
@@ -6,6 +5,7 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import {
   AdvancedHttpSettings,
   Auth,
+  AuthMethod,
   ConfigSection,
   ConnectionSettings,
   convertLegacyAuthProps,
@@ -43,7 +43,7 @@ export const ConfigEditor = (props: Props) => {
         id: 'custom-sigv4',
         label: 'SigV4 auth',
         description: 'AWS Signature Version 4 authentication',
-        component: <SIGV4ConnectionConfig {...props} />,
+        component: <SIGV4ConnectionConfig inExperimentalAuthComponent={true} {...props} />,
       },
     ];
     authProps.selectedMethod = options.jsonData.sigV4Auth ? 'custom-sigv4' : authProps.selectedMethod;
@@ -64,15 +64,20 @@ export const ConfigEditor = (props: Props) => {
       <Divider />
       <ConnectionSettings config={options} onChange={onOptionsChange} urlPlaceholder="http://localhost:9200" />
       <Divider />
-      <div className={options.jsonData.sigV4Auth ? styles.sigV4authContainer : ''}>
-        <Auth
-          {...authProps}
-          onAuthMethodSelect={(method) => {
-            options.jsonData.sigV4Auth = method === 'custom-sigv4';
-            authProps.onAuthMethodSelect(method);
-          }}
-        />
-      </div>
+      <Auth
+        {...authProps}
+        onAuthMethodSelect={(method) => {
+          onOptionsChange({
+            ...options,
+            basicAuth: method === AuthMethod.BasicAuth,
+            withCredentials: method === AuthMethod.CrossSiteCredentials,
+            jsonData: {
+              ...options.jsonData,
+              sigV4Auth: method === 'custom-sigv4',
+            },
+          });
+        }}
+      />
       <Divider />
       <ConfigSection
         title="Additional settings"
@@ -112,12 +117,4 @@ export const ConfigEditor = (props: Props) => {
       </ConfigSection>
     </>
   );
-};
-
-const styles = {
-  sigV4authContainer: css`
-    & > div {
-      max-width: 100%;
-    }
-  `,
 };

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -64,6 +64,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   dataLinks?: DataLinkConfig[];
   includeFrozen?: boolean;
   index?: string;
+  sigV4Auth?: boolean;
 }
 
 export type QueryType = 'metrics' | 'logs' | 'raw_data' | 'raw_document';

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -65,6 +65,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   includeFrozen?: boolean;
   index?: string;
   sigV4Auth?: boolean;
+  oauthPassThru?: boolean;
 }
 
 export type QueryType = 'metrics' | 'logs' | 'raw_data' | 'raw_document';


### PR DESCRIPTION
This PR migrates the upper part of the data sources configuration pages, to be split among the Connection, Auth, and Advanced settings. Also added missing tooltips for text fields.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/67383

**Special notes for your reviewer:**

How to test:
- Edit https://github.com/grafana/grafana/blob/main/devenv/datasources.yaml
- Add the following entries:
```
  - name: gdev-elastic-basic-auth
    type: elasticsearch
    access: proxy
    url: http://localhost:9200
    editable: true
    basicAuth: true
    basicAuthUser: "user"
    jsonData:
    secureJsonData:
      basicAuthPassword: "pass"

  - name: gdev-elastic-oauth-auth
    type: elasticsearch
    access: proxy
    url: http://localhost:9200
    editable: true
    basicAuth: false
    jsonData:
      oauthPassThru: true

  - name: gdev-elastic-no-auth
    type: elasticsearch
    access: proxy
    url: http://localhost:9200
    editable: true
    basicAuth: false
    jsonData:
      serverName: "domain.example.com"
      tlsAuth: true
      tlsAuthWithCACert: true
      tlsSkipVerify: true
    secureJsonData: 
      tlsCACert: "--- BEGIN CERTIFICATE ---"
      tlsClientCert: "--- BEGIN CERTIFICATE ---"
      tlsClientKey: "--- RSA PRIVATE KEY CERTIFICATE ---"

  - name: gdev-elastic-sigv4-auth
    type: elasticsearch
    access: proxy
    url: http://localhost:9200
    editable: true
    basicAuth: false
    jsonData:
      sigV4AssumeRoleArn: "test"
      sigV4Auth: true
      sigV4AuthType: "keys"
      sigV4Endpoint: undefined
      sigV4ExternalId: "test"
      sigV4Region: "ap-east-1"
    secureJsonData: 
      sigV4AccessKey: "test"
      sigV4SecretKey: "test"
```
- Run `setup.sh` and restart grafana.
- Look for each data source and you should see the expected options to be filled up.
- **Note**: To test SigV4 the `sigV4AuthEnabled` config option must be enabled.

![basic new](https://github.com/grafana/grafana/assets/1069378/60fea692-bc01-4705-af0d-6e2928ea5925)
![basic old](https://github.com/grafana/grafana/assets/1069378/fc4fef33-7a0c-4bf0-b7b9-e84f4c9864df)

--

![no auth new](https://github.com/grafana/grafana/assets/1069378/a3b97a0b-d250-46cd-9644-d559aeabaf8b)
![no auth old](https://github.com/grafana/grafana/assets/1069378/ae949e5c-d087-427d-b536-2aa108901744)

--

![oauth new](https://github.com/grafana/grafana/assets/1069378/0da679bf-2a6f-439e-98ff-3733473ea84b)
![oauth old](https://github.com/grafana/grafana/assets/1069378/fa9d40ee-7011-4686-88d2-089c272257ab)

--

![sigv4 new](https://github.com/grafana/grafana/assets/1069378/1dff546b-60aa-4bd6-b9ab-52aec5300419)
![sigv4 old](https://github.com/grafana/grafana/assets/1069378/dc559680-5ff8-4601-91f9-909809096e2e)
