### PR TITLE
Auth: Add documentation references to No Basic role

### DIFF
--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -85,21 +85,21 @@ The following table lists permissions for each role.
 
 | Permission                     | Organization administrator | Editor | Viewer | No Basic Role |
 | :----------------------------- | :------------------------: | :----: | :----: | :-----------: |
-| View dashboards                |                            |   x    |   x    |               |
-| Add, edit, delete dashboards   |             x              |   x    |        |               |
-| Add, edit, delete folders      |             x              |   x    |        |               |
-| View playlists                 |             x              |   x    |   x    |               |
-| Add, edit, delete playlists    |             x              |   x    |        |               |
-| Create library panels          |             x              |   x    |        |               |
-| View annotations               |             x              |   x    |   x    |               |
-| Add, edit, delete annotations  |             x              |   x    |        |               |
-| Access Explore                 |             x              |   x    |        |               |
-| Add, edit, delete data sources |             x              |        |        |               |
-| Add and edit users             |             x              |        |        |               |
-| Add and edit teams             |             x              |        |        |               |
-| Change organizations settings  |             x              |        |        |               |
-| Change team settings           |             x              |        |        |               |
-| Configure application plugins  |             x              |        |        |               |
+| View dashboards                |                            |  yes   |  yes   |               |
+| Add, edit, delete dashboards   |            yes             |  yes   |        |               |
+| Add, edit, delete folders      |            yes             |  yes   |        |               |
+| View playlists                 |            yes             |  yes   |  yes   |               |
+| Add, edit, delete playlists    |            yes             |  yes   |        |               |
+| Create library panels          |            yes             |  yes   |        |               |
+| View annotations               |            yes             |  yes   |  yes   |               |
+| Add, edit, delete annotations  |            yes             |  yes   |        |               |
+| Access Explore                 |            yes             |  yes   |        |               |
+| Add, edit, delete data sources |            yes             |        |        |               |
+| Add and edit users             |            yes             |        |        |               |
+| Add and edit teams             |            yes             |        |        |               |
+| Change organizations settings  |            yes             |        |        |               |
+| Change team settings           |            yes             |        |        |               |
+| Configure application plugins  |            yes             |        |        |               |
 
 ## Dashboard permissions
 

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -79,26 +79,27 @@ Grafana uses the following roles to control user access:
 - **Organization administrator**: Has access to all organization resources, including dashboards, users, and teams.
 - **Editor**: Can view and edit dashboards, folders, and playlists.
 - **Viewer**: Can view dashboards and playlists.
+- **No Basic Role**: Has no permissions. Permissions will be added with RBAC as needed.
 
 The following table lists permissions for each role.
 
-| Permission                     | Organization administrator | Editor | Viewer |
-| :----------------------------- | :------------------------: | :----: | :----: |
-| View dashboards                |             x              |   x    |   x    |
-| Add, edit, delete dashboards   |             x              |   x    |        |
-| Add, edit, delete folders      |             x              |   x    |        |
-| View playlists                 |             x              |   x    |   x    |
-| Add, edit, delete playlists    |             x              |   x    |        |
-| Create library panels          |             x              |   x    |        |
-| View annotations               |             x              |   x    |   x    |
-| Add, edit, delete annotations  |             x              |   x    |        |
-| Access Explore                 |             x              |   x    |        |
-| Add, edit, delete data sources |             x              |        |        |
-| Add and edit users             |             x              |        |        |
-| Add and edit teams             |             x              |        |        |
-| Change organizations settings  |             x              |        |        |
-| Change team settings           |             x              |        |        |
-| Configure application plugins  |             x              |        |        |
+| Permission                     | Organization administrator | Editor | Viewer | No Basic Role |
+| :----------------------------- | :------------------------: | :----: | :----: | :-----------: |
+| View dashboards                |                            |   x    |   x    |               |
+| Add, edit, delete dashboards   |             x              |   x    |        |               |
+| Add, edit, delete folders      |             x              |   x    |        |               |
+| View playlists                 |             x              |   x    |   x    |               |
+| Add, edit, delete playlists    |             x              |   x    |        |               |
+| Create library panels          |             x              |   x    |        |               |
+| View annotations               |             x              |   x    |   x    |               |
+| Add, edit, delete annotations  |             x              |   x    |        |               |
+| Access Explore                 |             x              |   x    |        |               |
+| Add, edit, delete data sources |             x              |        |        |               |
+| Add and edit users             |             x              |        |        |               |
+| Add and edit teams             |             x              |        |        |               |
+| Change organizations settings  |             x              |        |        |               |
+| Change team settings           |             x              |        |        |               |
+| Configure application plugins  |             x              |        |        |               |
 
 ## Dashboard permissions
 

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -85,7 +85,7 @@ The following table lists permissions for each role.
 
 | Permission                     | Organization administrator | Editor | Viewer | No Basic Role |
 | :----------------------------- | :------------------------: | :----: | :----: | :-----------: |
-| View dashboards                |                            |  yes   |  yes   |               |
+| View dashboards                |            yes             |  yes   |  yes   |               |
 | Add, edit, delete dashboards   |            yes             |  yes   |        |               |
 | Add, edit, delete folders      |            yes             |  yes   |        |               |
 | View playlists                 |            yes             |  yes   |  yes   |               |

