### PR TITLE
Add canonical to preferred latest content

### DIFF
--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-  - ../global-variables.md/
+  - ../global-variables/
+canonical: https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/
 keywords:
   - grafana
   - templating


### PR DESCRIPTION
Google has indexed this page and it is regularly accessed via the search term "grafana global variables". We would prefer people to go to the latest content which is in the URL set as the canonical.

The actual canonical prose is under https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables but I believe search engines only index entire pages and not semantic sections.