### PR TITLE
[v9.3.x] CI: Update secrets for publishing steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2229,7 +2229,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
@@ -2240,7 +2240,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
     STATIC_ASSET_EDITIONS:
@@ -2253,7 +2253,7 @@ steps:
   - compile-build-cmd
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
@@ -2304,7 +2304,7 @@ steps:
   - yarn-install
   environment:
     GCP_KEY:
-      from_secret: gcp_upload_artifacts_key
+      from_secret: gcp_grafanauploads_base64
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   failure: ignore
@@ -4083,6 +4083,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 716714c56814c0cb444ffa6047cdcaa695da0c8e5b3494ac497dcc201a05ffb8
+hmac: fc290ffe72cdad8e3d81f5e763aaeb2d370b6a58ae25886edb15837fc1503c79
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -52,7 +52,7 @@ load(
 load(
     "scripts/drone/vault.star",
     "from_secret",
-    "gcp_upload_artifacts_key",
+    "gcp_grafanauploads_base64",
     "npm_token",
     "prerelease_bucket",
     "rgm_gcp_key_base64",
@@ -92,7 +92,7 @@ def store_npm_packages_step():
             "build-frontend-packages",
         ],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret(prerelease_bucket),
         },
         "commands": ["./bin/build artifacts npm store --tag ${DRONE_TAG}"],
@@ -108,7 +108,7 @@ def retrieve_npm_packages_step():
         ],
         "failure": "ignore",
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret(prerelease_bucket),
         },
         "commands": ["./bin/build artifacts npm retrieve --tag ${DRONE_TAG}"],
@@ -267,7 +267,7 @@ def publish_artifacts_step():
         "name": "publish-artifacts",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
@@ -281,7 +281,7 @@ def publish_static_assets_step():
         "name": "publish-static-assets",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
             "STATIC_ASSET_EDITIONS": from_secret("static_asset_editions"),
         },
@@ -296,7 +296,7 @@ def publish_storybook_step():
         "name": "publish-storybook",
         "image": images["publish_image"],
         "environment": {
-            "GCP_KEY": from_secret(gcp_upload_artifacts_key),
+            "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [


### PR DESCRIPTION
Backport de118a37362c3492218797d45a7e7f1085043d7f from #73658

---

**What is this feature?**

Replaces `gcp_upload_artifacts_key` dev key which is used for e2e artifacts uploads, with `gcp_grafanauploads_base64`.
