### PR TITLE
Elasticsearch: Add missing tooltips to the configuration page

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -117,7 +117,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       </InlineField>
 
-      <InlineField label="X-Pack enabled" labelWidth={29} tooltip="Enable or disable X-Pack">
+      <InlineField label="X-Pack enabled" labelWidth={29} tooltip="Enable or disable X-Pack specific features">
         <InlineSwitch
           id="es_config_xpackEnabled"
           value={value.jsonData.xpack || false}

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -32,7 +32,12 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       }
     >
-      <InlineField label="Index name" htmlFor="es_config_indexName" labelWidth={26}>
+      <InlineField
+        label="Index name"
+        htmlFor="es_config_indexName"
+        labelWidth={29}
+        tooltip="Name of your Elasticsearch index. You can use a time pattern, such as YYYY.MM.DD, or a wildcard for the index name."
+      >
         <Input
           id="es_config_indexName"
           value={value.jsonData.index ?? (value.database || '')}
@@ -43,7 +48,12 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       </InlineField>
 
-      <InlineField label="Pattern" htmlFor="es_config_indexPattern" labelWidth={26}>
+      <InlineField
+        label="Pattern"
+        htmlFor="es_config_indexPattern"
+        labelWidth={29}
+        tooltip="If you're using a pattern for your index, select the type, or no pattern."
+      >
         <Select
           inputId="es_config_indexPattern"
           value={indexPatternTypes.find(
@@ -55,7 +65,12 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       </InlineField>
 
-      <InlineField label="Time field name" htmlFor="es_config_timeField" labelWidth={26}>
+      <InlineField
+        label="Time field name"
+        htmlFor="es_config_timeField"
+        labelWidth={29}
+        tooltip="Name of your time field. Defaults to @timestamp."
+      >
         <Input
           id="es_config_timeField"
           value={value.jsonData.timeField || ''}
@@ -66,7 +81,12 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       </InlineField>
 
-      <InlineField label="Max concurrent Shard Requests" htmlFor="es_config_shardRequests" labelWidth={26}>
+      <InlineField
+        label="Max concurrent Shard Requests"
+        htmlFor="es_config_shardRequests"
+        labelWidth={29}
+        tooltip="Maximum number of concurrent shards a search request can hit per node. Defaults to 5."
+      >
         <Input
           id="es_config_shardRequests"
           value={value.jsonData.maxConcurrentShardRequests || ''}
@@ -78,7 +98,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
       <InlineField
         label="Min time interval"
         htmlFor="es_config_minTimeInterval"
-        labelWidth={26}
+        labelWidth={29}
         tooltip={
           <>
             A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example{' '}
@@ -97,7 +117,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         />
       </InlineField>
 
-      <InlineField label="X-Pack enabled" labelWidth={26}>
+      <InlineField label="X-Pack enabled" labelWidth={29} tooltip="Enable or disable X-Pack">
         <InlineSwitch
           id="es_config_xpackEnabled"
           value={value.jsonData.xpack || false}
@@ -106,7 +126,12 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
       </InlineField>
 
       {value.jsonData.xpack && (
-        <InlineField label="Include Frozen Indices" htmlFor="es_config_frozenIndices" labelWidth={26}>
+        <InlineField
+          label="Include Frozen Indices"
+          htmlFor="es_config_frozenIndices"
+          labelWidth={29}
+          tooltip="Include frozen indices in searches."
+        >
           <InlineSwitch
             id="es_config_frozenIndices"
             value={value.jsonData.includeFrozen ?? false}

--- a/public/app/plugins/datasource/elasticsearch/configuration/LogsConfig.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/LogsConfig.tsx
@@ -31,7 +31,11 @@ export const LogsConfig = (props: Props) => {
         />
       }
     >
-      <InlineField label="Message field name" labelWidth={22}>
+      <InlineField
+        label="Message field name"
+        labelWidth={22}
+        tooltip="Configure the field to be used for log messages."
+      >
         <Input
           id="es_logs-config_logMessageField"
           value={value.logMessageField}
@@ -41,7 +45,11 @@ export const LogsConfig = (props: Props) => {
         />
       </InlineField>
 
-      <InlineField label="Level field name" labelWidth={22}>
+      <InlineField
+        label="Level field name"
+        labelWidth={22}
+        tooltip="Configure the field that determines the level of each log message."
+      >
         <Input
           id="es_logs-config_logLevelField"
           value={value.logLevelField}


### PR DESCRIPTION
As part of our configuration pages enhancements, we're adding more tooltips to the form fields.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/67383