### PR TITLE
Instrumentation: Improve instrumentation for database migrations

### DIFF
--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -487,6 +487,6 @@ func setupEnv(t *testing.T, sqlStore *sqlstore.SQLStore, b bus.Bus, quotaService
 		annotationstest.NewFakeAnnotationsRepo(), &pluginFakes.FakePluginStore{}, tracer, ruleStore,
 	)
 	require.NoError(t, err)
-	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), sqlStore.Cfg, quotaService, storesrv.ProvideSystemUsersService())
+	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), sqlStore.Cfg, quotaService, storesrv.ProvideSystemUsersService(), tracing.InitializeTracerForTest())
 	require.NoError(t, err)
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
@@ -12,6 +12,7 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -211,7 +212,7 @@ func TestMigrations(t *testing.T) {
 			require.NoError(t, errDeleteMig)
 
 			// Run accesscontrol migration (permissions insertion should not have conflicted)
-			acmigrator := migrator.NewMigrator(x, tc.config)
+			acmigrator := migrator.NewMigrator(x, tc.config, tracing.InitializeTracerForTest())
 			acmig.AddTeamMembershipMigrations(acmigrator)
 
 			errRunningMig := acmigrator.Start(false, 0)
@@ -262,7 +263,7 @@ func setupTestDB(t *testing.T) *xorm.Engine {
 	mg := migrator.NewMigrator(x, &setting.Cfg{
 		Logger: log.New("acmigration.test"),
 		Raw:    ini.Empty(),
-	})
+	}, tracing.InitializeTracerForTest())
 	migrations := &migrations.OSSMigrations{}
 	migrations.AddMigration(mg)
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/action_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/action_migrator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
@@ -210,7 +211,7 @@ func TestActionMigration(t *testing.T) {
 			}
 
 			// Run RBAC action name migration
