### PR TITLE
Plugins: Add remaining steps to inititialization stage

### DIFF
--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -71,11 +71,12 @@ func TestCallResource(t *testing.T) {
 	reg := registry.ProvideService()
 	angularInspector, err := angularinspector.NewStaticInspector()
 	require.NoError(t, err)
+	proc := process.NewManager(reg)
 
 	discovery := pipeline.ProvideDiscoveryStage(pCfg, finder.NewLocalFinder(pCfg.DevMode), reg)
 	bootstrap := pipeline.ProvideBootstrapStage(pCfg, signature.ProvideService(pCfg, statickey.New()), assetpath.ProvideService(pluginscdn.ProvideService(pCfg)))
-	initialize := pipeline.ProvideInitializationStage(pCfg, reg, fakes.NewFakeLicensingService(), provider.ProvideService(coreRegistry))
-	terminate, err := pipeline.ProvideTerminationStage(pCfg, reg, process.NewManager(reg))
+	initialize := pipeline.ProvideInitializationStage(pCfg, reg, fakes.NewFakeLicensingService(), provider.ProvideService(coreRegistry), proc, &fakes.FakeOauthService{}, fakes.NewFakeRoleRegistry())
+	terminate, err := pipeline.ProvideTerminationStage(pCfg, reg, proc)
 	require.NoError(t, err)
 
 	l := loader.ProvideService(pCfg, signature.NewUnsignedAuthorizer(pCfg),

--- a/pkg/plugins/manager/manager_integration_test.go
+++ b/pkg/plugins/manager/manager_integration_test.go
@@ -122,11 +122,12 @@ func TestIntegrationPluginManager(t *testing.T) {
 	lic := plicensing.ProvideLicensing(cfg, &licensing.OSSLicensingService{Cfg: cfg})
 	angularInspector, err := angularinspector.NewStaticInspector()
 	require.NoError(t, err)
+	proc := process.NewManager(reg)
 
 	discovery := pipeline.ProvideDiscoveryStage(pCfg, finder.NewLocalFinder(pCfg.DevMode), reg)
 	bootstrap := pipeline.ProvideBootstrapStage(pCfg, signature.ProvideService(pCfg, statickey.New()), assetpath.ProvideService(pluginscdn.ProvideService(pCfg)))
-	initialize := pipeline.ProvideInitializationStage(pCfg, reg, lic, provider.ProvideService(coreRegistry))
-	terminate, err := pipeline.ProvideTerminationStage(pCfg, reg, process.NewManager(reg))
+	initialize := pipeline.ProvideInitializationStage(pCfg, reg, lic, provider.ProvideService(coreRegistry), proc, &fakes.FakeOauthService{}, fakes.NewFakeRoleRegistry())
+	terminate, err := pipeline.ProvideTerminationStage(pCfg, reg, proc)
 	require.NoError(t, err)
 
 	l := loader.ProvideService(pCfg, signature.NewUnsignedAuthorizer(pCfg),

--- a/pkg/services/pluginsintegration/loader/loader_test.go
+++ b/pkg/services/pluginsintegration/loader/loader_test.go
@@ -1327,7 +1327,7 @@ func newLoader(t *testing.T, cfg *config.Cfg, reg registry.Service, proc process
 		angularInspector, &fakes.FakeOauthService{},
 		pipeline.ProvideDiscoveryStage(cfg, finder.NewLocalFinder(false), reg),
 		pipeline.ProvideBootstrapStage(cfg, signature.DefaultCalculator(cfg), assets),
-		pipeline.ProvideInitializationStage(cfg, reg, lic, backendFactory),
+		pipeline.ProvideInitializationStage(cfg, reg, lic, backendFactory, proc, &fakes.FakeOauthService{}, fakes.NewFakeRoleRegistry()),
 		terminate)
 }
 

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/plugins/log"
+	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/initialization"
+	"github.com/grafana/grafana/pkg/plugins/oauth"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// ExternalServiceRegistration implements an InitializeFunc for registering external services.
+type ExternalServiceRegistration struct {
+	cfg                     *config.Cfg
+	externalServiceRegistry oauth.ExternalServiceRegistry
+	log                     log.Logger
+}
+
+// ExternalServiceRegistrationStep returns an InitializeFunc for registering external services.
+func ExternalServiceRegistrationStep(cfg *config.Cfg, externalServiceRegistry oauth.ExternalServiceRegistry) initialization.InitializeFunc {
+	return newExternalServiceRegistration(cfg, externalServiceRegistry).Register
+}
+
+func newExternalServiceRegistration(cfg *config.Cfg, serviceRegistry oauth.ExternalServiceRegistry) *ExternalServiceRegistration {
+	return &ExternalServiceRegistration{
+		cfg:                     cfg,
+		externalServiceRegistry: serviceRegistry,
+		log:                     log.New("plugins.external.registration"),
+	}
+}
+
+// Register registers the external service with the external service registry, if the feature is enabled.
+func (r *ExternalServiceRegistration) Register(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	if p.ExternalServiceRegistration != nil && r.cfg.Features.IsEnabled(featuremgmt.FlagExternalServiceAuth) {
+		s, err := r.externalServiceRegistry.RegisterExternalService(ctx, p.ID, p.ExternalServiceRegistration)
+		if err != nil {
+			r.log.Error("Could not register an external service. Initialization skipped", "pluginID", p.ID, "err", err)
+			return nil, err
+		}
+		p.ExternalService = s
+	}
+	return p, nil
+}
+
+// RegisterPluginRoles implements an InitializeFunc for registering plugin roles.
+type RegisterPluginRoles struct {
+	log          log.Logger
+	roleRegistry plugins.RoleRegistry
+}
+
+// RegisterPluginRolesStep returns a new InitializeFunc for registering plugin roles.
+func RegisterPluginRolesStep(roleRegistry plugins.RoleRegistry) initialization.InitializeFunc {
+	return newRegisterPluginRoles(roleRegistry).Register
+}
+
+func newRegisterPluginRoles(registry plugins.RoleRegistry) *RegisterPluginRoles {
+	return &RegisterPluginRoles{
+		log:          log.New("plugins.roles.registration"),
+		roleRegistry: registry,
+	}
+}
+
+// Register registers the plugin roles with the role registry.
+func (r *RegisterPluginRoles) Register(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	if err := r.roleRegistry.DeclarePluginRoles(ctx, p.ID, p.Name, p.Roles); err != nil {
+		r.log.Warn("Declare plugin roles failed.", "pluginID", p.ID, "err", err)
+	}
+	return p, nil
+}
+
+// ReportBuildMetrics reports build information for all plugins, except core and bundled plugins.
+func ReportBuildMetrics(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	if !p.IsCorePlugin() && !p.IsBundledPlugin() {
+		metrics.SetPluginBuildInformation(p.ID, string(p.Type), p.Info.Version, string(p.Signature))
+	}
+	return p, nil
+}


### PR DESCRIPTION
**What is this feature?**

Continues the migration of the plugin loader to the pipeline pattern.

**Why do we need this feature?**

To continue the refactoring of the plugin loader to improve its API.

**Who is this feature for?**

Plugins Platform

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #

**Special notes for your reviewer:**
-->
Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
