### PR TITLE
Azure Monitor: Remove infra logger

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -115,7 +115,11 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 		req.URL.Host = serviceURL.Host
 		req.URL.Scheme = serviceURL.Scheme
 
-		s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
+		rw, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
+		if err != nil {
+			writeResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+			return
+		}
 	}
 }
 

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -37,7 +37,7 @@ func (s *httpServiceProxy) Do(rw http.ResponseWriter, req *http.Request, cli *ht
 		return nil, err
 	}
 	defer func() {
-		if err := res.Body.Close(); err == nil {
+		if err := res.Body.Close(); err != nil {
 			backend.Logger.Warn("Failed to close response body", "err", err)
 		}
 	}()

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -89,8 +89,6 @@ func writeResponse(rw http.ResponseWriter, code int, msg string) {
 
 func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		//log.DefaultLogger.Debug("Received resource call", "url", req.URL.String(), "method", req.Method)
-
 		newPath, err := getTarget(req.URL.Path)
 		if err != nil {
 			writeResponse(rw, http.StatusBadRequest, err.Error())

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -83,7 +83,7 @@ func writeResponse(rw http.ResponseWriter, code int, msg string) {
 	rw.WriteHeader(http.StatusBadRequest)
 	_, err := rw.Write([]byte(msg))
 	if err != nil {
-		log.DefaultLogger.Error("unable to write HTTP response", "error", err)
+		log.DefaultLogger.Error("unable to write HTTP response %v: %v", code, err)
 	}
 }
 

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
@@ -66,7 +66,10 @@ func Test_proxyRequest(t *testing.T) {
 			}
 			rw := httptest.NewRecorder()
 			proxy := httpServiceProxy{}
-			res := proxy.Do(rw, req, srv.Client())
+			res, err := proxy.Do(rw, req, srv.Client())
+			if err != nil {
+				t.Error(err)
+			}
 			if res.Header().Get("foo") != "bar" {
 				t.Errorf("Unexpected headers: %v", res.Header())
 			}
@@ -90,9 +93,9 @@ type fakeProxy struct {
 	requestedURL string
 }
 
-func (s *fakeProxy) Do(rw http.ResponseWriter, req *http.Request, cli *http.Client) http.ResponseWriter {
+func (s *fakeProxy) Do(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
 	s.requestedURL = req.URL.String()
-	return nil
+	return nil, nil
 }
 
 func Test_handleResourceReq(t *testing.T) {

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -329,7 +329,7 @@ func metricCheckHealth(dsInfo types.DatasourceInfo) (message string, defaultSubs
 	return "Successfully connected to Azure Monitor endpoint.", defaultSubscription, backend.HealthStatusOk
 }
 
-func logAnalytricsCheckHealth(dsInfo types.DatasourceInfo, defaultSubscription string) (message string, status backend.HealthStatus) {
+func logAnalyticsCheckHealth(dsInfo types.DatasourceInfo, defaultSubscription string) (message string, status backend.HealthStatus) {
 	logsRes, err := checkAzureLogAnalyticsHealth(dsInfo, defaultSubscription)
 	if err != nil {
 		if err.Error() == "no default workspace found" {
@@ -392,7 +392,10 @@ func parseSubscriptions(res *http.Response) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	result := make([]string, len(target.Value))
 	for i, v := range target.Value {
@@ -418,7 +421,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		status = metricsStatus
 	}
 
-	logAnalyticsLog, logAnalyticsStatus := logAnalytricsCheckHealth(dsInfo, defaultSubscription)
+	logAnalyticsLog, logAnalyticsStatus := logAnalyticsCheckHealth(dsInfo, defaultSubscription)
 	if logAnalyticsStatus != backend.HealthStatusOk {
 		status = logAnalyticsStatus
 	}

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -157,7 +157,7 @@ func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.Az
 
 type azDatasourceExecutor interface {
 	ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error)
-	ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client)
+	ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error)
 }
 
 func (s *Service) getDataSourceFromPluginReq(ctx context.Context, req *backend.QueryDataRequest) (types.DatasourceInfo, error) {

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -26,8 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/resourcegraph"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
-
-var logger = log.New("tsdb.azuremonitor")
 
 func ProvideService(cfg *setting.Cfg, httpClientProvider *httpclient.Provider, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	proxy := &httpServiceProxy{}
@@ -159,7 +156,7 @@ func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.Az
 }
 
 type azDatasourceExecutor interface {
-	ExecuteTimeSeriesQuery(ctx context.Context, logger log.Logger, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error)
+	ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error)
 	ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client)
 }
 
@@ -194,7 +191,7 @@ func (s *Service) newQueryMux() *datasource.QueryTypeMux {
 			if !ok {
 				return nil, fmt.Errorf("missing service for %s", dst)
 			}
-			return executor.ExecuteTimeSeriesQuery(ctx, logger, req.Queries, dsInfo, service.HTTPClient, service.URL, s.tracer)
+			return executor.ExecuteTimeSeriesQuery(ctx, req.Queries, dsInfo, service.HTTPClient, service.URL, s.tracer)
 		})
 	}
 	return mux

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -131,7 +131,8 @@ type fakeExecutor struct {
 	expectedURL string
 }
 
-func (f *fakeExecutor) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
+func (f *fakeExecutor) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
+	return nil, nil
 }
 
 func (f *fakeExecutor) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
@@ -135,7 +134,7 @@ type fakeExecutor struct {
 func (f *fakeExecutor) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
 }
 
-func (f *fakeExecutor) ExecuteTimeSeriesQuery(ctx context.Context, logger log.Logger, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
+func (f *fakeExecutor) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	if client == nil {
 		f.t.Errorf("The HTTP client for %s is missing", f.queryType)
 	} else {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -249,7 +249,6 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries 
 }
 
 func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.DataResponse, error) {
-
 	// If azureLogAnalyticsSameAs is defined and set to false, return an error
 	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok && !sameAs.(bool) {
 		return nil, fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials")

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -289,7 +289,10 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 		return nil, err
 	}
 
-	defer res.Body.Close()
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	logResponse, err := e.unmarshalResponse(res)
 	if err != nil {
@@ -559,7 +562,11 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 		if err != nil {
 			return AzureCorrelationAPIResponse{}, err
 		}
-		defer res.Body.Close()
+
+		defer func() {
+			err := res.Body.Close()
+			backend.Logger.Error("Failed to close response body", "err", err)
+		}()
 
 		if res.StatusCode/100 != 2 {
 			return AzureCorrelationAPIResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))
@@ -659,7 +666,10 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (Azu
 	if err != nil {
 		return AzureLogAnalyticsResponse{}, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	if res.StatusCode/100 != 2 {
 		return AzureLogAnalyticsResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -50,8 +50,8 @@ type AzureLogAnalyticsQuery struct {
 	IntersectTime           bool
 }
 
-func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
-	e.Proxy.Do(rw, req, cli)
+func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
+	return e.Proxy.Do(rw, req, cli)
 }
 
 // executeTimeSeriesQuery does the following:

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -565,7 +565,9 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 
 		defer func() {
 			err := res.Body.Close()
+		if err != nil {
 			backend.Logger.Error("Failed to close response body", "err", err)
+		}
 		}()
 
 		if res.StatusCode/100 != 2 {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -116,7 +116,6 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries 
 			}
 
 			azureLogAnalyticsTarget := queryJSONModel.AzureLogAnalytics
-			//logger.Debug("AzureLogAnalytics", "target", azureLogAnalyticsTarget)
 
 			if azureLogAnalyticsTarget.ResultFormat != nil {
 				resultFormat = *azureLogAnalyticsTarget.ResultFormat
@@ -157,7 +156,6 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries 
 			}
 
 			azureTracesTarget := queryJSONModel.AzureTraces
-			//logger.Debug("AzureTraces", "target", azureTracesTarget)
 
 			if azureTracesTarget.ResultFormat == nil {
 				resultFormat = types.Table
@@ -286,7 +284,6 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 
 	tracer.Inject(ctx, req.Header, span)
 
-	//logger.Debug("AzureLogAnalytics", "Request ApiURL", req.URL.String())
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -453,7 +450,6 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, queryURL, bytes.NewBuffer(jsonValue))
 	if err != nil {
-		//logger.Debug("Failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
@@ -537,7 +533,6 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 	callCorrelationAPI := func(url string) (AzureCorrelationAPIResponse, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer([]byte{}))
 		if err != nil {
-			//logger.Debug("Failed to create request", "error", err)
 			return AzureCorrelationAPIResponse{}, fmt.Errorf("%v: %w", "failed to create request", err)
 		}
 		req.URL.Path = url
@@ -556,7 +551,6 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 
 		tracer.Inject(ctx, req.Header, span)
 
-		//logger.Debug("AzureLogAnalytics", "Traces Correlation ApiURL", req.URL.String())
 		res, err := azMonService.HTTPClient.Do(req)
 		if err != nil {
 			return AzureCorrelationAPIResponse{}, err
@@ -565,15 +559,9 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 		if err != nil {
 			return AzureCorrelationAPIResponse{}, err
 		}
-		defer func() {
-			err := res.Body.Close()
-			if err != nil {
-				//logger.Warn("failed to close response body", "error", err)
-			}
-		}()
+		defer res.Body.Close()
 
 		if res.StatusCode/100 != 2 {
-			//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 			return AzureCorrelationAPIResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))
 		}
 		var data AzureCorrelationAPIResponse
@@ -581,7 +569,6 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 		d.UseNumber()
 		err = d.Decode(&data)
 		if err != nil {
-			//logger.Debug("Failed to unmarshal Azure Traces correlation API response", "error", err, "status", res.Status, "body", string(body))
 			return AzureCorrelationAPIResponse{}, err
 		}
 
@@ -672,14 +659,9 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (Azu
 	if err != nil {
 		return AzureLogAnalyticsResponse{}, err
 	}
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			//logger.Warn("Failed to close response body", "err", err)
-		}
-	}()
+	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
-		//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))
 	}
 
@@ -688,7 +670,6 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (Azu
 	d.UseNumber()
 	err = d.Decode(&data)
 	if err != nil {
-		//logger.Debug("Failed to unmarshal Azure Log Analytics response", "error", err, "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -564,10 +564,9 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 		}
 
 		defer func() {
-			err := res.Body.Close()
-		if err != nil {
-			backend.Logger.Error("Failed to close response body", "err", err)
-		}
+			if err := res.Body.Close(); err != nil {
+				backend.Logger.Error("Failed to close response body", "err", err)
+			}
 		}()
 
 		if res.StatusCode/100 != 2 {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -248,8 +248,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries 
 	return azureLogAnalyticsQueries, nil
 }
 
-func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client,
-	url string, tracer tracing.Tracer) (*backend.DataResponse, error) {
+func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.DataResponse, error) {
 
 	// If azureLogAnalyticsSameAs is defined and set to false, return an error
 	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok && !sameAs.(bool) {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/utils/strings/slices"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/macros"
@@ -59,16 +58,20 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 // 1. build the AzureMonitor url and querystring for each query
 // 2. executes each query by calling the Azure Monitor API
 // 3. parses the responses for each query into data frames
-func (e *AzureLogAnalyticsDatasource) ExecuteTimeSeriesQuery(ctx context.Context, logger log.Logger, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
+func (e *AzureLogAnalyticsDatasource) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
-	ctxLogger := logger.FromContext(ctx)
-	queries, err := e.buildQueries(ctx, ctxLogger, originalQueries, dsInfo, tracer)
+	queries, err := e.buildQueries(ctx, originalQueries, dsInfo, tracer)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, query := range queries {
-		result.Responses[query.RefID] = e.executeQuery(ctx, ctxLogger, query, dsInfo, client, url, tracer)
+		res, err := e.executeQuery(ctx, query, dsInfo, client, url, tracer)
+		if err != nil {
+			result.Responses[query.RefID] = backend.DataResponse{Error: err}
+			continue
+		}
+		result.Responses[query.RefID] = *res
 	}
 
 	return result, nil
@@ -88,7 +91,7 @@ func getApiURL(resourceOrWorkspace string, isAppInsightsQuery bool) string {
 	}
 }
 
-func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger log.Logger, queries []backend.DataQuery, dsInfo types.DatasourceInfo, tracer tracing.Tracer) ([]*AzureLogAnalyticsQuery, error) {
+func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries []backend.DataQuery, dsInfo types.DatasourceInfo, tracer tracing.Tracer) ([]*AzureLogAnalyticsQuery, error) {
 	azureLogAnalyticsQueries := []*AzureLogAnalyticsQuery{}
 	appInsightsRegExp, err := regexp.Compile("providers/Microsoft.Insights/components")
 	if err != nil {
@@ -113,7 +116,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			}
 
 			azureLogAnalyticsTarget := queryJSONModel.AzureLogAnalytics
-			logger.Debug("AzureLogAnalytics", "target", azureLogAnalyticsTarget)
+			//logger.Debug("AzureLogAnalytics", "target", azureLogAnalyticsTarget)
 
 			if azureLogAnalyticsTarget.ResultFormat != nil {
 				resultFormat = *azureLogAnalyticsTarget.ResultFormat
@@ -154,7 +157,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			}
 
 			azureTracesTarget := queryJSONModel.AzureTraces
-			logger.Debug("AzureTraces", "target", azureTracesTarget)
+			//logger.Debug("AzureTraces", "target", azureTracesTarget)
 
 			if azureTracesTarget.ResultFormat == nil {
 				resultFormat = types.Table
@@ -180,7 +183,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 			operationId := ""
 			if queryJSONModel.AzureTraces.OperationId != nil && *queryJSONModel.AzureTraces.OperationId != "" {
 				operationId = *queryJSONModel.AzureTraces.OperationId
-				resourcesMap, err = getCorrelationWorkspaces(ctx, logger, resourceOrWorkspace, resourcesMap, dsInfo, operationId, tracer)
+				resourcesMap, err = getCorrelationWorkspaces(ctx, resourceOrWorkspace, resourcesMap, dsInfo, operationId, tracer)
 				if err != nil {
 					return nil, fmt.Errorf("failed to retrieve correlation resources for operation ID - %s: %s", operationId, err)
 				}
@@ -204,15 +207,15 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 				traceParentExploreQuery = buildTracesQuery(operationId, &parentSpanIdVariable, queryJSONModel.AzureTraces.TraceTypes, queryJSONModel.AzureTraces.Filters, &resultFormat, queryResources)
 				traceLogsExploreQuery = buildTracesLogsQuery(operationId, queryResources)
 			}
-			traceExploreQuery, err = macros.KqlInterpolate(logger, query, dsInfo, traceExploreQuery, "TimeGenerated")
+			traceExploreQuery, err = macros.KqlInterpolate(query, dsInfo, traceExploreQuery, "TimeGenerated")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create traces explore query: %s", err)
 			}
-			traceParentExploreQuery, err = macros.KqlInterpolate(logger, query, dsInfo, traceParentExploreQuery, "TimeGenerated")
+			traceParentExploreQuery, err = macros.KqlInterpolate(query, dsInfo, traceParentExploreQuery, "TimeGenerated")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create parent span traces explore query: %s", err)
 			}
-			traceLogsExploreQuery, err = macros.KqlInterpolate(logger, query, dsInfo, traceLogsExploreQuery, "TimeGenerated")
+			traceLogsExploreQuery, err = macros.KqlInterpolate(query, dsInfo, traceLogsExploreQuery, "TimeGenerated")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create traces logs explore query: %s", err)
 			}
@@ -222,7 +225,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 
 		apiURL := getApiURL(resourceOrWorkspace, appInsightsQuery)
 
-		rawQuery, err := macros.KqlInterpolate(logger, query, dsInfo, queryString, "TimeGenerated")
+		rawQuery, err := macros.KqlInterpolate(query, dsInfo, queryString, "TimeGenerated")
 		if err != nil {
 			return nil, err
 		}
@@ -247,45 +250,29 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, logger l
 	return azureLogAnalyticsQueries, nil
 }
 
-func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger log.Logger, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client,
-	url string, tracer tracing.Tracer) backend.DataResponse {
-	dataResponse := backend.DataResponse{}
-
-	dataResponseErrorWithExecuted := func(err error) backend.DataResponse {
-		dataResponse.Error = err
-		dataResponse.Frames = data.Frames{
-			&data.Frame{
-				RefID: query.RefID,
-				Meta: &data.FrameMeta{
-					ExecutedQueryString: query.Query,
-				},
-			},
-		}
-		return dataResponse
-	}
+func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery, dsInfo types.DatasourceInfo, client *http.Client,
+	url string, tracer tracing.Tracer) (*backend.DataResponse, error) {
 
 	// If azureLogAnalyticsSameAs is defined and set to false, return an error
 	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok && !sameAs.(bool) {
-		return dataResponseErrorWithExecuted(fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
+		return nil, fmt.Errorf("credentials for Log Analytics are no longer supported. Go to the data source configuration to update Azure Monitor credentials")
 	}
 
 	queryJSONModel := dataquery.AzureMonitorQuery{}
 	err := json.Unmarshal(query.JSON, &queryJSONModel)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	if query.QueryType == string(dataquery.AzureQueryTypeAzureTraces) {
 		if dataquery.ResultFormat(query.ResultFormat) == (dataquery.ResultFormatTrace) && query.Query == "" {
-			return dataResponseErrorWithExecuted(fmt.Errorf("cannot visualise trace events using the trace visualiser"))
+			return nil, fmt.Errorf("cannot visualise trace events using the trace visualiser")
 		}
 	}
 
-	req, err := e.createRequest(ctx, logger, url, query)
+	req, err := e.createRequest(ctx, url, query)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	ctx, span := tracer.Start(ctx, "azure log analytics query")
@@ -299,42 +286,37 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 
 	tracer.Inject(ctx, req.Header, span)
 
-	logger.Debug("AzureLogAnalytics", "Request ApiURL", req.URL.String())
+	//logger.Debug("AzureLogAnalytics", "Request ApiURL", req.URL.String())
 	res, err := client.Do(req)
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
-	defer func() {
-		err := res.Body.Close()
-		if err != nil {
-			logger.Warn("failed to close response body", "error", err)
-		}
-	}()
+	defer res.Body.Close()
 
-	logResponse, err := e.unmarshalResponse(logger, res)
+	logResponse, err := e.unmarshalResponse(res)
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
 	t, err := logResponse.GetPrimaryResultTable()
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
 	frame, err := ResponseTableToFrame(t, query.RefID, query.Query, dataquery.AzureQueryType(query.QueryType), dataquery.ResultFormat(query.ResultFormat))
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 	frame = appendErrorNotice(frame, logResponse.Error)
 	if frame == nil {
-		return dataResponse
+		dataResponse := backend.DataResponse{}
+		return &dataResponse, nil
 	}
 
 	azurePortalBaseUrl, err := GetAzurePortalUrl(dsInfo.Cloud)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	if query.QueryType == string(dataquery.AzureQueryTypeAzureTraces) && query.ResultFormat == string(dataquery.ResultFormatTrace) {
@@ -359,22 +341,19 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 
 	queryUrl, err := getQueryUrl(query.Query, query.Resources, azurePortalBaseUrl, query.TimeRange)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	if query.QueryType == string(dataquery.AzureQueryTypeAzureTraces) {
 		tracesUrl, err := getTracesQueryUrl(query.Resources, azurePortalBaseUrl)
 		if err != nil {
-			dataResponse.Error = err
-			return dataResponse
+			return nil, err
 		}
 
 		queryJSONModel := dataquery.AzureMonitorQuery{}
 		err = json.Unmarshal(query.JSON, &queryJSONModel)
 		if err != nil {
-			dataResponse.Error = err
-			return dataResponse
+			return nil, err
 		}
 		traceIdVariable := "${__data.fields.traceID}"
 		resultFormat := dataquery.ResultFormatTrace
@@ -434,9 +413,8 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 	} else {
 		AddConfigLinks(*frame, queryUrl, nil)
 	}
-
-	dataResponse.Frames = data.Frames{frame}
-	return dataResponse
+	dataResponse := backend.DataResponse{Frames: data.Frames{frame}}
+	return &dataResponse, nil
 }
 
 func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) *data.Frame {
@@ -450,7 +428,7 @@ func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) *data.
 	return frame
 }
 
-func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger log.Logger, queryURL string, query *AzureLogAnalyticsQuery) (*http.Request, error) {
+func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryURL string, query *AzureLogAnalyticsQuery) (*http.Request, error) {
 	body := map[string]interface{}{
 		"query": query.Query,
 	}
@@ -475,7 +453,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger 
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, queryURL, bytes.NewBuffer(jsonValue))
 	if err != nil {
-		logger.Debug("Failed to create request", "error", err)
+		//logger.Debug("Failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
@@ -552,14 +530,14 @@ func getTracesQueryUrl(resources []string, azurePortalUrl string) (string, error
 	return portalUrl, nil
 }
 
-func getCorrelationWorkspaces(ctx context.Context, logger log.Logger, baseResource string, resourcesMap map[string]bool, dsInfo types.DatasourceInfo, operationId string, tracer tracing.Tracer) (map[string]bool, error) {
+func getCorrelationWorkspaces(ctx context.Context, baseResource string, resourcesMap map[string]bool, dsInfo types.DatasourceInfo, operationId string, tracer tracing.Tracer) (map[string]bool, error) {
 	azMonService := dsInfo.Services["Azure Monitor"]
 	correlationUrl := azMonService.URL + fmt.Sprintf("%s/providers/microsoft.insights/transactions/%s", baseResource, operationId)
 
 	callCorrelationAPI := func(url string) (AzureCorrelationAPIResponse, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer([]byte{}))
 		if err != nil {
-			logger.Debug("Failed to create request", "error", err)
+			//logger.Debug("Failed to create request", "error", err)
 			return AzureCorrelationAPIResponse{}, fmt.Errorf("%v: %w", "failed to create request", err)
 		}
 		req.URL.Path = url
@@ -578,7 +556,7 @@ func getCorrelationWorkspaces(ctx context.Context, logger log.Logger, baseResour
 
 		tracer.Inject(ctx, req.Header, span)
 
-		logger.Debug("AzureLogAnalytics", "Traces Correlation ApiURL", req.URL.String())
+		//logger.Debug("AzureLogAnalytics", "Traces Correlation ApiURL", req.URL.String())
 		res, err := azMonService.HTTPClient.Do(req)
 		if err != nil {
 			return AzureCorrelationAPIResponse{}, err
@@ -590,12 +568,12 @@ func getCorrelationWorkspaces(ctx context.Context, logger log.Logger, baseResour
 		defer func() {
 			err := res.Body.Close()
 			if err != nil {
-				logger.Warn("failed to close response body", "error", err)
+				//logger.Warn("failed to close response body", "error", err)
 			}
 		}()
 
 		if res.StatusCode/100 != 2 {
-			logger.Debug("Request failed", "status", res.Status, "body", string(body))
+			//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 			return AzureCorrelationAPIResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))
 		}
 		var data AzureCorrelationAPIResponse
@@ -603,7 +581,7 @@ func getCorrelationWorkspaces(ctx context.Context, logger log.Logger, baseResour
 		d.UseNumber()
 		err = d.Decode(&data)
 		if err != nil {
-			logger.Debug("Failed to unmarshal Azure Traces correlation API response", "error", err, "status", res.Status, "body", string(body))
+			//logger.Debug("Failed to unmarshal Azure Traces correlation API response", "error", err, "status", res.Status, "body", string(body))
 			return AzureCorrelationAPIResponse{}, err
 		}
 
@@ -689,19 +667,19 @@ func (ar *AzureLogAnalyticsResponse) GetPrimaryResultTable() (*types.AzureRespon
 	return nil, fmt.Errorf("no data as PrimaryResult table is missing from the response")
 }
 
-func (e *AzureLogAnalyticsDatasource) unmarshalResponse(logger log.Logger, res *http.Response) (AzureLogAnalyticsResponse, error) {
+func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (AzureLogAnalyticsResponse, error) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return AzureLogAnalyticsResponse{}, err
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Warn("Failed to close response body", "err", err)
+			//logger.Warn("Failed to close response body", "err", err)
 		}
 	}()
 
 	if res.StatusCode/100 != 2 {
-		logger.Debug("Request failed", "status", res.Status, "body", string(body))
+		//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, fmt.Errorf("request failed, status: %s, body: %s", res.Status, string(body))
 	}
 
@@ -710,7 +688,7 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(logger log.Logger, res *
 	d.UseNumber()
 	err = d.Decode(&data)
 	if err != nil {
-		logger.Debug("Failed to unmarshal Azure Log Analytics response", "error", err, "status", res.Status, "body", string(body))
+		//logger.Debug("Failed to unmarshal Azure Log Analytics response", "error", err, "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1535,9 +1535,8 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 		TimeRange: backend.TimeRange{},
 	}
 	tracer := tracing.InitializeTracerForTest()
-	res, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
-	require.NoError(t, err)
-	if !strings.Contains(res.Error.Error(), "credentials for Log Analytics are no longer supported") {
+	_, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
+	if !strings.Contains(err.Error(), "credentials for Log Analytics are no longer supported") {
 		t.Error("expecting the error to inform of bad credentials")
 	}
 }

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -16,13 +16,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
-
-var logger = log.New("test")
 
 func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 	datasource := &AzureLogAnalyticsDatasource{}
@@ -1396,7 +1393,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			queries, err := datasource.buildQueries(ctx, logger, tt.queryModel, dsInfo, tracer)
+			queries, err := datasource.buildQueries(ctx, tt.queryModel, dsInfo, tracer)
 			tt.Err(t, err)
 			if diff := cmp.Diff(tt.azureLogAnalyticsQueries[0], queries[0]); diff != "" {
 				t.Errorf("Result mismatch (-want +got): \n%s", diff)
@@ -1411,7 +1408,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 
 	t.Run("creates a request", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
 			Resources:        []string{"r"},
 			Query:            "Perf",
 			IntersectTime:    false,
@@ -1435,7 +1432,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 
 	t.Run("creates a request with timespan", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
 			Resources:        []string{"r"},
 			Query:            "Perf",
 			IntersectTime:    true,
@@ -1459,7 +1456,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 
 	t.Run("creates a request with multiple resources", func(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
 			Resources:        []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"},
 			Query:            "Perf",
 			QueryType:        string(dataquery.AzureQueryTypeAzureLogAnalytics),
@@ -1479,7 +1476,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		from := time.Now()
 		to := from.Add(3 * time.Hour)
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
 			Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/r2"},
 			Query:     "Perf",
 			QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
@@ -1503,7 +1500,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 		ds := AzureLogAnalyticsDatasource{}
 		from := time.Now()
 		to := from.Add(3 * time.Hour)
-		req, err := ds.createRequest(ctx, logger, url, &AzureLogAnalyticsQuery{
+		req, err := ds.createRequest(ctx, url, &AzureLogAnalyticsQuery{
 			Resources: []string{"/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1", "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"},
 			QueryType: string(dataquery.AzureQueryTypeAzureTraces),
 			TimeRange: backend.TimeRange{
@@ -1538,10 +1535,8 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 		TimeRange: backend.TimeRange{},
 	}
 	tracer := tracing.InitializeTracerForTest()
-	res := ds.executeQuery(ctx, logger, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
-	if res.Error == nil {
-		t.Fatal("expecting an error")
-	}
+	res, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
+	require.NoError(t, err)
 	if !strings.Contains(res.Error.Error(), "credentials for Log Analytics are no longer supported") {
 		t.Error("expecting the error to inform of bad credentials")
 	}

--- a/pkg/tsdb/azuremonitor/macros/macros.go
+++ b/pkg/tsdb/azuremonitor/macros/macros.go
@@ -117,7 +117,6 @@ func (m *kqlMacroEngine) evaluateMacro(name string, defaultTimeField string, arg
 			var queryInterval interval
 			err := json.Unmarshal(m.query.JSON, &queryInterval)
 			if err != nil {
-				//logger.Warn("Unable to parse model from query", "JSON", m.query.JSON)
 				it = defaultInterval
 			} else {
 				var (
@@ -129,7 +128,6 @@ func (m *kqlMacroEngine) evaluateMacro(name string, defaultTimeField string, arg
 				}
 				it, err = intervalv2.GetIntervalFrom(dsInterval, queryInterval.Interval, queryInterval.IntervalMs, defaultInterval)
 				if err != nil {
-					//logger.Warn("Unable to get interval from query", "model", queryInterval)
 					it = defaultInterval
 				}
 			}

--- a/pkg/tsdb/azuremonitor/macros/macros.go
+++ b/pkg/tsdb/azuremonitor/macros/macros.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
@@ -34,17 +33,17 @@ type kqlMacroEngine struct {
 //   - $__escapeMulti('\\vm\eth0\Total','\\vm\eth2\Total') -> @'\\vm\eth0\Total',@'\\vm\eth2\Total'
 
 // KqlInterpolate interpolates macros for Kusto Query Language (KQL) queries
-func KqlInterpolate(logger log.Logger, query backend.DataQuery, dsInfo types.DatasourceInfo, kql string, defaultTimeField ...string) (string, error) {
+func KqlInterpolate(query backend.DataQuery, dsInfo types.DatasourceInfo, kql string, defaultTimeField ...string) (string, error) {
 	engine := kqlMacroEngine{}
 
 	defaultTimeFieldForAllDatasources := "timestamp"
 	if len(defaultTimeField) > 0 && query.QueryType != string(dataquery.AzureQueryTypeAzureTraces) {
 		defaultTimeFieldForAllDatasources = defaultTimeField[0]
 	}
-	return engine.Interpolate(logger, query, dsInfo, kql, defaultTimeFieldForAllDatasources)
+	return engine.Interpolate(query, dsInfo, kql, defaultTimeFieldForAllDatasources)
 }
 
-func (m *kqlMacroEngine) Interpolate(logger log.Logger, query backend.DataQuery, dsInfo types.DatasourceInfo, kql string, defaultTimeField string) (string, error) {
+func (m *kqlMacroEngine) Interpolate(query backend.DataQuery, dsInfo types.DatasourceInfo, kql string, defaultTimeField string) (string, error) {
 	m.timeRange = query.TimeRange
 	m.query = query
 	rExp, _ := regexp.Compile(sExpr)
@@ -74,7 +73,7 @@ func (m *kqlMacroEngine) Interpolate(logger log.Logger, query backend.DataQuery,
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")
 		}
-		res, err := m.evaluateMacro(logger, groups[1], defaultTimeField, args, dsInfo)
+		res, err := m.evaluateMacro(groups[1], defaultTimeField, args, dsInfo)
 		if err != nil && macroError == nil {
 			macroError = err
 			return "macro_error()"
@@ -94,7 +93,7 @@ type interval struct {
 	Interval   string
 }
 
-func (m *kqlMacroEngine) evaluateMacro(logger log.Logger, name string, defaultTimeField string, args []string, dsInfo types.DatasourceInfo) (string, error) {
+func (m *kqlMacroEngine) evaluateMacro(name string, defaultTimeField string, args []string, dsInfo types.DatasourceInfo) (string, error) {
 	switch name {
 	case "timeFilter":
 		timeColumn := defaultTimeField
@@ -118,7 +117,7 @@ func (m *kqlMacroEngine) evaluateMacro(logger log.Logger, name string, defaultTi
 			var queryInterval interval
 			err := json.Unmarshal(m.query.JSON, &queryInterval)
 			if err != nil {
-				logger.Warn("Unable to parse model from query", "JSON", m.query.JSON)
+				//logger.Warn("Unable to parse model from query", "JSON", m.query.JSON)
 				it = defaultInterval
 			} else {
 				var (
@@ -130,7 +129,7 @@ func (m *kqlMacroEngine) evaluateMacro(logger log.Logger, name string, defaultTi
 				}
 				it, err = intervalv2.GetIntervalFrom(dsInterval, queryInterval.Interval, queryInterval.IntervalMs, defaultInterval)
 				if err != nil {
-					logger.Warn("Unable to get interval from query", "model", queryInterval)
+					//logger.Warn("Unable to get interval from query", "model", queryInterval)
 					it = defaultInterval
 				}
 			}

--- a/pkg/tsdb/azuremonitor/macros/macros_test.go
+++ b/pkg/tsdb/azuremonitor/macros/macros_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
 
@@ -138,7 +137,7 @@ func TestAzureLogAnalyticsMacros(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defaultTimeField := "TimeGenerated"
-			rawQuery, err := KqlInterpolate(log.New("test"), tt.query, types.DatasourceInfo{}, tt.kql, defaultTimeField)
+			rawQuery, err := KqlInterpolate(tt.query, types.DatasourceInfo{}, tt.kql, defaultTimeField)
 			tt.Err(t, err)
 			if diff := cmp.Diff(tt.expected, rawQuery, cmpopts.EquateNaNs()); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -263,7 +263,11 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	if err != nil {
 		return "", fmt.Errorf("failed to request subscription details: %s", err)
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -311,7 +315,11 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *types.
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	data, err := e.unmarshalResponse(res)
 	if err != nil {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -39,8 +39,8 @@ var (
 
 const AzureMonitorAPIVersion = "2021-05-01"
 
-func (e *AzureMonitorDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
-	e.Proxy.Do(rw, req, cli)
+func (e *AzureMonitorDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
+	return e.Proxy.Do(rw, req, cli)
 }
 
 // executeTimeSeriesQuery does the following:

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -49,23 +48,27 @@ func (e *AzureMonitorDatasource) ResourceRequest(rw http.ResponseWriter, req *ht
 // 1. build the AzureMonitor url and querystring for each query
 // 2. executes each query by calling the Azure Monitor API
 // 3. parses the responses for each query into data frames
-func (e *AzureMonitorDatasource) ExecuteTimeSeriesQuery(ctx context.Context, logger log.Logger, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
+func (e *AzureMonitorDatasource) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
-	ctxLogger := logger.FromContext(ctx)
 
-	queries, err := e.buildQueries(ctxLogger, originalQueries, dsInfo)
+	queries, err := e.buildQueries(originalQueries, dsInfo)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, query := range queries {
-		result.Responses[query.RefID] = e.executeQuery(ctx, ctxLogger, query, dsInfo, client, url, tracer)
+		res, err := e.executeQuery(ctx, query, dsInfo, client, url, tracer)
+		if err != nil {
+			result.Responses[query.RefID] = backend.DataResponse{Error: err}
+			continue
+		}
+		result.Responses[query.RefID] = *res
 	}
 
 	return result, nil
 }
 
-func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*types.AzureMonitorQuery, error) {
+func (e *AzureMonitorDatasource) buildQueries(queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*types.AzureMonitorQuery, error) {
 	azureMonitorQueries := []*types.AzureMonitorQuery{}
 
 	for _, query := range queries {
@@ -174,7 +177,7 @@ func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backe
 		target = params.Encode()
 
 		if setting.Env == setting.Dev {
-			logger.Debug("Azuremonitor request", "params", params)
+			//logger.Debug("Azuremonitor request", "params", params)
 		}
 
 		sub := ""
@@ -245,8 +248,8 @@ func getParams(azJSONModel *dataquery.AzureMetricQuery, query backend.DataQuery)
 	return params, nil
 }
 
-func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, ctx context.Context, logger log.Logger, tracer tracing.Tracer, subscriptionId string, baseUrl string, dsId int64, orgId int64) (string, error) {
-	req, err := e.createRequest(ctx, logger, fmt.Sprintf("%s/subscriptions/%s", baseUrl, subscriptionId))
+func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, ctx context.Context, tracer tracing.Tracer, subscriptionId string, baseUrl string, dsId int64, orgId int64) (string, error) {
+	req, err := e.createRequest(ctx, fmt.Sprintf("%s/subscriptions/%s", baseUrl, subscriptionId))
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve subscription details for subscription %s: %s", subscriptionId, err)
 	}
@@ -261,14 +264,14 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 
 	defer span.End()
 	tracer.Inject(ctx, req.Header, span)
-	logger.Debug("AzureMonitor", "Subscription Details Req")
+	//logger.Debug("AzureMonitor", "Subscription Details Req")
 	res, err := cli.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to request subscription details: %s", err)
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Warn("failed to close response body", "err", err)
+			//logger.Warn("failed to close response body", "err", err)
 		}
 	}()
 
@@ -290,14 +293,11 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	return data.DisplayName, nil
 }
 
-func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Logger, query *types.AzureMonitorQuery, dsInfo types.DatasourceInfo, cli *http.Client,
-	url string, tracer tracing.Tracer) backend.DataResponse {
-	dataResponse := backend.DataResponse{}
-
-	req, err := e.createRequest(ctx, logger, url)
+func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *types.AzureMonitorQuery, dsInfo types.DatasourceInfo, cli *http.Client,
+	url string, tracer tracing.Tracer) (*backend.DataResponse, error) {
+	req, err := e.createRequest(ctx, url)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	req.URL.Path = path.Join(req.URL.Path, query.URL)
@@ -317,49 +317,46 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 	defer span.End()
 	tracer.Inject(ctx, req.Header, span)
 
-	logger.Debug("AzureMonitor", "Request ApiURL", req.URL.String())
-	logger.Debug("AzureMonitor", "Target", query.Target)
+	//logger.Debug("AzureMonitor", "Request ApiURL", req.URL.String())
+	//logger.Debug("AzureMonitor", "Target", query.Target)
 	res, err := cli.Do(req)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Warn("failed to close response body", "err", err)
+			//logger.Warn("failed to close response body", "err", err)
 		}
 	}()
 
-	data, err := e.unmarshalResponse(logger, res)
+	data, err := e.unmarshalResponse(res)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	azurePortalUrl, err := loganalytics.GetAzurePortalUrl(dsInfo.Cloud)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
-	subscription, err := e.retrieveSubscriptionDetails(cli, ctx, logger, tracer, query.Subscription, dsInfo.Routes["Azure Monitor"].URL, dsInfo.DatasourceID, dsInfo.OrgID)
+	subscription, err := e.retrieveSubscriptionDetails(cli, ctx, tracer, query.Subscription, dsInfo.Routes["Azure Monitor"].URL, dsInfo.DatasourceID, dsInfo.OrgID)
 	if err != nil {
-		logger.Warn(err.Error())
+		return nil, err
 	}
 
-	dataResponse.Frames, err = e.parseResponse(data, query, azurePortalUrl, subscription)
+	frames, err := e.parseResponse(data, query, azurePortalUrl, subscription)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
-	return dataResponse
+	dataResponse := backend.DataResponse{Frames: frames}
+	return &dataResponse, nil
 }
 
-func (e *AzureMonitorDatasource) createRequest(ctx context.Context, logger log.Logger, url string) (*http.Request, error) {
+func (e *AzureMonitorDatasource) createRequest(ctx context.Context, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		logger.Debug("failed to create request", "error", err)
+		//logger.Debug("failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -367,21 +364,21 @@ func (e *AzureMonitorDatasource) createRequest(ctx context.Context, logger log.L
 	return req, nil
 }
 
-func (e *AzureMonitorDatasource) unmarshalResponse(logger log.Logger, res *http.Response) (types.AzureMonitorResponse, error) {
+func (e *AzureMonitorDatasource) unmarshalResponse(res *http.Response) (types.AzureMonitorResponse, error) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return types.AzureMonitorResponse{}, err
 	}
 
 	if res.StatusCode/100 != 2 {
-		logger.Debug("Request failed", "status", res.Status, "body", string(body))
+		//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 		return types.AzureMonitorResponse{}, fmt.Errorf("request failed, status: %s, error: %s", res.Status, string(body))
 	}
 
 	var data types.AzureMonitorResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		logger.Debug("failed to unmarshal AzureMonitor response", "error", err, "status", res.Status, "body", string(body))
+		//logger.Debug("failed to unmarshal AzureMonitor response", "error", err, "status", res.Status, "body", string(body))
 		return types.AzureMonitorResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/testdata"
 	azTime "github.com/grafana/grafana/pkg/tsdb/azuremonitor/time"
@@ -294,7 +293,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 				},
 			}
 
-			queries, err := datasource.buildQueries(log.New("test"), tsdbQuery, dsInfo)
+			queries, err := datasource.buildQueries(tsdbQuery, dsInfo)
 			require.NoError(t, err)
 
 			resources := map[string]dataquery.AzureMonitorResource{}
@@ -359,7 +358,7 @@ func TestCustomNamespace(t *testing.T) {
 			},
 		}
 
-		result, err := datasource.buildQueries(log.New("test"), q, types.DatasourceInfo{})
+		result, err := datasource.buildQueries(q, types.DatasourceInfo{})
 		require.NoError(t, err)
 		expected := "custom/namespace"
 		require.Equal(t, expected, result[0].Params.Get("metricnamespace"))
@@ -690,7 +689,7 @@ func TestAzureMonitorCreateRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ds := AzureMonitorDatasource{}
-			req, err := ds.createRequest(ctx, log.New("test"), url)
+			req, err := ds.createRequest(ctx, url)
 			tt.Err(t, err)
 			if req.URL.String() != tt.expectedURL {
 				t.Errorf("Expecting %s, got %s", tt.expectedURL, req.URL.String())

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -166,7 +166,10 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *
 		return nil, err
 	}
 
-	defer res.Body.Close()
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	argResponse, err := e.unmarshalResponse(res)
 	if err != nil {
@@ -216,7 +219,11 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(res *http.Response) (Az
 	if err != nil {
 		return AzureResourceGraphResponse{}, err
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	if res.StatusCode/100 != 2 {
 		return AzureResourceGraphResponse{}, fmt.Errorf("%s. Azure Resource Graph error: %s", res.Status, string(body))

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -95,7 +95,6 @@ func (e *AzureResourceGraphDatasource) buildQueries(queries []backend.DataQuery,
 		}
 
 		azureResourceGraphTarget := queryJSONModel.AzureResourceGraph
-		//logger.Debug("AzureResourceGraph", "target", azureResourceGraphTarget)
 
 		resultFormat := azureResourceGraphTarget.ResultFormat
 		if resultFormat == "" {
@@ -162,7 +161,6 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *
 
 	tracer.Inject(ctx, req.Header, span)
 
-	//logger.Debug("AzureResourceGraph", "Request ApiURL", req.URL.String())
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -205,7 +203,6 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *
 func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, reqBody []byte, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
-		//logger.Debug("Failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
@@ -222,7 +219,6 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(res *http.Response) (Az
 	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
-		//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureResourceGraphResponse{}, fmt.Errorf("%s. Azure Resource Graph error: %s", res.Status, string(body))
 	}
 
@@ -231,7 +227,6 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(res *http.Response) (Az
 	d.UseNumber()
 	err = d.Decode(&data)
 	if err != nil {
-		//logger.Debug("Failed to unmarshal azure resource graph response", "error", err, "status", res.Status, "body", string(body))
 		return AzureResourceGraphResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -47,8 +47,8 @@ type AzureResourceGraphQuery struct {
 const ArgAPIVersion = "2021-06-01-preview"
 const argQueryProviderName = "/providers/Microsoft.ResourceGraph/resources"
 
-func (e *AzureResourceGraphDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) {
-	e.Proxy.Do(rw, req, cli)
+func (e *AzureResourceGraphDatasource) ResourceRequest(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error) {
+	return e.Proxy.Do(rw, req, cli)
 }
 
 // executeTimeSeriesQuery does the following:

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics"
@@ -56,19 +55,23 @@ func (e *AzureResourceGraphDatasource) ResourceRequest(rw http.ResponseWriter, r
 // 1. builds the AzureMonitor url and querystring for each query
 // 2. executes each query by calling the Azure Monitor API
 // 3. parses the responses for each query into data frames
-func (e *AzureResourceGraphDatasource) ExecuteTimeSeriesQuery(ctx context.Context, logger log.Logger, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
+func (e *AzureResourceGraphDatasource) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	result := &backend.QueryDataResponse{
 		Responses: map[string]backend.DataResponse{},
 	}
-	ctxLogger := logger.FromContext(ctx)
 
-	queries, err := e.buildQueries(ctxLogger, originalQueries, dsInfo)
+	queries, err := e.buildQueries(originalQueries, dsInfo)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, query := range queries {
-		result.Responses[query.RefID] = e.executeQuery(ctx, ctxLogger, query, dsInfo, client, url, tracer)
+		res, err := e.executeQuery(ctx, query, dsInfo, client, url, tracer)
+		if err != nil {
+			result.Responses[query.RefID] = backend.DataResponse{Error: err}
+			continue
+		}
+		result.Responses[query.RefID] = *res
 	}
 
 	return result, nil
@@ -81,7 +84,7 @@ type argJSONQuery struct {
 	} `json:"azureResourceGraph"`
 }
 
-func (e *AzureResourceGraphDatasource) buildQueries(logger log.Logger, queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*AzureResourceGraphQuery, error) {
+func (e *AzureResourceGraphDatasource) buildQueries(queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*AzureResourceGraphQuery, error) {
 	var azureResourceGraphQueries []*AzureResourceGraphQuery
 
 	for _, query := range queries {
@@ -92,14 +95,14 @@ func (e *AzureResourceGraphDatasource) buildQueries(logger log.Logger, queries [
 		}
 
 		azureResourceGraphTarget := queryJSONModel.AzureResourceGraph
-		logger.Debug("AzureResourceGraph", "target", azureResourceGraphTarget)
+		//logger.Debug("AzureResourceGraph", "target", azureResourceGraphTarget)
 
 		resultFormat := azureResourceGraphTarget.ResultFormat
 		if resultFormat == "" {
 			resultFormat = "table"
 		}
 
-		interpolatedQuery, err := macros.KqlInterpolate(logger, query, dsInfo, azureResourceGraphTarget.Query)
+		interpolatedQuery, err := macros.KqlInterpolate(query, dsInfo, azureResourceGraphTarget.Query)
 
 		if err != nil {
 			return nil, err
@@ -118,31 +121,15 @@ func (e *AzureResourceGraphDatasource) buildQueries(logger log.Logger, queries [
 	return azureResourceGraphQueries, nil
 }
 
-func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger log.Logger, query *AzureResourceGraphQuery, dsInfo types.DatasourceInfo, client *http.Client,
-	dsURL string, tracer tracing.Tracer) backend.DataResponse {
-	dataResponse := backend.DataResponse{}
-
+func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *AzureResourceGraphQuery, dsInfo types.DatasourceInfo, client *http.Client,
+	dsURL string, tracer tracing.Tracer) (*backend.DataResponse, error) {
 	params := url.Values{}
 	params.Add("api-version", ArgAPIVersion)
 
-	dataResponseErrorWithExecuted := func(err error) backend.DataResponse {
-		dataResponse = backend.DataResponse{Error: err}
-		frames := data.Frames{
-			&data.Frame{
-				RefID: query.RefID,
-				Meta: &data.FrameMeta{
-					ExecutedQueryString: query.InterpolatedQuery,
-				},
-			},
-		}
-		dataResponse.Frames = frames
-		return dataResponse
-	}
 	var model dataquery.AzureMonitorQuery
 	err := json.Unmarshal(query.JSON, &model)
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	reqBody, err := json.Marshal(map[string]interface{}{
@@ -152,15 +139,13 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 	})
 
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
-	req, err := e.createRequest(ctx, logger, reqBody, dsURL)
+	req, err := e.createRequest(ctx, reqBody, dsURL)
 
 	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
+		return nil, err
 	}
 
 	req.URL.Path = path.Join(req.URL.Path, argQueryProviderName)
@@ -177,36 +162,32 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 
 	tracer.Inject(ctx, req.Header, span)
 
-	logger.Debug("AzureResourceGraph", "Request ApiURL", req.URL.String())
+	//logger.Debug("AzureResourceGraph", "Request ApiURL", req.URL.String())
 	res, err := client.Do(req)
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
-	defer func() {
-		err := res.Body.Close()
-		if err != nil {
-			logger.Warn("failed to close response body", "error", err)
-		}
-	}()
+	defer res.Body.Close()
 
-	argResponse, err := e.unmarshalResponse(logger, res)
+	argResponse, err := e.unmarshalResponse(res)
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
 	frame, err := loganalytics.ResponseTableToFrame(&argResponse.Data, query.RefID, query.InterpolatedQuery, dataquery.AzureQueryType(query.QueryType), dataquery.ResultFormat(query.ResultFormat))
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 	if frame == nil {
 		// empty response
-		return dataResponse
+		dataResponse := backend.DataResponse{}
+		return &dataResponse, nil
 	}
 
 	azurePortalUrl, err := loganalytics.GetAzurePortalUrl(dsInfo.Cloud)
 	if err != nil {
-		return dataResponseErrorWithExecuted(err)
+		return nil, err
 	}
 
 	url := azurePortalUrl + "/#blade/HubsExtension/ArgQueryBlade/query/" + url.PathEscape(query.InterpolatedQuery)
@@ -216,14 +197,15 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 	}
 	frameWithLink.Meta.ExecutedQueryString = req.URL.RawQuery
 
+	dataResponse := backend.DataResponse{}
 	dataResponse.Frames = data.Frames{&frameWithLink}
-	return dataResponse
+	return &dataResponse, nil
 }
 
-func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, logger log.Logger, reqBody []byte, url string) (*http.Request, error) {
+func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, reqBody []byte, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
-		logger.Debug("Failed to create request", "error", err)
+		//logger.Debug("Failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
@@ -232,19 +214,15 @@ func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, logger
 	return req, nil
 }
 
-func (e *AzureResourceGraphDatasource) unmarshalResponse(logger log.Logger, res *http.Response) (AzureResourceGraphResponse, error) {
+func (e *AzureResourceGraphDatasource) unmarshalResponse(res *http.Response) (AzureResourceGraphResponse, error) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return AzureResourceGraphResponse{}, err
 	}
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			logger.Warn("Failed to close response body", "err", err)
-		}
-	}()
+	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
-		logger.Debug("Request failed", "status", res.Status, "body", string(body))
+		//logger.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureResourceGraphResponse{}, fmt.Errorf("%s. Azure Resource Graph error: %s", res.Status, string(body))
 	}
 
@@ -253,7 +231,7 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(logger log.Logger, res 
 	d.UseNumber()
 	err = d.Decode(&data)
 	if err != nil {
-		logger.Debug("Failed to unmarshal azure resource graph response", "error", err, "status", res.Status, "body", string(body))
+		//logger.Debug("Failed to unmarshal azure resource graph response", "error", err, "status", res.Status, "body", string(body))
 		return AzureResourceGraphResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
@@ -17,12 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
-
-var logger = log.New("test")
 
 func TestBuildingAzureResourceGraphQueries(t *testing.T) {
 	datasource := &AzureResourceGraphDatasource{}
@@ -74,7 +71,7 @@ func TestBuildingAzureResourceGraphQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			queries, err := datasource.buildQueries(logger, tt.queryModel, types.DatasourceInfo{})
+			queries, err := datasource.buildQueries(tt.queryModel, types.DatasourceInfo{})
 			tt.Err(t, err)
 			if diff := cmp.Diff(tt.azureResourceGraphQueries, queries, cmpopts.IgnoreUnexported(struct{}{})); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
@@ -106,7 +103,7 @@ func TestAzureResourceGraphCreateRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ds := AzureResourceGraphDatasource{}
-			req, err := ds.createRequest(ctx, logger, []byte{}, url)
+			req, err := ds.createRequest(ctx, []byte{}, url)
 			tt.Err(t, err)
 			if req.URL.String() != tt.expectedURL {
 				t.Errorf("Expecting %s, got %s", tt.expectedURL, req.URL.String())
@@ -158,7 +155,7 @@ func TestGetAzurePortalUrl(t *testing.T) {
 
 func TestUnmarshalResponse400(t *testing.T) {
 	datasource := &AzureResourceGraphDatasource{}
-	res, err := datasource.unmarshalResponse(logger, &http.Response{
+	res, err := datasource.unmarshalResponse(&http.Response{
 		StatusCode: 400,
 		Status:     "400 Bad Request",
 		Body:       io.NopCloser(strings.NewReader(("Azure Error Message"))),
@@ -172,7 +169,7 @@ func TestUnmarshalResponse400(t *testing.T) {
 
 func TestUnmarshalResponse200Invalid(t *testing.T) {
 	datasource := &AzureResourceGraphDatasource{}
-	res, err := datasource.unmarshalResponse(logger, &http.Response{
+	res, err := datasource.unmarshalResponse(&http.Response{
 		StatusCode: 200,
 		Status:     "OK",
 		Body:       io.NopCloser(strings.NewReader(("Azure Data"))),
@@ -187,7 +184,7 @@ func TestUnmarshalResponse200Invalid(t *testing.T) {
 
 func TestUnmarshalResponse200(t *testing.T) {
 	datasource := &AzureResourceGraphDatasource{}
-	res, err2 := datasource.unmarshalResponse(logger, &http.Response{
+	res, err2 := datasource.unmarshalResponse(&http.Response{
 		StatusCode: 200,
 		Status:     "OK",
 		Body:       io.NopCloser(strings.NewReader("{}")),

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -190,7 +190,7 @@ type MetricVisualization struct {
 }
 
 type ServiceProxy interface {
-	Do(rw http.ResponseWriter, req *http.Request, cli *http.Client) http.ResponseWriter
+	Do(rw http.ResponseWriter, req *http.Request, cli *http.Client) (http.ResponseWriter, error)
 }
 
 type LogAnalyticsWorkspaceFeatures struct {


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/73651

I refactored the health check code so each API is discretely checked.

I removed the debug and warning logs. This seems a little controversial, but I doubt they are being used and the code looks better without passing a logger everywhere. We could put the logger in the service structs if we want these messages to remain.