### PR TITLE
Cfg: Add support to reset admin password at startup (setting: `reset_admin_password_at_start`)

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -602,7 +602,17 @@ Default is `admin`.
 
 ### admin_password
 
-The password of the default Grafana Admin. Set once on first-run. Default is `admin`.
+The password of the default Grafana Admin.
+Default is `admin`.
+
+> In Grafana < v10.1, only set once on first-run.
+> In Grafana v10.1+, behavior depends on `reset_admin_every_time_run`. When `reset_admin_every_time_run`=`false`, only set once on first-run.
+
+### reset_admin_every_time_run
+
+> Only available in Grafana v10.1+
+
+Reset the admin user and admin password every time start grafana server. Default is `false`.
 
 ### admin_email
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -606,9 +606,9 @@ The password of the default Grafana Admin.
 Default is `admin`.
 
 > In Grafana < v10.1, only set once on first-run.
-> In Grafana v10.1+, the behavior depends on the `reset_admin_every_time_run` value. When `reset_admin_every_time_run` is `false`, the password is set once on first run.
+> In Grafana v10.1+, the behavior depends on the `reset_admin_password_at_start` value. When `reset_admin_password_at_start` is `false`, the password is set once on first run.
 
-### reset_admin_every_time_run
+### reset_admin_password_at_start
 
 > Available in Grafana v10.1+
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -606,13 +606,13 @@ The password of the default Grafana Admin.
 Default is `admin`.
 
 > In Grafana < v10.1, only set once on first-run.
-> In Grafana v10.1+, behavior depends on `reset_admin_every_time_run`. When `reset_admin_every_time_run`=`false`, only set once on first-run.
+> In Grafana v10.1+, the behavior depends on the `reset_admin_every_time_run` value. When `reset_admin_every_time_run` is `false`, the password is set once on first run.
 
 ### reset_admin_every_time_run
 
-> Only available in Grafana v10.1+
+> Available in Grafana v10.1+
 
-Reset the admin user and admin password every time start grafana server. Default is `false`.
+Resets the Grafana Admin user and password every time the Grafana server starts. The default value is `false`.
 
 ### admin_email
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -213,7 +213,7 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser(test bool) error {
 				return fmt.Errorf("could not determine if admin user exists: %w", err)
 			}
 			if stats.Count > 0 {
-				if !ss.Cfg.ResetAdminEveryTimeRun {
+				if !ss.Cfg.ResetAdminPasswordAtStart {
 					return nil
 				}
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -226,6 +226,7 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser(test bool) error {
 				}); err != nil {
 					return fmt.Errorf("failed to update admin user: %s", err)
 				}
+				return nil
 			}
 		}
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -213,7 +213,19 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser(test bool) error {
 				return fmt.Errorf("could not determine if admin user exists: %w", err)
 			}
 			if stats.Count > 0 {
-				return nil
+				if !ss.Cfg.ResetAdminEveryTimeRun {
+					return nil
+				}
+
+				ss.log.Debug("Reset admin user name and password")
+				if _, err := ss.resetAdminUser(ctx, sess, user.CreateUserCommand{
+					Name:     ss.Cfg.AdminUser,
+					Login:    ss.Cfg.AdminUser,
+					Email:    ss.Cfg.AdminEmail,
+					Password: ss.Cfg.AdminPassword,
+				}); err != nil {
+					return fmt.Errorf("failed to update admin user: %s", err)
+				}
 			}
 		}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -209,7 +209,7 @@ type Cfg struct {
 
 	// Security
 	DisableInitAdminCreation          bool
-	ResetAdminEveryTimeRun            bool
+	ResetAdminPasswordAtStart         bool
 	DisableBruteForceLoginProtection  bool
 	CookieSecure                      bool
 	CookieSameSiteDisabled            bool
@@ -1463,7 +1463,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
-	cfg.ResetAdminEveryTimeRun = security.Key("reset_admin_every_time_run").MustBool(false)
+	cfg.ResetAdminPasswordAtStart = security.Key("reset_admin_password_at_start").MustBool(false)
 	cfg.AdminEmail = valueAsString(security, "admin_email", fmt.Sprintf("%s@localhost", cfg.AdminUser))
 
 	return nil

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -209,6 +209,7 @@ type Cfg struct {
 
 	// Security
 	DisableInitAdminCreation          bool
+	ResetAdminEveryTimeRun            bool
 	DisableBruteForceLoginProtection  bool
 	CookieSecure                      bool
 	CookieSameSiteDisabled            bool
@@ -1462,6 +1463,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
+	cfg.ResetAdminEveryTimeRun = security.Key("reset_admin_every_time_run").MustBool(false)
 	cfg.AdminEmail = valueAsString(security, "admin_email", fmt.Sprintf("%s@localhost", cfg.AdminUser))
 
 	return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49055
I can not reopen #55980 . Reopen a new PR.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
