### PR TITLE
Prom: response parser - use Iterator error wrapper

### DIFF
--- a/pkg/util/converter/jsonitere/jsonitere.go
+++ b/pkg/util/converter/jsonitere/jsonitere.go
@@ -1,9 +1,13 @@
+// package jsonitere wraps json-iterator/go's Iterator methods with error returns
+// so linting can catch unchecked errors.
 package jsonitere
 
 import j "github.com/json-iterator/go"
 
 type Iterator struct {
-	*j.Iterator
+	// named property instead of embedded so there is no
+	// confusion about which method or property is called
+	i *j.Iterator
 }
 
 func NewIterator(i *j.Iterator) *Iterator {
@@ -11,40 +15,44 @@ func NewIterator(i *j.Iterator) *Iterator {
 }
 
 func (iter *Iterator) Read() (interface{}, error) {
-	return iter.Iterator.Read(), iter.Error
+	return iter.i.Read(), iter.i.Error
 }
 
 func (iter *Iterator) ReadAny() (j.Any, error) {
-	// Clear iter.Error?
-	return iter.Iterator.ReadAny(), iter.Error
+	// Clear iter.i.Error?
+	return iter.i.ReadAny(), iter.i.Error
 }
 
 func (iter *Iterator) ReadArray() (bool, error) {
-	return iter.Iterator.ReadArray(), iter.Error
+	return iter.i.ReadArray(), iter.i.Error
 }
 
 func (iter *Iterator) ReadObject() (string, error) {
-	return iter.Iterator.ReadObject(), iter.Error
+	return iter.i.ReadObject(), iter.i.Error
 }
 
 func (iter *Iterator) ReadString() (string, error) {
-	return iter.Iterator.ReadString(), iter.Error
+	return iter.i.ReadString(), iter.i.Error
 }
 
 func (iter *Iterator) WhatIsNext() (j.ValueType, error) {
-	return iter.Iterator.WhatIsNext(), iter.Error
+	return iter.i.WhatIsNext(), iter.i.Error
 }
 
 func (iter *Iterator) Skip() error {
-	iter.Iterator.Skip()
-	return iter.Error
+	iter.i.Skip()
+	return iter.i.Error
 }
 
 func (iter *Iterator) ReadVal(obj interface{}) error {
-	iter.Iterator.ReadVal(obj)
-	return iter.Error
+	iter.i.ReadVal(obj)
+	return iter.i.Error
 }
 
 func (iter *Iterator) ReadFloat64() (float64, error) {
-	return iter.Iterator.ReadFloat64(), iter.Error
+	return iter.i.ReadFloat64(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt8() (int8, error) {
+	return iter.i.ReadInt8(), iter.i.Error
 }

--- a/pkg/util/converter/jsonitere/jsonitere.go
+++ b/pkg/util/converter/jsonitere/jsonitere.go
@@ -1,0 +1,24 @@
+package jsonitere
+
+import j "github.com/json-iterator/go"
+
+type Iterator struct {
+	*j.Iterator
+}
+
+func NewIterator(i *j.Iterator) *Iterator {
+	return &Iterator{i}
+}
+
+func (iter *Iterator) Read() (interface{}, error) {
+	return iter.Iterator.Read(), iter.Error
+}
+
+func (iter *Iterator) ReadAny() (j.Any, error) {
+	// Clear iter.Error?
+	return iter.Iterator.ReadAny(), iter.Error
+}
+
+func (iter *Iterator) ReadArray() (bool, error) {
+	return iter.Iterator.ReadArray(), iter.Error
+}

--- a/pkg/util/converter/jsonitere/jsonitere.go
+++ b/pkg/util/converter/jsonitere/jsonitere.go
@@ -22,3 +22,29 @@ func (iter *Iterator) ReadAny() (j.Any, error) {
 func (iter *Iterator) ReadArray() (bool, error) {
 	return iter.Iterator.ReadArray(), iter.Error
 }
+
+func (iter *Iterator) ReadObject() (string, error) {
+	return iter.Iterator.ReadObject(), iter.Error
+}
+
+func (iter *Iterator) ReadString() (string, error) {
+	return iter.Iterator.ReadString(), iter.Error
+}
+
+func (iter *Iterator) WhatIsNext() (j.ValueType, error) {
+	return iter.Iterator.WhatIsNext(), iter.Error
+}
+
+func (iter *Iterator) Skip() error {
+	iter.Iterator.Skip()
+	return iter.Error
+}
+
+func (iter *Iterator) ReadVal(obj interface{}) error {
+	iter.Iterator.ReadVal(obj)
+	return iter.Error
+}
+
+func (iter *Iterator) ReadFloat64() (float64, error) {
+	return iter.Iterator.ReadFloat64(), iter.Error
+}

--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -204,8 +204,7 @@ l1Fields:
 		case "stats":
 			v, err := iter.Read()
 			if err != nil {
-				rsp.Error = iter.Error
-				return rsp
+				rspErr(err)
 			}
 			if len(rsp.Frames) > 0 {
 				meta := rsp.Frames[0].Meta
@@ -651,7 +650,7 @@ func readTimeValuePair(iter *jsonitere.Iterator) (time.Time, float64, error) {
 
 	var v string
 	if v, err = iter.ReadString(); err != nil {
-		return time.Time{}, 0, iter.Error
+		return time.Time{}, 0, err
 	}
 
 	if _, err = iter.ReadArray(); err != nil {
@@ -732,7 +731,11 @@ func readHistogram(iter *jsonitere.Iterator, hist *histogramInfo) error {
 					return err
 				}
 
-				hist.yLayout.Append(iter.ReadInt8())
+				v, err := iter.ReadInt8()
+				if err != nil {
+					return err
+				}
+				hist.yLayout.Append(v)
 
 				if _, err := iter.ReadArray(); err != nil {
 					return err


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/73788 , wraps Iterator with composition to make funcs that return error.

Since this isn't done and I didn't check for err in all the places, the linter returns:

```
pkg/util/converter/prom.go:507:16: Error return value of `iter.ReadArray` is not checked (errcheck)
	iter.ReadArray()
```

Which demonstrates one of the reasons to consider doing it this way.

A downside is that if this is used, and we continue to embed jsoniter, then if the underlying jsoniter library adds a method that can set the Error property, that can get missed (as it isn't clear to the caller which functions are wrapped and which are not). Although we could keep this separate, not embed the jsoniter, and write all of the functions to avoid that. Or try to get this wrapper merged into the source lib.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
