### PR TITLE
Docs: Include Cloud support with RBAC API

### DIFF
--- a/docs/sources/developers/http_api/access_control.md
+++ b/docs/sources/developers/http_api/access_control.md
@@ -21,7 +21,7 @@ title: RBAC HTTP API
 
 # RBAC API
 
-> Role-based access control API is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
+> Role-based access control API is only available in Grafana Cloud or Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
 The API can be used to create, update, delete, get, and list roles.
 


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
Incorrect statement saying RBAC HTTP API only works with Grafana Enterprise. 