### PR TITLE
Exemplars: Add exemplar tooltip config

### DIFF
--- a/docs/sources/developers/kinds/composable/heatmap/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/heatmap/panelcfg/schema-reference.md
@@ -46,10 +46,9 @@ Controls cell value options
 
 Controls exemplar options
 
-| Property | Type     | Required | Default | Description                            |
-|----------|----------|----------|---------|----------------------------------------|
-| `color`  | string   | **Yes**  |         | Sets the color of the exemplar markers |
-| `labels` | string[] | **Yes**  |         |                                        |
+| Property | Type   | Required | Default | Description                            |
+|----------|--------|----------|---------|----------------------------------------|
+| `color`  | string | **Yes**  |         | Sets the color of the exemplar markers |
 
 ### FieldConfig
 
@@ -125,10 +124,11 @@ Controls legend options
 
 Controls tooltip options
 
-| Property     | Type    | Required | Default | Description                                                    |
-|--------------|---------|----------|---------|----------------------------------------------------------------|
-| `show`       | boolean | **Yes**  |         | Controls if the tooltip is shown                               |
-| `yHistogram` | boolean | No       |         | Controls if the tooltip shows a histogram of the y-axis values |
+| Property         | Type     | Required | Default | Description                                                                     |
+|------------------|----------|----------|---------|---------------------------------------------------------------------------------|
+| `show`           | boolean  | **Yes**  |         | Controls if the tooltip is shown                                                |
+| `exemplarLabels` | string[] | No       |         | Controls the exemplar labels to be shown on exemplar tooltip and in which order |
+| `yHistogram`     | boolean  | No       |         | Controls if the tooltip shows a histogram of the y-axis values                  |
 
 ### Options
 

--- a/docs/sources/developers/kinds/composable/heatmap/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/heatmap/panelcfg/schema-reference.md
@@ -46,9 +46,10 @@ Controls cell value options
 
 Controls exemplar options
 
-| Property | Type   | Required | Default | Description                            |
-|----------|--------|----------|---------|----------------------------------------|
-| `color`  | string | **Yes**  |         | Sets the color of the exemplar markers |
+| Property | Type     | Required | Default | Description                            |
+|----------|----------|----------|---------|----------------------------------------|
+| `color`  | string   | **Yes**  |         | Sets the color of the exemplar markers |
+| `labels` | string[] | **Yes**  |         |                                        |
 
 ### FieldConfig
 

--- a/docs/sources/developers/kinds/composable/timeseries/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/timeseries/panelcfg/schema-reference.md
@@ -20,15 +20,9 @@ title: TimeSeriesPanelCfg kind
 
 | Property         | Type                                  | Required | Default | Description |
 |------------------|---------------------------------------|----------|---------|-------------|
