### PR TITLE
Pyroscope: Template variable support

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
@@ -122,7 +122,7 @@ describe('Cascader', () => {
     await userEvent.click(screen.getByText('First'), { pointerEventsCheck: PointerEventsCheckLevel.Never });
     await userEvent.click(screen.getByText('Second'), { pointerEventsCheck: PointerEventsCheckLevel.Never });
 
-    expect(screen.getByDisplayValue('First/Second')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('First / Second')).toBeInTheDocument();
   });
 
   it('displays all levels selected with separator passed in when displayAllSelectedLevels is true', async () => {

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -15,12 +15,14 @@ export interface CascaderProps {
   /** The separator between levels in the search */
   separator?: string;
   placeholder?: string;
+  /** As the onSelect handler reports only the leaf node selected, the leaf nodes should have unique value. */
   options: CascaderOption[];
   /** Changes the value for every selection, including branch nodes. Defaults to true. */
   changeOnSelect?: boolean;
   onSelect(val: string): void;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number;
+  /** Single string that needs to be the same as value of the last item in the selection chain. */
   initialValue?: string;
   allowCustomValue?: boolean;
   /** A function for formatting the message for custom value creation. Only applies when allowCustomValue is set to true*/
@@ -94,7 +96,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
       if (!option.items) {
         selectOptions.push({
           singleLabel: cpy[cpy.length - 1].label,
-          label: cpy.map((o) => o.label).join(this.props.separator || ` ${DEFAULT_SEPARATOR} `),
+          label: cpy.map((o) => o.label).join(this.props.separator || DEFAULT_SEPARATOR),
           value: cpy.map((o) => o.value),
         });
       } else {
@@ -113,7 +115,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
     for (const option of searchableOptions) {
       const optionPath = option.value || [];
 
-      if (optionPath.indexOf(initValue) === optionPath.length - 1) {
+      if (optionPath[optionPath.length - 1] === initValue) {
         return {
           rcValue: optionPath,
           activeLabel: this.props.displayAllSelectedLevels ? option.label : option.singleLabel || '',

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -71,7 +71,7 @@ const disableDivFocus = css({
   },
 });
 
-const DEFAULT_SEPARATOR = '/';
+const DEFAULT_SEPARATOR = ' / ';
 
 export class Cascader extends PureComponent<CascaderProps, CascaderState> {
   constructor(props: CascaderProps) {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/LabelsEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/LabelsEditor.tsx
@@ -49,8 +49,8 @@ export function LabelsEditor(props: Props) {
           scrollBeyondLastLine: false,
           wordWrap: 'on',
           padding: {
-            top: 5,
-            bottom: 6,
+            top: 4,
+            bottom: 5,
           },
         }}
         onBeforeEditorMount={ensurePhlareQL}
@@ -141,6 +141,7 @@ function ensurePhlareQL(monaco: Monaco) {
 const getStyles = () => {
   return {
     queryField: css`
+      label: LabelsEditorQueryField;
       flex: 1;
       // Not exactly sure but without this the editor does not shrink after resizing (so you can make it bigger but not
       // smaller). At the same time this does not actually make the editor 100px because it has flex 1 so I assume
@@ -148,6 +149,7 @@ const getStyles = () => {
       width: 100px;
     `,
     wrapper: css`
+      label: LabelsEditorWrapper;
       display: flex;
       flex: 1;
       border: 1px solid rgba(36, 41, 46, 0.3);

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
@@ -34,6 +34,7 @@ function useCascaderOptions(profileTypes?: ProfileTypeMessage[]): CascaderOption
     }
     let mainTypes = new Map<string, CascaderOption>();
     // Classify profile types by name then sample type.
+    // The profileTypes are something like cpu:sample:nanoseconds:sample:count or app.something.something
     for (let profileType of profileTypes) {
       let parts: string[];
       // Phlare uses : as delimiter while Pyro uses .
@@ -63,6 +64,13 @@ function useCascaderOptions(profileTypes?: ProfileTypeMessage[]): CascaderOption
   }, [profileTypes]);
 }
 
+/**
+ * Loads the profile types.
+ *
+ * This is exported and not used directly in the ProfileTypesCascader component because in some case we need to know
+ * the profileTypes before rendering the cascader.
+ * @param datasource
+ */
 export function useProfileTypes(datasource: PhlareDataSource) {
   const [profileTypes, setProfileTypes] = useState<ProfileTypeMessage[]>();
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
@@ -22,6 +22,7 @@ export function ProfileTypesCascader(props: Props) {
       allowCustomValue={true}
       onSelect={props.onChange}
       options={cascaderOptions}
+      changeOnSelect={false}
     />
   );
 }

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { Cascader, CascaderOption } from '@grafana/ui';
+
+import { PhlareDataSource } from '../datasource';
+import { ProfileTypeMessage } from '../types';
+
+type Props = {
+  initialProfileTypeId?: string;
+  profileTypes?: ProfileTypeMessage[];
+  onChange: (value: string) => void;
+};
+
+export function ProfileTypesCascader(props: Props) {
+  const cascaderOptions = useCascaderOptions(props.profileTypes);
+
+  return (
+    <Cascader
+      separator={'-'}
+      displayAllSelectedLevels={true}
+      initialValue={props.initialProfileTypeId}
+      allowCustomValue={true}
+      onSelect={props.onChange}
+      options={cascaderOptions}
+    />
+  );
+}
+
+// Turn profileTypes into cascader options
+function useCascaderOptions(profileTypes?: ProfileTypeMessage[]): CascaderOption[] {
+  return useMemo(() => {
+    if (!profileTypes) {
+      return [];
+    }
+    let mainTypes = new Map<string, CascaderOption>();
+    // Classify profile types by name then sample type.
+    for (let profileType of profileTypes) {
+      let parts: string[];
+      // Phlare uses : as delimiter while Pyro uses .
+      if (profileType.id.indexOf(':') > -1) {
+        parts = profileType.id.split(':');
+      } else {
+        parts = profileType.id.split('.');
+        const last = parts.pop()!;
+        parts = [parts.join('.'), last];
+      }
+
+      const [name, type] = parts;
+
+      if (!mainTypes.has(name)) {
+        mainTypes.set(name, {
+          label: name,
+          value: name,
+          items: [],
+        });
+      }
+      mainTypes.get(name)?.items!.push({
+        label: type,
+        value: profileType.id,
+      });
+    }
+    return Array.from(mainTypes.values());
+  }, [profileTypes]);
+}
+
+export function useProfileTypes(datasource: PhlareDataSource) {
+  const [profileTypes, setProfileTypes] = useState<ProfileTypeMessage[]>();
+
+  useEffect(() => {
+    (async () => {
+      const profileTypes = await datasource.getProfileTypes();
+      setProfileTypes(profileTypes);
+    })();
+  }, [datasource]);
+
+  return profileTypes;
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
@@ -13,7 +13,7 @@ describe('QueryEditor', () => {
   it('should render without error', async () => {
     setup();
 
-    expect(await screen.findByText('process_cpu - cpu')).toBeDefined();
+    expect(await screen.findByDisplayValue('process_cpu-cpu')).toBeDefined();
   });
 
   it('should render options', async () => {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
@@ -31,8 +31,10 @@ export function QueryEditor(props: Props) {
   return (
     <EditorRows>
       <EditorRow stackProps={{ wrap: false, gap: 1 }}>
-        {/* we have to wait for query.profileTypeId to be set before we can render cascader as we cannot later change the value.
-            We set a default value in useNormalizeQuery if it's not set, so it should be always set eventually.
+        {/*
+            The cascader is uncontrolled component so if we want to set some default value we can do it only on initial
+            render, so we are waiting until we have the profileTypes and know what the default value should be before
+            rendering.
          */}
         {profileTypes && query.profileTypeId ? (
           <ProfileTypesCascader

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
@@ -31,7 +31,10 @@ export function QueryEditor(props: Props) {
   return (
     <EditorRows>
       <EditorRow stackProps={{ wrap: false, gap: 1 }}>
-        {profileTypes ? (
+        {/* we have to wait for query.profileTypeId to be set before we can render cascader as we cannot later change the value.
+            We set a default value in useNormalizeQuery if it's not set, so it should be always set eventually.
+         */}
+        {profileTypes && query.profileTypeId ? (
           <ProfileTypesCascader
             profileTypes={profileTypes}
             initialProfileTypeId={query.profileTypeId}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+
+import { VariableQueryEditor } from './VariableQueryEditor';
+import { PhlareDataSource } from './datasource';
+import { PhlareDataSourceOptions } from './types';
+
+describe('VariableQueryEditor', () => {
+  it('renders correctly with type profileType', () => {
+    render(
+      <VariableQueryEditor
+        datasource={getMockDatasource()}
+        query={{
+          refId: 'A',
+          type: 'profileType',
+        }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/Query type/)).toBeInTheDocument();
+  });
+
+  it('renders correctly with type labels', async () => {
+    render(
+      <VariableQueryEditor
+        datasource={getMockDatasource()}
+        query={{
+          refId: 'A',
+          type: 'label',
+          profileTypeId: 'profile:type:1',
+        }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/Query type/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Profile type/)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue(/profile-type/)).toBeInTheDocument();
+  });
+
+  it('renders correctly with type labelValue', async () => {
+    render(
+      <VariableQueryEditor
+        datasource={getMockDatasource()}
+        query={{
+          refId: 'A',
+          type: 'labelValue',
+          labelName: 'foo',
+          profileTypeId: 'cpu',
+        }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/Query type/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Profile type/)).toBeInTheDocument();
+    // using custom value for change
+    expect(await screen.findByDisplayValue(/cpu/)).toBeInTheDocument();
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(await screen.findByText(/foo/)).toBeInTheDocument();
+  });
+});
+
+function getMockDatasource() {
+  const ds = new PhlareDataSource(
+    {
+      jsonData: { backendType: 'phlare' },
+    } as DataSourceInstanceSettings<PhlareDataSourceOptions>,
+    new TemplateSrv()
+  );
+  ds.getResource = jest.fn();
+  (ds.getResource as jest.Mock).mockImplementation(async (type: string) => {
+    if (type === 'profileTypes') {
+      return [
+        { label: 'profile type 1', id: 'profile:type:1' },
+        { label: 'profile type 2', id: 'profile:type:2' },
+        { label: 'profile type 3', id: 'profile:type:3' },
+      ];
+    }
+    if (type === 'labelNames') {
+      return ['foo', 'bar'];
+    }
+
+    return ['val1', 'val2'];
+  });
+  return ds;
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
@@ -87,9 +87,9 @@ export function VariableQueryEditor(props: QueryEditorProps<PhlareDataSource, Qu
 }
 
 function LabelRow(props: {
-  value: string;
   datasource: PhlareDataSource;
-  profileTypeId: string;
+  value?: string;
+  profileTypeId?: string;
   from: number;
   to: number;
   onChange: (val: string) => void;
@@ -97,12 +97,12 @@ function LabelRow(props: {
   const [labels, setLabels] = useState<string[]>();
   useEffect(() => {
     (async () => {
-      setLabels(await props.datasource.getLabelNames(props.profileTypeId + '{}', props.from, props.to));
+      setLabels(await props.datasource.getLabelNames((props.profileTypeId || '') + '{}', props.from, props.to));
     })();
   }, [props.datasource, props.profileTypeId, props.to, props.from]);
 
   const options = labels ? labels.map<SelectableValue>((v) => ({ label: v, value: v })) : [];
-  if (labels && !labels.find((v) => v === props.value)) {
+  if (labels && props.value && !labels.find((v) => v === props.value)) {
     options.push({ value: props.value, label: props.value });
   }
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
@@ -15,7 +15,7 @@ export function VariableQueryEditor(props: QueryEditorProps<PhlareDataSource, Qu
           label="Query type"
           labelWidth={20}
           tooltip={
-            <div>The Prometheus data source plugin provides the following query types for template variables.</div>
+            <div>The Prometheus data source plugin provides the following query types for template variables</div>
           }
         >
           <Select

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.test.ts
@@ -1,0 +1,73 @@
+import { lastValueFrom } from 'rxjs';
+
+import { CoreApp, DataQueryRequest, getDefaultTimeRange } from '@grafana/data';
+
+import { DataAPI, VariableSupport } from './VariableSupport';
+import { ProfileTypeMessage, VariableQuery } from './types';
+
+describe('VariableSupport', () => {
+  it('should query profiles', async function () {
+    const mock = getDataApiMock();
+    const vs = new VariableSupport(mock);
+    const resp = await lastValueFrom(vs.query(getDefaultRequest()));
+    expect(resp.data).toEqual([
+      { text: 'profile type 1', value: 'profile:type:1' },
+      { text: 'profile type 2', value: 'profile:type:2' },
+      { text: 'profile type 3', value: 'profile:type:3' },
+    ]);
+  });
+
+  it('should query labels', async function () {
+    const mock = getDataApiMock();
+    const vs = new VariableSupport(mock);
+    const resp = await lastValueFrom(
+      vs.query(getDefaultRequest({ type: 'label', profileTypeId: 'profile:type:3', refId: 'A' }))
+    );
+    expect(resp.data).toEqual([{ text: 'foo' }, { text: 'bar' }, { text: 'baz' }]);
+    expect(mock.getLabelNames).toBeCalledWith('profile:type:3{}', expect.any(Number), expect.any(Number));
+  });
+
+  it('should query label values', async function () {
+    const mock = getDataApiMock();
+    const vs = new VariableSupport(mock);
+    const resp = await lastValueFrom(
+      vs.query(getDefaultRequest({ type: 'labelValue', labelName: 'foo', profileTypeId: 'profile:type:3', refId: 'A' }))
+    );
+    expect(resp.data).toEqual([{ text: 'val1' }, { text: 'val2' }, { text: 'val3' }]);
+    expect(mock.getLabelValues).toBeCalledWith('profile:type:3{}', 'foo', expect.any(Number), expect.any(Number));
+  });
+});
+
+function getDefaultRequest(
+  query: VariableQuery = { type: 'profileType', refId: 'A' }
+): DataQueryRequest<VariableQuery> {
+  return {
+    targets: [query],
+    interval: '1s',
+    intervalMs: 1000,
+    range: getDefaultTimeRange(),
+    scopedVars: {},
+    timezone: 'utc',
+    app: CoreApp.Unknown,
+    requestId: '1',
+    startTime: 0,
+  };
+}
+
+function getDataApiMock(): DataAPI {
+  const profiles: ProfileTypeMessage[] = [
+    { id: 'profile:type:1', label: 'profile type 1' },
+    { id: 'profile:type:2', label: 'profile type 2' },
+    { id: 'profile:type:3', label: 'profile type 3' },
+  ];
+  const getProfileTypes = jest.fn().mockResolvedValueOnce(profiles);
+
+  const getLabelValues = jest.fn().mockResolvedValueOnce(['val1', 'val2', 'val3']);
+  const getLabelNames = jest.fn().mockResolvedValueOnce(['foo', 'bar', 'baz']);
+
+  return {
+    getProfileTypes,
+    getLabelNames,
+    getLabelValues,
+  };
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
@@ -36,6 +36,9 @@ export class VariableSupport extends CustomVariableSupport<PhlareDataSource> {
     }
 
     if (request.targets[0].type === 'label') {
+      if (!request.targets[0].profileTypeId) {
+        return of({ data: [] });
+      }
       return from(
         this.dataAPI.getLabelNames(
           request.targets[0].profileTypeId + '{}',
@@ -50,6 +53,9 @@ export class VariableSupport extends CustomVariableSupport<PhlareDataSource> {
     }
 
     if (request.targets[0].type === 'labelValue') {
+      if (!request.targets[0].labelName || !request.targets[0].profileTypeId) {
+        return of({ data: [] });
+      }
       return from(
         this.dataAPI.getLabelValues(
           request.targets[0].profileTypeId + '{}',

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
@@ -1,0 +1,69 @@
+import { from, map, Observable, of } from 'rxjs';
+
+import { CustomVariableSupport, DataQueryRequest, DataQueryResponse, MetricFindValue } from '@grafana/data';
+
+import { getTimeSrv, TimeSrv } from '../../../features/dashboard/services/TimeSrv';
+
+import { VariableQueryEditor } from './VariableQueryEditor';
+import { PhlareDataSource } from './datasource';
+import { ProfileTypeMessage, VariableQuery } from './types';
+
+export interface DataAPI {
+  getProfileTypes(): Promise<ProfileTypeMessage[]>;
+  getLabelNames(query: string, start: number, end: number): Promise<string[]>;
+  getLabelValues(query: string, label: string, start: number, end: number): Promise<string[]>;
+}
+
+export class VariableSupport extends CustomVariableSupport<PhlareDataSource> {
+  constructor(
+    private readonly dataAPI: DataAPI,
+    private readonly timeSrv: TimeSrv = getTimeSrv()
+  ) {
+    super();
+    // This is needed because code in queryRunners.ts passes this method without binding it.
+    this.query = this.query.bind(this);
+  }
+
+  editor = VariableQueryEditor;
+
+  query(request: DataQueryRequest<VariableQuery>): Observable<DataQueryResponse> {
+    if (request.targets[0].type === 'profileType') {
+      return from(this.dataAPI.getProfileTypes()).pipe(
+        map((values) => {
+          return { data: values.map<MetricFindValue>((v) => ({ text: v.label, value: v.id })) };
+        })
+      );
+    }
+
+    if (request.targets[0].type === 'label') {
+      return from(
+        this.dataAPI.getLabelNames(
+          request.targets[0].profileTypeId + '{}',
+          this.timeSrv.timeRange().from.valueOf(),
+          this.timeSrv.timeRange().to.valueOf()
+        )
+      ).pipe(
+        map((values) => {
+          return { data: values.map((v) => ({ text: v })) };
+        })
+      );
+    }
+
+    if (request.targets[0].type === 'labelValue') {
+      return from(
+        this.dataAPI.getLabelValues(
+          request.targets[0].profileTypeId + '{}',
+          request.targets[0].labelName,
+          this.timeSrv.timeRange().from.valueOf(),
+          this.timeSrv.timeRange().to.valueOf()
+        )
+      ).pipe(
+        map((values) => {
+          return { data: values.map((v) => ({ text: v })) };
+        })
+      );
+    }
+
+    return of({ data: [] });
+  }
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import { from, map, Observable, of } from 'rxjs';
+
+import {
+  CustomVariableSupport,
+  DataQueryRequest,
+  DataQueryResponse,
+  MetricFindValue,
+  QueryEditorProps,
+} from '@grafana/data';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+
+import { getTimeSrv, TimeSrv } from '../../../features/dashboard/services/TimeSrv';
+
+import { PhlareDataSource } from './datasource';
+import { Query } from './types';
+
+export class VariableSupport extends CustomVariableSupport<PhlareDataSource> {
+  constructor(
+    private readonly datasource: PhlareDataSource,
+    private readonly timeSrv: TimeSrv = getTimeSrv()
+  ) {
+    super();
+    // This is needed because code in queryRunners.ts passes this method without binding it.
+    this.query = this.query.bind(this);
+  }
+
+  editor = VariableQueryEditor;
+
+  query(request: DataQueryRequest<VariableQuery>): Observable<DataQueryResponse> {
+    if (request.targets[0].type === 'profileType') {
+      return from(this.datasource.getProfileTypes()).pipe(
+        map((values) => {
+          return { data: values.map<MetricFindValue>((v) => ({ text: v.label, value: v.id })) };
+        })
+      );
+    }
+
+    if (request.targets[0].type === 'label') {
+      if (!request.targets[0].profileTypeId) {
+        return of({ data: [] });
+      }
+      return from(
+        this.datasource.getLabelNames(
+          request.targets[0].profileTypeId,
+          this.timeSrv.timeRange().from.valueOf(),
+          this.timeSrv.timeRange().to.valueOf()
+        )
+      ).pipe(
+        map((values) => {
+          return { data: values };
+        })
+      );
+    }
+
+    if (request.targets[0].type === 'labelValue') {
+      return from(this.datasource.getProfileTypes()).pipe(
+        map((values) => {
+          return { data: values };
+        })
+      );
+    }
+
+    return of({ data: [] });
+  }
+}
+
+// type QueryTypes = 'profileType' | 'label' | 'labelValue';
+
+type ProfileTypeQuery = {
+  type: 'profileType';
+  refId: string;
+};
+
+type LabelQuery = {
+  type: 'label';
+  profileTypeId: string;
+  refId: string;
+};
+
+type LabelValueQuery = {
+  type: 'labelValue';
+  profileTypeId: string;
+  labelName: string;
+  refId: string;
+};
+
+type VariableQuery = ProfileTypeQuery | LabelQuery | LabelValueQuery;
+
+function VariableQueryEditor(props: QueryEditorProps<PhlareDataSource, Query, {}, VariableQuery>) {
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField
+          label="Query type"
+          labelWidth={20}
+          tooltip={
+            <div>The Prometheus data source plugin provides the following query types for template variables.</div>
+          }
+        >
+          <Select
+            placeholder="Select query type"
+            aria-label="Query type"
+            width={25}
+            options={[
+              { label: 'Profile type', value: 'profileType' as const },
+              { label: 'Label', value: 'label' as const },
+              { label: 'Label value', value: 'labelValue' as const },
+            ]}
+            onChange={(value) => {
+              if (value.value! === 'profileType') {
+                props.onChange({
+                  ...props.query,
+                  type: value.value!,
+                });
+              }
+              if (value.value! === 'label') {
+                props.onChange({
+                  ...props.query,
+                  type: value.value!,
+                  profileTypeId: '',
+                });
+              }
+              if (value.value! === 'labelValue') {
+                props.onChange({
+                  ...props.query,
+                  type: value.value!,
+                  profileTypeId: '',
+                  labelName: '',
+                });
+              }
+            }}
+            value={props.query.type}
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      {/*{props.query.type === 'label' && <InlineFieldRow>*/}
+      {/*    <InlineField*/}
+      {/*        label="Query type"*/}
+      {/*        labelWidth={20}*/}
+      {/*        tooltip={*/}
+      {/*          <div>The Prometheus data source plugin provides the following query types for template variables.</div>*/}
+      {/*        }*/}
+      {/*    >*/}
+      {/*    </InlineField>*/}
+      {/*</InlineFieldRow>}*/}
+    </>
+  );
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -52,15 +52,15 @@ export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSou
   }
 
   async getProfileTypes(): Promise<ProfileTypeMessage[]> {
-    return await super.getResource('profileTypes');
+    return await this.getResource('profileTypes');
   }
 
   async getLabelNames(query: string, start: number, end: number): Promise<string[]> {
-    return await super.getResource('labelNames', { query: this.templateSrv.replace(query), start, end });
+    return await this.getResource('labelNames', { query: this.templateSrv.replace(query), start, end });
   }
 
   async getLabelValues(query: string, label: string, start: number, end: number): Promise<string[]> {
-    return await super.getResource('labelValues', {
+    return await this.getResource('labelValues', {
       label: this.templateSrv.replace(label),
       query: this.templateSrv.replace(query),
       start,

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
@@ -28,14 +28,14 @@ export type ProfileTypeQuery = {
 
 export type LabelQuery = {
   type: 'label';
-  profileTypeId: string;
+  profileTypeId?: string;
   refId: string;
 };
 
 export type LabelValueQuery = {
   type: 'labelValue';
-  profileTypeId: string;
-  labelName: string;
+  profileTypeId?: string;
+  labelName?: string;
   refId: string;
 };
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
@@ -20,3 +20,23 @@ export interface PhlareDataSourceOptions extends DataSourceJsonData {
 }
 
 export type BackendType = 'phlare' | 'pyroscope';
+
+export type ProfileTypeQuery = {
+  type: 'profileType';
+  refId: string;
+};
+
+export type LabelQuery = {
+  type: 'label';
+  profileTypeId: string;
+  refId: string;
+};
+
+export type LabelValueQuery = {
+  type: 'labelValue';
+  profileTypeId: string;
+  labelName: string;
+  refId: string;
+};
+
+export type VariableQuery = ProfileTypeQuery | LabelQuery | LabelValueQuery;


### PR DESCRIPTION
Adds template variable support for pyroscope. This includes
- profile or application type variable
- label variable
- label values variable

**Variables in dashboard settings**
<img width="891" alt="Screenshot 2023-08-23 at 17 29 37" src="https://github.com/grafana/grafana/assets/1014802/e5dc47b9-0259-4e3b-b9e1-a46203e3d945">

**Variable editor**
<img width="415" alt="Screenshot 2023-08-23 at 17 29 49" src="https://github.com/grafana/grafana/assets/1014802/f1727149-0267-4ed7-91bb-d251374e0fd4">

**Dashbard with variables**
<img width="983" alt="Screenshot 2023-08-23 at 17 30 00" src="https://github.com/grafana/grafana/assets/1014802/b4773295-5f8a-4a10-bc2d-0c5e2a30785a">


**Query editor**
Also one change to make this work was to make the profile selector in pyroscope query editor work with custom values:
<img width="766" alt="Screenshot 2023-08-23 at 17 45 56" src="https://github.com/grafana/grafana/assets/1014802/1bfab7a3-9c0d-4694-9edf-127e2547880d">


### testing
Use pyroscope or phlare dev env block and create dashboard creating variables similar to those in screenshots.