### PR TITLE
Explore Logs: Update log filtering functions to only have effect in the source query

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -16,7 +16,6 @@ import {
   SplitOpenOptions,
   SupplementaryQueryType,
   hasToggleableQueryFiltersSupport,
-  LogRowModel,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
@@ -191,11 +190,11 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
    * TODO: In the future, we would like to return active filters based the query that produced the log line.
    * @alpha
    */
-  isFilterLabelActive = async (key: string, value: string, row: LogRowModel) => {
+  isFilterLabelActive = async (key: string, value: string, refId?: string) => {
     if (!config.featureToggles.toggleLabelsInLogsUI) {
       return false;
     }
-    const query = this.props.queries.find((q) => q.refId === row.dataFrame.refId);
+    const query = this.props.queries.find((q) => q.refId === refId);
     if (!query) {
       return false;
     }
@@ -209,15 +208,15 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   /**
    * Used by Logs details.
    */
-  onClickFilterLabel = (key: string, value: string, row?: LogRowModel) => {
-    this.onModifyQueries({ type: 'ADD_FILTER', options: { key, value } }, row);
+  onClickFilterLabel = (key: string, value: string, refId?: string) => {
+    this.onModifyQueries({ type: 'ADD_FILTER', options: { key, value } }, refId);
   };
 
   /**
    * Used by Logs details.
    */
-  onClickFilterOutLabel = (key: string, value: string, row?: LogRowModel) => {
-    this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } }, row);
+  onClickFilterOutLabel = (key: string, value: string, refId?: string) => {
+    this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } }, refId);
   };
 
   onClickAddQueryRowButton = () => {
@@ -233,11 +232,11 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   /**
    * Used by Logs details.
    */
-  onModifyQueries = (action: QueryFixAction, row?: LogRowModel) => {
+  onModifyQueries = (action: QueryFixAction, refId?: string) => {
     const modifier = async (query: DataQuery, modification: QueryFixAction) => {
       // This gives Logs Details support to modify the query that produced the log line.
       // If not present, all queries are modified.
-      if (row && row.dataFrame.refId !== query.refId) {
+      if (refId && refId !== query.refId) {
         return query;
       }
       const { datasource } = query;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -210,14 +210,14 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
    * Used by Logs details.
    */
   onClickFilterLabel = (key: string, value: string, row?: LogRowModel) => {
-    this.onModifyQueries({ type: 'ADD_FILTER', options: { key, value } });
+    this.onModifyQueries({ type: 'ADD_FILTER', options: { key, value } }, row);
   };
 
   /**
    * Used by Logs details.
    */
   onClickFilterOutLabel = (key: string, value: string, row?: LogRowModel) => {
-    this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } });
+    this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } }, row);
   };
 
   onClickAddQueryRowButton = () => {
@@ -233,8 +233,13 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   /**
    * Used by Logs details.
    */
-  onModifyQueries = (action: QueryFixAction) => {
+  onModifyQueries = (action: QueryFixAction, row?: LogRowModel) => {
     const modifier = async (query: DataQuery, modification: QueryFixAction) => {
+      // This gives Logs Details support to modify the query that produced the log line.
+      // If not present, all queries are modified.
+      if (row && row.dataFrame.refId !== query.refId) {
+        return query;
+      }
       const { datasource } = query;
       if (datasource == null) {
         return query;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -209,14 +209,14 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   /**
    * Used by Logs details.
    */
-  onClickFilterLabel = (key: string, value: string) => {
+  onClickFilterLabel = (key: string, value: string, row?: LogRowModel) => {
     this.onModifyQueries({ type: 'ADD_FILTER', options: { key, value } });
   };
 
   /**
    * Used by Logs details.
    */
-  onClickFilterOutLabel = (key: string, value: string) => {
+  onClickFilterOutLabel = (key: string, value: string, row?: LogRowModel) => {
     this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } });
   };
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -82,8 +82,8 @@ interface Props extends Themeable2 {
   loadLogsVolumeData: () => void;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange) => void;
-  onClickFilterLabel?: (key: string, value: string) => void;
-  onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
   getRowContext?: (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions) => Promise<any>;

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -82,8 +82,8 @@ interface Props extends Themeable2 {
   loadLogsVolumeData: () => void;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange) => void;
-  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
   getRowContext?: (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions) => Promise<any>;
@@ -95,7 +95,7 @@ interface Props extends Themeable2 {
   eventBus: EventBus;
   panelState?: ExplorePanelsState;
   scrollElement?: HTMLDivElement;
-  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   logsFrames?: DataFrame[];
   range: TimeRange;
 }

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -95,7 +95,7 @@ interface Props extends Themeable2 {
   eventBus: EventBus;
   panelState?: ExplorePanelsState;
   scrollElement?: HTMLDivElement;
-  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
   logsFrames?: DataFrame[];
   range: TimeRange;
 }

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -47,14 +47,14 @@ interface LogsContainerProps extends PropsFromRedux {
   scanRange?: RawTimeRange;
   syncedTimes: boolean;
   loadingState: LoadingState;
-  onClickFilterLabel: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel: (key: string, value: string, refId?: string) => void;
   onStartScanning: () => void;
   onStopScanning: () => void;
   eventBus: EventBus;
   splitOpenFn: SplitOpen;
   scrollElement?: HTMLDivElement;
-  isFilterLabelActive: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive: (key: string, value: string, refId?: string) => Promise<boolean>;
 }
 
 interface LogsContainerState {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -47,8 +47,8 @@ interface LogsContainerProps extends PropsFromRedux {
   scanRange?: RawTimeRange;
   syncedTimes: boolean;
   loadingState: LoadingState;
-  onClickFilterLabel: (key: string, value: string) => void;
-  onClickFilterOutLabel: (key: string, value: string) => void;
+  onClickFilterLabel: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel: (key: string, value: string, row?: LogRowModel) => void;
   onStartScanning: () => void;
   onStopScanning: () => void;
   eventBus: EventBus;

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -54,7 +54,7 @@ interface LogsContainerProps extends PropsFromRedux {
   eventBus: EventBus;
   splitOpenFn: SplitOpen;
   scrollElement?: HTMLDivElement;
-  isFilterLabelActive: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
 }
 
 interface LogsContainerState {

--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -71,28 +71,30 @@ describe('LogDetails', () => {
         const onClickFilterLabelMock = jest.fn();
         const onClickFilterOutLabelMock = jest.fn();
         const isFilterLabelActiveMock = jest.fn().mockResolvedValue(true);
-        const mockRow = createLogRow({ logLevel: LogLevel.error, timeEpochMs: 1546297200000, labels: { key1: 'label1' } });
-  
-        setup(
-          {
-            onClickFilterLabel: onClickFilterLabelMock,
-            onClickFilterOutLabel: onClickFilterOutLabelMock,
-            isFilterLabelActive: isFilterLabelActiveMock,
-            row: mockRow
-          }
-        );
-  
+        const mockRow = createLogRow({
+          logLevel: LogLevel.error,
+          timeEpochMs: 1546297200000,
+          labels: { key1: 'label1' },
+        });
+
+        setup({
+          onClickFilterLabel: onClickFilterLabelMock,
+          onClickFilterOutLabel: onClickFilterOutLabelMock,
+          isFilterLabelActive: isFilterLabelActiveMock,
+          row: mockRow,
+        });
+
         expect(isFilterLabelActiveMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
-        
+
         await userEvent.click(screen.getByLabelText('Filter for value in query A'));
         expect(onClickFilterLabelMock).toHaveBeenCalledTimes(1);
         expect(onClickFilterLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
-  
+
         await userEvent.click(screen.getByLabelText('Filter out value in query A'));
         expect(onClickFilterOutLabelMock).toHaveBeenCalledTimes(1);
         expect(onClickFilterOutLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
       });
-    })
+    });
     it('should not render filter controls when the callbacks are not provided', () => {
       setup(
         {

--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -82,15 +82,15 @@ describe('LogDetails', () => {
           }
         );
   
-        expect(isFilterLabelActiveMock).toHaveBeenCalledWith('key1', 'label1', mockRow);
+        expect(isFilterLabelActiveMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
         
-        await userEvent.click(screen.getByLabelText('Filter for value'));
+        await userEvent.click(screen.getByLabelText('Filter for value in query A'));
         expect(onClickFilterLabelMock).toHaveBeenCalledTimes(1);
-        expect(onClickFilterLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow);
+        expect(onClickFilterLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
   
-        await userEvent.click(screen.getByLabelText('Filter out value'));
+        await userEvent.click(screen.getByLabelText('Filter out value in query A'));
         expect(onClickFilterOutLabelMock).toHaveBeenCalledTimes(1);
-        expect(onClickFilterOutLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow);
+        expect(onClickFilterOutLabelMock).toHaveBeenCalledWith('key1', 'label1', mockRow.dataFrame.refId);
       });
     })
     it('should not render filter controls when the callbacks are not provided', () => {

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -20,13 +20,13 @@ export interface Props extends Themeable2 {
   app?: CoreApp;
   styles: LogRowStyles;
 
-  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
 }
 
 class UnThemedLogDetails extends PureComponent<Props> {

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -26,7 +26,7 @@ export interface Props extends Themeable2 {
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
 }
 
 class UnThemedLogDetails extends PureComponent<Props> {

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -20,8 +20,8 @@ export interface Props extends Themeable2 {
   app?: CoreApp;
   styles: LogRowStyles;
 
-  onClickFilterLabel?: (key: string, value: string) => void;
-  onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -250,6 +250,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
       onClickFilterLabel,
       onClickFilterOutLabel,
       disableActions,
+      row,
     } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
     const styles = getStyles(theme);
@@ -257,6 +258,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const singleKey = parsedKeys == null ? false : parsedKeys.length === 1;
     const singleVal = parsedValues == null ? false : parsedValues.length === 1;
     const hasFilteringFunctionality = !disableActions && onClickFilterLabel && onClickFilterOutLabel;
+    const refIdTooltip = config.featureToggles.toggleLabelsInLogsUI && row.dataFrame.refId ? ` in query ${row.dataFrame.refId}` : '';
 
     const isMultiParsedValueWithNoContent =
       !singleVal && parsedValues != null && !parsedValues.every((val) => val === '');
@@ -275,18 +277,18 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
             <div className={styles.buttonRow}>
               {hasFilteringFunctionality && (
                 <>
-                  {config.featureToggles.toggleLabelsInLogsUI && (
+                  {config.featureToggles.toggleLabelsInLogsUI ? (
                     // If we are using the new label toggling, we want to use the async icon button
                     <AsyncIconButton
                       name="search-plus"
                       onClick={this.filterLabel}
                       isActive={this.isFilterLabelActive}
+                      tooltipSuffix={refIdTooltip}
                     />
-                  )}
-                  {!config.featureToggles.toggleLabelsInLogsUI && (
+                  ) : (
                     <IconButton name="search-plus" onClick={this.filterLabel} tooltip="Filter for value" />
                   )}
-                  <IconButton name="search-minus" tooltip="Filter out value" onClick={this.filterOutLabel} />
+                  <IconButton name="search-minus" tooltip={`Filter out value${refIdTooltip}`} onClick={this.filterOutLabel} />
                 </>
               )}
               {!disableActions && displayedFields && toggleFieldButton}
@@ -350,10 +352,12 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
 interface AsyncIconButtonProps extends Pick<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
   name: IconName;
   isActive(): Promise<boolean>;
+  tooltipSuffix: string;
 }
 
-const AsyncIconButton = ({ isActive, ...rest }: AsyncIconButtonProps) => {
+const AsyncIconButton = ({ isActive, tooltipSuffix, ...rest }: AsyncIconButtonProps) => {
   const [active, setActive] = useState(false);
+  const tooltip = active ? 'Remove filter' : 'Filter for value';
 
   /**
    * We purposely want to run this on every render to allow the active state to be updated
@@ -365,7 +369,7 @@ const AsyncIconButton = ({ isActive, ...rest }: AsyncIconButtonProps) => {
     <IconButton
       {...rest}
       variant={active ? 'primary' : undefined}
-      tooltip={active ? 'Remove filter' : 'Filter for value'}
+      tooltip={tooltip + tooltipSuffix}
     />
   );
 };

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -16,8 +16,8 @@ export interface Props extends Themeable2 {
   disableActions: boolean;
   wrapLogMessage?: boolean;
   isLabel?: boolean;
-  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
   displayedFields?: string[];
@@ -25,7 +25,7 @@ export interface Props extends Themeable2 {
   onClickHideField?: (key: string) => void;
   row: LogRowModel;
   app?: CoreApp;
-  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
 }
 
 interface State {
@@ -136,7 +136,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   isFilterLabelActive = async () => {
     const { isFilterLabelActive, parsedKeys, parsedValues, row } = this.props;
     if (isFilterLabelActive) {
-      return await isFilterLabelActive(parsedKeys[0], parsedValues[0], row);
+      return await isFilterLabelActive(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
     }
     return false;
   };
@@ -144,7 +144,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterLabel = () => {
     const { onClickFilterLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterLabel) {
-      onClickFilterLabel(parsedKeys[0], parsedValues[0], row);
+      onClickFilterLabel(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {
@@ -157,7 +157,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterOutLabel = () => {
     const { onClickFilterOutLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterOutLabel) {
-      onClickFilterOutLabel(parsedKeys[0], parsedValues[0], row);
+      onClickFilterOutLabel(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -136,7 +136,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   isFilterLabelActive = async () => {
     const { isFilterLabelActive, parsedKeys, parsedValues, row } = this.props;
     if (isFilterLabelActive) {
-      return await isFilterLabelActive(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
+      return await isFilterLabelActive(parsedKeys[0], parsedValues[0], row.dataFrame?.refId);
     }
     return false;
   };
@@ -144,7 +144,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterLabel = () => {
     const { onClickFilterLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterLabel) {
-      onClickFilterLabel(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
+      onClickFilterLabel(parsedKeys[0], parsedValues[0], row.dataFrame?.refId);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {
@@ -157,7 +157,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterOutLabel = () => {
     const { onClickFilterOutLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterOutLabel) {
-      onClickFilterOutLabel(parsedKeys[0], parsedValues[0], row.dataFrame.refId);
+      onClickFilterOutLabel(parsedKeys[0], parsedValues[0], row.dataFrame?.refId);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {
@@ -258,7 +258,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const singleKey = parsedKeys == null ? false : parsedKeys.length === 1;
     const singleVal = parsedValues == null ? false : parsedValues.length === 1;
     const hasFilteringFunctionality = !disableActions && onClickFilterLabel && onClickFilterOutLabel;
-    const refIdTooltip = config.featureToggles.toggleLabelsInLogsUI && row.dataFrame.refId ? ` in query ${row.dataFrame.refId}` : '';
+    const refIdTooltip = config.featureToggles.toggleLabelsInLogsUI && row.dataFrame?.refId ? ` in query ${row.dataFrame?.refId}` : '';
 
     const isMultiParsedValueWithNoContent =
       !singleVal && parsedValues != null && !parsedValues.every((val) => val === '');

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -16,8 +16,8 @@ export interface Props extends Themeable2 {
   disableActions: boolean;
   wrapLogMessage?: boolean;
   isLabel?: boolean;
-  onClickFilterLabel?: (key: string, value: string) => void;
-  onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
   displayedFields?: string[];
@@ -144,7 +144,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterLabel = () => {
     const { onClickFilterLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterLabel) {
-      onClickFilterLabel(parsedKeys[0], parsedValues[0]);
+      onClickFilterLabel(parsedKeys[0], parsedValues[0], row);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {
@@ -157,7 +157,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   filterOutLabel = () => {
     const { onClickFilterOutLabel, parsedKeys, parsedValues, row } = this.props;
     if (onClickFilterOutLabel) {
-      onClickFilterOutLabel(parsedKeys[0], parsedValues[0]);
+      onClickFilterOutLabel(parsedKeys[0], parsedValues[0], row);
     }
 
     reportInteraction('grafana_explore_logs_log_details_filter_clicked', {

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -25,7 +25,7 @@ export interface Props extends Themeable2 {
   onClickHideField?: (key: string) => void;
   row: LogRowModel;
   app?: CoreApp;
-  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
 }
 
 interface State {
@@ -134,9 +134,9 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   };
 
   isFilterLabelActive = async () => {
-    const { isFilterLabelActive, parsedKeys, parsedValues } = this.props;
+    const { isFilterLabelActive, parsedKeys, parsedValues, row } = this.props;
     if (isFilterLabelActive) {
-      return await isFilterLabelActive(parsedKeys[0], parsedValues[0]);
+      return await isFilterLabelActive(parsedKeys[0], parsedValues[0], row);
     }
     return false;
   };

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -258,7 +258,8 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const singleKey = parsedKeys == null ? false : parsedKeys.length === 1;
     const singleVal = parsedValues == null ? false : parsedValues.length === 1;
     const hasFilteringFunctionality = !disableActions && onClickFilterLabel && onClickFilterOutLabel;
-    const refIdTooltip = config.featureToggles.toggleLabelsInLogsUI && row.dataFrame?.refId ? ` in query ${row.dataFrame?.refId}` : '';
+    const refIdTooltip =
+      config.featureToggles.toggleLabelsInLogsUI && row.dataFrame?.refId ? ` in query ${row.dataFrame?.refId}` : '';
 
     const isMultiParsedValueWithNoContent =
       !singleVal && parsedValues != null && !parsedValues.every((val) => val === '');
@@ -288,7 +289,11 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
                   ) : (
                     <IconButton name="search-plus" onClick={this.filterLabel} tooltip="Filter for value" />
                   )}
-                  <IconButton name="search-minus" tooltip={`Filter out value${refIdTooltip}`} onClick={this.filterOutLabel} />
+                  <IconButton
+                    name="search-minus"
+                    tooltip={`Filter out value${refIdTooltip}`}
+                    onClick={this.filterOutLabel}
+                  />
                 </>
               )}
               {!disableActions && displayedFields && toggleFieldButton}
@@ -365,13 +370,7 @@ const AsyncIconButton = ({ isActive, tooltipSuffix, ...rest }: AsyncIconButtonPr
    */
   isActive().then(setActive);
 
-  return (
-    <IconButton
-      {...rest}
-      variant={active ? 'primary' : undefined}
-      tooltip={tooltip + tooltipSuffix}
-    />
-  );
+  return <IconButton {...rest} variant={active ? 'primary' : undefined} tooltip={tooltip + tooltipSuffix} />;
 };
 
 export const LogDetailsRow = withTheme2(UnThemedLogDetailsRow);

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -195,7 +195,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       row.hasUnescapedContent && forceEscape
         ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
         : row;
-    
+
     return (
       <>
         <tr

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -42,7 +42,7 @@ interface Props extends Themeable2 {
   styles: LogRowStyles;
   permalinkedRowId?: string;
   scrollIntoView?: (element: HTMLElement) => void;
-  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
   onPinLine?: (row: LogRowModel) => void;
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
@@ -195,7 +195,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       row.hasUnescapedContent && forceEscape
         ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
         : row;
-
+    
     return (
       <>
         <tr

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -29,8 +29,8 @@ interface Props extends Themeable2 {
   app?: CoreApp;
   displayedFields?: string[];
   getRows: () => LogRowModel[];
-  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   onContextClick?: () => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   showContextToggle?: (row?: LogRowModel) => boolean;
@@ -42,7 +42,7 @@ interface Props extends Themeable2 {
   styles: LogRowStyles;
   permalinkedRowId?: string;
   scrollIntoView?: (element: HTMLElement) => void;
-  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   onPinLine?: (row: LogRowModel) => void;
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -29,8 +29,8 @@ interface Props extends Themeable2 {
   app?: CoreApp;
   displayedFields?: string[];
   getRows: () => LogRowModel[];
-  onClickFilterLabel?: (key: string, value: string) => void;
-  onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
   onContextClick?: () => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   showContextToggle?: (row?: LogRowModel) => boolean;

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -38,8 +38,8 @@ export interface Props extends Themeable2 {
   displayedFields?: string[];
   app?: CoreApp;
   showContextToggle?: (row?: LogRowModel) => boolean;
-  onClickFilterLabel?: (key: string, value: string) => void;
-  onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -50,7 +50,7 @@ export interface Props extends Themeable2 {
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   permalinkedRowId?: string;
   scrollIntoView?: (element: HTMLElement) => void;
-  isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
   pinnedRowId?: string;
   containerRendered?: boolean;
 }

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -38,8 +38,8 @@ export interface Props extends Themeable2 {
   displayedFields?: string[];
   app?: CoreApp;
   showContextToggle?: (row?: LogRowModel) => boolean;
-  onClickFilterLabel?: (key: string, value: string, row?: LogRowModel) => void;
-  onClickFilterOutLabel?: (key: string, value: string, row?: LogRowModel) => void;
+  onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
+  onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
@@ -50,7 +50,7 @@ export interface Props extends Themeable2 {
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   permalinkedRowId?: string;
   scrollIntoView?: (element: HTMLElement) => void;
-  isFilterLabelActive?: (key: string, value: string, row: LogRowModel) => Promise<boolean>;
+  isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   pinnedRowId?: string;
   containerRendered?: boolean;
 }

--- a/public/app/features/logs/components/__mocks__/logRow.ts
+++ b/public/app/features/logs/components/__mocks__/logRow.ts
@@ -8,7 +8,7 @@ export const createLogRow = (overrides?: Partial<LogRowModel>): LogRowModel => {
   return {
     entryFieldIndex: 0,
     rowIndex: 0,
-    dataFrame: new MutableDataFrame(),
+    dataFrame: new MutableDataFrame({ refId: 'A', fields: [] }),
     uid,
     logLevel: LogLevel.info,
     entry,


### PR DESCRIPTION
When exploring logs, the produced log lines can potentially come from different queries. Before these changes, when we displayed a filter state (`isFilterLabelActive`) or when we filtered a label/field from log details 🔍  (`onClickFilterLabel`, `onClickFilterOutLabel`), we were checking and affecting all the present queries in Explore, and not the one that produced that particular log line from where these functions are being called.

With the changes in this PR, we're using the information in `LogRowModel.dataFrame` to read the `refId` linked from the corresponding log row, and only checking or changing the query that produced it. The effect is more accuracty and predictability when looking at UI states (active, inactive) and when using 🔍  filters.

**Why do we need this feature?**

To GA the recent updates to the filters, adding active states and a smarter behavior.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61765

**Special notes for your reviewer:**

- Enable the feature flag `toggleLabelsInLogsUI`.
- Browse logs ni Explore, check for the visual status of active filters, use the 🔍  icons to update the queries.
- Browse logs in Explore using Loki and Elasticsearch.
- Browse logs in Explore with mixed data sources.
- Browse logs in Explore with a single query and with multiple queries.

Expected behavior: the filters should behave in a predictable and intuitive way.

Demos:

https://github.com/grafana/grafana/assets/1069378/87615586-4417-4d55-b1c0-746222ad9027

https://github.com/grafana/grafana/assets/1069378/7ebf4d10-412f-4b97-b164-0331beba0b1e