### PR TITLE
[v10.0.x] CI: Different secret for verification and do not ignore build failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2748,7 +2748,6 @@ steps:
       from_secret: packages_gpg_private_key
     GPG_PUBLIC_KEY:
       from_secret: packages_gpg_public_key
-  failure: ignore
   image: grafana/grafana-build:main
   name: rgm-build
   volumes:
@@ -2862,8 +2861,7 @@ steps:
   environment:
     BUCKET: grafana-prerelease
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
-  failure: ignore
+      from_secret: gcp_key_base64
   image: google/cloud-sdk:431.0.0
   name: gsutil-stat
 trigger:
@@ -4192,6 +4190,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 50e07de5e688a14cc76c3e8cc992a2c01fd6285708683ab54b9662baa6212f46
+hmac: 43853395ba795100b3a69df8fce1336cefa06b7a65067cddee1d85ef79e62b11
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -57,6 +57,7 @@ load(
     "gcp_upload_artifacts_key",
     "npm_token",
     "prerelease_bucket",
+    "rgm_gcp_key_base64",
 )
 load(
     "scripts/drone/utils/images.star",
@@ -437,7 +438,7 @@ def integration_test_pipelines():
 def verify_release_pipeline(
         name = "verify-prerelease-assets",
         bucket = from_secret(prerelease_bucket),
-        gcp_key = from_secret(gcp_upload_artifacts_key),
+        gcp_key = from_secret(rgm_gcp_key_base64),
         version = "${DRONE_TAG}",
         trigger = release_trigger,
         depends_on = [
@@ -465,7 +466,6 @@ def verify_release_pipeline(
             "./scripts/list-release-artifacts.sh {} | xargs -n1 gsutil stat >> /tmp/stat.log".format(version),
             "! cat /tmp/stat.log | grep \"No URLs matched\"",
         ],
-        "failure": "ignore",
     }
     return pipeline(
         depends_on = depends_on,

--- a/scripts/drone/rgm.star
+++ b/scripts/drone/rgm.star
@@ -73,7 +73,7 @@ tag_trigger = {
     },
 }
 
-def rgm_build(script = "drone_publish_main.sh"):
+def rgm_build(script = "drone_publish_main.sh", canFail = True):
     rgm_build_step = {
         "name": "rgm-build",
         "image": "grafana/grafana-build:main",
@@ -85,8 +85,9 @@ def rgm_build(script = "drone_publish_main.sh"):
         # The docker socket is a requirement for running dagger programs
         # In the future we should find a way to use dagger without mounting the docker socket.
         "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
-        "failure": "ignore",
     }
+    if canFail:
+        rgm_build_step["failure"] = "ignore"
 
     return [
         rgm_build_step,
@@ -107,7 +108,7 @@ def rgm_main():
     return pipeline(
         name = "rgm-main-prerelease",
         trigger = trigger,
-        steps = rgm_build(),
+        steps = rgm_build(canFail = True),
         depends_on = ["main-test-backend", "main-test-frontend"],
     )
 
@@ -115,7 +116,7 @@ def rgm_tag():
     return pipeline(
         name = "rgm-tag-prerelease",
         trigger = tag_trigger,
-        steps = rgm_build(script = "drone_publish_tag_grafana.sh"),
+        steps = rgm_build(script = "drone_publish_tag_grafana.sh", canFail = False),
         depends_on = ["release-test-backend", "release-test-frontend"],
     )
 


### PR DESCRIPTION
Backport 8fc3be6b5a1919100f8e8408d2b06c48be6b0707 from #73613

---

The format for the GCP_KEY was wrong and various steps were allowed to fail that shouldn't.
