### PR TITLE
CI: Move npm token to Vault

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4450,6 +4450,12 @@ kind: secret
 name: azure_tenant
 ---
 get:
+  name: token
+  path: infra/data/ci/grafana-release-eng/npm
+kind: secret
+name: npm_token
+---
+get:
   name: public-key-b64
   path: infra/data/ci/packages-publish/gpg
 kind: secret
@@ -4540,6 +4546,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: fe5607d33fe4779ac63a4a77e9bf174afb0d477b0cb89009ed8a55abd733bfe0
+hmac: da71a34a4dca17f08a083941cc4f8582abc5c855dca13382a54db96c23ea7e65
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -56,6 +56,7 @@ load(
     "from_secret",
     "gcp_upload_artifacts_key",
     "prerelease_bucket",
+    "npm_token",
 )
 load(
     "scripts/drone/utils/images.star",
@@ -124,7 +125,7 @@ def release_npm_packages_step():
         ],
         "failure": "ignore",
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": ["./bin/build artifacts npm release --tag ${DRONE_TAG}"],
     }

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -55,8 +55,8 @@ load(
     "scripts/drone/vault.star",
     "from_secret",
     "gcp_upload_artifacts_key",
-    "prerelease_bucket",
     "npm_token",
+    "prerelease_bucket",
 )
 load(
     "scripts/drone/utils/images.star",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -9,6 +9,7 @@ load(
     "gcp_grafanauploads_base64",
     "gcp_upload_artifacts_key",
     "prerelease_bucket",
+    "npm_token",
 )
 load(
     "scripts/drone/utils/images.star",
@@ -1139,7 +1140,7 @@ def release_canary_npm_packages_step(trigger = None):
         "image": images["build_image"],
         "depends_on": end_to_end_tests_deps(),
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": [
             "./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'",

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -8,8 +8,8 @@ load(
     "gcp_grafanauploads",
     "gcp_grafanauploads_base64",
     "gcp_upload_artifacts_key",
-    "prerelease_bucket",
     "npm_token",
+    "prerelease_bucket",
 )
 load(
     "scripts/drone/utils/images.star",

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -17,6 +17,8 @@ rgm_destination = "destination"
 rgm_github_token = "github_token"
 rgm_dagger_token = "dagger_token"
 
+npm_token = "npm_token"
+
 def from_secret(secret):
     return {"from_secret": secret}
 
@@ -63,6 +65,11 @@ def secrets():
             azure_tenant,
             "infra/data/ci/datasources/cpp-azure-resourcemanager-credentials",
             "tenant_id",
+        ),
+        vault_secret(
+            npm_token,
+            "infra/data/ci/grafana-release-eng/npm",
+            "token",
         ),
         # Package publishing
         vault_secret(


### PR DESCRIPTION
Moving the npm token out of Drone and into Vault.