### PR TITLE
Folders: Access parent folder without view permission POC

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -458,7 +458,8 @@ func (hs *HTTPServer) registerRoutes() {
 			folderRoute.Post("/", authorize(ac.EvalPermission(dashboards.ActionFoldersCreate)), routing.Wrap(hs.CreateFolder))
 
 			folderRoute.Group("/:uid", func(folderUidRoute routing.RouteRegister) {
-				folderUidRoute.Get("/", authorize(ac.EvalPermission(dashboards.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderByUID))
+				// TODO: UID scope removed for now because of additional traverse check inside GetFolderByUID()
+				folderUidRoute.Get("/", authorize(ac.EvalPermission(dashboards.ActionFoldersRead)), routing.Wrap(hs.GetFolderByUID))
 				folderUidRoute.Put("/", authorize(ac.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.UpdateFolder))
 				folderUidRoute.Post("/move", authorize(ac.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.MoveFolder))
 				folderUidRoute.Delete("/", authorize(ac.EvalPermission(dashboards.ActionFoldersDelete, uidScope)), routing.Wrap(hs.DeleteFolder))

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -174,6 +174,7 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 	}
 
 	canView := false
+	canTraverse := false
 	if cmd.UID != "" {
 		g, err := guardian.NewByUID(ctx, cmd.UID, cmd.OrgID, cmd.SignedInUser)
 		if err != nil {
@@ -185,9 +186,11 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 			return nil, err
 		}
 
-		canTraverse, err := g.CanTraverse()
-		if err != nil {
-			return nil, err
+		if !canView {
+			canTraverse, err = g.CanTraverse()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if !canView && !canTraverse {
@@ -233,15 +236,20 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		if err != nil {
 			return nil, err
 		}
-		canView, err := g.CanView()
+
+		canViewChild, err := g.CanView()
 		if err != nil {
 			return nil, err
 		}
-		canTraverse, err := g.CanTraverse()
-		if err != nil {
-			return nil, err
+
+		canTraverseChild := false
+		if !canViewChild {
+			canTraverseChild, err = g.CanTraverse()
+			if err != nil {
+				return nil, err
+			}
 		}
-		if canView || canTraverse {
+		if canViewChild || canTraverseChild {
 			filtered = append(filtered, f)
 		}
 	}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -173,13 +173,14 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
+	canView := false
 	if cmd.UID != "" {
 		g, err := guardian.NewByUID(ctx, cmd.UID, cmd.OrgID, cmd.SignedInUser)
 		if err != nil {
 			return nil, err
 		}
 
-		canView, err := g.CanView()
+		canView, err = g.CanView()
 		if err != nil {
 			return nil, err
 		}
@@ -221,7 +222,7 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		// always expose the dashboard store sequential ID
 		f.ID = dashFolder.ID
 
-		if cmd.UID != "" {
+		if cmd.UID != "" && canView {
 			// parent access has been checked already
 			// the subfolder must be accessible as well (due to inheritance)
 			filtered = append(filtered, f)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -130,7 +130,17 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 		return nil, err
 	}
 
-	if canView, err := g.CanView(); err != nil || !canView {
+	canTraverse, err := g.CanTraverse()
+	if err != nil {
+		return nil, err
+	}
+
+	canView, err := g.CanView()
+	if err != nil {
+		return nil, err
+	}
+
+	if !canView && !canTraverse {
 		if err != nil {
 			return nil, toFolderError(err)
 		}
@@ -174,7 +184,12 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 			return nil, err
 		}
 
-		if !canView {
+		canTraverse, err := g.CanTraverse()
+		if err != nil {
+			return nil, err
+		}
+
+		if !canView && !canTraverse {
 			return nil, dashboards.ErrFolderAccessDenied
 		}
 	}
@@ -221,7 +236,11 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		if err != nil {
 			return nil, err
 		}
-		if canView {
+		canTraverse, err := g.CanTraverse()
+		if err != nil {
+			return nil, err
+		}
+		if canView || canTraverse {
 			filtered = append(filtered, f)
 		}
 	}

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -29,6 +29,7 @@ type DashboardGuardian interface {
 	CanSave() (bool, error)
 	CanEdit() (bool, error)
 	CanView() (bool, error)
+	CanTraverse() (bool, error)
 	CanAdmin() (bool, error)
 	CanDelete() (bool, error)
 	CanCreate(folderID int64, isFolder bool) (bool, error)
@@ -191,6 +192,10 @@ func (g *dashboardGuardianImpl) CanEdit() (bool, error) {
 }
 
 func (g *dashboardGuardianImpl) CanView() (bool, error) {
+	return g.HasPermission(dashboards.PERMISSION_VIEW)
+}
+
+func (g *dashboardGuardianImpl) CanTraverse() (bool, error) {
 	return g.HasPermission(dashboards.PERMISSION_VIEW)
 }
 
@@ -452,6 +457,10 @@ func (g *FakeDashboardGuardian) CanEdit() (bool, error) {
 
 func (g *FakeDashboardGuardian) CanView() (bool, error) {
 	return g.CanViewValue, nil
+}
+
+func (g *FakeDashboardGuardian) CanTraverse() (bool, error) {
+	return true, nil
 }
 
 func (g *FakeDashboardGuardian) CanAdmin() (bool, error) {

--- a/pkg/services/guardian/provider.go
+++ b/pkg/services/guardian/provider.go
@@ -17,11 +17,11 @@ type Provider struct{}
 func ProvideService(
 	cfg *setting.Cfg, store db.DB, ac accesscontrol.AccessControl,
 	folderPermissionsService accesscontrol.FolderPermissionsService, dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService, teamService team.Service,
+	dashboardService dashboards.DashboardService, teamService team.Service, folderService folder.Service,
 ) *Provider {
 	if !ac.IsDisabled() {
 		// TODO: Fix this hack, see https://github.com/grafana/grafana-enterprise/issues/2935
-		InitAccessControlGuardian(cfg, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		InitAccessControlGuardian(cfg, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService, folderService)
 	} else {
 		InitLegacyGuardian(cfg, store, dashboardService, teamService)
 	}
@@ -48,21 +48,21 @@ func InitLegacyGuardian(cfg *setting.Cfg, store db.DB, dashSvc dashboards.Dashbo
 
 func InitAccessControlGuardian(
 	cfg *setting.Cfg, store db.DB, ac accesscontrol.AccessControl, folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService, dashboardService dashboards.DashboardService,
+	dashboardPermissionsService accesscontrol.DashboardPermissionsService, dashboardService dashboards.DashboardService, folderService folder.Service,
 ) {
 	New = func(ctx context.Context, dashId int64, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService, folderService)
 	}
 
 	NewByUID = func(ctx context.Context, dashUID string, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService, folderService)
 	}
 
 	NewByDashboard = func(ctx context.Context, dash *dashboards.Dashboard, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService, folderService)
 	}
 
 	NewByFolder = func(ctx context.Context, f *folder.Folder, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlFolderGuardian(ctx, cfg, f, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlFolderGuardian(ctx, cfg, f, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService, folderService)
 	}
 }


### PR DESCRIPTION
**What is this feature?**

This is POC for #71425

It allow to display full subtree of the folders that user has access to, including parent folders without "view" permission.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #71425

**Special notes for your reviewer:**

So idea for this POC is that we can implement a kind of "traverse" permission which allows to access folders that parents for those with view access for the particular user.

![nested_folders_permissions_01](https://github.com/grafana/grafana/assets/4932851/e774bd40-7542-48d7-89a3-d21f59ac3d04)

The algorithm is pretty straightforward (I haven't checked performance yet, but the fact that we have `GetParents()` method which utilized SQL built-in recurse if possible sounds promising): 
1. Collect list of folders that user has access to (extract from user's permissions).
2. For each folder get list of the parents ( `GetParents()` returns all parents until the root folder). Most performance-demanding part.
3. When evaluating access to the folder, check if current user has view access to folder or it's in the list of parents (user can "traverse") folder.

![nested_folders_permissions_02](https://github.com/grafana/grafana/assets/4932851/5717a12b-aec7-4df7-811b-7e643d49a841)


Idea is similar to Unix execution (`x`) bit for directories, it does not allow to read dir, but traverse it.

From the performance perspective, I need to investigate the possibilities of optimization. Looks like one of the way is to cache list of parent folders for particular user since it's most complicated part.