### PR TITLE
AzureMonitor: Allow `serviceTags` and `tags` to be empty for trace results

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
@@ -135,7 +135,7 @@ var tagsConverter = data.FieldConverter{
 			return nil, fmt.Errorf("failed to unmarshal trace tags: %s", err)
 		}
 
-		parsedTags := make([]*KeyValue, 0, len(m)-1)
+		parsedTags := []KeyValue{}
 		for k, v := range m {
 			if v == nil {
 				continue
@@ -152,7 +152,7 @@ var tagsConverter = data.FieldConverter{
 				}
 			}
 
-			parsedTags = append(parsedTags, &KeyValue{Key: k, Value: v})
+			parsedTags = append(parsedTags, KeyValue{Key: k, Value: v})
 		}
 		sort.Slice(parsedTags, func(i, j int) bool {
 			return parsedTags[i].Key < parsedTags[j].Key

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
@@ -90,6 +90,11 @@ func TestTraceTableToFrame(t *testing.T) {
 			testFile:     "traces/2-traces-single-table.json",
 			resultFormat: dataquery.ResultFormatTrace,
 		},
+		{
+			name:         "single trace with empty serviceTags and tags",
+			testFile:     "traces/3-traces-empty-dynamics.json",
+			resultFormat: dataquery.ResultFormatTrace,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tsdb/azuremonitor/testdata/traces/3-traces-empty-dynamics.json
+++ b/pkg/tsdb/azuremonitor/testdata/traces/3-traces-empty-dynamics.json
@@ -1,0 +1,69 @@
+{
+    "tables": [
+      {
+        "name": "PrimaryResult",
+        "columns": [
+          {
+            "name": "traceID",
+            "type": "string"
+          },
+          {
+            "name": "spanID",
+            "type": "string"
+          },
+          {
+            "name": "parentSpanID",
+            "type": "string"
+          },
+          {
+            "name": "duration",
+            "type": "real"
+          },
+          {
+            "name": "serviceName",
+            "type": "string"
+          },
+          {
+            "name": "operationName",
+            "type": "string"
+          },
+          {
+            "name": "startTime",
+            "type": "datetime"
+          },
+          {
+            "name": "serviceTags",
+            "type": "dynamic"
+          },
+          {
+            "name": "tags",
+            "type": "dynamic"
+          },
+          {
+            "name": "itemId",
+            "type": "string"
+          },
+          {
+            "name": "itemType",
+            "type": "string"
+          }
+        ],
+        "rows": [
+          [
+            "cfae497bfd7a44169f35643940820938",
+            "b52403c5-5b27-43a8-9bc6-5938667a4470",
+            "|cfae497bfd7a44169f35643940820938.",
+            0,
+            "",
+            "GET /github/grafana/grafana/commits",
+            "2023-04-17T14:58:10.176Z",
+            "{}",
+            "{}",
+            "65863e6b-dd30-11ed-a808-002248268105",
+            "trace"
+          ]
+        ]
+      }
+    ]
+  }
+  

--- a/pkg/tsdb/azuremonitor/testdata/traces/3-traces-empty-dynamics.json.single-trace-with-empty-serviceTags-and-tags.golden.jsonc
+++ b/pkg/tsdb/azuremonitor/testdata/traces/3-traces-empty-dynamics.json.single-trace-with-empty-serviceTags-and-tags.golden.jsonc
@@ -1,0 +1,192 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "custom": {
+//          "azureColumnTypes": [
+//              "string",
+//              "string",
+//              "string",
+//              "real",
+//              "string",
+//              "string",
+//              "datetime",
+//              "dynamic",
+//              "dynamic",
+//              "string",
+//              "string"
+//          ]
+//      }
+//  }
+//  Name: 
+//  Dimensions: 11 Fields by 1 Rows
+//  +----------------------------------+--------------------------------------+------------------------------------+------------------+-------------------+-------------------------------------+-----------------------------------+--------------------------+--------------------------+--------------------------------------+-----------------+
+//  | Name: traceID                    | Name: spanID                         | Name: parentSpanID                 | Name: duration   | Name: serviceName | Name: operationName                 | Name: startTime                   | Name: serviceTags        | Name: tags               | Name: itemId                         | Name: itemType  |
+//  | Labels:                          | Labels:                              | Labels:                            | Labels:          | Labels:           | Labels:                             | Labels:                           | Labels:                  | Labels:                  | Labels:                              | Labels:         |
+//  | Type: []*string                  | Type: []*string                      | Type: []*string                    | Type: []*float64 | Type: []*string   | Type: []*string                     | Type: []*time.Time                | Type: []*json.RawMessage | Type: []*json.RawMessage | Type: []*string                      | Type: []*string |
+//  +----------------------------------+--------------------------------------+------------------------------------+------------------+-------------------+-------------------------------------+-----------------------------------+--------------------------+--------------------------+--------------------------------------+-----------------+
+//  | cfae497bfd7a44169f35643940820938 | b52403c5-5b27-43a8-9bc6-5938667a4470 | |cfae497bfd7a44169f35643940820938. | 0                |                   | GET /github/grafana/grafana/commits | 2023-04-17 14:58:10.176 +0000 UTC | []                       | []                       | 65863e6b-dd30-11ed-a808-002248268105 | trace           |
+//  +----------------------------------+--------------------------------------+------------------------------------+------------------+-------------------+-------------------------------------+-----------------------------------+--------------------------+--------------------------+--------------------------------------+-----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "custom": {
+            "azureColumnTypes": [
+              "string",
+              "string",
+              "string",
+              "real",
+              "string",
+              "string",
+              "datetime",
+              "dynamic",
+              "dynamic",
+              "string",
+              "string"
+            ]
+          }
+        },
+        "fields": [
+          {
+            "name": "traceID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "spanID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "parentSpanID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "duration",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "serviceName",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "operationName",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "startTime",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "serviceTags",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage",
+              "nullable": true
+            }
+          },
+          {
+            "name": "tags",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage",
+              "nullable": true
+            }
+          },
+          {
+            "name": "itemId",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "itemType",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "cfae497bfd7a44169f35643940820938"
+          ],
+          [
+            "b52403c5-5b27-43a8-9bc6-5938667a4470"
+          ],
+          [
+            "|cfae497bfd7a44169f35643940820938."
+          ],
+          [
+            0
+          ],
+          [
+            ""
+          ],
+          [
+            "GET /github/grafana/grafana/commits"
+          ],
+          [
+            1681743490176
+          ],
+          [
+            []
+          ],
+          [
+            []
+          ],
+          [
+            "65863e6b-dd30-11ed-a808-002248268105"
+          ],
+          [
+            "trace"
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is a fix for a bug where if `serviceTags` or `tags` is empty the query would fail. This change will return an empty array instead.