### PR TITLE
Dashboards: Add support for spanset combining operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",
     "@grafana/lezer-logql": "0.1.8",
-    "@grafana/lezer-traceql": "0.0.4",
+    "@grafana/lezer-traceql": "0.0.5",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "0.22.0",

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -237,6 +237,17 @@ describe('CompletionProvider', () => {
       )
     );
   });
+
+  it('suggests spanset combining operators after spanset selector', async () => {
+    const { provider, model } = setup('{.foo=300} ', 11, v1Tags);
+    const result = await provider.provideCompletionItems(
+      model as unknown as monacoTypes.editor.ITextModel,
+      {} as monacoTypes.Position
+    );
+    expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
+      CompletionProvider.spansetOps.map((s) => expect.objectContaining({ label: s, insertText: s }))
+    );
+  });
 });
 
 function setup(value: string, offset: number, tagsV1?: string[], tagsV2?: Scope[]) {

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -17,6 +17,8 @@ interface Props {
 /**
  * Class that implements CompletionItemProvider interface and allows us to provide suggestion for the Monaco
  * autocomplete system.
+ *
+ * Please refer to https://grafana.com/docs/tempo/latest/traceql for the syntax of TraceQL.
  */
 export class CompletionProvider implements monacoTypes.languages.CompletionItemProvider {
   languageProvider: TempoLanguageProvider;
@@ -28,8 +30,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
   }
 
   triggerCharacters = ['{', '.', '[', '(', '=', '~', ' ', '"'];
+
+  // Operators
   static readonly operators: string[] = ['=', '-', '+', '<', '>', '>=', '<=', '=~'];
   static readonly logicalOps: string[] = ['&&', '||'];
+  static readonly comparisonOps: string[] = ['=', '!=', '>', '>=', '<', '<=', '=~', '!~'];
+  static readonly structuralOps: string[] = ['>> ', '>', '~'];
+  static readonly spansetOps: string[] = ['|', ...CompletionProvider.logicalOps, ...CompletionProvider.structuralOps];
 
   // We set these directly and ae required for the provider to function.
   monaco: Monaco | undefined;
@@ -127,6 +134,12 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
         return this.getTagsCompletions(undefined, situation.scope);
       case 'SPANSET_EXPRESSION_OPERATORS':
         return [...CompletionProvider.logicalOps, ...CompletionProvider.operators].map((key) => ({
+          label: key,
+          insertText: key,
+          type: 'OPERATOR',
+        }));
+      case 'SPANSET_COMBINING_OPERATORS':
+        return CompletionProvider.spansetOps.map((key) => ({
           label: key,
           insertText: key,
           type: 'OPERATOR',

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -6,7 +6,7 @@
 // and we do not want to go higher than our node
 import { SyntaxNode, Tree } from '@lezer/common';
 
-import { AttributeField, FieldExpression, FieldOp, parser, SpansetFilter } from '@grafana/lezer-traceql';
+import { AttributeField, FieldExpression, FieldOp, parser, SpansetFilter, TraceQL } from '@grafana/lezer-traceql';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling' | 'prevSibling';
 type NodeType = number;
@@ -40,6 +40,9 @@ export type Situation =
     }
   | {
       type: 'SPANSET_AFTER_VALUE';
+    }
+  | {
+      type: 'SPANSET_COMBINING_OPERATORS';
     };
 
 type Path = Array<[Direction, NodeType[]]>;
@@ -154,6 +157,14 @@ const RESOLVERS: Resolver[] = [
   {
     path: [SpansetFilter],
     fun: resolveSpanset,
+  },
+  {
+    path: [TraceQL],
+    fun: () => {
+      return {
+        type: 'SPANSET_COMBINING_OPERATORS',
+      };
+    },
   },
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3868,12 +3868,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@grafana/lezer-traceql@npm:0.0.4"
+"@grafana/lezer-traceql@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@grafana/lezer-traceql@npm:0.0.5"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 69acea33476d3cdabfb99f3eb62bb34289bc205da69920e0eccc82f40407f9d584fa03f9662706ab667ee97d3ea84b964b22a11925e6699deef5afe1ca9e1906
+  checksum: 6fcf48acde1e444c155a4b4009f4c7211843b07960713821a2649b1db0e0ef819fd1062eec101173c2e6b8249b253faf0b6052e96f551663618fd2fe0d17e3c9
   languageName: node
   linkType: hard
 
@@ -19279,7 +19279,7 @@ __metadata:
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1
     "@grafana/lezer-logql": 0.1.8
-    "@grafana/lezer-traceql": 0.0.4
+    "@grafana/lezer-traceql": 0.0.5
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": 0.22.0


### PR DESCRIPTION
**What is this feature?**

Currently, the autocomplete option provider for TraceQL doesn't take into account that we can combine spansets, which is possible by [using these operators](https://grafana.com/docs/tempo/latest/traceql/#combining-spansets). For instance, you can see here that no option is provided after pressing space after the inserted input:
![image](https://github.com/grafana/grafana/assets/135109076/7889194a-9bb9-4f96-bd99-7eaf9b6eceae)

This PR adds the support for spanset operators. Example:
<img width="582" src="https://github.com/grafana/grafana/assets/135109076/664ae461-6704-4d71-9b5c-715cf0c6be3a">


**Which issue(s) does this PR fix?**:

Fixes #73091

**Known limitations**
The change does not work between spansets:
<img width="265" alt="image" src="https://github.com/grafana/grafana/assets/135109076/4f433362-728b-4406-b05c-94a2865d2882">
This is possibly due to a limitation of the grammar:
<img width="1418" alt="image" src="https://github.com/grafana/grafana/assets/135109076/6d0424fd-168c-46ea-8d60-b1f2895dffb0">
