### PR TITLE
Cloud Monitoring: Support AliasBy property in MQL mode

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-// import { act } from 'react-dom/test-utils';
-import TestRenderer from 'react-test-renderer';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
 import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+// import { act } from 'react-dom/test-utils';
+import TestRenderer from 'react-test-renderer';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
 import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';
@@ -63,5 +65,18 @@ describe('MetricQueryEditor', () => {
     render(<MetricQueryEditor {...defaultProps} />);
     const projectDropdown = await screen.findByLabelText('Project');
     expect(projectDropdown).toBeInTheDocument();
+  });
+
+  it('preserves the aliasBy property when switching between Builder and MQL queries', async () => {
+    const query = createMockQuery({ aliasBy: 'AliasTest' });
+    query.queryType = QueryType.TIME_SERIES_LIST;
+
+    render(<MetricQueryEditor {...defaultProps} query={query} />);
+
+    const aliasByInput = await screen.getByLabelText('Alias by');
+    expect(aliasByInput.closest('input')!.value).toEqual('AliasTest');
+
+    query.queryType = QueryType.TIME_SERIES_QUERY;
+    expect(aliasByInput.closest('input')!.value).toEqual('AliasTest');
   });
 });

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { act } from 'react-test-renderer';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
 import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';
@@ -67,14 +68,14 @@ describe('MetricQueryEditor', () => {
 
   it('preserves the aliasBy property when switching between Builder and MQL queries', async () => {
     const query = createMockQuery({ aliasBy: 'AliasTest' });
+    query.queryType = QueryType.TIME_SERIES_QUERY;
+
+    render(<MetricQueryEditor {...defaultProps} query={query} />);
+    await waitFor(() => expect(screen.getByLabelText('Alias by').closest('input')!.value).toEqual('AliasTest'));
+
     query.queryType = QueryType.TIME_SERIES_LIST;
 
     render(<MetricQueryEditor {...defaultProps} query={query} />);
-
-    const aliasByInput = await screen.getByLabelText('Alias by');
-    expect(aliasByInput.closest('input')!.value).toEqual('AliasTest');
-
-    query.queryType = QueryType.TIME_SERIES_QUERY;
-    expect(aliasByInput.closest('input')!.value).toEqual('AliasTest');
+    await waitFor(() => expect(screen.getByLabelText('Alias by').closest('input')!.value).toEqual('AliasTest'));
   });
 });

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { act } from 'react-test-renderer';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
 import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -63,7 +63,6 @@ function Editor({
   );
 
   useEffect(() => {
-    console.log('query', query);
     if (query.queryType === QueryType.TIME_SERIES_LIST && !query.timeSeriesList) {
       onQueryChange({
         refId: query.refId,

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorRows } from '@grafana/experimental';
+import { EditorRows, Stack } from '@grafana/experimental';
 
 import CloudMonitoringDatasource from '../datasource';
 import { AlignmentTypes, CloudMonitoringQuery, QueryType, TimeSeriesList, TimeSeriesQuery } from '../types/query';
 import { CustomMetaData } from '../types/types';
 
+import { AliasBy } from './AliasBy';
 import { GraphPeriod } from './GraphPeriod';
 import { MQLQueryEditor } from './MQLQueryEditor';
 import { Project } from './Project';
@@ -62,12 +63,14 @@ function Editor({
   );
 
   useEffect(() => {
+    console.log('query', query);
     if (query.queryType === QueryType.TIME_SERIES_LIST && !query.timeSeriesList) {
       onQueryChange({
         refId: query.refId,
         datasource: query.datasource,
         queryType: QueryType.TIME_SERIES_LIST,
         timeSeriesList: defaultTimeSeriesList(datasource),
+        aliasBy: query.aliasBy,
       });
     }
     if (query.queryType === QueryType.TIME_SERIES_QUERY && !query.timeSeriesQuery) {
@@ -76,6 +79,7 @@ function Editor({
         datasource: query.datasource,
         queryType: QueryType.TIME_SERIES_QUERY,
         timeSeriesQuery: defaultTimeSeriesQuery(datasource),
+        aliasBy: query.aliasBy,
       });
     }
   }, [onQueryChange, query, datasource]);
@@ -98,13 +102,22 @@ function Editor({
 
       {query.queryType === QueryType.TIME_SERIES_QUERY && query.timeSeriesQuery && (
         <>
-          <Project
-            refId={refId}
-            datasource={datasource}
-            onChange={(projectName) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, projectName: projectName })}
-            templateVariableOptions={variableOptionGroup.options}
-            projectName={query.timeSeriesQuery.projectName!}
-          />
+          <Stack gap={1} direction="row">
+            <Project
+              refId={refId}
+              datasource={datasource}
+              onChange={(projectName) =>
+                onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, projectName: projectName })
+              }
+              templateVariableOptions={variableOptionGroup.options}
+              projectName={query.timeSeriesQuery.projectName!}
+            />
+            <AliasBy
+              refId={refId}
+              value={query.aliasBy}
+              onChange={(aliasBy: string) => onQueryChange({ ...query, aliasBy })}
+            />
+          </Stack>
           <MQLQueryEditor
             onChange={(q: string) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, query: q })}
             onRunQuery={onRunQuery}


### PR DESCRIPTION
Adds support for AliasBy in Builder Mode and preserves AliasBy when switching between MQL and Builder mode.

<img width="1040" alt="Screenshot 2023-08-09 at 9 10 20 AM" src="https://github.com/grafana/grafana/assets/58453566/a580671f-e3ed-45b9-a763-fc835f31d809">

Fixes grafana/support-escalations#7004
