### PR TITLE
Explore: Relabel secondary actions buttons

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -183,7 +183,7 @@ export const Components = {
   QueryTab: {
     content: 'Query editor tab content',
     queryInspectorButton: 'Query inspector button',
-    queryHistoryButton: 'Rich history button',
+    queryHistoryButton: 'data-testid query-history-button',
     addQuery: 'Query editor add query button',
   },
   QueryHistory: {

--- a/public/app/features/explore/SecondaryActions.test.tsx
+++ b/public/app/features/explore/SecondaryActions.test.tsx
@@ -15,9 +15,9 @@ describe('SecondaryActions', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /Add row button/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Rich history button/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Query inspector button/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add query/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Query history/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Query inspector/i })).toBeInTheDocument();
   });
 
   it('should not render hidden elements', () => {
@@ -31,9 +31,9 @@ describe('SecondaryActions', () => {
       />
     );
 
-    expect(screen.queryByRole('button', { name: /Add row button/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Rich history button/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Query inspector button/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add query/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Query history/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Query inspector/i })).toBeInTheDocument();
   });
 
   it('should disable add row button if addQueryRowButtonDisabled=true', () => {
@@ -46,9 +46,9 @@ describe('SecondaryActions', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: /Add row button/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /Rich history button/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Query inspector button/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add query/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Query history/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Query inspector/i })).toBeInTheDocument();
   });
 
   it('should map click handlers correctly', async () => {
@@ -66,13 +66,13 @@ describe('SecondaryActions', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /Add row button/i }));
+    await user.click(screen.getByRole('button', { name: /Add query/i }));
     expect(onClickAddRow).toBeCalledTimes(1);
 
-    await user.click(screen.getByRole('button', { name: /Rich history button/i }));
+    await user.click(screen.getByRole('button', { name: /Query history/i }));
     expect(onClickHistory).toBeCalledTimes(1);
 
-    await user.click(screen.getByRole('button', { name: /Query inspector button/i }));
+    await user.click(screen.getByRole('button', { name: /Query inspector/i }));
     expect(onClickQueryInspector).toBeCalledTimes(1);
   });
 });

--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -33,7 +33,7 @@ export function SecondaryActions(props: Props) {
         {!props.addQueryRowButtonHidden && (
           <ToolbarButton
             variant="canvas"
-            aria-label="Add row button"
+            aria-label="Add query"
             onClick={props.onClickAddQueryRowButton}
             disabled={props.addQueryRowButtonDisabled}
             icon="plus"
@@ -44,7 +44,7 @@ export function SecondaryActions(props: Props) {
         {!props.richHistoryRowButtonHidden && (
           <ToolbarButton
             variant={props.richHistoryButtonActive ? 'active' : 'canvas'}
-            aria-label="Rich history button"
+            aria-label="Query history"
             onClick={props.onClickRichHistoryButton}
             icon="history"
           >
@@ -53,11 +53,11 @@ export function SecondaryActions(props: Props) {
         )}
         <ToolbarButton
           variant={props.queryInspectorButtonActive ? 'active' : 'canvas'}
-          aria-label="Query inspector button"
+          aria-label="Query inspector"
           onClick={props.onClickQueryInspectorButton}
           icon="info-circle"
         >
-          Inspector
+          Query inspector
         </ToolbarButton>
       </HorizontalGroup>
     </div>

--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { Components } from '@grafana/e2e-selectors';
 import { HorizontalGroup, ToolbarButton, useTheme2 } from '@grafana/ui';
 
 type Props = {
@@ -46,6 +47,7 @@ export function SecondaryActions(props: Props) {
             variant={props.richHistoryButtonActive ? 'active' : 'canvas'}
             aria-label="Query history"
             onClick={props.onClickRichHistoryButton}
+            data-testid={Components.QueryTab.queryHistoryButton}
             icon="history"
           >
             Query history

--- a/public/app/features/explore/spec/helper/interactions.ts
+++ b/public/app/features/explore/spec/helper/interactions.ts
@@ -27,7 +27,7 @@ export const runQuery = async (exploreId = 'left') => {
 
 export const openQueryHistory = async (exploreId = 'left') => {
   const selector = withinExplore(exploreId);
-  const button = selector.getByRole('button', { name: 'Rich history button' });
+  const button = selector.getByRole('button', { name: 'Query history' });
   await userEvent.click(button);
   expect(await selector.findByPlaceholderText('Search queries')).toBeInTheDocument();
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Relabels SecondaryActions buttons in Explore to improve consistency with Dashboards. Additionally, removes the `button` suffix in the labels as screen readers automatically announce the type of element, including that suffix in the labels adds unnecessary noise for screen reader users.

**Why do we need this feature?**

To slighlty increase consistency across the product


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of #73603

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
