### PR TITLE
Explore: Fix TimeSrv initializations

### DIFF
--- a/public/app/features/explore/state/time.test.ts
+++ b/public/app/features/explore/state/time.test.ts
@@ -7,6 +7,13 @@ import { ExploreItemState } from 'app/types';
 import { createDefaultInitialState } from './helpers';
 import { changeRangeAction, timeReducer, updateTime } from './time';
 
+const mockTimeSrv = {
+  init: jest.fn(),
+};
+jest.mock('app/features/dashboard/services/TimeSrv', () => ({
+  ...jest.requireActual('app/features/dashboard/services/TimeSrv'),
+  getTimeSrv: () => mockTimeSrv,
+}));
 const mockTemplateSrv = {
   updateTimeRange: jest.fn(),
 };
@@ -21,6 +28,8 @@ describe('Explore item reducer', () => {
       const state = createDefaultInitialState().defaultInitialState as any;
       const { dispatch } = configureStore(state);
       dispatch(updateTime({ exploreId: 'left' }));
+      expect(mockTemplateSrv.updateTimeRange).toBeCalledWith(state.explore.panes.left.range);
+      expect(mockTimeSrv.init).toBeCalled();
       expect(mockTemplateSrv.updateTimeRange).toBeCalledWith(state.explore.panes.left.range);
     });
   });

--- a/public/app/features/explore/state/time.ts
+++ b/public/app/features/explore/state/time.ts
@@ -5,6 +5,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { getTimeRange, refreshIntervalToSortOrder, stopQueryState } from 'app/core/utils/explore';
 import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { sortLogsResult } from 'app/features/logs/utils';
 import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';
 import { ExploreItemState, ThunkDispatch, ThunkResult } from 'app/types';
@@ -21,6 +22,7 @@ export interface ChangeRangePayload {
   range: TimeRange;
   absoluteRange: AbsoluteTimeRange;
 }
+
 export const changeRangeAction = createAction<ChangeRangePayload>('explore/changeRange');
 
 /**
@@ -30,6 +32,7 @@ export interface ChangeRefreshIntervalPayload {
   exploreId: string;
   refreshInterval: string;
 }
+
 export const changeRefreshInterval = createAction<ChangeRefreshIntervalPayload>('explore/changeRefreshInterval');
 
 export const updateTimeRange = (options: {
@@ -78,6 +81,13 @@ export const updateTime = (config: {
     const range = getTimeRange(timeZone, rawRange, fiscalYearStartMonth);
     const absoluteRange: AbsoluteTimeRange = { from: range.from.valueOf(), to: range.to.valueOf() };
 
+    // @deprecated - set because some internal plugins read the range this way; please use QueryEditorProps.range instead
+    getTimeSrv().init({
+      timepicker: {},
+      getTimezone: () => timeZone,
+      timeRangeUpdated(timeRange) {},
+      time: range.raw,
+    });
     // After re-initializing TimeSrv we need to update the time range in Template service for interpolation
     // of __from and __to variables
     getTemplateSrv().updateTimeRange(range);


### PR DESCRIPTION
#73600 removed setting up TimeSrv range that was used in Explore for keyboard shortcuts. 

Unfortunately, it turns out that some core data sources use TimeSrv internally to get the current time range and depend on that Explore's code. Some examples:

* [Jaeger](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/jaeger/datasource.ts#L20)
* [Elastic](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/datasource.ts#L40)
* [Loki](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/datasource.ts#L44)
* [Prometheus](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/datasource.tsx#L41)

This PR brings back TimeSrv initialization. I've marked it as deprecated. Using TimeSrv singleton at the moment works only in non-split mode. Data source plugins should use `QueryEditorProps.range` property instead. However, I'm not sure how complex / feasible it is to change it, it may require passing range in a few places and doing null-checks as it's an optional property. Also, even if data sources used  `QueryEditorProps.range` we still need to update Explore code to make it work in non-split mode as currently TimeSrv range is passed inside the [QueryRow anyway](https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRow.tsx#L294) (facepalm), but we will work on it.

cc @grafana/observability-traces-and-profiling, @grafana/observability-logs, @grafana/observability-metrics - do you have any plans for decoupling that dashboards dependency in your code? cc @grafana/oss-big-tent - I know you do ;) 