### PR TITLE
Revert "Dashboard: Set descending z-index of panels in a dashboard"

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -152,14 +152,10 @@ export class DashboardGrid extends PureComponent<Props> {
     for (const panel of this.props.dashboard.panels) {
       const panelClasses = classNames({ 'react-grid-item--fullscreen': panel.isViewing });
 
-      // used to allow overflowing content to show on top of the next panel
-      const descIndex = this.props.dashboard.panels.length - panelElements.length;
-
       panelElements.push(
         <GrafanaGridItem
           key={panel.key}
           className={panelClasses}
-          descendingOrderIndex={descIndex}
           data-panelid={panel.id}
           gridPos={panel.gridPos}
           gridWidth={gridWidth}
@@ -281,7 +277,6 @@ export class DashboardGrid extends PureComponent<Props> {
 interface GrafanaGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   gridWidth?: number;
   gridPos?: GridPos;
-  descendingOrderIndex?: number;
   isViewing: boolean;
   windowHeight: number;
   windowWidth: number;
@@ -296,7 +291,7 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
   let width = 100;
   let height = 100;
 
-  const { gridWidth, gridPos, isViewing, windowHeight, windowWidth, descendingOrderIndex, ...divProps } = props;
+  const { gridWidth, gridPos, isViewing, windowHeight, windowWidth, ...divProps } = props;
   const style: CSSProperties = props.style ?? {};
 
   if (isViewing) {
@@ -326,7 +321,7 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
 
   // props.children[0] is our main children. RGL adds the drag handle at props.children[1]
   return (
-    <div {...divProps} style={{ ...divProps.style, zIndex: descendingOrderIndex }} ref={ref}>
+    <div {...divProps} ref={ref}>
       {/* Pass width and height to children as render props */}
       {[props.children[0](width, height), props.children.slice(1)]}
     </div>


### PR DESCRIPTION
Reverts grafana/grafana#73401

Panels with hidden (shown on hover) header that are directly below any other panels, do not have the shown-on-hover header fully visible when user is hovering over them. issue: https://github.com/grafana/grafana/issues/73670

When user is hovering over a panel, this panel should have higher z-index than all other panels. 