### PR TITLE
Prometheus: fix auth component select for sigv4 option

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaul.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaul.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 
 import { DataSourceSettings } from '@grafana/data';
 import { Auth, ConnectionSettings, convertLegacyAuthProps } from '@grafana/experimental';
@@ -54,16 +54,6 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
   if (sigV4AuthToggleEnabled) {
     customMethods.push(sigV4Option);
   }
-
-  const onSettingsChange = useCallback(
-    (change: Partial<DataSourceSettings<PromOptions, {}>>) => {
-      onOptionsChange({
-        ...options,
-        ...change,
-      });
-    },
-    [options, onOptionsChange]
-  );
 
   const azureAuthEnabled: boolean =
     (azureAuthSettings?.azureAuthSupported && azureAuthSettings.getAzureAuthEnabled(options)) || false;
@@ -150,9 +140,8 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
           // sigV4Id
           if (sigV4AuthToggleEnabled) {
             setSigV4Selected(method === sigV4Id);
-            onSettingsChange({
-              jsonData: { ...options.jsonData, sigV4Auth: method === sigV4Id },
-            });
+            // mutate jsonData here to store the selected option because of auth component issue with onOptionsChange being overridden
+            options.jsonData.sigV4Auth = method === sigV4Id;
           }
 
           // Azure


### PR DESCRIPTION
**What is this feature?**
This is a bug fix for the new auth component.  This fix mutates the jsonData so that the selected SigV4 auth option is saved in jsonData.

**Why do we need this feature?**
Selecting the SigV4 option does not update the jsonData because the function that the auth component uses overrides `onOptionsChange`.

**Who is this feature for?**
Prometheus users who are creating a Prometheus datasource with the sigv4 auth option.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
