### PR TITLE
Alerting: Add new metrics

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -139,22 +139,6 @@ func NewEvaluatorFactory(
 	}
 }
 
-func NewEvaluatorFactoryWithMetrics(
-	cfg setting.UnifiedAlertingSettings,
-	datasourceCache datasources.CacheService,
-	expressionService *expr.Service,
-	pluginsStore plugins.Store,
-	metrics *metrics.Eval,
-) EvaluatorFactory {
-	return &evaluatorImpl{
-		evaluationTimeout: cfg.EvaluationTimeout,
-		dataSourceCache:   datasourceCache,
-		expressionService: expressionService,
-		pluginsStore:      pluginsStore,
-		metrics:           metrics,
-	}
-}
-
 // invalidEvalResultFormatError is an error for invalid format of the alert definition evaluation results.
 type invalidEvalResultFormatError struct {
 	refID  string

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -128,12 +128,14 @@ func NewEvaluatorFactory(
 	datasourceCache datasources.CacheService,
 	expressionService *expr.Service,
 	pluginsStore plugins.Store,
+	metrics *metrics.Eval,
 ) EvaluatorFactory {
 	return &evaluatorImpl{
 		evaluationTimeout: cfg.EvaluationTimeout,
 		dataSourceCache:   datasourceCache,
 		expressionService: expressionService,
 		pluginsStore:      pluginsStore,
+		metrics:           metrics,
 	}
 }
 

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -61,7 +61,7 @@ func (r *conditionEvaluator) EvaluateRaw(ctx context.Context, now time.Time) (re
 	labels := prometheus.Labels{"org": strconv.FormatInt(r.orgId, 10)}
 	if r.metrics != nil {
 		defer func() {
-			r.metrics.QueryDuration.With(labels).Observe(time.Now().Sub(start).Seconds())
+			r.metrics.QueryDuration.With(labels).Observe(time.Since(start).Seconds())
 			r.metrics.Total.With(labels).Inc()
 			if err != nil {
 				r.metrics.Failures.With(labels).Inc()
@@ -95,7 +95,7 @@ func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Resul
 	start := time.Now()
 	labels := prometheus.Labels{"org": strconv.FormatInt(r.orgId, 10)}
 	if r.metrics != nil {
-		defer func() { r.metrics.Duration.With(labels).Observe(time.Now().Sub(start).Seconds()) }()
+		defer func() { r.metrics.Duration.With(labels).Observe(time.Since(start).Seconds()) }()
 	}
 
 	response, err := r.EvaluateRaw(ctx, now)
@@ -106,7 +106,7 @@ func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Resul
 	processDurationStart := time.Now()
 	if r.metrics != nil {
 		defer func() {
-			r.metrics.ProcessDuration.With(labels).Observe(time.Now().Sub(processDurationStart).Seconds())
+			r.metrics.ProcessDuration.With(labels).Observe(time.Since(processDurationStart).Seconds())
 		}()
 	}
 

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -123,6 +123,20 @@ func NewEvaluatorFactory(
 	datasourceCache datasources.CacheService,
 	expressionService *expr.Service,
 	pluginsStore plugins.Store,
+) EvaluatorFactory {
+	return &evaluatorImpl{
+		evaluationTimeout: cfg.EvaluationTimeout,
+		dataSourceCache:   datasourceCache,
+		expressionService: expressionService,
+		pluginsStore:      pluginsStore,
+	}
+}
+
+func NewEvaluatorFactoryWithMetrics(
+	cfg setting.UnifiedAlertingSettings,
+	datasourceCache datasources.CacheService,
+	expressionService *expr.Service,
+	pluginsStore plugins.Store,
 	metrics *metrics.Eval,
 ) EvaluatorFactory {
 	return &evaluatorImpl{

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -92,21 +92,16 @@ func (r *conditionEvaluator) EvaluateRaw(ctx context.Context, now time.Time) (re
 
 // Evaluate evaluates the condition and converts the response to Results
 func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Results, error) {
-	start := time.Now()
-	labels := prometheus.Labels{"org": strconv.FormatInt(r.orgId, 10)}
-	if r.metrics != nil {
-		defer func() { r.metrics.Duration.With(labels).Observe(time.Since(start).Seconds()) }()
-	}
-
 	response, err := r.EvaluateRaw(ctx, now)
 	if err != nil {
 		return nil, err
 	}
 
-	processDurationStart := time.Now()
+	start := time.Now()
+	labels := prometheus.Labels{"org": strconv.FormatInt(r.orgId, 10)}
 	if r.metrics != nil {
 		defer func() {
-			r.metrics.ProcessDuration.With(labels).Observe(time.Since(processDurationStart).Seconds())
+			r.metrics.ProcessDuration.With(labels).Observe(time.Since(start).Seconds())
 		}()
 	}
 

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -128,6 +128,20 @@ func NewEvaluatorFactory(
 	datasourceCache datasources.CacheService,
 	expressionService *expr.Service,
 	pluginsStore plugins.Store,
+) EvaluatorFactory {
+	return &evaluatorImpl{
+		evaluationTimeout: cfg.EvaluationTimeout,
+		dataSourceCache:   datasourceCache,
+		expressionService: expressionService,
+		pluginsStore:      pluginsStore,
+	}
+}
+
+func NewEvaluatorFactoryWithMetrics(
+	cfg setting.UnifiedAlertingSettings,
+	datasourceCache datasources.CacheService,
+	expressionService *expr.Service,
+	pluginsStore plugins.Store,
 	metrics *metrics.Eval,
 ) EvaluatorFactory {
 	return &evaluatorImpl{

--- a/pkg/services/ngalert/eval/eval_bench_test.go
+++ b/pkg/services/ngalert/eval/eval_bench_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/expr"
@@ -17,6 +19,7 @@ func BenchmarkEvaluate(b *testing.B) {
 	var dataResp backend.QueryDataResponse
 	seedDataResponse(&dataResp, 10000)
 	var evaluator ConditionEvaluator = &conditionEvaluator{
+		clock: clock.NewMock(),
 		expressionService: &fakeExpressionService{
 			hook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {
 				return &dataResp, nil

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -536,7 +536,7 @@ func TestValidate(t *testing.T) {
 				pluginsStore: store,
 			})
 
-			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
+			evaluator := NewEvaluatorFactoryWithMetrics(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
 			evalCtx := NewContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -536,7 +536,7 @@ func TestValidate(t *testing.T) {
 				pluginsStore: store,
 			})
 
-			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store)
+			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
 			evalCtx := NewContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -540,7 +540,7 @@ func TestValidate(t *testing.T) {
 				pluginsStore: store,
 			})
 
-			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
+			evaluator := NewEvaluatorFactoryWithMetrics(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
 			evalCtx := NewContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/client_golang/prometheus"
@@ -724,6 +725,7 @@ func TestEvaluate(t *testing.T) {
 			r := prometheus.NewPedanticRegistry()
 			metrics := metrics.NewEvalMetrics(r)
 			ev := conditionEvaluator{
+				clock:    clock.NewMock(),
 				pipeline: nil,
 				expressionService: &fakeExpressionService{
 					hook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {
@@ -775,6 +777,7 @@ func TestEvaluateRaw(t *testing.T) {
 		unexpectedResponse := &backend.QueryDataResponse{}
 
 		e := conditionEvaluator{
+			clock:    clock.NewMock(),
 			pipeline: nil,
 			expressionService: &fakeExpressionService{
 				hook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -536,7 +536,7 @@ func TestValidate(t *testing.T) {
 				pluginsStore: store,
 			})
 
-			evaluator := NewEvaluatorFactoryWithMetrics(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
+			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), store, nil)
 			evalCtx := NewContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)

--- a/pkg/services/ngalert/metrics/eval.go
+++ b/pkg/services/ngalert/metrics/eval.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Eval struct {
+	Failures *prometheus.CounterVec
+	Total    *prometheus.CounterVec
+
+	// QueryDuration is the total time (in seconds) taken to execute any queries
+	// and expressions.
+	QueryDuration *prometheus.HistogramVec
+
+	// ProcessDuration is the total time (in seconds) taken to process the data
+	// frames returned by any queries and expressions.
+	ProcessDuration *prometheus.HistogramVec
+
+	// Duration is the total time (in seconds) taken to evaluate the rule, including
+	// executing any queries and expressions and process the data frames returned by
+	// any queries and expressions. You can think of it as the sum of QueryDuration
+	// and ProcessDuration.
+	Duration *prometheus.HistogramVec
+}
+
+func NewEvalMetrics(r prometheus.Registerer) *Eval {
+	return &Eval{
+		Failures: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "evaluation_failures_total",
+				Help:      "The total number of evaluation failures.",
+			},
+			[]string{"org"},
+		),
+		Total: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "evaluations_total",
+				Help:      "The total number of evaluations.",
+			},
+			[]string{"org"},
+		),
+		QueryDuration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "evaluation_query_duration_seconds",
+				Help:      "The total time taken to execute any queries and expressions.",
+				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+		ProcessDuration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "evaluation_process_duration_seconds",
+				Help:      "The total time taken to process the data frames returned by any queries and expressions.",
+				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+		Duration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "evaluation_duration_seconds",
+				Help:      "The total time taken to evaluate the rule, including executing any queries and expressions and processing any data frames.",
+				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+	}
+}

--- a/pkg/services/ngalert/metrics/eval.go
+++ b/pkg/services/ngalert/metrics/eval.go
@@ -16,12 +16,6 @@ type Eval struct {
 	// ProcessDuration is the total time (in seconds) taken to process the data
 	// frames returned by any queries and expressions.
 	ProcessDuration *prometheus.HistogramVec
-
-	// Duration is the total time (in seconds) taken to evaluate the rule, including
-	// executing any queries and expressions and process the data frames returned by
-	// any queries and expressions. You can think of it as the sum of QueryDuration
-	// and ProcessDuration.
-	Duration *prometheus.HistogramVec
 }
 
 func NewEvalMetrics(r prometheus.Registerer) *Eval {
@@ -50,7 +44,7 @@ func NewEvalMetrics(r prometheus.Registerer) *Eval {
 				Subsystem: Subsystem,
 				Name:      "evaluation_query_duration_seconds",
 				Help:      "The total time taken to execute any queries and expressions.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+				Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 240},
 			},
 			[]string{"org"},
 		),
@@ -60,17 +54,7 @@ func NewEvalMetrics(r prometheus.Registerer) *Eval {
 				Subsystem: Subsystem,
 				Name:      "evaluation_process_duration_seconds",
 				Help:      "The total time taken to process the data frames returned by any queries and expressions.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
-			},
-			[]string{"org"},
-		),
-		Duration: promauto.With(r).NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: Subsystem,
-				Name:      "evaluation_duration_seconds",
-				Help:      "The total time taken to evaluate the rule, including executing any queries and expressions and processing any data frames.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+				Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 240},
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -25,6 +25,7 @@ type NGAlert struct {
 	// Registerer is used by subcomponents which register their own metrics.
 	Registerer prometheus.Registerer
 
+	eval                        *Eval
 	schedulerMetrics            *Scheduler
 	stateMetrics                *State
 	multiOrgAlertmanagerMetrics *MultiOrgAlertmanager
@@ -36,12 +37,17 @@ type NGAlert struct {
 func NewNGAlert(r prometheus.Registerer) *NGAlert {
 	return &NGAlert{
 		Registerer:                  r,
+		eval:                        NewEvalMetrics(r),
 		schedulerMetrics:            NewSchedulerMetrics(r),
 		stateMetrics:                NewStateMetrics(r),
 		multiOrgAlertmanagerMetrics: NewMultiOrgAlertmanagerMetrics(r),
 		apiMetrics:                  NewAPIMetrics(r),
 		historianMetrics:            NewHistorianMetrics(r),
 	}
+}
+
+func (ng *NGAlert) GetEvalMetrics() *Eval {
+	return ng.eval
 }
 
 func (ng *NGAlert) GetSchedulerMetrics() *Scheduler {

--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -8,6 +8,15 @@ import (
 type State struct {
 	AlertState          *prometheus.GaugeVec
 	StateUpdateDuration prometheus.Histogram
+
+	// SaveDuration is the total time (in seconds) taken to save the alert instances
+	// for an evaluation to the database.
+	SaveDuration *prometheus.HistogramVec
+
+	// Duration is the total time (in seconds) taken to process all states for an
+	// evaluation, including saving the alert instances from those states to the
+	// database.
+	Duration *prometheus.HistogramVec
 }
 
 func NewStateMetrics(r prometheus.Registerer) *State {
@@ -26,6 +35,26 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Help:      "The duration of calculation of a single state.",
 				Buckets:   []float64{0.01, 0.1, 1, 2, 5, 10},
 			},
+		),
+		SaveDuration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "state_save_duration_seconds",
+				Help:      "The total time taken to save the alert instances to the database.",
+				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+		Duration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "state_duration_seconds",
+				Help:      "The total time taken to process all states, including saving alert instances to the database.",
+				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
 		),
 	}
 }

--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -12,11 +12,6 @@ type State struct {
 	// SaveDuration is the total time (in seconds) taken to save the alert instances
 	// for an evaluation to the database.
 	SaveDuration *prometheus.HistogramVec
-
-	// Duration is the total time (in seconds) taken to process all states for an
-	// evaluation, including saving the alert instances from those states to the
-	// database.
-	Duration *prometheus.HistogramVec
 }
 
 func NewStateMetrics(r prometheus.Registerer) *State {
@@ -42,17 +37,7 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Subsystem: Subsystem,
 				Name:      "state_save_duration_seconds",
 				Help:      "The total time taken to save the alert instances to the database.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
-			},
-			[]string{"org"},
-		),
-		Duration: promauto.With(r).NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: Subsystem,
-				Name:      "state_duration_seconds",
-				Help:      "The total time taken to process all states, including saving alert instances to the database.",
-				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+				Buckets:   []float64{1, 5, 10, 15, 30, 60, 120, 240},
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -189,7 +189,7 @@ func (ng *AlertNG) init() error {
 
 	ng.AlertsRouter = alertsRouter
 
-	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore, ng.Metrics.GetEvalMetrics())
+	evalFactory := eval.NewEvaluatorFactoryWithMetrics(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore, ng.Metrics.GetEvalMetrics())
 	schedCfg := schedule.SchedulerCfg{
 		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
 		C:                    clk,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -189,7 +189,7 @@ func (ng *AlertNG) init() error {
 
 	ng.AlertsRouter = alertsRouter
 
-	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore)
+	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore, ng.Metrics.GetEvalMetrics())
 	schedCfg := schedule.SchedulerCfg{
 		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
 		C:                    clk,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -189,7 +189,7 @@ func (ng *AlertNG) init() error {
 
 	ng.AlertsRouter = alertsRouter
 
-	evalFactory := eval.NewEvaluatorFactoryWithMetrics(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore, ng.Metrics.GetEvalMetrics())
+	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService, ng.pluginsStore, ng.Metrics.GetEvalMetrics())
 	schedCfg := schedule.SchedulerCfg{
 		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
 		C:                    clk,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -417,7 +417,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			logger.Debug("Skip updating the state because the context has been cancelled")
 			return
 		}
-		start = sch.clock.Now()
 		processedStates := sch.stateManager.ProcessEvalResults(
 			ctx,
 			e.scheduledAt,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -348,10 +348,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 	logger.Debug("Alert rule routine started")
 
 	orgID := fmt.Sprint(key.OrgID)
-	evalTotal := sch.metrics.EvalTotal.WithLabelValues(orgID)
-	evalDuration := sch.metrics.EvalDuration.WithLabelValues(orgID)
-	evalTotalFailures := sch.metrics.EvalFailures.WithLabelValues(orgID)
-	processDuration := sch.metrics.ProcessDuration.WithLabelValues(orgID)
 	sendDuration := sch.metrics.SendDuration.WithLabelValues(orgID)
 
 	notify := func(states []state.StateTransition) {
@@ -390,11 +386,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			}
 		}
 
-		evalTotal.Inc()
-		evalDuration.Observe(dur.Seconds())
-
 		if err != nil || results.HasErrors() {
-			evalTotalFailures.Inc()
 			if results == nil {
 				results = append(results, eval.NewResultFromError(err, e.scheduledAt, dur))
 			}
@@ -433,7 +425,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			results,
 			state.GetRuleExtraLabels(e.rule, e.folderTitle, !sch.disableGrafanaFolder),
 		)
-		processDuration.Observe(sch.clock.Now().Sub(start).Seconds())
 
 		start = sch.clock.Now()
 		alerts := state.FromStateTransitionToPostableAlerts(processedStates, sch.stateManager, sch.appURL)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -771,7 +771,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 
 	var evaluator = evalMock
 	if evalMock == nil {
-		evaluator = eval.NewEvaluatorFactoryWithMetrics(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{}, nil)
+		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{}, nil)
 	}
 
 	if registry == nil {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -454,49 +454,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			t.Run("it reports metrics", func(t *testing.T) {
 				// duration metric has 0 values because of mocked clock that do not advance
 				expectedMetric := fmt.Sprintf(
-					`# HELP grafana_alerting_rule_evaluation_duration_seconds The time to evaluate a rule.
-        	            	# TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
-							grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
-        	            	grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
-        	            	grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 1
-							# HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.
-        	            	# TYPE grafana_alerting_rule_evaluation_failures_total counter
-        	            	grafana_alerting_rule_evaluation_failures_total{org="%[1]d"} 0
-        	            	# HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
-        	            	# TYPE grafana_alerting_rule_evaluations_total counter
-        	            	grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
-							# HELP grafana_alerting_rule_process_evaluation_duration_seconds The time to process the evaluation results for a rule.
-							# TYPE grafana_alerting_rule_process_evaluation_duration_seconds histogram
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
-							grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d"} 0
-							grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d"} 1
-							# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
+					`# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
 							# TYPE grafana_alerting_rule_send_alerts_duration_seconds histogram
 							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
 							grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
@@ -677,49 +635,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		t.Run("it should increase failure counter", func(t *testing.T) {
 			// duration metric has 0 values because of mocked clock that do not advance
 			expectedMetric := fmt.Sprintf(
-				`# HELP grafana_alerting_rule_evaluation_duration_seconds The time to evaluate a rule.
-        	            # TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
-						grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
-        	            grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
-        	            grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 1
-						# HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.
-        	            # TYPE grafana_alerting_rule_evaluation_failures_total counter
-        	            grafana_alerting_rule_evaluation_failures_total{org="%[1]d"} 1
-        	            # HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
-        	            # TYPE grafana_alerting_rule_evaluations_total counter
-        	            grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
-						# HELP grafana_alerting_rule_process_evaluation_duration_seconds The time to process the evaluation results for a rule.
-						# TYPE grafana_alerting_rule_process_evaluation_duration_seconds histogram
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="15"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="30"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="60"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="120"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="180"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="240"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="300"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
-						grafana_alerting_rule_process_evaluation_duration_seconds_sum{org="%[1]d"} 0
-						grafana_alerting_rule_process_evaluation_duration_seconds_count{org="%[1]d"} 1
-						# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
+				`# HELP grafana_alerting_rule_send_alerts_duration_seconds The time to send the alerts to Alertmanager.
 						# TYPE grafana_alerting_rule_send_alerts_duration_seconds histogram
 						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
 						grafana_alerting_rule_send_alerts_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
@@ -855,7 +771,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 
 	var evaluator = evalMock
 	if evalMock == nil {
-		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{})
+		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{}, nil)
 	}
 
 	if registry == nil {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -771,7 +771,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 
 	var evaluator = evalMock
 	if evalMock == nil {
-		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{}, nil)
+		evaluator = eval.NewEvaluatorFactoryWithMetrics(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, &featuremgmt.FeatureManager{}, nil, tracing.InitializeTracerForTest()), &fakes.FakePluginStore{}, nil)
 	}
 
 	if registry == nil {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -284,8 +284,6 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 			{Num: int64(len(states))},
 		})
 	staleStates := st.deleteStaleStatesFromCache(ctx, logger, evaluatedAt, alertRule)
-
-	start = time.Now()
 	st.deleteAlertStates(tracingCtx, logger, staleStates)
 
 	if len(staleStates) > 0 {

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1300,8 +1300,21 @@ func TestProcessEvalResults(t *testing.T) {
         	            grafana_alerting_state_calculation_duration_seconds_bucket{le="+Inf"} %[1]d
         	            grafana_alerting_state_calculation_duration_seconds_sum 0
         	            grafana_alerting_state_calculation_duration_seconds_count %[1]d
+						# HELP grafana_alerting_state_save_duration_seconds The total time taken to save the alert instances to the database.
+						# TYPE grafana_alerting_state_save_duration_seconds histogram
+						grafana_alerting_state_save_duration_seconds_bucket{org="1",le="1"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="5"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="10"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="15"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="30"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="60"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="120"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="240"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_bucket{org="1",le="+Inf"} %[1]d
+            	        grafana_alerting_state_save_duration_seconds_sum{org="1"} 0
+            	        grafana_alerting_state_save_duration_seconds_count{org="1"} %[1]d
 						`, results)
-			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_state_calculation_duration_seconds", "grafana_alerting_state_calculation_total")
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_state_calculation_duration_seconds", "grafana_alerting_state_save_duration_seconds_bucket", "grafana_alerting_state_save_duration_seconds_count")
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

This pull request adds new metrics to Grafana Managed Alerts to measure both the separate and combined time taken to execute the queries and expressions, process the data frames from those queries and expressions, compute the next states and update the state cache, and write the resulting alert instances back to the database.

These metrics will help us better understand alert rule performance for open source and in Grafana Cloud.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