--- a/docs/sources/administration/service-accounts/index.md
+++ b/docs/sources/administration/service-accounts/index.md
@@ -120,6 +120,10 @@ You can assign roles to a service account using the Grafana UI or via the API. F
 
 In [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}), you can also [assign RBAC roles]({{< relref "../roles-and-permissions/access-control/assign-rbac-roles" >}}) to grant very specific permissions to applications that interact with Grafana.
 
+{{% admonition type="note" %}}
+Since Grafana 10.2.0, the `No Basic Role` is available for organization users or service accounts. This role has no permissions. Permissions can be granted with RBAC.
+{{% /admonition %}}
+
 ### Before you begin
 
 - Ensure you have permission to update service accounts roles. By default, the organization administrator role is required to update service accounts permissions. For more information about user permissions, refer to [About users and permissions]({{< relref "../roles-and-permissions/#" >}}).

--- a/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
+++ b/public/app/core/components/RolePicker/BuiltinRoleSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Icon, RadioButtonList, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { Icon, RadioButtonList, Tooltip, useStyles2, useTheme2, PopoverContent } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { OrgRole } from 'app/types';
 
@@ -24,7 +24,7 @@ interface Props {
   onChange: (value: OrgRole) => void;
   disabled?: boolean;
   disabledMesssage?: string;
-  tooltipMessage?: string;
+  tooltipMessage?: PopoverContent;
 }
 
 export const BuiltinRoleSelector = ({ value, onChange, disabled, disabledMesssage, tooltipMessage }: Props) => {

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { config } from '@grafana/runtime';
-import { Button, CustomScrollbar, HorizontalGroup, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, CustomScrollbar, HorizontalGroup, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
 import { getSelectStyles } from '@grafana/ui/src/components/Select/getSelectStyles';
 import { contextSrv } from 'app/core/core';
 import { OrgRole, Role } from 'app/types';
@@ -37,9 +37,20 @@ const fixedRoleGroupNames: Record<string, string> = {
 };
 
 const noBasicRoleFlag = contextSrv.licensedAccessControlEnabled() && config.featureToggles.noBasicRole;
-const tooltipMessage = noBasicRoleFlag
-  ? 'You can now select the "No basic role" option and add permissions to your custom needs.'
-  : undefined;
+const tooltipMessage = noBasicRoleFlag ? (
+  <>
+    You can now select the &quot;No basic role&quot; option and add permissions to your custom needs. You can find more
+    information in&nbsp;
+    <TextLink
+      href="https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles"
+      variant="bodySmall"
+      external
+    >
+      our documentation
+    </TextLink>
+    .
+  </>
+) : undefined;
 
 interface RolePickerMenuProps {
   basicRole?: OrgRole;

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -50,7 +50,9 @@ const tooltipMessage = noBasicRoleFlag ? (
     </TextLink>
     .
   </>
-) : undefined;
+) : (
+  ''
+);
 
 interface RolePickerMenuProps {
   basicRole?: OrgRole;

--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -38,7 +38,9 @@ const tooltipMessage = noBasicRoleFlag ? (
     </TextLink>
     .
   </>
-) : undefined;
+) : (
+  ''
+);
 
 const roles: Array<SelectableValue<OrgRole>> = Object.values(OrgRole)
   .filter((r) => noBasicRoleFlag || r !== OrgRole.None)

--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -14,6 +14,7 @@ import {
   InputControl,
   FieldSet,
   Icon,
+  TextLink,
   Tooltip,
   Label,
 } from '@grafana/ui';
@@ -24,10 +25,20 @@ import { OrgRole, useDispatch } from 'app/types';
 import { addInvitee } from '../invites/state/actions';
 
 const noBasicRoleFlag = contextSrv.licensedAccessControlEnabled() && config.featureToggles.noBasicRole;
-
-const tooltipMessage = noBasicRoleFlag
-  ? 'You can now select the "No basic role" option and add permissions to your custom needs.'
-  : undefined;
+const tooltipMessage = noBasicRoleFlag ? (
+  <>
+    You can now select the &quot;No basic role&quot; option and add permissions to your custom needs. You can find more
+    information in&nbsp;
+    <TextLink
+      href="https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles"
+      variant="bodySmall"
+      external
+    >
+      our documentation
+    </TextLink>
+    .
+  </>
+) : undefined;
 
 const roles: Array<SelectableValue<OrgRole>> = Object.values(OrgRole)
   .filter((r) => noBasicRoleFlag || r !== OrgRole.None)
@@ -82,7 +93,7 @@ export const UserInviteForm = () => {
                     <Stack gap={0.5}>
                       <span>Role</span>
                       {tooltipMessage && (
-                        <Tooltip placement="right-end" interactive={true} content={<>{tooltipMessage}</>}>
+                        <Tooltip placement="right-end" interactive={true} content={tooltipMessage}>
                           <Icon name="info-circle" size="xs" />
                         </Tooltip>
                       )}


### PR DESCRIPTION
**What is this feature?**

This will update the documentation regarding the newly introduced role `None` aka `No Basic Role`. This PR adds documentation references from within the tooltip suggestions.

**Why do we need this feature?**

Part of the features needed for the [epic](https://github.com/grafana/grafana-authnz-team/issues/134)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-authnz-team/issues/263

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
