### PR TITLE
CloudWatch Logs: Wrap sync error from executeGetQueryResults

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -299,7 +299,14 @@ func (e *cloudWatchExecutor) executeGetQueryResults(ctx context.Context, logsCli
 		QueryId: aws.String(logsQuery.QueryId),
 	}
 
-	return logsClient.GetQueryResultsWithContext(ctx, queryInput)
+	getQueryResultsResponse, err := logsClient.GetQueryResultsWithContext(ctx, queryInput)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			return getQueryResultsResponse, &AWSError{Code: awsErr.Code(), Message: err.Error()}
+		}
+	}
+	return getQueryResultsResponse, err
 }
 
 func (e *cloudWatchExecutor) handleGetQueryResults(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -83,7 +83,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 	queryContext backend.DataQuery, logsQuery models.LogsQuery, logsTimeout time.Duration) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CloudWatch Error: %w", err)
 	}
 
 	requestParams := models.LogsQuery{
@@ -108,7 +108,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 	for range ticker.C {
 		res, err := e.executeGetQueryResults(ctx, logsClient, requestParams)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("CloudWatch Error: %w", err)
 		}
 		if isTerminated(*res.Status) {
 			return res, err

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -83,7 +83,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 	queryContext backend.DataQuery, logsQuery models.LogsQuery, logsTimeout time.Duration) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {
-		return nil, fmt.Errorf("CloudWatch Error: %w", err)
+		return nil, err
 	}
 
 	requestParams := models.LogsQuery{

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -336,4 +336,36 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		assert.Error(t, err)
 		cli.AssertNumberOfCalls(t, "GetQueryResultsWithContext", 1)
 	})
+
+	t.Run("when getQueryResults returns aws error is returned, it keeps the context", func(t *testing.T) {
+		cli = &mockLogsSyncClient{}
+		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(
+			&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")},
+			&fakeAWSError{code: "foo", message: "bar"},
+		)
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs"
+					}`),
+				},
+			},
+		})
+
+		require.Nil(t, res)
+		require.Error(t, err)
+		require.Equal(t, "CloudWatch Error: foo: bar", err.Error())
+	})
 }

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -254,3 +254,24 @@ func (s *mockedCallResourceResponseSenderForOauth) Send(resp *backend.CallResour
 	s.Response = resp
 	return nil
 }
+
+type fakeAWSError struct {
+	code    string
+	message string
+}
+
+func (e fakeAWSError) OrigErr() error {
+	return nil
+}
+
+func (e fakeAWSError) Error() string {
+	return e.message
+}
+
+func (e fakeAWSError) Code() string {
+	return e.code
+}
+
+func (e fakeAWSError) Message() string {
+	return e.message
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Wraps errors for sync logs queries from CloudWatch, to hopefully make it clearer to users when errors are being returned from CloudWatch vs Grafana. I tried to track down the specific error in the issue so that we could check for it, but I wasn't able to find a const for it in the CloudWatch API. We could do string comparison, but I thought this general information adding might be more helpful.

**Why do we need this feature?**

Currently users get a "fetching of query results exceeded the max number of attempts" error when they hit AWS's cap of error attempts, which they assume is from us instead of from AWS.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #66171

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
