### PR TITLE
Update grafana/alerting to 0025eb4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/google/uuid v1.3.0 // @grafana/backend-platform
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20230824074554-e56bbccf8ed2 // @grafana/alerting-squad-backend
+	github.com/grafana/alerting v0.0.0-20230825092312-0025eb4fa8c2 // @grafana/alerting-squad-backend
 	github.com/grafana/cuetsy v0.1.10 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.19.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.7.0 // @grafana/backend-platform

--- a/go.sum
+++ b/go.sum
@@ -1779,6 +1779,8 @@ github.com/grafana/alerting v0.0.0-20230713081622-5aa8a0630b4f h1:rSGdigHMokMwKG
 github.com/grafana/alerting v0.0.0-20230713081622-5aa8a0630b4f/go.mod h1:zEflOvMVchYhRbFb5ziXVR/JG67FOLBzQTjhHh9xaI4=
 github.com/grafana/alerting v0.0.0-20230824074554-e56bbccf8ed2 h1:cXP1s24nZ3pIsImHR7hyGvY+WjQwHjIbL5E6JC/BZrA=
 github.com/grafana/alerting v0.0.0-20230824074554-e56bbccf8ed2/go.mod h1:ZiGFUeBow+S+b4yBKJBQJ+iq9zSXSYphPZ/tI2wtoN0=
+github.com/grafana/alerting v0.0.0-20230825092312-0025eb4fa8c2 h1:628p/+uCVk3A1q+Qjg6cv+bMDxvqXjj7ELRvdoEW4T8=
+github.com/grafana/alerting v0.0.0-20230825092312-0025eb4fa8c2/go.mod h1:ZiGFUeBow+S+b4yBKJBQJ+iq9zSXSYphPZ/tI2wtoN0=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.10 h1:+W9/7roI8LorL+D1RJhKGdhsTZ81adrK9dHS0r7qsXs=

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2531,7 +2531,7 @@ var expNonEmailNotifications = map[string][]string{
 		  "attachments": [
 			{
 			  "title": "Integration Test [FIRING:1] SlackAlert1 (default)",
-			  "title_link": "http://localhost:3000/alerting/list",
+			  "title_link": "http://localhost:3000/alerting/grafana/UID_SlackAlert1/view",
 			  "text": "Integration Test ",
 			  "fallback": "Integration Test [FIRING:1] SlackAlert1 (default)",
 			  "footer": "Grafana v",
@@ -2551,7 +2551,7 @@ var expNonEmailNotifications = map[string][]string{
 		  "attachments": [
 			{
 			  "title": "[FIRING:1] SlackAlert2 (default)",
-			  "title_link": "http://localhost:3000/alerting/list",
+			  "title_link": "http://localhost:3000/alerting/grafana/UID_SlackAlert2/view",
 			  "text": "**Firing**\n\nValue: A=1\nLabels:\n - alertname = SlackAlert2\n - grafana_folder = default\nAnnotations:\nSource: http://localhost:3000/alerting/grafana/UID_SlackAlert2/view?orgId=1\nSilence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=alertname%%3DSlackAlert2&matcher=grafana_folder%%3Ddefault&orgId=1\n",
 			  "fallback": "[FIRING:1] SlackAlert2 (default)",
 			  "footer": "Grafana v",


### PR DESCRIPTION
**What is this feature?**

This commit updates grafana/alerting to [`0025eb4`](https://github.com/grafana/alerting/commit/0025eb4fa8c2b30c46ff84519610a1db9af76ffc).

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
