### PR TITLE
Enable rate limit session header for Azure Monitor

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
@@ -1,6 +1,7 @@
 package azuremonitor
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -60,7 +61,7 @@ func Test_proxyRequest(t *testing.T) {
 					t.Fatal(err)
 				}
 			}))
-			req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 			if err != nil {
 				t.Error(err)
 			}
@@ -113,7 +114,7 @@ func Test_handleResourceReq(t *testing.T) {
 		},
 	}
 	rw := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "http://foo/azuremonitor/subscriptions/44693801", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://foo/azuremonitor/subscriptions/44693801", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/pkg/tsdb/azuremonitor/httpclient.go
+++ b/pkg/tsdb/azuremonitor/httpclient.go
@@ -31,6 +31,8 @@ func newHTTPClient(route types.AzRoute, model types.DatasourceInfo, settings *ba
 
 		authOpts := azhttpclient.NewAuthOptions(cfg.Azure)
 		authOpts.Scopes(route.Scopes)
+		authOpts.AddRateLimitSession(true)
+
 		azhttpclient.AddAzureAuthentication(&clientOpts, authOpts, model.Credentials)
 	}
 


### PR DESCRIPTION
Adds rate limit session header `X-RateLimit-Session` to requests to Azure Monitor endpoints.

This intended to address throttling issues occasionally occurring when popular dashboards being used by multiple users which causing multiple query requests with the same service identity.

Uses rate limit session implementation in Grafana Azure SDK:
- https://github.com/grafana/grafana-azure-sdk-go/pull/36

This PR does two things:
- Enables `AddRateLimitSession` in Azure `authOpts`.
- Passes user context with request context, so Azure middleware could extract it to generate session ID.


