### PR TITLE
Grafana/ui: Expose trigger method from `useForm` to children

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Form.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.tsx
@@ -46,7 +46,7 @@ export function Form<T extends FieldValues>({
       onSubmit={handleSubmit(onSubmit)}
       {...htmlProps}
     >
-      {children({ errors: formState.errors, formState, ...rest })}
+      {children({ errors: formState.errors, formState, trigger, ...rest })}
     </form>
   );
 }

--- a/packages/grafana-ui/src/types/forms.ts
+++ b/packages/grafana-ui/src/types/forms.ts
@@ -1,7 +1,7 @@
 import { UseFormReturn, FieldValues, FieldErrors, FieldArrayMethodProps } from 'react-hook-form';
 export type { SubmitHandler as FormsOnSubmit, FieldErrors as FormFieldErrors } from 'react-hook-form';
 
-export type FormAPI<T extends FieldValues> = Omit<UseFormReturn<T>, 'trigger' | 'handleSubmit'> & {
+export type FormAPI<T extends FieldValues> = Omit<UseFormReturn<T>, 'handleSubmit'> & {
   errors: FieldErrors<T>;
 };
 


### PR DESCRIPTION
**What is this feature?**

This PR exposes the `trigger` method from `useForm` to the children components of `Form`.

**Why do we need this feature?**

[(Link to docs)](https://react-hook-form.com/docs/useform/trigger) It allows to manually trigger form validation. A workaround can be made when `trigger` not available, but there is no real reason not to expose this method to the children components.
Almost all the other methods from `useForm` are returned, so it makes sense to also return this one.

For example, when building a Stepper component, you might need to trigger validation of the whole form on the last step to ensure there are no errors.

**Who is this feature for?**

Users of the `Form` component from `@grafana/ui`.

**Which issue(s) does this PR fix?**

Fixes issue [#94](https://github.com/grafana/app-observability-plugin/issues/94).
