### PR TITLE
Transformations: Fix partitionByValues when there is no match

### DIFF
--- a/public/app/features/transformers/partitionByValues/partitionByValues.ts
+++ b/public/app/features/transformers/partitionByValues/partitionByValues.ts
@@ -98,6 +98,11 @@ export function partitionByValues(
   options?: PartitionByValuesTransformerOptions
 ): DataFrame[] {
   const keyFields = frame.fields.filter((f) => matcher(f, frame, [frame]))!;
+
+  if (!keyFields.length) {
+    return [frame];
+  }
+
   const keyFieldsVals = keyFields.map((f) => f.values);
   const names = keyFields.map((f) => f.name);
 


### PR DESCRIPTION
In the transformation `Partition by values`, when no fields match, there is an error:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at lr (partition.ts:25:23)
    at Pl (partitionByValues.ts:109:10)
    at partitionByValues.ts:89:14
    at partitionByValues.ts:73:84
    at map.js:7:37
    at S._next (OperatorSubscriber.js:15:21)
    at D.next (Subscriber.js:34:18)
    at w._subscribe (innerFrom.js:51:24)
    at w._trySubscribe (Observable.js:38:25)
    at Observable.js:32:31
```

There could be no field match if someone set a field and then change the query and this field doesn't exist anymore for example.