### PR TITLE
Prometheus: Add ExecutedQueryString to first frame only

### DIFF
--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -41,11 +41,14 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 	}
 
 	// The ExecutedQueryString can be viewed in QueryInspector in UI
-	for _, frame := range r.Frames {
+	for i, frame := range r.Frames {
 		if s.enableWideSeries {
 			addMetadataToWideFrame(q, frame)
 		} else {
 			addMetadataToMultiFrame(q, frame, s.enableDataplane)
+			if i == 0 {
+				frame.Meta.ExecutedQueryString = executedQueryString(q)
+			}
 		}
 	}
 
@@ -112,7 +115,6 @@ func addMetadataToMultiFrame(q *models.Query, frame *data.Frame, enableDataplane
 	if frame.Meta == nil {
 		frame.Meta = &data.FrameMeta{}
 	}
-	frame.Meta.ExecutedQueryString = executedQueryString(q)
 	if len(frame.Fields) < 2 {
 		return
 	}

--- a/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
@@ -7,8 +7,7 @@
 //      ],
 //      "custom": {
 //          "resultType": "exemplar"
-//      },
-//      "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+//      }
 //  }
 //  Name: exemplar
 //  Dimensions: 14 Fields by 62 Rows
@@ -44,8 +43,7 @@
           ],
           "custom": {
             "resultType": "exemplar"
-          },
-          "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+          }
         },
         "fields": [
           {

--- a/pkg/tsdb/prometheus/testdata/range_simple.result.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/range_simple.result.golden.jsonc
@@ -33,8 +33,7 @@
 //      ],
 //      "custom": {
 //          "resultType": "matrix"
-//      },
-//      "executedQueryString": "Expr: \nStep: 1s"
+//      }
 //  }
 //  Name: prometheus_http_requests_total{code="400", handler="/api/v1/query_range", job="prometheus"}
 //  Dimensions: 2 Fields by 2 Rows
@@ -121,8 +120,7 @@
           ],
           "custom": {
             "resultType": "matrix"
-          },
-          "executedQueryString": "Expr: \nStep: 1s"
+          }
         },
         "fields": [
           {


### PR DESCRIPTION
**What is this feature?**

Since the backend expands certain macros, we attach the query post interpolation to the response data frames. Since this is the same for every Frame, this changes the response to only include it on the first frame.

**Why do we need this feature?**

A long query string with a high cardinal response will use up a lot of extra bytes.

For example, if the query is 1k bytes, and there are 1,000 items in the response, this will save ~ one megabyte.

**Special notes for your reviewer:**

Another case not covered here:
 - The query doesn't have `__name__`
 - When that is the case, we set the metric name to the query on each frame.
 - https://github.com/grafana/grafana/blob/efa428c329419c950c8ffb59b9f6262fedc5b6fd/pkg/tsdb/prometheus/querydata/response.go#L205-L207
 
I imagine we may want to backport this later, but can start with no backport.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
