### PR TITLE
POC/FeatureToggles: Support expressions for configuration

### DIFF
--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -27,6 +27,9 @@ func TestFeatureManager(t *testing.T) {
 	t.Run("check license validation", func(t *testing.T) {
 		ft := FeatureManager{
 			flags: map[string]*FeatureFlag{},
+			vars: map[string]interface{}{
+				"channel": "fast",
+			},
 		}
 		ft.registerFlags(FeatureFlag{
 			Name:            "a",
@@ -35,16 +38,16 @@ func TestFeatureManager(t *testing.T) {
 			Expression:      "true",
 		}, FeatureFlag{
 			Name:       "b",
-			Expression: "true",
+			Expression: "vars.channel == 'fast'",
 		})
 		require.False(t, ft.IsEnabled("a"))
-		require.True(t, ft.IsEnabled("b"))
-		require.False(t, ft.IsEnabled("c")) // uknown flag
+		require.True(t, ft.IsEnabled("b"))  // uses variable
+		require.False(t, ft.IsEnabled("c")) // unknown flag
 
 		// Try changing "requires license"
 		ft.registerFlags(FeatureFlag{
 			Name:            "a",
-			RequiresLicense: false, // shuld still require license!
+			RequiresLicense: false, // should still require license!
 		}, FeatureFlag{
 			Name:            "b",
 			RequiresLicense: true, // expression is still "true"


### PR DESCRIPTION
This revives some of the features @oscarkilhed explored way back in https://github.com/grafana/grafana/compare/experimentals/feature-toggle-by-headers


**What is this feature?**

This will support setting toggles based on an expression rather than just true/false

**Why do we need this feature?**

It would be nice to have toggles that are configured to run based on deployment settings, like the release channel


TODO:
- [ ] what variables/environment should we register?
- [ ] error handling
