### PR TITLE
Alerting: Add "no-rules" to redirect to rule viewer

### DIFF
--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -59,6 +59,17 @@ describe('Redirect to Rule viewer', () => {
     expect(screen.getAllByText('Cloud test alert')).toHaveLength(2);
   });
 
+  it('should show no rules if empty response', () => {
+    jest.mocked(combinedRuleHooks.useCloudCombinedRulesMatching).mockReturnValue({
+      rules: [],
+      loading: false,
+      error: undefined,
+    });
+    mockRuleSourceByName();
+    renderRedirectToRuleViewer('/alerting/test prom/prom alert/find');
+    expect(screen.getByTestId('no-rules')).toBeInTheDocument();
+  });
+
   it('should redirect to view rule page if only one match', () => {
     jest.mocked(combinedRuleHooks.useCloudCombinedRulesMatching).mockReturnValue({
       rules: [mockedRules[0]],

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
@@ -98,6 +98,17 @@ export function RedirectToRuleViewer(): JSX.Element | null {
     return <Redirect to={to} />;
   }
 
+  if (rules.length === 0) {
+    return (
+      <RuleViewerLayout title={pageTitle}>
+        <div data-testid="no-rules">
+          No rules in <span className={styles.param}>{sourceName}</span> matched the name{' '}
+          <span className={styles.param}>{name}</span>
+        </div>
+      </RuleViewerLayout>
+    );
+  }
+
   return (
     <RuleViewerLayout title={pageTitle}>
       <div>


### PR DESCRIPTION
**What is this feature?**

Adds a "no rules found" message to the `RedirectToRuleViewer` component.