### PR TITLE
Prometheus: Fix fetching label values when datasource has no labels match api support

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -274,6 +274,22 @@ describe('Language completion provider', () => {
         undefined
       );
     });
+
+    it('should call old series endpoint and should use match[] parameter and interpolate the template variables', () => {
+      const languageProvider = new LanguageProvider({
+        ...defaultDatasource,
+        interpolateString: (string: string) => string.replace(/\$/, 'interpolated-'),
+      } as PrometheusDatasource);
+      const getSeriesValues = languageProvider.getSeriesValues;
+      const requestSpy = jest.spyOn(languageProvider, 'request');
+      getSeriesValues('job', '{instance="$instance", job="grafana"}');
+      expect(requestSpy).toHaveBeenCalled();
+      expect(requestSpy).toHaveBeenCalledWith('/api/v1/series', [], {
+        end: toPrometheusTimeString,
+        'match[]': '{instance="interpolated-instance", job="grafana"}',
+        start: fromPrometheusTimeString,
+      });
+    });
   });
 
   describe('fetchSeries', () => {

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -284,11 +284,16 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(languageProvider, 'request');
       getSeriesValues('job', '{instance="$instance", job="grafana"}');
       expect(requestSpy).toHaveBeenCalled();
-      expect(requestSpy).toHaveBeenCalledWith('/api/v1/series', [], {
-        end: toPrometheusTimeString,
-        'match[]': '{instance="interpolated-instance", job="grafana"}',
-        start: fromPrometheusTimeString,
-      });
+      expect(requestSpy).toHaveBeenCalledWith(
+        '/api/v1/series',
+        [],
+        {
+          end: toPrometheusTimeString,
+          'match[]': '{instance="interpolated-instance", job="grafana"}',
+          start: fromPrometheusTimeString,
+        },
+        undefined
+      );
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -567,10 +567,11 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    */
   fetchSeriesValuesWithMatch = async (name: string, match?: string): Promise<string[]> => {
     const interpolatedName = name ? this.datasource.interpolateString(name) : null;
+    const interpolatedMatch = match ? this.datasource.interpolateString(match) : null;
     const range = this.datasource.getAdjustedInterval();
     const urlParams = {
       ...range,
-      ...(match && { 'match[]': match }),
+      ...(interpolatedMatch && { 'match[]': interpolatedMatch }),
     };
 
     // @todo clean up prometheusResourceBrowserCache feature flag


### PR DESCRIPTION
**What is this feature?**

When the Prometheus data source has no labels that match API support we fetch the label values with `resources/api/v1/label/<metric-name>values` endpoint. 
This flow is handled here: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/language_provider.ts#L548-L561

The fetch is done in `fetchSeriesValuesWithMatch` method: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/language_provider.ts#L568

In that method, we did not interpolate `match` string. When there is a template variable in the metric name (i.e. `process_cpu_seconds_total{instance="$instance",job=""}`) the autocomplete is not working for `job`. 

This PR is addressing that issue.

**Why do we need this feature?**

To fix autocomplete functionality when there are no labels match API support and a template variable is used in the query.

**Who is this feature for?**

Prometheus users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/66964

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
