### PR TITLE
Alerting: ScreenshotOptions From and To should be optional

### DIFF
--- a/pkg/services/screenshot/option.go
+++ b/pkg/services/screenshot/option.go
@@ -9,8 +9,6 @@ import (
 )
 
 var (
-	DefaultFrom    = "now-1h"
-	DefaultTo      = "now"
 	DefaultHeight  = 500
 	DefaultWidth   = 1000
 	DefaultTheme   = models.ThemeDark
@@ -19,25 +17,24 @@ var (
 
 // ScreenshotOptions are the options for taking a screenshot.
 type ScreenshotOptions struct {
+	// OrgID, DashboardUID and PanelID are required.
 	OrgID        int64
 	DashboardUID string
 	PanelID      int64
-	From         string
-	To           string
-	Width        int
-	Height       int
-	Theme        models.Theme
-	Timeout      time.Duration
+
+	// These are optional. From and To must both be set to take effect.
+	// Width, Height, Theme and Timeout inherit their defaults from
+	// DefaultWidth, DefaultHeight, DefaultTheme and DefaultTimeout.
+	From    string
+	To      string
+	Width   int
+	Height  int
+	Theme   models.Theme
+	Timeout time.Duration
 }
 
 // SetDefaults sets default values for missing or invalid options.
 func (s ScreenshotOptions) SetDefaults() ScreenshotOptions {
-	if s.From == "" {
-		s.From = DefaultFrom
-	}
-	if s.To == "" {
-		s.To = DefaultTo
-	}
 	if s.Width <= 0 {
 		s.Width = DefaultWidth
 	}

--- a/pkg/services/screenshot/option_test.go
+++ b/pkg/services/screenshot/option_test.go
@@ -12,8 +12,6 @@ func TestScreenshotOptions(t *testing.T) {
 
 	o = o.SetDefaults()
 	assert.Equal(t, ScreenshotOptions{
-		From:    DefaultFrom,
-		To:      DefaultTo,
 		Width:   DefaultWidth,
 		Height:  DefaultHeight,
 		Theme:   DefaultTheme,
@@ -24,7 +22,6 @@ func TestScreenshotOptions(t *testing.T) {
 	o = o.SetDefaults()
 	assert.Equal(t, ScreenshotOptions{
 		From:    "now-6h",
-		To:      DefaultTo,
 		Width:   DefaultWidth,
 		Height:  DefaultHeight,
 		Theme:   DefaultTheme,
@@ -91,13 +88,13 @@ func TestScreenshotOptions_Hash(t *testing.T) {
 	assert.Equal(t, []byte{0xd7, 0xf3, 0x56, 0x7f, 0xec, 0x7b, 0xdf, 0x95}, o.Hash())
 
 	o = o.SetDefaults()
-	assert.Equal(t, []byte{0x13, 0x59, 0xa3, 0x88, 0x6a, 0xdd, 0x26, 0x3}, o.Hash())
+	assert.Equal(t, []byte{0x71, 0x54, 0xe8, 0xea, 0x2, 0xf4, 0xd6, 0xd3}, o.Hash())
 
 	o.OrgID = 1
-	assert.Equal(t, []byte{0xd8, 0xfb, 0xf2, 0x7, 0x87, 0x92, 0x57, 0x28}, o.Hash())
+	assert.Equal(t, []byte{0x8, 0x75, 0x48, 0x46, 0x88, 0xa9, 0xf3, 0xe6}, o.Hash())
 
 	o.From = "now-6h"
-	assert.Equal(t, []byte{0x52, 0x3f, 0x86, 0xe3, 0x59, 0x1a, 0x7f, 0xfd}, o.Hash())
+	assert.Equal(t, []byte{0xfc, 0xd9, 0xe5, 0xa4, 0x32, 0xde, 0x33, 0x8b}, o.Hash())
 
 	o.To = "now-2h"
 	assert.Equal(t, []byte{0x8b, 0x78, 0xf4, 0xe7, 0xaa, 0x6, 0xba, 0xde}, o.Hash())

--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -99,8 +99,10 @@ func (s *HeadlessScreenshotService) Take(ctx context.Context, opts ScreenshotOpt
 	p := u.Query()
 	p.Add("orgId", strconv.FormatInt(dashboard.OrgID, 10))
 	p.Add("panelId", strconv.FormatInt(opts.PanelID, 10))
-	p.Add("from", opts.From)
-	p.Add("to", opts.To)
+	if opts.From != "" && opts.To != "" {
+		p.Add("from", opts.From)
+		p.Add("to", opts.To)
+	}
 	u.RawQuery = p.Encode()
 
 	renderOpts := rendering.Opts{


### PR DESCRIPTION
**What is this feature?**

This commit updates the screenshot package to make From and To optional. It also updates the docs for ScreenshotOptions so this behavior is well documented.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63718

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
