### PR TITLE
DataSourcePicker: remove default property from data source variable selection

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -261,6 +261,7 @@ export class DatasourceSrv implements DataSourceService {
           const key = `$\{${variable.name}\}`;
           base.push({
             ...dsSettings,
+            isDefault: false,
             name: key,
             uid: key,
           });


### PR DESCRIPTION
**What is this feature?**

When creating a new data source entry for the list from a variable using the `dsSettings` from the selected data source we need to override the default value to false since it is not the original DS.
This PR overrides the value `isDefault` always as false when creating a new DS for the data source picker list from a variable.
![image](https://github.com/grafana/grafana/assets/20256983/8b8650aa-d3a8-4f33-8d8c-856f8462e4e8)

With this change the variable datasource does not appear as `default` and can be selected
![image](https://github.com/grafana/grafana/assets/20256983/59c2adf2-ba7f-4e2b-bab8-b5eeba3d3d7b)

Fixes https://github.com/grafana/grafana/issues/73312

**Special notes for your reviewer:**
This is an attempt to fix this particular case but I'm not familiarized with this code so I don't have enough context of what side effects this could have. There are more details in the linked issue and the original escalation.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
