### PR TITLE
Geomap: Fix crosshair glitch

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -317,14 +317,14 @@ function findNearestTimeIndex(timestamps: number[], time: number): number | null
   if (time < timestamps[probableIdx]) {
     for (let i = probableIdx; i > 0; i--) {
       if (time > timestamps[i]) {
-        return i;
+        return i < lastIdx ? i + 1 : lastIdx;
       }
     }
     return 0;
   } else {
     for (let i = probableIdx; i < lastIdx; i++) {
       if (time < timestamps[i]) {
-        return i;
+        return i > 0 ? i - 1 : 0;
       }
     }
     return lastIdx;


### PR DESCRIPTION
**What is this feature?**

This PR fixes a little issue with shared crosshair on Geomap panel.

**Why do we need this feature?**

The issue happens when you use crosshair on pretty small time range. When you hover mouse and move it between 2 data points on graph. When mouse closer to first point, the second one is selected on the geomap, and when you move it closer to the second point, opposite, the first one is highlighted. That caused by mistake in algorithm, it's unstable in this area.

[Screencast from 2023-08-04 13-16-36.webm](https://github.com/grafana/grafana/assets/4932851/b4471b31-57c2-4b5e-8dd7-6421e686bd07)


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
