### PR TITLE
Tracing: Support remote, rate-limited, and probabilistic sampling in tracing.opentelemetry config section

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1374,6 +1374,18 @@ disable_shared_zipkin_spans = false
 
 # attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
 custom_attributes =
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+sampler_type =
+# Sampler configuration parameter
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0.0 and 1.0
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+#   and indicates the initial sampling rate before the actual one
+#   is received from the sampling server (set at sampling_server_url)
+sampler_param =
+# specifies the URL of the sampling server when sampler_type is remote
+sampling_server_url =
 
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1272,6 +1272,18 @@
 [tracing.opentelemetry]
 # attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
 ;custom_attributes = key1:value1,key2:value2
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+; sampler_type = remote
+# Sampler configuration parameter
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0.0 and 1.0
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+#   and indicates the initial sampling rate before the actual one
+#   is received from the sampling server (set at sampling_server_url)
+; sampler_param = 0.5
+# specifies the URL of the sampling server when sampler_type is remote
+; sampling_server_url = http://localhost:5778/sampling
 
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1867,8 +1867,8 @@ Depending on the value of `sampler_type`, the sampler configuration parameter ca
 - For `const` sampler, `0` or `1` to always `false`/`true` respectively
 - For the `probabilistic` sampler, you can use a decimal value between `0.0` and `1.0`
 - For the `rateLimiting` sampler, enter the number of spans per second
-- For `remote` sampler, param is the same as for `probabilistic`
-  and indicates the initial sampling rate before the actual one
+- For the `remote` sampler, use a decimal value between `0.0` and `1.0`
+  to specify the initial sampling rate used before the first update
   is received from the sampling server
 
 ### sampling_server_url

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1866,7 +1866,7 @@ Depending on the value of `sampler_type`, the sampler configuration parameter ca
 
 - For `const` sampler, `0` or `1` to always `false`/`true` respectively
 - For the `probabilistic` sampler, you can use a decimal value between `0.0` and `1.0`
-- For `rateLimiting` sampler, the number of spans per second
+- For the `rateLimiting` sampler, enter the number of spans per second
 - For `remote` sampler, param is the same as for `probabilistic`
   and indicates the initial sampling rate before the actual one
   is received from the sampling server

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1862,7 +1862,7 @@ Specifies the type of sampler: `const`, `probabilistic`, `ratelimiting`, or `rem
 
 Default value is `1`.
 
-Sampler configuration parameter. Depending on the value of `sampler_type`, it can be `0`, `1`, or a decimal value in between.
+Depending on the value of `sampler_type`, the sampler configuration parameter can be `0`, `1`, or any decimal value between `0` and `1`.
 
 - For `const` sampler, `0` or `1` to always `false`/`true` respectively
 - For `probabilistic` sampler, a probability between `0.0` and `1.0`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1801,6 +1801,8 @@ Refer to https://www.jaegertracing.io/docs/1.16/sampling/#client-sampling-config
 
 Can be set with the environment variable `JAEGER_SAMPLER_TYPE`.
 
+_Setting `sampler_type` in the `tracing.opentelemetry` section will override this setting._
+
 ### sampler_param
 
 Default value is `1`.
@@ -1816,9 +1818,13 @@ This is the sampler configuration parameter. Depending on the value of `sampler_
 
 May be set with the environment variable `JAEGER_SAMPLER_PARAM`.
 
+_Setting `sampler_param` in the `tracing.opentelemetry` section will override this setting._
+
 ### sampling_server_url
 
 sampling_server_url is the URL of a sampling manager providing a sampling strategy.
+
+_Setting `sampling_server_url` in the `tracing.opentelemetry` section will override this setting._
 
 ### zipkin_propagation
 
@@ -1845,6 +1851,31 @@ Configure general parameters shared between OpenTelemetry providers.
 Comma-separated list of attributes to include in all new spans, such as `key1:value1,key2:value2`.
 
 Can be set with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable).
