### PR TITLE
Secret: fix datasource password lost  from lower version upgrade

### DIFF
--- a/pkg/services/secrets/kvstore/migrations/datasource_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig.go
@@ -66,6 +66,13 @@ func (s *DataSourceSecretMigrationService) Migrate(ctx context.Context) error {
 				return err
 			}
 
+			if ds.Password != "" && secureJsonData["password"] == "" {
+				secureJsonData["password"] = ds.Password
+			}
+			if ds.BasicAuthPassword != "" && secureJsonData["basicAuthPassword"] == "" {
+				secureJsonData["basicAuthPassword"] = ds.BasicAuthPassword
+			}
+
 			// Secrets are set by the update data source function if the SecureJsonData is set in the command
 			// Secrets are deleted by the update data source function if the disableSecretsCompatibility flag is enabled
 			_, err = s.dataSourcesService.UpdateDataSource(ctx, &datasources.UpdateDataSourceCommand{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix password lost problem included in https://github.com/grafana/grafana/commit/6227528ea0fcdb3831d7bb837edbf823223545b9

**Why do we need this feature?**

This feature fix datasource password completely lost when upgrade from old version such as 7.x.

**Who is this feature for?**

For who still running the old version will safely upgrade to latest.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
