### PR TITLE
Tempo: Replace template variables in TraceQL tab when streaming is enabled

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -426,22 +426,21 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     return request;
   }
 
+  // This function can probably be simplified by avoiding passing both `targets` and `query`,
+  // since `query` is built from `targets`, if you look at how this function is currently called
   handleStreamingSearch(
     options: DataQueryRequest<TempoQuery>,
     targets: TempoQuery[],
     query: string
   ): Observable<DataQueryResponse> {
-    const validTargets = targets
-      .filter((t) => t.query || query)
-      .map((t): TempoQuery => ({ ...t, query: query || t.query.trim() }));
-    if (!validTargets.length) {
+    if (query === '') {
       return EMPTY;
     }
 
     return merge(
-      ...validTargets.map((q) =>
+      ...targets.map((target) =>
         doTempoChannelStream(
-          q,
+          { ...target, query },
           this, // the datasource
           options,
           this.instanceSettings

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -429,7 +429,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   handleStreamingSearch(
     options: DataQueryRequest<TempoQuery>,
     targets: TempoQuery[],
-    query?: string
+    query: string
   ): Observable<DataQueryResponse> {
     const validTargets = targets
       .filter((t) => t.query || query)

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -228,7 +228,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           });
 
           if (config.featureToggles.traceQLStreaming) {
-            subQueries.push(this.handleStreamingSearch(options, targets.traceql));
+            subQueries.push(this.handleStreamingSearch(options, targets.traceql, queryValue));
           } else {
             subQueries.push(
               this._request('/api/search', {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes #73100

Template variables are not replaced when the new streaming feature is enabled through the feature toggle. This PR fixes that.

