### PR TITLE
CI: Bump code-coverage in Explore workflow to use go v1.20.x

### DIFF
--- a/.github/workflows/ox-code-coverage.yml
+++ b/.github/workflows/ox-code-coverage.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.19
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.20
     with:
       frontend-path-regexp: public\/app\/features\/(explore|correlations)|public\/app\/plugins\/datasource\/(loki|elasticsearch)
       backend-path-regexp: pkg\/services\/(queryhistory)|pkg\/tsdb\/(loki|elasticsearch)


### PR DESCRIPTION
**What is this feature?**

The Explore code-coverage workflow was using go 1.19.x which lead to build errors. Bumping to 1.20 should help.

References:
- https://github.com/grafana/code-coverage/releases/tag/v.0.1.20
- Example failing PR: https://github.com/grafana/grafana/pull/73382