### PR TITLE
InfluxDB: Remove access mode configuration from docs

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -46,13 +46,13 @@ To configure basic settings for the data source, complete the following steps:
 
 1.  Set the data source's basic configuration options carefully:
 
-    | Name                  | Description                                                                                                                                                                                                  |
-    | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-    | **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
-    | **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
-    | **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |
-    | **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                                     |
-    | **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
+| Name                  | Description                                                                                                                                                                                                  |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
+| **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
+| **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |  
+| **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                                     |
+| **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
 
 You can also configure settings specific to the InfluxDB data source. These options are described in the sections below.
 
@@ -63,7 +63,7 @@ The **Min time interval** setting defines a lower limit for the auto group-by ti
 This value _must_ be formatted as a number followed by a valid time identifier:
 
 | Identifier | Description |
-| ---------- | ----------- |
+|------------|-------------|
 | `y`        | year        |
 | `M`        | month       |
 | `w`        | week        |
@@ -102,8 +102,7 @@ Though not required, we recommend that you append your query language choice to 
 Configure these options if you select the InfluxQL (classic InfluxDB) query language:
 
 | Name                | Description                                                                                                                                                                                         |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Access**          | Only Server access mode is functional. Direct browser access is deprecated.                                                                                                                         |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Allowed cookies** | Defines which cookies are forwarded to the data source. All other cookies are deleted.                                                                                                              |
 | **Database**        | Sets the ID of the bucket to query. Copy this from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.                            |
 | **User**            | Sets the username to sign into InfluxDB.                                                                                                                                                            |
@@ -114,11 +113,11 @@ Configure these options if you select the InfluxQL (classic InfluxDB) query lang
 
 Configure these options if you select the Flux query language:
 
-| Name               | Description                                                                                                                                                                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Organization**   | The [Influx organization](https://v2.docs.influxdata.com/v2.0/organizations/) that will be used for Flux queries. This is also used to for the `v.organization` query macro.                                                             |
-| **Token**          | The authentication token used for Flux queries. With Influx 2.0, use the [influx authentication token to function](https://v2.docs.influxdata.com/v2.0/security/tokens/create-token/). For influx 1.8, the token is `username:password`. |
-| **Default bucket** | _(Optional)_ The [Influx bucket](https://v2.docs.influxdata.com/v2.0/organizations/buckets/) that will be used for the `v.defaultBucket` macro in Flux queries.                                                                          |
+| Name               | Description                                                                                                                                                                                                                                                                                                                     |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Organization**   | The [Influx organization](https://v2.docs.influxdata.com/v2.0/organizations/) that will be used for Flux queries. This is also used to for the `v.organization` query macro.                                                                                                                                                    |
+| **Token**          | The authentication token used for Flux queries. With Influx 2.0, use the [influx authentication token to function](https://v2.docs.influxdata.com/v2.0/security/tokens/create-token/).  Token must be set as `Authorization` header with the value `Token <geenrated-token>`. For influx 1.8, the token is `username:password`. |
+| **Default bucket** | _(Optional)_ The [Influx bucket](https://v2.docs.influxdata.com/v2.0/organizations/buckets/) that will be used for the `v.defaultBucket` macro in Flux queries.                                                                                                                                                                 |
 
 ### Provision the data source
 

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -47,10 +47,10 @@ To configure basic settings for the data source, complete the following steps:
 1.  Set the data source's basic configuration options carefully:
 
 | Name                  | Description                                                                                                                                                                                                  |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
 | **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
-| **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |  
+| **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |
 | **Min time interval** | _(Optional)_ Refer to [Min time interval](#configure-min-time-interval).                                                                                                                                     |
 | **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
 
@@ -63,7 +63,7 @@ The **Min time interval** setting defines a lower limit for the auto group-by ti
 This value _must_ be formatted as a number followed by a valid time identifier:
 
 | Identifier | Description |
-|------------|-------------|
+| ---------- | ----------- |
 | `y`        | year        |
 | `M`        | month       |
 | `w`        | week        |
@@ -102,7 +102,7 @@ Though not required, we recommend that you append your query language choice to 
 Configure these options if you select the InfluxQL (classic InfluxDB) query language:
 
 | Name                | Description                                                                                                                                                                                         |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Allowed cookies** | Defines which cookies are forwarded to the data source. All other cookies are deleted.                                                                                                              |
 | **Database**        | Sets the ID of the bucket to query. Copy this from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.                            |
 | **User**            | Sets the username to sign into InfluxDB.                                                                                                                                                            |
@@ -113,11 +113,11 @@ Configure these options if you select the InfluxQL (classic InfluxDB) query lang
 
 Configure these options if you select the Flux query language:
 
-| Name               | Description                                                                                                                                                                                                                                                                                                                     |
-|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Organization**   | The [Influx organization](https://v2.docs.influxdata.com/v2.0/organizations/) that will be used for Flux queries. This is also used to for the `v.organization` query macro.                                                                                                                                                    |
-| **Token**          | The authentication token used for Flux queries. With Influx 2.0, use the [influx authentication token to function](https://v2.docs.influxdata.com/v2.0/security/tokens/create-token/).  Token must be set as `Authorization` header with the value `Token <geenrated-token>`. For influx 1.8, the token is `username:password`. |
-| **Default bucket** | _(Optional)_ The [Influx bucket](https://v2.docs.influxdata.com/v2.0/organizations/buckets/) that will be used for the `v.defaultBucket` macro in Flux queries.                                                                                                                                                                 |
+| Name               | Description                                                                                                                                                                                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Organization**   | The [Influx organization](https://v2.docs.influxdata.com/v2.0/organizations/) that will be used for Flux queries. This is also used to for the `v.organization` query macro.                                                                                                                                                   |
+| **Token**          | The authentication token used for Flux queries. With Influx 2.0, use the [influx authentication token to function](https://v2.docs.influxdata.com/v2.0/security/tokens/create-token/). Token must be set as `Authorization` header with the value `Token <geenrated-token>`. For influx 1.8, the token is `username:password`. |
+| **Default bucket** | _(Optional)_ The [Influx bucket](https://v2.docs.influxdata.com/v2.0/organizations/buckets/) that will be used for the `v.defaultBucket` macro in Flux queries.                                                                                                                                                                |
 
 ### Provision the data source
 


### PR DESCRIPTION
**What is this feature?**

Removing deprecated feature information from documentation. Also adds more explanation for setting a `token`. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/73106

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
