### PR TITLE
Docs: Data source picker everywhere updates (v10.1)

### DIFF
--- a/docs/sources/administration/correlations/create-a-new-correlation/index.md
+++ b/docs/sources/administration/correlations/create-a-new-correlation/index.md
@@ -106,6 +106,9 @@ When you set up a correlation with admin page you can use the target query edito
 
 1. Open Explore.
 1. Select the data source you want to use as the target of the correlation.
+
+   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Open the inspector tab and select “Query”.
 1. Run a sample query.
 1. Inspect results.

--- a/docs/sources/administration/correlations/create-a-new-correlation/index.md
+++ b/docs/sources/administration/correlations/create-a-new-correlation/index.md
@@ -106,9 +106,6 @@ When you set up a correlation with admin page you can use the target query edito
 
 1. Open Explore.
 1. Select the data source you want to use as the target of the correlation.
-
-   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
-
 1. Open the inspector tab and select “Query”.
 1. Run a sample query.
 1. Inspect results.

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -63,7 +63,7 @@ Define a query to get the data you want to measure and a condition that needs to
 
 All alert rules are managed by Grafana by default. To switch to a data source-managed alert rule, click **Switch to data source-managed alert rule**.
 
-1. Select a data source.
+1. Select a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
 1. Enter a PromQL or LogQL query.
 1. Click **Preview alerts**.
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -63,7 +63,10 @@ Define a query to get the data you want to measure and a condition that needs to
 
 All alert rules are managed by Grafana by default. To switch to a data source-managed alert rule, click **Switch to data source-managed alert rule**.
 
-1. Select a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
+1. Select a data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
+
 1. Enter a PromQL or LogQL query.
 1. Click **Preview alerts**.
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -98,7 +98,7 @@ To add a new annotation query to a dashboard, take the following steps:
 
 1. Select the data source for the annotations.
 
-   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
+   You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
 
 1. If you don't want to use the annotation query right away, clear the **Enabled** checkbox.
 1. If you don't want the annotation query toggle to be displayed in the dashboard, select the **Hidden** checkbox.

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -97,6 +97,9 @@ To add a new annotation query to a dashboard, take the following steps:
    This name is given to the toggle (checkbox) that will allow you to enable/disable showing annotation events from this query.
 
 1. Select the data source for the annotations.
+
+   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
+
 1. If you don't want to use the annotation query right away, clear the **Enabled** checkbox.
 1. If you don't want the annotation query toggle to be displayed in the dashboard, select the **Hidden** checkbox.
 1. Select a color for the event markers.

