### PR TITLE
[v8.4.x] Update `docs/shared` shortcode usage to use keyword argument interface

### DIFF
--- a/docs/sources/administration/preferences/change-grafana-name.md
+++ b/docs/sources/administration/preferences/change-grafana-name.md
@@ -12,7 +12,7 @@ weight: 100
 
 In Grafana, you can change your names and emails associated with groups or accounts in the Settings or Preferences. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Change organization name
 
@@ -23,7 +23,7 @@ Grafana server administrators and organization administrators can change organiz
 Follow these instructions if you are a Grafana Server Admin.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the organization list, click the name of the organization that you want to change.
 1. In **Name**, enter the new organization name.
@@ -35,7 +35,7 @@ Follow these instructions if you are a Grafana Server Admin.
 If you are an Organization Admin, follow these steps:
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In **Organization name**, enter the new name.
 1. Click **Update organization name**.

--- a/docs/sources/administration/preferences/change-grafana-theme.md
+++ b/docs/sources/administration/preferences/change-grafana-theme.md
@@ -13,7 +13,7 @@ weight: 200
 
 In Grafana, you can modify the UI theme configured in the Settings or Preferences. Set the UI theme for the server, an organization, a team, or your personal user account using the instructions in this topic.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Theme options
 
@@ -46,8 +46,8 @@ To see what the current settings are, refer to [View server settings]({{< relref
 Organization administrators can change the UI theme for all users in an organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Change team UI theme
@@ -55,10 +55,10 @@ Organization administrators can change the UI theme for all users in an organiza
 Organization and team administrators can change the UI theme for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team that you want to change the UI theme for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-ui-theme-list.md" >}}
+   {{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Change your personal UI theme
@@ -66,6 +66,6 @@ Organization and team administrators can change the UI theme for all users in a 
 You can change the UI theme for your user account. This setting overrides UI theme settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-grafana-timezone.md
+++ b/docs/sources/administration/preferences/change-grafana-timezone.md
@@ -13,7 +13,7 @@ weight: 400
 
 By default, Grafana uses the timezone in your web browser. However, you can override this setting at the server, organization, team, or individual user level. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Set server timezone
 
@@ -24,8 +24,8 @@ Grafana server administrators can choose a default timezone for all users on the
 Organization administrators can choose a default timezone for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set team timezone
@@ -33,10 +33,10 @@ Organization administrators can choose a default timezone for their organization
 Organization administrators and team administrators can choose a default timezone for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team you that you want to change the timezone for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-timezone-list.md" >}}
+   {{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Set your personal timezone
@@ -44,6 +44,6 @@ Organization administrators and team administrators can choose a default timezon
 You can change the timezone for your user account. This setting overrides timezone settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-home-dashboard.md
+++ b/docs/sources/administration/preferences/change-home-dashboard.md
@@ -15,7 +15,7 @@ weight: 300
 
 The home dashboard you set is the one all users will see by default when they log in. You can set the home dashboard for the server, an organization, a team, or your personal user account. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Navigate to the home dashboard
 
@@ -52,9 +52,9 @@ default_home_dashboard_path = data/main-dashboard.json
 Organization administrators can choose a home dashboard for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set home dashboard for your team
@@ -62,11 +62,11 @@ Organization administrators can choose a home dashboard for their organization.
 Organization administrators and Team Admins can choose a home dashboard for a team.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team that you want to change the home dashboard for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+   {{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Set your personal home dashboard
@@ -74,7 +74,7 @@ Organization administrators and Team Admins can choose a home dashboard for a te
 You can choose your own personal home dashboard. This setting overrides all home dashboards set at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -23,4 +23,4 @@ You can perform the following tasks for alerts:
 - [Test alert rules and troubleshoot]({{< relref "troubleshoot-alerts.md" >}})
 - [Add or edit an alert contact point]({{< relref "notifications.md" >}})
 
-{{< docs/shared "alerts/grafana-managed-alerts.md" >}}
+{{< docs/shared lookup="alerts/grafana-managed-alerts.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -7,8 +7,8 @@ weight: 15
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -13,7 +13,7 @@ weight: 700
 
 # InfluxDB data source
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic explains options, variables, querying, and other options specific to this data source. Refer to [Add a data source]({{< relref "../add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 

--- a/docs/sources/getting-started/getting-started-influxdb.md
+++ b/docs/sources/getting-started/getting-started-influxdb.md
@@ -11,11 +11,11 @@ weight: 250
 
 # Getting started with Grafana and InfluxDB
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 > **Note:** You can also configure a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance to display system metrics without having to host Grafana yourself. Grafana offers a [free account with Grafana Cloud](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) to help you get started.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Get InfluxDB
 

--- a/docs/sources/getting-started/getting-started-prometheus.md
+++ b/docs/sources/getting-started/getting-started-prometheus.md
@@ -18,7 +18,7 @@ Prometheus is an open source monitoring system for which Grafana provides out-of
 
 > **Note:** You can configure a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance to display system metrics without having to host Grafana yourself. A [free forever plan](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) provides 10,000 active series for metrics.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Download Prometheus and node_exporter
 

--- a/docs/sources/getting-started/getting-started-sql.md
+++ b/docs/sources/getting-started/getting-started-sql.md
@@ -18,7 +18,7 @@ weight: 400
 
 Microsoft SQL Server is a popular relational database management system that is widely used in development and production environments. This topic walks you through the steps to create a series of dashboards in Grafana to display metrics from a MS SQL Server database. You can also configure the MS SQL Server data source on a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance without having to host Grafana yourself.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 > **Note:** You must install Grafana 5.1+ in order to use the integrated MS SQL data source.
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -143,7 +143,7 @@ sudo systemctl enable grafana-server.service
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Start the server with init.d
 

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -179,7 +179,7 @@ sudo systemctl enable grafana-server
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 #### Serving Grafana behind a proxy
 

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -9,8 +9,8 @@ weight: 5
 
 Grafana is a complete observability stack that allows you to monitor and analyze metrics, logs and traces. It allows you to query, visualize, alert on and understand your data no matter where it is stored. Create, explore, and share beautiful dashboards with your team and foster a data driven culture. For more information, refer to [Grafana overview](https://grafana.com/grafana/). Our observability stack has the following products and components.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/linking/panel-links.md
+++ b/docs/sources/linking/panel-links.md
@@ -15,7 +15,7 @@ weight: 300
 
 # Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
+{{< docs/shared lookup="panels/panel-links-intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Click the icon on the top left corner of a panel to see available panel links.
 

--- a/docs/sources/manage-users/manage-teams/index.md
+++ b/docs/sources/manage-users/manage-teams/index.md
@@ -21,7 +21,7 @@ Teams members are assigned one of two permissions:
 
 See the complete list of teams in your Grafana organization.
 
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Org Admin view
 
@@ -36,7 +36,7 @@ See the complete list of teams in your Grafana organization.
 Add a team to your Grafana organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **New Team**.
 1. Enter team information:
@@ -50,7 +50,7 @@ Add a team to your Grafana organization.
 Add an existing user account to a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team that you want to add users to.
 1. Click **Add member**.
@@ -66,7 +66,7 @@ Add an existing user account to a team.
 Remove a user account from the team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team that you want to remove users from.
 1. Click the red **X** next to the name of the user that you want to remove from the team and then click **Delete**.
@@ -77,7 +77,7 @@ Remove a user account from the team.
 Change team member permission levels.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team in which you want to change user permissions.
 1. In the team member list, find and click the user account that you want to change. You can use the search field to filter the list if necessary.
@@ -91,7 +91,7 @@ Change team member permission levels.
 Permanently delete the team and all special permissions assigned to it.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the red **X** next to the team that you want to delete and then click **Delete**.
    {{< /docs/list >}}

--- a/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
@@ -15,7 +15,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of organizations set up on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all organizations set up on the server, listed in alphabetical order by organization name. The following information is displayed:
 
@@ -30,7 +30,7 @@ Add an organization to your Grafana server.
 
 {{< docs/list >}}
 
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **+ New org**.
 1. Enter the name of the new organization and then click **Create**.
@@ -51,7 +51,7 @@ Permanently remove an organization from your Grafana server.
 **Warning:** Deleting the organization also deletes all teams and dashboards for this organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the red **X** next to the organization that you want to remove.
 1. Click **Delete**.
@@ -68,7 +68,7 @@ Grafana Server Admins can perform some organization management tasks that are al
 See which user accounts are assigned to the organization and their assigned roles.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the organization for which you want to view members.
 1. Scroll down to the Organization Users section. User accounts are displayed in alphabetical order.
@@ -77,7 +77,7 @@ See which user accounts are assigned to the organization and their assigned role
 ### Change organization name
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the **Name** field, type the new organization name.
 1. Click **Update**.
@@ -88,7 +88,7 @@ See which user accounts are assigned to the organization and their assigned role
 Change the organization role assigned to a user account that is assigned to the organization you are editing.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. In the **Role** field, select the new role that you want to assign.
@@ -97,7 +97,7 @@ Change the organization role assigned to a user account that is assigned to the 
 ## Remove a user from an organization
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. Click the red **X** next to the user account listing and then click **Delete**.

--- a/docs/sources/manage-users/server-admin/server-admin-manage-users.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-users.md
@@ -18,7 +18,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of users with accounts on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all user accounts on the server, listed in alphabetical order by user name. The following information is displayed:
 
@@ -36,7 +36,7 @@ Grafana displays all user accounts on the server, listed in alphabetical order b
 See all details associated with a specific user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the user account you wish to view. If necessary, use the search field at the top of the tab to search for the specific user account that you need.
    {{< /docs/list >}}
@@ -77,7 +77,7 @@ See recent sessions that the user was logged on, including when they logged on a
 Create a new user account at the server level.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **New user**.
 1. Enter the following information:
@@ -101,7 +101,7 @@ Change information or settings in an individual user account.
 Edit information on an existing user account, including the user name, email, username, and password.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the User information section, click **Edit** next to the field that you want to change.
 1. Enter the new value and then click **Save**.
@@ -112,7 +112,7 @@ Edit information on an existing user account, including the user name, email, us
 Users can change their own passwords, but Server Admins can change user passwords as well.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the User information section, click **Edit** next to the **Password** field.
 1. Enter the new value and then click **Save**. Grafana requires a value at least four characters long in this field.
@@ -123,7 +123,7 @@ Users can change their own passwords, but Server Admins can change user password
 Permanently remove a user account from the server.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Delete User**.
 1. Click **Delete user** to confirm the action.
@@ -138,7 +138,7 @@ Temporarily turn on or off account access, but do not remove the account from th
 Prevent a user from logging in with this account, but do not delete the account. You might disable an account if a colleague goes on sabbatical.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Disable User**.
 1. Click **Disable user** to confirm the action.
@@ -149,7 +149,7 @@ Prevent a user from logging in with this account, but do not delete the account.
 Reactivate a disabled user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Enable User**.
    {{< /docs/list >}}
@@ -159,7 +159,7 @@ Reactivate a disabled user account.
 Give or remove the Grafana Server Admin role from a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Permissions section, click **Change**.
 1. Click **Yes** or **No**, depending on whether or not you want this user account to have the Grafana Server Admin role.
@@ -173,7 +173,7 @@ The next time this user logs in, their permissions will be updated.
 Add a user account to an existing organization. User accounts can belong to multiple organizations, but each user account must belong to at least one organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Add user to organisation**.
 1. In the **Add to an organization** window, select the **Organisation** that you are adding the user to.
@@ -186,7 +186,7 @@ Add a user account to an existing organization. User accounts can belong to mult
 Remove a user account from an organization that it is currently assigned to.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Remove from organisation** next to the organization that you want to remove the user from.
 1. Click **Confirm removal**.
@@ -197,7 +197,7 @@ Remove a user account from an organization that it is currently assigned to.
 Change the organization role assigned to a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Change role** next to the organization that you want to change the user role for.
 1. Select the new role and then click **Save**.
@@ -208,7 +208,7 @@ Change the organization role assigned to a user account.
 See when a user last logged in and information about how they logged in. You can also force the account to log out of Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section to view sessions associated with this user account.
    {{< /docs/list >}}
@@ -222,7 +222,7 @@ If you suspect a user account is compromised or is no longer authorized to acces
 Log the user account out of one specific device that is logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section.
 1. Click **Force logout** next to the session entry that you want logged out of Grafana.
@@ -234,7 +234,7 @@ Log the user account out of one specific device that is logged in to Grafana.
 Log the user account out of all devices that are logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section.
 1. Click **Force logout from all devices**.

--- a/docs/sources/panels/working-with-panels/add-link-to-panel.md
+++ b/docs/sources/panels/working-with-panels/add-link-to-panel.md
@@ -7,6 +7,6 @@ weight: 60
 
 # Add a link to a panel
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
+{{< docs/shared lookup="panels/panel-links-intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 For more information, refer to [Panel links]({{< relref "../../linking/panel-links.md" >}}).

--- a/docs/sources/shared/example.md
+++ b/docs/sources/shared/example.md
@@ -11,7 +11,7 @@ When you have a chunk of text or steps that stand alone, not part of an ordered 
 The syntax to invoke this file would be the following, minus the backslash:
 
 ```
-\{{< docs/shared "example.md" >}}
+\{{< docs/shared lookup="example.md" source="grafana" version="<GRAFANA VERSION>" >}}
 ```
 
 ## Part of a list
@@ -24,7 +24,7 @@ Below is an example from the docs, with backslashes added. The initial spaces ar
 
 ```
 \{{< docs/list >}}
-  \{{< docs/shared "manage-users/view-server-user-list.md" >}}
+  \{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 \{{< /docs/list >}}
 ```
@@ -36,7 +36,7 @@ You cannot use short codes in an ordered list with sublists. The shortcode break
 All unordered list steps included as part of a list will appear as second-level lists (with the hollow circle bullet) rather than first-level lists (solid circle bullet), even if the list is not indented in the shared file or the document file.
 
 {{< docs/list >}}
-{{< docs/shared "test.md" >}}
+{{< docs/shared lookup="test.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 - Bullet text
   {{< /docs/list >}}

--- a/docs/sources/visualizations/bar-chart.md
+++ b/docs/sources/visualizations/bar-chart.md
@@ -98,9 +98,9 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/histogram.md
+++ b/docs/sources/visualizations/histogram.md
@@ -65,9 +65,9 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/pie-chart-panel.md
+++ b/docs/sources/visualizations/pie-chart-panel.md
@@ -71,9 +71,9 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend values
 

--- a/docs/sources/visualizations/state-timeline.md
+++ b/docs/sources/visualizations/state-timeline.md
@@ -61,4 +61,4 @@ The panel can be used with time series data as well. In this case, the threshold
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Apply color to a series and fields]({{< relref "../panels/working-with-panels/apply-color-to-series.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/visualizations/status-history.md
+++ b/docs/sources/visualizations/status-history.md
@@ -58,4 +58,4 @@ use gradient color schemes to color values.
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` as referenced in [Apply color to a series and fields]({{< relref "../panels/working-with-panels/apply-color-to-series.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/visualizations/time-series/_index.md
+++ b/docs/sources/visualizations/time-series/_index.md
@@ -24,9 +24,9 @@ Time series visualization is the default and primary way to visualize time serie
 
 These options are available whether you are graphing your time series as lines, bars, or points.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-bars.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-bars.md
@@ -142,9 +142,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/bar-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Bar graph examples
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-lines.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-lines.md
@@ -207,9 +207,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/line-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Fill below to
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-points.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-points.md
@@ -43,6 +43,6 @@ Point size set to 35:
 
 ![Show points point size 35 example](/static/img/docs/time-series-panel/points-graph-show-points-35-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}


### PR DESCRIPTION
Previously, an empty version was inferred from the relative permalink for the page. Although the behavior was similar to the other version inference done in shortcodes like `docs/reference`, it did not allow specifying an empty version needed to include content from unversioned documentation.

For consistency with other shortcodes like `docs/reference`, the `docs/shared` shortcode version lookup has been replaced with the following behavior:

1. If `version=""`, use an empty version.
1. If `version="<SOMETHING VERSION>`, use version inference as described in https://grafana.com/docs/writers-toolkit/write/shortcodes/#docsreference-shortcode:~:text=The%20path%20to,becomes%20GRAFANA%20CLOUD..
1. If `version="ANYTHING ELSE"`, use that literal value.
