### PR TITLE
Plugins: Allow async panel migrations

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -137,7 +137,9 @@ export interface PanelEditorProps<T = any> {
 /**
  * Called when a panel is first loaded with current panel model
  */
-export type PanelMigrationHandler<TOptions = any> = (panel: PanelModel<TOptions>) => Partial<TOptions>;
+export type PanelMigrationHandler<TOptions = any> = (
+  panel: PanelModel<TOptions>
+) => Partial<TOptions> | Promise<Partial<TOptions>>;
 
 /**
  * Called before a panel is initialized. Allows panel inspection for any updates before changing the panel type.

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -135,7 +135,8 @@ export interface PanelEditorProps<T = any> {
 }
 
 /**
- * Called when a panel is first loaded with current panel model
+ * Called when a panel is first loaded with current panel model to migrate panel options if needed.
+ * Can return panel options, or a Promise that resolves to panel options for async migrations
  */
 export type PanelMigrationHandler<TOptions = any> = (
   panel: PanelModel<TOptions>

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -132,14 +132,14 @@ describe('DashboardPrompt', () => {
       });
     });
 
-    it('Should ignore panel schema migrations', () => {
+    it('Should ignore panel schema migrations', async () => {
       const { original, dash } = getTestContext();
       const plugin = getPanelPlugin({}).setMigrationHandler((panel) => {
         delete (panel as any).legend;
         return { option1: 'Aasd' };
       });
 
-      dash.panels[0].pluginLoaded(plugin);
+      await dash.panels[0].pluginLoaded(plugin);
       expect(hasChanges(dash, original)).toBe(false);
     });
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -436,7 +436,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.options = options.options;
   }
 
-  pluginLoaded(plugin: PanelPlugin) {
+  async pluginLoaded(plugin: PanelPlugin) {
     this.plugin = plugin;
 
     const version = getPluginVersion(plugin);
@@ -458,7 +458,8 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     if (plugin.onPanelMigration) {
       if (version !== this.pluginVersion) {
-        this.options = plugin.onPanelMigration(this);
+        const newPanelOptions = plugin.onPanelMigration(this);
+        this.options = await newPanelOptions;
         this.pluginVersion = version;
       }
     }

--- a/public/app/features/dashboard/utils/panel.test.ts
+++ b/public/app/features/dashboard/utils/panel.test.ts
@@ -83,9 +83,9 @@ describe('applyPanelTimeOverrides', () => {
     expect(height).toBe(82);
   });
 
-  it('Calculate panel height with panel plugin zeroChromePadding', () => {
+  it('Calculate panel height with panel plugin zeroChromePadding', async () => {
     const panelModel = new PanelModel({});
-    panelModel.pluginLoaded(
+    await panelModel.pluginLoaded(
       getPanelPlugin({ id: 'table' }, null as unknown as ComponentClass<PanelProps>, null).setNoPadding()
     );
 

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -30,7 +30,7 @@ export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
     }
 
     if (!panel.plugin) {
-      panel.pluginLoaded(plugin);
+      await panel.pluginLoaded(plugin);
     }
 
     dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
@@ -120,7 +120,7 @@ export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryEle
         plugin = await dispatch(loadPanelPlugin(newPluginId));
       }
 
-      panel.pluginLoaded(plugin);
+      await panel.pluginLoaded(plugin);
       panel.generateNewKey();
 
       await dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));


### PR DESCRIPTION
**What is this feature?**

Allows for panel plugins to declare async migrations, as well as sync. This is useful if the migration needs to refer to an API to migrate it's data, such as converting ID to UID in https://github.com/grafana/grafana/issues/73553

**Who is this feature for?**

Panel plugin developers :)

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/73553

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
