### PR TITLE
CloudMonitoring: `ConfigEditor` updates

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { ConnectionConfig } from '@grafana/google-sdk';
 import { reportInteraction } from '@grafana/runtime';
-import { SecureSocksProxySettings } from '@grafana/ui';
+import { Divider, SecureSocksProxySettings } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { CloudMonitoringOptions, CloudMonitoringSecureJsonData } from '../../types/types';
@@ -26,9 +27,25 @@ export class ConfigEditor extends PureComponent<Props> {
     const { options, onOptionsChange } = this.props;
     return (
       <>
+        <DataSourceDescription
+          dataSourceName="Google Cloud Monitoring"
+          docsLink="https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/"
+          hasRequiredFields
+        />
+        <Divider />
         <ConnectionConfig {...this.props} onOptionsChange={this.handleOnOptionsChange}></ConnectionConfig>
         {config.secureSocksDSProxyEnabled && (
-          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+          <>
+            <Divider />
+            <ConfigSection
+              title="Additional settings"
+              description="Additional settings are optional settings that can be configured for more control over your data source. This includes Secure Socks Proxy."
+              isCollapsible={true}
+              isInitiallyOpen={options.jsonData.enableSecureSocksProxy !== undefined}
+            >
+              <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+            </ConfigSection>
+          </>
         )}
       </>
     );

--- a/public/app/plugins/datasource/cloud-monitoring/types/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types/types.ts
@@ -37,6 +37,7 @@ export interface Aggregation {
 
 export interface CloudMonitoringOptions extends DataSourceOptions {
   gceDefaultProject?: string;
+  enableSecureSocksProxy?: boolean;
 }
 
 export interface CloudMonitoringSecureJsonData extends DataSourceSecureJsonData {}


### PR DESCRIPTION
For standardisation across Grafana we're updating datasource config editors to be more consistent. This is a part of https://github.com/grafana/oss-plugin-partnerships/issues/225.

The config editor has been refactored to use the new config editor structural components. The shared config components already appropriately use the `Field` component. We could add individual validation to the fields in the shared component but this isn't a requirement at the moment.

![image](https://github.com/grafana/grafana/assets/15019026/36706f80-86e4-4785-bf9c-478443536d9b)

Fixes https://github.com/grafana/oss-plugin-partnerships/issues/230