### PR TITLE
Alerting: Remove dump wrapper for yaml config

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaRuleInspector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaRuleInspector.tsx
@@ -1,4 +1,3 @@
-import { dump } from 'js-yaml';
 import React, { useMemo, useState } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -44,7 +43,7 @@ const GrafanaInspectorYamlTab = ({ alertUid }: YamlTabProps) => {
 
   const { currentData: ruleYamlConfig, isLoading } = useExportRuleQuery({ uid: alertUid, format: 'yaml' });
 
-  const yamlRule = useMemo(() => dump(ruleYamlConfig), [ruleYamlConfig]);
+  const yamlRule = useMemo(() => ruleYamlConfig, [ruleYamlConfig]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -59,7 +58,7 @@ const GrafanaInspectorYamlTab = ({ alertUid }: YamlTabProps) => {
               width="100%"
               height={height}
               language="yaml"
-              value={yamlRule}
+              value={yamlRule || ''}
               monacoOptions={{
                 minimap: {
                   enabled: false,


### PR DESCRIPTION
**What is this feature?**

Removes wrapping the `yamlConfig` in a `dump` call as it adds a pipe character at the beginning of the file. 

Before:

![image](https://github.com/grafana/grafana/assets/6271380/0a040664-d675-42d0-acfd-37fd19061415)

After: 

<img width="1313" alt="image" src="https://github.com/grafana/grafana/assets/6271380/3186aaf5-0c92-4040-b011-af6a5b852a04">
