### PR TITLE
Alerting: add route owner middleware

### DIFF
--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -195,6 +196,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Post(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/silences"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/grafana/api/v2/silences"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -205,6 +207,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/silences"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/{DatasourceUID}/api/v2/silences"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -215,6 +218,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -225,6 +229,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/alertmanager/grafana/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -235,6 +240,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/silence/{SilenceId}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/alertmanager/grafana/api/v2/silence/{SilenceId}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -245,6 +251,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/silence/{SilenceId}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/alertmanager/{DatasourceUID}/api/v2/silence/{SilenceId}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -255,6 +262,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/alerts/groups"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/api/v2/alerts/groups"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -265,6 +273,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/api/v2/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -275,6 +284,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/status"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/api/v2/status"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -285,6 +295,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -295,6 +306,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/alerts/groups"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/api/v2/alerts/groups"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -305,6 +317,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/api/v2/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -315,6 +328,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/status"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/api/v2/status"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -325,6 +339,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -335,6 +350,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/config/history"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/config/history"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -345,6 +361,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/receivers"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/config/api/v1/receivers"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -355,6 +372,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/silence/{SilenceId}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/api/v2/silence/{SilenceId}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -365,6 +383,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/grafana/api/v2/silences"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/grafana/api/v2/silences"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -375,6 +394,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/silence/{SilenceId}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/api/v2/silence/{SilenceId}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -385,6 +405,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/silences"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/alertmanager/{DatasourceUID}/api/v2/silences"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -395,6 +416,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/api/v2/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/{DatasourceUID}/api/v2/alerts"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -405,6 +427,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/{DatasourceUID}/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -415,6 +438,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/grafana/config/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -425,6 +449,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/grafana/config/history/{id}/_activate"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/grafana/config/history/{id}/_activate"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -435,6 +460,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/receivers/test"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/grafana/config/api/v1/receivers/test"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -445,6 +471,7 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/grafana/config/api/v1/templates/test"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/alertmanager/grafana/config/api/v1/templates/test"),
 			metrics.Instrument(
 				http.MethodPost,

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -51,6 +52,7 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/v1/ngalert/admin_config"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -61,6 +63,7 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 		)
 		group.Get(
 			toMacaronPath("/api/v1/ngalert/alertmanagers"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/ngalert/alertmanagers"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -71,6 +74,7 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 		)
 		group.Get(
 			toMacaronPath("/api/v1/ngalert/admin_config"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -81,6 +85,7 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 		)
 		group.Get(
 			toMacaronPath("/api/v1/ngalert"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/ngalert"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -91,6 +96,7 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 		)
 		group.Post(
 			toMacaronPath("/api/v1/ngalert/admin_config"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
 				http.MethodPost,

--- a/pkg/services/ngalert/api/generated_base_api_history.go
+++ b/pkg/services/ngalert/api/generated_base_api_history.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
@@ -28,6 +29,7 @@ func (api *API) RegisterHistoryApiEndpoints(srv HistoryApi, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Get(
 			toMacaronPath("/api/v1/rules/history"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/rules/history"),
 			metrics.Instrument(
 				http.MethodGet,

--- a/pkg/services/ngalert/api/generated_base_api_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_prometheus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/web"
@@ -45,6 +46,7 @@ func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApi, m *metrics.API
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Get(
 			toMacaronPath("/api/prometheus/{DatasourceUID}/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/prometheus/{DatasourceUID}/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -55,6 +57,7 @@ func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApi, m *metrics.API
 		)
 		group.Get(
 			toMacaronPath("/api/prometheus/grafana/api/v1/alerts"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/prometheus/grafana/api/v1/alerts"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -65,6 +68,7 @@ func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApi, m *metrics.API
 		)
 		group.Get(
 			toMacaronPath("/api/prometheus/grafana/api/v1/rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/prometheus/grafana/api/v1/rules"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -75,6 +79,7 @@ func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApi, m *metrics.API
 		)
 		group.Get(
 			toMacaronPath("/api/prometheus/{DatasourceUID}/api/v1/rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/prometheus/{DatasourceUID}/api/v1/rules"),
 			metrics.Instrument(
 				http.MethodGet,

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -216,6 +217,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -226,6 +228,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/v1/provisioning/contact-points/{UID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/provisioning/contact-points/{UID}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -236,6 +239,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -246,6 +250,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -256,6 +261,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -266,6 +272,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}/export"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/alert-rules/{UID}/export"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -276,6 +283,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -286,6 +294,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -296,6 +305,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/alert-rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/alert-rules"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -306,6 +316,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/alert-rules/export"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/alert-rules/export"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -316,6 +327,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/contact-points"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/contact-points"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -326,6 +338,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/contact-points/export"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/contact-points/export"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -336,6 +349,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -346,6 +360,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/mute-timings"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/mute-timings"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -356,6 +371,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/policies"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/policies"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -366,6 +382,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/policies/export"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/policies/export"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -376,6 +393,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -386,6 +404,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Get(
 			toMacaronPath("/api/v1/provisioning/templates"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/v1/provisioning/templates"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -396,6 +415,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/v1/provisioning/alert-rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/provisioning/alert-rules"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -406,6 +426,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/v1/provisioning/contact-points"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/provisioning/contact-points"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -416,6 +437,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Post(
 			toMacaronPath("/api/v1/provisioning/mute-timings"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/provisioning/mute-timings"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -426,6 +448,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -436,6 +459,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -446,6 +470,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/contact-points/{UID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/contact-points/{UID}"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -456,6 +481,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -466,6 +492,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/policies"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/policies"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -476,6 +503,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Put(
 			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPut, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodPut,
@@ -486,6 +514,7 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 		)
 		group.Delete(
 			toMacaronPath("/api/v1/provisioning/policies"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/v1/provisioning/policies"),
 			metrics.Instrument(
 				http.MethodDelete,

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -115,6 +116,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -125,6 +127,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Delete(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/ruler/grafana/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -135,6 +138,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Delete(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -145,6 +149,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Delete(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}/{Groupname}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodDelete, "/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}/{Groupname}"),
 			metrics.Instrument(
 				http.MethodDelete,
@@ -155,6 +160,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -165,6 +171,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/grafana/api/v1/rules"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -175,6 +182,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/grafana/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -185,6 +193,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -195,6 +204,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}/{Groupname}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}/{Groupname}"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -205,6 +215,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodGet, "/api/ruler/{DatasourceUID}/api/v1/rules"),
 			metrics.Instrument(
 				http.MethodGet,
@@ -215,6 +226,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/ruler/grafana/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/ruler/grafana/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -225,6 +237,7 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApi, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/ruler/{DatasourceUID}/api/v1/rules/{Namespace}"),
 			metrics.Instrument(
 				http.MethodPost,

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -64,6 +65,7 @@ func (api *API) RegisterTestingApiEndpoints(srv TestingApi, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Post(
 			toMacaronPath("/api/v1/rule/backtest"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/rule/backtest"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -74,6 +76,7 @@ func (api *API) RegisterTestingApiEndpoints(srv TestingApi, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/v1/eval"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/eval"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -84,6 +87,7 @@ func (api *API) RegisterTestingApiEndpoints(srv TestingApi, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/v1/rule/test/{DatasourceUID}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/rule/test/{DatasourceUID}"),
 			metrics.Instrument(
 				http.MethodPost,
@@ -94,6 +98,7 @@ func (api *API) RegisterTestingApiEndpoints(srv TestingApi, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/v1/rule/test/grafana"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
 			api.authorize(http.MethodPost, "/api/v1/rule/test/grafana"),
 			metrics.Instrument(
 				http.MethodPost,

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -36,6 +37,7 @@ func (api *API) Register{{classname}}Endpoints(srv {{classname}}, m *metrics.API
 	api.RouteRegister.Group("", func(group routing.RouteRegister){ {{#operations}}{{#operation}}
 	group.{{httpMethod}}(
 		toMacaronPath("{{{path}}}"),
+		requestmeta.SetOwner(requestmeta.TeamAlerting),
 		api.authorize(http.Method{{httpMethod}}, "{{{path}}}"),
 		metrics.Instrument(
 			http.Method{{httpMethod}},


### PR DESCRIPTION
Set alerting as owners for all routes in ngalerting. 

ref https://github.com/grafana/grafana/issues/67521

The code generation tooling is slighhly broken but go fmt fixes most of it :)