### PR TITLE
Add rotation support to canvas

### DIFF
--- a/docs/sources/developers/kinds/composable/canvas/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/canvas/panelcfg/schema-reference.md
@@ -127,14 +127,15 @@ It extends [BaseDimensionConfig](#basedimensionconfig).
 
 ### Placement
 
-| Property | Type   | Required | Default | Description |
-|----------|--------|----------|---------|-------------|
-| `bottom` | number | No       |         |             |
-| `height` | number | No       |         |             |
-| `left`   | number | No       |         |             |
-| `right`  | number | No       |         |             |
-| `top`    | number | No       |         |             |
-| `width`  | number | No       |         |             |
+| Property   | Type   | Required | Default | Description |
+|------------|--------|----------|---------|-------------|
+| `bottom`   | number | No       |         |             |
+| `height`   | number | No       |         |             |
+| `left`     | number | No       |         |             |
+| `right`    | number | No       |         |             |
+| `rotation` | number | No       |         |             |
+| `top`      | number | No       |         |             |
+| `width`    | number | No       |         |             |
 
 ### Options
 

--- a/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
@@ -39,6 +39,7 @@ export interface Placement {
   height?: number;
   left?: number;
   right?: number;
+  rotation?: number;
   top?: number;
   width?: number;
 }

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -425,6 +425,12 @@ export class ElementState implements LayerElement {
     event.target.style.transform = event.transform;
   };
 
+  applyRotate = (event: OnRotate) => {
+    //event.target.style.transform = event.transform;
+    event.target.style.transform = event.transform;
+    console.log(event);
+  };
+
   // kinda like:
   // https://github.com/grafana/grafana-edge-app/blob/main/src/panels/draw/WrapItem.tsx#L44
   applyResize = (event: OnResize) => {

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { OnDrag, OnResize } from 'react-moveable/declaration/types';
+import { OnDrag, OnResize, OnRotate } from 'react-moveable/declaration/types';
 
 import { LayerElement } from 'app/core/components/Layers/types';
 import {
@@ -182,8 +182,10 @@ export class ElementState implements LayerElement {
         style.width = '';
         break;
     }
-
-    style.transform = `translate(${translate[0]}, ${translate[1]})`;
+    // Apply rotation (positive clockwise)
+    style.transform = `translate(${translate[0]}, ${translate[1]}) rotate(${placement.rotation ?? 0}deg)`;
+    // TODO determine rotation origin
+    //style.transformOrigin = `bottom left`;
     this.options.placement = placement;
     this.sizeStyle = style;
     if (this.div) {
@@ -285,7 +287,10 @@ export class ElementState implements LayerElement {
         placement.right = (relativeRight / (parentContainer?.width ?? width)) * 100;
         break;
     }
-
+    // Apply rotation
+    if (this.options.placement?.rotation) {
+      placement.rotation = this.options.placement?.rotation;
+    }
     this.options.placement = placement;
 
     this.applyLayoutStylesToDiv();
@@ -426,9 +431,9 @@ export class ElementState implements LayerElement {
   };
 
   applyRotate = (event: OnRotate) => {
-    //event.target.style.transform = event.transform;
     event.target.style.transform = event.transform;
-    console.log(event);
+    const placement = this.options.placement!;
+    placement.rotation = event.rotation;
   };
 
   // kinda like:

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -99,6 +99,7 @@ export class Scene {
         return;
       }
       this.moveable.draggable = !open;
+      this.moveable.rotatable = true;
     });
 
     this.panel = panel;
@@ -379,6 +380,7 @@ export class Scene {
     this.moveable = new Moveable(this.div!, {
       draggable: allowChanges && !this.editModeEnabled.getValue(),
       resizable: allowChanges,
+      rotatable: allowChanges,
       ables: [dimensionViewable, constraintViewable(this), settingsViewable(this)],
       props: {
         dimensionViewable: allowChanges,
@@ -509,6 +511,28 @@ export class Scene {
 
           targetedElement.setPlacementFromConstraint();
         }
+      })
+      .on('rotateStart', (event) => {
+        this.ignoreDataUpdate = true;
+        this.setNonTargetPointerEvents(event.target, true);
+      })
+      .on('rotate', (event) => {
+        const targetedElement = this.findElementByTarget(event.target);
+        if (targetedElement) {
+          targetedElement.applyRotate(event);
+        }
+
+        console.log(event);
+      })
+      .on('rotateEnd', (event) => {
+        const targetedElement = this.findElementByTarget(event.target);
+        if (targetedElement) {
+          targetedElement.setPlacementFromConstraint();
+        }
+
+        this.moved.next(Date.now());
+        this.ignoreDataUpdate = false;
+        this.setNonTargetPointerEvents(event.target, false);
       });
 
     let targets: Array<HTMLElement | SVGElement> = [];

--- a/public/app/plugins/panel/canvas/panelcfg.cue
+++ b/public/app/plugins/panel/canvas/panelcfg.cue
@@ -40,8 +40,9 @@ composableKinds: PanelCfg: {
 					right?:  float64
 					bottom?: float64
 
-					width?:  float64
-					height?: float64
+					width?:    float64
+					height?:   float64
+					rotation?: float64
 				} @cuetsy(kind="interface")
 
 				BackgroundImageSize: "original" | "contain" | "cover" | "fill" | "tile" @cuetsy(kind="enum", memberNames="Original|Contain|Cover|Fill|Tile")

--- a/public/app/plugins/panel/canvas/panelcfg.gen.ts
+++ b/public/app/plugins/panel/canvas/panelcfg.gen.ts
@@ -36,6 +36,7 @@ export interface Placement {
   height?: number;
   left?: number;
   right?: number;
+  rotation?: number;
   top?: number;
   width?: number;
 }


### PR DESCRIPTION
Add rotation support to canvas elements, including UX.

Supported by the placement model and user interaction. [Bug was found](https://github.com/grafana/grafana/issues/73021) where the height / width is growing during rotation.

![Aug-07-2023 18-36-42](https://github.com/grafana/grafana/assets/60050885/e14f4ba0-023d-4409-b68e-0b5a142cbc12)

Please note that rotation is positive clockwise, whereas in AutoCAD, rotation is positive counter clockwise, so this will need to be addressed during entity conversion.

Closes #72940, #72941
