### PR TITLE
Tracer: Export ContextWithSpan

### DIFF
--- a/pkg/infra/tracing/test_helper.go
+++ b/pkg/infra/tracing/test_helper.go
@@ -92,7 +92,7 @@ func (t *FakeSpan) AddEvents(keys []string, values []EventValue) {
 	}
 }
 
-func (t *FakeSpan) contextWithSpan(ctx context.Context) context.Context {
+func (t *FakeSpan) ContextWithSpan(ctx context.Context) context.Context {
 	return ctx
 }
 

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -128,7 +128,7 @@ type Span interface {
 
 	// contextWithSpan returns a context.Context that holds the parent
 	// context plus a reference to this span.
-	contextWithSpan(ctx context.Context) context.Context
+	ContextWithSpan(ctx context.Context) context.Context
 }
 
 func ProvideService(cfg *setting.Cfg) (Tracer, error) {
@@ -188,7 +188,7 @@ func SpanFromContext(ctx context.Context) Span {
 // It is the equivalent of opentracing.ContextWithSpan and trace.ContextWithSpan.
 func ContextWithSpan(ctx context.Context, span Span) context.Context {
 	if span != nil {
-		return span.contextWithSpan(ctx)
+		return span.ContextWithSpan(ctx)
 	}
 	return ctx
 }
@@ -487,7 +487,7 @@ func (s OpentelemetrySpan) AddEvents(keys []string, values []EventValue) {
 	}
 }
 
-func (s OpentelemetrySpan) contextWithSpan(ctx context.Context) context.Context {
+func (s OpentelemetrySpan) ContextWithSpan(ctx context.Context) context.Context {
 	if s.span != nil {
 		ctx = trace.ContextWithSpan(ctx, s.span)
 		// Grafana also manages its own separate traceID in the context in addition to what opentracing handles.


### PR DESCRIPTION
**What is this feature?**

The unexported method on Span (that I wrote, lol) makes it so these interfaces are not implementable outside of the tracing package.

That makes the span interface difficult to use in a context outside the Grafana process.

**Why do we need this feature?**

The unexported method makes the interface effectively sealed. No implementations may exist outside the Tracing package, preventing us from writing any adapters to support grafana-style tracing.

**Who is this feature for?**

Any components consuming Grafana as a library.

**Which issue(s) does this PR fix?**:

Fixes: n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
