### PR TITLE
Rendering: Fix dashboard screenshot

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 
 import { config } from '@grafana/runtime';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
+import { contextSrv } from 'app/core/services/context_srv';
 import { DashboardPanelsChangedEvent } from 'app/types/events';
 
 import { AddLibraryPanelWidget } from '../components/AddLibraryPanelWidget';
@@ -207,7 +208,7 @@ export class DashboardGrid extends PureComponent<Props> {
    * This can be quite distracting and make the dashboard appear to less snappy.
    */
   onGetWrapperDivRef = (ref: HTMLDivElement | null) => {
-    if (ref) {
+    if (ref && contextSrv.user.authenticatedBy !== 'render') {
       setTimeout(() => {
         ref.classList.add('react-grid-layout--enable-move-animations');
       }, 50);


### PR DESCRIPTION
**What is this feature?**
This PR fixes dashboard screenshots taken by the [image-renderer](https://github.com/grafana/grafana-image-renderer).

**Why do we need this feature?**
Since this change: https://github.com/grafana/grafana/pull/67953, panels are overlapping in dashboard screenshots:
![image](https://github.com/grafana/grafana/assets/35176601/2233fda6-3b4b-48f4-b8df-b6fb5fcb7d9c)

This is because taking a screenshot is reloading the page so it triggers the animation again but it doesn't have time to end (see https://github.com/puppeteer/puppeteer/issues/8690). 

**Who is this feature for?**
Users of the reporting feature or any users using the image-renderer to get full dashboard screenshots.

**Special note for reviewers:**
To test it, you can generate a report (Grafana Enterprise feature) with the option "Embed a dashboard image in the email" checked (see below). Before this change, the panels should be overlapping as shown above; with this fix, you should see a screenshot of your dashboard.
![image](https://github.com/grafana/grafana/assets/35176601/9f473a0c-f4cf-4c4e-b457-6d35cf69b7c7)
