### PR TITLE
Alerting: optimize rules with multiple loki range queries

### DIFF
--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -72,7 +72,7 @@ func canBeInstant(r *models.AlertRule) ([]int, bool) {
 	return optimizableIndices, canBeOptimized
 }
 
-// migrateToInstant will move for the provided indices from a range-query to an instant query. This should only
+// migrateToInstant will move the provided indices from a range-query to an instant query. This should only
 // be used for loki.
 func migrateToInstant(r *models.AlertRule, optimizableIndices []int) error {
 	for _, lokiQueryIndex := range optimizableIndices {

--- a/pkg/services/ngalert/store/loki_range_to_instant.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant.go
@@ -19,57 +19,74 @@ func (t dsType) isLoki() bool {
 	return t.DS.Type == datasources.DS_LOKI
 }
 
-func canBeInstant(r *models.AlertRule) bool {
+// canBeInstant checks if any of the query nodes that are loki range queries can be migrated to instant queries.
+// If any are migratable, those indices are returned.
+func canBeInstant(r *models.AlertRule) ([]int, bool) {
 	if len(r.Data) < 2 {
-		return false
+		return nil, false
 	}
-	// First query part should be range query.
-	if r.Data[0].QueryType != "range" {
-		return false
-	}
+	var (
+		optimizableIndices []int
+		canBeOptimized     = false
+	)
+	// Loop over query nodes to find all Loki range queries.
+	for i := range r.Data {
+		if r.Data[i].QueryType != "range" {
+			continue
+		}
+		var t dsType
+		// We can ignore the error here, the query just won't be optimized.
+		_ = json.Unmarshal(r.Data[i].Model, &t)
 
-	var t dsType
-	// We can ignore the error here, the query just won't be optimized.
-	_ = json.Unmarshal(r.Data[0].Model, &t)
-
-	if !t.isLoki() {
-		return false
+		if !t.isLoki() {
+			continue
+		}
+		var reduceIndex int
+		// Loop over all query nodes to find the reduce node.
+		for ii := range r.Data {
+			// Second query part should be and expression.
+			if !expr.IsDataSource(r.Data[ii].DatasourceUID) {
+				continue
+			}
+			exprRaw := make(map[string]interface{})
+			if err := json.Unmarshal(r.Data[ii].Model, &exprRaw); err != nil {
+				continue
+			}
+			// Second query part should be "last()"
+			if val, ok := exprRaw["reducer"].(string); !ok || val != "last" {
+				continue
+			}
+			// Second query part should use first query part as expression.
+			if ref, ok := exprRaw["expression"].(string); !ok || ref != r.Data[i].RefID {
+				continue
+			}
+			reduceIndex = ii
+			break
+		}
+		// If we found a reduce node that uses last, we can add the loki query to the optimizations.
+		if reduceIndex != 0 {
+			canBeOptimized = true
+			optimizableIndices = append(optimizableIndices, i)
+		}
 	}
-
-	exprRaw := make(map[string]interface{})
-	if err := json.Unmarshal(r.Data[1].Model, &exprRaw); err != nil {
-		return false
-	}
-
-	// Second query part should be and expression.
-	if !expr.IsDataSource(r.Data[1].DatasourceUID) {
-		return false
-	}
-
-	// Second query part should be "last()"
-	if val, ok := exprRaw["reducer"].(string); !ok || val != "last" {
-		return false
-	}
-	// Second query part should use first query part as expression.
-	if ref, ok := exprRaw["expression"].(string); !ok || ref != r.Data[0].RefID {
-		return false
-	}
-	return true
+	return optimizableIndices, canBeOptimized
 }
 
-// migrateToInstant will move a range-query to an instant query. This should only
+// migrateToInstant will move for the provided indices from a range-query to an instant query. This should only
 // be used for loki.
-func migrateToInstant(r *models.AlertRule) error {
-	modelRaw := make(map[string]interface{})
-	if err := json.Unmarshal(r.Data[0].Model, &modelRaw); err != nil {
-		return err
+func migrateToInstant(r *models.AlertRule, optimizableIndices []int) error {
+	for _, lokiQueryIndex := range optimizableIndices {
+		modelRaw := make(map[string]interface{})
+		if err := json.Unmarshal(r.Data[lokiQueryIndex].Model, &modelRaw); err != nil {
+			return err
+		}
+		modelRaw["queryType"] = "instant"
+		model, err := json.Marshal(modelRaw)
+		if err != nil {
+			return err
+		}
+		r.Data[lokiQueryIndex].Model = model
+		r.Data[lokiQueryIndex].QueryType = "instant"
 	}
-	modelRaw["queryType"] = "instant"
-	model, err := json.Marshal(modelRaw)
-	if err != nil {
-		return err
-	}
-	r.Data[0].Model = model
-	r.Data[0].QueryType = "instant"
 	return nil
 }

--- a/pkg/services/ngalert/store/loki_range_to_instant_test.go
+++ b/pkg/services/ngalert/store/loki_range_to_instant_test.go
@@ -97,20 +97,7 @@ func TestCanBeInstant(t *testing.T) {
 func TestMigrateLokiQueryToInstant(t *testing.T) {
 	original := createMigrateableLokiRule(t)
 	mirgrated := createMigrateableLokiRule(t, func(r *models.AlertRule) {
-		r.Data[0].QueryType = "instant"
-		r.Data[0].Model = []byte(`{
-			"datasource": {
-				"type": "loki",
-				"uid": "grafanacloud-logs"
-			},
-			"editorMode": "code",
-			"expr": "1",
-			"hide": false,
-			"intervalMs": 1000,
-			"maxDataPoints": 43200,
-			"queryType": "instant",
-			"refId": "A"
-		}`)
+		r.Data[0] = lokiQuery(t, "A", "instant", "grafanacloud-logs")
 	})
 
 	optimizableIndices, canBeOptimized := canBeInstant(original)


### PR DESCRIPTION
This PR optimizes the Loki queries in the alert rules further. 

After rolling out the latest version we saw that some customers are using RED-Like queries with multiple Loki queries in one rule (one for request rate, one for error rate). 

The initial implementation always assumed that there is only one Loki query, and it was mapped with its reducer as the first and second query node. That is not true for those advanced users. 

This change does detect any Loki query, at any place in the model and will check against its reducer, if any is present.