### PR TITLE
Cloudwatch: Add traces to cloudwatch datasource plugin

### DIFF
--- a/contribute/backend/instrumentation.md
+++ b/contribute/backend/instrumentation.md
@@ -251,6 +251,8 @@ Be **careful** to not expose any sensitive information in span names, attribute 
 make devenv sources=jaeger
 ```
 
+> **Note:** See the [Set up your development environment](../../devenv/README.md) guide if you run into issues running jaeger
+
 #### 2. Enable tracing in Grafana
 
 To enable tracing in Grafana, you must set the address in your config.ini file

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -161,7 +161,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
 	fromExpression := req.GetHTTPHeader(query.HeaderFromExpression) != ""
 	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode
-	_, span := tracing.DefaultTracer().Start(
+	ctx, span := tracing.DefaultTracer().Start(
 		ctx,
 		"QueryData in Cloudwatch",
 		trace.WithAttributes(
@@ -250,7 +250,7 @@ func (e *cloudWatchExecutor) newSession(ctx context.Context, pluginCtx backend.P
 	if region == defaultRegion {
 		region = instance.Settings.Region
 	}
-	ctx, span := tracing.DefaultTracer().Start(
+	_, span := tracing.DefaultTracer().Start(
 		ctx,
 		"GetSession in Cloudwatch",
 		trace.WithAttributes(

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -161,7 +161,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
 	fromExpression := req.GetHTTPHeader(query.HeaderFromExpression) != ""
 	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode
-	ctx, span := tracing.DefaultTracer().Start(
+	_, span := tracing.DefaultTracer().Start(
 		ctx,
 		"QueryData in Cloudwatch",
 		trace.WithAttributes(


### PR DESCRIPTION
**What is this feature?**

I was reading through this doc: https://github.com/grafana/grafana/blob/63ffd9511021e1ee9957bc3a19cb7f5d49d49001/docs/sources/developers/plugins/create-a-grafana-plugin/extend-a-plugin/add-distributed-tracing-for-backend-plugins.md?plain=1#L4 and thought it would be cool try exploring adding some spans to the Cloudwatch datasource to start to gather more information specifically around:
- how long get session takes depending on auth type
- how long querying data takes based on query type

I noticed that we don't really start up Cloudwatch with datasource.Manage the way we do with some of our external plugins, so I'm not sure if it's considered best practice to create a new tracer in ProvideService the way it is described here?: https://github.com/grafana/grafana/blob/main/contribute/backend/instrumentation.md#traces. I ended up just trying to add to the existing default tracer which seems to attach itself to the http request it is apart of which makes sense to me:
<img width="969" alt="Screenshot 2023-08-11 at 3 32 53 PM" src="https://github.com/grafana/grafana/assets/6620164/445b6771-4f6b-4bf1-88a2-196ded97046b">

But maybe that's not ideal for some reason I might be missing? I wasn't clear if the instructions on adding tracing to backend datasource plugins was focused on external plugins or all plugins. 

I'm also not confident that I'm following naming conventions for spans/attributes, so feel free to correct me! I don't think I'm adding anything here that would cause issues around cardinality as all of the attributes I'm adding are from a fixed set of limited options, but again, feel free to correct if I'm missing things! None of these details are vitally important at the moment, just trying to become more familiar with our own tooling.

To test the spans locally:
- make sure to run ./setup.sh
script described here https://github.com/grafana/grafana/blob/63ffd9511021e1ee9957bc3a19cb7f5d49d49001/devenv/README.md#developer-dashboards-and-data-sources if you haven't already. 
- then starting jaeger: make devenv sources=jaeger (if you're on mac and hit an issue with this let me know, I tried to update docs here to hopefully make that easy to correct)
- then in your local grafana create a few cloudwatch queries
- then navigate to explore and load the the gdev tempo datasource that was created in the setup script and look for the span names listed in this pr

**Why do we need this feature?**

To get better insight into the performance of our cloudwatch datatsource plugin. 

**Who is this feature for?**

grafana devs

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
