### PR TITLE
Tempo: Autocomplete suggestions for multi-spanset operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "@grafana/faro-web-sdk": "1.1.2",
     "@grafana/google-sdk": "0.1.1",
     "@grafana/lezer-logql": "0.1.8",
-    "@grafana/lezer-traceql": "0.0.4",
+    "@grafana/lezer-traceql": "0.0.5",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "0.22.0",

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -260,7 +260,7 @@ describe('CompletionProvider', () => {
       {} as monacoTypes.Position
     );
     expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
-      ['count', 'avg', 'max', 'min', 'sum', 'select', 'by'].map((s) =>
+      [...CompletionProvider.spansetAggregatorOps, ...CompletionProvider.spansetGroupAndSelectOps].map((s) =>
         expect.objectContaining({ label: s, insertText: s })
       )
     );

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -237,6 +237,17 @@ describe('CompletionProvider', () => {
       )
     );
   });
+
+  it('suggests spanset combining operators after spanset selector', async () => {
+    const { provider, model } = setup('{.foo=300} ', 11, v1Tags);
+    const result = await provider.provideCompletionItems(
+      model as unknown as monacoTypes.editor.ITextModel,
+      {} as monacoTypes.Position
+    );
+    expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
+      CompletionProvider.spansetOps.map((s) => expect.objectContaining({ label: s, insertText: s }))
+    );
+  });
 });
 
 function setup(value: string, offset: number, tagsV1?: string[], tagsV2?: Scope[]) {

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -260,8 +260,8 @@ describe('CompletionProvider', () => {
       {} as monacoTypes.Position
     );
     expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
-      [...CompletionProvider.spansetAggregatorOps, ...CompletionProvider.spansetGroupAndSelectOps].map((s) =>
-        expect.objectContaining({ label: s, insertText: s })
+      CompletionProvider.functions.map((s) =>
+        expect.objectContaining({ label: s.label, insertText: s.insertText, documentation: s.documentation })
       )
     );
   });

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -38,6 +38,8 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
   static readonly comparisonOps: string[] = ['=', '!=', '>', '>=', '<', '<=', '=~', '!~'];
   static readonly structuralOps: string[] = ['>> ', '>', '~'];
   static readonly spansetOps: string[] = ['|', ...CompletionProvider.logicalOps, ...CompletionProvider.structuralOps];
+  static readonly spansetAggregatorOps: string[] = ['count', 'avg', 'max', 'min', 'sum'];
+  static readonly spansetGroupAndSelectOps: string[] = ['select', 'by'];
 
   // We set these directly and ae required for the provider to function.
   monaco: Monaco | undefined;
@@ -146,11 +148,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
           type: 'OPERATOR',
         }));
       case 'SPANSET_PIPELINE_AFTER_OPERATOR':
