### PR TITLE
Alerting: Fix auto-completion snippets for KV properties

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/editor/snippets.ts
+++ b/public/app/features/alerting/unified/components/receivers/editor/snippets.ts
@@ -28,11 +28,11 @@ Annotations:
 {{ end }}
 `;
 
-export const groupLabelsLoopSnippet = getKeyValueTemplate('GroupLabels');
-export const commonLabelsLoopSnippet = getKeyValueTemplate('CommonLabels');
-export const commonAnnotationsLoopSnippet = getKeyValueTemplate('CommonAnnotations');
-export const labelsLoopSnippet = getKeyValueTemplate('Labels');
-export const annotationsLoopSnippet = getKeyValueTemplate('Annotations');
+export const groupLabelsLoopSnippet = getKeyValueTemplate('GroupLabels.SortedPairs');
+export const commonLabelsLoopSnippet = getKeyValueTemplate('CommonLabels.SortedPairs');
+export const commonAnnotationsLoopSnippet = getKeyValueTemplate('CommonAnnotations.SortedPairs');
+export const labelsLoopSnippet = getKeyValueTemplate('Labels.SortedPairs');
+export const annotationsLoopSnippet = getKeyValueTemplate('Annotations.SortedPairs');
 
 function getKeyValueTemplate(arrayName: string) {
   return `


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix for some of the autocompletion snippets in the template editor

**Why do we need this feature?**

The current snippets are broken, resulting in an error similar to this: 
```
ERROR in <template name>:
execution_error
template: <template name>:17:9: executing "<template name>" at <.Name>: can't evaluate field Name in type string
```

**Who is this feature for?**

Users of the template editor

**Which issue(s) does this PR fix?**:

No issue created

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
