### PR TITLE
Devenv: add TracesToLogs(v2) configuration for self-instrumentation

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -298,3 +298,10 @@ datasources:
     access: proxy
     url: http://localhost:3200
     editable: false
+    jsonData:
+      tracesToLogsV2:
+          datasourceUid: gdev-loki
+          spanStartTimeShift: '5m'
+          spanEndTimeShift: '-5m'
+          customQuery: true
+          query: '{filename="/var/log/grafana/grafana.log"} |="$${__span.traceId}"'


### PR DESCRIPTION
**What is this feature?**

Adds Traces-Logs configuration to gdev-tempo so functionality is enabled when running `make devenv sources=self-instrumentation`

![image](https://github.com/grafana/grafana/assets/1692624/b163b17d-f9fb-4651-be48-8c60014c6a52)

![image](https://github.com/grafana/grafana/assets/1692624/c47ca837-ab50-4691-857e-e2705aac3dca)

Note: I'm not sure logs end up in the same file for everyone using devenv. It might be better to link it up using promtail and some configuration to tempo - but I'm not entirely sure how to do that right now and want to move on :-) Can always change it in the future.
