### PR TITLE
Alerting: Always invalidate the AM config after mutation

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -156,7 +156,6 @@ const AmRoutes = () => {
         oldConfig: result,
         alertManagerSourceName: selectedAlertmanager!,
         successMessage: 'Updated notification policies',
-        refetch: true,
       })
     )
       .unwrap()

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
@@ -68,7 +68,6 @@ export default function AlertmanagerConfig(): JSX.Element {
           oldConfig: config,
           alertManagerSourceName: selectedAlertmanager,
           successMessage: 'Alertmanager configuration updated.',
-          refetch: true,
         })
       );
     }

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v1.test.tsx
@@ -311,7 +311,7 @@ describe('Receivers', () => {
     // see that we're back to main page and proper api calls have been made
     await ui.receiversTable.find();
     expect(mocks.api.updateConfig).toHaveBeenCalledTimes(1);
-    expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(2);
     expect(locationService.getLocation().pathname).toEqual('/alerting/notifications');
     expect(mocks.api.updateConfig).toHaveBeenLastCalledWith(GRAFANA_RULES_SOURCE_NAME, {
       ...someGrafanaAlertManagerConfig,
@@ -405,7 +405,7 @@ describe('Receivers', () => {
     // see that we're back to main page and proper api calls have been made
     await ui.receiversTable.find();
     expect(mocks.api.updateConfig).toHaveBeenCalledTimes(1);
-    expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(2);
 
     expect(locationService.getLocation().pathname).toEqual('/alerting/notifications');
     expect(mocks.api.updateConfig).toHaveBeenLastCalledWith('CloudManager', {

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -498,13 +498,12 @@ interface UpdateAlertManagerConfigActionOptions {
   successMessage?: string; // show toast on success
   redirectPath?: string; // where to redirect on success
   redirectSearch?: string; // additional redirect query params
-  refetch?: boolean; // refetch config on success
 }
 
 export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlertManagerConfigActionOptions, {}>(
   'unifiedalerting/updateAMConfig',
   (
-    { alertManagerSourceName, oldConfig, newConfig, successMessage, redirectPath, redirectSearch, refetch },
+    { alertManagerSourceName, oldConfig, newConfig, successMessage, redirectPath, redirectSearch },
     thunkAPI
   ): Promise<void> =>
     withAppEvents(
@@ -523,9 +522,7 @@ export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlert
             );
           }
           await updateAlertManagerConfig(alertManagerSourceName, addDefaultsToAlertmanagerConfig(newConfig));
-          if (refetch) {
-            thunkAPI.dispatch(alertmanagerApi.util.invalidateTags(['AlertmanagerConfiguration']));
-          }
+          thunkAPI.dispatch(alertmanagerApi.util.invalidateTags(['AlertmanagerConfiguration']));
           if (redirectPath) {
             const options = new URLSearchParams(redirectSearch ?? '');
             locationService.push(makeAMLink(redirectPath, alertManagerSourceName, options));
@@ -604,7 +601,6 @@ export const deleteReceiverAction = (receiverName: string, alertManagerSourceNam
         oldConfig: config,
         alertManagerSourceName,
         successMessage: 'Contact point deleted.',
-        refetch: true,
       })
     );
   };
@@ -638,7 +634,6 @@ export const deleteTemplateAction = (templateName: string, alertManagerSourceNam
         oldConfig: config,
         alertManagerSourceName,
         successMessage: 'Template deleted.',
-        refetch: true,
       })
     );
   };
@@ -707,7 +702,6 @@ export const deleteMuteTimingAction = (alertManagerSourceName: string, muteTimin
                 mute_time_intervals: muteIntervals,
               },
             },
-            refetch: true,
           })
         ),
         {


### PR DESCRIPTION
**What is this feature?**

This PR will _always_ invalidate the RTK Query cache of the Alertmanager configuration after modifying it. This prevents stale data from being shown in the UI when creating / updating or deleting alertmanager entities.

**Special notes for your reviewer:**
