### PR TITLE
Authn: external identity sync

### DIFF
--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -352,7 +352,7 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(tag.Service), new(*tagimpl.Service)),
 	authnimpl.ProvideService,
 	wire.Bind(new(authn.Service), new(*authnimpl.Service)),
-	wire.Bind(new(authn.IdentitySyncronizer), new(*authnimpl.Service)),
+	wire.Bind(new(authn.IdentitySynchronizer), new(*authnimpl.Service)),
 	supportbundlesimpl.ProvideService,
 	grafanaapiserver.WireSet,
 	oasimpl.ProvideService,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
+	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authnimpl"
 	"github.com/grafana/grafana/pkg/services/certgenerator"
 	"github.com/grafana/grafana/pkg/services/cleanup"
@@ -350,6 +351,8 @@ var wireBasicSet = wire.NewSet(
 	tagimpl.ProvideService,
 	wire.Bind(new(tag.Service), new(*tagimpl.Service)),
 	authnimpl.ProvideService,
+	wire.Bind(new(authn.Service), new(*authnimpl.Service)),
+	wire.Bind(new(authn.IdentitySyncronizer), new(*authnimpl.Service)),
 	supportbundlesimpl.ProvideService,
 	grafanaapiserver.WireSet,
 	oasimpl.ProvideService,

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -84,6 +84,10 @@ type Service interface {
 	RegisterClient(c Client)
 }
 
+type IdentitySyncronizer interface {
+	SyncIdentity(ctx context.Context, identity *Identity) error
+}
+
 type Client interface {
 	// Name returns the name of a client
 	Name() string

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -84,7 +84,7 @@ type Service interface {
 	RegisterClient(c Client)
 }
 
-type IdentitySyncronizer interface {
+type IdentitySynchronizer interface {
 	SyncIdentity(ctx context.Context, identity *Identity) error
 }
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -50,6 +50,9 @@ var (
 // make sure service implements authn.Service interface
 var _ authn.Service = new(Service)
 
+// make sure service implements authn.IdentitySyncronizer interface
+var _ authn.IdentitySyncronizer = new(Service)
+
 func ProvideService(
 	cfg *setting.Cfg, tracer tracing.Tracer,
 	orgService org.Service, sessionService auth.UserTokenService,
@@ -65,7 +68,7 @@ func ProvideService(
 	socialService social.Service, cache *remotecache.RemoteCache,
 	ldapService service.LDAP, registerer prometheus.Registerer,
 	signingKeysService signingkeys.Service, oauthServer oauthserver.OAuth2Server,
-) authn.Service {
+) *Service {
 	s := &Service{
 		log:            log.New("authn.service"),
 		cfg:            cfg,
@@ -228,11 +231,9 @@ func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Req
 		return nil, err
 	}
 
-	for _, hook := range s.postAuthHooks.items {
-		if err := hook.v(ctx, identity, r); err != nil {
-			s.log.FromContext(ctx).Warn("Failed to run post auth hook", "client", c.Name(), "id", identity.ID, "error", err)
-			return nil, err
-		}
+	if err := s.runPostAuthHooks(ctx, identity, r); err != nil {
+		s.log.FromContext(ctx).Warn("Failed to run post auth hook", "client", c.Name(), "id", identity.ID, "error", err)
+		return nil, err
 	}
 
 	if identity.IsDisabled {
@@ -247,6 +248,15 @@ func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Req
 	}
 
 	return identity, nil
+}
+
+func (s *Service) runPostAuthHooks(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
+	for _, hook := range s.postAuthHooks.items {
+		if err := hook.v(ctx, identity, r); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Service) RegisterPostAuthHook(hook authn.PostAuthHookFn, priority uint) {
@@ -330,6 +340,13 @@ func (s *Service) RegisterClient(c authn.Client) {
 	if cac, ok := c.(authn.ContextAwareClient); ok {
 		s.clientQueue.insert(cac, cac.Priority())
 	}
+}
+
+func (s *Service) SyncIdentity(ctx context.Context, identity *authn.Identity) error {
+	r := &authn.Request{OrgID: identity.OrgID}
+	// hack to not update last seen on external syncs
+	r.SetMeta(authn.MetaKeyIsLogin, "true")
+	return s.runPostAuthHooks(ctx, identity, r)
 }
 
 func orgIDFromRequest(r *authn.Request) int64 {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -50,8 +50,8 @@ var (
 // make sure service implements authn.Service interface
 var _ authn.Service = new(Service)
 
-// make sure service implements authn.IdentitySyncronizer interface
-var _ authn.IdentitySyncronizer = new(Service)
+// make sure service implements authn.IdentitySynchronizer interface
+var _ authn.IdentitySynchronizer = new(Service)
 
 func ProvideService(
 	cfg *setting.Cfg, tracer tracing.Tracer,

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -7,6 +7,7 @@ import (
 )
 
 var _ authn.Service = new(FakeService)
+var _ authn.IdentitySyncronizer = new(FakeService)
 
 type FakeService struct {
 	ExpectedErr        error
@@ -66,6 +67,10 @@ func (f *FakeService) RedirectURL(ctx context.Context, client string, r *authn.R
 }
 
 func (f *FakeService) RegisterClient(c authn.Client) {}
+
+func (f *FakeService) SyncIdentity(ctx context.Context, identity *authn.Identity) error {
+	return f.ExpectedErr
+}
 
 var _ authn.ContextAwareClient = new(FakeClient)
 

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ authn.Service = new(FakeService)
-var _ authn.IdentitySyncronizer = new(FakeService)
+var _ authn.IdentitySynchronizer = new(FakeService)
 
 type FakeService struct {
 	ExpectedErr        error

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -6,6 +6,44 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
+var _ authn.Service = new(MockService)
+var _ authn.IdentitySyncronizer = new(MockService)
+
+type MockService struct {
+	SyncIdentityFunc func(ctx context.Context, identity *authn.Identity) error
+}
+
+func (m *MockService) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	panic("unimplemented")
+}
+
+func (m *MockService) Login(ctx context.Context, client string, r *authn.Request) (*authn.Identity, error) {
+	panic("unimplemented")
+}
+
+func (m *MockService) RedirectURL(ctx context.Context, client string, r *authn.Request) (*authn.Redirect, error) {
+	panic("unimplemented")
+}
+
+func (m *MockService) RegisterClient(c authn.Client) {
+	panic("unimplemented")
+}
+
+func (m *MockService) RegisterPostAuthHook(hook authn.PostAuthHookFn, priority uint) {
+	panic("unimplemented")
+}
+
+func (m *MockService) RegisterPostLoginHook(hook authn.PostLoginHookFn, priority uint) {
+	panic("unimplemented")
+}
+
+func (m *MockService) SyncIdentity(ctx context.Context, identity *authn.Identity) error {
+	if m.SyncIdentityFunc != nil {
+		return m.SyncIdentityFunc(ctx, identity)
+	}
+	return nil
+}
+
 var _ authn.HookClient = new(MockClient)
 var _ authn.ContextAwareClient = new(MockClient)
 

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ authn.Service = new(MockService)
-var _ authn.IdentitySyncronizer = new(MockService)
+var _ authn.IdentitySynchronizer = new(MockService)
 
 type MockService struct {
 	SyncIdentityFunc func(ctx context.Context, identity *authn.Identity) error

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -16,9 +16,10 @@ type FakeUserService struct {
 	ExpectedUserProfileDTOs  []*user.UserProfileDTO
 	ExpectedUsageStats       map[string]interface{}
 
-	GetSignedInUserFn func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error)
-	CreateFn          func(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error)
-	DisableFn         func(ctx context.Context, cmd *user.DisableUserCommand) error
+	GetSignedInUserFn   func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error)
+	CreateFn            func(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error)
+	DisableFn           func(ctx context.Context, cmd *user.DisableUserCommand) error
+	BatchDisableUsersFn func(ctx context.Context, cmd *user.BatchDisableUsersCommand) error
 
 	counter int
 }
@@ -105,6 +106,9 @@ func (f *FakeUserService) Disable(ctx context.Context, cmd *user.DisableUserComm
 }
 
 func (f *FakeUserService) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableUsersCommand) error {
+	if f.BatchDisableUsersFn != nil {
+		return f.BatchDisableUsersFn(ctx, cmd)
+	}
 	return f.ExpectedError
 }
 


### PR DESCRIPTION
**What is this feature?**
Add a new interface IdentitySynchronizer that we can can use to trigger authn syncs from other places than during authentication process. Atm syncs triggered outside of the auth proccess uses https://github.com/grafana/grafana/blob/main/pkg/services/login/loginservice/loginservice.go#L46 but should reuse the same code.


**Why do we need this feature?**
Two not have different implementation of user, role and team syncs

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
