### PR TITLE
Logs: Add datalinks to table visualisation in Explore

### DIFF
--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -72,9 +72,11 @@ export const LogsTable: React.FunctionComponent<Props> = (props) => {
           });
         };
         field.config = {
+          ...field.config,
           custom: {
             filterable: true,
             inspect: true,
+            ...field.config.custom,
           },
         };
       }


### PR DESCRIPTION
**What is this feature?**
This PR adds a fix that datalinks were not visible in the experimental table visualisation. Datalinks reside in the `custom.links` property and that was overwritten previously.

**Special notes for your reviewer:**

1. Configure a derived field/datalink/correlation for your logging datasource
2. Make sure the `logsExploreTableVisualisation` feature flag is set.
3. Query logs containing a link.
4. Switch to table visualisation to see logs.
