### PR TITLE
Publish documentation from the HEAD of the matching version branch on tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -55,7 +55,7 @@ jobs:
         # Tags aren't necessarily made to the HEAD of the version branch.
         # The documentation to be published is always on the HEAD of the version branch.
         if: "steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'"
-        run: "git switch --force-create ${{ steps.target.output.target }}.x"
+        run: "git switch --detach origin/${{ steps.target.output.target }}.x"
 
       - name: "Publish to website repository (release)"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -51,6 +51,12 @@ jobs:
         # The IT helpdesk can update the organization secret.
         run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
 
+      - name: "Switch to HEAD of version branch for tags"
+        # Tags aren't necessarily made to the HEAD of the version branch.
+        # The documentation to be published is always on the HEAD of the version branch.
+        if: "steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'"
+        run: "git switch --force-create ${{ steps.target.output.target }}.x"
+
       - name: "Publish to website repository (release)"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"
         uses: "./.github/actions/website-sync"


### PR DESCRIPTION
Tags aren't necessarily made to the HEAD of the version branch.
The documentation that should be published is always on the HEAD of the version branch.

This changes means that there is a mismatch between the code and documentation but that is deemed preferable because the "What's new" documentation is typically added much later than commit the tag targets but is a critical part of the release from a documentation perspective.

Technically, it would be more correct for the "What's new" documentation to be in place before the commit that is tagged.
However, the significant lag between the start of a release and the actual publishing of the tag would be challenging to codify in this action's logic.
It would also require a side channel for non-code related documentation updates to be made to the docs released by the tag.
This would likely require a long lived branch to be created at the tag commit and I'm not sure that the additional work is justified.

In practice, I think we can get away with publishing more recent documentation than the code given the assumption that no significant feature is going to be absent from the initial major/minor release.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
