### PR TITLE
TestData: Fix pipeline find filter

### DIFF
--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -27,11 +27,11 @@ func ProvideDiscoveryStage(cfg *config.Cfg, pf finder.Finder, pr registry.Servic
 			return pf.Find(ctx, src)
 		},
 		FindFilterFuncs: []discovery.FindFilterFunc{
-			func(ctx context.Context, _ plugins.Class, b []*plugins.FoundBundle) ([]*plugins.FoundBundle, error) {
-				return discovery.NewDuplicatePluginFilterStep(pr).Filter(ctx, b)
-			},
 			func(ctx context.Context, cl plugins.Class, bundles []*plugins.FoundBundle) ([]*plugins.FoundBundle, error) {
 				return discovery.NewCorePluginFilterStep(cfg).Filter(ctx, cl, bundles)
+			},
+			func(ctx context.Context, _ plugins.Class, b []*plugins.FoundBundle) ([]*plugins.FoundBundle, error) {
+				return discovery.NewDuplicatePluginFilterStep(pr).Filter(ctx, b)
 			},
 		},
 	})


### PR DESCRIPTION
**What is this feature?**

Follow up on #72205 to fix core plugin filter step running before the duplicate plugin filter step to remove warning log message "Skipping loading of plugin as it's a duplicate".

**Which issue(s) does this PR fix?**:

Ref ##72205 