### PR TITLE
Cloudwatch: Upgrade grafana-aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "@emotion/css": "11.11.2",
     "@emotion/react": "11.11.1",
     "@glideapps/glide-data-grid": "^5.2.1",
-    "@grafana/aws-sdk": "0.1.1",
+    "@grafana/aws-sdk": "0.1.2",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,13 +3604,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.1.1":
-  version: 0.1.1
-  resolution: "@grafana/aws-sdk@npm:0.1.1"
+"@grafana/aws-sdk@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@grafana/aws-sdk@npm:0.1.2"
   dependencies:
     "@grafana/async-query-data": 0.1.4
     "@grafana/experimental": 1.1.0
-  checksum: 12d1b27b0959a4d16ddf643b360ce067f6debd4141eb28652ff36fece98a99087f865aa2b9f6fda78df2b9e38870a6a7cfa48e0fd1a1ec03de63bc340b344f05
+  checksum: ea0248c8458caeccfb5326db60fba36692868bf71ed17cb9aa9c6797e6acb9a90687cceaa274416841935b2f2ba362f80dec22f603351f180724f56bf2ed0450
   languageName: node
   linkType: hard
 
@@ -19234,7 +19234,7 @@ __metadata:
     "@emotion/eslint-plugin": 11.11.0
     "@emotion/react": 11.11.1
     "@glideapps/glide-data-grid": ^5.2.1
-    "@grafana/aws-sdk": 0.1.1
+    "@grafana/aws-sdk": 0.1.2
     "@grafana/data": "workspace:*"
     "@grafana/e2e": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Related to the Temporary Credentials project, small bug fix:  https://github.com/grafana/oss-plugin-partnerships/issues/223

**Why do we need this feature?**

Ensures that the new Temporary Credentials feature will appear in cloudwatch but not other datasources for now.

**Who is this feature for?**

Grafana Devs (for now!)

**Which issue(s) does this PR fix?**:

relates to https://github.com/grafana/oss-plugin-partnerships/issues/223

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
