### PR TITLE
Authz: fix snapshot tests legacy guardian

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -285,11 +285,6 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 	return s
 }
 
-var (
-	viewerRole = org.RoleViewer
-	editorRole = org.RoleEditor
-)
-
 type mockSearchService struct{ ExpectedResult model.HitList }
 
 func (mss *mockSearchService) SearchHandler(_ context.Context, q *search.Query) (model.HitList, error) {

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -121,7 +121,6 @@ func TestHTTPServer_DeleteDashboardSnapshot(t *testing.T) {
 		assert.Equal(t, http.StatusOK, res.StatusCode)
 		require.NoError(t, res.Body.Close())
 	})
-
 }
 
 func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web/webtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -19,10 +23,106 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
+
+func TestHTTPServer_DeleteDashboardSnapshot(t *testing.T) {
+	setup := func(t *testing.T, svc dashboards.DashboardService, userID int64, deleteURL string) *webtest.Server {
+		t.Helper()
+
+		return SetupAPITestServer(t, func(hs *HTTPServer) {
+			cfg := setting.NewCfg()
+			cfg.SnapshotEnabled = true
+			hs.Cfg = cfg
+			hs.dashboardsnapshotsService = setUpSnapshotTest(t, userID, deleteURL)
+
+			hs.DashboardService = svc
+
+			hs.AccessControl = acimpl.ProvideAccessControl(hs.Cfg)
+			guardian.InitAccessControlGuardian(hs.Cfg, hs.AccessControl, hs.DashboardService)
+		})
+	}
+
+	allowedUser := userWithPermissions(1, []accesscontrol.Permission{
+		{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:1"},
+	})
+
+	t.Run("User should not be able to delete snapshot without permissions", func(t *testing.T) {
+		svc := dashboards.NewFakeDashboardService(t)
+		svc.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{UID: "1"}, nil)
+		server := setup(t, svc, 0, "")
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodDelete, "/api/snapshots/12345", nil),
+			&user.SignedInUser{UserID: 1, OrgID: 1},
+		))
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("User should be able to delete snapshot with correct permissions", func(t *testing.T) {
+		svc := dashboards.NewFakeDashboardService(t)
+		svc.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{UID: "1"}, nil)
+
+		server := setup(t, svc, 0, "")
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodDelete, "/api/snapshots/12345", nil),
+			allowedUser,
+		))
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("User should not be able to delete snapshot if fetching dashboard fails", func(t *testing.T) {
+		svc := dashboards.NewFakeDashboardService(t)
+		svc.On("GetDashboard", mock.Anything, mock.Anything).Return(nil, errors.New("some-error"))
+
+		server := setup(t, svc, 0, "")
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodDelete, "/api/snapshots/12345", nil),
+			allowedUser,
+		))
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("User should be able to delete snapshot if connected dashboard no longer exists", func(t *testing.T) {
+		svc := dashboards.NewFakeDashboardService(t)
+		svc.On("GetDashboard", mock.Anything, mock.Anything).Return(nil, dashboards.ErrDashboardNotFound)
+
+		server := setup(t, svc, 0, "")
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodDelete, "/api/snapshots/12345", nil),
+			allowedUser,
+		))
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("User should be able to delete when user is creator but does not have permissions to edit dashboard", func(t *testing.T) {
+		svc := dashboards.NewFakeDashboardService(t)
+		svc.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{UID: "1"}, nil)
+
+		server := setup(t, svc, 1, "")
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodDelete, "/api/snapshots/12345", nil),
+			&user.SignedInUser{UserID: 1, OrgID: 1},
+		))
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+}
 
 func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 	setupRemoteServer := func(fn func(http.ResponseWriter, *http.Request)) *httptest.Server {
@@ -34,60 +134,6 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 	}
 
 	sqlmock := dbtest.NewFakeDB()
