### PR TITLE
Chore: Fix bingo variables for Windows

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -2,7 +2,8 @@
 # All tools are designed to be build inside $GOBIN.
 BINGO_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GOPATH ?= $(shell go env GOPATH)
-GOBIN  ?= $(firstword $(subst :, ,${GOPATH}))/bin
+PATHSEP := $(if $(COMSPEC),;,:)
+GOBIN  ?= $(firstword $(subst $(PATHSEP), ,$(subst \,/,${GOPATH})))/bin
 GO     ?= $(shell which go)
 
 # Below generated variables ensure that every time a tool under each variable is invoked, the correct version

--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -2,8 +2,12 @@
 # All tools are designed to be build inside $GOBIN.
 BINGO_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 GOPATH ?= $(shell go env GOPATH)
-PATHSEP := $(if $(COMSPEC),;,:)
-GOBIN  ?= $(firstword $(subst $(PATHSEP), ,$(subst \,/,${GOPATH})))/bin
+ifeq ($(OS),Windows_NT)
+	PATHSEP := $(if $(COMSPEC),;,:)
+	GOBIN  ?= $(firstword $(subst $(PATHSEP), ,$(subst \,/,${GOPATH})))/bin
+else
+	GOBIN  ?= $(firstword $(subst :, ,${GOPATH}))/bin
+endif
 GO     ?= $(shell which go)
 
 # Below generated variables ensure that every time a tool under each variable is invoked, the correct version


### PR DESCRIPTION
**What is this feature?**
This PR fixes the usage of bingo on Windows

**Why do we need this feature?**
Without this, we can't run commands like `make run` to start Grafana.

**Who is this feature for?**
Grafana developers working on Windows

**Special notes for your reviewer:**
This PR fixes the issue on Windows and try to not change anything for other OS but I couldn't test it.
