### PR TITLE
Loki: Label browser sticky footer

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -133,10 +133,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: ${theme.spacing(2)};
     background-color: ${theme.colors.background.primary};
     position: sticky;
-    bottom: 0;
+    bottom: -24px; /* offset the padding on modal */
     left: 0;
-
-    z-index: 1;
   `,
   selector: css`
     font-family: ${theme.typography.fontFamilyMonospace};

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -139,7 +139,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   selector: css`
     font-family: ${theme.typography.fontFamilyMonospace};
     margin-bottom: ${theme.spacing(1)};
-    overflow: scroll;
     width: 100%;
   `,
   status: css`

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -148,6 +148,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     text-overflow: ellipsis;
     transition: opacity 100ms linear;
     opacity: 0;
+    font-size: ${theme.typography.pxToRem(12)};
+    height: calc(${theme.typography.pxToRem(12)} + 10px);
   `,
   statusShowing: css`
     opacity: 1;

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -528,9 +528,9 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
         </div>
         <div className={styles.footerSectionStyles}>
           <Label>3. Resulting selector</Label>
-          <div aria-label="selector" className={styles.selector}>
+          <pre aria-label="selector" className={styles.selector}>
             {selector}
-          </div>
+          </pre>
           {validationStatus && <div className={styles.validationStatus}>{validationStatus}</div>}
           <div className={cx(styles.status, (status || error) && styles.statusShowing)}>
             <span className={error ? styles.error : ''}>{error || status}</span>

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -133,7 +133,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: ${theme.spacing(1)};
     background-color: ${theme.colors.background.primary};
     position: sticky;
-    bottom: -24px; /* offset the padding on modal */
+    bottom: -${theme.spacing(3)}; /* offset the padding on modal */
     left: 0;
   `,
   selector: css`

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -130,7 +130,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: relative;
   `,
   footerSectionStyles: css`
-    padding: ${theme.spacing(2)};
+    padding: ${theme.spacing(1)};
     background-color: ${theme.colors.background.primary};
     position: sticky;
     bottom: -24px; /* offset the padding on modal */
@@ -139,6 +139,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   selector: css`
     font-family: ${theme.typography.fontFamilyMonospace};
     margin-bottom: ${theme.spacing(1)};
+    overflow: scroll;
+    width: 100%;
   `,
   status: css`
     margin-bottom: ${theme.spacing(1)};
@@ -148,8 +150,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     text-overflow: ellipsis;
     transition: opacity 100ms linear;
     opacity: 0;
-    font-size: ${theme.typography.pxToRem(12)};
-    height: calc(${theme.typography.pxToRem(12)} + 10px);
+    font-size: ${theme.typography.bodySmall.fontSize};
+    height: calc(${theme.typography.bodySmall.fontSize} + 10px);
   `,
   statusShowing: css`
     opacity: 1;


### PR DESCRIPTION

**What is this feature?**

Making the buttons and query preview in the label browser modal sticky so it cannot be pushed out of the viewport.

**Why do we need this feature?**
Buttons can be pushed out by content, or never visible due to users data/viewport, if these aren't visible the UX suffers greatly as users need to scroll down to reset/select/etc within a modal that may not be obvious is scrollable.

**Who is this feature for?**
Users of Loki labels browser.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71747

**Special notes for your reviewer:**
First loki PR! What did I break :P

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
