### PR TITLE
Docs: update dataplane portal links

### DIFF
--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -80,7 +80,7 @@ This setting supports the `$__interval` and `$__rate_interval` macros.
 
 Switch between the following format options:
 
-- **Time series** - The default time series format. See [Time series kind formats](https://grafana.github.io/dataplane/timeseries/) for information on time series data frames and how time and value fields are structured.
+- **Time series** - The default time series format. See [Time series kind formats](https://grafana.com/developers/dataplane/timeseries/) for information on time series data frames and how time and value fields are structured.
 - **Table** - This works only in a [Table panel][table].
 - **Heatmap** - Displays metrics of the Histogram type on a [Heatmap panel][heatmap] by converting cumulative histograms to regular ones and sorting the series by the bucket bound.
 

--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -361,7 +361,7 @@ Data types are now being defined to create a data plane layer between producers 
 
 Learn more:
 
-- [Data plane contract - Technical specification](https://grafana.github.io/dataplane/contract/)
+- [Data plane contract - Technical specification](https://grafana.com/developers/dataplane/)
 - [Example typed dataframes and Go lib to use them in tests](https://github.com/grafana/dataplane/tree/main/examples)
 - [Go library for reading and writing dataplane data](https://github.com/grafana/dataplane/tree/main/sdata)
 

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -267,7 +267,7 @@ export interface DataFrameDTO extends QueryResultBase {
 
 export interface FieldCalcs extends Record<string, any> {}
 
-/** @deprecated check data plane docs: https://grafana.github.io/dataplane/heatmap **/
+/** @deprecated check data plane docs: https://grafana.com/developers/dataplane/heatmap **/
 export const TIME_SERIES_VALUE_FIELD_NAME = 'Value';
 export const TIME_SERIES_TIME_FIELD_NAME = 'Time';
 export const TIME_SERIES_METRIC_FIELD_NAME = 'Metric';

--- a/packages/grafana-data/src/types/dataFrameTypes.ts
+++ b/packages/grafana-data/src/types/dataFrameTypes.ts
@@ -13,12 +13,12 @@ export enum DataFrameType {
 
   TimeSeriesMulti = 'timeseries-multi',
 
-  /** Numeric types: https://grafana.github.io/dataplane/contract/numeric */
+  /** Numeric types: https://grafana.com/developers/dataplane/numeric */
   NumericWide = 'numeric-wide',
   NumericMulti = 'numeric-multi',
   NumericLong = 'numeric-long',
 
-  /** Logs types: https://grafana.github.io/dataplane/logs */
+  /** Logs types: https://grafana.com/developers/dataplane/logs */
   LogLines = 'log-lines',
 
   /** Directory listing */


### PR DESCRIPTION
part of https://github.com/grafana/dataplane/issues/32, updating the new dataplane portal links