### PR TITLE
Drawer: Clicking a `Select` arrow within a `Drawer` no longer causes it to close

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -4,7 +4,6 @@ import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import RcDrawer from 'rc-drawer';
 import React, { ReactNode, useEffect } from 'react';
-import { useClickAway } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -73,8 +72,6 @@ export function Drawer({
 
   // Adds body class while open so the toolbar nav can hide some actions while drawer is open
   useBodyClassWhileOpen();
-  // Close when we click outside mask (topnav) but only if closeOnMaskClick is true
-  useClickAway(overlayRef, closeOnMaskClick ? onClose : doNothing);
 
   // Apply size styles (unless deprecated width prop is used)
   const rootClass = cx(styles.drawer, !width && styles.sizes[size]);
@@ -143,8 +140,6 @@ export function Drawer({
   );
 }
 
-function doNothing() {}
-
 function useBodyClassWhileOpen() {
   useEffect(() => {
     if (!document.body) {
@@ -170,11 +165,15 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     drawer: css({
       '.main-view &': {
-        top: '81px',
+        top: 81,
       },
 
       '.main-view--search-bar-hidden &': {
-        top: '41px',
+        top: 41,
+      },
+
+      '.main-view--chrome-hidden &': {
+        top: 0,
       },
 
       '.rc-drawer-content-wrapper': {
@@ -232,9 +231,35 @@ const getStyles = (theme: GrafanaTheme2) => {
         },
       },
     }),
+    // we want the mask itself to span the whole page including the top bar
+    // this ensures trying to click something in the top bar will close the drawer correctly
+    // but we don't want the backdrop styling to apply over the top bar as it looks weird
+    // instead have a child pseudo element to apply the backdrop styling below the top bar
     mask: css({
-      backgroundColor: `${theme.components.overlay.background} !important`,
-      backdropFilter: 'blur(1px)',
+      backgroundColor: 'transparent',
+      position: 'fixed',
+
+      '&:before': {
+        backgroundColor: `${theme.components.overlay.background} !important`,
+        backdropFilter: 'blur(1px)',
+        bottom: 0,
+        content: '""',
+        left: 0,
+        position: 'fixed',
+        right: 0,
+
+        '.main-view &': {
+          top: 81,
+        },
+
+        '.main-view--search-bar-hidden &': {
+          top: 41,
+        },
+
+        '.main-view--chrome-hidden &': {
+          top: 0,
+        },
+      },
     }),
     maskMotion: css({
       '&-appear': {

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -34,7 +34,12 @@ export function AppChrome({ children }: Props) {
   // doesn't get re-mounted when chromeless goes from true to false.
 
   return (
-    <div className={classNames('main-view', searchBarHidden && 'main-view--search-bar-hidden')}>
+    <div
+      className={classNames('main-view', {
+        'main-view--search-bar-hidden': searchBarHidden && !state.chromeless,
+        'main-view--chrome-hidden': state.chromeless,
+      })}
+    >
       {!state.chromeless && (
         <>
           <LinkButton className={styles.skipLink} href="#pageContent">


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

this does 2 things:
- stops the drawer closing when clicking a select arrow within the drawer
  - why this was happening:
    - we were using `useClickAway` to determine whether the element clicked was inside the drawer content
    - for a select, once the dropdown is opened the caret-down icon is replaced with a search icon
    - by the time the code in `useClickAway` runs, `<drawerElement>.contains(<caretDownIcon>)` returns false because the caret-down icon has been removed from the dom completely and replaced with the search icon
  - the whole reason for using `useClickAway` is because the drawer mask doesn't extend the full page height, it sits underneath the top bar
  - instead, extend the area of the drawer mask to fill the full page
  - introduce a new pseudo element as part of the drawer mask to only apply the styling to the part of the page under the top bar
  - this means we can now remove `useClickAway` and rely on the drawer mask handling the behaviour 🥳 
- fixes the drawer and mask positioning in full kiosk mode. think this has been broken for a while:

| before | after |
| --- | --- |
| ![image](https://github.com/grafana/grafana/assets/20999846/d850ec60-4b82-4664-97c4-4272f0c0fe85) | ![image](https://github.com/grafana/grafana/assets/20999846/6b8389d1-fe7d-4915-8251-dfdfa5157427) | 

**Why do we need this feature?**

- so drawers don't close when clicking dropdown arrows inside them

**Who is this feature for?**

- anyone using drawer!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #73465 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
