### PR TITLE
Alerting: Fix incorrect timing meta information for policy

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -17,11 +17,7 @@ import { useGetContactPointsState } from './api/receiversApi';
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerDeliveryWarning } from './components/GrafanaAlertmanagerDeliveryWarning';
 import { MuteTimingsTable } from './components/mute-timings/MuteTimingsTable';
-import {
-  computeInheritedTree,
-  findRoutesMatchingPredicate,
-  NotificationPoliciesFilter,
-} from './components/notification-policies/Filters';
+import { findRoutesMatchingPredicate, NotificationPoliciesFilter } from './components/notification-policies/Filters';
 import {
   useAddPolicyModal,
   useEditPolicyModal,
@@ -37,6 +33,7 @@ import { useRouteGroupsMatcher } from './useRouteGroupsMatcher';
 import { addUniqueIdentifierToRoute } from './utils/amroutes';
 import { isVanillaPrometheusAlertManagerDataSource } from './utils/datasource';
 import { normalizeMatchers } from './utils/matchers';
+import { computeInheritedTree } from './utils/notification-policies';
 import { initialAsyncRequestState } from './utils/redux';
 import { addRouteToParentRoute, mergePartialAmRouteWithRouteTree, omitRouteFromRouteTree } from './utils/routeTree';
 

--- a/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
@@ -5,11 +5,10 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Button, Field, Icon, Input, Label as LabelElement, Select, Tooltip, useStyles2 } from '@grafana/ui';
-import { ObjectMatcher, Receiver, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
+import { ObjectMatcher, Receiver, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import { useURLSearchParams } from '../../hooks/useURLSearchParams';
 import { matcherToObjectMatcher, parseMatchers } from '../../utils/alertmanager';
-import { getInheritedProperties } from '../../utils/notification-policies';
 
 interface NotificationPoliciesFilterProps {
   receivers: Receiver[];
@@ -127,23 +126,6 @@ export function findRoutesMatchingPredicate(routeTree: RouteWithID, predicateFn:
 
   findMatch(routeTree);
   return matches;
-}
-
-/**
- * This function will compute the full tree with inherited properties – this is mostly used for search and filtering
- */
-export function computeInheritedTree<T extends Route>(parent: T): T {
-  return {
-    ...parent,
-    routes: parent.routes?.map((child) => {
-      const inheritedProperties = getInheritedProperties(parent, child);
-
-      return computeInheritedTree({
-        ...child,
-        ...inheritedProperties,
-      });
-    }),
-  };
 }
 
 const toOption = (receiver: Receiver) => ({

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -462,7 +462,8 @@ const TimingOptionsMeta: FC<{ timingOptions: TimingOptions }> = ({ timingOptions
           content="How long to initially wait to send a notification for a group of alert instances."
         >
           <span>
-            <Strong>{groupWait}</Strong> <span>to group instances</span>,
+            <Strong>{groupWait}</Strong> <span>to group instances</span>
+            {groupWait && groupInterval && ','}
           </span>
         </Tooltip>
       )}

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -279,8 +279,11 @@ const Policy: FC<PolicyComponentProps> = ({
                     <MuteTimings timings={muteTimings} alertManagerSourceName={alertManagerSourceName} />
                   </MetaText>
                 )}
-                {timingOptions && Object.values(timingOptions).some(Boolean) && (
-                  <TimingOptionsMeta timingOptions={timingOptions} />
+                {timingOptions && (
+                  // for the default policy we will also merge the default timings, that way a user can observe what the timing options would be
+                  <TimingOptionsMeta
+                    timingOptions={isDefaultPolicy ? { ...timingOptions, ...TIMING_OPTIONS_DEFAULTS } : timingOptions}
+                  />
                 )}
                 {hasInheritedProperties && (
                   <>
@@ -441,28 +444,38 @@ const MuteTimings: FC<{ timings: string[]; alertManagerSourceName: string }> = (
 };
 
 const TimingOptionsMeta: FC<{ timingOptions: TimingOptions }> = ({ timingOptions }) => {
-  const groupWait = timingOptions.group_wait ?? TIMING_OPTIONS_DEFAULTS.group_wait;
-  const groupInterval = timingOptions.group_interval ?? TIMING_OPTIONS_DEFAULTS.group_interval;
+  const groupWait = timingOptions.group_wait;
+  const groupInterval = timingOptions.group_interval;
+
+  // we don't have any timing options to show – we're inheriting everything from the parent
+  // and those show up in a separate "inherited properties" component
+  if (!groupWait && !groupInterval) {
+    return null;
+  }
 
   return (
     <MetaText icon="hourglass" data-testid="timing-options">
       <span>Wait</span>
-      <Tooltip
-        placement="top"
-        content="How long to initially wait to send a notification for a group of alert instances."
-      >
-        <span>
-          <Strong>{groupWait}</Strong> <span>to group instances</span>,
-        </span>
-      </Tooltip>
-      <Tooltip
-        placement="top"
-        content="How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent."
-      >
-        <span>
-          <Strong>{groupInterval}</Strong> <span>before sending updates</span>
-        </span>
-      </Tooltip>
+      {groupWait && (
+        <Tooltip
+          placement="top"
+          content="How long to initially wait to send a notification for a group of alert instances."
+        >
+          <span>
+            <Strong>{groupWait}</Strong> <span>to group instances</span>,
+          </span>
+        </Tooltip>
+      )}
+      {groupInterval && (
+        <Tooltip
+          placement="top"
+          content="How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent."
+        >
+          <span>
+            <Strong>{groupInterval}</Strong> <span>before sending updates</span>
+          </span>
+        </Tooltip>
+      )}
     </MetaText>
   );
 };

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
@@ -6,8 +6,7 @@ import { Labels } from '../../../../../../types/unified-alerting-dto';
 import { useAlertmanagerConfig } from '../../../hooks/useAlertmanagerConfig';
 import { useRouteGroupsMatcher } from '../../../useRouteGroupsMatcher';
 import { addUniqueIdentifierToRoute } from '../../../utils/amroutes';
-import { AlertInstanceMatch, normalizeRoute } from '../../../utils/notification-policies';
-import { computeInheritedTree } from '../../notification-policies/Filters';
+import { AlertInstanceMatch, computeInheritedTree, normalizeRoute } from '../../../utils/notification-policies';
 
 import { getRoutesByIdMap, RouteWithPath } from './route';
 

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -232,4 +232,21 @@ function getInheritedProperties(
   return inherited;
 }
 
+/**
+ * This function will compute the full tree with inherited properties – this is mostly used for search and filtering
+ */
+export function computeInheritedTree<T extends Route>(parent: T): T {
+  return {
+    ...parent,
+    routes: parent.routes?.map((child) => {
+      const inheritedProperties = getInheritedProperties(parent, child);
+
+      return computeInheritedTree({
+        ...child,
+        ...inheritedProperties,
+      });
+    }),
+  };
+}
+
 export { findMatchingAlertGroups, findMatchingRoutes, getInheritedProperties };


### PR DESCRIPTION
**What is this feature?**

This PR does two things

1. Moves the `computeInheritedTree` function to utils and adds a few tests
2. Updates the `Policy` component to no longer show the default timing options if we're also inheriting from the parent.

**Which issue(s) does this PR fix?**:

Fixes #73573

The inheritance algorithm was working as intended, but the component showed both the default timing options and inherited properties, which it shouldn't (with the exception of the default policy, which cannot inherit from a parent).

**Special notes for your reviewer:**

I didn't write a regression test for this in `Policy.test.tsx` but might be a good addition to this PR :)