### PR TITLE
Config editor: add url placeholder

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -56,7 +56,7 @@ export const ConfigEditor = (props: Props) => {
         hasRequiredFields={false}
       />
       <Divider />
-      <ConnectionSettings config={options} onChange={onOptionsChange} />
+      <ConnectionSettings config={options} onChange={onOptionsChange} urlPlaceholder="http://localhost:3100" />
       <Divider />
       <Auth
         {...convertLegacyAuthProps({


### PR DESCRIPTION
Adding a URL placeholder to the connection settings component to display the default Loki URL, in the same way as with the old configuration components.

**Which issue(s) does this PR fix?**:

Doing the same for Elasticsearch, source: https://github.com/grafana/grafana/pull/72840#discussion_r1293434066