### PR TITLE
LogRowMenu: Remove erroneously added `true` to `shouldShowMenu`

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -80,7 +80,7 @@ export const LogRowMessage = React.memo((props: Props) => {
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const shouldShowMenu = useMemo(() => mouseIsOver || pinned || true, [mouseIsOver, pinned]);
+  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>
       {


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/pull/72686 added a `true` which would make `shouldShowMenu` always true. This PR reverts the change.