-			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")}, tracing.InitializeTracerForTest())
 			acmig.AddActionNameMigrator(acmigrator)
 
 			errRunningMig := acmigrator.Start(false, 0)

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -10,6 +10,7 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -157,7 +158,7 @@ func TestManagedPermissionsMigration(t *testing.T) {
 			putTestPermissions(t, x, tc.putRolePerms)
 
 			// Run accesscontrol migration (permissions insertion should not have conflicted)
-			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")}, tracing.InitializeTracerForTest())
 			acmig.AddManagedPermissionsMigration(acmigrator, acmig.ManagedPermissionsMigrationID)
 
 			errRunningMig := acmigrator.Start(false, 0)
@@ -215,7 +216,7 @@ func TestManagedPermissionsMigrationRunTwice(t *testing.T) {
 				}
 
 				// Run accesscontrol migration (permissions insertion should not have conflicted)
-				acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+				acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")}, tracing.InitializeTracerForTest())
 				acmig.AddManagedPermissionsMigration(acmigrator, acmig.ManagedPermissionsMigrationID+fmt.Sprint(i))
 
 				errRunningMig := acmigrator.Start(false, 0)

--- a/pkg/services/sqlstore/migrations/ualert/migration_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/migration_test.go
@@ -15,6 +15,7 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/alerting/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -114,7 +115,7 @@ func TestAddDashAlertMigration(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			mg := migrator.NewMigrator(x, tt.config)
+			mg := migrator.NewMigrator(x, tt.config, tracing.InitializeTracerForTest())
 
 			ualert.AddDashAlertMigration(mg)
 			require.Equal(t, tt.expected, mg.GetMigrationIDs(false))
@@ -630,7 +631,7 @@ func setupTestDB(t *testing.T) *xorm.Engine {
 	err = migrator.NewDialect(x.DriverName()).CleanDB(x)
 	require.NoError(t, err)
 
-	mg := migrator.NewMigrator(x, &setting.Cfg{Raw: ini.Empty()})
+	mg := migrator.NewMigrator(x, &setting.Cfg{Raw: ini.Empty()}, tracing.InitializeTracerForTest())
 	migrations := &migrations.OSSMigrations{}
 	migrations.AddMigration(mg)
 
@@ -765,7 +766,7 @@ func runDashAlertMigrationTestRun(t *testing.T, x *xorm.Engine) {
 	_, errDeleteMig := x.Exec("DELETE FROM migration_log WHERE migration_id = ?", ualert.MigTitle)
 	require.NoError(t, errDeleteMig)
 
-	alertMigrator := migrator.NewMigrator(x, &setting.Cfg{})
+	alertMigrator := migrator.NewMigrator(x, &setting.Cfg{}, tracing.InitializeTracerForTest())
 	alertMigrator.AddMigration(ualert.RmMigTitle, &ualert.RmMigration{})
 	ualert.AddDashAlertMigration(alertMigrator)
 

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -55,7 +55,7 @@ func (e MigrationError) Error() string {
 func (e *MigrationError) Unwrap() error { return e.Err }
 
 func AddDashAlertMigration(mg *migrator.Migrator) {
-	logs, err := mg.GetMigrationLog()
+	logs, err := mg.GetMigrationLog(context.TODO())
 	if err != nil {
 		mg.Logger.Error("alert migration failure: could not get migration log", "error", err)
 		os.Exit(1)
@@ -105,7 +105,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 // RerunDashAlertMigration force the dashboard alert migration to run
 // to make sure that the Alertmanager configurations will be created for each organisation
 func RerunDashAlertMigration(mg *migrator.Migrator) {
-	logs, err := mg.GetMigrationLog()
+	logs, err := mg.GetMigrationLog(context.TODO())
 	if err != nil {
 		mg.Logger.Error("alert migration failure: could not get migration log", "error", err)
 		os.Exit(1)
@@ -126,7 +126,7 @@ func RerunDashAlertMigration(mg *migrator.Migrator) {
 }
 
 func AddDashboardUIDPanelIDMigration(mg *migrator.Migrator) {
-	logs, err := mg.GetMigrationLog()
+	logs, err := mg.GetMigrationLog(context.TODO())
 	if err != nil {
 		mg.Logger.Error("alert migration failure: could not get migration log", "error", err)
 		os.Exit(1)

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -136,7 +136,7 @@ func (ss *SQLStore) Migrate(isDatabaseLockingEnabled bool) error {
 		return nil
 	}
 
-	migrator := migrator.NewMigrator(ss.engine, ss.Cfg)
+	migrator := migrator.NewMigrator(ss.engine, ss.Cfg, ss.tracer)
 	ss.migrations.AddMigration(migrator)
 
 	return migrator.Start(isDatabaseLockingEnabled, ss.dbCfg.MigrationLockAttemptTimeout)

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/filestorage"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -98,13 +99,14 @@ func ProvideService(
 	cfg *setting.Cfg,
 	quotaService quota.Service,
 	systemUsersService SystemUsers,
+	tracer tracing.Tracer,
 ) (StorageService, error) {
 	settings, err := LoadStorageConfig(cfg, features)
 	if err != nil {
 		grafanaStorageLogger.Warn("error loading storage config", "error", err)
 	}
 
-	if err := migrations.MigrateEntityStore(sql, features); err != nil {
+	if err := migrations.MigrateEntityStore(sql, features, tracer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What is this feature?**

Improve instrumentation for database migrations. 

Experimented with both creating a span for each migration and recording events for each migration. Running migrations for a new Grafana instance creates a rather big trace which might be a problem? 

Span for each migration: 
1678 spans. Note in the first screenshot below it didn't record all the spans, but in the second one it did so feels a bit unstable. I was using Jaeger with UDP and that might be the problem?

![image](https://github.com/grafana/grafana/assets/1668778/96c7eaeb-6c13-4642-a755-c6da9ec0d966)

![image](https://github.com/grafana/grafana/assets/1668778/f164467d-915d-4626-99eb-718cee8e088c)

Span events for each migration:
~1100 spans. 

![image](https://github.com/grafana/grafana/assets/1668778/3787d562-a7a3-4ae2-8875-8c4df6fccdd4)

![image](https://github.com/grafana/grafana/assets/1668778/8bc662a8-e752-40e7-9218-405fea1d9a2a)

**Why do we need this feature?**

To make it easier for an operator to understand how long time did each migration take, what migrations did run etc.

**Who is this feature for?**

Grafana operators.

**Which issue(s) does this PR fix?**:

Fixes #70987 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
