### PR TITLE
CloudMonitoring: Update docs with instructions for multiple projects

### DIFF
--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -46,7 +46,7 @@ To visualize data from multiple GCP Projects, create one data source per GCP Pro
    The file's contents are encrypted and saved in the Grafana database.
    Remember to save the file after uploading.
 
-#### Create a GCP Service Account for multiple projects
+#### Create a GCP service account for multiple projects
 
 You can create a service account and key file that can be used to access multiple projects. Follow steps 1-5 above, then:
 

--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -46,6 +46,19 @@ To visualize data from multiple GCP Projects, create one data source per GCP Pro
    The file's contents are encrypted and saved in the Grafana database.
    Remember to save the file after uploading.
 
+#### Create a GCP Service Account for multiple projects
+
+You can create a service account and key file that can be used to access multiple projects. Follow steps 1-5 above, then:
+
+1. Note the email address of the service account, it will look a little strange like `foobar-478@main-boardwalk-90210.iam.gserviceaccount.com`.
+1. Navigtate to the other project(s) you want to access.
+1. Add the service account email address to the IAM page of each project, and grant it the required roles.
+1. Navigate back to the original project's service account and create a [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console). A JSON key file is created and downloaded to your computer
+1. Store the key file in a secure place, because it grants access to your Google data.
+1. In the Grafana data source configuration page, upload the key file.
+   The file's contents are encrypted and saved in the Grafana database.
+   Remember to save the file after uploading.
+
 ## Configure a GCE Default Service Account
 
 When Grafana is running on a Google Compute Engine (GCE) virtual machine, Grafana can automatically retrieve default credentials from the metadata server. As a result, there is no need to generate a private key file for the service account. You also do not need to upload the file to Grafana. The following preconditions must be met before Grafana can retrieve default credentials.

--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -59,7 +59,7 @@ You can create a service account and key file that can be used to access multipl
    The file's contents are encrypted and saved in the Grafana database.
    Remember to save the file after uploading.
 
-## Configure a GCE Default Service Account
+## Configure a GCE default service account
 
 When Grafana is running on a Google Compute Engine (GCE) virtual machine, Grafana can automatically retrieve default credentials from the metadata server. As a result, there is no need to generate a private key file for the service account. You also do not need to upload the file to Grafana. The following preconditions must be met before Grafana can retrieve default credentials.
 


### PR DESCRIPTION
This PR updates the docs for Google Cloud Monitoring to explain how to create a service key file that grants access to multiple projects.
