### PR TITLE
Implement schema composition in dashboard kinds

### DIFF
--- a/docs/sources/developers/kinds/composable/geomap/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/geomap/panelcfg/schema-reference.md
@@ -18,14 +18,19 @@ title: GeomapPanelCfg kind
 
 
 
-| Property          | Type                       | Required | Default | Description                                   |
-|-------------------|----------------------------|----------|---------|-----------------------------------------------|
-| `ControlsOptions` | [object](#controlsoptions) | **Yes**  |         |                                               |
-| `MapCenterID`     | string                     | **Yes**  |         | Possible values are: `zero`, `coords`, `fit`. |
-| `MapViewConfig`   | [object](#mapviewconfig)   | **Yes**  |         |                                               |
-| `Options`         | [object](#options)         | **Yes**  |         |                                               |
-| `TooltipMode`     | string                     | **Yes**  |         | Possible values are: `none`, `details`.       |
-| `TooltipOptions`  | [object](#tooltipoptions)  | **Yes**  |         |                                               |
+| Property  | Type               | Required | Default | Description |
+|-----------|--------------------|----------|---------|-------------|
+| `Options` | [object](#options) | **Yes**  |         |             |
+
+### Options
+
+| Property   | Type                                  | Required | Default | Description |
+|------------|---------------------------------------|----------|---------|-------------|
+| `basemap`  | [MapLayerOptions](#maplayeroptions)   | **Yes**  |         |             |
+| `controls` | [ControlsOptions](#controlsoptions)   | **Yes**  |         |             |
+| `layers`   | [MapLayerOptions](#maplayeroptions)[] | **Yes**  |         |             |
+| `tooltip`  | [TooltipOptions](#tooltipoptions)     | **Yes**  |         |             |
+| `view`     | [MapViewConfig](#mapviewconfig)       | **Yes**  |         |             |
 
 ### ControlsOptions
 
@@ -38,43 +43,17 @@ title: GeomapPanelCfg kind
 | `showScale`       | boolean | No       |         | Scale options            |
 | `showZoom`        | boolean | No       |         | Zoom (upper left)        |
 
-### MapViewConfig
-
-| Property    | Type    | Required | Default | Description |
-|-------------|---------|----------|---------|-------------|
-| `id`        | string  | **Yes**  | `zero`  |             |
-| `allLayers` | boolean | No       | `true`  |             |
-| `lastOnly`  | boolean | No       |         |             |
-| `lat`       | int64   | No       | `0`     |             |
-| `layer`     | string  | No       |         |             |
-| `lon`       | int64   | No       | `0`     |             |
-| `maxZoom`   | integer | No       |         |             |
-| `minZoom`   | integer | No       |         |             |
-| `padding`   | integer | No       |         |             |
-| `shared`    | boolean | No       |         |             |
-| `zoom`      | int64   | No       | `1`     |             |
-
-### Options
-
-| Property   | Type                                  | Required | Default | Description |
-|------------|---------------------------------------|----------|---------|-------------|
-| `basemap`  | [MapLayerOptions](#maplayeroptions)   | **Yes**  |         |             |
-| `controls` | [ControlsOptions](#controlsoptions)   | **Yes**  |         |             |
-| `layers`   | [MapLayerOptions](#maplayeroptions)[] | **Yes**  |         |             |
-| `tooltip`  | [TooltipOptions](#tooltipoptions)     | **Yes**  |         |             |
-| `view`     | [MapViewConfig](#mapviewconfig)       | **Yes**  |         |             |
-
 ### MapLayerOptions
 
-| Property     | Type                                        | Required | Default | Description                                                                                                                |
-|--------------|---------------------------------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------|
-| `name`       | string                                      | **Yes**  |         | configured unique display name                                                                                             |
-| `type`       | string                                      | **Yes**  |         |                                                                                                                            |
-| `config`     |                                             | No       |         | Custom options depending on the type                                                                                       |
-| `filterData` |                                             | No       |         | Defines a frame MatcherConfig that may filter data for the given layer                                                     |
-| `location`   | [FrameGeometrySource](#framegeometrysource) | No       |         |                                                                                                                            |
-| `opacity`    | integer                                     | No       |         | Common properties:<br/>https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html<br/>Layer opacity (0-1) |
-| `tooltip`    | boolean                                     | No       |         | Check tooltip (defaults to true)                                                                                           |
+| Property     | Type                                        | Required | Default | Description                                                                                                                                             |
+|--------------|---------------------------------------------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`       | string                                      | **Yes**  |         | configured unique display name                                                                                                                          |
+| `type`       | string                                      | **Yes**  |         |                                                                                                                                                         |
+| `config`     |                                             | No       |         | Custom options depending on the type                                                                                                                    |
+| `filterData` |                                             | No       |         | Defines a frame MatcherConfig that may filter data for the given layer                                                                                  |
+| `location`   | [FrameGeometrySource](#framegeometrysource) | No       |         |                                                                                                                                                         |
+| `opacity`    | number                                      | No       |         | Common properties:<br/>https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html<br/>Layer opacity (0-1)<br/>Constraint: `>=0 & <=1`. |
+| `tooltip`    | boolean                                     | No       |         | Check tooltip (defaults to true)                                                                                                                        |
 
 ### FrameGeometrySource
 
@@ -87,6 +66,22 @@ title: GeomapPanelCfg kind
 | `longitude` | string | No       |         |                                                             |
 | `lookup`    | string | No       |         |                                                             |
 | `wkt`       | string | No       |         |                                                             |
+
+### MapViewConfig
+
+| Property    | Type    | Required | Default | Description                                                                                                         |
+|-------------|---------|----------|---------|---------------------------------------------------------------------------------------------------------------------|
+| `id`        | string  | **Yes**  | `zero`  |                                                                                                                     |
+| `allLayers` | boolean | No       | `true`  |                                                                                                                     |
+| `lastOnly`  | boolean | No       |         |                                                                                                                     |
+| `lat`       | number  | No       | `0`     | Constraint: `>=-1.797693134862315708145274237317043567981E+308 & <=1.797693134862315708145274237317043567981E+308`. |
+| `layer`     | string  | No       |         |                                                                                                                     |
+| `lon`       | number  | No       | `0`     | Constraint: `>=-1.797693134862315708145274237317043567981E+308 & <=1.797693134862315708145274237317043567981E+308`. |
+| `maxZoom`   | number  | No       |         |                                                                                                                     |
+| `minZoom`   | number  | No       |         |                                                                                                                     |
+| `padding`   | number  | No       |         |                                                                                                                     |
+| `shared`    | boolean | No       |         |                                                                                                                     |
+| `zoom`      | number  | No       | `1`     | Constraint: `>=-340282346638528859811704183484516925440 & <=340282346638528859811704183484516925440`.               |
 
 ### TooltipOptions
 

--- a/docs/sources/developers/kinds/composable/text/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/text/panelcfg/schema-reference.md
@@ -18,20 +18,9 @@ title: TextPanelCfg kind
 
 
 
-| Property       | Type                   | Required | Default     | Description                                                                                             |
-|----------------|------------------------|----------|-------------|---------------------------------------------------------------------------------------------------------|
-| `CodeLanguage` | string                 | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
-| `CodeOptions`  | [object](#codeoptions) | **Yes**  |             |                                                                                                         |
-| `Options`      | [object](#options)     | **Yes**  |             |                                                                                                         |
-| `TextMode`     | string                 | **Yes**  |             | Possible values are: `html`, `markdown`, `code`.                                                        |
-
-### CodeOptions
-
-| Property          | Type    | Required | Default     | Description                                                                                             |
-|-------------------|---------|----------|-------------|---------------------------------------------------------------------------------------------------------|
-| `language`        | string  | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
-| `showLineNumbers` | boolean | **Yes**  | `false`     |                                                                                                         |
-| `showMiniMap`     | boolean | **Yes**  | `false`     |                                                                                                         |
+| Property  | Type               | Required | Default | Description |
+|-----------|--------------------|----------|---------|-------------|
+| `Options` | [object](#options) | **Yes**  |         |             |
 
 ### Options
 
@@ -42,5 +31,13 @@ title: TextPanelCfg kind
 |           |                             |          | For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)` |                                                  |
 | `mode`    | string                      | **Yes**  |                                                                                | Possible values are: `html`, `markdown`, `code`. |
 | `code`    | [CodeOptions](#codeoptions) | No       |                                                                                |                                                  |
+
+### CodeOptions
+
+| Property          | Type    | Required | Default     | Description                                                                                             |
+|-------------------|---------|----------|-------------|---------------------------------------------------------------------------------------------------------|
+| `language`        | string  | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
+| `showLineNumbers` | boolean | **Yes**  | `false`     |                                                                                                         |
+| `showMiniMap`     | boolean | **Yes**  | `false`     |                                                                                                         |
 
 

--- a/docs/sources/developers/kinds/core/dashboard/schema-reference.md
+++ b/docs/sources/developers/kinds/core/dashboard/schema-reference.md
@@ -137,10 +137,10 @@ these match the properties of the "grafana" datasouce that is default in most da
 
 | Property   | Type     | Required | Default | Description                                                                                                       |
 |------------|----------|----------|---------|-------------------------------------------------------------------------------------------------------------------|
-| `limit`    | integer  | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `matchAny` | boolean  | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `tags`     | string[] | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `type`     | string   | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `matchAny` | boolean  | **Yes**  | `false` | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `limit`    | integer  | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `tags`     | string[] | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `type`     | string   | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
 
 ### DataSourceRef
 
@@ -164,9 +164,9 @@ Links with references to other dashboards or external resources
 | `tags`        | string[] | **Yes**  |         | List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards                                                  |
 | `targetBlank` | boolean  | **Yes**  | `false` | If true, the link will be opened in a new tab                                                                                                                                  |
 | `title`       | string   | **Yes**  |         | Title to display with the link                                                                                                                                                 |
-| `tooltip`     | string   | **Yes**  |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
 | `type`        | string   | **Yes**  |         | Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)<br/>Possible values are: `link`, `dashboards`. |
-| `url`         | string   | **Yes**  |         | Link URL. Only required/valid if the type is link                                                                                                                              |
+| `tooltip`     | string   | No       |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
+| `url`         | string   | No       |         | Link URL. Only required/valid if the type is link                                                                                                                              |
 
 ### Snapshot
 
@@ -282,7 +282,7 @@ They are used to conditionally style and color visualizations based on query res
 | Property | Type           | Required | Default | Description                                                                                                                                                                                                    |
 |----------|----------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `color`  | string         | **Yes**  |         | Color represents the color of the visual change that will occur in the dashboard when the threshold value is met or exceeded.                                                                                  |
-| `value`  | number or null | **Yes**  |         | Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.<br/>Nulls currently appear here when serializing -Infinity to JSON. |
+| `value`  | number or null | No       |         | Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.<br/>Nulls currently appear here when serializing -Infinity to JSON. |
 
 ### ValueMapping
 

--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics
 	github.com/grafana/dataplane/sdata v0.0.6 // @grafana/observability-metrics
 	github.com/grafana/go-mssqldb v0.9.1 // @grafana/grafana-bi-squad
-	github.com/grafana/kindsys v0.0.0-20230710031138-57f73e1488a7 //  @grafana/grafana-as-code
+	github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 //  @grafana/grafana-as-code
 	github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b // @grafana/observability-traces-and-profiling
 	github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed // @grafana/grafana-as-code
 	github.com/ory/fosite v0.44.1-0.20230317114349-45a6785cc54f // @grafana/grafana-authnz-team
@@ -492,3 +492,5 @@ replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20220421
 replace github.com/lib/pq => github.com/lib/pq v1.10.6
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
+
+//replace github.com/grafana/kindsys => ../kindsys

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
 	github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890 // @grafana/alerting-squad-backend
-	github.com/grafana/cuetsy v0.1.10 // @grafana/grafana-as-code
+	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.16.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.7.0 // @grafana/backend-platform
 	github.com/grafana/grafana-plugin-sdk-go v0.171.0 // @grafana/plugins-platform-backend
@@ -266,7 +266,7 @@ require (
 	github.com/grafana/go-mssqldb v0.9.1 // @grafana/grafana-bi-squad
 	github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 //  @grafana/grafana-as-code
 	github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b // @grafana/observability-traces-and-profiling
-	github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed // @grafana/grafana-as-code
+	github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f // @grafana/grafana-as-code
 	github.com/ory/fosite v0.44.1-0.20230317114349-45a6785cc54f // @grafana/grafana-authnz-team
 	github.com/redis/go-redis/v9 v9.0.2 // @grafana/alerting-squad-backend
 	github.com/weaveworks/common v0.0.0-20230511094633-334485600903 // @grafana/alerting-squad-backend

--- a/go.sum
+++ b/go.sum
@@ -1342,8 +1342,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW3
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/grafana-plugin-sdk-go v0.171.0 h1:f4W4sTgm3zJzh5EewTORMoKax4PorCmNeqINzIZ0mJw=
 github.com/grafana/grafana-plugin-sdk-go v0.171.0/go.mod h1:SvYXsAQWSuV9TtHqXZJdOFCaC8G0q02U+IHWMTKIGIQ=
-github.com/grafana/kindsys v0.0.0-20230710031138-57f73e1488a7 h1:UzmfEDqmHGeqiCxKnxr0aPsFoJjkLFlHtH0WtV1YbLg=
-github.com/grafana/kindsys v0.0.0-20230710031138-57f73e1488a7/go.mod h1:tReyLqR9xponnYrhIpA/eShnEkAixy6b2U/TSz5PZN0=
+github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 h1:jigcyvw77sbdURDAIRbBmSFq6KY/35huhkd8wSeWJ7I=
+github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34/go.mod h1:tReyLqR9xponnYrhIpA/eShnEkAixy6b2U/TSz5PZN0=
 github.com/grafana/phlare/api v0.1.4-0.20230426005640-f90edba05413 h1:bBzCezZNRyYlJpXTkyZdY4fpPxHZUdyeyRWzhtw/P6I=
 github.com/grafana/phlare/api v0.1.4-0.20230426005640-f90edba05413/go.mod h1:IvwuGG9xa/h96UH/exgvsfy3zE+ZpctkNT9o5aaGdrU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20230508090422-7d5630522a53 h1:X3Jl4PBIGCtlPSMa6Uiu2+3FDNWmddSjivp+1DDznQs=

--- a/go.sum
+++ b/go.sum
@@ -1320,6 +1320,8 @@ github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.10 h1:+W9/7roI8LorL+D1RJhKGdhsTZ81adrK9dHS0r7qsXs=
 github.com/grafana/cuetsy v0.1.10/go.mod h1:Ix97+CPD8ws9oSSxR3/Lf4ahU1I4Np83kjJmDVnLZvc=
+github.com/grafana/cuetsy v0.1.11 h1:I3IwBhF+UaQxRM79HnImtrAn8REGdb5M3+C4QrYHoWk=
+github.com/grafana/cuetsy v0.1.11/go.mod h1:Ix97+CPD8ws9oSSxR3/Lf4ahU1I4Np83kjJmDVnLZvc=
 github.com/grafana/dataplane/examples v0.0.1 h1:K9M5glueWyLoL4//H+EtTQq16lXuHLmOhb6DjSCahzA=
 github.com/grafana/dataplane/examples v0.0.1/go.mod h1:h5YwY8s407/17XF5/dS8XrUtsTVV2RnuW8+m1Mp46mg=
 github.com/grafana/dataplane/sdata v0.0.6 h1:Ejlj8d1Hvy/uDLeI4sOvL34Y8WLlVDd9iN270F+8aTw=
@@ -1359,6 +1361,8 @@ github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b h1:mDlkqgTEJuK7vjP
 github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b/go.mod h1:UK7kTP5llPeRcGBOe5mm4QTNTd0k/mAqTVSOFdDH6AU=
 github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed h1:TMtHc+B0SSNw2in6Ro1dAiBYSPRp4NzKgndFDfupt18=
 github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed/go.mod h1:3zLJnssFRPCnebCBRlq53t5LgYv9P1mbj0XMozZMTww=
+github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f h1:VzrhDNQHjuiKcTzwGBcsDTlqUpnwZiRsT2N1JQy+eyk=
+github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f/go.mod h1:ZXI/fRzEyG0SMdwjDCYf0L2URHzgdY6R2C5qaamRkHc=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6 h1:I9dh1MXGX0wGyxdV/Sl7+ugnki4Dfsy8lv2s5Yf887o=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6/go.mod h1:ZkJLEYLoVyg7amJK/5r779bHyzs2AU8f8VMiP6BM7uY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -132,16 +132,16 @@ lineage: schemas: [{
 		#AnnotationTarget: {
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			limit: int64
+			limit?: int64
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			matchAny: bool
+			matchAny: bool | *false
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			tags: [...string]
+			tags?: [...string]
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			type: string
+			type?: string
 			... // datasource will stick their raw DataQuery here
 		} @cuetsy(kind="interface") @grafanamaturity(NeedsExpertReview)
 
@@ -280,9 +280,9 @@ lineage: schemas: [{
 			// Icon name to be displayed with the link
 			icon: string
 			// Tooltip to display when the user hovers their mouse over it
-			tooltip: string
+			tooltip?: string
 			// Link URL. Only required/valid if the type is link
-			url: string
+			url?: string
 			// List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards
 			tags: [...string]
 			// If true, all dashboards links will be displayed in a dropdown. If false, all dashboards links will be displayed side by side. Only valid if the type is dashboards
@@ -361,7 +361,7 @@ lineage: schemas: [{
 		#Threshold: {
 			// Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.
 			// Nulls currently appear here when serializing -Infinity to JSON.
-			value: number | null @grafanamaturity(NeedsExpertReview)
+			value?: number | null @grafanamaturity(NeedsExpertReview)
 			// Color represents the color of the visual change that will occur in the dashboard when the threshold value is met or exceeded.
 			color: string @grafanamaturity(NeedsExpertReview)
 		} @cuetsy(kind="interface") @grafanamaturity(NeedsExpertReview)

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -8,6 +8,14 @@ import (
 name:        "Dashboard"
 maturity:    "experimental"
 description: "A Grafana dashboard."
+slots: {
+	panel: {
+		schemaInterface: "PanelCfg"
+	}
+	query: {
+		schemaInterface: "DataQuery"
+	}
+}
 
 crd: dummySchema: true
 

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -605,7 +605,7 @@ export interface VizLegendOptions {
   displayMode: LegendDisplayMode;
   isVisible?: boolean;
   placement: LegendPlacement;
-  showLegend: boolean;
+  showLegend: boolean; // TODO existing devenv dashboards seem to omit this field
   sortBy?: string;
   sortDesc?: boolean;
   width?: number;
@@ -695,7 +695,7 @@ export interface TableSortByFieldState {
 export interface TableFooterOptions {
   countRows?: boolean;
   enablePagination?: boolean;
-  fields?: Array<string>;
+  fields?: Array<string>; // TODO many devenv dashboards put an empty string here
   reducer: Array<string>; // actually 1 value
   show: boolean;
 }

--- a/packages/grafana-schema/src/common/geo.cue
+++ b/packages/grafana-schema/src/common/geo.cue
@@ -13,7 +13,7 @@ MapLayerOptions: {
 		// Common properties:
 		// https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html
 		// Layer opacity (0-1)
-		opacity?: int64
+		opacity?: float32 & >=0 & <=1
 		// Check tooltip (defaults to true)
 		tooltip?: bool
 } @cuetsy(kind="interface") @grafana(TSVeneer="type")

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -1,40 +1,40 @@
 package common
 
 // TODO docs
-AxisPlacement:      "auto" | "top" | "right" | "bottom" | "left" | "hidden" @cuetsy(kind="enum")
+AxisPlacement: "auto" | "top" | "right" | "bottom" | "left" | "hidden" @cuetsy(kind="enum")
 
 // TODO docs
-AxisColorMode:      "text" | "series"                                       @cuetsy(kind="enum")
+AxisColorMode: "text" | "series" @cuetsy(kind="enum")
 
 // TODO docs
-VisibilityMode:     "auto" | "never" | "always"                             @cuetsy(kind="enum")
+VisibilityMode: "auto" | "never" | "always" @cuetsy(kind="enum")
 
 // TODO docs
-GraphDrawStyle:     "line" | "bars" | "points"                              @cuetsy(kind="enum")
+GraphDrawStyle: "line" | "bars" | "points" @cuetsy(kind="enum")
 
 // TODO docs
-GraphTransform:     "constant" | "negative-Y"                               @cuetsy(kind="enum",memberNames="Constant|NegativeY")
+GraphTransform: "constant" | "negative-Y" @cuetsy(kind="enum",memberNames="Constant|NegativeY")
 
 // TODO docs
-LineInterpolation:  "linear" | "smooth" | "stepBefore" | "stepAfter"        @cuetsy(kind="enum")
+LineInterpolation: "linear" | "smooth" | "stepBefore" | "stepAfter" @cuetsy(kind="enum")
 
 // TODO docs
-ScaleDistribution:  "linear" | "log" | "ordinal" | "symlog"                 @cuetsy(kind="enum")
+ScaleDistribution: "linear" | "log" | "ordinal" | "symlog" @cuetsy(kind="enum")
 
 // TODO docs
-GraphGradientMode:  "none" | "opacity" | "hue" | "scheme"                   @cuetsy(kind="enum")
+GraphGradientMode: "none" | "opacity" | "hue" | "scheme" @cuetsy(kind="enum")
 
 // TODO docs
-StackingMode:       "none" | "normal" | "percent"                           @cuetsy(kind="enum")
+StackingMode: "none" | "normal" | "percent" @cuetsy(kind="enum")
 
 // TODO docs
-BarAlignment:       -1 | 0 | 1                                              @cuetsy(kind="enum",memberNames="Before|Center|After")
+BarAlignment: -1 | 0 | 1 @cuetsy(kind="enum",memberNames="Before|Center|After")
 
 // TODO docs
-ScaleOrientation:   0 | 1                                                   @cuetsy(kind="enum",memberNames="Horizontal|Vertical")
+ScaleOrientation: 0 | 1 @cuetsy(kind="enum",memberNames="Horizontal|Vertical")
 
 // TODO docs
-ScaleDirection:     1 | 1 | -1 | -1                                         @cuetsy(kind="enum",memberNames="Up|Right|Down|Left")
+ScaleDirection: 1 | 1 | -1 | -1 @cuetsy(kind="enum",memberNames="Up|Right|Down|Left")
 
 // TODO docs
 LineStyle: {
@@ -227,15 +227,15 @@ GraphFieldConfig: {
 
 // TODO docs
 VizLegendOptions: {
-	displayMode:  LegendDisplayMode
-	placement:    LegendPlacement
-	showLegend: 	bool
-	asTable?:     bool
-	isVisible?:   bool
-	sortBy?:      string
-	sortDesc?:    bool
-	width?:       number
-	calcs:        [...string]
+	displayMode: LegendDisplayMode
+	placement:   LegendPlacement
+	showLegend:  bool // TODO existing devenv dashboards seem to omit this field
+	asTable?:    bool
+	isVisible?:  bool
+	sortBy?:     string
+	sortDesc?:   bool
+	width?:      number
+	calcs: [...string]
 } @cuetsy(kind="interface")
 
 // Enum expressing the possible display modes

--- a/packages/grafana-schema/src/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen.ts
@@ -54,7 +54,7 @@ export interface Options extends common.OptionsWithLegend, common.OptionsWithToo
   /**
    * Sets the max length that a label can have before it is truncated.
    */
-  xTickLabelMaxLength: number;
+  xTickLabelMaxLength: number; // TODO field is absent in some devenv dashboards
   /**
    * Controls the rotation of the x axis labels.
    */

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -17,7 +17,7 @@ export interface AnnotationTarget {
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  limit: number;
+  limit?: number;
   /**
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
@@ -27,15 +27,16 @@ export interface AnnotationTarget {
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  tags: Array<string>;
+  tags?: Array<string>;
   /**
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  type: string;
+  type?: string;
 }
 
 export const defaultAnnotationTarget: Partial<AnnotationTarget> = {
+  matchAny: false,
   tags: [],
 };
 
@@ -305,7 +306,7 @@ export interface DashboardLink {
   /**
    * Tooltip to display when the user hovers their mouse over it
    */
-  tooltip: string;
+  tooltip?: string;
   /**
    * Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
    */
@@ -313,7 +314,7 @@ export interface DashboardLink {
   /**
    * Link URL. Only required/valid if the type is link
    */
-  url: string;
+  url?: string;
 }
 
 export const defaultDashboardLink: Partial<DashboardLink> = {
@@ -449,7 +450,7 @@ export interface Threshold {
    * Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.
    * Nulls currently appear here when serializing -Infinity to JSON.
    */
-  value: (number | null);
+  value?: (number | null);
 }
 
 /**

--- a/pkg/codegen/tmpl/kind_core.tmpl
+++ b/pkg/codegen/tmpl/kind_core.tmpl
@@ -20,6 +20,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/accesspolicy/accesspolicy_kind_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/dashboard/compose.go
+++ b/pkg/kinds/dashboard/compose.go
@@ -1,0 +1,149 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"cuelang.org/go/cue"
+	cjson "cuelang.org/go/encoding/json"
+	"github.com/grafana/kindsys"
+)
+
+func (k *Kind) Compose(slot kindsys.Slot, kinds ...kindsys.Composable) (kindsys.Core, error) {
+	// TODO remove this whole method once we sufficiently describe slots declaratively, and all of this can be handled generically in kindsys
+	// first, check that this kind supports this slot
+	if k.Props().(kindsys.CoreProperties).Slots[slot.Name] != slot {
+		return nil, &kindsys.ErrNoSlotInKind{
+			Slot: slot,
+			Kind: k,
+		}
+	}
+
+	schif, err := kindsys.FindSchemaInterface(slot.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	}
+
+	// then check that all provided kinds are implementors of the slot
+	for _, kind := range kinds {
+		if kind.Implements().Name() != schif.Name() {
+			return nil, &kindsys.ErrKindDoesNotImplementInterface{
+				Kind:      kind,
+				Interface: schif,
+			}
+		}
+	}
+
+	// Inputs look good. Make a copy with our built-up compose map
+	com := make(map[string][]kindsys.Composable)
+	for k, v := range k.composed {
+		com[k] = v
+	}
+
+	var all []kindsys.Composable
+	copy(all, com[slot.Name])
+	all = append(all, kinds...)
+	// Sort to ensure deterministic output of validation error messages, etc.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name() < all[j].Name()
+	})
+	com[slot.Name] = all
+
+	return &Kind{
+		Core:   k.Core,
+		lin:    k.lin,
+		jcodec: k.jcodec,
+		valmux: k.valmux,
+	}, nil
+}
+
+func (k *Kind) Validate(b []byte, codec kindsys.Decoder) error {
+	// TODO remove this whole method once slots are described declaratively and this is all handled generically
+	if err := k.Core.Validate(b, codec); err != nil {
+		return err
+	}
+
+	type pseudoDash struct {
+		Panels []struct {
+			Type        string          `json:"type"`
+			Options     json.RawMessage `json:"options"`
+			FieldConfig struct {
+				Defaults struct {
+					Custom json.RawMessage `json:"custom"`
+				} `json:"defaults"`
+			} `json:"fieldConfig"`
+			Targets []json.RawMessage `json:"targets"`
+		} `json:"panels"`
+	}
+
+	type pcfg struct {
+		Options     json.RawMessage `json:"Options"`
+		FieldConfig json.RawMessage `json:"FieldConfig,omitempty"`
+	}
+
+	type dqt struct {
+		Datasource struct {
+			Type string `json:"type"`
+		}
+	}
+
+	// Base validation succeeded. Now, perform additional validation with composed kinds
+	pd := pseudoDash{}
+	err := json.Unmarshal(b, &pd)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling panel into intermediate struct: %w", err)
+	}
+	cctx := k.lin.Runtime().Context()
+
+	for _, panel := range pd.Panels {
+		for _, ckind := range k.composed["panel"] {
+			// Only attempt panel type validation if panel is of that kind. If none match,
+			// that's ok, we let it fall through
+			if ckind.Name() == panel.Type {
+				// TODO this is fine until we allow multi-schema
+				sch := ckind.Lineage().First()
+
+				pcfgbits := pcfg{
+					Options:     panel.Options,
+					FieldConfig: panel.FieldConfig.Defaults.Custom,
+				}
+				cv := cctx.Encode(pcfgbits, cue.NilIsAny(false))
+				_, err := sch.Validate(cv)
+				if err != nil {
+					// TODO check all and combine errs instead of terminating early with one
+					return err
+				}
+			}
+		}
+
+		for _, targbyt := range panel.Targets {
+			for _, ckind := range k.composed["query"] {
+				var targtyp dqt
+				err := json.Unmarshal(targbyt, &targtyp)
+				if err != nil {
+					return fmt.Errorf("err unmarshaling target into intermediate struct: %w", err)
+				}
+				// Only attempt dataquery validation if query is of that kind. Fall through if none match
+				if ckind.Name() == targtyp.Datasource.Type {
+					// TODO this is fine until we allow multi-schema
+					sch := ckind.Lineage().First()
+
+					ex, err := cjson.Extract(fmt.Sprintf("target-%s.json", ckind.Name()), targbyt)
+					cv := cctx.BuildExpr(ex)
+					if err != nil {
+						return fmt.Errorf("err extracting target into cue value: %w", err)
+					}
+					_, err = sch.Validate(cv)
+					if err != nil {
+						// TODO check all and combine errs instead of terminating early with one
+						return err
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/kinds/dashboard/dashboard_kind_gen.go
+++ b/pkg/kinds/dashboard/dashboard_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -212,7 +212,7 @@ type AnnotationQuery struct {
 type AnnotationTarget struct {
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Limit int64 `json:"limit"`
+	Limit *int64 `json:"limit,omitempty"`
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
@@ -220,11 +220,11 @@ type AnnotationTarget struct {
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Type string `json:"type"`
+	Type *string `json:"type,omitempty"`
 }
 
 // 0 for no shared crosshair or tooltip (default).
@@ -256,13 +256,13 @@ type Link struct {
 	Title string `json:"title"`
 
 	// Tooltip to display when the user hovers their mouse over it
-	Tooltip string `json:"tooltip"`
+	Tooltip *string `json:"tooltip,omitempty"`
 
 	// Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
 	Type LinkType `json:"type"`
 
 	// Link URL. Only required/valid if the type is link
-	Url string `json:"url"`
+	Url *string `json:"url,omitempty"`
 }
 
 // Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)

--- a/pkg/kinds/dashboard/devenv_test.go
+++ b/pkg/kinds/dashboard/devenv_test.go
@@ -1,0 +1,179 @@
+package dashboard_test
+
+import (
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"cuelang.org/go/cue/errors"
+	"github.com/grafana/kindsys/encoding"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/kinds"
+	"github.com/grafana/grafana/pkg/kinds/dashboard"
+	"github.com/grafana/grafana/pkg/registry/corekind"
+)
+
+// TODO these should all go away
+var skiplist = map[string]string{
+	"feature-templating/datadata-macros.json":            "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-common/shared_queries.json":                   "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/reuse.json":                              "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/filter.json":                             "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/extract-json-paths.json":                 "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/join-by-field.json":                      "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/join-by-labels.json":                     "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-timeseries/timeseries-formats.json":           "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-table/table_tests_new.json":                   "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-table/table_sparkline_cell.json":              "instance of common.TableFooterOptions.fields contains empty string",
+	"datasource-elasticsearch/elasticsearch_simple.json": "instance of common.TableFooterOptions.fields contains empty string",
+
+	"e2e-repeats/Repeating-a-row-with-a-non-repeating-panel-and-horizontal-repeating-panel.json": "instance of common.VizLegendOptions.showLegend is absent",
+	"e2e-repeats/Repeating-a-panel-horizontally.json":                                            "instance of common.VizLegendOptions.showLegend is absent",
+	"panel-barchart/barchart-autosizing.json":                                                    "instance of common.VizLegendOptions.showLegend is absent",
+	"panel-timeseries/timeseries-stacking2.json":                                                 "instance of common.VizLegendOptions.showLegend is absent",
+
+	"panel-barchart/barchart-label-rotation-skipping.json": "instance of barchart.Options.xTickLabelMaxLength is absent",
+	"panel-barchart/barchart-thresholds-mappings.json":     "instance of barchart.Options.xTickLabelMaxLength is absent",
+	"panel-barchart/barchart-tooltips.json":                "instance of barchart.Options.xTickLabelMaxLength is absent",
+
+	"panel-histogram/histogram_tests.json": "instance of common.OptionsWithTooltip.mode is absent, probably needs a default",
+
+	"panel-candlestick/candlestick.json": "many required fields are absent - seems like lots of defaults needed?",
+
+	"panel-heatmap/heatmap-legacy.json": "tons of missing fields in the data - is this a problem with how we're converting a legacy heatmap panel, perhaps?",
+
+	"panel-heatmap/heatmap-calculate-log.json":  "odd whole-panel errors",
+	"panel-heatmap/heatmap-x.json":              "odd whole-panel errors",
+	"panel-bargauge/panel_tests_bar_gauge.json": "for some reason only wanting the graph or heatmap branch path",
+
+	// In each of these cases, there's a real mismatch between the schema and the
+	// datasource in question. But the error massager in thema that makes CUE errors
+	// more readable by differentiating what the schema specifies from what the data contains
+	// has a bug that's causing an error without any string output to be emitted.
+	//
+	// Because the massager's behavior depends on the logical nature of the error,
+	// it's plausible that all of the following problems are have the same logical
+	// structure - for example, data contains some value that's not included on any
+	// branch of a union type specified in the schema.
+	"panel-canvas/canvas-examples.json":                       "thema error massager is swallowing the whole error message",
+	"panel-canvas/canvas-connection-examples.json":            "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-color-field.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-photo-layer.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-route-layer.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-spatial-operations-transformer.json": "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap_multi-layers.json":                   "thema error massager is swallowing the whole error message",
+	"panel-geomap/panel-geomap.json":                          "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-v91.json":                            "thema error massager is swallowing the whole error message",
+	"panel-timeseries/timeseries-nulls.json":                  "thema error massager is swallowing the whole error message",
+}
+
+func TestDevenvDashboardValidity(t *testing.T) {
+	dpath, err := filepath.Abs("../../../devenv/dev-dashboards")
+	require.NoError(t, err)
+
+	m, err := kindTestableDashboards(os.DirFS(dpath))
+	require.NoError(t, err)
+	dk := corekind.NewDist(nil).ByName("Dashboard")
+	require.NotNil(t, dk)
+	// dk, err := dashboard.NewKind(cuectx.GrafanaThemaRuntime())
+	// require.NoError(t, err)
+
+	type res struct {
+		Kind       string                        `json:"kind"`
+		APIVersion string                        `json:"apiVersion"`
+		Metadata   kinds.GrafanaResourceMetadata `json:"metadata"`
+		Spec       json.RawMessage               `json:"spec"`
+	}
+
+	for _, pb := range m {
+		path, b := pb.path, pb.b
+		t.Run(path, func(t *testing.T) {
+			// Unfortunately, assembling the translated resource this way means that we
+			// don't have real line numbers in errors emitted from CUE. We could if we
+			// dynamically pieced the parts together in CUE, but because the
+			// kindsys.Core.Validate() method doesn't take a cue.Value, we'd lose that
+			// context again.
+			k8sr := res{
+				Kind:       "Dashboard",
+				APIVersion: "core.kinds.grafana.com/v0-0-alpha",
+				Metadata: kinds.GrafanaResourceMetadata{
+					Name: path,
+				},
+				Spec: b,
+			}
+
+			b, err = json.Marshal(k8sr)
+			require.NoError(t, err)
+
+			err = dk.Validate(b, &encoding.KubernetesJSONDecoder{})
+			if err != nil {
+				// Testify trims errors to short length. We want the full text
+				t.Logf("%T, %s", err, err)
+				errstr := errors.Details(err, nil)
+				t.Log(errstr)
+				if reason, has := skiplist[path]; has {
+					t.Skip(reason)
+				}
+				t.FailNow()
+			}
+		})
+	}
+}
+
+type pathbyt struct {
+	path string
+	b    []byte
+}
+
+func kindTestableDashboards(in fs.FS) ([]pathbyt, error) {
+	var pb []pathbyt
+
+	err := fs.WalkDir(in, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(d.Name()) != ".json" {
+			return nil
+		}
+
+		// nolint:gosec
+		f, err := in.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close() //nolint:errcheck
+
+		b, err := io.ReadAll(f)
+		if err != nil {
+			return err
+		}
+
+		jtree := make(map[string]interface{})
+		err = json.Unmarshal(b, &jtree)
+		if err != nil {
+			return err
+		}
+		if oldschemav, has := jtree["schemaVersion"]; !has || !(oldschemav.(float64) > dashboard.HandoffSchemaVersion-1) {
+			return nil
+		}
+
+		pb = append(pb, pathbyt{path, b})
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(pb, func(i, j int) bool {
+		return pb[i].path < pb[j].path
+	})
+
+	return pb, nil
+}

--- a/pkg/kinds/folder/folder_kind_gen.go
+++ b/pkg/kinds/folder/folder_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/librarypanel/librarypanel_kind_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/playlist/playlist_kind_gen.go
+++ b/pkg/kinds/playlist/playlist_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/preferences/preferences_kind_gen.go
+++ b/pkg/kinds/preferences/preferences_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/publicdashboard/publicdashboard_kind_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/role/role_kind_gen.go
+++ b/pkg/kinds/role/role_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/rolebinding/rolebinding_kind_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/team/team_kind_gen.go
+++ b/pkg/kinds/team/team_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kindsysreport/codegen/report.json
+++ b/pkg/kindsysreport/codegen/report.json
@@ -386,7 +386,17 @@
       "maturity": "experimental",
       "name": "Dashboard",
       "pluralMachineName": "dashboards",
-      "pluralName": "Dashboards"
+      "pluralName": "Dashboards",
+      "slots": {
+        "panel": {
+          "name": "panel",
+          "schemaInterface": "PanelCfg"
+        },
+        "query": {
+          "name": "query",
+          "schemaInterface": "DataQuery"
+        }
+      }
     },
     "dashboarddataquery": {
       "category": "composable",

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -125,7 +125,7 @@ schemas: [{
 
 			// Required Grafana version for this plugin. Validated using
 			// https://github.com/npm/node-semver.
-			grafanaDependency: =~"^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)(\\.[0-9x\\*]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x]+)(\\.[0-9x]+))?$"
+			grafanaDependency?: =~"^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)(\\.[0-9x\\*]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x]+)(\\.[0-9x]+))?$"
 
 			// An array of required plugins on which this plugin depends
 			plugins?: [...#Dependency]

--- a/pkg/plugins/plugindef/plugindef_bindings_gen.go
+++ b/pkg/plugins/plugindef/plugindef_bindings_gen.go
@@ -10,6 +10,7 @@
 package plugindef
 
 import (
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
 	"github.com/grafana/thema"
 )
@@ -67,6 +68,7 @@ func baseLineage(rt *thema.Runtime, opts ...thema.BindOption) (thema.Lineage, er
 	}
 
 	raw := rt.Context().BuildInstance(inst)
+	raw = raw.LookupPath(cue.ParsePath(""))
 
 	// An error returned from thema.BindLineage indicates one of the following:
 	//   - The parsed path does not exist in the loaded CUE file (["github.com/grafana/thema/errors".ErrValueNotExist])

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -98,7 +98,7 @@ type BuildInfo struct {
 type Dependencies struct {
 	// Required Grafana version for this plugin. Validated using
 	// https://github.com/npm/node-semver.
-	GrafanaDependency string `json:"grafanaDependency"`
+	GrafanaDependency *string `json:"grafanaDependency,omitempty"`
 
 	// (Deprecated) Required Grafana version for this plugin, e.g.
 	// `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or

--- a/pkg/registry/corekind/base.go
+++ b/pkg/registry/corekind/base.go
@@ -21,8 +21,8 @@ var (
 	defaultBase *Base
 )
 
-// NewBase provides a registry of all core raw and structured kinds, without any
-// composition of slot kinds.
+// NewBase provides a registry of all core kinds, without any composable kinds
+// injected.
 //
 // All calling code within grafana/grafana is expected to use Grafana's
 // singleton [thema.Runtime], returned from [cuectx.GrafanaThemaRuntime]. If nil
@@ -55,7 +55,7 @@ func (b *Base) ByName(name string) kindsys.Core {
 		return b.all[i].Name() >= name
 	})
 
-	if b.all[i].Name() == name {
+	if i < len(b.all) && b.all[i].Name() == name {
 		return b.all[i]
 	}
 	return nil

--- a/pkg/registry/corekind/dist.go
+++ b/pkg/registry/corekind/dist.go
@@ -1,0 +1,90 @@
+package corekind
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/grafana/kindsys"
+	"github.com/grafana/thema"
+
+	"github.com/grafana/grafana/pkg/cuectx"
+	"github.com/grafana/grafana/pkg/plugins/pfs/corelist"
+)
+
+var (
+	distOnce    sync.Once
+	defaultDist *Dist
+)
+
+// Dist contains all of the core kinds in the [Base] registry, composed with
+// all of the composable kinds defined by plugins within grafana/grafana.
+type Dist struct {
+	all []kindsys.Core
+}
+
+// NewDist provides a registry of all core kinds, with all composable kinds
+// provided by Grafana core injected.
+//
+// All calling code within grafana/grafana is expected to use Grafana's
+// singleton [thema.Runtime], returned from [cuectx.GrafanaThemaRuntime]. If nil
+// is passed, the singleton will be used.
+func NewDist(rt *thema.Runtime) *Dist {
+	allrt := cuectx.GrafanaThemaRuntime()
+	if rt == nil || rt == allrt {
+		distOnce.Do(func() {
+			defaultDist = buildDistRegistry(allrt, NewBase(allrt))
+		})
+		return defaultDist
+	}
+
+	return defaultDist
+}
+
+// All is the same as [Base.All], but with all composable kinds composed.
+func (b *Dist) All() []kindsys.Core {
+	ret := make([]kindsys.Core, len(b.all))
+	copy(ret, b.all)
+	return ret
+}
+
+// ByName looks up a kind in the registry by name. If no kind exists for the
+// given name, nil is returned.
+func (b *Dist) ByName(name string) kindsys.Core {
+	i := sort.Search(len(b.all), func(i int) bool {
+		return b.all[i].Name() >= name
+	})
+
+	if i < len(b.all) && b.all[i].Name() == name {
+		return b.all[i]
+	}
+	return nil
+}
+
+func buildDistRegistry(rt *thema.Runtime, reg *Base) *Dist {
+	dr := &Dist{
+		all: make([]kindsys.Core, 0, len(reg.All())),
+	}
+
+	coreplugins := corelist.New(rt)
+	for _, corek := range reg.All() {
+		for _, slot := range corek.Props().(kindsys.CoreProperties).Slots {
+			var toCompose []kindsys.Composable
+			for _, pp := range coreplugins {
+				for _, compok := range pp.ComposableKinds {
+					if compok.Implements().Name() == slot.SchemaInterface {
+						toCompose = append(toCompose, compok)
+					}
+				}
+			}
+			var err error
+			corek, err = corek.Compose(slot, toCompose...)
+			if err != nil {
+				// should be unreachable, panic for now, err once this is separated out
+				panic(err)
+			}
+		}
+		dr.all = append(dr.all, corek)
+	}
+
+	return dr
+}

--- a/pkg/services/k8s/apiserver/admission/schema_validate.go
+++ b/pkg/services/k8s/apiserver/admission/schema_validate.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
+	"github.com/grafana/kindsys"
 	"github.com/grafana/kindsys/encoding"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apiserver/pkg/admission"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/pfs/corelist"
 	"github.com/grafana/grafana/pkg/registry/corekind"
 )
 
@@ -25,7 +28,7 @@ func RegisterSchemaValidate(plugins *admission.Plugins, reg *corekind.Base) {
 
 type schemaValidate struct {
 	log log.Logger
-	reg *corekind.Base
+	reg *distreg
 }
 
 var _ admission.ValidationInterface = schemaValidate{}
@@ -47,6 +50,9 @@ func (sv schemaValidate) Validate(ctx context.Context, a admission.Attributes, o
 
 	switch a.GetOperation() { //nolint:exhaustive
 	case admission.Create, admission.Update:
+		// Add in all composable kinds
+		// FIXME re-composing on every admission control call is absurd. This is a plugin management responsibility. Fix after https://github.com/grafana/grafana/pull/71184 lands
+
 		// This logic will accept any known version of the kind, not just the
 		// current/latest one that is known to the server. Errors may occur when
 		// translating to the current/latest version, but that's not this admission
@@ -75,6 +81,61 @@ func (schemaValidate) Handles(operation admission.Operation) bool {
 func NewSchemaValidate(reg *corekind.Base) admission.Interface {
 	return schemaValidate{
 		log: log.New("admission.schema-validate"),
-		reg: reg,
+		reg: buildDistRegistry(reg),
 	}
+}
+
+type distreg struct {
+	all []kindsys.Core
+}
+
+// All returns a slice of [kindsys.Core] containing all core Grafana kinds.
+//
+// The returned slice is sorted lexicographically by kind machine name.
+func (b *distreg) All() []kindsys.Core {
+	ret := make([]kindsys.Core, len(b.all))
+	copy(ret, b.all)
+	return ret
+}
+
+// ByName looks up a kind in the registry by name. If no kind exists for the
+// given name, nil is returned.
+func (b *distreg) ByName(name string) kindsys.Core {
+	i := sort.Search(len(b.all), func(i int) bool {
+		return b.all[i].Name() >= name
+	})
+
+	if b.all[i].Name() == name {
+		return b.all[i]
+	}
+	return nil
+}
+
+func buildDistRegistry(reg *corekind.Base) *distreg {
+	dr := &distreg{
+		all: make([]kindsys.Core, 0, len(reg.All())),
+	}
+
+	coreplugins := corelist.New(nil)
+	for _, corek := range reg.All() {
+		for _, slot := range corek.Props().(kindsys.CoreProperties).Slots {
+			var toCompose []kindsys.Composable
+			for _, pp := range coreplugins {
+				for _, compok := range pp.ComposableKinds {
+					if compok.Implements().Name() == slot.SchemaInterface {
+						toCompose = append(toCompose, compok)
+					}
+				}
+			}
+			var err error
+			corek, err = corek.Compose(slot, toCompose...)
+			if err != nil {
+				// should be unreachable, panic for now, err once this is separated out
+				panic(err)
+			}
+		}
+		dr.all = append(dr.all, corek)
+	}
+
+	return dr
 }

--- a/public/app/plugins/gen.go
+++ b/public/app/plugins/gen.go
@@ -16,11 +16,12 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/kindsys"
 
+	"github.com/grafana/thema"
+
 	corecodegen "github.com/grafana/grafana/pkg/codegen"
 	"github.com/grafana/grafana/pkg/cuectx"
 	"github.com/grafana/grafana/pkg/plugins/codegen"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
-	"github.com/grafana/thema"
 )
 
 var skipPlugins = map[string]bool{

--- a/public/app/plugins/panel/barchart/panelcfg.cue
+++ b/public/app/plugins/panel/barchart/panelcfg.cue
@@ -42,7 +42,7 @@ composableKinds: PanelCfg: {
 					// Controls the rotation of the x axis labels.
 					xTickLabelRotation: int32 & >=-90 & <=90 | *0
 					// Sets the max length that a label can have before it is truncated.
-					xTickLabelMaxLength: int32 & >=0
+					xTickLabelMaxLength: int32 & >=0 // TODO field is absent in some devenv dashboards
 					// Controls the spacing between x axis labels.
 					// negative values indicate backwards skipping behavior
 					xTickLabelSpacing?: int32 | *0

--- a/public/app/plugins/panel/barchart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/barchart/panelcfg.gen.ts
@@ -51,7 +51,7 @@ export interface Options extends common.OptionsWithLegend, common.OptionsWithToo
   /**
    * Sets the max length that a label can have before it is truncated.
    */
-  xTickLabelMaxLength: number;
+  xTickLabelMaxLength: number; // TODO field is absent in some devenv dashboards
   /**
    * Controls the rotation of the x axis labels.
    */

--- a/public/app/plugins/panel/geomap/panelcfg.cue
+++ b/public/app/plugins/panel/geomap/panelcfg.cue
@@ -26,28 +26,28 @@ composableKinds: PanelCfg: {
 			version: [0, 0]
 			schema: {
 				Options: {
-					view:     MapViewConfig
-					controls: ControlsOptions
+					view:     #MapViewConfig
+					controls: #ControlsOptions
 					basemap:  ui.MapLayerOptions
 					layers: [...ui.MapLayerOptions]
-					tooltip: TooltipOptions
+					tooltip: #TooltipOptions
 				} @cuetsy(kind="interface")
 
-				MapViewConfig: {
+				#MapViewConfig: {
 					id:         string | *"zero"
-					lat?:       int64 | *0
-					lon?:       int64 | *0
-					zoom?:      int64 | *1
-					minZoom?:   int64
-					maxZoom?:   int64
-					padding?:   int64
+					lat?:       float64 | *0.0
+					lon?:       float64 | *0.0
+					zoom?:      float32 | *1.0
+					minZoom?:   float32
+					maxZoom?:   float32
+					padding?:   float32
 					allLayers?: bool | *true
 					lastOnly?:  bool
 					layer?:     string
 					shared?:    bool
 				} @cuetsy(kind="interface")
 
-				ControlsOptions: {
+				#ControlsOptions: {
 					// Zoom (upper left)
 					showZoom?: bool
 					// let the mouse wheel zoom
@@ -62,13 +62,13 @@ composableKinds: PanelCfg: {
 					showMeasure?: bool
 				} @cuetsy(kind="interface")
 
-				TooltipOptions: {
-					mode: TooltipMode
+				#TooltipOptions: {
+					mode: #TooltipMode
 				} @cuetsy(kind="interface")
 
-				TooltipMode: "none" | "details" @cuetsy(kind="enum",memberNames="None|Details")
+				#TooltipMode: "none" | "details" @cuetsy(kind="enum",memberNames="None|Details")
 
-				MapCenterID: "zero" | "coords" | "fit" @cuetsy(kind="enum",members="Zero|Coordinates|Fit")
+				#MapCenterID: "zero" | "coords" | "fit" @cuetsy(kind="enum",members="Zero|Coordinates|Fit")
 			}
 		}]
 		lenses: []

--- a/public/app/plugins/panel/text/panelcfg.cue
+++ b/public/app/plugins/panel/text/panelcfg.cue
@@ -21,20 +21,20 @@ composableKinds: PanelCfg: {
 		schemas: [{
 			version: [0, 0]
 			schema: {
-				TextMode: "html" | "markdown" | "code" @cuetsy(kind="enum",memberNames="HTML|Markdown|Code")
+				#TextMode: "html" | "markdown" | "code" @cuetsy(kind="enum",memberNames="HTML|Markdown|Code")
 
-				CodeLanguage: "json" | "yaml" | "xml" | "typescript" | "sql" | "go" | "markdown" | "html" | *"plaintext" @cuetsy(kind="enum")
+				#CodeLanguage: "json" | "yaml" | "xml" | "typescript" | "sql" | "go" | "markdown" | "html" | *"plaintext" @cuetsy(kind="enum")
 
-				CodeOptions: {
+				#CodeOptions: {
 					// The language passed to monaco code editor
-					language:        CodeLanguage
+					language:        #CodeLanguage
 					showLineNumbers: bool | *false
 					showMiniMap:     bool | *false
 				} @cuetsy(kind="interface")
 
 				Options: {
-					mode:    TextMode & (*"markdown" | _)
-					code?:   CodeOptions
+					mode:    #TextMode & (*"markdown" | _)
+					code?:   #CodeOptions
 					content: string | *"""
 						# Title
 


### PR DESCRIPTION
**What is this feature?**

This introduces compositional validation of dashboard schemas using all of the composable kinds in core plugins.

The primary test vector is through restoring a test we had for a long time that runs against sufficiently new (`schemaVersion > 35`) dashboards in `devenv`. That's 50 total dashboards. Of these, 16 pass, and 34 are skipped because they'd otherwise fail.

The purpose of this PR is not to decide how to fix all these issues, but rather to get a test in place that exercises compositional validation. That's why i opted for the skiplist, which the appropriate teams can easily iterate on in follow-ups. i did make a few tweaks to existing schemas in places where it seemed minimally invasive and i was reasonably confident of minimal impact.

The 34 skipped failures generally correspond to small issues in the schemas themselves. The skiplist gives a reason for each case being skipped, and if you run `go test ./pkg/kinds/dashboard -v` (or look at drone output), you can see the actual validation error. Breaking down the 34 further:

* 19 look like quite straightforward cases of schema fixes
* 10 are cases where thema is swallowing the error. See [this comment](https://github.com/grafana/grafana/pull/72844/files#diff-34a1b9971dce0731c3162f3acc518b927ea889e7d1eb8d37e233e641bc571110R54-R62) - we need a bugfix in thema's error massager before we can fix these
* 3 emit errors which are hard to debug b/c thema is spitting out an entire object in a less-than-helpful way. More cases for us to cover in the massager.
* 2 have an overwhelming number of fields absent, which smells fishy to me, especially [legacy heatmap](https://github.com/grafana/grafana/pull/72844/files#diff-34a1b9971dce0731c3162f3acc518b927ea889e7d1eb8d37e233e641bc571110R48), but maybe is the same as the straightforward cases just with more fields needing attention

Note that, when the failures are in the composable kinds (as almost all are), it's possible that fixing a failure in one panel of a dashboard will reveal a new validation error in another panel, because this first pass doesn't stack up validation errors into a set.

Depends on grafana/kindsys#31

**Why do we need this feature?**

It's the thing! Composed dashboard validation!
