### PR TITLE
CloudWatch: Add missing region Middle East (UAE) me-central-1

### DIFF
--- a/pkg/tsdb/cloudwatch/constants/metrics.go
+++ b/pkg/tsdb/cloudwatch/constants/metrics.go
@@ -550,6 +550,7 @@ func Regions() RegionsSet {
 		"eu-west-1":      {},
 		"eu-west-2":      {},
 		"eu-west-3":      {},
+		"me-central-1":   {},
 		"me-south-1":     {},
 		"sa-east-1":      {},
 		"us-east-1":      {},


### PR DESCRIPTION
Same issue as in #17448

What happened:
Tried to add Cloudwatch monitoring for some elements in `me-central-1`. However, the region is missing from the list

What you expected to happen:
Be able to select `me-central-1` from the dropdown menu

Environment:

Grafana version: v9.2.20 (8d9c05a160)