### PR TITLE
Plugins: Make Installer responsible for removing plugins from file system

### DIFF
--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -486,7 +486,7 @@ func pluginAssetScenario(t *testing.T, desc string, url string, urlPattern strin
 		cfg.IsFeatureToggleEnabled = func(_ string) bool { return false }
 		hs := HTTPServer{
 			Cfg:             cfg,
-			pluginStore:     store.New(pluginRegistry),
+			pluginStore:     store.New(pluginRegistry, &fakes.FakeLoader{}),
 			pluginFileStore: filestore.ProvideService(pluginRegistry),
 			log:             log.NewNopLogger(),
 			pluginsCDNService: pluginscdn.ProvideService(&config.Cfg{
@@ -598,7 +598,7 @@ func Test_PluginsList_AccessControl(t *testing.T) {
 			server := SetupAPITestServer(t, func(hs *HTTPServer) {
 				hs.Cfg = setting.NewCfg()
 				hs.PluginSettings = &pluginSettings
-				hs.pluginStore = store.New(pluginRegistry)
+				hs.pluginStore = store.New(pluginRegistry, &fakes.FakeLoader{})
 				hs.pluginFileStore = filestore.ProvideService(pluginRegistry)
 				var err error
 				hs.pluginsUpdateChecker, err = updatechecker.ProvidePluginsService(hs.Cfg, nil, tracing.InitializeTracerForTest())

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -40,7 +40,7 @@ func (i *FakePluginInstaller) Remove(ctx context.Context, pluginID string) error
 
 type FakeLoader struct {
 	LoadFunc   func(_ context.Context, _ plugins.PluginSource) ([]*plugins.Plugin, error)
-	UnloadFunc func(_ context.Context, _ string) (*plugins.Plugin, error)
+	UnloadFunc func(_ context.Context, _ *plugins.Plugin) (*plugins.Plugin, error)
 }
 
 func (l *FakeLoader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins.Plugin, error) {
@@ -50,9 +50,9 @@ func (l *FakeLoader) Load(ctx context.Context, src plugins.PluginSource) ([]*plu
 	return nil, nil
 }
 
-func (l *FakeLoader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
+func (l *FakeLoader) Unload(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
 	if l.UnloadFunc != nil {
-		return l.UnloadFunc(ctx, pluginID)
+		return l.UnloadFunc(ctx, p)
 	}
 	return nil, nil
 }
@@ -509,12 +509,12 @@ func (f *FakeInitializer) Initialize(ctx context.Context, ps []*plugins.Plugin) 
 }
 
 type FakeTerminator struct {
-	TerminateFunc func(ctx context.Context, pluginID string) (*plugins.Plugin, error)
+	TerminateFunc func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error)
 }
 
-func (f *FakeTerminator) Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
+func (f *FakeTerminator) Terminate(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
 	if f.TerminateFunc != nil {
-		return f.TerminateFunc(ctx, pluginID)
+		return f.TerminateFunc(ctx, p)
 	}
 	return nil, nil
 }

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -40,7 +40,7 @@ func (i *FakePluginInstaller) Remove(ctx context.Context, pluginID string) error
 
 type FakeLoader struct {
 	LoadFunc   func(_ context.Context, _ plugins.PluginSource) ([]*plugins.Plugin, error)
-	UnloadFunc func(_ context.Context, _ string) error
+	UnloadFunc func(_ context.Context, _ string) (*plugins.Plugin, error)
 }
 
 func (l *FakeLoader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins.Plugin, error) {
@@ -50,11 +50,11 @@ func (l *FakeLoader) Load(ctx context.Context, src plugins.PluginSource) ([]*plu
 	return nil, nil
 }
 
-func (l *FakeLoader) Unload(ctx context.Context, pluginID string) error {
+func (l *FakeLoader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
 	if l.UnloadFunc != nil {
 		return l.UnloadFunc(ctx, pluginID)
 	}
-	return nil
+	return nil, nil
 }
 
 type FakePluginClient struct {
@@ -509,14 +509,14 @@ func (f *FakeInitializer) Initialize(ctx context.Context, ps []*plugins.Plugin) 
 }
 
 type FakeTerminator struct {
-	TerminateFunc func(ctx context.Context, pluginID string) error
+	TerminateFunc func(ctx context.Context, pluginID string) (*plugins.Plugin, error)
 }
 
-func (f *FakeTerminator) Terminate(ctx context.Context, pluginID string) error {
+func (f *FakeTerminator) Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
 	if f.TerminateFunc != nil {
 		return f.TerminateFunc(ctx, pluginID)
 	}
-	return nil
+	return nil, nil
 }
 
 type FakeBackendPlugin struct {

--- a/pkg/plugins/manager/installer.go
+++ b/pkg/plugins/manager/installer.go
@@ -145,9 +145,17 @@ func (m *PluginInstaller) Remove(ctx context.Context, pluginID string) error {
 		return plugins.ErrUninstallCorePlugin
 	}
 
-	if err := m.pluginLoader.Unload(ctx, plugin.ID); err != nil {
+	p, err := m.pluginLoader.Unload(ctx, plugin.ID)
+	if err != nil {
 		return err
 	}
+
+	if remover, ok := p.FS.(plugins.FSRemover); ok {
+		if err = remover.Remove(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/plugins/manager/installer.go
+++ b/pkg/plugins/manager/installer.go
@@ -145,7 +145,7 @@ func (m *PluginInstaller) Remove(ctx context.Context, pluginID string) error {
 		return plugins.ErrUninstallCorePlugin
 	}
 
-	p, err := m.pluginLoader.Unload(ctx, plugin.ID)
+	p, err := m.pluginLoader.Unload(ctx, plugin)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/manager/installer_test.go
+++ b/pkg/plugins/manager/installer_test.go
@@ -40,6 +40,9 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 				require.Equal(t, []string{zipNameV1}, src.PluginURIs(ctx))
 				return []*plugins.Plugin{pluginV1}, nil
 			},
+			UnloadFunc: func(_ context.Context, _ string) (*plugins.Plugin, error) {
+				return pluginV1, nil
+			},
 		}
 
 		pluginRepo := &fakes.FakePluginRepo{
@@ -129,9 +132,9 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 
 			var unloadedPlugins []string
 			inst.pluginLoader = &fakes.FakeLoader{
-				UnloadFunc: func(_ context.Context, id string) error {
+				UnloadFunc: func(_ context.Context, id string) (*plugins.Plugin, error) {
 					unloadedPlugins = append(unloadedPlugins, id)
-					return nil
+					return pluginV1, nil
 				},
 			}
 

--- a/pkg/plugins/manager/installer_test.go
+++ b/pkg/plugins/manager/installer_test.go
@@ -134,7 +134,7 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 			inst.pluginLoader = &fakes.FakeLoader{
 				UnloadFunc: func(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
 					unloadedPlugins = append(unloadedPlugins, p.ID)
-					return pluginV1, nil
+					return p, nil
 				},
 			}
 

--- a/pkg/plugins/manager/installer_test.go
+++ b/pkg/plugins/manager/installer_test.go
@@ -40,8 +40,8 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 				require.Equal(t, []string{zipNameV1}, src.PluginURIs(ctx))
 				return []*plugins.Plugin{pluginV1}, nil
 			},
-			UnloadFunc: func(_ context.Context, _ string) (*plugins.Plugin, error) {
-				return pluginV1, nil
+			UnloadFunc: func(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+				return p, nil
 			},
 		}
 
@@ -132,8 +132,8 @@ func TestPluginManager_Add_Remove(t *testing.T) {
 
 			var unloadedPlugins []string
 			inst.pluginLoader = &fakes.FakeLoader{
-				UnloadFunc: func(_ context.Context, id string) (*plugins.Plugin, error) {
-					unloadedPlugins = append(unloadedPlugins, id)
+				UnloadFunc: func(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+					unloadedPlugins = append(unloadedPlugins, p.ID)
 					return pluginV1, nil
 				},
 			}

--- a/pkg/plugins/manager/loader/ifaces.go
+++ b/pkg/plugins/manager/loader/ifaces.go
@@ -11,5 +11,5 @@ type Service interface {
 	// Load will return a list of plugins found in the provided file system paths.
 	Load(ctx context.Context, src plugins.PluginSource) ([]*plugins.Plugin, error)
 	// Unload will unload a specified plugin from the file system.
-	Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error)
+	Unload(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error)
 }

--- a/pkg/plugins/manager/loader/ifaces.go
+++ b/pkg/plugins/manager/loader/ifaces.go
@@ -11,5 +11,5 @@ type Service interface {
 	// Load will return a list of plugins found in the provided file system paths.
 	Load(ctx context.Context, src plugins.PluginSource) ([]*plugins.Plugin, error)
 	// Unload will unload a specified plugin from the file system.
-	Unload(ctx context.Context, pluginID string) error
+	Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error)
 }

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -57,6 +57,6 @@ func (l *Loader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins
 	return initializedPlugins, nil
 }
 
-func (l *Loader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
-	return l.termination.Terminate(ctx, pluginID)
+func (l *Loader) Unload(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	return l.termination.Terminate(ctx, p)
 }

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -57,6 +57,6 @@ func (l *Loader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins
 	return initializedPlugins, nil
 }
 
-func (l *Loader) Unload(ctx context.Context, pluginID string) error {
+func (l *Loader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
 	return l.termination.Terminate(ctx, pluginID)
 }

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -496,13 +496,13 @@ func TestLoader_Unload(t *testing.T) {
 				&fakes.FakeValidator{},
 				&fakes.FakeInitializer{},
 				&fakes.FakeTerminator{
-					TerminateFunc: func(ctx context.Context, pID string) error {
+					TerminateFunc: func(ctx context.Context, pID string) (*plugins.Plugin, error) {
 						require.Equal(t, pluginID, pID)
-						return tc.expectedErr
+						return nil, tc.expectedErr
 					},
 				})
 
-			err := l.Unload(context.Background(), pluginID)
+			_, err := l.Unload(context.Background(), pluginID)
 			require.ErrorIs(t, err, tc.expectedErr)
 		}
 	})

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -500,7 +500,7 @@ func TestLoader_Unload(t *testing.T) {
 				&fakes.FakeTerminator{
 					TerminateFunc: func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
 						require.Equal(t, plugin, p)
-						return nil, tc.expectedErr
+						return p, tc.expectedErr
 					},
 				})
 

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -478,7 +478,9 @@ func TestLoader_Load(t *testing.T) {
 
 func TestLoader_Unload(t *testing.T) {
 	t.Run("Termination stage error is returned from Unload", func(t *testing.T) {
-		pluginID := "grafana-test-panel"
+		plugin := &plugins.Plugin{
+			JSONData: plugins.JSONData{ID: "test-datasource", Type: plugins.TypeDataSource, Info: plugins.Info{Version: "1.0.0"}},
+		}
 		tcs := []struct {
 			expectedErr error
 		}{
@@ -496,13 +498,13 @@ func TestLoader_Unload(t *testing.T) {
 				&fakes.FakeValidator{},
 				&fakes.FakeInitializer{},
 				&fakes.FakeTerminator{
-					TerminateFunc: func(ctx context.Context, pID string) (*plugins.Plugin, error) {
-						require.Equal(t, pluginID, pID)
+					TerminateFunc: func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+						require.Equal(t, plugin, p)
 						return nil, tc.expectedErr
 					},
 				})
 
-			_, err := l.Unload(context.Background(), pluginID)
+			_, err := l.Unload(context.Background(), plugin)
 			require.ErrorIs(t, err, tc.expectedErr)
 		}
 	})

--- a/pkg/plugins/manager/pipeline/termination/steps.go
+++ b/pkg/plugins/manager/pipeline/termination/steps.go
@@ -93,13 +93,3 @@ func (d *Deregister) Deregister(ctx context.Context, p *plugins.Plugin) error {
 	d.log.Debug("Plugin unregistered", "pluginId", p.ID)
 	return nil
 }
-
-// FSRemoval implements a TerminateFunc for removing plugin files from the filesystem.
-func FSRemoval(_ context.Context, p *plugins.Plugin) error {
-	if remover, ok := p.FS.(plugins.FSRemover); ok {
-		if err := remover.Remove(); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/pkg/plugins/manager/pipeline/termination/steps.go
+++ b/pkg/plugins/manager/pipeline/termination/steps.go
@@ -9,39 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 )
 
-// TerminablePluginResolver implements a ResolveFunc for resolving a plugin that can be terminated.
-type TerminablePluginResolver struct {
-	pluginRegistry registry.Service
-	log            log.Logger
-}
-
-// TerminablePluginResolverStep returns a new ResolveFunc for resolving a plugin that can be terminated.
-func TerminablePluginResolverStep(pluginRegistry registry.Service) ResolveFunc {
-	return newTerminablePluginResolver(pluginRegistry).Resolve
-}
-
-func newTerminablePluginResolver(pluginRegistry registry.Service) *TerminablePluginResolver {
-	return &TerminablePluginResolver{
-		pluginRegistry: pluginRegistry,
-		log:            log.New("plugins.resolver"),
-	}
-}
-
-// Resolve returns a plugin that can be terminated.
-func (r *TerminablePluginResolver) Resolve(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
-	p, exists := r.pluginRegistry.Plugin(ctx, pluginID)
-	if !exists {
-		return nil, plugins.ErrPluginNotInstalled
-	}
-
-	// core plugins and bundled plugins cannot be terminated
-	if p.IsCorePlugin() || p.IsBundledPlugin() {
-		return nil, plugins.ErrUninstallCorePlugin
-	}
-
-	return p, nil
-}
-
 // BackendProcessTerminator implements a TerminateFunc for stopping a backend plugin process.
 //
 // It uses the process.Manager to stop the backend plugin process.

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -11,7 +11,7 @@ import (
 
 // Terminator is responsible for the Termination stage of the plugin loader pipeline.
 type Terminator interface {
-	Terminate(ctx context.Context, pluginID string) error
+	Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error)
 }
 
 // ResolveFunc is the function used for the Resolve step of the Termination stage.
@@ -52,16 +52,16 @@ func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
 }
 
 // Terminate will execute the Terminate steps of the Termination stage.
-func (t *Terminate) Terminate(ctx context.Context, pluginID string) error {
+func (t *Terminate) Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
 	p, err := t.resolveStep(ctx, pluginID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, terminate := range t.terminateSteps {
 		if err = terminate(ctx, p); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return p, nil
 }

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -2,7 +2,6 @@ package termination
 
 import (
 	"context"
-	"errors"
 
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/config"
@@ -14,38 +13,27 @@ type Terminator interface {
 	Terminate(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error)
 }
 
-// ResolveFunc is the function used for the Resolve step of the Termination stage.
-type ResolveFunc func(ctx context.Context, pluginID string) (*plugins.Plugin, error)
-
 // TerminateFunc is the function used for the Terminate step of the Termination stage.
 type TerminateFunc func(ctx context.Context, p *plugins.Plugin) error
 
 type Terminate struct {
 	cfg            *config.Cfg
-	resolveStep    ResolveFunc
 	terminateSteps []TerminateFunc
 	log            log.Logger
 }
 
 type Opts struct {
-	ResolveFunc    ResolveFunc
 	TerminateFuncs []TerminateFunc
 }
 
 // New returns a new Termination stage.
 func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
-	// without a resolve function, we can't do anything so return an error
-	if opts.ResolveFunc == nil && opts.TerminateFuncs != nil {
-		return nil, errors.New("resolve function is required")
-	}
-
 	if opts.TerminateFuncs == nil {
 		opts.TerminateFuncs = []TerminateFunc{}
 	}
 
 	return &Terminate{
 		cfg:            cfg,
-		resolveStep:    opts.ResolveFunc,
 		terminateSteps: opts.TerminateFuncs,
 		log:            log.New("plugins.termination"),
 	}, nil

--- a/pkg/plugins/manager/pipeline/termination/termination.go
+++ b/pkg/plugins/manager/pipeline/termination/termination.go
@@ -11,7 +11,7 @@ import (
 
 // Terminator is responsible for the Termination stage of the plugin loader pipeline.
 type Terminator interface {
-	Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error)
+	Terminate(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error)
 }
 
 // ResolveFunc is the function used for the Resolve step of the Termination stage.
@@ -52,14 +52,9 @@ func New(cfg *config.Cfg, opts Opts) (*Terminate, error) {
 }
 
 // Terminate will execute the Terminate steps of the Termination stage.
-func (t *Terminate) Terminate(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
-	p, err := t.resolveStep(ctx, pluginID)
-	if err != nil {
-		return nil, err
-	}
-
+func (t *Terminate) Terminate(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
 	for _, terminate := range t.terminateSteps {
-		if err = terminate(ctx, p); err != nil {
+		if err := terminate(ctx, p); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/services/pluginsintegration/loader/loader.go
+++ b/pkg/services/pluginsintegration/loader/loader.go
@@ -30,6 +30,6 @@ func (l *Loader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins
 	return l.loader.Load(ctx, src)
 }
 
-func (l *Loader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
-	return l.loader.Unload(ctx, pluginID)
+func (l *Loader) Unload(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	return l.loader.Unload(ctx, p)
 }

--- a/pkg/services/pluginsintegration/loader/loader.go
+++ b/pkg/services/pluginsintegration/loader/loader.go
@@ -30,6 +30,6 @@ func (l *Loader) Load(ctx context.Context, src plugins.PluginSource) ([]*plugins
 	return l.loader.Load(ctx, src)
 }
 
-func (l *Loader) Unload(ctx context.Context, pluginID string) error {
+func (l *Loader) Unload(ctx context.Context, pluginID string) (*plugins.Plugin, error) {
 	return l.loader.Unload(ctx, pluginID)
 }

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -69,7 +69,6 @@ func ProvideInitializationStage(cfg *config.Cfg, pr registry.Service, l plugins.
 
 func ProvideTerminationStage(cfg *config.Cfg, pr registry.Service, pm process.Manager) (*termination.Terminate, error) {
 	return termination.New(cfg, termination.Opts{
-		ResolveFunc: termination.TerminablePluginResolverStep(pr),
 		TerminateFuncs: []termination.TerminateFunc{
 			termination.BackendProcessTerminatorStep(pm),
 			termination.DeregisterStep(pr),

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -73,7 +73,6 @@ func ProvideTerminationStage(cfg *config.Cfg, pr registry.Service, pm process.Ma
 		TerminateFuncs: []termination.TerminateFunc{
 			termination.BackendProcessTerminatorStep(pm),
 			termination.DeregisterStep(pr),
-			termination.FSRemoval,
 		},
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Historically the plugin loader was responsible for removing plugins from disk (via `Unload`). This was invoked only during the uninstallation process. However, since the installer is the one who places plugins on disk, it should also be the one to remove them. It also means that other parts of the code can now re-use the unload functionality IE the plugin shutdown hook.

**Why do we need this feature?**

Should make things easier to reason about.

**Who is this feature for?**

Plugins Platform

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->
**Special notes for your reviewer:**
Can also now remove the `resolve` step from the termination stage.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