-| `ExemplarConfig` | [object](#exemplarconfig)             | **Yes**  |         |             |
 | `FieldConfig`    | [GraphFieldConfig](#graphfieldconfig) | **Yes**  |         | TODO docs   |
 | `Options`        | [object](#options)                    | **Yes**  |         |             |
-
-### ExemplarConfig
-
-| Property | Type     | Required | Default | Description |
-|----------|----------|----------|---------|-------------|
-| `labels` | string[] | **Yes**  |         |             |
+| `TooltipOptions` | [object](#tooltipoptions)             | **Yes**  |         |             |
 
 ### GraphFieldConfig
 
@@ -196,12 +190,11 @@ TODO docs
 
 It extends [OptionsWithTimezones](#optionswithtimezones).
 
-| Property    | Type                                    | Required | Default | Description                                                      |
-|-------------|-----------------------------------------|----------|---------|------------------------------------------------------------------|
-| `exemplars` | [ExemplarConfig](#exemplarconfig)       | **Yes**  |         |                                                                  |
-| `legend`    | [VizLegendOptions](#vizlegendoptions)   | **Yes**  |         | TODO docs                                                        |
-| `tooltip`   | [VizTooltipOptions](#viztooltipoptions) | **Yes**  |         | TODO docs                                                        |
-| `timezone`  | string[]                                | No       |         | *(Inherited from [OptionsWithTimezones](#optionswithtimezones))* |
+| Property   | Type                                  | Required | Default | Description                                                      |
+|------------|---------------------------------------|----------|---------|------------------------------------------------------------------|
+| `legend`   | [VizLegendOptions](#vizlegendoptions) | **Yes**  |         | TODO docs                                                        |
+| `tooltip`  | [TooltipOptions](#tooltipoptions)     | **Yes**  |         |                                                                  |
+| `timezone` | string[]                              | No       |         | *(Inherited from [OptionsWithTimezones](#optionswithtimezones))* |
 
 ### OptionsWithTimezones
 
@@ -210,6 +203,25 @@ TODO docs
 | Property   | Type     | Required | Default | Description |
 |------------|----------|----------|---------|-------------|
 | `timezone` | string[] | No       |         |             |
+
+### TooltipOptions
+
+It extends [VizTooltipOptions](#viztooltipoptions).
+
+| Property         | Type     | Required | Default | Description                                                                                                                  |
+|------------------|----------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
+| `mode`           | string   | **Yes**  |         | *(Inherited from [VizTooltipOptions](#viztooltipoptions))*<br/>TODO docs<br/>Possible values are: `single`, `multi`, `none`. |
+| `sort`           | string   | **Yes**  |         | *(Inherited from [VizTooltipOptions](#viztooltipoptions))*<br/>TODO docs<br/>Possible values are: `asc`, `desc`, `none`.     |
+| `exemplarLabels` | string[] | No       |         |                                                                                                                              |
+
+### VizTooltipOptions
+
+TODO docs
+
+| Property | Type   | Required | Default | Description                                                   |
+|----------|--------|----------|---------|---------------------------------------------------------------|
+| `mode`   | string | **Yes**  |         | TODO docs<br/>Possible values are: `single`, `multi`, `none`. |
+| `sort`   | string | **Yes**  |         | TODO docs<br/>Possible values are: `asc`, `desc`, `none`.     |
 
 ### VizLegendOptions
 
@@ -226,14 +238,5 @@ TODO docs
 | `sortBy`      | string   | No       |         |                                                                                                                                         |
 | `sortDesc`    | boolean  | No       |         |                                                                                                                                         |
 | `width`       | number   | No       |         |                                                                                                                                         |
-
-### VizTooltipOptions
-
-TODO docs
-
-| Property | Type   | Required | Default | Description                                                   |
-|----------|--------|----------|---------|---------------------------------------------------------------|
-| `mode`   | string | **Yes**  |         | TODO docs<br/>Possible values are: `single`, `multi`, `none`. |
-| `sort`   | string | **Yes**  |         | TODO docs<br/>Possible values are: `asc`, `desc`, `none`.     |
 
 

--- a/docs/sources/developers/kinds/composable/timeseries/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/timeseries/panelcfg/schema-reference.md
@@ -18,10 +18,17 @@ title: TimeSeriesPanelCfg kind
 
 
 
-| Property      | Type                                  | Required | Default | Description |
-|---------------|---------------------------------------|----------|---------|-------------|
-| `FieldConfig` | [GraphFieldConfig](#graphfieldconfig) | **Yes**  |         | TODO docs   |
-| `Options`     | [object](#options)                    | **Yes**  |         |             |
+| Property         | Type                                  | Required | Default | Description |
+|------------------|---------------------------------------|----------|---------|-------------|
+| `ExemplarConfig` | [object](#exemplarconfig)             | **Yes**  |         |             |
+| `FieldConfig`    | [GraphFieldConfig](#graphfieldconfig) | **Yes**  |         | TODO docs   |
+| `Options`        | [object](#options)                    | **Yes**  |         |             |
+
+### ExemplarConfig
+
+| Property | Type     | Required | Default | Description |
+|----------|----------|----------|---------|-------------|
+| `labels` | string[] | **Yes**  |         |             |
 
 ### GraphFieldConfig
 
@@ -189,11 +196,12 @@ TODO docs
 
 It extends [OptionsWithTimezones](#optionswithtimezones).
 
-| Property   | Type                                    | Required | Default | Description                                                      |
-|------------|-----------------------------------------|----------|---------|------------------------------------------------------------------|
-| `legend`   | [VizLegendOptions](#vizlegendoptions)   | **Yes**  |         | TODO docs                                                        |
-| `tooltip`  | [VizTooltipOptions](#viztooltipoptions) | **Yes**  |         | TODO docs                                                        |
-| `timezone` | string[]                                | No       |         | *(Inherited from [OptionsWithTimezones](#optionswithtimezones))* |
+| Property    | Type                                    | Required | Default | Description                                                      |
+|-------------|-----------------------------------------|----------|---------|------------------------------------------------------------------|
+| `exemplars` | [ExemplarConfig](#exemplarconfig)       | **Yes**  |         |                                                                  |
+| `legend`    | [VizLegendOptions](#vizlegendoptions)   | **Yes**  |         | TODO docs                                                        |
+| `tooltip`   | [VizTooltipOptions](#viztooltipoptions) | **Yes**  |         | TODO docs                                                        |
+| `timezone`  | string[]                                | No       |         | *(Inherited from [OptionsWithTimezones](#optionswithtimezones))* |
 
 ### OptionsWithTimezones
 

--- a/packages/grafana-schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen.ts
@@ -130,6 +130,10 @@ export interface FilterValueRange {
  */
 export interface HeatmapTooltip {
   /**
+   * Controls the exemplar labels to be shown on exemplar tooltip and in which order
+   */
+  exemplarLabels?: Array<string>;
+  /**
    * Controls if the tooltip is shown
    */
   show: boolean;
@@ -138,6 +142,10 @@ export interface HeatmapTooltip {
    */
   yHistogram?: boolean;
 }
+
+export const defaultHeatmapTooltip: Partial<HeatmapTooltip> = {
+  exemplarLabels: [],
+};
 
 /**
  * Controls legend options
@@ -157,12 +165,7 @@ export interface ExemplarConfig {
    * Sets the color of the exemplar markers
    */
   color: string;
-  labels: Array<string>;
 }
-
-export const defaultExemplarConfig: Partial<ExemplarConfig> = {
-  labels: [],
-};
 
 /**
  * Controls frame rows options
@@ -258,7 +261,6 @@ export const defaultOptions: Partial<Options> = {
   },
   exemplars: {
     color: 'rgba(255,0,255,0.7)',
-    labels: [],
   },
   filterValues: {
     le: 1e-09,
@@ -270,6 +272,7 @@ export const defaultOptions: Partial<Options> = {
   tooltip: {
     show: true,
     yHistogram: false,
+    exemplarLabels: [],
   },
 };
 

--- a/packages/grafana-schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen.ts
@@ -157,7 +157,12 @@ export interface ExemplarConfig {
    * Sets the color of the exemplar markers
    */
   color: string;
+  labels: Array<string>;
 }
+
+export const defaultExemplarConfig: Partial<ExemplarConfig> = {
+  labels: [],
+};
 
 /**
  * Controls frame rows options
@@ -253,6 +258,7 @@ export const defaultOptions: Partial<Options> = {
   },
   exemplars: {
     color: 'rgba(255,0,255,0.7)',
+    labels: [],
   },
   filterValues: {
     le: 1e-09,

--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen.ts
@@ -14,8 +14,17 @@ import * as common from '@grafana/schema';
 export const pluginVersion = "10.2.0-pre";
 
 export interface Options extends common.OptionsWithTimezones {
+  exemplars: ExemplarConfig;
   legend: common.VizLegendOptions;
   tooltip: common.VizTooltipOptions;
 }
+
+export interface ExemplarConfig {
+  labels: Array<string>;
+}
+
+export const defaultExemplarConfig: Partial<ExemplarConfig> = {
+  labels: [],
+};
 
 export interface FieldConfig extends common.GraphFieldConfig {}

--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen.ts
@@ -14,17 +14,16 @@ import * as common from '@grafana/schema';
 export const pluginVersion = "10.2.0-pre";
 
 export interface Options extends common.OptionsWithTimezones {
-  exemplars: ExemplarConfig;
   legend: common.VizLegendOptions;
-  tooltip: common.VizTooltipOptions;
+  tooltip: TooltipOptions;
 }
 
-export interface ExemplarConfig {
-  labels: Array<string>;
+export interface TooltipOptions extends common.VizTooltipOptions {
+  exemplarLabels?: Array<string>;
 }
 
-export const defaultExemplarConfig: Partial<ExemplarConfig> = {
-  labels: [],
+export const defaultTooltipOptions: Partial<TooltipOptions> = {
+  exemplarLabels: [],
 };
 
 export interface FieldConfig extends common.GraphFieldConfig {}

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -192,6 +192,9 @@ export function ExploreGraph({
         placement: 'bottom',
         calcs: [],
       },
+      exemplars: {
+        labels: [],
+      },
     }),
     [tooltipDisplayMode]
   );

--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -21,6 +21,7 @@ export interface Props {
   sortOrder?: SortOrder;
   mode?: TooltipDisplayMode | null;
   header?: string;
+  exemplarLabels?: string[];
 }
 
 interface DisplayValue {
@@ -30,7 +31,15 @@ interface DisplayValue {
   highlight: boolean;
 }
 
-export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, header = undefined }: Props) => {
+export const DataHoverView = ({
+  data,
+  rowIndex,
+  columnIndex,
+  sortOrder,
+  mode,
+  header = undefined,
+  exemplarLabels,
+}: Props) => {
   const styles = useStyles2(getStyles);
 
   if (!data || rowIndex == null) {
@@ -41,12 +50,23 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
   });
   const visibleFields = fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
   const traceIDField = visibleFields.find((field) => field.name === 'traceID') || fields[0];
-  const orderedVisibleFields = [];
-  // Only include traceID if it's visible and put it in front.
-  if (visibleFields.filter((field) => traceIDField === field).length > 0) {
-    orderedVisibleFields.push(traceIDField);
+
+  let orderedVisibleFields = [];
+  if (exemplarLabels && exemplarLabels.length > 0) {
+    for (let i in exemplarLabels) {
+      const label = exemplarLabels[i];
+      const field = visibleFields.find((field) => field.name === label);
+      if (field) {
+        orderedVisibleFields.push(field);
+      }
+    }
+  } else {
+    // Only include traceID if it's visible and put it in front.
+    if (visibleFields.filter((field) => traceIDField === field).length > 0) {
+      orderedVisibleFields.push(traceIDField);
+    }
+    orderedVisibleFields.push(...visibleFields.filter((field) => traceIDField !== field));
   }
-  orderedVisibleFields.push(...visibleFields.filter((field) => traceIDField !== field));
 
   if (orderedVisibleFields.length === 0) {
     return null;

--- a/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
+++ b/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
@@ -6,7 +6,6 @@ import { InlineField, TagsInput } from '@grafana/ui';
 export const ExemplarLabelEditor = ({ value, onChange, context }: StandardEditorProps<string[]>) => {
   const labels = context.options?.exemplars?.labels;
   const setExemplarLabels = (ls?: string[]) => {
-    console.log(ls);
     onChange(ls);
   };
   return (

--- a/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
+++ b/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
@@ -4,7 +4,7 @@ import { StandardEditorProps } from '@grafana/data';
 import { InlineField, TagsInput } from '@grafana/ui';
 
 export const ExemplarLabelEditor = ({ value, onChange, context }: StandardEditorProps<string[]>) => {
-  const labels = context.options?.exemplars?.labels;
+  const labels = context.options?.tooltip?.exemplarLabels;
   const setExemplarLabels = (ls?: string[]) => {
     onChange(ls);
   };

--- a/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
+++ b/public/app/plugins/panel/heatmap/ExemplarLabelEditor.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { StandardEditorProps } from '@grafana/data';
+import { InlineField, TagsInput } from '@grafana/ui';
+
+export const ExemplarLabelEditor = ({ value, onChange, context }: StandardEditorProps<string[]>) => {
+  const labels = context.options?.exemplars?.labels;
+  const setExemplarLabels = (ls?: string[]) => {
+    console.log(ls);
+    onChange(ls);
+  };
+  return (
+    <InlineField
+      label="Labels"
+      tooltip="Add exemplar labels to be displayed on exemplar tooltip. Note that the order of labels added is also important and the same order is displayed on the exemplar tooltip"
+    >
+      <TagsInput placeholder="trace_id" tags={labels} onChange={(ls) => setExemplarLabels(ls)} />
+    </InlineField>
+  );
+};

--- a/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
@@ -28,7 +28,7 @@ type Props = {
   timeRange: TimeRange;
   replaceVars: InterpolateFunction;
   scopedVars: ScopedVars[];
-  exemplarLabels: string[];
+  exemplarLabels?: string[];
 };
 
 export const HeatmapHoverView = (props: Props) => {

--- a/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
@@ -28,11 +28,19 @@ type Props = {
   timeRange: TimeRange;
   replaceVars: InterpolateFunction;
   scopedVars: ScopedVars[];
+  exemplarLabels: string[];
 };
 
 export const HeatmapHoverView = (props: Props) => {
   if (props.hover.seriesIdx === 2) {
-    return <DataHoverView data={props.data.exemplars} rowIndex={props.hover.dataIdx} header={'Exemplar'} />;
+    return (
+      <DataHoverView
+        data={props.data.exemplars}
+        rowIndex={props.hover.dataIdx}
+        header={'Exemplar'}
+        exemplarLabels={props.exemplarLabels}
+      />
+    );
   }
   return <HeatmapHoverCell {...props} />;
 };

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -222,6 +222,7 @@ export const HeatmapPanel = ({
               showHistogram={options.tooltip.yHistogram}
               replaceVars={replaceVariables}
               scopedVars={scopedVarsFromRawData}
+              exemplarLabels={options.exemplars?.labels}
             />
           </VizTooltipContainer>
         )}

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -222,7 +222,7 @@ export const HeatmapPanel = ({
               showHistogram={options.tooltip.yHistogram}
               replaceVars={replaceVariables}
               scopedVars={scopedVarsFromRawData}
-              exemplarLabels={options.exemplars?.labels}
+              exemplarLabels={options.tooltip?.exemplarLabels}
             />
           </VizTooltipContainer>
         )}

--- a/public/app/plugins/panel/heatmap/migrations.test.ts
+++ b/public/app/plugins/panel/heatmap/migrations.test.ts
@@ -62,6 +62,7 @@ describe('Heatmap Migrations', () => {
           },
           "exemplars": {
             "color": "rgba(255,0,255,0.7)",
+            "labels": [],
           },
           "filterValues": {
             "le": 1e-9,

--- a/public/app/plugins/panel/heatmap/migrations.test.ts
+++ b/public/app/plugins/panel/heatmap/migrations.test.ts
@@ -62,7 +62,6 @@ describe('Heatmap Migrations', () => {
           },
           "exemplars": {
             "color": "rgba(255,0,255,0.7)",
-            "labels": [],
           },
           "filterValues": {
             "le": 1e-9,

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -399,6 +399,14 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       showIf: (opts) => opts.tooltip.show,
     });
 
+    builder.addCustomEditor({
+      id: 'exemplar labels',
+      path: 'tooltip.exemplarLabels',
+      name: 'Exemplar Labels',
+      editor: ExemplarLabelEditor,
+      category,
+    });
+
     category = ['Legend'];
     builder.addBooleanSwitch({
       path: 'legend.show',
@@ -412,14 +420,6 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       path: 'exemplars.color',
       name: 'Color',
       defaultValue: defaultOptions.exemplars.color,
-      category,
-    });
-
-    builder.addCustomEditor({
-      id: 'exemplar labels',
-      path: 'exemplars.labels',
-      name: 'Labels',
-      editor: ExemplarLabelEditor,
       category,
     });
   })

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -14,6 +14,7 @@ import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { addHeatmapCalculationOptions } from 'app/features/transformers/calculateHeatmap/editor/helper';
 import { readHeatmapRowsCustomMeta } from 'app/features/transformers/calculateHeatmap/heatmap';
 
+import { ExemplarLabelEditor } from './ExemplarLabelEditor';
 import { HeatmapPanel } from './HeatmapPanel';
 import { prepareHeatmapData } from './fields';
 import { heatmapChangedHandler, heatmapMigrationHandler } from './migrations';
@@ -411,6 +412,14 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       path: 'exemplars.color',
       name: 'Color',
       defaultValue: defaultOptions.exemplars.color,
+      category,
+    });
+
+    builder.addCustomEditor({
+      id: 'exemplar labels',
+      path: 'exemplars.labels',
+      name: 'Labels',
+      editor: ExemplarLabelEditor,
       category,
     });
   })

--- a/public/app/plugins/panel/heatmap/panelcfg.cue
+++ b/public/app/plugins/panel/heatmap/panelcfg.cue
@@ -82,6 +82,8 @@ composableKinds: PanelCfg: lineage: {
 				show: bool
 				// Controls if the tooltip shows a histogram of the y-axis values
 				yHistogram?: bool
+				// Controls the exemplar labels to be shown on exemplar tooltip and in which order
+				exemplarLabels?: [...string]
 			} @cuetsy(kind="interface")
 			// Controls legend options
 			HeatmapLegend: {
@@ -92,7 +94,6 @@ composableKinds: PanelCfg: lineage: {
 			ExemplarConfig: {
 				// Sets the color of the exemplar markers
 				color: string
-				labels: [...string]
 			} @cuetsy(kind="interface")
 			// Controls frame rows options
 			RowsHeatmapOptions: {
@@ -146,11 +147,11 @@ composableKinds: PanelCfg: lineage: {
 				tooltip: HeatmapTooltip | *{
 					show:       true
 					yHistogram: false
+					exemplarLabels: []
 				}
 				// Controls exemplar options
 				exemplars: ExemplarConfig | *{
 					color: "rgba(255,0,255,0.7)"
-					labels: []
 				}
 			} @cuetsy(kind="interface")
 			FieldConfig: {

--- a/public/app/plugins/panel/heatmap/panelcfg.cue
+++ b/public/app/plugins/panel/heatmap/panelcfg.cue
@@ -92,6 +92,7 @@ composableKinds: PanelCfg: lineage: {
 			ExemplarConfig: {
 				// Sets the color of the exemplar markers
 				color: string
+				labels: [...string]
 			} @cuetsy(kind="interface")
 			// Controls frame rows options
 			RowsHeatmapOptions: {
@@ -149,6 +150,7 @@ composableKinds: PanelCfg: lineage: {
 				// Controls exemplar options
 				exemplars: ExemplarConfig | *{
 					color: "rgba(255,0,255,0.7)"
+					labels: []
 				}
 			} @cuetsy(kind="interface")
 			FieldConfig: {

--- a/public/app/plugins/panel/heatmap/panelcfg.gen.ts
+++ b/public/app/plugins/panel/heatmap/panelcfg.gen.ts
@@ -154,7 +154,12 @@ export interface ExemplarConfig {
    * Sets the color of the exemplar markers
    */
   color: string;
+  labels: Array<string>;
 }
+
+export const defaultExemplarConfig: Partial<ExemplarConfig> = {
+  labels: [],
+};
 
 /**
  * Controls frame rows options
@@ -250,6 +255,7 @@ export const defaultOptions: Partial<Options> = {
   },
   exemplars: {
     color: 'rgba(255,0,255,0.7)',
+    labels: [],
   },
   filterValues: {
     le: 1e-09,

--- a/public/app/plugins/panel/heatmap/panelcfg.gen.ts
+++ b/public/app/plugins/panel/heatmap/panelcfg.gen.ts
@@ -127,6 +127,10 @@ export interface FilterValueRange {
  */
 export interface HeatmapTooltip {
   /**
+   * Controls the exemplar labels to be shown on exemplar tooltip and in which order
+   */
+  exemplarLabels?: Array<string>;
+  /**
    * Controls if the tooltip is shown
    */
   show: boolean;
@@ -135,6 +139,10 @@ export interface HeatmapTooltip {
    */
   yHistogram?: boolean;
 }
+
+export const defaultHeatmapTooltip: Partial<HeatmapTooltip> = {
+  exemplarLabels: [],
+};
 
 /**
  * Controls legend options
@@ -154,12 +162,7 @@ export interface ExemplarConfig {
    * Sets the color of the exemplar markers
    */
   color: string;
-  labels: Array<string>;
 }
-
-export const defaultExemplarConfig: Partial<ExemplarConfig> = {
-  labels: [],
-};
 
 /**
  * Controls frame rows options
@@ -255,7 +258,6 @@ export const defaultOptions: Partial<Options> = {
   },
   exemplars: {
     color: 'rgba(255,0,255,0.7)',
-    labels: [],
   },
   filterValues: {
     le: 1e-09,
@@ -267,6 +269,7 @@ export const defaultOptions: Partial<Options> = {
   tooltip: {
     show: true,
     yHistogram: false,
+    exemplarLabels: [],
   },
 };
 

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -150,6 +150,7 @@ export const TimeSeriesPanel = ({
                 config={config}
                 exemplars={data.annotations}
                 timeZone={timeZone}
+                options={options}
               />
             )}
 

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -36,6 +36,9 @@ exports[`Graph Migrations legend with multiple values 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -67,6 +70,9 @@ exports[`Graph Migrations legend with single value 1`] = `
     "overrides": [],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "sum",
@@ -96,6 +102,9 @@ exports[`Graph Migrations legend without values 1`] = `
     "overrides": [],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -162,6 +171,9 @@ exports[`Graph Migrations preserves colors from series overrides 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -234,6 +246,9 @@ exports[`Graph Migrations preserves series overrides using a regex alias 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -269,6 +284,9 @@ exports[`Graph Migrations simple bars 1`] = `
     "overrides": [],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -353,6 +371,9 @@ exports[`Graph Migrations stacking groups 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -411,6 +432,9 @@ exports[`Graph Migrations stacking simple 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -451,6 +475,9 @@ exports[`Graph Migrations stairscase 1`] = `
     "overrides": [],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [
         "mean",
@@ -507,6 +534,9 @@ exports[`Graph Migrations stepped line 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -538,6 +568,9 @@ exports[`Graph Migrations time regions should migrate 1`] = `
     "overrides": [],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -675,6 +708,9 @@ exports[`Graph Migrations twoYAxis 1`] = `
     ],
   },
   "options": {
+    "exemplars": {
+      "labels": [],
+    },
     "legend": {
       "calcs": [],
       "displayMode": "list",

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -36,9 +36,6 @@ exports[`Graph Migrations legend with multiple values 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -50,6 +47,7 @@ exports[`Graph Migrations legend with multiple values 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -70,9 +68,6 @@ exports[`Graph Migrations legend with single value 1`] = `
     "overrides": [],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "sum",
@@ -82,6 +77,7 @@ exports[`Graph Migrations legend with single value 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "single",
       "sort": "none",
     },
@@ -102,9 +98,6 @@ exports[`Graph Migrations legend without values 1`] = `
     "overrides": [],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -112,6 +105,7 @@ exports[`Graph Migrations legend without values 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "single",
       "sort": "none",
     },
@@ -171,9 +165,6 @@ exports[`Graph Migrations preserves colors from series overrides 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -187,6 +178,7 @@ exports[`Graph Migrations preserves colors from series overrides 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -246,9 +238,6 @@ exports[`Graph Migrations preserves series overrides using a regex alias 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -262,6 +251,7 @@ exports[`Graph Migrations preserves series overrides using a regex alias 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -284,9 +274,6 @@ exports[`Graph Migrations simple bars 1`] = `
     "overrides": [],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -294,6 +281,7 @@ exports[`Graph Migrations simple bars 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "single",
       "sort": "none",
     },
@@ -371,9 +359,6 @@ exports[`Graph Migrations stacking groups 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -385,6 +370,7 @@ exports[`Graph Migrations stacking groups 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -432,9 +418,6 @@ exports[`Graph Migrations stacking simple 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -446,6 +429,7 @@ exports[`Graph Migrations stacking simple 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -475,9 +459,6 @@ exports[`Graph Migrations stairscase 1`] = `
     "overrides": [],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [
         "mean",
@@ -491,6 +472,7 @@ exports[`Graph Migrations stairscase 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -534,9 +516,6 @@ exports[`Graph Migrations stepped line 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -544,6 +523,7 @@ exports[`Graph Migrations stepped line 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },
@@ -568,9 +548,6 @@ exports[`Graph Migrations time regions should migrate 1`] = `
     "overrides": [],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -578,6 +555,7 @@ exports[`Graph Migrations time regions should migrate 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "single",
       "sort": "none",
     },
@@ -708,9 +686,6 @@ exports[`Graph Migrations twoYAxis 1`] = `
     ],
   },
   "options": {
-    "exemplars": {
-      "labels": [],
-    },
     "legend": {
       "calcs": [],
       "displayMode": "list",
@@ -718,6 +693,7 @@ exports[`Graph Migrations twoYAxis 1`] = `
       "showLegend": true,
     },
     "tooltip": {
+      "exemplarLabels": [],
       "mode": "multi",
       "sort": "none",
     },

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -356,9 +356,7 @@ export function graphToTimeseriesOptions(angular: any): {
     tooltip: {
       mode: TooltipDisplayMode.Single,
       sort: SortOrder.None,
-    },
-    exemplars: {
-      labels: [],
+      exemplarLabels: [],
     },
   };
 

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -357,6 +357,9 @@ export function graphToTimeseriesOptions(angular: any): {
       mode: TooltipDisplayMode.Single,
       sort: SortOrder.None,
     },
+    exemplars: {
+      labels: [],
+    },
   };
 
   // Legend config migration

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -1,6 +1,8 @@
 import { PanelPlugin } from '@grafana/data';
 import { commonOptionsBuilder } from '@grafana/ui';
 
+import { ExemplarLabelEditor } from '../heatmap/ExemplarLabelEditor';
+
 import { TimeSeriesPanel } from './TimeSeriesPanel';
 import { TimezonesEditor } from './TimezonesEditor';
 import { defaultGraphConfig, getGraphFieldConfig } from './config';
@@ -22,6 +24,14 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
       category: ['Axis'],
       editor: TimezonesEditor,
       defaultValue: undefined,
+    });
+
+    builder.addCustomEditor({
+      id: 'exemplar labels',
+      path: 'exemplars.labels',
+      name: 'Labels',
+      editor: ExemplarLabelEditor,
+      category: ['Exemplars'],
     });
   })
   .setSuggestionsSupplier(new TimeSeriesSuggestionsSupplier())

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -28,10 +28,10 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
 
     builder.addCustomEditor({
       id: 'exemplar labels',
-      path: 'exemplars.labels',
-      name: 'Labels',
+      path: 'tooltip.exemplarLabels',
+      name: 'Exemplar Labels',
       editor: ExemplarLabelEditor,
-      category: ['Exemplars'],
+      category: ['Tooltip'],
     });
   })
   .setSuggestionsSupplier(new TimeSeriesSuggestionsSupplier())

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -24,12 +24,11 @@ composableKinds: PanelCfg: lineage: {
 		schema: {
 			Options: common.OptionsWithTimezones & {
 				legend:    common.VizLegendOptions
-				tooltip:   common.VizTooltipOptions
-				exemplars: ExemplarConfig
+				tooltip:   TooltipOptions
 			} @cuetsy(kind="interface")
 
-			ExemplarConfig: {
-				labels: [...string]
+			TooltipOptions: common.VizTooltipOptions & {
+				exemplarLabels?: [...string]
 			} @cuetsy(kind="interface")
 
 			FieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -23,8 +23,13 @@ composableKinds: PanelCfg: lineage: {
 		version: [0, 0]
 		schema: {
 			Options: common.OptionsWithTimezones & {
-				legend:  common.VizLegendOptions
-				tooltip: common.VizTooltipOptions
+				legend:    common.VizLegendOptions
+				tooltip:   common.VizTooltipOptions
+				exemplars: ExemplarConfig
+			} @cuetsy(kind="interface")
+
+			ExemplarConfig: {
+				labels: [...string]
 			} @cuetsy(kind="interface")
 
 			FieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -11,17 +11,16 @@
 import * as common from '@grafana/schema';
 
 export interface Options extends common.OptionsWithTimezones {
-  exemplars: ExemplarConfig;
   legend: common.VizLegendOptions;
-  tooltip: common.VizTooltipOptions;
+  tooltip: TooltipOptions;
 }
 
-export interface ExemplarConfig {
-  labels: Array<string>;
+export interface TooltipOptions extends common.VizTooltipOptions {
+  exemplarLabels?: Array<string>;
 }
 
-export const defaultExemplarConfig: Partial<ExemplarConfig> = {
-  labels: [],
+export const defaultTooltipOptions: Partial<TooltipOptions> = {
+  exemplarLabels: [],
 };
 
 export interface FieldConfig extends common.GraphFieldConfig {}

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -11,8 +11,17 @@
 import * as common from '@grafana/schema';
 
 export interface Options extends common.OptionsWithTimezones {
+  exemplars: ExemplarConfig;
   legend: common.VizLegendOptions;
   tooltip: common.VizTooltipOptions;
 }
+
+export interface ExemplarConfig {
+  labels: Array<string>;
+}
+
+export const defaultExemplarConfig: Partial<ExemplarConfig> = {
+  labels: [],
+};
 
 export interface FieldConfig extends common.GraphFieldConfig {}

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
@@ -126,7 +126,7 @@ export const ExemplarMarker = ({
 
   const renderMarker = useCallback(() => {
     // Show only configured labels and in the same order
-    const exemplarLabels = options?.exemplars?.labels;
+    const exemplarLabels = options?.tooltip?.exemplarLabels;
     let orderedDataFrameFields = [];
     if (!exemplarLabels || exemplarLabels?.length === 0) {
       const fieldsWithLinks =

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -10,6 +10,7 @@ import {
   TimeZone,
 } from '@grafana/data';
 import { EventsCanvas, FIXED_UNIT, UPlotConfigBuilder } from '@grafana/ui';
+import { PanelModel } from 'app/features/dashboard/state';
 
 import { ExemplarMarker } from './ExemplarMarker';
 
@@ -18,9 +19,10 @@ interface ExemplarsPluginProps {
   exemplars: DataFrame[];
   timeZone: TimeZone;
   visibleSeries?: VisibleExemplarLabels;
+  options?: PanelModel['options'];
 }
 
-export const ExemplarsPlugin = ({ exemplars, timeZone, config, visibleSeries }: ExemplarsPluginProps) => {
+export const ExemplarsPlugin = ({ exemplars, timeZone, config, visibleSeries, options }: ExemplarsPluginProps) => {
   const plotInstance = useRef<uPlot>();
 
   const [lockedExemplarFieldIndex, setLockedExemplarFieldIndex] = useState<DataFrameFieldIndex | undefined>();
@@ -83,10 +85,11 @@ export const ExemplarsPlugin = ({ exemplars, timeZone, config, visibleSeries }: 
           dataFrameFieldIndex={dataFrameFieldIndex}
           config={config}
           exemplarColor={markerColor}
+          options={options}
         />
       );
     },
-    [config, timeZone, visibleSeries, setLockedExemplarFieldIndex, lockedExemplarFieldIndex]
+    [config, timeZone, visibleSeries, setLockedExemplarFieldIndex, lockedExemplarFieldIndex, options]
   );
 
   return (


### PR DESCRIPTION
This PR adds a new feature to the Options Pane for PanelEditor. It adds a new section called Exemplar Configuration where you can order, hide or unhide different exemplar labels.

This feature is needed because when there are too many labels for Exemplars, the tooltip is very hard to be readable and we want to provide a configuration for multiple users where they can configure by themselves.