### PR TITLE
Alerting: Optimize external Loki queries

### DIFF
--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -3,6 +3,8 @@ package store
 import (
 	"encoding/json"
 
+	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -20,7 +22,7 @@ type dsType struct {
 }
 
 func (t dsType) isLoki() bool {
-	return t.DS.Type == "loki"
+	return t.DS.Type == datasources.DS_LOKI
 }
 
 func canBeInstant(r *models.AlertRule) bool {
@@ -47,8 +49,9 @@ func canBeInstant(r *models.AlertRule) bool {
 	if err := json.Unmarshal(r.Data[1].Model, &exprRaw); err != nil {
 		return false
 	}
-	// Second query part should be and expression, '-100' is the legacy way to define it.
-	if r.Data[1].DatasourceUID != "__expr__" && r.Data[1].DatasourceUID != "-100" {
+
+	// Second query part should be and expression.
+	if expr.IsDataSource(r.Data[1].DatasourceUID) {
 		return false
 	}
 

--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -8,12 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-const (
-	grafanaCloudLogs          = "grafanacloud-logs"
-	grafanaCloudUsageInsights = "grafanacloud-usage-insights"
-	grafanaCloudStateHistory  = "grafanacloud-loki-alert-state-history"
-)
-
 // DSType can be used to check the datasource type if it's set in the model.
 type dsType struct {
 	DS struct {
@@ -38,10 +32,7 @@ func canBeInstant(r *models.AlertRule) bool {
 	// We can ignore the error here, the query just won't be optimized.
 	_ = json.Unmarshal(r.Data[0].Model, &t)
 
-	if r.Data[0].DatasourceUID != grafanaCloudLogs &&
-		r.Data[0].DatasourceUID != grafanaCloudUsageInsights &&
-		r.Data[0].DatasourceUID != grafanaCloudStateHistory &&
-		!t.isLoki() {
+	if !t.isLoki() {
 		return false
 	}
 

--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -42,7 +42,7 @@ func canBeInstant(r *models.AlertRule) bool {
 	}
 
 	// Second query part should be and expression.
-	if expr.IsDataSource(r.Data[1].DatasourceUID) {
+	if !expr.IsDataSource(r.Data[1].DatasourceUID) {
 		return false
 	}
 

--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -12,6 +12,17 @@ const (
 	grafanaCloudStateHistory  = "grafanacloud-loki-alert-state-history"
 )
 
+// DSType can be used to check the datasource type if it's set in the model.
+type dsType struct {
+	DS struct {
+		Type string `json:"type"`
+	} `json:"datasource"`
+}
+
+func (t dsType) isLoki() bool {
+	return t.DS.Type == "loki"
+}
+
 func canBeInstant(r *models.AlertRule) bool {
 	if len(r.Data) < 2 {
 		return false
@@ -20,20 +31,27 @@ func canBeInstant(r *models.AlertRule) bool {
 	if r.Data[0].QueryType != "range" {
 		return false
 	}
-	// First query part should go to cloud logs or insights.
+
+	var t dsType
+	// We can ignore the error here, the query just won't be optimized.
+	_ = json.Unmarshal(r.Data[0].Model, &t)
+
 	if r.Data[0].DatasourceUID != grafanaCloudLogs &&
 		r.Data[0].DatasourceUID != grafanaCloudUsageInsights &&
-		r.Data[0].DatasourceUID != grafanaCloudStateHistory {
+		r.Data[0].DatasourceUID != grafanaCloudStateHistory &&
+		!t.isLoki() {
+		return false
+	}
+
+	exprRaw := make(map[string]interface{})
+	if err := json.Unmarshal(r.Data[1].Model, &exprRaw); err != nil {
 		return false
 	}
 	// Second query part should be and expression, '-100' is the legacy way to define it.
 	if r.Data[1].DatasourceUID != "__expr__" && r.Data[1].DatasourceUID != "-100" {
 		return false
 	}
-	exprRaw := make(map[string]interface{})
-	if err := json.Unmarshal(r.Data[1].Model, &exprRaw); err != nil {
-		return false
-	}
+
 	// Second query part should be "last()"
 	if val, ok := exprRaw["reducer"].(string); !ok || val != "last" {
 		return false

--- a/pkg/services/ngalert/store/loki_range_to_instant_test.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant_test.go
@@ -121,7 +121,7 @@ func createMigrateableLokiRule(t *testing.T, muts ...func(*models.AlertRule)) *m
 			{
 				RefID:         "A",
 				QueryType:     "range",
-				DatasourceUID: grafanaCloudLogs,
+				DatasourceUID: "grafanacloud-logs",
 				Model: []byte(`{
 					"datasource": {
 						"type": "loki",

--- a/pkg/services/ngalert/store/loki_range_to_instant_test.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func TestCanBeInstant(t *testing.T) {
@@ -18,6 +19,13 @@ func TestCanBeInstant(t *testing.T) {
 			name:     "valid rule that can be migrated from range to instant",
 			expected: true,
 			rule:     createMigrateableLokiRule(t),
+		},
+		{
+			name:     "valid rule with external loki datasource",
+			expected: true,
+			rule: createMigrateableLokiRule(t, func(r *models.AlertRule) {
+				r.Data[0].DatasourceUID = "something-external"
+			}),
 		},
 		{
 			name:     "invalid rule where the data array is too short to be migrateable",
@@ -34,20 +42,6 @@ func TestCanBeInstant(t *testing.T) {
 			}),
 		},
 		{
-			name:     "invalid rule that does not use a cloud datasource",
-			expected: false,
-			rule: createMigrateableLokiRule(t, func(r *models.AlertRule) {
-				r.Data[0].DatasourceUID = "something-else"
-			}),
-		},
-		{
-			name:     "invalid rule that has no aggregation as second item",
-			expected: false,
-			rule: createMigrateableLokiRule(t, func(r *models.AlertRule) {
-				r.Data[1].DatasourceUID = "something-else"
-			}),
-		},
-		{
 			name:     "invalid rule that has not last() as aggregation",
 			expected: false,
 			rule: createMigrateableLokiRule(t, func(r *models.AlertRule) {
@@ -57,6 +51,13 @@ func TestCanBeInstant(t *testing.T) {
 				raw["reducer"] = "avg"
 				r.Data[1].Model, err = json.Marshal(raw)
 				require.NoError(t, err)
+			}),
+		},
+		{
+			name:     "invalid rule that has no aggregation as second item",
+			expected: false,
+			rule: createMigrateableLokiRule(t, func(r *models.AlertRule) {
+				r.Data[1].DatasourceUID = "something-else"
 			}),
 		},
 		{


### PR DESCRIPTION
This PR also enables the optimization of external loki queries. We had a few users running external queries from another stack in cloud, that would not be optimized. So instead of only allowing the provisioned datasource, we also will enable the optimization on any arbitrary loki query.