### PR TITLE
Add upload file button to editor

### DIFF
--- a/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
@@ -6,7 +6,7 @@ import { useObservable } from 'react-use';
 import { DataFrame, GrafanaTheme2, PanelOptionsEditorBuilder, StandardEditorContext } from '@grafana/data';
 import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
 import { NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
-import { useStyles2 } from '@grafana/ui/src';
+import { FileUpload, useStyles2 } from '@grafana/ui/src';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 import { OptionsPaneCategory } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategory';
@@ -17,7 +17,7 @@ import { setOptionImmutably } from 'app/features/dashboard/components/PanelEdito
 import { activePanelSubject, InstanceState } from '../../CanvasPanel';
 import { addStandardCanvasEditorOptions } from '../../module';
 import { InlineEditTabs } from '../../types';
-import { getElementTypes, onAddItem } from '../../utils';
+import { getElementTypes, onAddItem, onImportFile } from '../../utils';
 import { getElementEditor } from '../element/elementEditor';
 import { getLayerEditor } from '../layer/layerEditor';
 
@@ -89,6 +89,11 @@ export function InlineEditBody() {
       <div style={topLevelItemsContainerStyle}>{pane.items.map((item) => item.render())}</div>
       <div style={topLevelItemsContainerStyle}>
         <AddLayerButton onChange={(sel) => onAddItem(sel, rootLayer)} options={typeOptions} label={'Add item'} />
+      </div>
+      <div style={topLevelItemsContainerStyle}>
+        <FileUpload size="sm" accept=".dxf" onFileUpload={({ currentTarget }) => onImportFile(currentTarget)}>
+          <span>Upload CAD file</span>
+        </FileUpload>
       </div>
       <div style={topLevelItemsContainerStyle}>
         <TabsEditor onTabChange={onTabChange} />

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -5,14 +5,14 @@ import React, { Key, useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Button, HorizontalGroup, Icon, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, FileUpload, HorizontalGroup, Icon, useStyles2, useTheme2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { ElementState } from 'app/features/canvas/runtime/element';
 
 import { getGlobalStyles } from '../../globalStyles';
 import { Options } from '../../panelcfg.gen';
 import { DragNode, DropNode } from '../../types';
-import { doSelect, getElementTypes, onAddItem } from '../../utils';
+import { doSelect, getElementTypes, onAddItem, onImportFile } from '../../utils';
 import { TreeViewEditorProps } from '../element/elementEditor';
 
 import { TreeNodeTitle } from './TreeNodeTitle';
@@ -151,6 +151,9 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<any, TreeView
         <div className={styles.addLayerButton}>
           <AddLayerButton onChange={(sel) => onAddItem(sel, layer)} options={typeOptions} label={'Add item'} />
         </div>
+        <FileUpload size="sm" accept=".dxf" onFileUpload={({ currentTarget }) => onImportFile(currentTarget)}>
+          <span>Upload CAD file</span>
+        </FileUpload>
         {selection.length > 0 && (
           <Button size="sm" variant="secondary" onClick={onClearSelection}>
             Clear selection

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -151,9 +151,17 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<any, TreeView
         <div className={styles.addLayerButton}>
           <AddLayerButton onChange={(sel) => onAddItem(sel, layer)} options={typeOptions} label={'Add item'} />
         </div>
-        <FileUpload size="sm" accept=".dxf" onFileUpload={({ currentTarget }) => onImportFile(currentTarget)}>
-          <span>Upload CAD file</span>
-        </FileUpload>
+        <div className={styles.uploadFileButtonDiv}>
+          <FileUpload
+            className={styles.uploadFileButton}
+            size="sm"
+            accept=".dxf"
+            onFileUpload={({ currentTarget }) => onImportFile(currentTarget)}
+          >
+            <span>Upload CAD file</span>
+          </FileUpload>
+        </div>
+
         {selection.length > 0 && (
           <Button size="sm" variant="secondary" onClick={onClearSelection}>
             Clear selection
@@ -172,6 +180,12 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<any, TreeView
 const getStyles = (theme: GrafanaTheme2) => ({
   addLayerButton: css`
     margin-left: 18px;
+    min-width: calc(min(100px, 0.05vw));
+  `,
+  uploadFileButton: css`
+    float: right;
+  `,
+  uploadFileButtonDiv: css`
     min-width: 150px;
   `,
 });

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -106,6 +106,11 @@ export function onAddItem(sel: SelectableValue<string>, rootLayer: FrameState | 
   }
 }
 
+export async function onImportFile(target: EventTarget & HTMLInputElement) {
+  // eslint-disable-next-line no-console
+  console.debug('file', target.files && target.files[0]); // TODO: remove debugging
+}
+
 export function getDataLinks(ctx: DimensionContext, cfg: TextConfig, textData: string | undefined): LinkModel[] {
   const panelData = ctx.getPanelData();
   const frames = panelData?.series;


### PR DESCRIPTION
Add a no-op file upload button to the canvas editor as a placeholder.


<img width="392" alt="Screenshot 2023-08-07 at 12 26 52 PM" src="https://github.com/grafana/grafana/assets/4155337/0cbf102a-a1b3-46bd-be38-7f67c4a8660f">

Closes #72943
Closes #72945