### PR TITLE
Prometheus: Add parser option to error if response is above limit

### DIFF
--- a/docs/sources/developers/kinds/composable/prometheus/dataquery/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/prometheus/dataquery/schema-reference.md
@@ -14,7 +14,7 @@ title: PrometheusDataQuery kind
 ## PrometheusDataQuery
 
 #### Maturity: [experimental](../../../maturity/#experimental)
-#### Version: 0.0
+#### Version: 0.1
 
 
 
@@ -22,6 +22,7 @@ title: PrometheusDataQuery kind
 |------------------|---------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `expr`           | string  | **Yes**  |         | The actual expression/query that will be evaluated by Prometheus                                                                                                                                                                                        |
 | `refId`          | string  | **Yes**  |         | A unique identifier for the query within the list of targets.<br/>In server side expressions, the refId is used as a variable name to identify results.<br/>By default, the UI will assign A->Z; however setting meaningful names may be useful.        |
+| `cellLimit`      | integer | No       |         | Dataframe cells to be created before returning an error.                                                                                                                                                                                                |
 | `datasource`     |         | No       |         | For mixed data sources the selected datasource is on the query level.<br/>For non mixed scenarios this is undefined.<br/>TODO find a better way to do this ^ that's friendly to schema<br/>TODO this shouldn't be unknown but DataSourceRef &#124; null |
 | `editorMode`     | string  | No       |         | Possible values are: `code`, `builder`.                                                                                                                                                                                                                 |
 | `exemplar`       | boolean | No       |         | Execute an additional query to identify interesting raw samples relevant for the given expr                                                                                                                                                             |

--- a/packages/grafana-schema/src/raw/composable/prometheus/dataquery/x/PrometheusDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/prometheus/dataquery/x/PrometheusDataQuery_types.gen.ts
@@ -22,6 +22,10 @@ export type PromQueryFormat = ('time_series' | 'table' | 'heatmap');
 
 export interface PrometheusDataQuery extends common.DataQuery {
   /**
+   * Dataframe cells to be created before returning an error.
+   */
+  cellLimit?: number;
+  /**
    * Specifies which editor is being used to prepare the query. It can be "code" or "builder"
    */
   editorMode?: QueryEditorMode;

--- a/pkg/kindsysreport/codegen/report.json
+++ b/pkg/kindsysreport/codegen/report.json
@@ -1433,7 +1433,7 @@
       ],
       "currentVersion": [
         0,
-        0
+        1
       ],
       "grafanaMaturityCount": 0,
       "lineageIsGroup": false,

--- a/pkg/tsdb/prometheus/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/prometheus/kinds/dataquery/types_dataquery_gen.go
@@ -57,6 +57,9 @@ type PrometheusDataQuery struct {
 	// properties for the given context.
 	DataQuery
 
+	// Dataframe cells to be created before returning an error.
+	CellLimit *int64 `json:"cellLimit,omitempty"`
+
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema

--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -72,6 +72,7 @@ type Query struct {
 	RangeQuery    bool
 	ExemplarQuery bool
 	UtcOffsetSec  int64
+	CellLimit     int64
 }
 
 func Parse(query backend.DataQuery, timeInterval string, intervalCalculator intervalv2.Calculator, fromAlert bool) (*Query, error) {
@@ -114,6 +115,11 @@ func Parse(query backend.DataQuery, timeInterval string, intervalCalculator inte
 		exemplarQuery = false
 	}
 
+	var cellLimit int64
+	if model.CellLimit != nil && *model.CellLimit > 0 {
+		cellLimit = *model.CellLimit
+	}
+
 	return &Query{
 		Expr:          expr,
 		Step:          interval,
@@ -125,6 +131,7 @@ func Parse(query backend.DataQuery, timeInterval string, intervalCalculator inte
 		RangeQuery:    rangeQuery,
 		ExemplarQuery: exemplarQuery,
 		UtcOffsetSec:  model.UtcOffsetSec,
+		CellLimit:     cellLimit,
 	}, nil
 }
 

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -33,6 +33,7 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		MatrixWideSeries: s.enableWideSeries,
 		VectorWideSeries: s.enableWideSeries,
 		Dataplane:        s.enableDataplane,
+		CellLimit:        q.CellLimit,
 	})
 
 	// Add frame to attach metadata

