### PR TITLE
Query splitting: combine nanos attribute con time fields

### DIFF
--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -403,6 +403,81 @@ describe('combineResponses', () => {
     expect(combined.errors?.[1]?.message).toBe('errorB');
   });
 
+  it('combines frames with nanoseconds', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    logFrameA.fields[0].nanos = [333333, 444444];
+    logFrameB.fields[0].nanos = [111111, 222222];
+    const responseA: DataQueryResponse = {
+      data: [logFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [logFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [
+        {
+          fields: [
+            {
+              config: {},
+              name: 'Time',
+              type: 'time',
+              values: [1, 2, 3, 4],
+              nanos: [111111, 222222, 333333, 444444],
+            },
+            {
+              config: {},
+              name: 'Line',
+              type: 'string',
+              values: ['line3', 'line4', 'line1', 'line2'],
+            },
+            {
+              config: {},
+              name: 'labels',
+              type: 'other',
+              values: [
+                {
+                  otherLabel: 'other value',
+                },
+                {
+                  label: 'value',
+                },
+                {
+                  otherLabel: 'other value',
+                },
+              ],
+            },
+            {
+              config: {},
+              name: 'tsNs',
+              type: 'string',
+              values: ['1000000', '2000000', '3000000', '4000000'],
+            },
+            {
+              config: {},
+              name: 'id',
+              type: 'string',
+              values: ['id3', 'id4', 'id1', 'id2'],
+            },
+          ],
+          length: 4,
+          meta: {
+            custom: {
+              frameType: 'LabeledTimeValues',
+            },
+            stats: [
+              {
+                displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
+                value: 33,
+              },
+            ],
+          },
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
   describe('combine stats', () => {
     const { metricFrameA } = getMockFrames();
     const makeResponse = (stats?: QueryResultMetaStat[]): DataQueryResponse => ({

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -203,6 +203,10 @@ function combineFrames(dest: DataFrame, source: DataFrame) {
   const totalFields = dest.fields.length;
   for (let i = 0; i < totalFields; i++) {
     dest.fields[i].values = [].concat.apply(source.fields[i].values, dest.fields[i].values);
+    if (source.fields[i].nanos) {
+      const nanos: number[] = dest.fields[i].nanos?.slice() || [];
+      dest.fields[i].nanos = source.fields[i].nanos?.concat(nanos);
+    }
   }
   dest.length += source.length;
   dest.meta = {


### PR DESCRIPTION
In recent changes we added a `nanos` attribute to the Time field in dataframe along `values`, which is also a numeric array containting the nanoseconds for each entry.

When query splitting is enabled, we were supposed to combine partial dataframe responses into a single one, and for fields we were only combining values, but we never combined this `nanos` property. This caused errors on transformations that were run with query splitting.

In this PR we're also merging this `nanos` property in combined data frames.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/73089

**Special notes for your reviewer:**

Query to reproduce:

- Query: `{age="old"} | logfmt | level="info"`
- Time interval: 2 days, 7 days, as much as you need to get at least 2 sub-requests for splitting.
- Transformations: `organize fields` > `hide tsNs`

![query](https://github.com/grafana/grafana/assets/1069378/72535354-087c-44e5-a830-2aef810258f2)

Without merging nanos:

![error](https://github.com/grafana/grafana/assets/1069378/432d88a2-848c-4fe8-a508-7f16538d0c82)

Merging nanos:

![no error](https://github.com/grafana/grafana/assets/1069378/ec1757fb-492a-40f2-9251-cd71313a8cb2)
