### PR TITLE
Database: Add database migration to clean up dashboard slugs

### DIFF
--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -234,4 +234,10 @@ func addDashboardMigration(mg *Migrator) {
 	mg.AddMigration("Add isPublic for dashboard", NewAddColumnMigration(dashboardV2, &Column{
 		Name: "is_public", Type: DB_Bool, Nullable: false, Default: "0",
 	}))
+
+	mg.AddMigration("clean up mangled slugs", NewRawSQLMigration("").
+		SQLite("UPDATE dashboard SET slug=replace(replace(replace(replace(slug,'%2f',''),'%',''),'---','-'),'--','-') WHERE slug GLOB '*[-%]*'").
+		Postgres("UPDATE dashboard SET slug=replace(replace(replace(replace(slug,'%2f',''),'%',''),'---','-'),'--','-') WHERE slug ~ '[-%]+'").
+		Mysql("UPDATE dashboard SET slug=replace(replace(replace(replace(slug,'%2f',''),'%',''),'---','-'),'--','-') WHERE slug REGEXP '[-%]+'"),
+	)
 }


### PR DESCRIPTION
This PR adds a migration to tidy up slugs generated between #70691 and #73164 which were stored in the database with special characters url-encoded, and potentially multiple consecutive dash characters. I tried to keep the replace chain minimal, so there may be cases (such as slugs containing 5 consecutive dashes) where we don't fully fold dashes, but that's acceptable in my opinion (we could add yet another replace to the chain if we really want to solve that).

It completely removes the %2f sequence for dashboards with titles containing a forward slash, and removes the % prefix for all other character escape sequences.  This will not produce the exact same slug as the go code in all situations, but should be close enough for our purposes. There is also no special handling for the case where we end up with duplicate slugs.