### PR TITLE
Alerting: Fix Recording Rule QueryEditor builder view

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -60,14 +60,17 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
 
     const merged = {
       ...query,
-      refId: changedQuery.refId,
-      queryType: changedQuery.queryType ?? '',
+      ...changedQuery,
       datasourceUid: dataSourceId,
       expr,
       model: {
-        refId: changedQuery.refId,
         expr,
-        editorMode: 'code',
+        datasource: changedQuery.datasource,
+        refId: changedQuery.refId,
+        editorMode: changedQuery.editorMode,
+        instant: Boolean(changedQuery.instant),
+        range: Boolean(changedQuery.range),
+        legendFormat: changedQuery.legendFormat,
       },
     };
     onChangeQuery([merged]);

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -80,7 +80,7 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
       const query = payload.recordingRuleQueries[0];
       const recordingRuleQuery = {
         ...query,
-        ...{ expr: payload.expression, model: { expr: payload.expression, refId: query.model.refId } },
+        ...{ expr: payload.expression, model: payload.recordingRuleQueries[0].model },
       };
 
       state.queries = [recordingRuleQuery];

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -80,7 +80,7 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
       const query = payload.recordingRuleQueries[0];
       const recordingRuleQuery = {
         ...query,
-        ...{ expr: payload.expression, model: payload.recordingRuleQueries[0].model },
+        ...{ expr: payload.expression, model: query?.model },
       };
 
       state.queries = [recordingRuleQuery];


### PR DESCRIPTION
This PR fixes the Builder button in the query editor for Recording Rules as previously it was not performing any action upon clicking it.

**Who is this feature for?**

All users

Before:

![2023-08-17 16 14 24](https://github.com/grafana/grafana/assets/6271380/6d54e404-6e49-4ea8-b339-095f9b946fd0)

After: 

![2023-08-17 16 14 58](https://github.com/grafana/grafana/assets/6271380/408c0472-4e14-4c57-8d50-1237e8c36b35)

