### PR TITLE
DataSourceProxy: Fix url validation error handling

### DIFF
--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -122,7 +122,8 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqConte
 	proxy, err := pluginproxy.NewDataSourceProxy(ds, plugin.Routes, c, proxyPath, p.Cfg, p.HTTPClientProvider,
 		p.OAuthTokenService, p.DataSourcesService, p.tracer)
 	if err != nil {
-		if errors.Is(err, datasource.URLValidationError{}) {
+		var urlValidationError datasource.URLValidationError
+		if errors.As(err, &urlValidationError) {
 			c.JsonApiErr(http.StatusBadRequest, fmt.Sprintf("Invalid data source URL: %q", ds.URL), err)
 		} else {
 			c.JsonApiErr(http.StatusInternalServerError, "Failed creating data source proxy", err)

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -1,9 +1,22 @@
 package datasourceproxy
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/manager/fakes"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDataProxy(t *testing.T) {
@@ -51,4 +64,75 @@ func TestDataProxy(t *testing.T) {
 			})
 		}
 	})
+}
+
+// Tests request to datasource proxy service
+func TestDatasourceProxy_proxyDatasourceRequest(t *testing.T) {
+	tcs := []struct {
+		name             string
+		dsURL            string
+		expectedErrorMsg string
+	}{
+		{
+			name:             "Empty datasource URL will return a 400 HTTP status code",
+			dsURL:            "",
+			expectedErrorMsg: "validation of data source URL \"\" failed: empty URL string",
+		},
+		{
+			name:             "Invalid datasource URL will return a 400 HTTP status code",
+			dsURL:            "://host/path",
+			expectedErrorMsg: "validation of data source URL \"://host/path\" failed: parse \"://host/path\": missing protocol scheme",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pluginID := datasources.DS_PROMETHEUS
+
+			pluginStore := &fakes.FakePluginStore{PluginList: []plugins.PluginDTO{
+				{JSONData: plugins.JSONData{ID: pluginID}},
+			}}
+
+			p := DataSourceProxyService{
+				PluginRequestValidator: &fakePluginRequestValidator{},
+				pluginStore:            pluginStore,
+			}
+
+			responseRecorder := httptest.NewRecorder()
+			c := &contextmodel.ReqContext{
+				Context: &web.Context{
+					Req:  &http.Request{URL: &url.URL{}},
+					Resp: web.NewResponseWriter("GET", responseRecorder),
+				},
+				Logger: log.NewNopLogger(),
+			}
+
+			p.proxyDatasourceRequest(c, &datasources.DataSource{
+				Type: pluginID,
+				URL:  tc.dsURL,
+			})
+
+			resp := responseRecorder.Result()
+			body := resp.Body
+			defer func() {
+				require.NoError(t, body.Close())
+			}()
+
+			b, err := io.ReadAll(body)
+			require.NoError(t, err)
+
+			jsonBody := make(map[string]string)
+			err = json.Unmarshal(b, &jsonBody)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.Equal(t, fmt.Sprintf("Invalid data source URL: %q", tc.dsURL), jsonBody["message"])
+			require.Equal(t, tc.expectedErrorMsg, jsonBody["error"])
+		})
+	}
+}
+
+type fakePluginRequestValidator struct{}
+
+func (rv *fakePluginRequestValidator) Validate(_ string, _ *http.Request) error {
+	return nil
 }

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -113,12 +113,10 @@ func TestDatasourceProxy_proxyDatasourceRequest(t *testing.T) {
 
 			resp := responseRecorder.Result()
 			body := resp.Body
-			defer func() {
-				require.NoError(t, body.Close())
-			}()
 
 			b, err := io.ReadAll(body)
 			require.NoError(t, err)
+			require.NoError(t, body.Close())
 
 			jsonBody := make(map[string]string)
 			err = json.Unmarshal(b, &jsonBody)


### PR DESCRIPTION
**What is this feature?**

Fixes error handling during url validation in data source proxy service.

**Why do we need this feature?**

Without this fix even if url validation fails it will fall into the else case and return a generic 500 status code, even though a 400 status code is expected.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #73032

**Special notes for your reviewer:**

Another way of fixing this would be by adding the `Is` method in `pkg/api/datasource/validation.go`.
Also let me know if I should add any tests. I'm not sure if I should add any to `datasourceproxy.go` or create a test file for `validation.go`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
