### PR TITLE
Loki config: update doc links

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
+++ b/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
@@ -3,13 +3,20 @@ import React from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConfigSubSection } from '@grafana/experimental';
 import { InlineField, InlineSwitch } from '@grafana/ui';
+import { ConfigDescriptionLink } from 'app/core/components/ConfigDescriptionLink';
 
 export function AlertingSettings({
   options,
   onOptionsChange,
 }: Pick<DataSourcePluginOptionsEditorProps, 'options' | 'onOptionsChange'>) {
   return (
-    <ConfigSubSection title="Alerting">
+    <ConfigSubSection title="Alerting" description={
+        <ConfigDescriptionLink
+          description="Manage alert rules for the Loki data source."
+          suffix="loki/configure-loki-data-source/#alerting"
+          feature="alerting"
+        />
+      }>
       <InlineField
         labelWidth={29}
         label="Manage alert rules in Alerting UI"

--- a/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
+++ b/public/app/plugins/datasource/loki/configuration/AlertingSettings.tsx
@@ -10,13 +10,16 @@ export function AlertingSettings({
   onOptionsChange,
 }: Pick<DataSourcePluginOptionsEditorProps, 'options' | 'onOptionsChange'>) {
   return (
-    <ConfigSubSection title="Alerting" description={
+    <ConfigSubSection
+      title="Alerting"
+      description={
         <ConfigDescriptionLink
           description="Manage alert rules for the Loki data source."
           suffix="loki/configure-loki-data-source/#alerting"
           feature="alerting"
         />
-      }>
+      }
+    >
       <InlineField
         labelWidth={29}
         label="Manage alert rules in Alerting UI"

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -52,7 +52,7 @@ export const ConfigEditor = (props: Props) => {
     <>
       <DataSourceDescription
         dataSourceName="Loki"
-        docsLink="https://grafana.com/docs/grafana/latest/datasources/loki"
+        docsLink="https://grafana.com/docs/grafana/latest/datasources/loki/configure-loki-data-source/"
         hasRequiredFields={false}
       />
       <Divider />

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -50,7 +50,7 @@ export const DerivedFields = ({ fields = [], onChange }: Props) => {
       description={
         <ConfigDescriptionLink
           description="Derived fields can be used to extract new fields from a log message and create a link from its value."
-          suffix="loki/#configure-derived-fields"
+          suffix="loki/configure-loki-data-source/#derived-fields"
           feature="derived fields"
         />
       }

--- a/public/app/plugins/datasource/loki/configuration/QuerySettings.tsx
+++ b/public/app/plugins/datasource/loki/configuration/QuerySettings.tsx
@@ -21,8 +21,8 @@ export const QuerySettings = (props: Props) => {
       title="Queries"
       description={
         <ConfigDescriptionLink
-          description="Additional options to customize your querying experience. "
-          suffix="loki/#configure-the-data-source"
+          description="Additional options to customize your querying experience."
+          suffix="loki/configure-loki-data-source/#queries"
           feature="query settings"
         />
       }


### PR DESCRIPTION
Recently the doc pages have been updated, so updating the links accordingly.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

- Go to Loki settings.
- The links must work and match the content.