### PR TITLE
Canvas: Fix data links

### DIFF
--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -1,6 +1,6 @@
 import { isNumber, isString } from 'lodash';
 
-import { AppEvents, Field, LinkModel, PluginState, SelectableValue } from '@grafana/data';
+import { AppEvents, Field, getFieldDisplayName, LinkModel, PluginState, SelectableValue } from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { hasAlphaPanels } from 'app/core/config';
 import {
@@ -116,8 +116,8 @@ export function getDataLinks(ctx: DimensionContext, cfg: TextConfig, textData: s
   frames?.forEach((frame) => {
     const visibleFields = frame.fields.filter((field) => !Boolean(field.config.custom?.hideFrom?.tooltip));
 
-    if (cfg.text?.field && visibleFields.some((f) => f.name === cfg.text?.field)) {
-      const field = visibleFields.filter((field) => field.name === cfg.text?.field)[0];
+    if (cfg.text?.field && visibleFields.some((f) => getFieldDisplayName(f, frame) === cfg.text?.field)) {
+      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === cfg.text?.field)[0];
       if (field?.getLinks) {
         const disp = field.display ? field.display(textData) : { text: `${textData}`, numeric: +textData! };
         field.getLinks({ calculatedValue: disp }).forEach((link) => {


### PR DESCRIPTION
This fixes the name check for datalinks by using `getFieldDisplayName`. I know this check is happening in a few other places outside Canvas, maybe we should re-test and update accordingly.

Before

https://github.com/grafana/grafana/assets/88068998/7fb0dc18-22a5-4e35-8122-58b12b35fadc

After

https://github.com/grafana/grafana/assets/88068998/7d6ff7aa-7461-443c-9ddd-6367e68b4b47


Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
