### PR TITLE
SqlDataSources: Update metricFindQuery to pass on scopedVars to templateSrv

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -383,6 +383,13 @@ export interface MetadataInspectorProps<
   data: DataFrame[];
 }
 
+export interface LegacyMetricFindQueryOptions {
+  searchFilter?: string;
+  scopedVars?: ScopedVars;
+  range?: TimeRange;
+  variable?: { name: string };
+}
+
 export interface QueryEditorProps<
   DSType extends DataSourceApi<TQuery, TOptions>,
   TQuery extends DataQuery = DataQuery,


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/283

This is likely a problem with many other (esp older) data sources that rely on metricFindQuery for variable queries. 