### PR TITLE
PluginProxy: Reuse dataproxy connection settings

### DIFF
--- a/pkg/api/plugin_proxy.go
+++ b/pkg/api/plugin_proxy.go
@@ -28,10 +28,12 @@ func (hs *HTTPServer) ProxyPluginRequest(c *contextmodel.ReqContext) {
 			},
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
+				Timeout:   time.Duration(hs.Cfg.DataProxyTimeout) * time.Second,
+				KeepAlive: time.Duration(hs.Cfg.DataProxyKeepAlive) * time.Second,
 			}).DialContext,
-			TLSHandshakeTimeout: 10 * time.Second,
+			TLSHandshakeTimeout:   time.Duration(hs.Cfg.DataProxyTLSHandshakeTimeout) * time.Second,
+			IdleConnTimeout:       time.Duration(hs.Cfg.DataProxyIdleConnTimeout) * time.Second,
+			ExpectContinueTimeout: time.Duration(hs.Cfg.DataProxyExpectContinueTimeout) * time.Second,
 		}
 	})
 


### PR DESCRIPTION
**What is this feature?**

Reuse dataproxy connection settings for the plugin proxy HTTP client. Leaving out max idle connections setting for now since the plugin proxy HTTP client are a singleton.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
