### PR TITLE
Dashboards: PanelChrome -  remove untitled placeholder and add border when panel is transparent

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -102,12 +102,6 @@ function getStyles(theme: GrafanaTheme2) {
         background: theme.colors.secondary.main,
       },
     }),
-    untitled: css({
-      color: theme.colors.text.disabled,
-      fontStyle: 'italic',
-      padding: theme.spacing(0, 1),
-      marginBottom: 0,
-    }),
     draggableIcon: css({
       transform: 'rotate(45deg)',
       color: theme.colors.text.secondary,

--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -48,7 +48,6 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32, on
           <Icon name="expand-arrows" className={styles.draggableIcon} />
         </div>
       )}
-      {!title && <h6 className={cx(styles.untitled, { [styles.draggable]: !!dragClass }, dragClass)}>Untitled</h6>}
       {children}
       {menu && (
         <PanelMenu

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -122,6 +122,7 @@ export function PanelChrome({
 
   // hover menu is only shown on hover when not on touch devices
   const showOnHoverClass = 'show-on-hover';
+  const isPanelTransparent = displayMode === 'transparent';
 
   const headerHeight = getHeaderHeight(theme, hasHeader);
   const { contentStyle, innerWidth, innerHeight } = getContentStyle(
@@ -139,11 +140,6 @@ export function PanelChrome({
   };
 
   const containerStyles: CSSProperties = { width, height: isOpen ? height : headerHeight };
-  if (displayMode === 'transparent') {
-    containerStyles.backgroundColor = 'transparent';
-    containerStyles.border = 'none';
-  }
-
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
 
   /** Old property name now maps to actions */
@@ -214,8 +210,13 @@ export function PanelChrome({
 
   return (
     // tabIndex={0} is needed for keyboard accessibility in the plot area
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    <div className={styles.container} style={containerStyles} data-testid={testid} tabIndex={0} ref={ref}>
+    <div
+      className={cx(styles.container, { [styles.transparentContainer]: isPanelTransparent })}
+      style={containerStyles}
+      data-testid={testid}
+      tabIndex={0} //eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+      ref={ref}
+    >
       <div className={styles.loadingBarContainer}>
         {loadingState === LoadingState.Loading ? (
           <LoadingBar width={loadingBarWidth} ariaLabel="Panel loading bar" />
@@ -359,6 +360,15 @@ const getStyles = (theme: GrafanaTheme2) => {
           visibility: 'visible',
           opacity: '1',
         },
+      },
+    }),
+    transparentContainer: css({
+      label: 'panel-transparent-container',
+      backgroundColor: 'transparent',
+      border: '1px solid transparent',
+      boxSizing: 'border-box',
+      '&:hover': {
+        border: `1px solid ${borderColor}`,
       },
     }),
     loadingBarContainer: css({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

During the redesign of the panel header, we decided to add a placeholder name, "Untitled". This decision was based on feedback about the menu not being discoverable and the drag icon conflicting with the menu icon, which looked like nine dots.
After receiving both internal and external feedback, we decided to remove this placeholder. It was causing confusion and wasn't adding enough value, especially since the original issues were addressed differently.

**This PR addresses two issues:**

1. It removes the "Untitled" placeholder.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td> 

![image](https://github.com/grafana/grafana/assets/239999/feb547ce-11e7-47a9-8fec-df523c5d0bd8)

 <td> 

![image](https://github.com/grafana/grafana/assets/239999/58082b15-ca0a-42f7-842a-632245197e1a)

</table>

2. It adds a border on hover when the panel is transparent.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td> 

https://github.com/grafana/grafana/assets/239999/0b5ed7d7-39ff-464c-950c-e76e4aede3c6

 <td> 

https://github.com/grafana/grafana/assets/239999/0cf73696-d7d3-40cd-89be-7caa3975e98f

</table>


**Why do we need this feature?**
Removes the current confusion about panels without headers.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #72978, #70510

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