-	jsonModel, err := simplejson.NewJson([]byte(`{"id":100}`))
-	require.NoError(t, err)
-
-	setUpSnapshotTest := func(t *testing.T, userId int64, deleteUrl string) dashboardsnapshots.Service {
-		t.Helper()
-
-		dashSnapSvc := dashboardsnapshots.NewMockService(t)
-		dashSnapSvc.On("DeleteDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.DeleteDashboardSnapshotCommand")).Return(nil).Maybe()
-		res := &dashboardsnapshots.DashboardSnapshot{
-			ID:        1,
-			Key:       "12345",
-			DeleteKey: "54321",
-			Dashboard: jsonModel,
-			Expires:   time.Now().Add(time.Duration(1000) * time.Second),
-			UserID:    999999,
-		}
-		if userId != 0 {
-			res.UserID = userId
-		}
-		if deleteUrl != "" {
-			res.External = true
-			res.ExternalDeleteURL = deleteUrl
-		}
-		dashSnapSvc.On("GetDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.GetDashboardSnapshotQuery")).Return(res, nil)
-		dashSnapSvc.On("DeleteDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.DeleteDashboardSnapshotCommand")).Return(nil).Maybe()
-		return dashSnapSvc
-	}
-
-	t.Run("When user has editor role and is not in the ACL", func(t *testing.T) {
-		loggedInUserScenarioWithRole(t, "Should not be able to delete snapshot when calling DELETE on",
-			"DELETE", "/api/snapshots/12345", "/api/snapshots/:key", org.RoleEditor, func(sc *scenarioContext) {
-				d := setUpSnapshotTest(t, 0, "")
-				hs := buildHttpServer(d, true)
-				sc.handlerFunc = hs.DeleteDashboardSnapshot
-
-				teamSvc := &teamtest.FakeService{}
-				dashSvc := dashboards.NewFakeDashboardService(t)
-				var qResult *dashboards.Dashboard
-				dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*dashboards.GetDashboardQuery)
-					qResult = &dashboards.Dashboard{
-						ID:  q.ID,
-						UID: q.UID,
-					}
-				}).Return(qResult, nil).Maybe()
-				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(nil, nil).Maybe()
-				hs.DashboardService = dashSvc
-
-				guardian.InitLegacyGuardian(setting.NewCfg(), sc.sqlStore, dashSvc, teamSvc)
-				sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
-
-				assert.Equal(t, 403, sc.resp.Code)
-			}, sqlmock)
-	})
 
 	t.Run("When user is anonymous", func(t *testing.T) {
 		anonymousUserScenario(t, "Should be able to delete a snapshot when calling GET on", "GET",
@@ -114,113 +160,6 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 				assert.Equal(t, ts.URL, fmt.Sprintf("http://%s", externalRequest.Host))
 				assert.Equal(t, "/", externalRequest.URL.EscapedPath())
 			})
-	})
-
-	t.Run("When user is editor and dashboard has default ACL", func(t *testing.T) {
-		teamSvc := &teamtest.FakeService{}
-		dashSvc := &dashboards.FakeDashboardService{}
-		qResult := []*dashboards.DashboardACLInfoDTO{
-			{Role: &viewerRole, Permission: dashboards.PERMISSION_VIEW},
-			{Role: &editorRole, Permission: dashboards.PERMISSION_EDIT},
-		}
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(qResult, nil)
-
-		loggedInUserScenarioWithRole(t, "Should not be able to delete a snapshot when fetching guardian fails during calling DELETE on", "DELETE",
-			"/api/snapshots/12345", "/api/snapshots/:key", org.RoleEditor, func(sc *scenarioContext) {
-				ts := setupRemoteServer(func(rw http.ResponseWriter, req *http.Request) {
-					rw.WriteHeader(200)
-				})
-				dashSvc := dashboards.NewFakeDashboardService(t)
-				dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(nil, errutil.Error{PublicMessage: "some error"}).Maybe()
-
-				guardian.InitLegacyGuardian(sc.cfg, sc.sqlStore, dashSvc, teamSvc)
-				d := setUpSnapshotTest(t, 0, ts.URL)
-				hs := buildHttpServer(d, true)
-				hs.DashboardService = dashSvc
-				sc.handlerFunc = hs.DeleteDashboardSnapshot
-				sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
-
-				assert.Equal(t, http.StatusInternalServerError, sc.resp.Code)
-			}, sqlmock)
-
-		loggedInUserScenarioWithRole(t, "Should be able to delete a snapshot from a deleted dashboard when calling DELETE on", "DELETE",
-			"/api/snapshots/12345", "/api/snapshots/:key", org.RoleEditor, func(sc *scenarioContext) {
-				var externalRequest *http.Request
-				ts := setupRemoteServer(func(rw http.ResponseWriter, req *http.Request) {
-					rw.WriteHeader(200)
-					externalRequest = req
-				})
-				dashSvc := dashboards.NewFakeDashboardService(t)
-				dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(nil, dashboards.ErrDashboardNotFound).Maybe()
-
-				guardian.InitLegacyGuardian(sc.cfg, sc.sqlStore, dashSvc, teamSvc)
-				d := setUpSnapshotTest(t, 0, ts.URL)
-				hs := buildHttpServer(d, true)
-				hs.DashboardService = dashSvc
-				sc.handlerFunc = hs.DeleteDashboardSnapshot
-				sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
-
-				assert.Equal(t, 200, sc.resp.Code)
-				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
-				require.NoError(t, err)
-
-				assert.True(t, strings.HasPrefix(respJSON.Get("message").MustString(), "Snapshot deleted"))
-				assert.Equal(t, 1, respJSON.Get("id").MustInt())
-				assert.Equal(t, ts.URL, fmt.Sprintf("http://%s", externalRequest.Host))
-				assert.Equal(t, "/", externalRequest.URL.EscapedPath())
-			}, sqlmock)
-
-		loggedInUserScenarioWithRole(t, "Should be able to delete a snapshot when calling DELETE on", "DELETE",
-			"/api/snapshots/12345", "/api/snapshots/:key", org.RoleEditor, func(sc *scenarioContext) {
-				var externalRequest *http.Request
-				ts := setupRemoteServer(func(rw http.ResponseWriter, req *http.Request) {
-					rw.WriteHeader(200)
-					externalRequest = req
-				})
-				dashSvc := dashboards.NewFakeDashboardService(t)
-				qResult := &dashboards.Dashboard{}
-				dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(qResult, nil).Maybe()
-				qResultACL := []*dashboards.DashboardACLInfoDTO{
-					{Role: &viewerRole, Permission: dashboards.PERMISSION_VIEW},
-					{Role: &editorRole, Permission: dashboards.PERMISSION_EDIT},
-				}
-				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(qResultACL, nil)
-				guardian.InitLegacyGuardian(sc.cfg, sc.sqlStore, dashSvc, teamSvc)
-				d := setUpSnapshotTest(t, 0, ts.URL)
-				hs := buildHttpServer(d, true)
-				hs.DashboardService = dashSvc
-				sc.handlerFunc = hs.DeleteDashboardSnapshot
-				sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
-
-				assert.Equal(t, 200, sc.resp.Code)
-				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
-				require.NoError(t, err)
-
-				assert.True(t, strings.HasPrefix(respJSON.Get("message").MustString(), "Snapshot deleted"))
-				assert.Equal(t, 1, respJSON.Get("id").MustInt())
-				assert.Equal(t, ts.URL, fmt.Sprintf("http://%s", externalRequest.Host))
-				assert.Equal(t, "/", externalRequest.URL.EscapedPath())
-			}, sqlmock)
-	})
-
-	t.Run("When user is editor and creator of the snapshot", func(t *testing.T) {
-		loggedInUserScenarioWithRole(t, "Should be able to delete a snapshot when calling DELETE on",
-			"DELETE", "/api/snapshots/12345", "/api/snapshots/:key", org.RoleEditor, func(sc *scenarioContext) {
-				d := setUpSnapshotTest(t, testUserID, "")
-
-				dashSvc := dashboards.NewFakeDashboardService(t)
-				hs := buildHttpServer(d, true)
-				hs.DashboardService = dashSvc
-				sc.handlerFunc = hs.DeleteDashboardSnapshot
-				sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
-
-				assert.Equal(t, 200, sc.resp.Code)
-				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
-				require.NoError(t, err)
-
-				assert.True(t, strings.HasPrefix(respJSON.Get("message").MustString(), "Snapshot deleted"))
-				assert.Equal(t, 1, respJSON.Get("id").MustInt())
-			}, sqlmock)
 	})
 
 	t.Run("When deleting an external snapshot", func(t *testing.T) {
@@ -441,4 +380,32 @@ func buildHttpServer(d dashboardsnapshots.Service, snapshotEnabled bool) *HTTPSe
 		},
 	}
 	return hs