-        return ['count', 'avg', 'max', 'min', 'sum', 'select', 'by'].map((key) => ({
-          label: key,
-          insertText: key,
-          type: 'OPERATOR',
-        }));
+        return [...CompletionProvider.spansetAggregatorOps, ...CompletionProvider.spansetGroupAndSelectOps].map(
+          (key) => ({
+            label: key,
+            insertText: key,
+            type: 'OPERATOR',
+          })
+        );
       case 'SPANSET_COMPARISON_OPERATORS':
         return CompletionProvider.comparisonOps.map((key) => ({
           label: key,

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -149,13 +149,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
         return ['count', 'avg', 'max', 'min', 'sum', 'select', 'by'].map((key) => ({
           label: key,
           insertText: key,
-          type: 'OPERATOR', // TODO aggregator? and what about `select`?
+          type: 'OPERATOR',
         }));
-      case 'SPANSET_ARITMETHIC_OPERATORS': // TODO not actually `ARITMETHIC` operators, but comparisons
+      case 'SPANSET_COMPARISON_OPERATORS':
         return CompletionProvider.comparisonOps.map((key) => ({
           label: key,
           insertText: key,
-          type: 'OPERATOR', // TODO aggregator? and what about `select`?
+          type: 'OPERATOR',
         }));
       case 'SPANSET_IN_VALUE':
         let tagValues;

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -18,7 +18,8 @@ interface Props {
  * Class that implements CompletionItemProvider interface and allows us to provide suggestion for the Monaco
  * autocomplete system.
  *
- * Please refer to https://grafana.com/docs/tempo/latest/traceql for the syntax of TraceQL.
+ * Here we want to provide suggestions for TraceQL. Please refer to
+ * https://grafana.com/docs/tempo/latest/traceql for the syntax of the language.
  */
 export class CompletionProvider implements monacoTypes.languages.CompletionItemProvider {
   languageProvider: TempoLanguageProvider;
@@ -143,6 +144,18 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
           label: key,
           insertText: key,
           type: 'OPERATOR',
+        }));
+      case 'SPANSET_PIPELINE_AFTER_OPERATOR':
+        return ['count', 'avg', 'max', 'min', 'sum', 'select', 'by'].map((key) => ({
+          label: key,
+          insertText: key,
+          type: 'OPERATOR', // TODO aggregator? and what about `select`?
+        }));
+      case 'SPANSET_ARITMETHIC_OPERATORS': // TODO not actually `ARITMETHIC` operators, but comparisons
+        return CompletionProvider.comparisonOps.map((key) => ({
+          label: key,
+          insertText: key,
+          type: 'OPERATOR', // TODO aggregator? and what about `select`?
         }));
       case 'SPANSET_IN_VALUE':
         let tagValues;

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -17,6 +17,8 @@ interface Props {
 /**
  * Class that implements CompletionItemProvider interface and allows us to provide suggestion for the Monaco
  * autocomplete system.
+ *
+ * Please refer to https://grafana.com/docs/tempo/latest/traceql for the syntax of TraceQL.
  */
 export class CompletionProvider implements monacoTypes.languages.CompletionItemProvider {
   languageProvider: TempoLanguageProvider;
@@ -28,8 +30,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
   }
 
   triggerCharacters = ['{', '.', '[', '(', '=', '~', ' ', '"'];
+
+  // Operators
   static readonly operators: string[] = ['=', '-', '+', '<', '>', '>=', '<=', '=~'];
   static readonly logicalOps: string[] = ['&&', '||'];
+  static readonly comparisonOps: string[] = ['=', '!=', '>', '>=', '<', '<=', '=~', '!~'];
+  static readonly structuralOps: string[] = ['>> ', '>', '~'];
+  static readonly spansetOps: string[] = ['|', ...CompletionProvider.logicalOps, ...CompletionProvider.structuralOps];
 
   // We set these directly and ae required for the provider to function.
   monaco: Monaco | undefined;
@@ -127,6 +134,12 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
         return this.getTagsCompletions(undefined, situation.scope);
       case 'SPANSET_EXPRESSION_OPERATORS':
         return [...CompletionProvider.logicalOps, ...CompletionProvider.operators].map((key) => ({
+          label: key,
+          insertText: key,
+          type: 'OPERATOR',
+        }));
+      case 'SPANSET_COMBINING_OPERATORS':
+        return CompletionProvider.spansetOps.map((key) => ({
           label: key,
           insertText: key,
           type: 'OPERATOR',

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -259,7 +259,7 @@ function resolveErrorInFilterRoot(): SituationType {
   };
 }
 
-function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): Situation {
+function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): SituationType {
   if (node.prevSibling?.type.id === ComparisonOp) {
     return {
       type: 'UNKNOWN',
@@ -271,13 +271,13 @@ function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): Si
   };
 }
 
-function resolveSpansetPipelineExpression(_0: SyntaxNode, _1: string, _2: number): Situation {
+function resolveSpansetPipelineExpression(_0: SyntaxNode, _1: string, _2: number): SituationType {
   return {
     type: 'SPANSET_COMBINING_OPERATORS',
   };
 }
 
-function resolveSpansetPipeline(_0: SyntaxNode, _1: string, _2: number): Situation {
+function resolveSpansetPipeline(_0: SyntaxNode, _1: string, _2: number): SituationType {
   return {
     type: 'SPANSET_PIPELINE_AFTER_OPERATOR',
   };

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -1,6 +1,6 @@
 import { SyntaxNode, Tree } from '@lezer/common';
 
-import { AttributeField, FieldExpression, FieldOp, parser, SpansetFilter } from '@grafana/lezer-traceql';
+import { AttributeField, FieldExpression, FieldOp, parser, SpansetFilter, TraceQL } from '@grafana/lezer-traceql';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling' | 'prevSibling';
 type NodeType = number;
@@ -37,6 +37,9 @@ export type SituationType =
     }
   | {
       type: 'SPANSET_AFTER_VALUE';
+    }
+  | {
+      type: 'SPANSET_COMBINING_OPERATORS';
     };
 
 type Path = Array<[Direction, NodeType[]]>;
@@ -153,6 +156,14 @@ const RESOLVERS: Resolver[] = [
   {
     path: [SpansetFilter],
     fun: resolveSpanset,
+  },
+  {
+    path: [TraceQL],
+    fun: () => {
+      return {
+        type: 'SPANSET_COMBINING_OPERATORS',
+      };
+    },
   },
 ];
 

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -56,7 +56,7 @@ export type SituationType =
       type: 'SPANSET_PIPELINE_AFTER_OPERATOR';
     }
   | {
-      type: 'SPANSET_ARITMETHIC_OPERATORS';
+      type: 'SPANSET_COMPARISON_OPERATORS';
     };
 
 type Path = Array<[Direction, NodeType[]]>;
@@ -267,7 +267,7 @@ function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): Si
   }
 
   return {
-    type: 'SPANSET_ARITMETHIC_OPERATORS',
+    type: 'SPANSET_COMPARISON_OPERATORS',
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3868,12 +3868,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@grafana/lezer-traceql@npm:0.0.4"
+"@grafana/lezer-traceql@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@grafana/lezer-traceql@npm:0.0.5"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 69acea33476d3cdabfb99f3eb62bb34289bc205da69920e0eccc82f40407f9d584fa03f9662706ab667ee97d3ea84b964b22a11925e6699deef5afe1ca9e1906
+  checksum: 6fcf48acde1e444c155a4b4009f4c7211843b07960713821a2649b1db0e0ef819fd1062eec101173c2e6b8249b253faf0b6052e96f551663618fd2fe0d17e3c9
   languageName: node
   linkType: hard
 
@@ -19279,7 +19279,7 @@ __metadata:
     "@grafana/faro-web-sdk": 1.1.2
     "@grafana/google-sdk": 0.1.1
     "@grafana/lezer-logql": 0.1.8
-    "@grafana/lezer-traceql": 0.0.4
+    "@grafana/lezer-traceql": 0.0.5
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": 0.22.0


### PR DESCRIPTION
EDIT: Closed in favor of https://github.com/grafana/grafana/pull/73707

**What is this feature?**
We improve the autocompletion system for TraceQL. In particular, we add some initial support to operators to combine, aggregate,  group, and filter spansets—further improvements will be done in following PRs.

**Which issue(s) does this PR fix?**:

Fixes #73091
Fixes #73092 
Fixes #73093 
Fixes #73094
Fixes #73094
