### PR TITLE
[v10.0.x] Update `docs/shared` shortcode usage to use keyword argument interface

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -22,7 +22,7 @@ weight: 700
 
 # InfluxDB data source
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana includes built-in support for InfluxDB.
 This topic explains options, variables, querying, and other features specific to the InfluxDB data source, which include its [feature-rich code editor for queries and visual query builder]({{< relref "./query-editor" >}}).

--- a/docs/sources/datasources/tempo/query-editor/index.md
+++ b/docs/sources/datasources/tempo/query-editor/index.md
@@ -80,7 +80,7 @@ You can create TraceQL queries using the Query editor or using Search query tab 
 
 [//]: # 'Include content for preview of Search tab featuring TraceQL query builder'
 
-{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" >}}
+{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" version="<GRAFANA VERSION>" >}}
 
 ## Query Loki for traces
 

--- a/docs/sources/fundamentals/_index.md
+++ b/docs/sources/fundamentals/_index.md
@@ -15,8 +15,8 @@ weight: 8
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/getting-started/get-started-grafana-influxdb.md
+++ b/docs/sources/getting-started/get-started-grafana-influxdb.md
@@ -12,7 +12,7 @@ weight: 400
 
 # Get started with Grafana and InfluxDB
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 #### Get InfluxDB
 

--- a/docs/sources/old-alerting/_index.md
+++ b/docs/sources/old-alerting/_index.md
@@ -30,4 +30,4 @@ You can perform the following tasks for alerts:
 - [Test alert rules and troubleshoot]({{< relref "./troubleshoot-alerts" >}})
 - [Add or edit an alert contact point]({{< relref "./notifications" >}})
 
-{{< docs/shared "alerts/grafana-managed-alerts.md" >}}
+{{< docs/shared lookup="alerts/grafana-managed-alerts.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -127,9 +127,9 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -71,9 +71,9 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -77,9 +77,9 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend values
 

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -67,4 +67,4 @@ The panel can be used with time series data as well. In this case, the threshold
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Color scheme]({{< relref "../../configure-standard-options/#color-scheme" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -64,4 +64,4 @@ use gradient color schemes to color values.
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Color scheme]({{< relref "../../configure-standard-options/#color-scheme" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -47,13 +47,13 @@ You can migrate from the old Graph visualization to the new Time series visualiz
 
 Tooltip options control the information overlay that appears when you hover over data points in the graph.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Legend options
 
 Legend options control the series names and statistics that appear under or to the right of the graph.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Graph styles
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -19,7 +19,7 @@ weight: 700
 
 # Configure generic OAuth2 authentication
 
-{{< docs/shared "auth/intro.md" >}}
+{{< docs/shared lookup="auth/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana provides OAuth2 integrations for the following auth providers:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/github/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/github/index.md
@@ -19,7 +19,7 @@ weight: 900
 
 # Configure GitHub OAuth2 authentication
 
-{{< docs/shared "auth/intro.md" >}}
+{{< docs/shared lookup="auth/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic describes how to configure GitHub OAuth2 authentication.
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
@@ -19,7 +19,7 @@ weight: 1000
 
 # Configure GitLab OAuth2 authentication
 
-{{< docs/shared "auth/intro.md" >}}
+{{< docs/shared lookup="auth/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic describes how to configure GitLab OAuth2 authentication.
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/okta/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/okta/index.md
@@ -14,7 +14,7 @@ weight: 1400
 
 # Configure Okta OAuth2 authentication
 
-{{< docs/shared "auth/intro.md" >}}
+{{< docs/shared lookup="auth/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Before you begin
 

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -52,7 +52,7 @@ sudo systemctl enable grafana-server.service
 
 #### Serve Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Restart the Grafana server using systemd
 

--- a/docs/sources/shared/example.md
+++ b/docs/sources/shared/example.md
@@ -15,7 +15,7 @@ When you have a chunk of text or steps that stand alone, not part of an ordered 
 The syntax to invoke this file would be the following, minus the backslash:
 
 ```
-\{{< docs/shared "example.md" >}}
+\{{< docs/shared lookup="example.md" source="grafana" version="<GRAFANA VERSION>" >}}
 ```
 
 ## Part of a list
@@ -28,7 +28,7 @@ Below is an example from the docs, with backslashes added. The initial spaces ar
 
 ```
 \{{< docs/list >}}
-  \{{< docs/shared "manage-users/view-server-user-list.md" >}}
+  \{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 \{{< /docs/list >}}
 ```
@@ -40,7 +40,7 @@ You cannot use short codes in an ordered list with sublists. The shortcode break
 All unordered list steps included as part of a list will appear as second-level lists (with the hollow circle bullet) rather than first-level lists (solid circle bullet), even if the list is not indented in the shared file or the document file.
 
 {{< docs/list >}}
-{{< docs/shared "test.md" >}}
+{{< docs/shared lookup="test.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 - Bullet text
   {{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -7,7 +7,7 @@ title: View org list as server admin
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the organization that you want to edit.
 

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -7,7 +7,7 @@ title: View user list and search - list format
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 

--- a/docs/sources/upgrade-guide/upgrade-v10.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v10.0/index.md
@@ -16,7 +16,7 @@ weight: 1700
 
 # Upgrade to Grafana v10.0
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.0/index.md
@@ -16,7 +16,7 @@ weight: 2900
 
 # Upgrade to Grafana v8.0
 
-{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.1/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.1/index.md
@@ -16,7 +16,7 @@ weight: 2800
 
 # Upgrade to Grafana v8.1
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.2/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.2/index.md
@@ -16,7 +16,7 @@ weight: 2700
 
 # Upgrade to Grafana v8.2
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.3/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.3/index.md
@@ -16,7 +16,7 @@ weight: 2600
 
 # Upgrade to Grafana v8.3
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.4/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.4/index.md
@@ -16,7 +16,7 @@ weight: 2500
 
 # Upgrade to Grafana v8.4
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v8.5/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.5/index.md
@@ -16,7 +16,7 @@ weight: 2400
 
 # Upgrade to Grafana v8.5
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.0/index.md
@@ -16,7 +16,7 @@ weight: 2300
 
 # Upgrade to Grafana v9.0
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.1/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.1/index.md
@@ -16,7 +16,7 @@ weight: 2200
 
 # Upgrade to Grafana v9.1
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.2/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.2/index.md
@@ -16,7 +16,7 @@ weight: 2100
 
 # Upgrade to Grafana v9.2
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.3/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.3/index.md
@@ -16,7 +16,7 @@ weight: 2000
 
 # Upgrade to Grafana v9.3
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.4/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.4/index.md
@@ -16,7 +16,7 @@ weight: 1995
 
 # Upgrade to Grafana v9.4
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 

--- a/docs/sources/upgrade-guide/upgrade-v9.5/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.5/index.md
@@ -16,7 +16,7 @@ weight: 1800
 
 # Upgrade to Grafana v9.5
 
-{{< docs/shared "upgrade/upgrade-common-tasks.md" >}}
+{{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes
 


### PR DESCRIPTION
Previously, an empty version was inferred from the relative permalink for the page. Although the behavior was similar to the other version inference done in shortcodes like `docs/reference`, it did not allow specifying an empty version needed to include content from unversioned documentation.

For consistency with other shortcodes like `docs/reference`, the `docs/shared` shortcode version lookup has been replaced with the following behavior:

1. If `version=""`, use an empty version.
1. If `version="<SOMETHING VERSION>"`, use version inference as described in https://grafana.com/docs/writers-toolkit/write/shortcodes/#docsreference-shortcode:~:text=The%20path%20to,becomes%20GRAFANA%20CLOUD..
1. If `version="ANYTHING ELSE"`, use that literal value.