+}
+func setUpSnapshotTest(t *testing.T, userId int64, deleteUrl string) dashboardsnapshots.Service {
+	t.Helper()
+
+	dashSnapSvc := dashboardsnapshots.NewMockService(t)
+	dashSnapSvc.On("DeleteDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.DeleteDashboardSnapshotCommand")).Return(nil).Maybe()
+
+	jsonModel, err := simplejson.NewJson([]byte(`{"id":100}`))
+	require.NoError(t, err)
+
+	res := &dashboardsnapshots.DashboardSnapshot{
+		ID:        1,
+		Key:       "12345",
+		DeleteKey: "54321",
+		Dashboard: jsonModel,
+		Expires:   time.Now().Add(time.Duration(1000) * time.Second),
+		UserID:    999999,
+	}
+	if userId != 0 {
+		res.UserID = userId
+	}
+	if deleteUrl != "" {
+		res.External = true
+		res.ExternalDeleteURL = deleteUrl
+	}
+	dashSnapSvc.On("GetDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.GetDashboardSnapshotQuery")).Return(res, nil)
+	dashSnapSvc.On("DeleteDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.DeleteDashboardSnapshotCommand")).Return(nil).Maybe()
+	return dashSnapSvc
 }

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -842,7 +842,7 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 			foldertest.NewFakeService(),
 		)
 		require.NoError(t, err)
