### PR TITLE
LogRowMessage: remove hardcoded true from condition

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -42,6 +42,11 @@ describe('LogRowMessage', () => {
     expect(screen.queryByText('test123')).toBeInTheDocument();
   });
 
+  it('should hide the menu if the mouse is not over', async () => {
+    setup({ showContextToggle: () => true, mouseIsOver: false });
+    expect(screen.queryByLabelText('Show context')).not.toBeInTheDocument();
+  });
+
   describe('with show context', () => {
     it('should show context button', async () => {
       setup({ showContextToggle: () => true });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -80,7 +80,7 @@ export const LogRowMessage = React.memo((props: Props) => {
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const shouldShowMenu = useMemo(() => mouseIsOver || pinned || true, [mouseIsOver, pinned]);
+  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>
       {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/72686, a hardcoded `true` was added for testing, which was not removed before merging. Removing it here.

**Why do we need this feature?**

[[Add a description of the problem the feature is trying to solve.]](https://github.com/grafana/grafana/pull/72686#pullrequestreview-1564888352)

**Special notes for your reviewer:**

Log rows menu should not be visible unless the mouse is over.