### PR TITLE
InfluxDB: make influxql options the default if nothing defined

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -121,7 +121,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       case InfluxVersion.SQL:
         return <InfluxSqlConfig {...this.props} />;
       default:
-        return null;
+        return <InfluxInfluxQLConfig {...this.props} />;
     }
   }
 


### PR DESCRIPTION
**What is this feature?**
Some influx datasources are older then flux, and they don't have a version defined in the database. This just fixes a UI regression recently introduced for those users.

**Why do we need this feature?**
So folks can use config UI as normal

**Who is this feature for?**
Influx users, especially ones that have been using influx in Grafana for a while.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/73245

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
