### PR TITLE
Fix `dupicated` typo into `duplicated`

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
@@ -31,7 +31,7 @@ describe('align frames', () => {
     });
 
     // the following does not work for tabular joins where the joined on field value is duplicated
-    // the time will never have a dupicated time which is joined on
+    // the time will never have a duplicated time which is joined on
     it('should perform an outer join', () => {
       const out = joinDataFrames({ frames: [series1, series2] })!;
       expect(
@@ -415,7 +415,7 @@ describe('align frames', () => {
   it('supports duplicate times', () => {
     //----------
     // NOTE!!!
-    // * ideally we would *keep* dupicate fields
+    // * ideally we would *keep* duplicate fields
     //----------
     const series1 = toDataFrame({
       fields: [

--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -24,7 +24,7 @@ const modes = [
     value: JoinMode.outerTabular,
     label: 'OUTER (TABULAR)',
     description:
-      'Join on a field value with dupicated values. Non performant outer join best used for tabular(SQL like) data.',
+      'Join on a field value with duplicated values. Non performant outer join best used for tabular(SQL like) data.',
   },
   { value: JoinMode.inner, label: 'INNER', description: 'Drop rows that do not match a value in all tables.' },
 ];


### PR DESCRIPTION
**What is this feature?**

Fixes `dupicated` typo. Discovered in transformation but also fixing in comments. Or am I missing something and `dupicated` is a thing?