-		guardian.InitAccessControlGuardian(cfg, sqlStore, ac, folderPermissions, dashboardPermissions, dashboardService)
+		guardian.InitAccessControlGuardian(cfg, ac, dashboardService)
 
 		savedFolder := saveTestFolder(t, "Saved folder", testOrgID, sqlStore)
 		savedDashInFolder := saveTestDashboard(t, "Saved dash in folder", testOrgID, savedFolder.ID, sqlStore)

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -18,10 +17,7 @@ var _ DashboardGuardian = new(accessControlDashboardGuardian)
 // NewAccessControlDashboardGuardianByDashboard creates a dashboard guardian by the provided dashboardId.
 func NewAccessControlDashboardGuardian(
 	ctx context.Context, cfg *setting.Cfg, dashboardId int64, user *user.SignedInUser,
-	store db.DB, ac accesscontrol.AccessControl,
-	folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
 ) (DashboardGuardian, error) {
 	var dashboard *dashboards.Dashboard
 	if dashboardId != 0 {
@@ -47,12 +43,10 @@ func NewAccessControlDashboardGuardian(
 				cfg:              cfg,
 				log:              log.New("folder.permissions"),
 				user:             user,
-				store:            store,
 				ac:               ac,
 				dashboardService: dashboardService,
 			},
-			folder:                   dashboards.FromDashboard(dashboard),
-			folderPermissionsService: folderPermissionsService,
+			folder: dashboards.FromDashboard(dashboard),
 		}, nil
 	}
 
@@ -62,22 +56,17 @@ func NewAccessControlDashboardGuardian(
 			cfg:              cfg,
 			log:              log.New("dashboard.permissions"),
 			user:             user,
-			store:            store,
 			ac:               ac,
 			dashboardService: dashboardService,
 		},
-		dashboard:                   dashboard,
-		dashboardPermissionsService: dashboardPermissionsService,
+		dashboard: dashboard,
 	}, nil
 }
 
 // NewAccessControlDashboardGuardianByDashboard creates a dashboard guardian by the provided dashboardUID.
 func NewAccessControlDashboardGuardianByUID(
 	ctx context.Context, cfg *setting.Cfg, dashboardUID string, user *user.SignedInUser,
-	store db.DB, ac accesscontrol.AccessControl,
-	folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
 ) (DashboardGuardian, error) {
 	var dashboard *dashboards.Dashboard
 	if dashboardUID != "" {
@@ -103,12 +92,10 @@ func NewAccessControlDashboardGuardianByUID(
 				cfg:              cfg,
 				log:              log.New("folder.permissions"),
 				user:             user,
-				store:            store,
 				ac:               ac,
 				dashboardService: dashboardService,
 			},
-			folder:                   dashboards.FromDashboard(dashboard),
-			folderPermissionsService: folderPermissionsService,
+			folder: dashboards.FromDashboard(dashboard),
 		}, nil
 	}
 
