### PR TITLE
Alerting: Update provisioning to validate user-defined UID on create

### DIFF
--- a/conf/provisioning/alerting/sample.yaml
+++ b/conf/provisioning/alerting/sample.yaml
@@ -82,7 +82,7 @@ apiVersion: 1
 #     # <string, required> name of the contact point
 #     name: cp_1
 #     receivers:
-#       # <string, required> unique identifier for the receiver
+#       # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
 #     - uid: first_uid
 #       # <string, required> type of the receiver
 #       type: prometheus-alertmanager

--- a/conf/provisioning/alerting/sample.yaml
+++ b/conf/provisioning/alerting/sample.yaml
@@ -13,7 +13,7 @@ apiVersion: 1
 #     interval: 60s
 #     # <list, required> list of rules that are part of the rule group
 #     rules:
-#       # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
+#       # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
 #     - uid: my_id_1
 #       # <string, required> title of the rule, will be displayed in the UI
 #       title: my_first_rule
@@ -82,7 +82,7 @@ apiVersion: 1
 #     # <string, required> name of the contact point
 #     name: cp_1
 #     receivers:
-#       # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
+#       # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
 #     - uid: first_uid
 #       # <string, required> type of the receiver
 #       type: prometheus-alertmanager

--- a/conf/provisioning/alerting/sample.yaml
+++ b/conf/provisioning/alerting/sample.yaml
@@ -13,7 +13,7 @@ apiVersion: 1
 #     interval: 60s
 #     # <list, required> list of rules that are part of the rule group
 #     rules:
-#       # <string, required> unique identifier for the rule
+#       # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
 #     - uid: my_id_1
 #       # <string, required> title of the rule, will be displayed in the UI
 #       title: my_first_rule

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -45,7 +45,7 @@ datasources:
 
   - name: gdev-alertmanager
     type: alertmanager
-    uid: gdev-alertmanager12312312312312=234234322
+    uid: gdev-alertmanager
     access: proxy
     url: http://localhost:9093
     jsonData:

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -45,7 +45,7 @@ datasources:
 
   - name: gdev-alertmanager
     type: alertmanager
-    uid: gdev-alertmanager
+    uid: gdev-alertmanager12312312312312=234234322
     access: proxy
     url: http://localhost:9093
     jsonData:

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -158,7 +158,7 @@ contactPoints:
     # <string, required> name of the contact point
     name: cp_1
     receivers:
-      # <string, required> unique identifier for the receiver
+      # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
       - uid: first_uid
         # <string, required> type of the receiver
         type: prometheus-alertmanager

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -65,7 +65,7 @@ groups:
     interval: 60s
     # <list, required> list of rules that are part of the rule group
     rules:
-      # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
+      # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
       - uid: my_id_1
         # <string, required> title of the rule that will be displayed in the UI
         title: my_first_rule
@@ -158,7 +158,7 @@ contactPoints:
     # <string, required> name of the contact point
     name: cp_1
     receivers:
-      # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
+      # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
       - uid: first_uid
         # <string, required> type of the receiver
         type: prometheus-alertmanager

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -65,7 +65,7 @@ groups:
     interval: 60s
     # <list, required> list of rules that are part of the rule group
     rules:
