### PR TITLE
Bug(sqlstore): fix issue with postgres unable to find existing main organization

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -146,8 +146,6 @@ func verifyExistingOrg(sess *DBSession, orgId int64) error {
 
 func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, error) {
 	var org org.Org
-	org.Created = time.Now()
-	org.Updated = org.Created
 
 	if ss.Cfg.AutoAssignOrg {
 		has, err := sess.Where("id=?", ss.Cfg.AutoAssignOrgId).Get(&org)
@@ -167,6 +165,8 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 		}
 
 		org.Name = mainOrgName
+		org.Created = time.Now()
+		org.Updated = org.Created
 		org.ID = int64(ss.Cfg.AutoAssignOrgId)
 		if err := sess.InsertId(&org, ss.Dialect); err != nil {
 			ss.log.Error("failed to insert organization with provided id", "org_id", org.ID, "err", err)

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -178,6 +178,8 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 		}
 	} else {
 		org.Name = orgName
+		org.Created = time.Now()
+		org.Updated = org.Created
 		if _, err := sess.InsertOne(&org); err != nil {
 			return 0, err
 		}

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,0 +1,40 @@
+package sqlstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testing a regression which shows up when the main org is created, but not the
+// admin user: getOrCreateOrg was unable to find the existing org.
+// https://github.com/grafana/grafana/issues/71781
+func TestIntegrationGetOrCreateOrg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ss := InitTestDB(t)
+
+	err := ss.WithNewDbSession(context.Background(), func(sess *DBSession) error {
+		// Create the org only:
+		ss.Cfg.AutoAssignOrg = true
+		ss.Cfg.DisableInitAdminCreation = true
+		ss.Cfg.AutoAssignOrgId = 1
+		createdOrgID, err := ss.getOrCreateOrg(sess, mainOrgName)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), createdOrgID)
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = ss.WithNewDbSession(context.Background(), func(sess *DBSession) error {
+		// Run it a second time and verify that it finds the org that was
+		// created above.
+		gotOrgId, err := ss.getOrCreateOrg(sess, mainOrgName)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), gotOrgId)
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/grafana/grafana/pull/64763 which resulted in an interesting edge case: Grafana, running with a Postgres database, with the default organization created but not the default admin user, would fail to restart after a successful initial run. In that setup, the first time Grafana is restarted, `getOrCreateOrg` gets called because the user does not exist, and then (again, just in Postgres!) does not find the (very clearly existing) org.

I confirmed the bug and this patch locally, but the test I added didn't actually fail (when run as a Postgres integration test) before this patch was added (I'm leaving it in because it isn't the worst unit test I've ever written). I'm not happy that I haven't yet managed to reproduce the actual error inside the test, and I'd welcome any suggestions (I'll put my whole thought process below).

Fixes #71781

-----
Bug weirdness:
This error occurs when `ensureMainOrgAndUser` fails to find the existing organization, tries to create said org, and then runs into an error because said org already exists. This patch fixes the issue that Postgres could not find the existing org because we called `Get` with a struct that had the created and updated fields pre-populated.

But why is this even returning an error? We clearly trigger the code path that ignores the [unique constraint error](https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/user.go#L174) and returns nil, yet when I run this locally, `ensureMainOrgAndUser` reports that the transaction returned an error: `"pq: Could not complete operation in a failed transaction"`. Is xorm, Postgres, or our DBSession-related code silently _saving_ this error somewhere, instead of the usual silently ignoring it? That seems unlikely, but I'm running out of ideas. 

My custom.ini to reproduce this (+ postgres db config, not shown)
```custom.ini
[security]
disable_initial_admin_creation = true
```

Here's the log output from a failed startup, built from main, with a bit of extra logging added by me to confirm that `getOrCreateOrg` returned nil - `"Organization already exists, ignoring error"`  :

```
DEBUG[08-28|09:43:56] Ensuring main org and admin user exist   logger=sqlstore
DEBUG[08-28|09:43:56] Creating default org                     logger=sqlstore name="Main Org."
DEBUG[08-28|09:43:56] auto assigned organization not found     logger=sqlstore
ERROR[08-28|09:43:56] failed to insert organization with provided id logger=sqlstore org_id=1 err="pq: duplicate key value violates unique constraint \"org_pkey\""
INFO [08-28|09:43:56] Organization already exists, ignoring error logger=sqlstore
INFO [08-28|09:43:56] Created default organization             logger=sqlstore
ERROR[08-28|09:43:56] Critical error                           logger=cli reason="pq: Could not complete operation in a failed transaction"
```  