### PR TITLE
Alerting: Add more tests for state manager ProcessEvalResults

### DIFF
--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -2,19 +2,31 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+
 	"github.com/grafana/grafana/pkg/util"
 )
+
+var testMetrics = metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics()
 
 // Not for parallel tests.
 type CountingImageService struct {
@@ -146,4 +158,2261 @@ func TestManager_saveAlertStates(t *testing.T) {
 			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
 		}
 	})
+}
+
+func TestProcessEvalResultsExtended(t *testing.T) {
+	evaluationDuration := 10 * time.Millisecond
+	evaluationInterval := 10 * time.Second
+
+	tN := func(n int) time.Time {
+		return time.Time{}.Add(time.Duration(n) * evaluationInterval)
+	}
+	t1 := tN(1)
+	t2 := tN(2)
+	t3 := tN(3)
+
+	baseRule := &ngmodels.AlertRule{
+		OrgID: 1,
+		Title: "test_title",
+		UID:   "test_alert_rule_uid",
+		Data: []ngmodels.AlertQuery{{
+			RefID:         "A",
+			DatasourceUID: "datasource_uid_1",
+		}, {
+			RefID:         "B",
+			DatasourceUID: expr.DatasourceType,
+		}},
+		NamespaceUID:    "test_namespace_uid",
+		Annotations:     map[string]string{"annotation": "test"},
+		Labels:          map[string]string{"label": "test"},
+		IntervalSeconds: int64(evaluationInterval.Seconds()),
+		NoDataState:     ngmodels.NoData,
+		ExecErrState:    ngmodels.ErrorErrState,
+	}
+
+	newEvaluation := func(evalTime time.Time, evalState eval.State) Evaluation {
+		return Evaluation{
+			EvaluationTime:  evalTime,
+			EvaluationState: evalState,
+			Values:          make(map[string]*float64),
+		}
+	}
+
+	baseRuleWith := func(mutators ...ngmodels.AlertRuleMutator) *ngmodels.AlertRule {
+		r := ngmodels.CopyRule(baseRule)
+		for _, mutator := range mutators {
+			mutator(r)
+		}
+		return r
+	}
+
+	newResult := func(mutators ...eval.ResultMutator) eval.Result {
+		r := eval.Result{
+			State:              eval.Normal,
+			EvaluationDuration: evaluationDuration,
+		}
+		for _, mutator := range mutators {
+			mutator(&r)
+		}
+		return r
+	}
+
+	genericError := errors.New("test-error")
+	datasourceError := expr.MakeQueryError("A", "datasource_uid_1", errors.New("this is an error"))
+	expectedDatasourceErrorLabels := data.Labels{
+		"datasource_uid": "datasource_uid_1",
+		"ref_id":         "A",
+	}
+
+	labels1 := data.Labels{
+		"instance_label": "test-1",
+	}
+	labels2 := data.Labels{
+		"instance_label": "test-2",
+	}
+	labels3 := data.Labels{
+		"instance_label": "test-3",
+	}
+	systemLabels := data.Labels{
+		"system": "owned",
+	}
+	noDataLabels := data.Labels{
+		"datasource_uid": "1",
+		"ref_id":         "A",
+	}
+
+	labels := map[string]data.Labels{
+		"system + rule":                    mergeLabels(baseRule.Labels, systemLabels),
+		"system + rule + labels1":          mergeLabels(mergeLabels(labels1, baseRule.Labels), systemLabels),
+		"system + rule + labels2":          mergeLabels(mergeLabels(labels2, baseRule.Labels), systemLabels),
+		"system + rule + labels3":          mergeLabels(mergeLabels(labels3, baseRule.Labels), systemLabels),
+		"system + rule + no-data":          mergeLabels(mergeLabels(noDataLabels, baseRule.Labels), systemLabels),
+		"system + rule + datasource-error": mergeLabels(mergeLabels(expectedDatasourceErrorLabels, baseRule.Labels), systemLabels),
+	}
+
+	patchState := func(r *ngmodels.AlertRule, s *State) {
+		// patch all optional fields of the expected state
+		setCacheID(s)
+		if s.AlertRuleUID == "" {
+			s.AlertRuleUID = r.UID
+		}
+		if s.OrgID == 0 {
+			s.OrgID = r.OrgID
+		}
+		if s.Annotations == nil {
+			s.Annotations = r.Annotations
+		}
+		if s.EvaluationDuration == 0 {
+			s.EvaluationDuration = evaluationDuration
+		}
+		if s.Values == nil {
+			s.Values = make(map[string]float64)
+		}
+	}
+
+	executeTest := func(t *testing.T, alertRule *ngmodels.AlertRule, resultsAtTime map[time.Time]eval.Results, expectedTransitionsAtTime map[time.Time][]StateTransition) {
+		clk := clock.NewMock()
+
+		cfg := ManagerCfg{
+			Metrics:                 testMetrics,
+			ExternalURL:             nil,
+			InstanceStore:           &FakeInstanceStore{},
+			Images:                  &NotAvailableImageService{},
+			Clock:                   clk,
+			Historian:               &FakeHistorian{},
+			MaxStateSaveConcurrency: 1,
+		}
+		st := NewManager(cfg)
+
+		tss := make([]time.Time, 0, len(resultsAtTime))
+		for ts, results := range resultsAtTime {
+			for i := range results {
+				results[i].EvaluatedAt = ts
+			}
+			tss = append(tss, ts)
+		}
+		sort.Slice(tss, func(i, j int) bool {
+			return tss[i].Before(tss[j])
+		})
+
+		for _, ts := range tss {
+			results := resultsAtTime[ts]
+			clk.Set(ts)
+			actual := st.ProcessEvalResults(context.Background(), ts, alertRule, results, systemLabels)
+
+			expectedTransitions, ok := expectedTransitionsAtTime[ts]
+			if !ok { // skip if nothing to assert
+				continue
+			}
+			expectedTransitionsMap := make(map[string]StateTransition, len(expectedTransitions))
+			for i := range expectedTransitions {
+				patchState(alertRule, expectedTransitions[i].State)
+				expectedTransitionsMap[expectedTransitions[i].CacheID] = expectedTransitions[i]
+			}
+
+			tn := ts.Sub(t1)/evaluationInterval + 1
+			for _, transition := range actual {
+				expected, ok := expectedTransitionsMap[transition.CacheID]
+				if !ok {
+					assert.Failf(t, fmt.Sprintf("transition is not expected at time [t%d]", tn), "CacheID: %s.\nTransition: %s->%s", transition.CacheID, transition.PreviousFormatted(), transition.Formatted())
+				}
+				delete(expectedTransitionsMap, transition.CacheID)
+				if !assert.ObjectsAreEqual(expected, transition) {
+					assert.Failf(t, fmt.Sprintf("expected and actual transitions at time [t%d] are not equal", tn), "CacheID: %s\nDiff: %s", transition.CacheID, cmp.Diff(expected, transition, cmpopts.EquateErrors()))
+				}
+			}
+			if len(expectedTransitionsMap) > 0 {
+				vals := make([]string, 0, len(expectedTransitionsMap))
+				for _, s := range expectedTransitionsMap {
+					vals = append(vals, s.CacheID)
+				}
+				assert.Failf(t, fmt.Sprintf("some expected states do not exist at time [t%d]", tn), "States: %v", vals)
+			}
+		}
+	}
+
+	type testCase struct {
+		desc                string
+		alertRule           *ngmodels.AlertRule
+		results             map[time.Time]eval.Results
+		expectedTransitions map[time.Time][]StateTransition
+	}
+
+	testCases := []testCase{
+		{
+			desc:      "[]->[normal,normal]",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels2)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t1,
+						},
+					},
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels2"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[]->[alerting,normal]",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels2)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Alerting,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3),
+							LastEvaluationTime: t1,
+						},
+					},
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels2"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[]->[alerting,normal] and 'for'>0",
+			alertRule: baseRuleWith(ngmodels.WithForNTimes(3)),
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels2)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Pending,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3),
+							LastEvaluationTime: t1,
+						},
+					},
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels2"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[normal,normal]->[alerting,normal]",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels2)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels2)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t2: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Alerting,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+								newEvaluation(t2, eval.Alerting),
+							},
+							StartsAt:           t2,
+							EndsAt:             t2.Add(ResendDelay * 3),
+							LastEvaluationTime: t2,
+						},
+					},
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels2"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+								newEvaluation(t2, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t2,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[alerting]->[alerting]->[alerting] and 'for'=2",
+			alertRule: baseRuleWith(ngmodels.WithForNTimes(2)),
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				t3: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Pending,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3),
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+				t2: {
+					{
+						PreviousState: eval.Pending,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Pending,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+								newEvaluation(t2, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3), // TODO should we fix it to be t2.Add(ResendDelay * 3)?
+							LastEvaluationTime: t2,
+						},
+					},
+				},
+				t3: {
+					{
+						PreviousState: eval.Pending,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Alerting,
+							Results: []Evaluation{
+								newEvaluation(t2, eval.Alerting),
+								newEvaluation(t3, eval.Alerting),
+							},
+							StartsAt:           t3,
+							EndsAt:             t3.Add(ResendDelay * 3),
+							LastEvaluationTime: t3,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[alerting]->[normal] and 'for'=2",
+			alertRule: baseRuleWith(ngmodels.WithForNTimes(2)),
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t2: {
+					{
+						PreviousState: eval.Pending,
+						State: &State{
+							Labels: labels["system + rule + labels1"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+								newEvaluation(t2, eval.Normal),
+							},
+							StartsAt:           t2,
+							EndsAt:             t2,
+							LastEvaluationTime: t2,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "[alerting]->[normal]",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t2: {{
+					PreviousState: eval.Alerting,
+					State: &State{
+						Labels: labels["system + rule + labels1"],
+						State:  eval.Normal,
+						Results: []Evaluation{
+							newEvaluation(t1, eval.Alerting),
+							newEvaluation(t2, eval.Normal),
+						},
+						StartsAt:           t2,
+						EndsAt:             t2,
+						LastEvaluationTime: t2,
+						Resolved:           true,
+					},
+				},
+				},
+			},
+		},
+		{
+			desc:      "[normal,alerting,normal]->[-,-,normal]->[-,-,normal]",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels3)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels3)),
+				},
+				t3: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels3)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t2: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels3"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+								newEvaluation(t2, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t2,
+						},
+					},
+				},
+				t3: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels:      labels["system + rule + labels1"],
+							State:       eval.Normal,
+							StateReason: ngmodels.StateReasonMissingSeries,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t3,
+							LastEvaluationTime: t3,
+						},
+					},
+					{
+						PreviousState: eval.Alerting,
+						State: &State{
+							Labels:      labels["system + rule + labels2"],
+							State:       eval.Normal,
+							StateReason: ngmodels.StateReasonMissingSeries,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t3,
+							LastEvaluationTime: t3,
+							Resolved:           true,
+						},
+					},
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule + labels3"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+								newEvaluation(t2, eval.Normal),
+								newEvaluation(t3, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t3,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "->normal",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule"],
+							State:  eval.Normal,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1,
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "->alerting",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule"],
+							State:  eval.Alerting,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3),
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "->alerting and 'for'>0",
+			alertRule: baseRuleWith(ngmodels.WithForNTimes(3)),
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Alerting)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t1: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule"],
+							State:  eval.Pending,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Alerting),
+							},
+							StartsAt:           t1,
+							EndsAt:             t1.Add(ResendDelay * 3),
+							LastEvaluationTime: t1,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:      "normal->alerting",
+			alertRule: baseRule,
+			results: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.Alerting)),
+				},
+			},
+			expectedTransitions: map[time.Time][]StateTransition{
+				t2: {
+					{
+						PreviousState: eval.Normal,
+						State: &State{
+							Labels: labels["system + rule"],
+							State:  eval.Alerting,
+							Results: []Evaluation{
+								newEvaluation(t1, eval.Normal),
+								newEvaluation(t2, eval.Alerting),
+							},
+							StartsAt:           t2,
+							EndsAt:             t2.Add(ResendDelay * 3),
+							LastEvaluationTime: t2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			executeTest(t, tc.alertRule, tc.results, tc.expectedTransitions)
+		})
+	}
+
+	t.Run("no-data", func(t *testing.T) {
+		rules := map[ngmodels.NoDataState]*ngmodels.AlertRule{
+			ngmodels.NoData:   baseRuleWith(ngmodels.WithNoDataExecAs(ngmodels.NoData)),
+			ngmodels.Alerting: baseRuleWith(ngmodels.WithNoDataExecAs(ngmodels.Alerting)),
+			ngmodels.OK:       baseRuleWith(ngmodels.WithNoDataExecAs(ngmodels.OK)),
+		}
+
+		type noDataTestCase struct {
+			desc                string
+			ruleMutators        []ngmodels.AlertRuleMutator
+			results             map[time.Time]eval.Results
+			expectedTransitions map[ngmodels.NoDataState]map[time.Time][]StateTransition
+		}
+
+		executeForEachRule := func(t *testing.T, tc noDataTestCase) {
+			t.Helper()
+			for stateExec, rule := range rules {
+				r := rule
+				if len(tc.ruleMutators) > 0 {
+					r = ngmodels.CopyRule(r)
+					for _, mutateRule := range tc.ruleMutators {
+						mutateRule(r)
+					}
+				}
+				t.Run(fmt.Sprintf("execute as %s", stateExec), func(t *testing.T) {
+					expectedTransitions, ok := tc.expectedTransitions[stateExec]
+					if !ok {
+						require.Fail(t, "no expected state transitions")
+					}
+					executeTest(t, r, tc.results, expectedTransitions)
+				})
+			}
+		}
+
+		testCases := []noDataTestCase{
+			{
+				desc: "->NoData",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1,
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "[normal]->NoData",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "[normal,alerting]->NoData->NoData",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+						newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState: eval.NoData,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState:       eval.Alerting,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState:       eval.Normal,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "[normal,alerting]->NoData->NoData, and 'for'=1",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(1)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+						newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.NoData,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Pending,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState:       eval.Pending,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + labels1"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule + labels2"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState:       eval.Normal,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "[alerting]->NoData->[alerting], and 'for'=2",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(2)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "NoData->[normal]->[normal]",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Normal,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Normal),
+										newEvaluation(t3, eval.Normal),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState: eval.NoData,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Normal,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Normal),
+										newEvaluation(t3, eval.Normal),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState:       eval.Alerting,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + labels1"],
+									State:  eval.Normal,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Normal),
+										newEvaluation(t3, eval.Normal),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+							{
+								PreviousState:       eval.Normal,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.NoData),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "normal->NoData",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "alerting->NoData->NoData",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState: eval.NoData,
+								State: &State{
+									Labels: labels["system + rule + no-data"],
+									State:  eval.NoData,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t3: {
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState:       eval.Alerting,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Alerting,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Alerting,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: ngmodels.StateReasonMissingSeries,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t3,
+									LastEvaluationTime: t3,
+									Resolved:           true,
+								},
+							},
+							{
+								PreviousState:       eval.Normal,
+								PreviousStateReason: eval.NoData.String(),
+								State: &State{
+									Labels:      labels["system + rule + no-data"],
+									State:       eval.Normal,
+									StateReason: eval.NoData.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.NoData),
+										newEvaluation(t3, eval.NoData),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "alerting->NoData->alerting, and 'for'=2",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(2)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+					t2: {
+						newResult(eval.WithState(eval.NoData), eval.WithLabels(noDataLabels)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+				},
+				expectedTransitions: map[ngmodels.NoDataState]map[time.Time][]StateTransition{
+					ngmodels.NoData: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.Alerting: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OK: {
+						t3: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				executeForEachRule(t, tc)
+			})
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		rules := map[ngmodels.ExecutionErrorState]*ngmodels.AlertRule{
+			ngmodels.ErrorErrState:    baseRuleWith(ngmodels.WithErrorExecAs(ngmodels.ErrorErrState)),
+			ngmodels.AlertingErrState: baseRuleWith(ngmodels.WithErrorExecAs(ngmodels.AlertingErrState)),
+			ngmodels.OkErrState:       baseRuleWith(ngmodels.WithErrorExecAs(ngmodels.OkErrState)),
+		}
+
+		cacheID := func(lbls data.Labels) string {
+			l := ngmodels.InstanceLabels(lbls)
+			r, err := l.StringKey()
+			if err != nil {
+				panic(err)
+			}
+			return r
+		}
+
+		type errorTestCase struct {
+			desc                string
+			ruleMutators        []ngmodels.AlertRuleMutator
+			results             map[time.Time]eval.Results
+			expectedTransitions map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition
+		}
+
+		executeForEachRule := func(t *testing.T, tc errorTestCase) {
+			t.Helper()
+			for stateExec, rule := range rules {
+				r := rule
+				if len(tc.ruleMutators) > 0 {
+					r = ngmodels.CopyRule(r)
+					for _, mutateRule := range tc.ruleMutators {
+						mutateRule(r)
+					}
+				}
+				t.Run(fmt.Sprintf("execute as %s", stateExec), func(t *testing.T) {
+					expectedTransitions, ok := tc.expectedTransitions[stateExec]
+					if !ok {
+						require.Fail(t, "no expected state transitions")
+					}
+					executeTest(t, r, tc.results, expectedTransitions)
+				})
+			}
+		}
+
+		testCases := []errorTestCase{
+			{
+				desc: "->QueryError",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithError(datasourceError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Alerting,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1,
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "->GenericError",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithError(genericError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Error,
+									Error:  genericError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": genericError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Alerting,
+									StateReason: eval.Error.String(),
+									Error:       genericError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1,
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "[alerting]->QueryError, and 'for'=1",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(1)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					},
+					t2: {
+						newResult(eval.WithError(datasourceError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Pending,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "[normal]->QueryError",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+					},
+					t2: {
+						newResult(eval.WithError(datasourceError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Alerting,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc: "normal->QueryError",
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Normal)),
+					},
+					t2: {
+						newResult(eval.WithError(datasourceError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Alerting,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t2: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Normal),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "alerting->QueryError, and 'for'=1",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(1)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+					t2: {
+						newResult(eval.WithError(datasourceError)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t1: {
+							{
+								PreviousState: eval.Normal,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Pending,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3),
+									LastEvaluationTime: t1,
+								},
+							},
+						},
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Alerting,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				desc:         "alerting->QueryError->alerting, and 'for'=2",
+				ruleMutators: []ngmodels.AlertRuleMutator{ngmodels.WithForNTimes(2)},
+				results: map[time.Time]eval.Results{
+					t1: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+					t2: {
+						newResult(eval.WithError(datasourceError)),
+					},
+					t3: {
+						newResult(eval.WithState(eval.Alerting)),
+					},
+				},
+				expectedTransitions: map[ngmodels.ExecutionErrorState]map[time.Time][]StateTransition{
+					ngmodels.ErrorErrState: {
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									CacheID: cacheID(labels["system + rule"]),
+									Labels:  labels["system + rule + datasource-error"],
+									State:   eval.Error,
+									Error:   datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2.Add(ResendDelay * 3),
+									LastEvaluationTime: t2,
+									Annotations: mergeLabels(baseRule.Annotations, data.Labels{
+										"Error": datasourceError.Error(),
+									}),
+								},
+							},
+						},
+						t3: {
+							{
+								PreviousState: eval.Error,
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Pending,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.AlertingErrState: {
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Pending,
+									StateReason: eval.Error.String(),
+									Error:       datasourceError,
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t1,
+									EndsAt:             t1.Add(ResendDelay * 3), // TODO probably it should be t2.Add(...)?
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+						t3: {
+							{
+								PreviousState:       eval.Pending,
+								PreviousStateReason: eval.Error.String(),
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Alerting,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+					ngmodels.OkErrState: {
+						t2: {
+							{
+								PreviousState: eval.Pending,
+								State: &State{
+									Labels:      labels["system + rule"],
+									State:       eval.Normal,
+									StateReason: eval.Error.String(),
+									Results: []Evaluation{
+										newEvaluation(t1, eval.Alerting),
+										newEvaluation(t2, eval.Error),
+									},
+									StartsAt:           t2,
+									EndsAt:             t2,
+									LastEvaluationTime: t2,
+								},
+							},
+						},
+						t3: {
+							{
+								PreviousState:       eval.Normal,
+								PreviousStateReason: eval.Error.String(),
+								State: &State{
+									Labels: labels["system + rule"],
+									State:  eval.Pending,
+									Results: []Evaluation{
+										newEvaluation(t2, eval.Error),
+										newEvaluation(t3, eval.Alerting),
+									},
+									StartsAt:           t3,
+									EndsAt:             t3.Add(ResendDelay * 3),
+									LastEvaluationTime: t3,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				executeForEachRule(t, tc)
+			})
+		}
+	})
+}
+
+func setCacheID(s *State) *State {
+	if s.CacheID != "" {
+		return s
+	}
+	il := ngmodels.InstanceLabels(s.Labels)
+	id, err := il.StringKey()
+	if err != nil {
+		panic(err)
+	}
+	s.CacheID = id
+	return s
 }

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -2565,9 +2565,8 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Error,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule"],
-									State:   eval.Normal,
+									Labels: labels["system + rule"],
+									State:  eval.Normal,
 									Results: []Evaluation{
 										newEvaluation(t1, eval.Error),
 										newEvaluation(t2, eval.Normal),

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -580,7 +580,7 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								newEvaluation(t2, eval.Alerting),
 							},
 							StartsAt:           t1,
-							EndsAt:             t1.Add(ResendDelay * 3), // TODO should we fix it to be t2.Add(ResendDelay * 3)?
+							EndsAt:             t1.Add(ResendDelay * 3), // TODO probably it should be t1 (semantic of Normal)?
 							LastEvaluationTime: t2,
 						},
 					},
@@ -2488,7 +2488,7 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 										newEvaluation(t2, eval.Error),
 									},
 									StartsAt:           t1,
-									EndsAt:             t1.Add(ResendDelay * 3), // TODO probably it should be t2.Add(...)?
+									EndsAt:             t1.Add(ResendDelay * 3), // TODO probably it should be t1 (semantic of Normal)?
 									LastEvaluationTime: t2,
 								},
 							},

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -160,40 +160,40 @@ func TestManager_saveAlertStates(t *testing.T) {
 	})
 }
 
-// TestProcessEvalResults_StateTransitions tests state.Manager's how method ProcessEvalResults processes results and creates or changes states.
+// TestProcessEvalResults_StateTransitions tests how state.Manager's ProcessEvalResults processes results and creates or changes states.
 // In other words, it tests the state transition.
 //
-// The tests use a micro-framework that has few features:
-// 1. It uses a base rule definition and allows each test case mutate its copy
-// 2. Expected State definition omits several fields which are patched before assertion
-// if they are not specified explicitly (see function "patchState" for patched fields).
-// 3. This allows specifications to be more condense and mention only important fields
-// 4. Expected State definition uses some shortcut functions to make the specification more clear.
-// Expected labels are populated from labels map where keys - description of what labels included in its values.
-// This allows to us to specify the list of labels expected to be in the state in one line, e.g. "system + rule + labels1"
-// Evaluations are populated using function `newEvaluation` that pre-set all important fields.
-// 5. Each test case can contain multiple consecutive evaluations at different time and assertions at every interval.
-// The framework offers variables t1, t2, t3 and function tN(n) that provide timestamps of different evaluations.
-// 6. NoData and Error tests require assertions for all possible execution options for the same input.
+// The tests use a micro-framework that has the following features:
+//  1. It uses a base rule definition and allows each test case mutate its copy.
+//  2. Expected State definition omits several fields which are patched before assertion
+//     if they are not specified explicitly (see function "patchState" for patched fields).
+//     This allows specifications to be more condense and mention only important fields.
+//  3. Expected State definition uses some shortcut functions to make the specification more clear.
+//     Expected labels are populated from a labels map where keys = description of what labels included in its values.
+//     This allows us to specify the list of labels expected to be in the state in one line, e.g. "system + rule + labels1"
+//     Evaluations are populated using function `newEvaluation` that pre-set all important fields.
+//  4. Each test case can contain multiple consecutive evaluations at different times with assertions at every interval.
+//     The framework offers variables t1, t2, t3 and function tN(n) that provide timestamps of different evaluations.
+//  5. NoData and Error tests require assertions for all possible execution options for the same input.
 //
-// Naming convention for tests cases.
+// # Naming convention for tests cases.
+//
 // The tests are formatted to the input characteristics, such as rule definition,
 // result format (multi- or single- dimensional) and at which times the assertions are defined.
 //
 // <time>[(<labelSet>:)<eval.State>] (and <rule_modifications>) at <asserted_time>
 //
-//    where
-//      <time> can be t1, t2 or t3, i.e. timestamp of evaluation
-//      <labelSet> indicates a label set of the normal result. It be 1,2,3 which corresponds to labels1, labels2 or labels3 or {} - for result without labels
-//        in the case of NoData or Error it is omitted
-//      <rule_modifications> rule modifications.
-//      <asserted_time> at which time intervals the test executes assertions. Can be t1,t2 or t3
+//	Where:
+//	  - <time> can be t1, t2 or t3, i.e. timestamp of evaluation.
+//	  - <labelSet> indicates the label set of the normal result. It can be 1,2,3 which corresponds to labels1, labels2 and labels3, or {} for results without labels.
+//	    In the case of NoData or Error labelSet is omitted
+//	  - <rule_modifications> rule modifications.
+//	  - <asserted_time> at which time intervals the test executes assertions. Can be t1,t2 or t3.
 //
 // For example:
 //
-//     t1[1:normal] t2[1:alerting] and 'for'=2 at t2
-//     t1[{}:alerting] t2[{}:normal] t3[NoData] at t2,t3
-//
+//	t1[1:normal] t2[1:alerting] and 'for'=2 at t2
+//	t1[{}:alerting] t2[{}:normal] t3[NoData] at t2,t3
 func TestProcessEvalResults_StateTransitions(t *testing.T) {
 	evaluationDuration := 10 * time.Millisecond
 	evaluationInterval := 10 * time.Second


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds more tests for ProcessEvalResults.  The new tests assert StateTransitions instead of the internal state of the manager. This allows to assert state changes at every evaluation interval.

Tests are split into 3 categories:
- normal transitions.
- no-data, where each test is evaluated against all possible values of execution of NoData
- error, where each test is evaluated against all possible values of execution of Error
All categories of tests check two kinds of results: with labels (i.e. multi-dimensional) and ones without labels (i.e. classic-condition). 

Test description does not include the desired result because I could not figure out some succinct description for many of tests. So, the description just mentions what evaluation results and rule mutations are applied.
I decided to encode the difference between multi- and single- dimension evaluation results in the test description. 
- Multi-dimensional results are described with the result's state wrapped in square brackets, e.g. `[normal]`
- Classic condition results are described as just state, e.g `normal`


**Why do we need this feature?**
Increase coverage of the tests + test logic against real input data and different execution of exceptional states.

**Who is this feature for?**
Developers

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

- The test function begins with a description of a small framework that I wrote to make test cases more brief and contain only important information.

- Each test supports multiple evaluation intervals. After each evaluation, the result of ProcessEvalResults can be asserted. However, this is not mandatory. The test framework supports assertion for any timestamp. For example
```

{
			results: map[time.Time]eval.Results{
				t1: {
					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
				},
				t2: {
					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
				},
				t3: {
					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
				},
			},
			expectedTransitions: map[time.Time][]StateTransition{
				t1: {
					...
				},
				t3: {
                    ...
				},
			},
		},
```

will not assert state transitions at timestamp `t2`.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