--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -20,6 +20,7 @@ const (
 	// corresponding document to return to the request.
 	// HTTP status code 404.
 	StatusNotFound CoreStatus = "Not found"
+
 	// StatusTooManyRequests means that the client is rate limited
 	// by the server and should back-off before trying again.
 	// HTTP status code 429.

--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -20,7 +20,6 @@ const (
 	// corresponding document to return to the request.
 	// HTTP status code 404.
 	StatusNotFound CoreStatus = "Not found"
-
 	// StatusTooManyRequests means that the client is rate limited
 	// by the server and should back-off before trying again.
 	// HTTP status code 429.

--- a/public/app/plugins/datasource/prometheus/dataquery.cue
+++ b/public/app/plugins/datasource/prometheus/dataquery.cue
@@ -48,7 +48,38 @@ composableKinds: DataQuery: {
 				#QueryEditorMode: "code" | "builder"                  @cuetsy(kind="enum")
 				#PromQueryFormat: "time_series" | "table" | "heatmap" @cuetsy(kind="type")
 			}
-		}]
+		},
+			{
+				version: [0, 1]
+				schema: {
+					common.DataQuery
+
+					// The actual expression/query that will be evaluated by Prometheus
+					expr: string
+					// Returns only the latest value that Prometheus has scraped for the requested time series
+					instant?: bool
+					// Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series
+					range?: bool
+					// Execute an additional query to identify interesting raw samples relevant for the given expr
+					exemplar?: bool
+					// Specifies which editor is being used to prepare the query. It can be "code" or "builder"
+					editorMode?: #QueryEditorMode
+					// Query format to determine how to display data points in panel. It can be "time_series", "table", "heatmap"
+					format?: #PromQueryFormat
+					// Series name override or template. Ex. {{hostname}} will be replaced with label value for hostname
+					legendFormat?: string
+					// @deprecated Used to specify how many times to divide max data points by. We use max data points under query options
+					// See https://github.com/grafana/grafana/issues/48081
+					intervalFactor?: number
+
+					// Dataframe cells to be created before returning an error.
+					// A value of 0 means no limit.
+					cellLimit?: int64
+
+					#QueryEditorMode: "code" | "builder"                  @cuetsy(kind="enum")
+					#PromQueryFormat: "time_series" | "table" | "heatmap" @cuetsy(kind="type")
+				}
+			}]
 		lenses: []
 	}
 }

--- a/public/app/plugins/datasource/prometheus/dataquery.gen.ts
+++ b/public/app/plugins/datasource/prometheus/dataquery.gen.ts
@@ -19,6 +19,10 @@ export type PromQueryFormat = ('time_series' | 'table' | 'heatmap');
 
 export interface Prometheus extends common.DataQuery {
   /**
+   * Dataframe cells to be created before returning an error.
+   */
+  cellLimit?: number;
+  /**
    * Specifies which editor is being used to prepare the query. It can be "code" or "builder"
    */
   editorMode?: QueryEditorMode;


### PR DESCRIPTION
**What is this feature?**

Adds a query paramater (could come from elsewhere) to limit how large of a Prometheus matrix/vector response the datasource will return before not returning data and returning an error instead.

This does this by counting dataframe "cells" (a single entry in a vector within a dataframe). In this way, the limit can still apply to:
 - Wide Dataframes (lots of Fields (a.k.a. columns))
 - Long dataframes (the Fields are long)
 - Lots of dataframes (currently we return one frame per item with prom, and max datapoints per series won't help us here if it `up` with thousands of items.

In this way, the main way to bypass this limit would be to have a very large cell - but that would seem to be generally an uncommon case compared to the others.

Limiting by cell isn't as user friendly (as depending on the data type, they may think the number or "rows', "datapoints", "buckets" etc. But those concepts would all be convertible to an _n_ cell multiple, so for the backend implementation of the limit I think cell is the correct unit.

**Why do we need this feature?**

Protect the process from OOM. Prometheus has limits (and generally it would be better to hit those). But practically since Grafana is currently a monolith, and those are often not set, we need an additional defense layer.

**Who is this feature for?**

People that like less out of memory issues, crashes, escalations etc. 

The exact nature depends on exactly how we want to implement this. Currently it is a query option - but it could be a data source option (or both). So who it is for depends on where we present and enforce it. A soft limit with a warning might make for a better experience.

**Special notes for your reviewer:**
Nothing in the UI currently exposes this. And we need to decide if maybe there should be a per query and datasource limit.

Currently one needs to pass `cellLimit` in the json query:

```bash
--data-raw '{"queries":[{"refId":"A","expr":"up","range":true,"instant":false,"datasource":{"type":"prometheus","uid":"gdev-prometheus"},"editorMode":"code","legendFormat":"__auto","exemplar":false,"cellLimit":10,"requestId":"undefinedA","utcOffsetSec":-14400,"interval":"","datasourceId":4,"intervalMs":15000,"maxDataPoints":1276}],"from":"1691406836171","to":"1691428436171"}' \
  --compressed
{"results":{"A":{"error":"[datasource.prometheus.responseTooLarge] response exceeded limit of 10 cells","status":500,"frames":[{"schema":{"refId":"A","meta":{"typeVersion":[0,0],"executedQueryString":"Expr: up\nStep: 15s"},"fields":[]},"data":{"values":[]}}]}}}
```

Old issue: https://github.com/grafana/grafana/issues/26789



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
