### PR TITLE
Alerting: Add config options to use a provisioned Alertmanager as the main one

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1109,6 +1109,10 @@ min_interval = 10s
 # (concurrent queries per rule disabled).
 max_state_save_concurrency = 1
 
+# Disable the internal alertmanager and use a provisioned external one instead.
+# The default value is `false`.
+disable_internal_alertmanager = false
+
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. You must have either installed the Grafana image rendering
 # plugin, or set up Grafana to use a remote rendering service.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -161,11 +161,11 @@ func (ng *AlertNG) init() error {
 		}
 		am, err := ng.DataSourceService.GetDataSource(initCtx, &query)
 		if err != nil {
-			return fmt.Errorf("Failed to find provisioned Alertmanager: %w", err)
+			return fmt.Errorf("failed to find provisioned Alertmanager: %w", err)
 		}
 		_, err = ng.DataSourceService.DecryptedBasicAuthPassword(initCtx, am)
 		if err != nil {
-			return fmt.Errorf("Error decrypting basic auth password: %w", err)
+			return fmt.Errorf("error decrypting basic auth password: %w", err)
 		}
 		// TODO: disable internal Alertmanager
 	}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -78,6 +78,7 @@ type UnifiedAlertingSettings struct {
 	HARedisUsername                string
 	HARedisPassword                string
 	HARedisDB                      int
+	DisableInternalAlertmanager    bool
 	MaxAttempts                    int64
 	MinInterval                    time.Duration
 	EvaluationTimeout              time.Duration
@@ -248,6 +249,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 			uaCfg.HAPeers = append(uaCfg.HAPeers, peer)
 		}
 	}
+
+	uaCfg.DisableInternalAlertmanager = ua.Key("disable_internal_alertmanager").MustBool(false)
 
 	// TODO load from ini file
 	uaCfg.DefaultConfiguration = alertmanagerDefaultConfiguration


### PR DESCRIPTION
This PR adds configuration options for disabling the internal Alertmanager and connecting to an external one.
It's an alternative to https://github.com/grafana/grafana/pull/71318, which added options to configure a URL and basic auth credentials. In this PR that data is automatically taken from our provisioned data sources.

This feature needs a provisioned Alertmanager with `grafanacloud-ngalertmanager` as its UID.
<details><summary>Here's an example.</summary>

```yaml
# conf/provisioning/datasources/sample.yaml
apiVersion: 1

datasources:
- name: Provisioned Alertmanager 
  uid: "grafanacloud-ngalertmanager"
  type: alertmanager
  access: proxy
  orgId: 1
  url: http://localhost:8080
  basicAuth: true
  basicAuthUser: test
  secureJsonData:
    basicAuthPassword: test
```

</details>

Note: spinning up a new instance of Grafana with its internal Alertmanager disabled will fail since we provision data sources once the Alerting engine is running. We should either change the order in which we run our services or start Grafana with its internal Alertmanager enabled before disabling it in a later boot.