### PR TITLE
Implement schema composition and validation in dashboard kinds

### DIFF
--- a/docs/sources/developers/kinds/composable/geomap/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/geomap/panelcfg/schema-reference.md
@@ -18,14 +18,19 @@ title: GeomapPanelCfg kind
 
 
 
-| Property          | Type                       | Required | Default | Description                                   |
-|-------------------|----------------------------|----------|---------|-----------------------------------------------|
-| `ControlsOptions` | [object](#controlsoptions) | **Yes**  |         |                                               |
-| `MapCenterID`     | string                     | **Yes**  |         | Possible values are: `zero`, `coords`, `fit`. |
-| `MapViewConfig`   | [object](#mapviewconfig)   | **Yes**  |         |                                               |
-| `Options`         | [object](#options)         | **Yes**  |         |                                               |
-| `TooltipMode`     | string                     | **Yes**  |         | Possible values are: `none`, `details`.       |
-| `TooltipOptions`  | [object](#tooltipoptions)  | **Yes**  |         |                                               |
+| Property  | Type               | Required | Default | Description |
+|-----------|--------------------|----------|---------|-------------|
+| `Options` | [object](#options) | **Yes**  |         |             |
+
+### Options
+
+| Property   | Type                                  | Required | Default | Description |
+|------------|---------------------------------------|----------|---------|-------------|
+| `basemap`  | [MapLayerOptions](#maplayeroptions)   | **Yes**  |         |             |
+| `controls` | [ControlsOptions](#controlsoptions)   | **Yes**  |         |             |
+| `layers`   | [MapLayerOptions](#maplayeroptions)[] | **Yes**  |         |             |
+| `tooltip`  | [TooltipOptions](#tooltipoptions)     | **Yes**  |         |             |
+| `view`     | [MapViewConfig](#mapviewconfig)       | **Yes**  |         |             |
 
 ### ControlsOptions
 
@@ -38,43 +43,17 @@ title: GeomapPanelCfg kind
 | `showScale`       | boolean | No       |         | Scale options            |
 | `showZoom`        | boolean | No       |         | Zoom (upper left)        |
 
-### MapViewConfig
-
-| Property    | Type    | Required | Default | Description |
-|-------------|---------|----------|---------|-------------|
-| `id`        | string  | **Yes**  | `zero`  |             |
-| `allLayers` | boolean | No       | `true`  |             |
-| `lastOnly`  | boolean | No       |         |             |
-| `lat`       | int64   | No       | `0`     |             |
-| `layer`     | string  | No       |         |             |
-| `lon`       | int64   | No       | `0`     |             |
-| `maxZoom`   | integer | No       |         |             |
-| `minZoom`   | integer | No       |         |             |
-| `padding`   | integer | No       |         |             |
-| `shared`    | boolean | No       |         |             |
-| `zoom`      | int64   | No       | `1`     |             |
-
-### Options
-
-| Property   | Type                                  | Required | Default | Description |
-|------------|---------------------------------------|----------|---------|-------------|
-| `basemap`  | [MapLayerOptions](#maplayeroptions)   | **Yes**  |         |             |
-| `controls` | [ControlsOptions](#controlsoptions)   | **Yes**  |         |             |
-| `layers`   | [MapLayerOptions](#maplayeroptions)[] | **Yes**  |         |             |
-| `tooltip`  | [TooltipOptions](#tooltipoptions)     | **Yes**  |         |             |
-| `view`     | [MapViewConfig](#mapviewconfig)       | **Yes**  |         |             |
-
 ### MapLayerOptions
 
-| Property     | Type                                        | Required | Default | Description                                                                                                                |
-|--------------|---------------------------------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------|
-| `name`       | string                                      | **Yes**  |         | configured unique display name                                                                                             |
-| `type`       | string                                      | **Yes**  |         |                                                                                                                            |
-| `config`     |                                             | No       |         | Custom options depending on the type                                                                                       |
-| `filterData` |                                             | No       |         | Defines a frame MatcherConfig that may filter data for the given layer                                                     |
-| `location`   | [FrameGeometrySource](#framegeometrysource) | No       |         |                                                                                                                            |
-| `opacity`    | integer                                     | No       |         | Common properties:<br/>https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html<br/>Layer opacity (0-1) |
-| `tooltip`    | boolean                                     | No       |         | Check tooltip (defaults to true)                                                                                           |
+| Property     | Type                                        | Required | Default | Description                                                                                                                                             |
+|--------------|---------------------------------------------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`       | string                                      | **Yes**  |         | configured unique display name                                                                                                                          |
+| `type`       | string                                      | **Yes**  |         |                                                                                                                                                         |
+| `config`     |                                             | No       |         | Custom options depending on the type                                                                                                                    |
+| `filterData` |                                             | No       |         | Defines a frame MatcherConfig that may filter data for the given layer                                                                                  |
+| `location`   | [FrameGeometrySource](#framegeometrysource) | No       |         |                                                                                                                                                         |
+| `opacity`    | number                                      | No       |         | Common properties:<br/>https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html<br/>Layer opacity (0-1)<br/>Constraint: `>=0 & <=1`. |
+| `tooltip`    | boolean                                     | No       |         | Check tooltip (defaults to true)                                                                                                                        |
 
 ### FrameGeometrySource
 
@@ -87,6 +66,22 @@ title: GeomapPanelCfg kind
 | `longitude` | string | No       |         |                                                             |
 | `lookup`    | string | No       |         |                                                             |
 | `wkt`       | string | No       |         |                                                             |
+
+### MapViewConfig
+
+| Property    | Type    | Required | Default | Description                                                                                                         |
+|-------------|---------|----------|---------|---------------------------------------------------------------------------------------------------------------------|
+| `id`        | string  | **Yes**  | `zero`  |                                                                                                                     |
+| `allLayers` | boolean | No       | `true`  |                                                                                                                     |
+| `lastOnly`  | boolean | No       |         |                                                                                                                     |
+| `lat`       | number  | No       | `0`     | Constraint: `>=-1.797693134862315708145274237317043567981E+308 & <=1.797693134862315708145274237317043567981E+308`. |
+| `layer`     | string  | No       |         |                                                                                                                     |
+| `lon`       | number  | No       | `0`     | Constraint: `>=-1.797693134862315708145274237317043567981E+308 & <=1.797693134862315708145274237317043567981E+308`. |
+| `maxZoom`   | number  | No       |         |                                                                                                                     |
+| `minZoom`   | number  | No       |         |                                                                                                                     |
+| `padding`   | number  | No       |         |                                                                                                                     |
+| `shared`    | boolean | No       |         |                                                                                                                     |
+| `zoom`      | number  | No       | `1`     | Constraint: `>=-340282346638528859811704183484516925440 & <=340282346638528859811704183484516925440`.               |
 
 ### TooltipOptions
 

--- a/docs/sources/developers/kinds/composable/text/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/text/panelcfg/schema-reference.md
@@ -18,20 +18,9 @@ title: TextPanelCfg kind
 
 
 
-| Property       | Type                   | Required | Default     | Description                                                                                             |
-|----------------|------------------------|----------|-------------|---------------------------------------------------------------------------------------------------------|
-| `CodeLanguage` | string                 | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
-| `CodeOptions`  | [object](#codeoptions) | **Yes**  |             |                                                                                                         |
-| `Options`      | [object](#options)     | **Yes**  |             |                                                                                                         |
-| `TextMode`     | string                 | **Yes**  |             | Possible values are: `html`, `markdown`, `code`.                                                        |
-
-### CodeOptions
-
-| Property          | Type    | Required | Default     | Description                                                                                             |
-|-------------------|---------|----------|-------------|---------------------------------------------------------------------------------------------------------|
-| `language`        | string  | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
-| `showLineNumbers` | boolean | **Yes**  | `false`     |                                                                                                         |
-| `showMiniMap`     | boolean | **Yes**  | `false`     |                                                                                                         |
+| Property  | Type               | Required | Default | Description |
+|-----------|--------------------|----------|---------|-------------|
+| `Options` | [object](#options) | **Yes**  |         |             |
 
 ### Options
 
@@ -42,5 +31,13 @@ title: TextPanelCfg kind
 |           |                             |          | For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)` |                                                  |
 | `mode`    | string                      | **Yes**  |                                                                                | Possible values are: `html`, `markdown`, `code`. |
 | `code`    | [CodeOptions](#codeoptions) | No       |                                                                                |                                                  |
+
+### CodeOptions
+
+| Property          | Type    | Required | Default     | Description                                                                                             |
+|-------------------|---------|----------|-------------|---------------------------------------------------------------------------------------------------------|
+| `language`        | string  | **Yes**  | `plaintext` | Possible values are: `plaintext`, `yaml`, `xml`, `typescript`, `sql`, `go`, `markdown`, `html`, `json`. |
+| `showLineNumbers` | boolean | **Yes**  | `false`     |                                                                                                         |
+| `showMiniMap`     | boolean | **Yes**  | `false`     |                                                                                                         |
 
 

--- a/docs/sources/developers/kinds/core/dashboard/schema-reference.md
+++ b/docs/sources/developers/kinds/core/dashboard/schema-reference.md
@@ -137,10 +137,10 @@ these match the properties of the "grafana" datasouce that is default in most da
 
 | Property   | Type     | Required | Default | Description                                                                                                       |
 |------------|----------|----------|---------|-------------------------------------------------------------------------------------------------------------------|
-| `limit`    | integer  | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `matchAny` | boolean  | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `tags`     | string[] | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
-| `type`     | string   | **Yes**  |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `matchAny` | boolean  | **Yes**  | `false` | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `limit`    | integer  | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `tags`     | string[] | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
+| `type`     | string   | No       |         | Only required/valid for the grafana datasource...<br/>but code+tests is already depending on it so hard to change |
 
 ### DataSourceRef
 
@@ -164,9 +164,9 @@ Links with references to other dashboards or external resources
 | `tags`        | string[] | **Yes**  |         | List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards                                                  |
 | `targetBlank` | boolean  | **Yes**  | `false` | If true, the link will be opened in a new tab                                                                                                                                  |
 | `title`       | string   | **Yes**  |         | Title to display with the link                                                                                                                                                 |
-| `tooltip`     | string   | **Yes**  |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
 | `type`        | string   | **Yes**  |         | Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)<br/>Possible values are: `link`, `dashboards`. |
-| `url`         | string   | **Yes**  |         | Link URL. Only required/valid if the type is link                                                                                                                              |
+| `tooltip`     | string   | No       |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
+| `url`         | string   | No       |         | Link URL. Only required/valid if the type is link                                                                                                                              |
 
 ### Snapshot
 
@@ -282,7 +282,7 @@ They are used to conditionally style and color visualizations based on query res
 | Property | Type           | Required | Default | Description                                                                                                                                                                                                    |
 |----------|----------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `color`  | string         | **Yes**  |         | Color represents the color of the visual change that will occur in the dashboard when the threshold value is met or exceeded.                                                                                  |
-| `value`  | number or null | **Yes**  |         | Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.<br/>Nulls currently appear here when serializing -Infinity to JSON. |
+| `value`  | number or null | No       |         | Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.<br/>Nulls currently appear here when serializing -Infinity to JSON. |
 
 ### ValueMapping
 

--- a/docs/sources/developers/kinds/core/dashboard/schema-reference.md
+++ b/docs/sources/developers/kinds/core/dashboard/schema-reference.md
@@ -166,7 +166,7 @@ Links with references to other dashboards or external resources
 | `title`       | string   | **Yes**  |         | Title to display with the link                                                                                                                                                 |
 | `tooltip`     | string   | **Yes**  |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
 | `type`        | string   | **Yes**  |         | Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)<br/>Possible values are: `link`, `dashboards`. |
-| `url`         | string   | No       |         | Link URL. Only required/valid if the type is link                                                                                                                              |
+| `url`         | string   | **Yes**  |         | Link URL. Only required/valid if the type is link                                                                                                                              |
 
 ### Snapshot
 

--- a/docs/sources/developers/kinds/core/dashboard/schema-reference.md
+++ b/docs/sources/developers/kinds/core/dashboard/schema-reference.md
@@ -164,8 +164,8 @@ Links with references to other dashboards or external resources
 | `tags`        | string[] | **Yes**  |         | List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards                                                  |
 | `targetBlank` | boolean  | **Yes**  | `false` | If true, the link will be opened in a new tab                                                                                                                                  |
 | `title`       | string   | **Yes**  |         | Title to display with the link                                                                                                                                                 |
+| `tooltip`     | string   | **Yes**  |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
 | `type`        | string   | **Yes**  |         | Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)<br/>Possible values are: `link`, `dashboards`. |
-| `tooltip`     | string   | No       |         | Tooltip to display when the user hovers their mouse over it                                                                                                                    |
 | `url`         | string   | No       |         | Link URL. Only required/valid if the type is link                                                                                                                              |
 
 ### Snapshot

--- a/go.mod
+++ b/go.mod
@@ -300,9 +300,11 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
+	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/buildkite/yaml v2.1.0+incompatible // indirect
 	github.com/bwmarrin/snowflake v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1 // @grafana/backend-platform
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // @grafana/alerting-squad-backend
-	xorm.io/builder v0.3.6 // @grafana/backend-platform
+	xorm.io/builder v0.3.6 // indirect; @grafana/backend-platform
 	xorm.io/core v0.7.3 // @grafana/backend-platform
 	xorm.io/xorm v0.8.2 // @grafana/alerting-squad-backend
 )
@@ -177,7 +177,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // @grafana/grafana-as-code
+	github.com/hashicorp/go-multierror v1.1.1 // indirect; @grafana/grafana-as-code
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
@@ -264,7 +264,7 @@ require (
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics
 	github.com/grafana/dataplane/sdata v0.0.6 // @grafana/observability-metrics
 	github.com/grafana/go-mssqldb v0.9.1 // @grafana/grafana-bi-squad
-	github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482 //  @grafana/grafana-as-code
+	github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 //  @grafana/grafana-as-code
 	github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b // @grafana/observability-traces-and-profiling
 	github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed // @grafana/grafana-as-code
 	github.com/ory/fosite v0.44.1-0.20230317114349-45a6785cc54f // @grafana/grafana-authnz-team
@@ -287,6 +287,11 @@ require (
 )
 
 require (
+	github.com/apache/arrow/go/v12 v12.0.1
+	github.com/blang/semver/v4 v4.0.0
+)
+
+require (
 	cloud.google.com/go v0.110.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
@@ -294,13 +299,10 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
-	github.com/alvaroloes/enumer v1.1.2 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
-	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/buildkite/yaml v2.1.0+incompatible // indirect
 	github.com/bwmarrin/snowflake v0.3.0 // indirect
@@ -372,7 +374,6 @@ require (
 	github.com/ory/go-convenience v0.1.0 // indirect
 	github.com/ory/viper v1.7.5 // indirect
 	github.com/ory/x v0.0.214 // indirect
-	github.com/pascaldekloe/name v0.0.0-20180628100202-0fd16699aae1 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
@@ -513,3 +514,5 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.45.0
 replace github.com/lib/pq => github.com/lib/pq v1.10.6
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
+
+//replace github.com/grafana/kindsys => ../kindsys

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
 	github.com/grafana/alerting v0.0.0-20230606080147-55b8d71c7890 // @grafana/alerting-squad-backend
-	github.com/grafana/cuetsy v0.1.10 // @grafana/grafana-as-code
+	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.16.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.7.0 // @grafana/backend-platform
 	github.com/grafana/grafana-plugin-sdk-go v0.171.0 // @grafana/plugins-platform-backend
@@ -266,7 +266,7 @@ require (
 	github.com/grafana/go-mssqldb v0.9.1 // @grafana/grafana-bi-squad
 	github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 //  @grafana/grafana-as-code
 	github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b // @grafana/observability-traces-and-profiling
-	github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed // @grafana/grafana-as-code
+	github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f // @grafana/grafana-as-code
 	github.com/ory/fosite v0.44.1-0.20230317114349-45a6785cc54f // @grafana/grafana-authnz-team
 	github.com/redis/go-redis/v9 v9.0.2 // @grafana/alerting-squad-backend
 	github.com/weaveworks/common v0.0.0-20230511094633-334485600903 // @grafana/alerting-squad-backend

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,7 @@ cloud.google.com/go/logging v1.6.1/go.mod h1:5ZO0mHHbvm8gEmeEUHrmDlTDSu5imF6MUP9
 cloud.google.com/go/logging v1.7.0/go.mod h1:3xjP2CjkM3ZkO73aj4ASA5wRPGGCRrPIAeNqVNkzY8M=
 cloud.google.com/go/longrunning v0.1.1/go.mod h1:UUFxuDWkv22EuY93jjmDMFT5GPQKeFVJBIF6QlTqdsE=
 cloud.google.com/go/longrunning v0.3.0/go.mod h1:qth9Y41RRSUE69rDcOn6DdK3HfQfsUI0YSmW3iIlLJc=
+cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
 cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 cloud.google.com/go/managedidentities v1.3.0/go.mod h1:UzlW3cBOiPrzucO5qWkNkh0w33KFtBJU281hacNvsdE=
 cloud.google.com/go/managedidentities v1.4.0/go.mod h1:NWSBYbEMgqmbZsLIyKvxrYbtqOsxY1ZrGM+9RgDqInM=
@@ -622,6 +623,7 @@ github.com/GoogleCloudPlatform/cloudsql-proxy v1.29.0/go.mod h1:spvB9eLJH9dutlbP
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -685,8 +687,6 @@ github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZp
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.30.1 h1:HM1rlQjq1bm9yQcsawJqSZBJ9AYgxvjkMsNtddh90+g=
 github.com/alicebob/miniredis/v2 v2.30.1/go.mod h1:b25qWj4fCEsBeAAR2mlb0ufImGC6uH3VlUfb/HS5zKg=
-github.com/alvaroloes/enumer v1.1.2 h1:5khqHB33TZy1GWCO/lZwcroBFh7u+0j40T83VUbfAMY=
-github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT0m65DJ+Wo=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -1045,7 +1045,6 @@ github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac h1:XDAn206aIqKPdF5
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac h1:9yrT5tmn9Zc0ytWPASlaPwQfQMQYnRf0RSDe1XvHw0Q=
-github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
@@ -1712,7 +1711,6 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20230228050547-1710fef4ab10 h1:CqYfpuYIjnlNxM3msdyPRKabhXZWbKjf3Q8BWROFBso=
 github.com/google/pprof v0.0.0-20230228050547-1710fef4ab10/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1787,10 +1785,6 @@ github.com/grafana/go-mssqldb v0.9.2 h1:FkyRJR4ywsT07iMtpFMHStrl8uuNkGIwp253Fee0
 github.com/grafana/go-mssqldb v0.9.2/go.mod h1:HTCsUqZdb7oIO7jc37YauiSB5C3P/13AnpctVWBhlus=
 github.com/grafana/grafana-apiserver v0.0.0-20230713001719-88a9ed41992d h1:fjc6vlNnKCDewr/5GiObiiGLeqr6YnXUbZ44YZtlu5Q=
 github.com/grafana/grafana-apiserver v0.0.0-20230713001719-88a9ed41992d/go.mod h1:2g9qGdCeU6x/69QAs82WM52bwBUT5/CBaBD0I94+txU=
-github.com/grafana/grafana-aws-sdk v0.15.0 h1:ZOPHQcC5NUFi1bLTwnju91G0KmGh1z+qXOKj9nDfxNs=
-github.com/grafana/grafana-aws-sdk v0.15.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
-github.com/grafana/grafana-aws-sdk v0.16.0 h1:FFVab0jvhENce5cMEAodANCa5ARjyObN1dSOrvciW0c=
-github.com/grafana/grafana-aws-sdk v0.16.0/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-aws-sdk v0.16.1 h1:R/hMtQP7H0+8nWFoIOApaZj0qstmZM+5Pw0rRzk3A3Y=
 github.com/grafana/grafana-aws-sdk v0.16.1/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-azure-sdk-go v1.7.0 h1:2EAPwNl/qsDMHwKjlzaHif+H+bHcF1W7sM8/jAcxVcI=
@@ -1799,14 +1793,10 @@ github.com/grafana/grafana-google-sdk-go v0.1.0 h1:LKGY8z2DSxKjYfr2flZsWgTRTZ6HG
 github.com/grafana/grafana-google-sdk-go v0.1.0/go.mod h1:Vo2TKWfDVmNTELBUM+3lkrZvFtBws0qSZdXhQxRdJrE=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
-github.com/grafana/grafana-plugin-sdk-go v0.165.0 h1:PTCW1bSlqPr5/k/9oz4R8NLZIiQaOMP0xlSaRWwKUxg=
-github.com/grafana/grafana-plugin-sdk-go v0.165.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=
-github.com/grafana/grafana-plugin-sdk-go v0.170.0 h1:6vT+AcruJ7do4uISu+sXJCB8DSJh85SWNzClyM1caOU=
-github.com/grafana/grafana-plugin-sdk-go v0.170.0/go.mod h1:4jbsFzZvseLhsEmsPhI18fZG40mkJ2xIKPj9UopNz/8=
 github.com/grafana/grafana-plugin-sdk-go v0.171.0 h1:f4W4sTgm3zJzh5EewTORMoKax4PorCmNeqINzIZ0mJw=
 github.com/grafana/grafana-plugin-sdk-go v0.171.0/go.mod h1:SvYXsAQWSuV9TtHqXZJdOFCaC8G0q02U+IHWMTKIGIQ=
-github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482 h1:1YNoeIhii4UIIQpCPU+EXidnqf449d0C3ZntAEt4KSo=
-github.com/grafana/kindsys v0.0.0-20230508162304-452481b63482/go.mod h1:GNcfpy5+SY6RVbNGQW264gC0r336Dm+0zgQ5vt6+M8Y=
+github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34 h1:jigcyvw77sbdURDAIRbBmSFq6KY/35huhkd8wSeWJ7I=
+github.com/grafana/kindsys v0.0.0-20230803163628-16bde441fe34/go.mod h1:tReyLqR9xponnYrhIpA/eShnEkAixy6b2U/TSz5PZN0=
 github.com/grafana/phlare/api v0.1.4-0.20230426005640-f90edba05413 h1:bBzCezZNRyYlJpXTkyZdY4fpPxHZUdyeyRWzhtw/P6I=
 github.com/grafana/phlare/api v0.1.4-0.20230426005640-f90edba05413/go.mod h1:IvwuGG9xa/h96UH/exgvsfy3zE+ZpctkNT9o5aaGdrU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20230508090422-7d5630522a53 h1:X3Jl4PBIGCtlPSMa6Uiu2+3FDNWmddSjivp+1DDznQs=
@@ -2111,7 +2101,6 @@ github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
-github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
@@ -2323,7 +2312,6 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monoculum/formam v0.0.0-20180901015400-4e68be1d79ba/go.mod h1:RKgILGEJq24YyJ2ban8EO0RUVSJlF1pGsEvoLEACr/Q=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -2465,8 +2453,6 @@ github.com/parnurzeal/gorequest v0.2.15/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfD
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/pascaldekloe/name v0.0.0-20180628100202-0fd16699aae1 h1:/I3lTljEEDNYLho3/FUB7iD/oc2cEFgVmbHzV+O0PtU=
-github.com/pascaldekloe/name v0.0.0-20180628100202-0fd16699aae1/go.mod h1:eD5JxqMiuNYyFNmyY9rkJ/slN8y59oEu4Ei7F8OoKWQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
@@ -2694,8 +2680,6 @@ github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -2901,6 +2885,7 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=
 github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
@@ -3278,8 +3263,6 @@ golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
-golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
 golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -3312,7 +3295,6 @@ golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri
 golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
-golang.org/x/oauth2 v0.4.0/go.mod h1:RznEsdpjGAINPTOF0UH/t+xJ75L18YO3Ho6Pyn+uRec=
 golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
 golang.org/x/oauth2 v0.8.0 h1:6dkIjl3j3LtZ/O3sTgZTMsLKSftL/B8Zgq4huOIIUu8=
@@ -3592,7 +3574,6 @@ golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190425222832-ad9eeb80039a/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190524210228-3d17549cdc6b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
@@ -3875,7 +3856,6 @@ google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220413183235-5e96e2839df9/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
-google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3 h1:SeX3QUcBj3fciwnfPT9kt5gBhFy/FCZtYZ+I/RB8agc=
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
@@ -4077,7 +4057,6 @@ k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
-modernc.org/cc v1.0.0 h1:nPibNuDEx6tvYrUAtvDTTw98rx5juGsa5zuDnKwEEQQ=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/cc/v3 v3.36.0/go.mod h1:NFUHyPn4ekoC/JHeZFfZurN6ixxawE1BnVonP/oahEI=
 modernc.org/cc/v3 v3.36.2/go.mod h1:NFUHyPn4ekoC/JHeZFfZurN6ixxawE1BnVonP/oahEI=
@@ -4092,8 +4071,10 @@ modernc.org/ccgo/v3 v3.16.8/go.mod h1:zNjwkizS+fIFDrDjIAgBSCLkWbJuHF+ar3QRn+Z9aw
 modernc.org/ccgo/v3 v3.16.9/go.mod h1:zNMzC9A9xeNUepy6KuZBbugn3c0Mc9TeiJO4lgvkJDo=
 modernc.org/ccgo/v3 v3.16.13 h1:Mkgdzl46i5F/CNR/Kj80Ri59hC8TKAhZrYSaqvkwzUw=
 modernc.org/ccgo/v3 v3.16.13/go.mod h1:2Quk+5YgpImhPjv2Qsob1DnZ/4som1lJTodubIcoUkY=
+modernc.org/ccorpus v1.11.6 h1:J16RXiiqiCgua6+ZvQot4yUuUy8zxgqbqEEUuGPlISk=
 modernc.org/ccorpus v1.11.6/go.mod h1:2gEUTrWqdpH2pXsmTM1ZkjeSrUWDpjMu2T6m29L/ErQ=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
+modernc.org/httpfs v1.0.6 h1:AAgIpFZRXuYnkjftxTAZwMIiwEqAfk8aVB2/oA6nAeM=
 modernc.org/httpfs v1.0.6/go.mod h1:7dosgurJGp0sPaRanU53W4xZYKh14wfzX420oZADeHM=
 modernc.org/libc v0.0.0-20220428101251-2d5f3daf273b/go.mod h1:p7Mg4+koNjc8jkqwcoFBJx7tXkpj00G77X7A72jXPXA=
 modernc.org/libc v1.16.0/go.mod h1:N4LD6DBE9cf+Dzf9buBlzVJndKr/iJHG97vGLHYnb5A=
@@ -4125,10 +4106,12 @@ modernc.org/strutil v1.1.1/go.mod h1:DE+MQQ/hjKBZS2zNInV5hhcipt5rLPWkmpbGeW5mmdw
 modernc.org/strutil v1.1.3 h1:fNMm+oJklMGYfU9Ylcywl0CO5O6nTfaowNsh2wpPjzY=
 modernc.org/strutil v1.1.3/go.mod h1:MEHNA7PdEnEwLvspRMtWTNnp2nnyvMfkimT1NKNAGbw=
 modernc.org/tcl v1.13.1/go.mod h1:XOLfOwzhkljL4itZkK6T72ckMgvj0BDsnKNdZVUOecw=
+modernc.org/tcl v1.13.2 h1:5PQgL/29XkQ9wsEmmNPjzKs+7iPCaYqUJAhzPvQbjDA=
 modernc.org/token v1.0.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
+modernc.org/z v1.5.1 h1:RTNHdsrOpeoSeOF4FbzTo8gBYByaJ5xT7NgZ9ZqRiJM=
 modernc.org/z v1.5.1/go.mod h1:eWFB510QWW5Th9YGZT81s+LwvaAs3Q2yr4sP0rmLkv8=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -1773,6 +1773,8 @@ github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.10 h1:+W9/7roI8LorL+D1RJhKGdhsTZ81adrK9dHS0r7qsXs=
 github.com/grafana/cuetsy v0.1.10/go.mod h1:Ix97+CPD8ws9oSSxR3/Lf4ahU1I4Np83kjJmDVnLZvc=
+github.com/grafana/cuetsy v0.1.11 h1:I3IwBhF+UaQxRM79HnImtrAn8REGdb5M3+C4QrYHoWk=
+github.com/grafana/cuetsy v0.1.11/go.mod h1:Ix97+CPD8ws9oSSxR3/Lf4ahU1I4Np83kjJmDVnLZvc=
 github.com/grafana/dataplane/examples v0.0.1 h1:K9M5glueWyLoL4//H+EtTQq16lXuHLmOhb6DjSCahzA=
 github.com/grafana/dataplane/examples v0.0.1/go.mod h1:h5YwY8s407/17XF5/dS8XrUtsTVV2RnuW8+m1Mp46mg=
 github.com/grafana/dataplane/sdata v0.0.6 h1:Ejlj8d1Hvy/uDLeI4sOvL34Y8WLlVDd9iN270F+8aTw=
@@ -1812,6 +1814,8 @@ github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b h1:mDlkqgTEJuK7vjP
 github.com/grafana/tempo v1.5.1-0.20230524121406-1dc1bfe7085b/go.mod h1:UK7kTP5llPeRcGBOe5mm4QTNTd0k/mAqTVSOFdDH6AU=
 github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed h1:TMtHc+B0SSNw2in6Ro1dAiBYSPRp4NzKgndFDfupt18=
 github.com/grafana/thema v0.0.0-20230712153715-375c1b45f3ed/go.mod h1:3zLJnssFRPCnebCBRlq53t5LgYv9P1mbj0XMozZMTww=
+github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f h1:VzrhDNQHjuiKcTzwGBcsDTlqUpnwZiRsT2N1JQy+eyk=
+github.com/grafana/thema v0.0.0-20230801151112-711d7fd5162f/go.mod h1:ZXI/fRzEyG0SMdwjDCYf0L2URHzgdY6R2C5qaamRkHc=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6 h1:I9dh1MXGX0wGyxdV/Sl7+ugnki4Dfsy8lv2s5Yf887o=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6/go.mod h1:ZkJLEYLoVyg7amJK/5r779bHyzs2AU8f8VMiP6BM7uY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -282,7 +282,7 @@ lineage: schemas: [{
 			// Tooltip to display when the user hovers their mouse over it
 			tooltip: string
 			// Link URL. Only required/valid if the type is link
-			url?: string
+			url: string
 			// List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards
 			tags: [...string]
 			// If true, all dashboards links will be displayed in a dropdown. If false, all dashboards links will be displayed side by side. Only valid if the type is dashboards

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -132,16 +132,16 @@ lineage: schemas: [{
 		#AnnotationTarget: {
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			limit: int64
+			limit?: int64
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			matchAny: bool
+			matchAny: bool | *false
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			tags: [...string]
+			tags?: [...string]
 			// Only required/valid for the grafana datasource...
 			// but code+tests is already depending on it so hard to change
-			type: string
+			type?: string
 			... // datasource will stick their raw DataQuery here
 		} @cuetsy(kind="interface") @grafanamaturity(NeedsExpertReview)
 
@@ -280,9 +280,9 @@ lineage: schemas: [{
 			// Icon name to be displayed with the link
 			icon: string
 			// Tooltip to display when the user hovers their mouse over it
-			tooltip: string
+			tooltip?: string
 			// Link URL. Only required/valid if the type is link
-			url: string
+			url?: string
 			// List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards
 			tags: [...string]
 			// If true, all dashboards links will be displayed in a dropdown. If false, all dashboards links will be displayed side by side. Only valid if the type is dashboards
@@ -361,7 +361,7 @@ lineage: schemas: [{
 		#Threshold: {
 			// Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.
 			// Nulls currently appear here when serializing -Infinity to JSON.
-			value: number | null @grafanamaturity(NeedsExpertReview)
+			value?: number | null @grafanamaturity(NeedsExpertReview)
 			// Color represents the color of the visual change that will occur in the dashboard when the threshold value is met or exceeded.
 			color: string @grafanamaturity(NeedsExpertReview)
 		} @cuetsy(kind="interface") @grafanamaturity(NeedsExpertReview)

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -280,7 +280,7 @@ lineage: schemas: [{
 			// Icon name to be displayed with the link
 			icon: string
 			// Tooltip to display when the user hovers their mouse over it
-			tooltip?: string
+			tooltip: string
 			// Link URL. Only required/valid if the type is link
 			url?: string
 			// List of tags to limit the linked dashboards. If empty, all dashboards will be displayed. Only valid if the type is dashboards

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -8,6 +8,14 @@ import (
 name:        "Dashboard"
 maturity:    "experimental"
 description: "A Grafana dashboard."
+slots: {
+	panel: {
+		schemaInterface: "PanelCfg"
+	}
+	query: {
+		schemaInterface: "DataQuery"
+	}
+}
 
 crd: dummySchema: true
 

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -605,7 +605,7 @@ export interface VizLegendOptions {
   displayMode: LegendDisplayMode;
   isVisible?: boolean;
   placement: LegendPlacement;
-  showLegend: boolean;
+  showLegend: boolean; // TODO existing devenv dashboards seem to omit this field
   sortBy?: string;
   sortDesc?: boolean;
   width?: number;
@@ -695,7 +695,7 @@ export interface TableSortByFieldState {
 export interface TableFooterOptions {
   countRows?: boolean;
   enablePagination?: boolean;
-  fields?: Array<string>;
+  fields?: Array<string>; // TODO many devenv dashboards put an empty string here
   reducer: Array<string>; // actually 1 value
   show: boolean;
 }

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -695,7 +695,7 @@ export interface TableSortByFieldState {
 export interface TableFooterOptions {
   countRows?: boolean;
   enablePagination?: boolean;
-  fields?: Array<string>; // TODO many devenv dashboards put an empty string here
+  fields?: Array<string>;
   reducer: Array<string>; // actually 1 value
   show: boolean;
 }

--- a/packages/grafana-schema/src/common/geo.cue
+++ b/packages/grafana-schema/src/common/geo.cue
@@ -13,7 +13,7 @@ MapLayerOptions: {
 		// Common properties:
 		// https://openlayers.org/en/latest/apidoc/module-ol_layer_Base-BaseLayer.html
 		// Layer opacity (0-1)
-		opacity?: int64
+		opacity?: float32 & >=0 & <=1
 		// Check tooltip (defaults to true)
 		tooltip?: bool
 } @cuetsy(kind="interface") @grafana(TSVeneer="type")

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -1,40 +1,40 @@
 package common
 
 // TODO docs
-AxisPlacement:      "auto" | "top" | "right" | "bottom" | "left" | "hidden" @cuetsy(kind="enum")
+AxisPlacement: "auto" | "top" | "right" | "bottom" | "left" | "hidden" @cuetsy(kind="enum")
 
 // TODO docs
-AxisColorMode:      "text" | "series"                                       @cuetsy(kind="enum")
+AxisColorMode: "text" | "series" @cuetsy(kind="enum")
 
 // TODO docs
-VisibilityMode:     "auto" | "never" | "always"                             @cuetsy(kind="enum")
+VisibilityMode: "auto" | "never" | "always" @cuetsy(kind="enum")
 
 // TODO docs
-GraphDrawStyle:     "line" | "bars" | "points"                              @cuetsy(kind="enum")
+GraphDrawStyle: "line" | "bars" | "points" @cuetsy(kind="enum")
 
 // TODO docs
-GraphTransform:     "constant" | "negative-Y"                               @cuetsy(kind="enum",memberNames="Constant|NegativeY")
+GraphTransform: "constant" | "negative-Y" @cuetsy(kind="enum",memberNames="Constant|NegativeY")
 
 // TODO docs
-LineInterpolation:  "linear" | "smooth" | "stepBefore" | "stepAfter"        @cuetsy(kind="enum")
+LineInterpolation: "linear" | "smooth" | "stepBefore" | "stepAfter" @cuetsy(kind="enum")
 
 // TODO docs
-ScaleDistribution:  "linear" | "log" | "ordinal" | "symlog"                 @cuetsy(kind="enum")
+ScaleDistribution: "linear" | "log" | "ordinal" | "symlog" @cuetsy(kind="enum")
 
 // TODO docs
-GraphGradientMode:  "none" | "opacity" | "hue" | "scheme"                   @cuetsy(kind="enum")
+GraphGradientMode: "none" | "opacity" | "hue" | "scheme" @cuetsy(kind="enum")
 
 // TODO docs
-StackingMode:       "none" | "normal" | "percent"                           @cuetsy(kind="enum")
+StackingMode: "none" | "normal" | "percent" @cuetsy(kind="enum")
 
 // TODO docs
-BarAlignment:       -1 | 0 | 1                                              @cuetsy(kind="enum",memberNames="Before|Center|After")
+BarAlignment: -1 | 0 | 1 @cuetsy(kind="enum",memberNames="Before|Center|After")
 
 // TODO docs
-ScaleOrientation:   0 | 1                                                   @cuetsy(kind="enum",memberNames="Horizontal|Vertical")
+ScaleOrientation: 0 | 1 @cuetsy(kind="enum",memberNames="Horizontal|Vertical")
 
 // TODO docs
-ScaleDirection:     1 | 1 | -1 | -1                                         @cuetsy(kind="enum",memberNames="Up|Right|Down|Left")
+ScaleDirection: 1 | 1 | -1 | -1 @cuetsy(kind="enum",memberNames="Up|Right|Down|Left")
 
 // TODO docs
 LineStyle: {
@@ -227,15 +227,15 @@ GraphFieldConfig: {
 
 // TODO docs
 VizLegendOptions: {
-	displayMode:  LegendDisplayMode
-	placement:    LegendPlacement
-	showLegend: 	bool
-	asTable?:     bool
-	isVisible?:   bool
-	sortBy?:      string
-	sortDesc?:    bool
-	width?:       number
-	calcs:        [...string]
+	displayMode: LegendDisplayMode
+	placement:   LegendPlacement
+	showLegend:  bool // TODO existing devenv dashboards seem to omit this field
+	asTable?:    bool
+	isVisible?:  bool
+	sortBy?:     string
+	sortDesc?:   bool
+	width?:      number
+	calcs: [...string]
 } @cuetsy(kind="interface")
 
 // Enum expressing the possible display modes

--- a/packages/grafana-schema/src/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen.ts
@@ -54,7 +54,7 @@ export interface Options extends common.OptionsWithLegend, common.OptionsWithToo
   /**
    * Sets the max length that a label can have before it is truncated.
    */
-  xTickLabelMaxLength: number;
+  xTickLabelMaxLength: number; // TODO field is absent in some devenv dashboards
   /**
    * Controls the rotation of the x axis labels.
    */

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -314,7 +314,7 @@ export interface DashboardLink {
   /**
    * Link URL. Only required/valid if the type is link
    */
-  url?: string;
+  url: string;
 }
 
 export const defaultDashboardLink: Partial<DashboardLink> = {

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -306,7 +306,7 @@ export interface DashboardLink {
   /**
    * Tooltip to display when the user hovers their mouse over it
    */
-  tooltip?: string;
+  tooltip: string;
   /**
    * Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
    */

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -17,7 +17,7 @@ export interface AnnotationTarget {
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  limit: number;
+  limit?: number;
   /**
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
@@ -27,15 +27,16 @@ export interface AnnotationTarget {
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  tags: Array<string>;
+  tags?: Array<string>;
   /**
    * Only required/valid for the grafana datasource...
    * but code+tests is already depending on it so hard to change
    */
-  type: string;
+  type?: string;
 }
 
 export const defaultAnnotationTarget: Partial<AnnotationTarget> = {
+  matchAny: false,
   tags: [],
 };
 
@@ -305,7 +306,7 @@ export interface DashboardLink {
   /**
    * Tooltip to display when the user hovers their mouse over it
    */
-  tooltip: string;
+  tooltip?: string;
   /**
    * Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
    */
@@ -313,7 +314,7 @@ export interface DashboardLink {
   /**
    * Link URL. Only required/valid if the type is link
    */
-  url: string;
+  url?: string;
 }
 
 export const defaultDashboardLink: Partial<DashboardLink> = {
@@ -449,7 +450,7 @@ export interface Threshold {
    * Value represents a specified metric for the threshold, which triggers a visual change in the dashboard when this value is met or exceeded.
    * Nulls currently appear here when serializing -Infinity to JSON.
    */
-  value: (number | null);
+  value?: (number | null);
 }
 
 /**

--- a/pkg/codegen/tmpl/kind_core.tmpl
+++ b/pkg/codegen/tmpl/kind_core.tmpl
@@ -20,6 +20,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/accesspolicy/accesspolicy_kind_gen.go
+++ b/pkg/kinds/accesspolicy/accesspolicy_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/dashboard/compose.go
+++ b/pkg/kinds/dashboard/compose.go
@@ -1,0 +1,163 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"cuelang.org/go/cue"
+	cjson "cuelang.org/go/encoding/json"
+	"github.com/grafana/kindsys"
+)
+
+func (k *Kind) Compose(slot kindsys.Slot, kinds ...kindsys.Composable) (kindsys.Core, error) {
+	// TODO remove this whole method once we sufficiently describe slots declaratively, and all of this can be handled generically in kindsys
+	// first, check that this kind supports this slot
+	if k.Props().(kindsys.CoreProperties).Slots[slot.Name] != slot {
+		return nil, &kindsys.ErrNoSlotInKind{
+			Slot: slot,
+			Kind: k,
+		}
+	}
+
+	schif, err := kindsys.FindSchemaInterface(slot.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	}
+
+	// then check that all provided kinds are implementors of the slot
+	for _, kind := range kinds {
+		if kind.Implements().Name() != schif.Name() {
+			return nil, &kindsys.ErrKindDoesNotImplementInterface{
+				Kind:      kind,
+				Interface: schif,
+			}
+		}
+	}
+
+	// Inputs look good. Make a copy with our built-up compose map
+	com := make(map[string][]kindsys.Composable)
+	for k, v := range k.composed {
+		com[k] = v
+	}
+
+	var all []kindsys.Composable
+	copy(all, com[slot.Name])
+	all = append(all, kinds...)
+	// Sort to ensure deterministic output of validation error messages, etc.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name() < all[j].Name()
+	})
+	com[slot.Name] = all
+
+	return &Kind{
+		Core:     k.Core,
+		lin:      k.lin,
+		jcodec:   k.jcodec,
+		valmux:   k.valmux,
+		composed: com,
+	}, nil
+}
+
+func (k *Kind) Validate(b []byte, codec kindsys.Decoder) error {
+	dashv := struct {
+		SchemaVersion int `json:"schemaVersion,omitempty"`
+	}{}
+	// any error here will be caught later
+	_ = json.Unmarshal(b, &dashv)
+	// Only try to validate dashboards that are at least the HandoffSchemaVersion
+	if dashv.SchemaVersion != 0 && dashv.SchemaVersion < HandoffSchemaVersion {
+		return nil
+	}
+
+	// TODO remove this whole method once slots are described declaratively and this is all handled generically
+	if err := k.Core.Validate(b, codec); err != nil {
+		return err
+	}
+
+	// Base validation succeeded. Now, perform additional validation with composed kinds
+	type pdt struct {
+		Spec struct {
+			Panels []struct {
+				Type        string          `json:"type"`
+				Options     json.RawMessage `json:"options"`
+				FieldConfig struct {
+					Defaults struct {
+						Custom json.RawMessage `json:"custom"`
+					} `json:"defaults"`
+				} `json:"fieldConfig"`
+				Targets []json.RawMessage `json:"targets"`
+			} `json:"panels"`
+		} `json:"spec"`
+	}
+
+	pd := pdt{}
+	err := json.Unmarshal(b, &pd)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling panel into intermediate struct: %w", err)
+	}
+	cctx := k.lin.Runtime().Context()
+
+	type pcfg struct {
+		Options     json.RawMessage `json:"Options"`
+		FieldConfig json.RawMessage `json:"FieldConfig,omitempty"`
+	}
+
+	type dqt struct {
+		Datasource struct {
+			Type string `json:"type"`
+		}
+	}
+
+	for _, panel := range pd.Spec.Panels {
+		for _, ckind := range k.composed["panel"] {
+			// Only attempt panel type validation if panel is of that kind. If none match,
+			// that's ok, we let it fall through
+			if strings.TrimSuffix(ckind.MachineName(), "panelcfg") == panel.Type {
+				// TODO this is fine until we allow multi-schema
+				sch := ckind.Lineage().First()
+
+				pcfgbits := pcfg{
+					Options:     panel.Options,
+					FieldConfig: panel.FieldConfig.Defaults.Custom,
+				}
+				cv := cctx.Encode(pcfgbits, cue.NilIsAny(false))
+				_, err := sch.Validate(cv)
+				if err != nil {
+					// TODO check all and combine errs instead of terminating early with one
+					return err
+				}
+			}
+		}
+
+		for _, targbyt := range panel.Targets {
+			for _, ckind := range k.composed["query"] {
+				var targtyp dqt
+				err := json.Unmarshal(targbyt, &targtyp)
+				if err != nil {
+					return fmt.Errorf("err unmarshaling target into intermediate struct: %w", err)
+				}
+				// Only attempt dataquery validation if query is of that kind. Fall through if none match
+				if ckind.Name() == targtyp.Datasource.Type {
+					// TODO this is fine until we allow multi-schema
+					sch := ckind.Lineage().First()
+
+					ex, err := cjson.Extract(fmt.Sprintf("target-%s.json", ckind.Name()), targbyt)
+					cv := cctx.BuildExpr(ex)
+					if err != nil {
+						return fmt.Errorf("err extracting target into cue value: %w", err)
+					}
+					_, err = sch.Validate(cv)
+					if err != nil {
+						// TODO check all and combine errs instead of terminating early with one
+						return err
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/kinds/dashboard/dashboard_kind_gen.go
+++ b/pkg/kinds/dashboard/dashboard_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -256,7 +256,7 @@ type Link struct {
 	Title string `json:"title"`
 
 	// Tooltip to display when the user hovers their mouse over it
-	Tooltip *string `json:"tooltip,omitempty"`
+	Tooltip string `json:"tooltip"`
 
 	// Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
 	Type LinkType `json:"type"`

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -262,7 +262,7 @@ type Link struct {
 	Type LinkType `json:"type"`
 
 	// Link URL. Only required/valid if the type is link
-	Url *string `json:"url,omitempty"`
+	Url string `json:"url"`
 }
 
 // Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -212,7 +212,7 @@ type AnnotationQuery struct {
 type AnnotationTarget struct {
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Limit int64 `json:"limit"`
+	Limit *int64 `json:"limit,omitempty"`
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
@@ -220,11 +220,11 @@ type AnnotationTarget struct {
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// Only required/valid for the grafana datasource...
 	// but code+tests is already depending on it so hard to change
-	Type string `json:"type"`
+	Type *string `json:"type,omitempty"`
 }
 
 // 0 for no shared crosshair or tooltip (default).
@@ -256,13 +256,13 @@ type Link struct {
 	Title string `json:"title"`
 
 	// Tooltip to display when the user hovers their mouse over it
-	Tooltip string `json:"tooltip"`
+	Tooltip *string `json:"tooltip,omitempty"`
 
 	// Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)
 	Type LinkType `json:"type"`
 
 	// Link URL. Only required/valid if the type is link
-	Url string `json:"url"`
+	Url *string `json:"url,omitempty"`
 }
 
 // Dashboard Link type. Accepted values are dashboards (to refer to another dashboard) and link (to refer to an external resource)

--- a/pkg/kinds/dashboard/devenv_test.go
+++ b/pkg/kinds/dashboard/devenv_test.go
@@ -1,0 +1,179 @@
+package dashboard_test
+
+import (
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"cuelang.org/go/cue/errors"
+	"github.com/grafana/kindsys/encoding"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/kinds"
+	"github.com/grafana/grafana/pkg/kinds/dashboard"
+	"github.com/grafana/grafana/pkg/registry/corekind"
+)
+
+// TODO these should all go away
+var skiplist = map[string]string{
+	"feature-templating/datadata-macros.json":            "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-common/shared_queries.json":                   "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/reuse.json":                              "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/filter.json":                             "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/extract-json-paths.json":                 "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/join-by-field.json":                      "instance of common.TableFooterOptions.fields contains empty string",
+	"transforms/join-by-labels.json":                     "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-timeseries/timeseries-formats.json":           "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-table/table_tests_new.json":                   "instance of common.TableFooterOptions.fields contains empty string",
+	"panel-table/table_sparkline_cell.json":              "instance of common.TableFooterOptions.fields contains empty string",
+	"datasource-elasticsearch/elasticsearch_simple.json": "instance of common.TableFooterOptions.fields contains empty string",
+
+	"e2e-repeats/Repeating-a-row-with-a-non-repeating-panel-and-horizontal-repeating-panel.json": "instance of common.VizLegendOptions.showLegend is absent",
+	"e2e-repeats/Repeating-a-panel-horizontally.json":                                            "instance of common.VizLegendOptions.showLegend is absent",
+	"panel-barchart/barchart-autosizing.json":                                                    "instance of common.VizLegendOptions.showLegend is absent",
+	"panel-timeseries/timeseries-stacking2.json":                                                 "instance of common.VizLegendOptions.showLegend is absent",
+
+	"panel-barchart/barchart-label-rotation-skipping.json": "instance of barchart.Options.xTickLabelMaxLength is absent",
+	"panel-barchart/barchart-thresholds-mappings.json":     "instance of barchart.Options.xTickLabelMaxLength is absent",
+	"panel-barchart/barchart-tooltips.json":                "instance of barchart.Options.xTickLabelMaxLength is absent",
+
+	"panel-histogram/histogram_tests.json": "instance of common.OptionsWithTooltip.mode is absent, probably needs a default",
+
+	"panel-candlestick/candlestick.json": "many required fields are absent - seems like lots of defaults needed?",
+
+	"panel-heatmap/heatmap-legacy.json": "tons of missing fields in the data - is this a problem with how we're converting a legacy heatmap panel, perhaps?",
+
+	"panel-heatmap/heatmap-calculate-log.json":  "odd whole-panel errors",
+	"panel-heatmap/heatmap-x.json":              "odd whole-panel errors",
+	"panel-bargauge/panel_tests_bar_gauge.json": "for some reason only wanting the graph or heatmap branch path",
+
+	// In each of these cases, there's a real mismatch between the schema and the
+	// datasource in question. But the error massager in thema that makes CUE errors
+	// more readable by differentiating what the schema specifies from what the data contains
+	// has a bug that's causing an error without any string output to be emitted.
+	//
+	// Because the massager's behavior depends on the logical nature of the error,
+	// it's plausible that all of the following problems are have the same logical
+	// structure - for example, data contains some value that's not included on any
+	// branch of a union type specified in the schema.
+	"panel-canvas/canvas-examples.json":                       "thema error massager is swallowing the whole error message",
+	"panel-canvas/canvas-connection-examples.json":            "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-color-field.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-photo-layer.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-route-layer.json":                    "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-spatial-operations-transformer.json": "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap_multi-layers.json":                   "thema error massager is swallowing the whole error message",
+	"panel-geomap/panel-geomap.json":                          "thema error massager is swallowing the whole error message",
+	"panel-geomap/geomap-v91.json":                            "thema error massager is swallowing the whole error message",
+	"panel-timeseries/timeseries-nulls.json":                  "thema error massager is swallowing the whole error message",
+}
+
+func TestDevenvDashboardValidity(t *testing.T) {
+	dpath, err := filepath.Abs("../../../devenv/dev-dashboards")
+	require.NoError(t, err)
+
+	m, err := kindTestableDashboards(os.DirFS(dpath))
+	require.NoError(t, err)
+	dk := corekind.NewDist(nil).ByName("Dashboard")
+	require.NotNil(t, dk)
+	// dk, err := dashboard.NewKind(cuectx.GrafanaThemaRuntime())
+	// require.NoError(t, err)
+
+	type res struct {
+		Kind       string                        `json:"kind"`
+		APIVersion string                        `json:"apiVersion"`
+		Metadata   kinds.GrafanaResourceMetadata `json:"metadata"`
+		Spec       json.RawMessage               `json:"spec"`
+	}
+
+	for _, pb := range m {
+		path, b := pb.path, pb.b
+		t.Run(path, func(t *testing.T) {
+			// Unfortunately, assembling the translated resource this way means that we
+			// don't have real line numbers in errors emitted from CUE. We could if we
+			// dynamically pieced the parts together in CUE, but because the
+			// kindsys.Core.Validate() method doesn't take a cue.Value, we'd lose that
+			// context again.
+			k8sr := res{
+				Kind:       "Dashboard",
+				APIVersion: "core.kinds.grafana.com/v0-0-alpha",
+				Metadata: kinds.GrafanaResourceMetadata{
+					Name: path,
+				},
+				Spec: b,
+			}
+
+			b, err = json.Marshal(k8sr)
+			require.NoError(t, err)
+
+			err = dk.Validate(b, &encoding.KubernetesJSONDecoder{})
+			if err != nil {
+				// Testify trims errors to short length. We want the full text
+				t.Logf("%T, %s", err, err)
+				errstr := errors.Details(err, nil)
+				t.Log(errstr)
+				if reason, has := skiplist[path]; has {
+					t.Skip(reason)
+				}
+				t.FailNow()
+			}
+		})
+	}
+}
+
+type pathbyt struct {
+	path string
+	b    []byte
+}
+
+func kindTestableDashboards(in fs.FS) ([]pathbyt, error) {
+	var pb []pathbyt
+
+	err := fs.WalkDir(in, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(d.Name()) != ".json" {
+			return nil
+		}
+
+		// nolint:gosec
+		f, err := in.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close() //nolint:errcheck
+
+		b, err := io.ReadAll(f)
+		if err != nil {
+			return err
+		}
+
+		jtree := make(map[string]interface{})
+		err = json.Unmarshal(b, &jtree)
+		if err != nil {
+			return err
+		}
+		if oldschemav, has := jtree["schemaVersion"]; !has || !(oldschemav.(float64) > dashboard.HandoffSchemaVersion-1) {
+			return nil
+		}
+
+		pb = append(pb, pathbyt{path, b})
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(pb, func(i, j int) bool {
+		return pb[i].path < pb[j].path
+	})
+
+	return pb, nil
+}

--- a/pkg/kinds/dashboard/devenv_test.go
+++ b/pkg/kinds/dashboard/devenv_test.go
@@ -41,6 +41,8 @@ var skiplist = map[string]string{
 	"panel-barchart/barchart-thresholds-mappings.json":     "instance of barchart.Options.xTickLabelMaxLength is absent",
 	"panel-barchart/barchart-tooltips.json":                "instance of barchart.Options.xTickLabelMaxLength is absent",
 
+	"panel-timeseries/timeseries-yaxis-ticks.json": "instance of dashboard.#DashboardLinks.tooltip is absent - schema should probably change to let this field be optional",
+
 	"panel-histogram/histogram_tests.json": "instance of common.OptionsWithTooltip.mode is absent, probably needs a default",
 
 	"panel-candlestick/candlestick.json": "many required fields are absent - seems like lots of defaults needed?",

--- a/pkg/kinds/folder/folder_kind_gen.go
+++ b/pkg/kinds/folder/folder_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/librarypanel/librarypanel_kind_gen.go
+++ b/pkg/kinds/librarypanel/librarypanel_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/playlist/playlist_kind_gen.go
+++ b/pkg/kinds/playlist/playlist_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/preferences/preferences_kind_gen.go
+++ b/pkg/kinds/preferences/preferences_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/publicdashboard/publicdashboard_kind_gen.go
+++ b/pkg/kinds/publicdashboard/publicdashboard_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/role/role_kind_gen.go
+++ b/pkg/kinds/role/role_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/rolebinding/rolebinding_kind_gen.go
+++ b/pkg/kinds/rolebinding/rolebinding_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kinds/team/team_kind_gen.go
+++ b/pkg/kinds/team/team_kind_gen.go
@@ -29,6 +29,9 @@ type Kind struct {
 	lin    thema.ConvergentLineage[*Resource]
 	jcodec vmux.Codec
 	valmux vmux.ValueMux[*Resource]
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]kindsys.Composable
 }
 
 // type guard - ensure generated Kind type satisfies the kindsys.Core interface

--- a/pkg/kindsysreport/codegen/report.json
+++ b/pkg/kindsysreport/codegen/report.json
@@ -386,7 +386,17 @@
       "maturity": "experimental",
       "name": "Dashboard",
       "pluralMachineName": "dashboards",
-      "pluralName": "Dashboards"
+      "pluralName": "Dashboards",
+      "slots": {
+        "panel": {
+          "name": "panel",
+          "schemaInterface": "PanelCfg"
+        },
+        "query": {
+          "name": "query",
+          "schemaInterface": "DataQuery"
+        }
+      }
     },
     "dashboarddataquery": {
       "category": "composable",

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -125,7 +125,7 @@ schemas: [{
 
 			// Required Grafana version for this plugin. Validated using
 			// https://github.com/npm/node-semver.
-			grafanaDependency: =~"^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)(\\.[0-9x\\*]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x]+)(\\.[0-9x]+))?$"
+			grafanaDependency?: =~"^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)(\\.[0-9x\\*]+)?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x]+)(\\.[0-9x]+))?$"
 
 			// An array of required plugins on which this plugin depends
 			plugins?: [...#Dependency]

--- a/pkg/plugins/plugindef/plugindef_bindings_gen.go
+++ b/pkg/plugins/plugindef/plugindef_bindings_gen.go
@@ -10,6 +10,7 @@
 package plugindef
 
 import (
+	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
 	"github.com/grafana/thema"
 )
@@ -67,6 +68,7 @@ func baseLineage(rt *thema.Runtime, opts ...thema.BindOption) (thema.Lineage, er
 	}
 
 	raw := rt.Context().BuildInstance(inst)
+	raw = raw.LookupPath(cue.ParsePath(""))
 
 	// An error returned from thema.BindLineage indicates one of the following:
 	//   - The parsed path does not exist in the loaded CUE file (["github.com/grafana/thema/errors".ErrValueNotExist])

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -98,7 +98,7 @@ type BuildInfo struct {
 type Dependencies struct {
 	// Required Grafana version for this plugin. Validated using
 	// https://github.com/npm/node-semver.
-	GrafanaDependency string `json:"grafanaDependency"`
+	GrafanaDependency *string `json:"grafanaDependency,omitempty"`
 
 	// (Deprecated) Required Grafana version for this plugin, e.g.
 	// `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or

--- a/pkg/registry/corekind/base.go
+++ b/pkg/registry/corekind/base.go
@@ -1,6 +1,7 @@
 package corekind
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/google/wire"

--- a/pkg/registry/corekind/base.go
+++ b/pkg/registry/corekind/base.go
@@ -20,8 +20,8 @@ var (
 	defaultBase *Base
 )
 
-// NewBase provides a registry of all core raw and structured kinds, without any
-// composition of slot kinds.
+// NewBase provides a registry of all core kinds, without any composable kinds
+// injected.
 //
 // All calling code within grafana/grafana is expected to use Grafana's
 // singleton [thema.Runtime], returned from [cuectx.GrafanaThemaRuntime]. If nil
@@ -45,4 +45,17 @@ func (b *Base) All() []kindsys.Core {
 	ret := make([]kindsys.Core, len(b.all))
 	copy(ret, b.all)
 	return ret
+}
+
+// ByName looks up a kind in the registry by name. If no kind exists for the
+// given name, nil is returned.
+func (b *Base) ByName(name string) kindsys.Core {
+	i := sort.Search(len(b.all), func(i int) bool {
+		return b.all[i].Name() >= name
+	})
+
+	if i < len(b.all) && b.all[i].Name() == name {
+		return b.all[i]
+	}
+	return nil
 }

--- a/pkg/registry/corekind/dist.go
+++ b/pkg/registry/corekind/dist.go
@@ -1,0 +1,90 @@
+package corekind
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/grafana/kindsys"
+	"github.com/grafana/thema"
+
+	"github.com/grafana/grafana/pkg/cuectx"
+	"github.com/grafana/grafana/pkg/plugins/pfs/corelist"
+)
+
+var (
+	distOnce    sync.Once
+	defaultDist *Dist
+)
+
+// Dist contains all of the core kinds in the [Base] registry, composed with
+// all of the composable kinds defined by plugins within grafana/grafana.
+type Dist struct {
+	all []kindsys.Core
+}
+
+// NewDist provides a registry of all core kinds, with all composable kinds
+// provided by Grafana core injected.
+//
+// All calling code within grafana/grafana is expected to use Grafana's
+// singleton [thema.Runtime], returned from [cuectx.GrafanaThemaRuntime]. If nil
+// is passed, the singleton will be used.
+func NewDist(rt *thema.Runtime) *Dist {
+	allrt := cuectx.GrafanaThemaRuntime()
+	if rt == nil || rt == allrt {
+		distOnce.Do(func() {
+			defaultDist = buildDistRegistry(allrt, NewBase(allrt))
+		})
+		return defaultDist
+	}
+
+	return defaultDist
+}
+
+// All is the same as [Base.All], but with all composable kinds composed.
+func (b *Dist) All() []kindsys.Core {
+	ret := make([]kindsys.Core, len(b.all))
+	copy(ret, b.all)
+	return ret
+}
+
+// ByName looks up a kind in the registry by name. If no kind exists for the
+// given name, nil is returned.
+func (b *Dist) ByName(name string) kindsys.Core {
+	i := sort.Search(len(b.all), func(i int) bool {
+		return b.all[i].Name() >= name
+	})
+
+	if i < len(b.all) && b.all[i].Name() == name {
+		return b.all[i]
+	}
+	return nil
+}
+
+func buildDistRegistry(rt *thema.Runtime, reg *Base) *Dist {
+	dr := &Dist{
+		all: make([]kindsys.Core, 0, len(reg.All())),
+	}
+
+	coreplugins := corelist.New(rt)
+	for _, corek := range reg.All() {
+		for _, slot := range corek.Props().(kindsys.CoreProperties).Slots {
+			var toCompose []kindsys.Composable
+			for _, pp := range coreplugins {
+				for _, compok := range pp.ComposableKinds {
+					if compok.Implements().Name() == slot.SchemaInterface {
+						toCompose = append(toCompose, compok)
+					}
+				}
+			}
+			var err error
+			corek, err = corek.Compose(slot, toCompose...)
+			if err != nil {
+				// should be unreachable, panic for now, err once this is separated out
+				panic(err)
+			}
+		}
+		dr.all = append(dr.all, corek)
+	}
+
+	return dr
+}

--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -54,9 +54,13 @@ func (pd *PublicDashboardServiceImpl) FindAnnotations(ctx context.Context, reqDT
 		}
 
 		if anno.Target != nil {
-			annoQuery.Limit = anno.Target.Limit
+			if anno.Target.Limit != nil {
+				annoQuery.Limit = *anno.Target.Limit
+			} else {
+				annoQuery.Limit = 0
+			}
 			annoQuery.MatchAny = anno.Target.MatchAny
-			if anno.Target.Type == "tags" {
+			if anno.Target.Type != nil && *anno.Target.Type == "tags" {
 				annoQuery.DashboardID = 0
 				annoQuery.Tags = anno.Target.Tags
 			}
@@ -88,7 +92,7 @@ func (pd *PublicDashboardServiceImpl) FindAnnotations(ctx context.Context, reqDT
 
 			// We want events from tag queries to overwrite existing events
 			_, has := uniqueEvents[event.Id]
-			if !has || (has && anno.Target != nil && anno.Target.Type == "tags") {
+			if !has || (has && anno.Target != nil && anno.Target.Type != nil && *anno.Target.Type == "tags") {
 				uniqueEvents[event.Id] = event
 			}
 		}

--- a/public/app/plugins/gen.go
+++ b/public/app/plugins/gen.go
@@ -16,11 +16,12 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/kindsys"
 
+	"github.com/grafana/thema"
+
 	corecodegen "github.com/grafana/grafana/pkg/codegen"
 	"github.com/grafana/grafana/pkg/cuectx"
 	"github.com/grafana/grafana/pkg/plugins/codegen"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
-	"github.com/grafana/thema"
 )
 
 var skipPlugins = map[string]bool{

--- a/public/app/plugins/panel/barchart/panelcfg.cue
+++ b/public/app/plugins/panel/barchart/panelcfg.cue
@@ -42,7 +42,7 @@ composableKinds: PanelCfg: {
 					// Controls the rotation of the x axis labels.
 					xTickLabelRotation: int32 & >=-90 & <=90 | *0
 					// Sets the max length that a label can have before it is truncated.
-					xTickLabelMaxLength: int32 & >=0
+					xTickLabelMaxLength: int32 & >=0 // TODO field is absent in some devenv dashboards
 					// Controls the spacing between x axis labels.
 					// negative values indicate backwards skipping behavior
 					xTickLabelSpacing?: int32 | *0

--- a/public/app/plugins/panel/barchart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/barchart/panelcfg.gen.ts
@@ -51,7 +51,7 @@ export interface Options extends common.OptionsWithLegend, common.OptionsWithToo
   /**
    * Sets the max length that a label can have before it is truncated.
    */
-  xTickLabelMaxLength: number;
+  xTickLabelMaxLength: number; // TODO field is absent in some devenv dashboards
   /**
    * Controls the rotation of the x axis labels.
    */

--- a/public/app/plugins/panel/geomap/panelcfg.cue
+++ b/public/app/plugins/panel/geomap/panelcfg.cue
@@ -26,28 +26,28 @@ composableKinds: PanelCfg: {
 			version: [0, 0]
 			schema: {
 				Options: {
-					view:     MapViewConfig
-					controls: ControlsOptions
+					view:     #MapViewConfig
+					controls: #ControlsOptions
 					basemap:  ui.MapLayerOptions
 					layers: [...ui.MapLayerOptions]
-					tooltip: TooltipOptions
+					tooltip: #TooltipOptions
 				} @cuetsy(kind="interface")
 
-				MapViewConfig: {
+				#MapViewConfig: {
 					id:         string | *"zero"
-					lat?:       int64 | *0
-					lon?:       int64 | *0
-					zoom?:      int64 | *1
-					minZoom?:   int64
-					maxZoom?:   int64
-					padding?:   int64
+					lat?:       float64 | *0.0
+					lon?:       float64 | *0.0
+					zoom?:      float32 | *1.0
+					minZoom?:   float32
+					maxZoom?:   float32
+					padding?:   float32
 					allLayers?: bool | *true
 					lastOnly?:  bool
 					layer?:     string
 					shared?:    bool
 				} @cuetsy(kind="interface")
 
-				ControlsOptions: {
+				#ControlsOptions: {
 					// Zoom (upper left)
 					showZoom?: bool
 					// let the mouse wheel zoom
@@ -62,13 +62,13 @@ composableKinds: PanelCfg: {
 					showMeasure?: bool
 				} @cuetsy(kind="interface")
 
-				TooltipOptions: {
-					mode: TooltipMode
+				#TooltipOptions: {
+					mode: #TooltipMode
 				} @cuetsy(kind="interface")
 
-				TooltipMode: "none" | "details" @cuetsy(kind="enum",memberNames="None|Details")
+				#TooltipMode: "none" | "details" @cuetsy(kind="enum",memberNames="None|Details")
 
-				MapCenterID: "zero" | "coords" | "fit" @cuetsy(kind="enum",members="Zero|Coordinates|Fit")
+				#MapCenterID: "zero" | "coords" | "fit" @cuetsy(kind="enum",members="Zero|Coordinates|Fit")
 			}
 		}]
 		lenses: []

--- a/public/app/plugins/panel/text/panelcfg.cue
+++ b/public/app/plugins/panel/text/panelcfg.cue
@@ -21,20 +21,20 @@ composableKinds: PanelCfg: {
 		schemas: [{
 			version: [0, 0]
 			schema: {
-				TextMode: "html" | "markdown" | "code" @cuetsy(kind="enum",memberNames="HTML|Markdown|Code")
+				#TextMode: "html" | "markdown" | "code" @cuetsy(kind="enum",memberNames="HTML|Markdown|Code")
 
-				CodeLanguage: "json" | "yaml" | "xml" | "typescript" | "sql" | "go" | "markdown" | "html" | *"plaintext" @cuetsy(kind="enum")
+				#CodeLanguage: "json" | "yaml" | "xml" | "typescript" | "sql" | "go" | "markdown" | "html" | *"plaintext" @cuetsy(kind="enum")
 
-				CodeOptions: {
+				#CodeOptions: {
 					// The language passed to monaco code editor
-					language:        CodeLanguage
+					language:        #CodeLanguage
 					showLineNumbers: bool | *false
 					showMiniMap:     bool | *false
 				} @cuetsy(kind="interface")
 
 				Options: {
-					mode:    TextMode & (*"markdown" | _)
-					code?:   CodeOptions
+					mode:    #TextMode & (*"markdown" | _)
+					code?:   #CodeOptions
 					content: string | *"""
 						# Title
 


### PR DESCRIPTION
(supersedes #72844)

**What is this feature?**

This introduces compositional validation of dashboard schemas using all of the composable kinds in core plugins.

The primary test vector is through restoring a test we had for a long time that runs against sufficiently new (`schemaVersion > 35`) dashboards in `devenv`. That's 50 total dashboards. Of these, 15 pass, and 35 are skipped because they'd otherwise fail.

The purpose of this PR is not to decide how to fix any issues in the way that our schemas are currently written, but to get a test in place that exercises compositional validation. So, instead of trying to fix all of these issues, i opted for a skiplist, which the appropriate teams can easily iterate on in follow-ups. That said, i did make a few tweaks to existing schemas in places where it seemed minimally invasive and i was reasonably confident of minimal impact.

The 35 skipped failures generally correspond to small issues in the schemas themselves. That's a benefit of us already using the generated TS types in the frontend - `tsc` already makes it hard for what's in schema to go out of sync with what's in JSON.

The skiplist gives a reason for each case being skipped, and if you run `go test ./pkg/kinds/dashboard -v` (or look at drone output), you can see the actual validation error. Breaking down the 35 further:

* 20 look like quite straightforward cases of schema fixes, like fields needing to be optional, or frontend logic needing to put a default value in place instead of omitting a field
* 10 are cases where thema is swallowing the error. See [this comment](https://github.com/grafana/grafana/pull/72844/files#diff-34a1b9971dce0731c3162f3acc518b927ea889e7d1eb8d37e233e641bc571110R54-R62) - we need a bugfix in thema's error massager before we can fix these
* 3 emit errors which are hard to debug b/c thema is spitting out an entire object in a less-than-helpful way. More cases for us to cover in the massager.
* 2 have an overwhelming number of fields absent, which smells fishy to me, especially [legacy heatmap](https://github.com/grafana/grafana/pull/72844/files#diff-34a1b9971dce0731c3162f3acc518b927ea889e7d1eb8d37e233e641bc571110R48), but maybe is the same as the straightforward cases just with more fields needing attention

Note that, when the failures are in the composable kinds (as almost all are), it's possible that fixing a failure in one panel of a dashboard will reveal a new validation error in another panel, because this first pass doesn't stack up validation errors into a set.

Depends on grafana/kindsys#31

**Why do we need this feature?**

It's the thing! Composed dashboard validation!
