### PR TITLE
Alerting: Fix delete cloud rule from detail page

### DIFF
--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -382,6 +382,8 @@ export function deleteRuleAction(
    * reload ruler rules
    */
   return async (dispatch, getState) => {
+    await dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName: ruleIdentifier.ruleSourceName }));
+
     withAppEvents(
       (async () => {
         const rulerConfig = getDataSourceRulerConfig(getState, ruleIdentifier.ruleSourceName);


### PR DESCRIPTION
**What is this feature?**

This PR fixes a small bug when a user directly enters the detail page of a cloud rule and wants to delete it – if a list of available data source was not yet discovered it would throw an exception and refuse to delete the alert rule.

The following line would be invoked and throw an exception

https://github.com/grafana/grafana/blob/ca46a5c1af0282a6dbacbf1fa1304c740f864e63/public/app/features/alerting/unified/state/actions.ts#L387

```
Error: Data source configuration is not available for "grafana-cloud" data source
```

This PR basically dispatches an action to fetch the data source information prior to invoking the delete action.
