### PR TITLE
[v10.1.x] CI: Move npm token to Vault

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4452,6 +4452,12 @@ kind: secret
 name: azure_tenant
 ---
 get:
+  name: token
+  path: infra/data/ci/grafana-release-eng/npm
+kind: secret
+name: npm_token
+---
+get:
   name: public-key-b64
   path: infra/data/ci/packages-publish/gpg
 kind: secret
@@ -4542,6 +4548,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 12ff5339f60d173517d4e7480de10b4c925e57a87279d610ffac3e34450efe72
+hmac: 728c159587c47f2df5132626abb56674bc7271f227a930893783926ffe645157
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -55,6 +55,7 @@ load(
     "scripts/drone/vault.star",
     "from_secret",
     "gcp_upload_artifacts_key",
+    "npm_token",
     "prerelease_bucket",
 )
 load(
@@ -124,7 +125,7 @@ def release_npm_packages_step():
         ],
         "failure": "ignore",
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": ["./bin/build artifacts npm release --tag ${DRONE_TAG}"],
     }

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -8,6 +8,7 @@ load(
     "gcp_grafanauploads",
     "gcp_grafanauploads_base64",
     "gcp_upload_artifacts_key",
+    "npm_token",
     "prerelease_bucket",
 )
 load(
@@ -1140,7 +1141,7 @@ def release_canary_npm_packages_step(trigger = None):
         "image": images["build_image"],
         "depends_on": end_to_end_tests_deps(),
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": [
             "./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'",

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -17,6 +17,8 @@ rgm_destination = "destination"
 rgm_github_token = "github_token"
 rgm_dagger_token = "dagger_token"
 
+npm_token = "npm_token"
+
 def from_secret(secret):
     return {"from_secret": secret}
 
@@ -63,6 +65,11 @@ def secrets():
             azure_tenant,
             "infra/data/ci/datasources/cpp-azure-resourcemanager-credentials",
             "tenant_id",
+        ),
+        vault_secret(
+            npm_token,
+            "infra/data/ci/grafana-release-eng/npm",
+            "token",
         ),
         # Package publishing
         vault_secret(


### PR DESCRIPTION
Backport c86a73c79405e9b539c26a58d5890f61fb302618 from #73407

---

Moving the npm token out of Drone and into Vault.
