### PR TITLE
Docs: Add hide_edition config to the docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
@@ -73,6 +73,9 @@ The configuration file in Grafana Enterprise contains the following options. Eac
 
 # Set to complete URL to override loading logo
 ;loading_logo =
+
+# Hides the Grafana edition being used in the footer if set to "true"
+;hide_edition =
 ```
 
 You can replace the default footer links (Documentation, Support, Community) and even add your own custom links.

--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
@@ -74,7 +74,7 @@ The configuration file in Grafana Enterprise contains the following options. Eac
 # Set to complete URL to override loading logo
 ;loading_logo =
 
-# Hides the Grafana edition being used in the footer if set to "true"
+# Set to `true` to remove the Grafana edition from appearing in the footer
 ;hide_edition =
 ```
 

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -84,7 +84,7 @@ Set to complete URL to override Apple/iOS icon.
 
 ### hide_edition
 
-Hides the Grafana edition from being used in the footer if set to "true"
+Set to `true` to remove the Grafana edition from appearing in the footer.
 
 ### footer_links
 

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -82,6 +82,10 @@ Set to complete URL to override fav icon (icon shown in browser tab).
 
 Set to complete URL to override Apple/iOS icon.
 
+### hide_edition
+
+Hides the Grafana edition from being used in the footer if set to "true"
+
 ### footer_links
 
 List the link IDs to use here. Grafana will look for matching link configurations, the link IDs should be space-separated and contain no whitespace.


### PR DESCRIPTION
**What is this feature?**

Adds docs to a config that was recently added in these PRs: https://github.com/grafana/grafana-enterprise/pull/5656 and https://github.com/grafana/grafana/pull/73412

**Why do we need this feature?**

To document the new config options.

**Who is this feature for?**

Enterprise clients using white labelling options.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
