### PR TITLE
Auth: Google OAuth set `skip_org_role_sync = true`

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/google/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/google/index.md
@@ -102,7 +102,7 @@ auto_login = true
 
 ## Skip organization role sync
 
-We do not currently sync roles from Google and instead set the AutoAssigned role to the user at first login. To manage your user's organization role from within Grafana, set `skip_org_role_sync` to `true`.
+We do not currently sync roles from Google and instead set the AutoAssigned role to the user at first login. The default setting for `skip_org_role_sync` is `true`, which means that role modifications can still be made through the user interface.
 
 ```ini
 [auth.google]

--- a/pkg/login/social/google_oauth.go
+++ b/pkg/login/social/google_oauth.go
@@ -20,8 +20,9 @@ const googleIAMScope = "https://www.googleapis.com/auth/cloud-identity.groups.re
 
 type SocialGoogle struct {
 	*SocialBase
-	hostedDomain string
-	apiUrl       string
+	hostedDomain    string
+	apiUrl          string
+	skipOrgRoleSync bool
 }
 
 type googleUserData struct {

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -189,9 +189,10 @@ func ProvideService(cfg *setting.Cfg,
 				ss.log.Warn("Using legacy Google API URL, please update your configuration")
 			}
 			ss.socialMap["google"] = &SocialGoogle{
-				SocialBase:   newSocialBase(name, &config, info, cfg.AutoAssignOrgRole, cfg.OAuthSkipOrgRoleUpdateSync, *features),
-				hostedDomain: info.HostedDomain,
-				apiUrl:       info.ApiUrl,
+				SocialBase:      newSocialBase(name, &config, info, cfg.AutoAssignOrgRole, cfg.OAuthSkipOrgRoleUpdateSync, *features),
+				hostedDomain:    info.HostedDomain,
+				apiUrl:          info.ApiUrl,
+				skipOrgRoleSync: cfg.GoogleSkipOrgRoleSync,
 			}
 		}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1482,7 +1482,9 @@ func readAuthGithubSettings(cfg *Cfg) {
 func readAuthGoogleSettings(cfg *Cfg) {
 	sec := cfg.SectionWithEnvOverrides("auth.google")
 	cfg.GoogleAuthEnabled = sec.Key("enabled").MustBool(false)
-	cfg.GoogleSkipOrgRoleSync = sec.Key("skip_org_role_sync").MustBool(false)
+	// FIXME: for now we skip org role sync for google auth
+	// as we do not sync organization roles from Google
+	cfg.GoogleSkipOrgRoleSync = true
 }
 
 func readAuthGitlabSettings(cfg *Cfg) {


### PR DESCRIPTION
### What is this feature?
We enable users to change org roles for different providers by setting skip_org_role_sync. This is not relevant for Google as we are not syncing their roles on login, hence we set this to true by default until we sync roles from the groups of Google provider.

### Why do we need this feature?
Currently the UI for updating org roles is locked for Google synced users, this feature enables the org roles changes in the UI for Google by default, as that is what we have currently. Until we make group sync possible for Google this will be the default.

Which issue(s) does this PR fix?:
https://github.com/grafana/grafana/issues/72816