@@ -118,12 +105,10 @@ func NewAccessControlDashboardGuardianByUID(
 			ctx:              ctx,
 			log:              log.New("dashboard.permissions"),
 			user:             user,
-			store:            store,
 			ac:               ac,
 			dashboardService: dashboardService,
 		},
-		dashboard:                   dashboard,
-		dashboardPermissionsService: dashboardPermissionsService,
+		dashboard: dashboard,
 	}, nil
 }
 
@@ -132,10 +117,7 @@ func NewAccessControlDashboardGuardianByUID(
 // since it avoids querying the database for fetching the dashboard.
 func NewAccessControlDashboardGuardianByDashboard(
 	ctx context.Context, cfg *setting.Cfg, dashboard *dashboards.Dashboard, user *user.SignedInUser,
-	store db.DB, ac accesscontrol.AccessControl,
-	folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
 ) (DashboardGuardian, error) {
 	if dashboard != nil && dashboard.IsFolder {
 		return &accessControlFolderGuardian{
@@ -144,12 +126,10 @@ func NewAccessControlDashboardGuardianByDashboard(
 				cfg:              cfg,
 				log:              log.New("folder.permissions"),
 				user:             user,
-				store:            store,
 				ac:               ac,
 				dashboardService: dashboardService,
 			},
-			folder:                   dashboards.FromDashboard(dashboard),
-			folderPermissionsService: folderPermissionsService,
+			folder: dashboards.FromDashboard(dashboard),
 		}, nil
 	}
 
@@ -159,22 +139,17 @@ func NewAccessControlDashboardGuardianByDashboard(
 			ctx:              ctx,
 			log:              log.New("dashboard.permissions"),
 			user:             user,
-			store:            store,
 			ac:               ac,
 			dashboardService: dashboardService,
 		},
-		dashboard:                   dashboard,
-		dashboardPermissionsService: dashboardPermissionsService,
+		dashboard: dashboard,
 	}, nil
 }
 
 // NewAccessControlFolderGuardian creates a folder guardian by the provided folder.
 func NewAccessControlFolderGuardian(
 	ctx context.Context, cfg *setting.Cfg, f *folder.Folder, user *user.SignedInUser,
-	store db.DB, ac accesscontrol.AccessControl,
-	folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
 ) (DashboardGuardian, error) {
 	return &accessControlFolderGuardian{
 		accessControlBaseGuardian: accessControlBaseGuardian{
@@ -182,12 +157,10 @@ func NewAccessControlFolderGuardian(
 			cfg:              cfg,
 			log:              log.New("folder.permissions"),
 			user:             user,
-			store:            store,
 			ac:               ac,
 			dashboardService: dashboardService,
 		},
-		folder:                   f,
-		folderPermissionsService: folderPermissionsService,
+		folder: f,
 	}, nil
 }
 
@@ -197,20 +170,17 @@ type accessControlBaseGuardian struct {
 	log              log.Logger
 	user             *user.SignedInUser
 	ac               accesscontrol.AccessControl
-	store            db.DB
 	dashboardService dashboards.DashboardService
 }
 
 type accessControlDashboardGuardian struct {
 	accessControlBaseGuardian
-	dashboard                   *dashboards.Dashboard
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService
+	dashboard *dashboards.Dashboard
 }
 
 type accessControlFolderGuardian struct {
 	accessControlBaseGuardian
-	folder                   *folder.Folder
-	folderPermissionsService accesscontrol.FolderPermissionsService
+	folder *folder.Folder
 }
 
 func (a *accessControlDashboardGuardian) CanSave() (bool, error) {

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -19,7 +19,6 @@ var (
 	ErrGuardianPermissionExists    = errors.New("permission already exists")
 	ErrGuardianOverride            = errors.New("you can only override a permission to be higher")
 	ErrGuardianGetDashboardFailure = errutil.Internal("guardian.getDashboardFailure", errutil.WithPublicMessage("Failed to get dashboard"))
-	ErrGuardianGetFolderFailure    = errutil.Internal("guardian.getFolderFailure", errutil.WithPublicMessage("Failed to get folder"))
 	ErrGuardianDashboardNotFound   = errutil.NotFound("guardian.dashboardNotFound")
 	ErrGuardianFolderNotFound      = errutil.NotFound("guardian.folderNotFound")
 )

--- a/pkg/services/guardian/provider.go
+++ b/pkg/services/guardian/provider.go
@@ -16,12 +16,11 @@ type Provider struct{}
 
 func ProvideService(
 	cfg *setting.Cfg, store db.DB, ac accesscontrol.AccessControl,
-	folderPermissionsService accesscontrol.FolderPermissionsService, dashboardPermissionsService accesscontrol.DashboardPermissionsService,
 	dashboardService dashboards.DashboardService, teamService team.Service,
 ) *Provider {
 	if !ac.IsDisabled() {
 		// TODO: Fix this hack, see https://github.com/grafana/grafana-enterprise/issues/2935
-		InitAccessControlGuardian(cfg, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		InitAccessControlGuardian(cfg, ac, dashboardService)
 	} else {
 		InitLegacyGuardian(cfg, store, dashboardService, teamService)
 	}
@@ -47,22 +46,21 @@ func InitLegacyGuardian(cfg *setting.Cfg, store db.DB, dashSvc dashboards.Dashbo
 }
 
 func InitAccessControlGuardian(
-	cfg *setting.Cfg, store db.DB, ac accesscontrol.AccessControl, folderPermissionsService accesscontrol.FolderPermissionsService,
-	dashboardPermissionsService accesscontrol.DashboardPermissionsService, dashboardService dashboards.DashboardService,
+	cfg *setting.Cfg, ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
 ) {
 	New = func(ctx context.Context, dashId int64, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardian(ctx, cfg, dashId, user, ac, dashboardService)
 	}
 
 	NewByUID = func(ctx context.Context, dashUID string, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardianByUID(ctx, cfg, dashUID, user, ac, dashboardService)
 	}
 
 	NewByDashboard = func(ctx context.Context, dash *dashboards.Dashboard, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlDashboardGuardianByDashboard(ctx, cfg, dash, user, ac, dashboardService)
 	}
 
 	NewByFolder = func(ctx context.Context, f *folder.Folder, orgId int64, user *user.SignedInUser) (DashboardGuardian, error) {
-		return NewAccessControlFolderGuardian(ctx, cfg, f, user, store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
+		return NewAccessControlFolderGuardian(ctx, cfg, f, user, ac, dashboardService)
 	}
 }

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -382,7 +382,7 @@ func scenarioWithPanel(t *testing.T, desc string, fn func(t *testing.T, sc scena
 		foldertest.NewFakeService(),
 	)
 	require.NoError(t, svcErr)
-	guardian.InitAccessControlGuardian(sqlStore.Cfg, sqlStore, ac, folderPermissions, dashboardPermissions, dashboardService)
+	guardian.InitAccessControlGuardian(sqlStore.Cfg, ac, dashboardService)
 
 	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {
 		command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel")
@@ -440,7 +440,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			foldertest.NewFakeService(),
 		)
 		require.NoError(t, dashSvcErr)
-		guardian.InitAccessControlGuardian(sqlStore.Cfg, sqlStore, ac, folderPermissions, dashboardPermissions, dashService)
+		guardian.InitAccessControlGuardian(sqlStore.Cfg, ac, dashService)
 		service := LibraryElementService{
 			Cfg:           sqlStore.Cfg,
 			features:      featuremgmt.WithFeatures(),

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -823,7 +823,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			foldertest.NewFakeService(),
 		)
 		require.NoError(t, err)
-		guardian.InitAccessControlGuardian(setting.NewCfg(), sqlStore, ac, acmock.NewMockedPermissionsService(), acmock.NewMockedPermissionsService(), dashService)
+		guardian.InitAccessControlGuardian(setting.NewCfg(), ac, dashService)
 
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
 		require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**
Remove unused dependencies from dashboards / folder guardian and refactor dashboard snapshots test to use access control guardian.

There are a couple of other tests that we need to fix in order to remove the legacy guardian and will follow up with in another pr


Part of: https://github.com/grafana/grafana/issues/73674

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
