### PR TITLE
Logs: Fix displaying the wrong field as body

### DIFF
--- a/packages/grafana-data/src/dataframe/FieldCache.test.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.test.ts
@@ -100,4 +100,22 @@ describe('FieldCache', () => {
       expect(field!.index).toEqual(2);
     });
   });
+
+  describe('getFirstFieldOfType', () => {
+    let fieldCache: FieldCache;
+    beforeEach(() => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      });
+      fieldCache = new FieldCache(frame);
+    });
+
+    it('should return undefined if type is not present', () => {
+      const field = fieldCache.getFirstFieldOfType(FieldType.string);
+      expect(field).toBeUndefined();
+    });
+  });
 });

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -59,7 +59,7 @@ export class FieldCache {
 
   getFirstFieldOfType(type: FieldType, includeHidden = false): FieldWithIndex | undefined {
     const fields = this.fieldByType[type];
-    const firstField = fields.find((field) => includeHidden || !field.config.custom?.hidden);
+    const firstField = fields?.find((field) => includeHidden || !field.config.custom?.hidden);
     return firstField;
   }
 

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import saveAs from 'file-saver';
 import React, { ComponentProps } from 'react';
 
-import { LogLevel, LogsDedupStrategy, MutableDataFrame } from '@grafana/data';
+import { FieldType, LogLevel, LogsDedupStrategy, toDataFrame } from '@grafana/data';
 
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';
 import { logRowsToReadableJson } from '../../logs/utils';
@@ -150,7 +150,24 @@ describe('LogsMetaRow', () => {
       {
         rowIndex: 1,
         entryFieldIndex: 0,
-        dataFrame: new MutableDataFrame(),
+        dataFrame: toDataFrame({
+          name: 'logs',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: ['1970-01-01T00:00:00Z'],
+            },
+            {
+              name: 'message',
+              type: FieldType.string,
+              values: ['INFO 1'],
+              labels: {
+                foo: 'bar',
+              },
+            },
+          ],
+        }),
         entry: 'test entry',
         hasAnsi: false,
         hasUnescapedContent: false,

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -34,8 +34,8 @@ function makeLabelsGetter(
 
 export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
   const cache = new FieldCache(frame);
-  const timeField = cache.getFields(FieldType.time)[0];
-  const bodyField = cache.getFields(FieldType.string)[0];
+  const timeField = cache.getFirstFieldOfType(FieldType.time);
+  const bodyField = cache.getFirstFieldOfType(FieldType.string);
 
   // these two are mandatory
   if (timeField === undefined || bodyField === undefined) {

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -186,6 +186,31 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result!.getAttributes()).toBeNull();
     expect(result?.extraFields).toStrictEqual([]);
   });
+
+  it('should parse an old-style frame with a hidden string field', () => {
+    const time = makeTime('Time', [1687185711795, 1687185711995]);
+    const hidden = makeString('Hidden', ['hidden1', 'hidden2']);
+    const line = makeString('Line', ['line1', 'line2']);
+
+    hidden.config.custom = {
+      hidden: true,
+    };
+
+    const result = parseLogsFrame({
+      fields: [time, hidden, line],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.severityField).toBeNull();
+    expect(result!.idField).toBeNull();
+    expect(result!.timeNanosecondField).toBeNull();
+    expect(result!.getAttributesAsLabels()).toBeNull();
+    expect(result!.getAttributes()).toBeNull();
+  });
 });
 
 describe('attributesToLabels', () => {


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/70318 we changed the way how to parse logs frames. Unfortunately we missed excluding hidden fields when determining which field to display as logs body.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/7003

**Special notes for your reviewer:**

Use the following DataFrame with a testdatasource to test and you should see `THIS IS THE LOG LINE's BODY` as the log line's body.

```json
[
  {
    "schema": {
      "refId": "A",
      "meta": {
        "typeVersion": [
          0,
          0
        ],
        "custom": {
          "Status": "Complete"
        },
        "stats": [
        ],
        "preferredVisualisationType": "logs"
      },
      "name": "A",
      "fields": [
        {
          "name": "@timestamp",
          "type": "time",
          "typeInfo": {
            "frame": "time.Time",
            "nullable": true
          }
        },
        {
          "name": "hidden1",
          "type": "string",
          "typeInfo": {
            "frame": "string",
            "nullable": true
          },
          "config": {
            "custom": {
              "hidden": true
            }
          }
        },
        {
          "name": "body",
          "type": "string",
          "typeInfo": {
            "frame": "string",
            "nullable": true
          }
        }
      ]
    },
    "data": {
      "values": [
        [
          1691476785757
        ],
        [
          "THIS IS NOT THE BODY"
        ],
        [
          "THIS IS THE LOG LINE's BODY"
        ]
      ]
    }
  }
]
```