+
+### sampler_type
+
+Default value is `const`.
+
+Specifies the type of sampler: `const`, `probabilistic`, `ratelimiting`, or `remote`.
+
+### sampler_param
+
+Default value is `1`.
+
+Sampler configuration parameter. Depending on the value of `sampler_type`, it can be `0`, `1`, or a decimal value in between.
+
+- For `const` sampler, `0` or `1` to always `false`/`true` respectively
+- For `probabilistic` sampler, a probability between `0.0` and `1.0`
+- For `rateLimiting` sampler, the number of spans per second
+- For `remote` sampler, param is the same as for `probabilistic`
+  and indicates the initial sampling rate before the actual one
+  is received from the sampling server
+
+### sampling_server_url
+
+When `sampler_type` is `remote`, this specifies the URL of the sampling server. This can be used by all tracing providers. 
+
+The sampling server should implement the Jaeger remote sampling API, which can be exposed by a jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or the Grafana Agent.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1875,7 +1875,7 @@ Depending on the value of `sampler_type`, the sampler configuration parameter ca
 
 When `sampler_type` is `remote`, this specifies the URL of the sampling server. This can be used by all tracing providers. 
 
-Use a sampling server that supports the Jaeger remote sampling API, such as jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or [Grafana Agent](https://grafana.com/oss/agent/).
+Use a sampling server that supports the Jaeger remote sampling API, such as jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or [Grafana Agent](/oss/agent/).
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1873,7 +1873,7 @@ Depending on the value of `sampler_type`, the sampler configuration parameter ca
 
 ### sampling_server_url
 
-When `sampler_type` is `remote`, this specifies the URL of the sampling server. This can be used by all tracing providers. 
+When `sampler_type` is `remote`, this specifies the URL of the sampling server. This can be used by all tracing providers.
 
 Use a sampling server that supports the Jaeger remote sampling API, such as jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or [Grafana Agent](/oss/agent/).
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1864,7 +1864,7 @@ Default value is `1`.
 
 Depending on the value of `sampler_type`, the sampler configuration parameter can be `0`, `1`, or any decimal value between `0` and `1`.
 
-- For `const` sampler, `0` or `1` to always `false`/`true` respectively
+- For the `const` sampler, use `0` to never sample or `1` to always sample
 - For the `probabilistic` sampler, you can use a decimal value between `0.0` and `1.0`
 - For the `rateLimiting` sampler, enter the number of spans per second
 - For the `remote` sampler, use a decimal value between `0.0` and `1.0`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1875,7 +1875,7 @@ Depending on the value of `sampler_type`, the sampler configuration parameter ca
 
 When `sampler_type` is `remote`, this specifies the URL of the sampling server. This can be used by all tracing providers. 
 
-The sampling server should implement the Jaeger remote sampling API, which can be exposed by a jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or the Grafana Agent.
+Use a sampling server that supports the Jaeger remote sampling API, such as jaeger-agent, jaeger-collector, opentelemetry-collector-contrib, or [Grafana Agent](https://grafana.com/oss/agent/).
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1801,7 +1801,7 @@ Refer to https://www.jaegertracing.io/docs/1.16/sampling/#client-sampling-config
 
 Can be set with the environment variable `JAEGER_SAMPLER_TYPE`.
 
-_Setting `sampler_type` in the `tracing.opentelemetry` section will override this setting._
+_To override this setting, enter `sampler_type` in the `tracing.opentelemetry` section._
 
 ### sampler_param
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1865,7 +1865,7 @@ Default value is `1`.
 Depending on the value of `sampler_type`, the sampler configuration parameter can be `0`, `1`, or any decimal value between `0` and `1`.
 
 - For `const` sampler, `0` or `1` to always `false`/`true` respectively
-- For `probabilistic` sampler, a probability between `0.0` and `1.0`
+- For the `probabilistic` sampler, you can use a decimal value between `0.0` and `1.0`
 - For `rateLimiting` sampler, the number of spans per second
 - For `remote` sampler, param is the same as for `probabilistic`
   and indicates the initial sampling rate before the actual one

--- a/pkg/infra/tracing/test_helper.go
+++ b/pkg/infra/tracing/test_helper.go
@@ -7,13 +7,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
 func InitializeTracerForTest() Tracer {
 	exp := tracetest.NewInMemoryExporter()
-	tp, _ := initTracerProvider(exp, "testing")
+	tp, _ := initTracerProvider(exp, "testing", tracesdk.AlwaysSample())
 	otel.SetTracerProvider(tp)
 
 	ots := &Opentelemetry{Propagation: "jaeger,w3c", tracerProvider: tp}

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -224,6 +224,22 @@ func (ots *Opentelemetry) parseSettings() error {
 		return err
 	}
 
+	// if sampler_type is set in tracing.opentelemetry, we ignore the config in tracing.jaeger
+	sampler := section.Key("sampler_type").MustString("")
+	if sampler != "" {
+		ots.sampler = sampler
+	}
+
+	samplerParam := section.Key("sampler_param").MustFloat64(0)
+	if samplerParam != 0 {
+		ots.samplerParam = samplerParam
+	}
+
+	samplerRemoteURL := section.Key("sampling_server_url").MustString("")
+	if samplerRemoteURL != "" {
+		ots.samplerRemoteURL = samplerRemoteURL
+	}
+
 	section = ots.Cfg.Raw.Section("tracing.opentelemetry.jaeger")
 	ots.enabled = noopExporter
 
@@ -295,16 +311,9 @@ func (ots *Opentelemetry) initJaegerTracerProvider() (*tracesdk.TracerProvider, 
 		return nil, err
 	}
 
-	sampler := tracesdk.AlwaysSample()
-	if ots.sampler == "const" || ots.sampler == "probabilistic" {
-		sampler = tracesdk.TraceIDRatioBased(ots.samplerParam)
-	} else if ots.sampler == "rateLimiting" {
-		sampler = newRateLimiter(ots.samplerParam)
-	} else if ots.sampler == "remote" {
-		sampler = jaegerremote.New("grafana", jaegerremote.WithSamplingServerURL(ots.samplerRemoteURL),
-			jaegerremote.WithInitialSampler(tracesdk.TraceIDRatioBased(ots.samplerParam)))
-	} else if ots.sampler != "" {
-		return nil, fmt.Errorf("invalid sampler type: %s", ots.sampler)
+	sampler, err := ots.initSampler()
+	if err != nil {
+		return nil, err
 	}
 
 	tp := tracesdk.NewTracerProvider(
@@ -323,10 +332,39 @@ func (ots *Opentelemetry) initOTLPTracerProvider() (*tracesdk.TracerProvider, er
 		return nil, err
 	}
 
-	return initTracerProvider(exp, ots.Cfg.BuildVersion, ots.customAttribs...)
+	sampler, err := ots.initSampler()
+	if err != nil {
+		return nil, err
+	}
+
+	return initTracerProvider(exp, ots.Cfg.BuildVersion, sampler, ots.customAttribs...)
 }
 
-func initTracerProvider(exp tracesdk.SpanExporter, version string, customAttribs ...attribute.KeyValue) (*tracesdk.TracerProvider, error) {
+func (ots *Opentelemetry) initSampler() (tracesdk.Sampler, error) {
+	switch ots.sampler {
+	case "const", "":
+		if ots.samplerParam >= 1 {
+			return tracesdk.AlwaysSample(), nil
+		} else if ots.samplerParam <= 0 {
+			return tracesdk.NeverSample(), nil
+		}
+
+		return nil, fmt.Errorf("invalid param for const sampler - must be 0 or 1: %f", ots.samplerParam)
+	case "probabilistic":
+		return tracesdk.TraceIDRatioBased(ots.samplerParam), nil
+	case "rateLimiting":
+		return newRateLimiter(ots.samplerParam), nil
+	case "remote":
+		return jaegerremote.New("grafana",
+			jaegerremote.WithSamplingServerURL(ots.samplerRemoteURL),
+			jaegerremote.WithInitialSampler(tracesdk.TraceIDRatioBased(ots.samplerParam)),
+		), nil
+	default:
+		return nil, fmt.Errorf("invalid sampler type: %s", ots.sampler)
+	}
+}
+
+func initTracerProvider(exp tracesdk.SpanExporter, version string, sampler tracesdk.Sampler, customAttribs ...attribute.KeyValue) (*tracesdk.TracerProvider, error) {
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
@@ -343,9 +381,7 @@ func initTracerProvider(exp tracesdk.SpanExporter, version string, customAttribs
 
 	tp := tracesdk.NewTracerProvider(
 		tracesdk.WithBatcher(exp),
-		tracesdk.WithSampler(tracesdk.ParentBased(
-			tracesdk.AlwaysSample(),
-		)),
+		tracesdk.WithSampler(tracesdk.ParentBased(sampler)),
 		tracesdk.WithResource(res),
 	)
 	return tp, nil
@@ -501,21 +537,23 @@ func (s OpentelemetrySpan) ContextWithSpan(ctx context.Context) context.Context 
 
 type rateLimiter struct {
 	sync.Mutex
-	rps        float64
-	balance    float64
-	maxBalance float64
-	lastTick   time.Time
+	description string
+	rps         float64
+	balance     float64
+	maxBalance  float64
+	lastTick    time.Time
 
 	now func() time.Time
 }
 
 func newRateLimiter(rps float64) *rateLimiter {
 	return &rateLimiter{
-		rps:        rps,
-		balance:    math.Max(rps, 1),
-		maxBalance: math.Max(rps, 1),
-		lastTick:   time.Now(),
-		now:        time.Now,
+		rps:         rps,
+		description: fmt.Sprintf("RateLimitingSampler{%g}", rps),
+		balance:     math.Max(rps, 1),
+		maxBalance:  math.Max(rps, 1),
+		lastTick:    time.Now(),
+		now:         time.Now,
 	}
 }
 
@@ -538,4 +576,4 @@ func (rl *rateLimiter) ShouldSample(p tracesdk.SamplingParameters) tracesdk.Samp
 	return tracesdk.SamplingResult{Decision: tracesdk.Drop, Tracestate: psc.TraceState()}
 }
 
-func (rl *rateLimiter) Description() string { return "RateLimitingSampler" }
+func (rl *rateLimiter) Description() string { return rl.description }

--- a/pkg/plugins/localfiles.go
+++ b/pkg/plugins/localfiles.go
@@ -33,7 +33,7 @@ func NewLocalFS(basePath string) LocalFS {
 // fileIsAllowed takes an absolute path to a file and an os.FileInfo for that file, and it checks if access to that
 // file is allowed or not. Access to a file is allowed if the file is in the FS's Base() directory, and if it's a
 // symbolic link it should not end up outside the plugin's directory.
-func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info fs.FileInfo) (bool, error) {
+func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.FileInfo) (bool, error) {
 	upperLevelPrefix := ".." + string(filepath.Separator)
 	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 		symlinkPath, err := filepath.EvalSymlinks(absolutePath)

--- a/pkg/plugins/localfiles.go
+++ b/pkg/plugins/localfiles.go
@@ -33,7 +33,7 @@ func NewLocalFS(basePath string) LocalFS {
 // fileIsAllowed takes an absolute path to a file and an os.FileInfo for that file, and it checks if access to that
 // file is allowed or not. Access to a file is allowed if the file is in the FS's Base() directory, and if it's a
 // symbolic link it should not end up outside the plugin's directory.
-func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info os.FileInfo) (bool, error) {
+func (f LocalFS) fileIsAllowed(basePath string, absolutePath string, info fs.FileInfo) (bool, error) {
 	upperLevelPrefix := ".." + string(filepath.Separator)
 	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 		symlinkPath, err := filepath.EvalSymlinks(absolutePath)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Supports sampling configuration in the `tracing.opentelemetry` config section. All sampling strategies that were supported with Jaeger are supported now with all OTel providers (Jaeger & OTLP), especially the remote sampling server.

**Why do we need this feature?**

The `tracing.jaeger` section is deprecated, but there's no way to configure sampling otherwise.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

Fixes #43947

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
