### PR TITLE
Units: Fix display

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -346,9 +346,9 @@ export const getCategories = (): ValueFormatCategory[] => [
     formats: [
       { name: 'Revolutions per minute (rpm)', id: 'rotrpm', fn: toFixedUnit('rpm') },
       { name: 'Hertz (Hz)', id: 'rothz', fn: SIPrefix('Hz') },
-      { name: 'Kilohertz (kHz)', id: 'rotkhz', fn: SIPrefix('kHz', 1) },
-      { name: 'Megahertz (MHz)', id: 'rotmhz', fn: SIPrefix('MHz', 2) },
-      { name: 'Gigahertz (GHz)', id: 'rotghz', fn: SIPrefix('GHz', 3) },
+      { name: 'Kilohertz (kHz)', id: 'rotkhz', fn: SIPrefix('Hz', 1) },
+      { name: 'Megahertz (MHz)', id: 'rotmhz', fn: SIPrefix('Hz', 2) },
+      { name: 'Gigahertz (GHz)', id: 'rotghz', fn: SIPrefix('Hz', 3) },
       { name: 'Radians per second (rad/s)', id: 'rotrads', fn: toFixedUnit('rad/s') },
       { name: 'Degrees per second (°/s)', id: 'rotdegs', fn: toFixedUnit('°/s') },
     ],


### PR DESCRIPTION
This fixes the unit display for Kilohertz (kHz), Megahertz (MHz) & Gigahertz (GHz).


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
