### PR TITLE
Add a warning in the documentation

### DIFF
--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -25,6 +25,10 @@ title: Data source HTTP API
 
 `GET /api/datasources`
 
+{{% admonition type="warning" %}}
+This API currently doesn't handle pagination. The default maximum number of data sources returned is 5000. You can change this value in the default.ini file.
+{{% /admonition %}}
+
 **Required permissions**
 
 See note in the [introduction]({{< ref "#data-source-api" >}}) for an explanation.


### PR DESCRIPTION
A partner complained in the name of a customer. They have 6k datasources and it took them some time to figure out why they only had 5k coming back.

This commit add a warning for this edge case, content is pretty clear.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