-      # <string, required> unique identifier for the rule
+      # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Allowed only letters, numbers, - (hyphen), and _ (underscore).
       - uid: my_id_1
         # <string, required> title of the rule that will be displayed in the UI
         title: my_first_rule

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -33,6 +33,7 @@ import (
 	secrets_fakes "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -283,7 +284,7 @@ func TestProvisioningApi(t *testing.T) {
 
 			t.Run("PUT sets expected fields with no provenance", func(t *testing.T) {
 				sut := createProvisioningSrvSut(t)
-				uid := t.Name()
+				uid := util.GenerateShortUID()
 				rule := createTestAlertRule("rule", 1)
 				rule.UID = uid
 				insertRuleInOrg(t, sut, rule, 3)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2631,6 +2631,9 @@
      "type": "string"
     },
     "uid": {
+     "maxLength": 40,
+     "minLength": 1,
+     "pattern": "^[a-zA-Z0-9-_]+$",
      "type": "string"
     },
     "updated": {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -94,7 +94,11 @@ type AlertRuleHeaders struct {
 type ProvisionedAlertRules []ProvisionedAlertRule
 
 type ProvisionedAlertRule struct {
-	ID  int64  `json:"id"`
+	ID int64 `json:"id"`
+	// required: false
+	// minLength: 1
+	// maxLength: 40
+	// pattern: ^[a-zA-Z0-9-_]+$
 	UID string `json:"uid"`
 	// required: true
 	OrgID int64 `json:"orgID"`

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -81,6 +81,10 @@ type ContactPoints []EmbeddedContactPoint
 type EmbeddedContactPoint struct {
 	// UID is the unique identifier of the contact point. The UID can be
 	// set by the user.
+	// required: false
+	// minLength: 1
+	// maxLength: 40
+	// pattern: ^[a-zA-Z0-9\-\_]+$
 	// example: my_external_reference
 	UID string `json:"uid"`
 	// Name is used as grouping key in the UI. Contact points with the

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -764,6 +764,9 @@
     "uid": {
      "description": "UID is the unique identifier of the contact point. The UID can be\nset by the user.",
      "example": "my_external_reference",
+     "maxLength": 40,
+     "minLength": 1,
+     "pattern": "^[a-zA-Z0-9\\-\\_]+$",
      "type": "string"
     }
    },
@@ -2631,6 +2634,9 @@
      "type": "string"
     },
     "uid": {
+     "maxLength": 40,
+     "minLength": 1,
+     "pattern": "^[a-zA-Z0-9-_]+$",
      "type": "string"
     },
     "updated": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3613,6 +3613,9 @@
         "uid": {
           "description": "UID is the unique identifier of the contact point. The UID can be\nset by the user.",
           "type": "string",
+          "maxLength": 40,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9\\-\\_]+$",
           "example": "my_external_reference"
         }
       }

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5490,7 +5490,10 @@
           "example": "Always firing"
         },
         "uid": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 40,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9-_]+$"
         },
         "updated": {
           "type": "string",

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -112,6 +112,10 @@ func (service *AlertRuleService) GetAlertRuleWithFolderTitle(ctx context.Context
 func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule models.AlertRule, provenance models.Provenance, userID int64) (models.AlertRule, error) {
 	if rule.UID == "" {
 		rule.UID = util.GenerateShortUID()
+	} else {
+		if !util.IsValidShortUID(rule.UID) {
+			return models.AlertRule{}, errors.New("invalid UID. ")
+		}
 	}
 	interval, err := service.ruleStore.GetRuleGroupInterval(ctx, rule.OrgID, rule.NamespaceUID, rule.RuleGroup)
 	// if the alert group does not exists we just use the default interval

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -112,10 +112,8 @@ func (service *AlertRuleService) GetAlertRuleWithFolderTitle(ctx context.Context
 func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule models.AlertRule, provenance models.Provenance, userID int64) (models.AlertRule, error) {
 	if rule.UID == "" {
 		rule.UID = util.GenerateShortUID()
-	} else {
-		if !util.IsValidShortUID(rule.UID) {
-			return models.AlertRule{}, errors.New("invalid UID. ")
-		}
+	} else if err := util.ValidateUID(rule.UID); err != nil {
+		return models.AlertRule{}, errors.Join(models.ErrAlertRuleFailedValidation, fmt.Errorf("cannot create rule with UID '%s': %w", rule.UID, err))
 	}
 	interval, err := service.ruleStore.GetRuleGroupInterval(ctx, rule.OrgID, rule.NamespaceUID, rule.RuleGroup)
 	// if the alert group does not exists we just use the default interval

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -190,6 +191,8 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 
 	if contactPoint.UID == "" {
 		contactPoint.UID = util.GenerateShortUID()
+	} else if err := util.ValidateUID(contactPoint.UID); err != nil {
+		return apimodels.EmbeddedContactPoint{}, errors.Join(ErrValidation, fmt.Errorf("cannot create contact point with UID '%s': %w", contactPoint.UID, err))
 	}
 
 	jsonData, err := contactPoint.Settings.MarshalJSON()

--- a/pkg/util/shortid_generator.go
+++ b/pkg/util/shortid_generator.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
 	"regexp"
 	"sync"
@@ -9,9 +11,16 @@ import (
 	"github.com/google/uuid"
 )
 
+const MaxUIDLength = 40
+
 var uidrand = rand.New(rand.NewSource(time.Now().UnixNano()))
 var alphaRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 var hexLetters = []rune("abcdef")
+
+var (
+	ErrUIDTooLong       = fmt.Errorf("UID is longer than %d symbols", MaxUIDLength)
+	ErrUIDFormatInvalid = errors.New("invalid format of UID. Only letters, numbers, '-' and '_' are allowed")
+)
 
 // We want to protect our number generator as they are not thread safe. Not using
 // the mutex could result in panics in certain cases where UIDs would be generated
@@ -29,7 +38,7 @@ func IsValidShortUID(uid string) bool {
 
 // IsShortUIDTooLong checks if short unique identifier is too long
 func IsShortUIDTooLong(uid string) bool {
-	return len(uid) > 40
+	return len(uid) > MaxUIDLength
 }
 
 // GenerateShortUID will generate a UUID that can also be a k8s name
@@ -50,4 +59,15 @@ func GenerateShortUID() string {
 		return string(hexLetters[uidrand.Intn(len(hexLetters))]) + uuid[1:]
 	}
 	return uuid
+}
+
+// ValidateUID checks the format and length of the string and returns error if it does not pass the condition
+func ValidateUID(uid string) error {
+	if IsShortUIDTooLong(uid) {
+		return ErrUIDTooLong
+	}
+	if !IsValidShortUID(uid) {
+		return ErrUIDFormatInvalid
+	}
+	return nil
 }

--- a/pkg/util/shortid_generator.go
+++ b/pkg/util/shortid_generator.go
@@ -20,6 +20,7 @@ var hexLetters = []rune("abcdef")
 var (
 	ErrUIDTooLong       = fmt.Errorf("UID is longer than %d symbols", MaxUIDLength)
 	ErrUIDFormatInvalid = errors.New("invalid format of UID. Only letters, numbers, '-' and '_' are allowed")
+	ErrUIDEmpty         = fmt.Errorf("UID is empty")
 )
 
 // We want to protect our number generator as they are not thread safe. Not using
@@ -63,6 +64,9 @@ func GenerateShortUID() string {
 
 // ValidateUID checks the format and length of the string and returns error if it does not pass the condition
 func ValidateUID(uid string) error {
+	if len(uid) == 0 {
+		return ErrUIDEmpty
+	}
 	if IsShortUIDTooLong(uid) {
 		return ErrUIDTooLong
 	}

--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -98,22 +98,22 @@ func TestValidate(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:     "error when it is empty",
+			name:     "error when string is empty",
 			uid:      "",
 			expected: ErrUIDEmpty,
 		},
 		{
-			name:     "error when it is too long",
+			name:     "error when string is too long",
 			uid:      strings.Repeat("1", MaxUIDLength+1),
 			expected: ErrUIDTooLong,
 		},
 		{
-			name:     "error when it has invalid characters",
+			name:     "error when string has invalid characters",
 			uid:      "f8cc010c.ee72.4681;89d2+d46e1bd47d33",
 			expected: ErrUIDFormatInvalid,
 		},
 		{
-			name:     "error when it has whitespaces",
+			name:     "error when string has only whitespaces",
 			uid:      " ",
 			expected: ErrUIDFormatInvalid,
 		},

--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -86,7 +86,7 @@ func TestIsShortUIDTooLong(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestValidateUID(t *testing.T) {
 	var tests = []struct {
 		name     string
 		uid      string

--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"cuelang.org/go/pkg/strings"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -81,6 +82,40 @@ func TestIsShortUIDTooLong(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, IsShortUIDTooLong(tt.uid))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	var tests = []struct {
+		name     string
+		uid      string
+		expected error
+	}{
+		{
+			name:     "no error when string is of correct length",
+			uid:      "f8cc010c-ee72-4681-89d2-d46e1bd47d33",
+			expected: nil,
+		},
+		{
+			name:     "error when it is too long",
+			uid:      strings.Repeat("1", MaxUIDLength+1),
+			expected: ErrUIDTooLong,
+		},
+		{
+			name:     "error when it has invalid characters",
+			uid:      "f8cc010c.ee72.4681;89d2+d46e1bd47d33",
+			expected: ErrUIDFormatInvalid,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateUID(tt.uid)
+			if tt.expected == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.expected)
+			}
 		})
 	}
 }

--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -98,6 +98,11 @@ func TestValidate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "error when it is empty",
+			uid:      "",
+			expected: ErrUIDEmpty,
+		},
+		{
 			name:     "error when it is too long",
 			uid:      strings.Repeat("1", MaxUIDLength+1),
 			expected: ErrUIDTooLong,
@@ -105,6 +110,11 @@ func TestValidate(t *testing.T) {
 		{
 			name:     "error when it has invalid characters",
 			uid:      "f8cc010c.ee72.4681;89d2+d46e1bd47d33",
+			expected: ErrUIDFormatInvalid,
+		},
+		{
+			name:     "error when it has whitespaces",
+			uid:      " ",
 			expected: ErrUIDFormatInvalid,
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes provisioning service to validate user-assigned UID of alert rule and contact points, and return error if the UID does not meet the requirements. 

Validation does not affect the update operation and therefore, existing resources will not be affected.

**Why do we need this feature?**
To enforce uniform rules for UIDs across all APIs and databases. In SQLite mode, the long UID will be accepted because the field has TEXT type. However, in MySQL and Postgres - the UID will be rejected by the database.

Also, it will help prevent users from getting in trouble while using manually assigned UIDs. For example, UID like `my=abc` will be accepted by provisioning but user will not be able to reach out the rule via UI.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/62904

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
