### PR TITLE
Tempo: Fix [object Object] shown as an Event message in Trace view

### DIFF
--- a/pkg/tsdb/tempo/trace_transform.go
+++ b/pkg/tsdb/tempo/trace_transform.go
@@ -263,7 +263,7 @@ func spanEventsToLogs(events ptrace.SpanEventSlice) []*TraceLog {
 		if event.Name() != "" {
 			fields = append(fields, &KeyValue{
 				Key:   TagMessage,
-				Value: attribute.StringValue(event.Name()),
+				Value: event.Name(),
 			})
 		}
 		event.Attributes().Range(func(key string, attr pcommon.Value) bool {


### PR DESCRIPTION
At some point the format of the value of `message` attribute changed by error to a Json instead of string. This reverts it back so it's simple string and Trace view knows how to properly show it.

![68747470733a2f2f67726166616e612e7a656e6465736b2e636f6d2f6174746163686d656e74732f746f6b656e2f6b455249434f667a37397672395a46577156464b306b4f70312f3f6e616d653d696d6167653030312e706e67](https://github.com/grafana/grafana/assets/1014802/9d56681b-c3e0-43b2-a732-55bb71169a54)
