### PR TITLE
Prometheus: Add 1000 result warning as sticky footer in metric select

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -1,12 +1,23 @@
 import { css } from '@emotion/css';
 import debounce from 'debounce-promise';
-import React, { useCallback, useState } from 'react';
+import React, { RefCallback, useCallback, useState } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
-import { AsyncSelect, Button, FormatOptionLabelMeta, Icon, InlineField, InlineFieldRow, useStyles2 } from '@grafana/ui';
+import {
+  AsyncSelect,
+  Button,
+  CustomScrollbar,
+  FormatOptionLabelMeta,
+  getSelectStyles,
+  Icon,
+  InlineField,
+  InlineFieldRow,
+  useStyles2,
+  useTheme2,
+} from '@grafana/ui';
 import { SelectMenuOptions } from '@grafana/ui/src/components/Select/SelectMenu';
 
 import { PrometheusDatasource } from '../../datasource';
@@ -58,7 +69,7 @@ export function MetricSelect({
     {
       value: 'BrowseMetrics',
       label: 'Metrics explorer',
-      description: 'Browse and filter metrics and metadata with a fuzzy search',
+      description: 'Browse and filter all metrics and metadata with a fuzzy search',
     },
   ];
 
@@ -199,6 +210,42 @@ export function MetricSelect({
     return SelectMenuOptions(props);
   };
 
+  interface SelectMenuProps {
+    maxHeight: number;
+    innerRef: RefCallback<HTMLDivElement>;
+    innerProps: {};
+  }
+
+  const CustomMenu = ({ children, maxHeight, innerRef, innerProps }: React.PropsWithChildren<SelectMenuProps>) => {
+    const theme = useTheme2();
+    const stylesMenu = getSelectStyles(theme);
+
+    // Show the open modal button only if the options are loaded
+    // The children are a react node(options loading node) or an array(not a valid element)
+    const optionsLoaded = !React.isValidElement(children);
+
+    return (
+      <div
+        {...innerProps}
+        className={`${stylesMenu.menu} ${styles.customMenuContainer}`}
+        style={{ maxHeight }}
+        aria-label="Select options menu"
+      >
+        <CustomScrollbar scrollRefCallback={innerRef} autoHide={false} autoHeightMax="inherit" hideHorizontalTrack>
+          {children}
+        </CustomScrollbar>
+        {optionsLoaded && (
+          <div className={styles.customMenuFooter}>
+            <div>
+              Only the top 1000 metrics are displayed in the metric select. Use the metrics explorer to view all
+              metrics.
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const asyncSelect = () => {
     return (
       <AsyncSelect
@@ -250,7 +297,9 @@ export function MetricSelect({
             onChange({ ...query, metric: '' });
           }
         }}
-        components={prometheusMetricEncyclopedia ? { Option: CustomOption } : {}}
+        components={
+          prometheusMetricEncyclopedia ? { Option: CustomOption, MenuList: CustomMenu } : { MenuList: CustomMenu }
+        }
         onBlur={onBlur ? onBlur : () => {}}
       />
     );
@@ -321,6 +370,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   customOptionWidth: css`
     min-width: 400px;
+  `,
+  customMenuFooter: css`
+    flex: 0;
+    display: flex;
+    justify-content: space-between;
+    padding: ${theme.spacing(1.5)};
+    border-top: 1px solid ${theme.colors.border.weak};
+    color: ${theme.colors.text.secondary};
+  `,
+  customMenuContainer: css`
+    display: flex;
+    flex-direction: column;
+    background: ${theme.colors.background.primary};
+    box-shadow: ${theme.shadows.z3};
   `,
 });
 


### PR DESCRIPTION
**What is this feature?**
Adds a sticky footer indicating that the metric names have been truncated in the metric select component.
![Screenshot 2023-08-22 at 3 29 40 PM](https://github.com/grafana/grafana/assets/25674746/5455182c-2d7d-4c3b-8e79-58fc1af93baa)

**Why do we need this feature?**
For better UX, so people know their metric list has been capped at 1000.

**Who is this feature for?**
Prometheus users.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/observability-metrics-squad/issues/129

**Special notes for your reviewer:**
See the metric select in the query builder AND the variable query editor with the label values query type.

Related: https://github.com/grafana/grafana/pull/73643

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
