### PR TITLE
Bump version for @grafana/experimental

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "@grafana/aws-sdk": "0.0.47",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "1.6.1",
+    "@grafana/experimental": "1.7.0",
     "@grafana/faro-core": "1.1.2",
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,21 +3804,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/experimental@npm:1.6.1":
-  version: 1.6.1
-  resolution: "@grafana/experimental@npm:1.6.1"
+"@grafana/experimental@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@grafana/experimental@npm:1.7.0"
   dependencies:
     "@types/uuid": ^8.3.3
     uuid: ^8.3.2
   peerDependencies:
     "@emotion/css": 11.1.3
-    "@grafana/data": ^9.2.0
-    "@grafana/runtime": ^9.2.0
-    "@grafana/ui": ^9.2.0
+    "@grafana/data": ^10.0.0
+    "@grafana/runtime": ^10.0.0
+    "@grafana/ui": ^10.0.0
     react: 17.0.2
     react-dom: 17.0.2
     react-select: ^5.2.1
-  checksum: 64c32bc9e3bf96c88fbe9522c53e13e4cbc3848ff83df2b1b76735ad5cf9e1775b31094d1298c4bc6a8c75dbcac015eedb14dd9269f492f296c240c58c9916e7
+    rxjs: 7.8.0
+  checksum: f418072aab298bf5fa4b80d59593f10c62e77347e346cc5f669bdee1de2626fdd9f3d999da55a3079ccf6c6df979fc82e8e4d2e3d3bff2e66e49a0c38b8b80a0
   languageName: node
   linkType: hard
 
@@ -19274,7 +19275,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 6.0.0
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules"
-    "@grafana/experimental": 1.6.1
+    "@grafana/experimental": 1.7.0
     "@grafana/faro-core": 1.1.2
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1


### PR DESCRIPTION
**What is this feature?**

Bumps version of @grafana/experimental the 1.7.0 release.
Release 1.7.0 adds LLM support, misc other changes

**Why do we need this feature?**

Allows continued experimentation with experimental branch of Grafana for UI purposes

**Who is this feature for?**

Anyone using experimental features in core Grafana.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
