### PR TITLE
[v10.0.x] CI: Update secrets for publishing steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2280,7 +2280,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
@@ -2291,7 +2291,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
     STATIC_ASSET_EDITIONS:
@@ -2304,7 +2304,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
@@ -2355,7 +2355,7 @@ steps:
   - yarn-install
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   failure: ignore
@@ -2862,7 +2862,7 @@ steps:
   environment:
     BUCKET: grafana-prerelease
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
   failure: ignore
   image: google/cloud-sdk:431.0.0
   name: gsutil-stat
@@ -4192,6 +4192,6 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 kind: signature
-hmac: 50e07de5e688a14cc76c3e8cc992a2c01fd6285708683ab54b9662baa6212f46
+hmac: d9357f6d759e2e9b7bec6811fea9306da52ea136303db847f78538619005dd1a
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -54,7 +54,7 @@ load(
 load(
     "scripts/drone/vault.star",
     "from_secret",
-    "gcp_upload_artifacts_key",
+    "gcp_grafanauploads_base64",
     "npm_token",
     "prerelease_bucket",
 )
@@ -93,7 +93,7 @@ def store_npm_packages_step():
             "build-frontend-packages",
         ],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret(prerelease_bucket),
         },
         "commands": ["./bin/build artifacts npm store --tag ${DRONE_TAG}"],
@@ -109,7 +109,7 @@ def retrieve_npm_packages_step():
         ],
         "failure": "ignore",
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret(prerelease_bucket),
         },
         "commands": ["./bin/build artifacts npm retrieve --tag ${DRONE_TAG}"],
@@ -270,7 +270,7 @@ def publish_artifacts_step():
         "name": "publish-artifacts",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
@@ -284,7 +284,7 @@ def publish_static_assets_step():
         "name": "publish-static-assets",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
             "STATIC_ASSET_EDITIONS": from_secret("static_asset_editions"),
         },
@@ -299,7 +299,7 @@ def publish_storybook_step():
         "name": "publish-storybook",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
@@ -437,7 +437,7 @@ def integration_test_pipelines():
 def verify_release_pipeline(
         name = "verify-prerelease-assets",
         bucket = from_secret(prerelease_bucket),
-        gcp_key = from_secret(gcp_upload_artifacts_key),
+        gcp_key = from_secret(gcp_grafanauploads_base64),
         version = "${DRONE_TAG}",
         trigger = release_trigger,
         depends_on = [


### PR DESCRIPTION
Backport de118a37362c3492218797d45a7e7f1085043d7f from #73658

---

**What is this feature?**

Replaces `gcp_upload_artifacts_key` dev key which is used for e2e artifacts uploads, with `gcp_grafanauploads_base64`.
