### PR TITLE
Add pan and zoom to canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -411,6 +411,7 @@
     "react-virtualized-auto-sizer": "1.0.7",
     "react-window": "1.8.9",
     "react-window-infinite-loader": "1.0.9",
+    "react-zoom-pan-pinch": "^3.1.0",
     "redux": "4.2.1",
     "redux-thunk": "2.4.2",
     "regenerator-runtime": "0.13.11",

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -15,9 +15,10 @@ import { getElementTypes, onAddItem } from '../utils';
 type Props = {
   scene: Scene;
   panel: CanvasPanel;
+  visibleFun: (v: boolean) => void;
 };
 
-export const CanvasContextMenu = ({ scene, panel }: Props) => {
+export const CanvasContextMenu = ({ scene, panel, visibleFun }: Props) => {
   const inlineEditorOpen = panel.state.openInlineEdit;
   const [isMenuVisible, setIsMenuVisible] = useState<boolean>(false);
   const [anchorPoint, setAnchorPoint] = useState<AnchorPoint>({ x: 0, y: 0 });
@@ -29,7 +30,7 @@ export const CanvasContextMenu = ({ scene, panel }: Props) => {
 
   const handleContextMenu = useCallback(
     (event: Event) => {
-      if (!(event instanceof MouseEvent)) {
+      if (!(event instanceof MouseEvent) || event.ctrlKey) {
         return;
       }
 
@@ -45,8 +46,9 @@ export const CanvasContextMenu = ({ scene, panel }: Props) => {
       }
       setAnchorPoint({ x: event.pageX, y: event.pageY });
       setIsMenuVisible(true);
+      visibleFun(true);
     },
-    [scene, panel]
+    [scene, panel, visibleFun]
   );
 
   useEffect(() => {
@@ -65,6 +67,7 @@ export const CanvasContextMenu = ({ scene, panel }: Props) => {
 
   const closeContextMenu = () => {
     setIsMenuVisible(false);
+    visibleFun(false);
   };
 
   const renderMenuItems = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19555,6 +19555,7 @@ __metadata:
     react-virtualized-auto-sizer: 1.0.7
     react-window: 1.8.9
     react-window-infinite-loader: 1.0.9
+    react-zoom-pan-pinch: ^3.1.0
     redux: 4.2.1
     redux-mock-store: 1.5.4
     redux-thunk: 2.4.2
@@ -28195,6 +28196,16 @@ __metadata:
     react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: cefa232f4f37269d292529ef15780fb108123d6bb5beee19eeac657e75cf8d4664be66f2da04baf0cb1bc64c5ab3d83a88199c3358f023b78940acd37b0673b2
+  languageName: node
+  linkType: hard
+
+"react-zoom-pan-pinch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "react-zoom-pan-pinch@npm:3.1.0"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 3289cd01edd207697c97303c217e91fe137e3469c39ff54ab51cb17ff8bf8a045b95fb2cc4692b826da2ae69b045589e093e9e561225b696bbc18da95e852242
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add basic pan and zoom to canvas.

Zoom with mouse wheel. Pan with middle mouse or ctrl+right mouse. Disabled when context menu is open. Double click to reset.

![Aug-08-2023 19-06-32](https://github.com/grafana/grafana/assets/60050885/7ef1d7e5-68fe-441e-8dcb-d26b4219cdc1)

Closes #72937, #72939