--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -147,7 +147,7 @@ _Data source_ variables enable you to quickly change the data source for an enti
 1. [Enter general options](#enter-general-options).
 1. In the **Type** list, select the target data source for the variable.
 
-   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+   You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
 
 1. (Optional) In **Instance name filter**, enter a regex filter for which data source instances to choose from in the variable value drop-down list. Leave this field empty to display all instances.
 1. (Optional) Enter [Selection Options]({{< relref "#configure-variable-selection-options" >}}).
@@ -193,7 +193,7 @@ Ad hoc filter variables only work with Prometheus, Loki, InfluxDB, and Elasticse
 1. [Enter general options](#enter-general-options).
 1. In the **Data source** list, select the target data source.
 
-Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+   You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
 
 1. Click **Add** to add the variable to the dashboard.
 

--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -145,7 +145,10 @@ Constant variables are useful when you have complex values that you need to incl
 _Data source_ variables enable you to quickly change the data source for an entire dashboard. They are useful if you have multiple instances of a data source, perhaps in different environments.
 
 1. [Enter general options](#enter-general-options).
-1. In the **Type** list, select the target data source for the variable. For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+1. In the **Type** list, select the target data source for the variable.
+
+   Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+
 1. (Optional) In **Instance name filter**, enter a regex filter for which data source instances to choose from in the variable value drop-down list. Leave this field empty to display all instances.
 1. (Optional) Enter [Selection Options]({{< relref "#configure-variable-selection-options" >}}).
 1. In **Preview of values**, Grafana displays a list of the current variable values. Review them to ensure they match what you expect.
@@ -188,7 +191,10 @@ Ad hoc filter variables only work with Prometheus, Loki, InfluxDB, and Elasticse
 {{% /admonition %}}
 
 1. [Enter general options](#enter-general-options).
-1. In the **Data source** list, select the target data source. For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+1. In the **Data source** list, select the target data source.
+
+Choose a data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source]({{< relref "../../../administration/data-source-management#add-a-data-source" >}}).
+
 1. Click **Add** to add the variable to the dashboard.
 
 ### Create ad hoc filters

--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -72,14 +72,14 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in trace, it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source does not allow dots in labels. In that case, you can, for example, remap `http.status` to `http_status`.
 1. Optionally, switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in the trace, you may need to widen or shift the time range to find the desired logs.
 1. Optionally, select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as a list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source does not allow dots in labels. For example, you can remap `http.status` to `http_status`. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -126,7 +126,7 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -72,14 +72,20 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in trace, it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source does not allow dots in labels. In that case, you can, for example, remap `http.status` to `http_status`.
 1. Optionally, switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in the trace, you may need to widen or shift the time range to find the desired logs.
 1. Optionally, select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as a list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source does not allow dots in labels. For example, you can remap `http.status` to `http_status`. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -126,7 +132,10 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -72,14 +72,14 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in trace it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful for example if the tag has dots in the name and the target data source does not allow using dots in labels. In that case you can for example remap `http.status` to `http_status`.
 1. Optionally switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in the trace it may be necessary to widen or shift the time range to find the desired logs.
 1. Optionally select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source does not allow using dots in labels. For example, you can remap `http.status` to `http_status` in such a case. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -126,7 +126,7 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -72,14 +72,20 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in trace it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful for example if the tag has dots in the name and the target data source does not allow using dots in labels. In that case you can for example remap `http.status` to `http_status`.
 1. Optionally switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in the trace it may be necessary to widen or shift the time range to find the desired logs.
 1. Optionally select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source does not allow using dots in labels. For example, you can remap `http.status` to `http_status` in such a case. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -126,7 +132,10 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -70,14 +70,20 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in trace it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source does not allow using dots in labels. In that case, you can for example remap `http.status` to `http_status`.
 1. Optionally, switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in the trace, you may need to widen or shift the time range to find the desired logs.
 1. Optionally, select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful when the tag has dots in the name and the target data source does not allow using dots in labels. For example, you can remap `http.status` to `http_status`. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -124,7 +130,10 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
+1. Select the target data source from the drop-down list.
+
+   You can also click **Open advanced data source picker** to see more options, including adding a data source.
+
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -70,14 +70,14 @@ There are two ways to configure the trace to logs feature:
 
 #### Use a simple configuration
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in trace it may be necessary to search in larger or shifted time range to find the desired logs.
 1. Select which tags to use in the logs query. The tags you configure must be present in the spans attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source does not allow using dots in labels. In that case, you can for example remap `http.status` to `http_status`.
 1. Optionally, switch on the **Filter by trace ID** and/or **Filter by span ID** setting to further filter the logs if your logs consistently contain trace or span IDs.
 
 #### Configure a custom query
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Set start and end time shift. Since the logs timestamps may not exactly match the timestamps of the spans in the trace, you may need to widen or shift the time range to find the desired logs.
 1. Optionally, select tags to map. These tags can be used in the custom query with `${__tags}` variable. This variable will interpolate the mapped tags as list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren't present. You can optionally configure a new name for the tag. This is useful when the tag has dots in the name and the target data source does not allow using dots in labels. For example, you can remap `http.status` to `http_status`. If you don't map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.
 1. Skip **Filter by trace ID** and **Filter by span ID** settings as these cannot be used with a custom query.
@@ -124,7 +124,7 @@ The **Trace to metrics** setting configures the [trace to metrics feature](/blog
 
 To configure trace to metrics:
 
-1. Select the target data source.
+1. Select the target data source from the drop-down list or click **Open advanced data source picker** to see more options, including adding a data source.
 1. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -45,7 +45,7 @@ To access Explore:
 
 1. Choose your data source from the drop-down in the top left.
 
-   You can also click **Open advanced data source picker** to see more data source options including adding a data source.
+   You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
 
 1. Write the query using a query editor provided by the selected data source. Please check [data sources documentation]({{< relref "../datasources" >}}) to see how to use various query editors.
 1. For general documentation on querying data sources in Grafana, see [Query and transform data]({{< relref "../panels-visualizations/query-transform-data" >}}).


### PR DESCRIPTION
Adds language about the advanced data source picker in several areas in the application (added in 10.1) and the option to add a new data source. 

In topics where the task described could be done by non-admin users, an "Admins only" parenthetical is included, since adding a data source can only be done by users with the Admin role. In data sources topics, this parenthetical is omitted. 

@lwandz13 and @brendamuir - I've just left you on as reviewers in case you have any objections to adding this language in these spots.

Related to issue #66916 