### PR TITLE
DatePicker: Fix calendar not showing correct selected range when changing time zones

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -761,8 +761,7 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-e2e/src/flows/revertAllChanges.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-e2e/src/flows/selectOption.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -777,9 +776,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "packages/grafana-e2e/src/support/scenarioContext.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "packages/grafana-e2e/src/support/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/e2e/dashboards-suite/dashboard-timepicker.spec.ts
+++ b/e2e/dashboards-suite/dashboard-timepicker.spec.ts
@@ -7,20 +7,12 @@ e2e.scenario({
   addScenarioDashBoard: false,
   skipScenario: false,
   scenario: () => {
-    //Make sure that the browser time zone is set to UTC - it's set to Pacific/Honolulu UTC-12
-    //Open preferences page and set timezone to Tokyo
-    e2e.pages.ProfilePage.visit();
-
-    e2e.flows.selectOption({
-      container: e2e.components.TimeZonePicker.containerV2(),
-      optionText: 'Asia/Tokyo',
+    e2e.flows.setUserPreferences({
+      timezone: 'Asia/Tokyo',
     });
 
-    // This refreshes the page
-    e2e.components.UserProfile.preferencesSaveButton().click();
-
-    //Open dashboard with time range from 2022-06-08 00:00:00 to 2022-06-10 23:59:59
-    // e2e().visit('/dashboard/new');
+    // Open dashboard with time range from 8th to end of 10th.
+    // Will be Tokyo time because of above preference
     e2e.flows.openDashboard({
       uid: '5SdHCasdf',
       timeRange: {
@@ -30,11 +22,33 @@ e2e.scenario({
       },
     });
 
-    //Open timepicker
+    // Assert that the calendar shows 08 and 09 and 10 as selected days
     e2e.components.TimePicker.openButton().click();
-    //Open calendar
     e2e.components.TimePicker.calendar.openButton().first().click();
-    //Assert that the calendar shows 08 and 09 and 10 as selected days
+    e2e().get('.react-calendar__tile--active, .react-calendar__tile--hasActive').should('have.length', 3);
+  },
+});
+
+e2e.scenario({
+  describeName: 'Dashboard timepicker',
+  itName: 'Shows the correct calendar days with custom timezone set via time picker',
+  addScenarioDataSource: false,
+  addScenarioDashBoard: false,
+  skipScenario: false,
+  scenario: () => {
+    // Open dashboard with time range from 2022-06-08 00:00:00 to 2022-06-10 23:59:59 in Tokyo time
+    e2e.flows.openDashboard({
+      uid: '5SdHCasdf',
+      timeRange: {
+        zone: 'Asia/Tokyo',
+        from: '2022-06-08 00:00:00',
+        to: '2022-06-10 23:59:59',
+      },
+    });
+
+    // Assert that the calendar shows 08 and 09 and 10 as selected days
+    e2e.components.TimePicker.openButton().click();
+    e2e.components.TimePicker.calendar.openButton().first().click();
     e2e().get('.react-calendar__tile--active, .react-calendar__tile--hasActive').should('have.length', 3);
   },
 });

--- a/e2e/dashboards-suite/dashboard-timepicker.spec.ts
+++ b/e2e/dashboards-suite/dashboard-timepicker.spec.ts
@@ -1,0 +1,123 @@
+import {
+  addDays,
+  addHours,
+  differenceInCalendarDays,
+  differenceInMinutes,
+  format,
+  isBefore,
+  parseISO,
+  toDate,
+} from 'date-fns';
+
+import { e2e } from '@grafana/e2e';
+
+e2e.scenario({
+  describeName: 'Dashboard timepicker',
+  itName: 'Shows the correct calendar days with custom timezone set via preferences',
+  addScenarioDataSource: false,
+  addScenarioDashBoard: false,
+  skipScenario: true,
+  scenario: () => {
+    e2e.flows.openDashboard({
+      uid: '5SdHCasdf',
+      timeRange: {
+        from: '2022-06-08 00:00:00',
+        to: '2022-06-10 23:59:59',
+      },
+    });
+
+    const fromTimeZone = 'UTC';
+    const toTimeZone = 'America/Chicago';
+    const offset = offsetBetweenTimeZones(toTimeZone, fromTimeZone);
+
+    const panelsToCheck = [
+      'Random walk series',
+      'Millisecond res x-axis and tooltip',
+      '2 yaxis and axis labels',
+      'Stacking value ontop of nulls',
+      'Null between points',
+      'Legend Table No Scroll Visible',
+    ];
+
+    const timesInUtc: Record<string, string> = {};
+
+    for (const title of panelsToCheck) {
+      e2e.components.Panels.Panel.containerByTitle(title)
+        .should('be.visible')
+        .within(() =>
+          e2e.components.Panels.Visualization.Graph.xAxis
+            .labels()
+            .should('be.visible')
+            .last()
+            .should((element) => {
+              timesInUtc[title] = element.text();
+            })
+        );
+    }
+
+    e2e.components.PageToolbar.item('Dashboard settings').click();
+
+    e2e.components.TimeZonePicker.containerV2()
+      .should('be.visible')
+      .within(() => {
+        e2e.components.Select.singleValue().should('have.text', 'Coordinated Universal Time');
+        e2e.components.Select.input().should('be.visible').click();
+      });
+
+    e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
+
+    // click to go back to the dashboard.
+    e2e.components.BackButton.backArrow().click({ force: true });
+    e2e.components.RefreshPicker.runButtonV2().should('be.visible').click();
+
+    for (const title of panelsToCheck) {
+      e2e.components.Panels.Panel.containerByTitle(title)
+        .should('be.visible')
+        .within(() =>
+          e2e.components.Panels.Visualization.Graph.xAxis
+            .labels()
+            .should('be.visible')
+            .last()
+            .should((element) => {
+              const inUtc = timesInUtc[title];
+              const inTz = element.text();
+              const isCorrect = isTimeCorrect(inUtc, inTz, offset);
+              expect(isCorrect, `Expect the panel "${title}" to have the new timezone applied but isn't`).to.be.equal(
+                true
+              );
+            })
+        );
+    }
+  },
+});
+
+const isTimeCorrect = (inUtc: string, inTz: string, offset: number): boolean => {
+  if (inUtc === inTz) {
+    // we need to catch issues when timezone isn't changed for some reason like https://github.com/grafana/grafana/issues/35504
+    return false;
+  }
+
+  const reference = format(new Date(), 'yyyy-LL-dd');
+
+  const utcDate = toDate(parseISO(`${reference} ${inUtc}`));
+  const utcDateWithOffset = addHours(toDate(parseISO(`${reference} ${inUtc}`)), offset);
+  const dayDifference = differenceInCalendarDays(utcDate, utcDateWithOffset); // if the utcDate +/- offset is the day before/after then we need to adjust reference
+  const dayOffset = isBefore(utcDateWithOffset, utcDate) ? dayDifference * -1 : dayDifference;
+  const tzDate = addDays(toDate(parseISO(`${reference} ${inTz}`)), dayOffset); // adjust tzDate with any dayOffset
+  const diff = Math.abs(differenceInMinutes(utcDate, tzDate)); // use Math.abs if tzDate is in future
+
+  return diff <= Math.abs(offset * 60);
+};
+
+const offsetBetweenTimeZones = (timeZone1: string, timeZone2: string, when: Date = new Date()): number => {
+  const t1 = convertDateToAnotherTimeZone(when, timeZone1);
+  const t2 = convertDateToAnotherTimeZone(when, timeZone2);
+  return (t1.getTime() - t2.getTime()) / (1000 * 60 * 60);
+};
+
+const convertDateToAnotherTimeZone = (date: Date, timeZone: string): Date => {
+  const dateString = date.toLocaleString('en-US', {
+    timeZone: timeZone,
+  });
+  return new Date(dateString);
+};

--- a/e2e/dashboards-suite/dashboard-timepicker.spec.ts
+++ b/e2e/dashboards-suite/dashboard-timepicker.spec.ts
@@ -1,14 +1,3 @@
-import {
-  addDays,
-  addHours,
-  differenceInCalendarDays,
-  differenceInMinutes,
-  format,
-  isBefore,
-  parseISO,
-  toDate,
-} from 'date-fns';
-
 import { e2e } from '@grafana/e2e';
 
 e2e.scenario({
@@ -16,8 +5,13 @@ e2e.scenario({
   itName: 'Shows the correct calendar days with custom timezone set via preferences',
   addScenarioDataSource: false,
   addScenarioDashBoard: false,
-  skipScenario: true,
+  skipScenario: false,
   scenario: () => {
+    //Make sure that the browser time zone is set to UTC
+    //Open preferences page and set timezone to Tokyo
+    e2e.pages.ProfilePage.visit();
+    
+    //Open dashboard with time range from 2022-06-08 00:00:00 to 2022-06-10 23:59:59
     e2e.flows.openDashboard({
       uid: '5SdHCasdf',
       timeRange: {
@@ -25,99 +19,10 @@ e2e.scenario({
         to: '2022-06-10 23:59:59',
       },
     });
-
-    const fromTimeZone = 'UTC';
-    const toTimeZone = 'America/Chicago';
-    const offset = offsetBetweenTimeZones(toTimeZone, fromTimeZone);
-
-    const panelsToCheck = [
-      'Random walk series',
-      'Millisecond res x-axis and tooltip',
-      '2 yaxis and axis labels',
-      'Stacking value ontop of nulls',
-      'Null between points',
-      'Legend Table No Scroll Visible',
-    ];
-
-    const timesInUtc: Record<string, string> = {};
-
-    for (const title of panelsToCheck) {
-      e2e.components.Panels.Panel.containerByTitle(title)
-        .should('be.visible')
-        .within(() =>
-          e2e.components.Panels.Visualization.Graph.xAxis
-            .labels()
-            .should('be.visible')
-            .last()
-            .should((element) => {
-              timesInUtc[title] = element.text();
-            })
-        );
-    }
-
-    e2e.components.PageToolbar.item('Dashboard settings').click();
-
-    e2e.components.TimeZonePicker.containerV2()
-      .should('be.visible')
-      .within(() => {
-        e2e.components.Select.singleValue().should('have.text', 'Coordinated Universal Time');
-        e2e.components.Select.input().should('be.visible').click();
-      });
-
-    e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
-
-    // click to go back to the dashboard.
-    e2e.components.BackButton.backArrow().click({ force: true });
-    e2e.components.RefreshPicker.runButtonV2().should('be.visible').click();
-
-    for (const title of panelsToCheck) {
-      e2e.components.Panels.Panel.containerByTitle(title)
-        .should('be.visible')
-        .within(() =>
-          e2e.components.Panels.Visualization.Graph.xAxis
-            .labels()
-            .should('be.visible')
-            .last()
-            .should((element) => {
-              const inUtc = timesInUtc[title];
-              const inTz = element.text();
-              const isCorrect = isTimeCorrect(inUtc, inTz, offset);
-              expect(isCorrect, `Expect the panel "${title}" to have the new timezone applied but isn't`).to.be.equal(
-                true
-              );
-            })
-        );
-    }
+    //Open timepicker
+    //Open calendar
+    //Assert that the calendar shows 08, 09 and 10 as selected days
   },
 });
 
-const isTimeCorrect = (inUtc: string, inTz: string, offset: number): boolean => {
-  if (inUtc === inTz) {
-    // we need to catch issues when timezone isn't changed for some reason like https://github.com/grafana/grafana/issues/35504
-    return false;
-  }
 
-  const reference = format(new Date(), 'yyyy-LL-dd');
-
-  const utcDate = toDate(parseISO(`${reference} ${inUtc}`));
-  const utcDateWithOffset = addHours(toDate(parseISO(`${reference} ${inUtc}`)), offset);
-  const dayDifference = differenceInCalendarDays(utcDate, utcDateWithOffset); // if the utcDate +/- offset is the day before/after then we need to adjust reference
-  const dayOffset = isBefore(utcDateWithOffset, utcDate) ? dayDifference * -1 : dayDifference;
-  const tzDate = addDays(toDate(parseISO(`${reference} ${inTz}`)), dayOffset); // adjust tzDate with any dayOffset
-  const diff = Math.abs(differenceInMinutes(utcDate, tzDate)); // use Math.abs if tzDate is in future
-
-  return diff <= Math.abs(offset * 60);
-};
-
-const offsetBetweenTimeZones = (timeZone1: string, timeZone2: string, when: Date = new Date()): number => {
-  const t1 = convertDateToAnotherTimeZone(when, timeZone1);
-  const t2 = convertDateToAnotherTimeZone(when, timeZone2);
-  return (t1.getTime() - t2.getTime()) / (1000 * 60 * 60);
-};
-
-const convertDateToAnotherTimeZone = (date: Date, timeZone: string): Date => {
-  const dateString = date.toLocaleString('en-US', {
-    timeZone: timeZone,
-  });
-  return new Date(dateString);
-};

--- a/e2e/dashboards-suite/dashboard-timepicker.spec.ts
+++ b/e2e/dashboards-suite/dashboard-timepicker.spec.ts
@@ -7,22 +7,34 @@ e2e.scenario({
   addScenarioDashBoard: false,
   skipScenario: false,
   scenario: () => {
-    //Make sure that the browser time zone is set to UTC
+    //Make sure that the browser time zone is set to UTC - it's set to Pacific/Honolulu UTC-12
     //Open preferences page and set timezone to Tokyo
     e2e.pages.ProfilePage.visit();
-    
+
+    e2e.flows.selectOption({
+      container: e2e.components.TimeZonePicker.containerV2(),
+      optionText: 'Asia/Tokyo',
+    });
+
+    // This refreshes the page
+    e2e.components.UserProfile.preferencesSaveButton().click();
+
     //Open dashboard with time range from 2022-06-08 00:00:00 to 2022-06-10 23:59:59
+    // e2e().visit('/dashboard/new');
     e2e.flows.openDashboard({
       uid: '5SdHCasdf',
       timeRange: {
+        zone: 'Default',
         from: '2022-06-08 00:00:00',
         to: '2022-06-10 23:59:59',
       },
     });
+
     //Open timepicker
+    e2e.components.TimePicker.openButton().click();
     //Open calendar
-    //Assert that the calendar shows 08, 09 and 10 as selected days
+    e2e.components.TimePicker.calendar.openButton().first().click();
+    //Assert that the calendar shows 08 and 09 and 10 as selected days
+    e2e().get('.react-calendar__tile--active, .react-calendar__tile--hasActive').should('have.length', 3);
   },
 });
-
-

--- a/e2e/run-suite
+++ b/e2e/run-suite
@@ -115,6 +115,7 @@ function join () {
   echo "$res"
 }
 
+export TZ="Pacific/Honolulu"
 
 yarn $CMD --env "$(join env)" \
   --config "$(join cypressConfig)" \

--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -22,6 +22,10 @@ export const timeZoneFormatUserFriendly = (timeZone: TimeZone | undefined) => {
   }
 };
 
+export const getZone = (timeZone: string) => {
+  return moment.tz.zone(timeZone);
+};
+
 export interface TimeZoneCountry {
   code: string;
   name: string;

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -320,4 +320,7 @@ export const Pages = {
       },
     },
   },
+  ProfilePage: {
+    url: '/profile',
+  }
 };

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -322,5 +322,5 @@ export const Pages = {
   },
   ProfilePage: {
     url: '/profile',
-  }
+  },
 };

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -64,6 +64,7 @@
     "@babel/preset-env": "7.22.9",
     "@cypress/webpack-preprocessor": "5.17.1",
     "@grafana/e2e-selectors": "10.2.0-pre",
+    "@grafana/schema": "10.2.0-pre",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@mochajs/json-file-reporter": "^1.2.0",
     "babel-loader": "9.1.3",

--- a/packages/grafana-e2e/src/flows/index.ts
+++ b/packages/grafana-e2e/src/flows/index.ts
@@ -13,6 +13,7 @@ export * from './saveDashboard';
 export * from './selectOption';
 export * from './importDashboard';
 export * from './importDashboards';
+export * from './userPreferences';
 
 export {
   VISUALIZATION_ALERT_LIST,

--- a/packages/grafana-e2e/src/flows/revertAllChanges.ts
+++ b/packages/grafana-e2e/src/flows/revertAllChanges.ts
@@ -1,8 +1,12 @@
 import { e2e } from '../index';
 
 export const revertAllChanges = () => {
-  e2e.getScenarioContext().then(({ addedDashboards, addedDataSources }: any) => {
+  e2e.getScenarioContext().then(({ addedDashboards, addedDataSources, hasChangedUserPreferences }) => {
     addedDashboards.forEach((dashboard: any) => e2e.flows.deleteDashboard({ ...dashboard, quick: true }));
     addedDataSources.forEach((dataSource: any) => e2e.flows.deleteDataSource({ ...dataSource, quick: true }));
+
+    if (hasChangedUserPreferences) {
+      e2e.flows.setDefaultUserPreferences();
+    }
   });
 };

--- a/packages/grafana-e2e/src/flows/setTimeRange.ts
+++ b/packages/grafana-e2e/src/flows/setTimeRange.ts
@@ -13,6 +13,7 @@ export const setTimeRange = ({ from, to, zone }: TimeRangeConfig) => {
 
   if (zone) {
     e2e().contains('button', 'Change time settings').click();
+    e2e().log('setting time zone to ' + zone);
 
     if (e2e.components.TimeZonePicker.containerV2) {
       selectOption({

--- a/packages/grafana-e2e/src/flows/userPreferences.ts
+++ b/packages/grafana-e2e/src/flows/userPreferences.ts
@@ -1,0 +1,25 @@
+import { Preferences as UserPreferencesDTO } from '@grafana/schema/src/raw/preferences/x/preferences_types.gen';
+
+import { e2e } from '..';
+import { fromBaseUrl } from '../support/url';
+
+const defaultUserPreferences = {
+  timezone: '', // "Default" option
+} as const; // TODO: when we update typescript >4.9 change to `as const satisfies UserPreferencesDTO`
+
+// Only accept preferences we have defaults for as arguments. To allow a new preference to be set, add a default for it
+type UserPreferences = Pick<UserPreferencesDTO, keyof typeof defaultUserPreferences>;
+
+export function setUserPreferences(prefs: UserPreferences) {
+  e2e.setScenarioContext({ hasChangedUserPreferences: prefs !== defaultUserPreferences });
+
+  return cy.request({
+    method: 'PUT',
+    url: fromBaseUrl('/api/user/preferences'),
+    body: prefs,
+  });
+}
+
+export function setDefaultUserPreferences() {
+  return setUserPreferences(defaultUserPreferences);
+}

--- a/packages/grafana-e2e/src/support/scenario.ts
+++ b/packages/grafana-e2e/src/support/scenario.ts
@@ -23,7 +23,10 @@ export const e2eScenario = ({
     if (skipScenario) {
       it.skip(itName, () => scenario());
     } else {
-      before(() => e2e.flows.login(e2e.env('USERNAME'), e2e.env('PASSWORD'), loginViaApi));
+      before(() => {
+        e2e.flows.login(e2e.env('USERNAME'), e2e.env('PASSWORD'), loginViaApi);
+        e2e.flows.setDefaultUserPreferences();
+      });
 
       beforeEach(() => {
         Cypress.Cookies.preserveOnce('grafana_session');

--- a/packages/grafana-e2e/src/support/scenarioContext.ts
+++ b/packages/grafana-e2e/src/support/scenarioContext.ts
@@ -9,12 +9,14 @@ export interface ScenarioContext {
   lastAddedDashboardUid: string;
   lastAddedDataSource: string; // @todo rename to `lastAddedDataSourceName`
   lastAddedDataSourceId: string;
+  hasChangedUserPreferences: boolean;
   [key: string]: any;
 }
 
 const scenarioContext: ScenarioContext = {
   addedDashboards: [],
   addedDataSources: [],
+  hasChangedUserPreferences: false,
   get lastAddedDashboard() {
     return lastProperty(this.addedDashboards, 'title');
   },
@@ -34,8 +36,7 @@ const lastProperty = <T extends DeleteDashboardConfig | DeleteDataSourceConfig, 
   key: K
 ) => items[items.length - 1]?.[key] ?? '';
 
-// @todo this actually returns type `Cypress.Chainable`
-export const getScenarioContext = (): any =>
+export const getScenarioContext = (): Cypress.Chainable<ScenarioContext> =>
   e2e()
     .wrap(
       {
@@ -45,8 +46,7 @@ export const getScenarioContext = (): any =>
     )
     .invoke({ log: false }, 'getScenarioContext');
 
-// @todo this actually returns type `Cypress.Chainable`
-export const setScenarioContext = (newContext: Partial<ScenarioContext>): any =>
+export const setScenarioContext = (newContext: Partial<ScenarioContext>): Cypress.Chainable<ScenarioContext> =>
   e2e()
     .wrap(
       {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
 import Calendar from 'react-calendar';
 
-import { GrafanaTheme2, dateTime, dateTimeParse, DateTime, TimeZone } from '@grafana/data';
+import { GrafanaTheme2, dateTime, dateTimeParse, DateTime, TimeZone, getZone } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
 import { Icon } from '../../Icon/Icon';
@@ -10,7 +10,7 @@ import { Icon } from '../../Icon/Icon';
 import { TimePickerCalendarProps } from './TimePickerCalendar';
 
 export function Body({ onChange, from, to, timeZone }: TimePickerCalendarProps) {
-  const value = inputToValue(from, to);
+  const value = inputToValue(from, to, new Date(), timeZone);
   const onCalendarChange = useOnCalendarChange(onChange, timeZone);
   const styles = useStyles2(getBodyStyles);
 
@@ -32,14 +32,28 @@ export function Body({ onChange, from, to, timeZone }: TimePickerCalendarProps) 
 
 Body.displayName = 'Body';
 
-export function inputToValue(from: DateTime, to: DateTime, invalidDateDefault: Date = new Date()): [Date, Date] {
+export function inputToValue(
+  from: DateTime,
+  to: DateTime,
+  invalidDateDefault: Date = new Date(),
+  timezone?: string
+): [Date, Date] {
   const fromAsDate = from.toDate();
   const toAsDate = to.toDate();
   const fromAsValidDate = dateTime(fromAsDate).isValid() ? fromAsDate : invalidDateDefault;
   const toAsValidDate = dateTime(toAsDate).isValid() ? toAsDate : invalidDateDefault;
-
-  fromAsValidDate.setMinutes(fromAsValidDate.getMinutes() + 540);
-  toAsValidDate.setMinutes(toAsValidDate.getMinutes() + 540);
+  if (timezone) {
+    const zone = getZone(timezone);
+    if (zone) {
+      const fromOffset = zone.offset(fromAsValidDate.getTime());
+      const toOffset = zone.offset(toAsValidDate.getTime());
+      // fromAsValidDate.setMinutes(fromAsValidDate.getMinutes() - fromOffset);
+      // toAsValidDate.setMinutes(toAsValidDate.getMinutes() - toOffset);
+      fromAsValidDate.setMinutes(fromAsValidDate.getMinutes() + 480);
+      toAsValidDate.setMinutes(toAsValidDate.getMinutes() + 480);
+      console.log({ fromOffset, toOffset });
+    }
+  }
 
   if (fromAsValidDate > toAsValidDate) {
     return [toAsValidDate, fromAsValidDate];

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -38,6 +38,9 @@ export function inputToValue(from: DateTime, to: DateTime, invalidDateDefault: D
   const fromAsValidDate = dateTime(fromAsDate).isValid() ? fromAsDate : invalidDateDefault;
   const toAsValidDate = dateTime(toAsDate).isValid() ? toAsDate : invalidDateDefault;
 
+  fromAsValidDate.setMinutes(fromAsValidDate.getMinutes() + 540);
+  toAsValidDate.setMinutes(toAsValidDate.getMinutes() + 540);
+
   if (fromAsValidDate > toAsValidDate) {
     return [toAsValidDate, fromAsValidDate];
   }

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -159,8 +159,8 @@ export const TimeRangeContent = (props: Props) => {
       <TimePickerCalendar
         isFullscreen={isFullscreen}
         isOpen={isOpen}
-        from={dateTimeParse(from.value)}
-        to={dateTimeParse(to.value)}
+        from={dateTimeParse(from.value, { timeZone })}
+        to={dateTimeParse(to.value, { timeZone })}
         onApply={onApply}
         onClose={() => setOpen(false)}
         onChange={onChange}

--- a/scripts/grafana-server/custom.ini
+++ b/scripts/grafana-server/custom.ini
@@ -1,6 +1,6 @@
 [security]
-; content_security_policy = true
-; content_security_policy_template = """require-trusted-types-for 'script'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+content_security_policy = true
+content_security_policy_template = """require-trusted-types-for 'script'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
 [feature_toggles]
 enable = publicDashboards

--- a/scripts/grafana-server/custom.ini
+++ b/scripts/grafana-server/custom.ini
@@ -1,6 +1,6 @@
 [security]
-content_security_policy = true
-content_security_policy_template = """require-trusted-types-for 'script'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+; content_security_policy = true
+; content_security_policy_template = """require-trusted-types-for 'script'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
 [feature_toggles]
 enable = publicDashboards

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,6 +3719,7 @@ __metadata:
     "@babel/preset-env": 7.22.9
     "@cypress/webpack-preprocessor": 5.17.1
     "@grafana/e2e-selectors": 10.2.0-pre
+    "@grafana/schema": 10.2.0-pre
     "@grafana/tsconfig": ^1.2.0-rc1
     "@mochajs/json-file-reporter": ^1.2.0
     "@rollup/plugin-node-resolve": 15.1.0


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/69939

Fixes the Date Picker calendar not showing the correct selected dates when the user's timezone Grafana preference is different to their browser/OS.
    - [react-calendar doesn't support time zones](https://github.com/wojtekmaj/react-calendar/issues/511#issuecomment-835333976), so we must fiddle with the date to make them 'appear' correct to react-calendar. e.g. If 5 PM in New York is being selected we change the date to 5 PM in the user's browser's local time zone. 

Added E2E tests for the above, which required adding a new flow to set user preferences, and reset them when the test is finished.