### PR TITLE
web: removes unused function from request metadata

### DIFF
--- a/pkg/middleware/requestmeta/request_metadata.go
+++ b/pkg/middleware/requestmeta/request_metadata.go
@@ -49,17 +49,6 @@ func GetRequestMetaData(ctx context.Context) *RequestMetaData {
 	return defaultRequestMetadata()
 }
 
-// SetRequestMetaData returns an `web.Handler` that overrides the request metadata
-// with the provided param.
-func SetRequestMetaData(rmd RequestMetaData) web.Handler {
-	return func(w http.ResponseWriter, r *http.Request) {
-		v := GetRequestMetaData(r.Context())
-		if rmd.Team != "" {
-			v.Team = rmd.Team
-		}
-	}
-}
-
 // SetOwner returns an `web.Handler` that sets the team name for an request.
 func SetOwner(team string) web.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I should have removed this before merging https://github.com/grafana/grafana/pull/71010