### PR TITLE
Transformations Documentation: Add Images for Disable and Delete

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -74,6 +74,8 @@ The input and output results sets can help you debug a transformation.
 
 You can disable or hide one or more transformations by clicking on the eye icon on the top right side of the transformation row. This disables the applied actions of that specific transformation and can help to identify issues when you change several transformations one after another.
 
+{{< figure src="/static/img/docs/transformations/screenshot-example-disable-transformation.png" class="docs-image--no-shadow" max-width= "1100px" >}}
+
 ## Filter a transformation
 
 If your panel uses more than one query, you can filter these and apply the selected transformation to only one of the queries. To do this, click the filter icon on the top right of the transformation row. This opens a drop-down with a list of queries used on the panel. From here, you can select the query you want to transform.
@@ -93,6 +95,8 @@ We recommend that you remove transformations that you don't need. When you delet
 1. Open a panel for editing.
 1. Click the **Transform** tab.
 1. Click the trash icon next to the transformation you want to delete.
+
+{{< figure src="/static/img/docs/transformations/screenshot-example-remove-transformation.png" class="docs-image--no-shadow" max-width= "1100px" >}}
 
 ## Transformation functions
 


### PR DESCRIPTION
This PR adds images for deleting a transformation:


![](https://grafana.com/static/img/docs/transformations/screenshot-example-remove-transformation.png)

and for disabling a transformation:


![](https://grafana.com/static/img/docs/transformations/screenshot-example-disable-transformation.png)

Please check that:
- [x] The docs are updated
