### PR TITLE
Docs: Fix broken links to create-plugin docs

### DIFF
--- a/docs/sources/breaking-changes/breaking-changes-v10-0.md
+++ b/docs/sources/breaking-changes/breaking-changes-v10-0.md
@@ -361,7 +361,7 @@ npx @grafana/create-plugin@latest migrate
 
 #### Learn more
 
-- [Migration guide](https://grafana.github.io/plugin-tools/docs/getting-started/migrating-from-toolkit/)
+- [Migration guide](https://grafana.github.io/plugin-tools/docs/get-started/migrate-from-toolkit)
 
 ## Deprecations
 

--- a/docs/sources/breaking-changes/breaking-changes-v10-0.md
+++ b/docs/sources/breaking-changes/breaking-changes-v10-0.md
@@ -343,7 +343,7 @@ Here are some of the benefits of create-plugin:
 
 - **Improved testing capabilities:** Testing plugins with @grafana/create-plugin is much easier with GitHub workflows that automate unit and e2e test runs whenever changes are pushed to GitHub.
 
-- **Better documentation:** The [documentation](https://grafana.github.io/plugin-tools/docs/creating-a-plugin) for @grafana/create-plugin is more comprehensive and easier to discover than that of @grafana/toolkit.
+- **Better documentation:** The [documentation](https://grafana.github.io/plugin-tools/docs/get-started/) for @grafana/create-plugin is more comprehensive and easier to discover than that of @grafana/toolkit.
 
 #### Migration path
 

--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/_index.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/_index.md
@@ -29,4 +29,4 @@ This section contains how-to topics for developing Grafana plugins:
 
 Additional resources:
 
-- [Build a Grafana plugin with the create-plugin tool](https://grafana.github.io/plugin-tools/docs/getting-started/creating-a-plugin)
+- [Build a Grafana plugin with the create-plugin tool](https://grafana.github.io/plugin-tools/docs/get-started/)

--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/_index.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/_index.md
@@ -29,4 +29,4 @@ This section contains how-to topics for developing Grafana plugins:
 
 Additional resources:
 
-- [Build a Grafana plugin with the create-plugin tool](https://grafana.github.io/plugin-tools/docs/get-started/)
+- [Build a Grafana plugin with the create-plugin tool](https://grafana.github.io/plugin-tools/docs/get-started/).

--- a/docs/sources/developers/plugins/get-started-with-plugins/_index.md
+++ b/docs/sources/developers/plugins/get-started-with-plugins/_index.md
@@ -24,4 +24,4 @@ Additional resources:
 
 - [Get started with creating a plugin](https://grafana.github.io/plugin-tools/docs/get-started/)
 - [Types of Grafana plugins](/docs/grafana/latest/administration/plugin-management/)
-- [Set up your development environment](https://grafana.github.io/plugin-tools/docs/development/docker)
+- [Set up your development environment](https://grafana.github.io/plugin-tools/docs/get-started/set-up-development-environment)

--- a/docs/sources/developers/plugins/get-started-with-plugins/_index.md
+++ b/docs/sources/developers/plugins/get-started-with-plugins/_index.md
@@ -22,6 +22,6 @@ This section contains guidance for building plugins:
 
 Additional resources:
 
-- [Get started with creating a plugin](https://grafana.github.io/plugin-tools/docs/getting-started)
+- [Get started with creating a plugin](https://grafana.github.io/plugin-tools/docs/get-started/)
 - [Types of Grafana plugins](/docs/grafana/latest/administration/plugin-management/)
 - [Set up your development environment](https://grafana.github.io/plugin-tools/docs/development/docker)

--- a/docs/sources/developers/plugins/migration-guide/v6.x-v7.x/_index.md
+++ b/docs/sources/developers/plugins/migration-guide/v6.x-v7.x/_index.md
@@ -41,7 +41,7 @@ With Grafana 7.0, we released a new tool for making it easier to develop plugins
 
 For more information, refer to [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit).
 
-{{% admonition type="note" %}} As of Grafana 10.0, `@grafana/toolkit` is deprecated. It is replaced by the [`create-plugin`](https://grafana.github.io/plugin-tools/docs/getting-started/creating-a-plugin) tool.
+{{% admonition type="note" %}} As of Grafana 10.0, `@grafana/toolkit` is deprecated. It is replaced by the [`create-plugin`](https://grafana.github.io/plugin-tools/docs/get-started/) tool.
 {{% /admonition %}}
 
 ### Field options


### PR DESCRIPTION
On the plugin-tools repo, the path to create-plugin docs has changed to https://grafana.github.io/plugin-tools/docs/get-started/. Fixing links.
