### PR TITLE
Alerting: Remove Org ID from scheduler metrics

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -15,11 +15,11 @@ const (
 type Scheduler struct {
 	Registerer                          prometheus.Registerer
 	BehindSeconds                       prometheus.Gauge
-	EvalTotal                           *prometheus.CounterVec
-	EvalFailures                        *prometheus.CounterVec
-	EvalDuration                        *prometheus.HistogramVec
-	ProcessDuration                     *prometheus.HistogramVec
-	SendDuration                        *prometheus.HistogramVec
+	EvalTotal                           prometheus.Counter
+	EvalFailures                        prometheus.Counter
+	EvalDuration                        prometheus.Histogram
+	ProcessDuration                     prometheus.Histogram
+	SendDuration                        prometheus.Histogram
 	GroupRules                          *prometheus.GaugeVec
 	SchedulePeriodicDuration            prometheus.Histogram
 	SchedulableAlertRules               prometheus.Gauge
@@ -40,27 +40,25 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 		}),
 		// TODO: once rule groups support multiple rules, consider partitioning
 		// on rule group as well as tenant, similar to loki|cortex.
-		EvalTotal: promauto.With(r).NewCounterVec(
+		EvalTotal: promauto.With(r).NewCounter(
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
 				Name:      "rule_evaluations_total",
 				Help:      "The total number of rule evaluations.",
 			},
-			[]string{"org"},
 		),
 		// TODO: once rule groups support multiple rules, consider partitioning
 		// on rule group as well as tenant, similar to loki|cortex.
-		EvalFailures: promauto.With(r).NewCounterVec(
+		EvalFailures: promauto.With(r).NewCounter(
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
 				Name:      "rule_evaluation_failures_total",
 				Help:      "The total number of rule evaluation failures.",
 			},
-			[]string{"org"},
 		),
-		EvalDuration: promauto.With(r).NewHistogramVec(
+		EvalDuration: promauto.With(r).NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
@@ -68,9 +66,8 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The time to evaluate a rule.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
 			},
-			[]string{"org"},
 		),
-		ProcessDuration: promauto.With(r).NewHistogramVec(
+		ProcessDuration: promauto.With(r).NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
@@ -78,9 +75,8 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The time to process the evaluation results for a rule.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
 			},
-			[]string{"org"},
 		),
-		SendDuration: promauto.With(r).NewHistogramVec(
+		SendDuration: promauto.With(r).NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
@@ -88,7 +84,6 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The time to send the alerts to Alertmanager.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
 			},
-			[]string{"org"},
 		),
 		// TODO: partition on rule group as well as tenant, similar to loki|cortex.
 		GroupRules: promauto.With(r).NewGaugeVec(

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -347,12 +347,11 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 	logger := sch.log.FromContext(grafanaCtx)
 	logger.Debug("Alert rule routine started")
 
-	orgID := fmt.Sprint(key.OrgID)
-	evalTotal := sch.metrics.EvalTotal.WithLabelValues(orgID)
-	evalDuration := sch.metrics.EvalDuration.WithLabelValues(orgID)
-	evalTotalFailures := sch.metrics.EvalFailures.WithLabelValues(orgID)
-	processDuration := sch.metrics.ProcessDuration.WithLabelValues(orgID)
-	sendDuration := sch.metrics.SendDuration.WithLabelValues(orgID)
+	evalTotal := sch.metrics.EvalTotal
+	evalDuration := sch.metrics.EvalDuration
+	evalTotalFailures := sch.metrics.EvalFailures
+	processDuration := sch.metrics.ProcessDuration
+	sendDuration := sch.metrics.SendDuration
 
 	notify := func(states []state.StateTransition) {
 		expiredAlerts := state.FromAlertsStateToStoppedAlert(states, sch.appURL, sch.clock)


### PR DESCRIPTION
**What is this feature?**

This commit removes the Org ID from scheduler metrics as it is unused in Grafana Cloud and I'm not sure what use it has for open source users or enterprise customers.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
