### PR TITLE
Rendering: Use image for server timeout errors

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -216,7 +216,7 @@ func (rs *RenderingService) RenderErrorImage(theme models.Theme, err error) (*Re
 		theme = models.ThemeDark
 	}
 	imgUrl := "public/img/rendering_%s_%s.png"
-	if errors.Is(err, ErrTimeout) {
+	if errors.Is(err, ErrTimeout) || errors.Is(err, ErrServerTimeout) {
 		imgUrl = fmt.Sprintf(imgUrl, "timeout", theme)
 	} else {
 		imgUrl = fmt.Sprintf(imgUrl, "error", theme)


### PR DESCRIPTION
**What is this feature?**
This PR updates the rendering feature to return the "rendering timeout error" image for server timeouts as well.

**Why do we need this feature?**
It's better to return an error image so the user immediately knows what happened instead of having to read the logs to find out.

**Who is this feature for?**
Users using the rendering features (mostly the reporting one).
