### PR TITLE
Logs: Fix scrolling with `exploreScrollableLogsContainer` feature

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -454,7 +454,18 @@ class UnthemedLogs extends PureComponent<Props, State> {
     return { from: firstTimeStamp, to: lastTimeStamp };
   });
 
-  scrollToTopLogs = () => this.topLogsRef.current?.scrollIntoView();
+  scrollToTopLogs = () => {
+    if (config.featureToggles.exploreScrollableLogsContainer) {
+      if (this.logsContainer.current) {
+        this.logsContainer.current.scroll({
+          behavior: 'auto',
+          top: 0,
+        });
+      }
+    } else {
+      this.topLogsRef.current?.scrollIntoView();
+    }
+  };
 
   render() {
     const {


### PR DESCRIPTION
**What is this feature?**

Using the `exploreScrollableLogsContainer` feature toggle the scrollable container for logs in Explore changed. This broke the behavior of the "scroll to top" button.

This PR fixes the scrolling behavior.

Reproduce:
1. Show a lot of logs in Explore
2. Click the "scroll to top" button 