### PR TITLE
Sandbox: Fix prismjs syntax for plugins defining its own language

### DIFF
--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -115,6 +115,11 @@ export function patchObjectAsLiveTarget(obj: unknown) {
   ) {
     Reflect.defineProperty(obj, SANDBOX_LIVE_VALUE, {});
   } else {
+    // prismjs languages are defined by directly modifying the prism.languages objects.
+    // Plugins inside the sandbox can't modify objects from the blue realm and prismjs.languages
+    // is one of them.
+    // Marking it as a live target allows plugins inside the sandbox to modify the object directly
+    // and make syntax work again.
     if (obj === Prism.languages) {
       Object.defineProperty(obj, SANDBOX_LIVE_VALUE, {});
     }

--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -1,4 +1,5 @@
 import { isNearMembraneProxy, ProxyTarget } from '@locker/near-membrane-shared';
+import Prism from 'prismjs';
 
 import { DataSourceApi } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -94,10 +95,16 @@ export function markDomElementStyleAsALiveTarget(el: Element) {
  * but not all objects, only the ones that are allowed to be modified
  */
 export function patchObjectAsLiveTarget(obj: unknown) {
+  if (!obj) {
+    return;
+  }
+
+  // do not patch it twice
+  if (Object.hasOwn(obj, SANDBOX_LIVE_VALUE)) {
+    return;
+  }
+
   if (
-    obj &&
-    // do not define it twice
-    !Object.hasOwn(obj, SANDBOX_LIVE_VALUE) &&
     // only for proxies
     isNearMembraneProxy(obj) &&
     // do not patch functions
@@ -107,6 +114,10 @@ export function patchObjectAsLiveTarget(obj: unknown) {
     (isReactClassComponent(obj) || obj instanceof DataSourceApi)
   ) {
     Reflect.defineProperty(obj, SANDBOX_LIVE_VALUE, {});
+  } else {
+    if (obj === Prism.languages) {
+      Object.defineProperty(obj, SANDBOX_LIVE_VALUE, {});
+    }
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes custom language definitions for prismjs in plugins running inside the sandbox

**Why do we need this feature?**

Without this query editors with custom language definitions will not work

**Who is this feature for?**

Plugins using prismjs with their own language definition

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/73392

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
