### PR TITLE
Logs: Hide filters in log details if the data source doesn't support them

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -82,8 +82,8 @@ interface Props extends Themeable2 {
   loadLogsVolumeData: () => void;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange) => void;
-  onClickFilterLabel: (key: string, value: string) => void;
-  onClickFilterOutLabel: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
   getRowContext?: (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions) => Promise<any>;
@@ -95,7 +95,7 @@ interface Props extends Themeable2 {
   eventBus: EventBus;
   panelState?: ExplorePanelsState;
   scrollElement?: HTMLDivElement;
-  isFilterLabelActive: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
   logsFrames?: DataFrame[];
   range: TimeRange;
 }

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -17,7 +17,9 @@ import {
   LogRowContextOptions,
   DataSourceWithLogsContextSupport,
   DataSourceApi,
+  hasToggleableQueryFiltersSupport,
 } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Collapse } from '@grafana/ui';
 import { StoreState } from 'app/types';
@@ -55,7 +57,46 @@ interface LogsContainerProps extends PropsFromRedux {
   isFilterLabelActive: (key: string, value: string) => Promise<boolean>;
 }
 
-class LogsContainer extends PureComponent<LogsContainerProps> {
+interface LogsContainerState {
+  logDetailsFilterAvailable: boolean;
+}
+
+class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState> {
+  state: LogsContainerState = {
+    logDetailsFilterAvailable: false,
+  };
+
+  componentDidMount() {
+    this.checkFiltersAvailability();
+  }
+
+  componentDidUpdate(prevProps: LogsContainerProps) {
+    this.checkFiltersAvailability();
+  }
+
+  private checkFiltersAvailability() {
+    const { queries, datasourceInstance } = this.props;
+
+    if (datasourceInstance?.modifyQuery || hasToggleableQueryFiltersSupport(queries)) {
+      this.setState({ logDetailsFilterAvailable: true });
+      return;
+    }
+
+    const promises = [];
+    for (const query of queries) {
+      if (query.datasource) {
+        promises.push(getDataSourceSrv().get(query.datasource));
+      }
+    }
+
+    Promise.all(promises).then((dataSources) => {
+      const logDetailsFilterAvailable = dataSources.some(
+        (ds) => ds.modifyQuery || hasToggleableQueryFiltersSupport(ds)
+      );
+      this.setState({ logDetailsFilterAvailable });
+    });
+  }
+
   onChangeTime = (absoluteRange: AbsoluteTimeRange) => {
     const { exploreId, updateTimeRange } = this.props;
     updateTimeRange({ exploreId, absoluteRange });
@@ -153,6 +194,7 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
       logsVolume,
       scrollElement,
     } = this.props;
+    const { logDetailsFilterAvailable } = this.state;
 
     if (!logRows) {
       return null;
@@ -197,8 +239,8 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
             loadingState={loadingState}
             loadLogsVolumeData={() => loadSupplementaryQueryData(exploreId, SupplementaryQueryType.LogsVolume)}
             onChangeTime={this.onChangeTime}
-            onClickFilterLabel={onClickFilterLabel}
-            onClickFilterOutLabel={onClickFilterOutLabel}
+            onClickFilterLabel={logDetailsFilterAvailable ? onClickFilterLabel : undefined}
+            onClickFilterOutLabel={logDetailsFilterAvailable ? onClickFilterOutLabel : undefined}
             onStartScanning={onStartScanning}
             onStopScanning={onStopScanning}
             absoluteRange={absoluteRange}
@@ -217,7 +259,7 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
             panelState={this.props.panelState}
             logsFrames={this.props.logsFrames}
             scrollElement={scrollElement}
-            isFilterLabelActive={this.props.isFilterLabelActive}
+            isFilterLabelActive={logDetailsFilterAvailable ? this.props.isFilterLabelActive : undefined}
             range={range}
           />
         </LogsCrossFadeTransition>
@@ -239,6 +281,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     range,
     absoluteRange,
     supplementaryQueries,
+    queries,
   } = item;
   const loading = selectIsWaitingForData(exploreId)(state);
   const panelState = item.panelsState;
@@ -263,6 +306,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     logsVolume,
     panelState,
     logsFrames: item.queryResponse.logsFrames,
+    queries,
   };
 }
 

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -75,15 +75,19 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   }
 
   private checkFiltersAvailability() {
-    const { queries, datasourceInstance } = this.props;
+    const { logsQueries, datasourceInstance } = this.props;
 
-    if (datasourceInstance?.modifyQuery || hasToggleableQueryFiltersSupport(queries)) {
+    if (!logsQueries) {
+      return;
+    }
+
+    if (datasourceInstance?.modifyQuery || hasToggleableQueryFiltersSupport(datasourceInstance)) {
       this.setState({ logDetailsFilterAvailable: true });
       return;
     }
 
     const promises = [];
-    for (const query of queries) {
+    for (const query of logsQueries) {
       if (query.datasource) {
         promises.push(getDataSourceSrv().get(query.datasource));
       }
@@ -281,7 +285,6 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     range,
     absoluteRange,
     supplementaryQueries,
-    queries,
   } = item;
   const loading = selectIsWaitingForData(exploreId)(state);
   const panelState = item.panelsState;
@@ -306,7 +309,6 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     logsVolume,
     panelState,
     logsFrames: item.queryResponse.logsFrames,
-    queries,
   };
 }
 

--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -47,6 +47,28 @@ describe('LogDetails', () => {
       expect(screen.getByRole('cell', { name: 'key2' })).toBeInTheDocument();
       expect(screen.getByRole('cell', { name: 'label2' })).toBeInTheDocument();
     });
+    it('should render filter controls when the callbacks are provided', () => {
+      setup(
+        {
+          onClickFilterLabel: () => {},
+          onClickFilterOutLabel: () => {},
+        },
+        { labels: { key1: 'label1' } }
+      );
+      expect(screen.getByLabelText('Filter for value')).toBeInTheDocument();
+      expect(screen.getByLabelText('Filter out value')).toBeInTheDocument();
+    });
+    it('should not render filter controls when the callbacks are not provided', () => {
+      setup(
+        {
+          onClickFilterLabel: undefined,
+          onClickFilterOutLabel: undefined,
+        },
+        { labels: { key1: 'label1' } }
+      );
+      expect(screen.queryByLabelText('Filter for value')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Filter out value')).not.toBeInTheDocument();
+    });
   });
   describe('when log row has error', () => {
     it('should not render log level border', () => {


### PR DESCRIPTION
This PR checks for data source support for log details filtering at the `LogsContainer` level, and optionally passes down the filtering methods to children components.

Log details filtering is supported:
- If the data source implements `modifyQuery` method.
Or
- If the data source implements the `DataSourceWithToggleableQueryFiltersSupport` interface.

This is the same method we use in the `LogsPanel` for dashboards, which doesn't support these filters, and doesn't passes down these props.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/72505

**Special notes for your reviewer:**

Test logs in Explore with multiple data sources, only those that supports filtering should show the controls.

ES:
![Elasticsearch](https://github.com/grafana/grafana/assets/1069378/8b98c7af-63db-4674-9de9-87fee8912268)

Mixed:
![Mixed](https://github.com/grafana/grafana/assets/1069378/782cef14-8fe6-418b-9565-34a28667cc74)

Test data:
![Test data](https://github.com/grafana/grafana/assets/1069378/1d34f5ec-0a93-47a4-9bdb-615d322633a3)

Loki:
![Loki](https://github.com/grafana/grafana/assets/1069378/9e219d21-1098-4037-b814-11d04506374d)
