### PR TITLE
Hackathon: PromQAIL with AI/ML and Prometheus

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -29,6 +29,9 @@ export interface Props {
   showExplain: boolean;
 }
 
+// starting the branch for hackathon-2023-08-promqail
+// AI/ML + Prometheus
+
 export const PromQueryBuilder = React.memo<Props>((props) => {
   const { datasource, query, onChange, onRunQuery, data, showExplain } = props;
   const [highlightedOp, setHighlightedOp] = useState<QueryBuilderOperation | undefined>();


### PR DESCRIPTION
**What is this feature?**
This is PromQAIL, AI/ML + Prometheus

A user can select a metric and have queries suggested via AI/ML as well as have these queries explained.

**Why do we need this feature?**
PromQL is hard for new users. New users struggle to write useful queries. PromQAIL solves this problem by leveraging ML/AI to support these folk with query suggestions and explanations.

**Who is this feature for?**
Beginning and intermediate Prometheus users.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
