### PR TITLE
[v10.0.x] CI: Move npm token to Vault

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4078,6 +4078,12 @@ kind: secret
 name: azure_tenant
 ---
 get:
+  name: token
+  path: infra/data/ci/grafana-release-eng/npm
+kind: secret
+name: npm_token
+---
+get:
   name: public-key-b64
   path: infra/data/ci/packages-publish/gpg
 kind: secret
@@ -4186,6 +4192,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: bcfadd7159da5ee1d6f5e7b2b1d5f24b66919fb2f3919edb37b89d33ece31192
+hmac: 50e07de5e688a14cc76c3e8cc992a2c01fd6285708683ab54b9662baa6212f46
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -55,6 +55,7 @@ load(
     "scripts/drone/vault.star",
     "from_secret",
     "gcp_upload_artifacts_key",
+    "npm_token",
     "prerelease_bucket",
 )
 load(
@@ -124,7 +125,7 @@ def release_npm_packages_step():
         ],
         "failure": "ignore",
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": ["./bin/build artifacts npm release --tag ${DRONE_TAG}"],
     }

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -8,6 +8,7 @@ load(
     "gcp_grafanauploads",
     "gcp_grafanauploads_base64",
     "gcp_upload_artifacts_key",
+    "npm_token",
     "prerelease_bucket",
 )
 load(
@@ -1078,7 +1079,7 @@ def release_canary_npm_packages_step(trigger = None):
         "image": images["build_image"],
         "depends_on": end_to_end_tests_deps(),
         "environment": {
-            "NPM_TOKEN": from_secret("npm_token"),
+            "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": [
             "./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'",

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -17,6 +17,8 @@ rgm_destination = "destination"
 rgm_github_token = "github_token"
 rgm_dagger_token = "dagger_token"
 
+npm_token = "npm_token"
+
 def from_secret(secret):
     return {"from_secret": secret}
 
@@ -63,6 +65,11 @@ def secrets():
             azure_tenant,
             "infra/data/ci/datasources/cpp-azure-resourcemanager-credentials",
             "tenant_id",
+        ),
+        vault_secret(
+            npm_token,
+            "infra/data/ci/grafana-release-eng/npm",
+            "token",
         ),
         # Package publishing
         vault_secret(


### PR DESCRIPTION
Backport c86a73c79405e9b539c26a58d5890f61fb302618 from #73407

---

Moving the npm token out of Drone and into Vault.
