### PR TITLE
Navigation: Remove "preview" from Pyroscope Profiles nav item

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -254,7 +254,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
 		"grafana-k8s-app":                  {SectionID: navtree.NavIDMonitoring, SortWeight: 1, Text: "Kubernetes"},
 		"grafana-app-observability-app":    {SectionID: navtree.NavIDMonitoring, SortWeight: 2, Text: "Application (preview)"},
-		"grafana-pyroscope-app":            {SectionID: navtree.NavIDMonitoring, SortWeight: 3, Text: "Profiles (preview)"},
+		"grafana-pyroscope-app":            {SectionID: navtree.NavIDMonitoring, SortWeight: 3, Text: "Profiles"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDMonitoring, SortWeight: 4, Text: "Frontend"},
 		"grafana-synthetic-monitoring-app": {SectionID: navtree.NavIDMonitoring, SortWeight: 5, Text: "Synthetics"},
 		"grafana-oncall-app":               {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 1, Text: "OnCall"},

--- a/public/app/core/components/AppChrome/MegaMenu/navBarItem-translations.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navBarItem-translations.ts
@@ -131,7 +131,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'plugin-page-grafana-app-observability-app':
       return t('nav.application.title', 'Application (preview)');
     case 'plugin-page-grafana-pyroscope-app':
-      return t('nav.profiles.title', 'Profiles (preview)');
+      return t('nav.profiles.title', 'Profiles');
     case 'plugin-page-grafana-kowalski-app':
       return t('nav.frontend.title', 'Frontend');
     case 'plugin-page-grafana-synthetic-monitoring-app':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -454,7 +454,7 @@
       "title": "Profile"
     },
     "profiles": {
-      "title": "Profiles (preview)"
+      "title": "Profiles"
     },
     "public": {
       "title": "Public dashboards"

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -454,7 +454,7 @@
       "title": "Přőƒįľę"
     },
     "profiles": {
-      "title": "Přőƒįľęş (přęvįęŵ)"
+      "title": "Přőƒįľęş"
     },
     "public": {
       "title": "Pūþľįč đäşĥþőäřđş"


### PR DESCRIPTION
Follow up to [Navigation: puts Profiles app under Observability](https://github.com/grafana/grafana/pull/69973) PR — We're getting to GA, so removing the "preview" part.

[Relevant slack thread](https://raintank-corp.slack.com/archives/C0556N2KHTP/p1691523812107449)