### PR TITLE
Check constructor property when deciding if a plugin is Angular based

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -162,7 +162,7 @@ export class DatasourceSrv implements DataSourceService {
       }
 
       // If there is only one constructor argument it is instanceSettings
-      const useAngular = dsPlugin.DataSourceClass.length !== 1;
+      const useAngular = dsPlugin.DataSourceClass.constructor.length !== 1;
       let instance: DataSourceApi<any, any>;
 
       if (useAngular) {


### PR DESCRIPTION
**What is this feature?**

I'm building a set of a data source plugins, and I wrote my own base class that extends from DataSourceApi. The base class has a constructor that takes in `instanceSettings`, and then my subclass data sources don't need to define a constructor. However, the `useAngular` length check doesn't work for subclasses - it's returning 0. This led to cryptic errors trying to load the data sources. 

The correct way to do this is to use the [constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor) property.

**Why do we need this feature?**

It allows plugin developers to define their own base class for data sources.

**Who is this feature for?**

Me 😄  and any other advanced plugin developers.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
