### PR TITLE
Chore: prepare for removing `RBACenabled` config option

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -224,7 +224,6 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 		features = featuremgmt.WithFeatures()
 	}
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 
 	return &HTTPServer{

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -120,9 +120,7 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 		folderPermService.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 
 		srv := SetupAPITestServer(t, func(hs *HTTPServer) {
-			hs.Cfg = &setting.Cfg{
-				RBACEnabled: true,
-			}
+			hs.Cfg = setting.NewCfg()
 
 			if tc.withNestedFolders {
 				hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders)
@@ -232,9 +230,7 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 		folderService.ExpectedError = tc.expectedFolderSvcError
 
 		srv := SetupAPITestServer(t, func(hs *HTTPServer) {
-			hs.Cfg = &setting.Cfg{
-				RBACEnabled: true,
-			}
+			hs.Cfg = setting.NewCfg()
 			hs.folderService = folderService
 		})
 
@@ -273,9 +269,7 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 	folderService := &foldertest.FakeService{}
 	features := featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders)
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
-		hs.Cfg = &setting.Cfg{
-			RBACEnabled: true,
-		}
+		hs.Cfg = setting.NewCfg()
 		hs.folderService = folderService
 		hs.QuotaService = quotatest.New(false, nil)
 		hs.SearchService = &mockSearchService{
@@ -404,9 +398,7 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 
 	for _, tc := range tcs {
 		srv := SetupAPITestServer(t, func(hs *HTTPServer) {
-			hs.Cfg = &setting.Cfg{
-				RBACEnabled: true,
-			}
+			hs.Cfg = setting.NewCfg()
 			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders)
 			hs.folderService = folderService
 		})
@@ -479,9 +471,7 @@ func TestFolderGetAPIEndpoint(t *testing.T) {
 
 	for _, tc := range tcs {
 		srv := SetupAPITestServer(t, func(hs *HTTPServer) {
-			hs.Cfg = &setting.Cfg{
-				RBACEnabled: true,
-			}
+			hs.Cfg = setting.NewCfg()
 			hs.Features = tc.features
 			hs.folderService = folderService
 		})

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -24,7 +24,6 @@ import (
 func setupTestEnv(t testing.TB) *Service {
 	t.Helper()
 	cfg := setting.NewCfg()
-	cfg.RBACEnabled = true
 
 	ac := &Service{
 		cfg:           cfg,
@@ -41,12 +40,10 @@ func setupTestEnv(t testing.TB) *Service {
 func TestUsageMetrics(t *testing.T) {
 	tests := []struct {
 		name          string
-		enabled       bool
 		expectedValue int
 	}{
 		{
 			name:          "Expecting metric with value 1",
-			enabled:       true,
 			expectedValue: 1,
 		},
 	}
@@ -54,7 +51,6 @@ func TestUsageMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			cfg.RBACEnabled = tt.enabled
 
 			s := ProvideOSSService(
 				cfg,

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -45,7 +45,6 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 
 		setup := func() {
 			sqlStore = db.InitTestDB(t)
-			sqlStore.Cfg.RBACEnabled = false
 			quotaService := quotatest.New(false, nil)
 			var err error
 			dashboardStore, err = ProvideDashboardStore(sqlStore, sqlStore.Cfg, testFeatureToggles, tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
@@ -247,7 +246,6 @@ func TestIntegrationDashboardInheritedFolderRBAC(t *testing.T) {
 
 	setup := func() {
 		sqlStore = db.InitTestDB(t)
-		sqlStore.Cfg.RBACEnabled = true
 		quotaService := quotatest.New(false, nil)
 
 		// enable nested folders so that the folder table is populated for all the tests

--- a/pkg/services/publicdashboards/api/query_test.go
+++ b/pkg/services/publicdashboards/api/query_test.go
@@ -88,7 +88,6 @@ func TestAPIViewPublicDashboard(t *testing.T) {
 				Return(&PublicDashboard{Uid: "pubdashuid"}, test.DashboardResult, test.Err).Maybe()
 
 			cfg := setting.NewCfg()
-			cfg.RBACEnabled = false
 
 			testServer := setupTestServer(
 				t,
@@ -326,7 +325,6 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 	cfg := setting.NewCfg()
 	ac := acmock.New()
 	ws := publicdashboardsService.ProvideServiceWrapper(store)
-	cfg.RBACEnabled = false
 	service := publicdashboardsService.ProvideService(cfg, store, qds, annotationsService, ac, ws)
 	pubdash, err := service.Create(context.Background(), &user.SignedInUser{}, savePubDashboardCmd)
 	require.NoError(t, err)
@@ -415,7 +413,6 @@ func TestAPIGetAnnotations(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			cfg.RBACEnabled = false
 			service := publicdashboards.NewFakePublicDashboardService(t)
 
 			if test.ExpectedServiceCalled {


### PR DESCRIPTION
**What is this feature?**

Clean up the usage of `RBACenabled` config option, so that we can remove it soon, as RBAC is always enabled from 10.0 onwards.

**Why do we need this feature?**

Cleanup.