### PR TITLE
[v9.2.x] Update `docs/shared` shortcode usage to use keyword argument interface

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -13,7 +13,7 @@ weight: 700
 
 # InfluxDB data source
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic explains options, variables, querying, and other options specific to this data source. Refer to [Add a data source]({{< relref "../add-a-data-source/" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 

--- a/docs/sources/fundamentals/_index.md
+++ b/docs/sources/fundamentals/_index.md
@@ -9,8 +9,8 @@ weight: 8
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/getting-started/get-started-grafana-influxdb.md
+++ b/docs/sources/getting-started/get-started-grafana-influxdb.md
@@ -8,7 +8,7 @@ weight: 400
 
 # Get started with Grafana and InfluxDB
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 #### Get InfluxDB
 

--- a/docs/sources/old-alerting/_index.md
+++ b/docs/sources/old-alerting/_index.md
@@ -24,4 +24,4 @@ You can perform the following tasks for alerts:
 - [Test alert rules and troubleshoot]({{< relref "troubleshoot-alerts/" >}})
 - [Add or edit an alert contact point]({{< relref "notifications/" >}})
 
-{{< docs/shared "alerts/grafana-managed-alerts.md" >}}
+{{< docs/shared lookup="alerts/grafana-managed-alerts.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -99,9 +99,9 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -66,9 +66,9 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -72,9 +72,9 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend values
 

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -62,4 +62,4 @@ The panel can be used with time series data as well. In this case, the threshold
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Color scheme]({{< relref "../../configure-standard-options/#color-scheme" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -59,4 +59,4 @@ use gradient color schemes to color values.
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Color scheme]({{< relref "../../configure-standard-options/#color-scheme" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -40,13 +40,13 @@ The time series visualization type is the default and primary way to visualize t
 
 Tooltip options control the information overlay that appears when you hover over data points in the graph.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Legend options
 
 Legend options control the series names and statistics that appear under or to the right of the graph.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Graph styles
 

--- a/docs/sources/setup-grafana/installation/debian.md
+++ b/docs/sources/setup-grafana/installation/debian.md
@@ -122,7 +122,7 @@ sudo systemctl enable grafana-server.service
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Start the server with init.d
 

--- a/docs/sources/setup-grafana/installation/rpm.md
+++ b/docs/sources/setup-grafana/installation/rpm.md
@@ -162,7 +162,7 @@ sudo systemctl enable grafana-server
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 #### Serving Grafana behind a proxy
 

--- a/docs/sources/shared/example.md
+++ b/docs/sources/shared/example.md
@@ -11,7 +11,7 @@ When you have a chunk of text or steps that stand alone, not part of an ordered 
 The syntax to invoke this file would be the following, minus the backslash:
 
 ```
-\{{< docs/shared "example.md" >}}
+\{{< docs/shared lookup="example.md" source="grafana" version="<GRAFANA VERSION>" >}}
 ```
 
 ## Part of a list
@@ -24,7 +24,7 @@ Below is an example from the docs, with backslashes added. The initial spaces ar
 
 ```
 \{{< docs/list >}}
-  \{{< docs/shared "manage-users/view-server-user-list.md" >}}
+  \{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 \{{< /docs/list >}}
 ```
@@ -36,7 +36,7 @@ You cannot use short codes in an ordered list with sublists. The shortcode break
 All unordered list steps included as part of a list will appear as second-level lists (with the hollow circle bullet) rather than first-level lists (solid circle bullet), even if the list is not indented in the shared file or the document file.
 
 {{< docs/list >}}
-{{< docs/shared "test.md" >}}
+{{< docs/shared lookup="test.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 - Bullet text
   {{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -3,7 +3,7 @@ title: View org list as server admin
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the organization that you want to edit.
 

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -3,7 +3,7 @@ title: View user list and search - list format
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 


### PR DESCRIPTION
Previously, an empty version was inferred from the relative permalink for the page. Although the behavior was similar to the other version inference done in shortcodes like `docs/reference`, it did not allow specifying an empty version needed to include content from unversioned documentation.

For consistency with other shortcodes like `docs/reference`, the `docs/shared` shortcode version lookup has been replaced with the following behavior:

1. If `version=""`, use an empty version.
1. If `version="<SOMETHING VERSION>`, use version inference as described in https://grafana.com/docs/writers-toolkit/write/shortcodes/#docsreference-shortcode:~:text=The%20path%20to,becomes%20GRAFANA%20CLOUD..
1. If `version="ANYTHING ELSE"`, use that literal value.
