### PR TITLE
Plugins: remove 'admin/plugins' redirect 

### DIFF
--- a/public/app/features/plugins/admin/routes.tsx
+++ b/public/app/features/plugins/admin/routes.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import { Redirect } from 'react-router-dom';
-
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
 import { RouteDescriptor } from 'app/core/navigation/types';
 
@@ -27,11 +24,6 @@ const DEFAULT_ROUTES = [
     roles: () => ['Admin', 'ServerAdmin'],
     routeName: PluginAdminRoutes.Details,
     component: SafeDynamicImport(() => import(/* webpackChunkName: "PluginPage" */ './pages/PluginDetails')),
-  },
-  {
-    path: '/admin/plugins/*',
-    navId: 'admin-plugins',
-    component: () => <Redirect to="/plugins" />,
   },
 ];
 


### PR DESCRIPTION
**What is this feature?**
There is a redirect in /admin/plugins for grafana 9.2.* and with grafana 10 we do not need it anymore. Related with [this PR](https://github.com/grafana/grafana/pull/54386)

**Who is this feature for?**
It is for us to keep our codebase clean

**Which issue(s) does this PR fix?**:

Fixes #54422
