### PR TITLE
AuthProxy: Fix user retrieval through cache

### DIFF
--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -26,7 +26,7 @@ const (
 	proxyFieldLogin  = "Login"
 	proxyFieldRole   = "Role"
 	proxyFieldGroups = "Groups"
-	proxyCachePrefix = "auth-proxy-sync-ttl"
+	proxyCachePrefix = "authn-proxy-sync-ttl"
 )
 
 var proxyFields = [...]string{proxyFieldName, proxyFieldEmail, proxyFieldLogin, proxyFieldRole, proxyFieldGroups}
@@ -84,7 +84,7 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	if ok {
 		// See if we have cached the user id, in that case we can fetch the signed-in user and skip sync.
 		// Error here means that we could not find anything in cache, so we can proceed as usual
-		if entry, err := c.cache.Get(ctx, cacheKey); err == nil {
+		if entry, err := c.cache.Get(ctx, cacheKey); err == nil && len(entry) == 8 {
 			uid := int64(binary.LittleEndian.Uint64(entry))
 
 			usr, err := c.userSrv.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -2,12 +2,12 @@ package clients
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"hash/fnv"
 	"net"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,8 +84,11 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	if ok {
 		// See if we have cached the user id, in that case we can fetch the signed-in user and skip sync.
 		// Error here means that we could not find anything in cache, so we can proceed as usual
-		if entry, err := c.cache.Get(ctx, cacheKey); err == nil && len(entry) == 8 {
-			uid := int64(binary.LittleEndian.Uint64(entry))
+		if entry, err := c.cache.Get(ctx, cacheKey); err == nil {
+			uid, err := strconv.ParseInt(string(entry), 10, 64)
+			if err != nil {
+				c.log.FromContext(ctx).Warn("failed to parse user id from cache", "error", err, "userId", string(entry))
+			}
 
 			usr, err := c.userSrv.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
 				UserID: uid,
@@ -137,8 +140,7 @@ func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Req
 	}
 
 	c.log.FromContext(ctx).Debug("Cache proxy user", "userId", id)
-	bytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(bytes, uint64(id))
+	bytes := []byte(strconv.FormatInt(id, 10))
 	if err := c.cache.Set(ctx, identity.ClientParams.CacheAuthProxyKey, bytes, time.Duration(c.cfg.AuthProxySyncTTL)*time.Minute); err != nil {
 		c.log.Warn("failed to cache proxy user", "error", err, "userId", id)
 	}


### PR DESCRIPTION
**What is this feature?**
Between 10.0 and 10.1 we made an incompatible change of how user id is encoded for auth proxy sync cache entry.

In 10.0 the user id is encoded by converting the id to a string and then a byte slice and in 10.1 little endian is used.

This fix changes the cache key prefix so all old values will be discarded and revert back to the same encoding used for 10.0

Fixes #73786

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
