### PR TITLE
Grafana versioning: Remove `pre` suffix from Grafana version

### DIFF
--- a/pkg/build/config/genmetadata_test.go
+++ b/pkg/build/config/genmetadata_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 const (
-	hashedGrafanaVersion = "9.2.0-12345pre"
+	hashedGrafanaVersion = "9.2.0-12345"
 	versionedBranch      = "v9.2.x"
 )
 

--- a/pkg/build/config/version.go
+++ b/pkg/build/config/version.go
@@ -81,9 +81,6 @@ func GenerateGrafanaVersion(buildID, grafanaDir string) (string, error) {
 		buildID = shortenBuildID(buildID)
 		verComponents := strings.Split(version, "-")
 		version = verComponents[0]
-		if len(verComponents) > 1 {
-			buildID = fmt.Sprintf("%s%s", buildID, verComponents[1])
-		}
 		version = fmt.Sprintf("%s-%s", version, buildID)
 	}
 


### PR DESCRIPTION
**What is this feature?**

Removes the `pre` suffix from the generated Grafana versions. To date, when Grafana is built, the generated version consists of whatever the `version` is assigned to in the `package.json` file (say `10.2.0-pre`). The way the version is generated is that we split the `version` string in `10.2.0` and `pre`, we concatenate the Drone build ID int after the semver version, and append `pre` at the end of the version. So for example a Drone build with ID `12345`, will produce 
`10.2.0-12345pre` version.

**Why do we need this feature?**

CS is asking for it.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-delivery/issues/204

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
