### PR TITLE
Update naming to match behaviour

### DIFF
--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -129,7 +129,7 @@ Select one of the following palettes:
 | **Shades of a color**                | Selects shades of a single color, useful in an override rule                                                                                             |
 | **From thresholds**                  | Informs Grafana to take the color from the matching threshold                                                                                            |
 | **Classic palette**                  | Grafana will assign color by looking up a color in a palette by series index. Useful for Graphs and pie charts and other categorical data visualizations |
-| **Classic palette (by series name)** | Grafana will assign color based on the name of the series. Useful when the series names to be visualized depend on the available data.                   |
+| **Classic palette (by metric name)** | Grafana will assign color based on the name of the metric. Useful when the metric names to be visualized depend on the available data.                   |
 | **Green-Yellow-Red (by value)**      | Continuous color scheme                                                                                                                                  |
 | **Red-Yellow-Green (by value)**      | Continuous color scheme                                                                                                                                  |
 | **Blue-Yellow-Red (by value)**       | Continuous color scheme                                                                                                                                  |

--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -62,10 +62,10 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
     }),
     new FieldColorSchemeMode({
       id: FieldColorModeId.PaletteClassicByName,
-      name: 'Classic palette (by series name)',
+      name: 'Classic palette (by metric name)',
       isContinuous: false,
       isByValue: false,
-      useSeriesName: true,
+      useMetricName: true,
       getColors: (theme: GrafanaTheme2) => {
         return theme.visualization.palette.filter(
           (color) =>
@@ -156,7 +156,7 @@ interface FieldColorSchemeModeOptions {
   getColors: (theme: GrafanaTheme2) => string[];
   isContinuous: boolean;
   isByValue: boolean;
-  useSeriesName?: boolean;
+  useMetricName?: boolean;
 }
 
 export class FieldColorSchemeMode implements FieldColorMode {
@@ -178,7 +178,7 @@ export class FieldColorSchemeMode implements FieldColorMode {
     this.getNamedColors = options.getColors;
     this.isContinuous = options.isContinuous;
     this.isByValue = options.isByValue;
-    this.useSeriesName = options.useSeriesName;
+    this.useSeriesName = options.useMetricName;
   }
 
   getColors(theme: GrafanaTheme2): string[] {


### PR DESCRIPTION
Color choices are made from the metric name alone, not from the
series name as a whole, or indeed the entire field.
