### PR TITLE
Docs: Update screenshots for generating an access token for signing a plugin

### DIFF
--- a/docs/sources/developers/plugins/publish-a-plugin/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/publish-a-plugin/sign-a-plugin.md
@@ -39,13 +39,13 @@ To verify ownership of your plugin, generate an access token that you'll use eve
    Realm: has to be your-org-name (all-stacks)
    Scope: plugins:write
 
-   {{< figure src="/static/img/docs/plugins/create-access-policy.png" class="docs-image--no-shadow" max-width="650px" >}}
+   {{< figure src="/media/docs/plugins/create-access-policy-v2.png" class="docs-image--no-shadow" max-width="650px" >}}
 
 1. Click **Create token** to create a new token.
 
    The expiration date field is optional, though you should change tokens periodically for increased security.
 
-   {{< figure src="/static/img/docs/plugins/create-access-policy-token.png" class="docs-image--no-shadow" max-width="650px" >}}
+   {{< figure src="/media/docs/plugins/create-access-policy-token.png" class="docs-image--no-shadow" max-width="650px" >}}
 
 1. Click **Create** and save a copy of the token somewhere secure for future reference.
 


### PR DESCRIPTION
**What is this feature?**
Update screenshots for generating an access token for signing a plugin in docs

**Why do we need this feature?**
because of the new location of uploading screenshots. from `/static` to `/media`
and one screenshot was changed, because it contained my name