### PR TITLE
RBAC: remove LoadPermissionsMiddleware

### DIFF
--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -242,22 +242,6 @@ func UseGlobalOrg(c *contextmodel.ReqContext) (int64, error) {
 	return GlobalOrgID, nil
 }
 
-func LoadPermissionsMiddleware(service Service) web.Handler {
-	return func(c *contextmodel.ReqContext) {
-		permissions, err := service.GetUserPermissions(c.Req.Context(), c.SignedInUser,
-			Options{ReloadCache: false})
-		if err != nil {
-			c.JsonApiErr(http.StatusForbidden, "", err)
-			return
-		}
-
-		if c.SignedInUser.Permissions == nil {
-			c.SignedInUser.Permissions = make(map[int64]map[string][]string)
-		}
-		c.SignedInUser.Permissions[c.OrgID] = GroupScopesByAction(permissions)
-	}
-}
-
 // scopeParams holds the parameters used to fill in scope templates
 type scopeParams struct {
 	OrgID     int64

--- a/pkg/services/publicdashboards/api/common_test.go
+++ b/pkg/services/publicdashboards/api/common_test.go
@@ -17,9 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	pluginFakes "github.com/grafana/grafana/pkg/plugins/manager/fakes"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -47,19 +45,6 @@ func setupTestServer(
 	// build router to register routes
 	rr := routing.NewRouteRegister()
 
-	var permissions []accesscontrol.Permission
-	if user != nil && user.Permissions != nil {
-		for action, scopes := range user.Permissions[user.OrgID] {
-			for _, scope := range scopes {
-				permissions = append(permissions, accesscontrol.Permission{
-					Action: action,
-					Scope:  scope,
-				})
-			}
-		}
-	}
-
-	acService := actest.FakeService{ExpectedPermissions: permissions, ExpectedDisabled: !cfg.RBACEnabled}
 	ac := acimpl.ProvideAccessControl(cfg)
 
 	// build mux
@@ -67,7 +52,6 @@ func setupTestServer(
 
 	// set initial context
 	m.Use(contextProvider(&testContext{user}))
-	m.Use(accesscontrol.LoadPermissionsMiddleware(acService))
 
 	// build api, this will mount the routes at the same time if
 	// featuremgmt.FlagPublicDashboard is enabled


### PR DESCRIPTION
**What is this feature?**
`LoadPermissionsMiddleware` is no longer used and can be removed.

Loading permissions is now done in a hook during authentication process.


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
