### PR TITLE
RBAC: Remove unused scope from alert.instances:read fixed role

### DIFF
--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -65,7 +65,6 @@ var (
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingInstanceRead,
-					Scope:  dashboards.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingInstancesExternalRead,


### PR DESCRIPTION
**What is this feature?**
Remove the unused/unnecessary scope restriction from the `fixed:alert.instances:read` role.

**Why do we need this feature?**
Permission validation (enterprise feature) does fail for createrole/updaterole requests when `alert.instances:read` specified without a scope (the validation is not enabled by default), because the validator collects the accepted actions and scopes from the fixed roles and fixed roles should contain the widest expected/possible scope(s).

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
