### PR TITLE
Chore: Make log messages start with a capital letter

### DIFF
--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -118,7 +118,7 @@ func (a *AvatarCacheServer) Handler(ctx *contextmodel.ReqContext) {
 	ctx.Resp.Header().Set("Cache-Control", "private, max-age=3600")
 
 	if err := avatar.Encode(ctx.Resp); err != nil {
-		ctx.Logger.Warn("avatar encode error:", "err", err)
+		ctx.Logger.Warn("Avatar encode error:", "err", err)
 		ctx.Resp.WriteHeader(http.StatusInternalServerError)
 	}
 }
@@ -143,7 +143,7 @@ func (a *AvatarCacheServer) getAvatarForHash(hash string, baseUrl string) *Avata
 	if avatar.Expired() {
 		// The cache item is either expired or newly created, update it from the server
 		if err := avatar.update(baseUrl); err != nil {
-			alog.Debug("avatar update", "err", err)
+			alog.Debug("Avatar update", "err", err)
 			avatar = a.notFound
 		}
 	}
@@ -152,7 +152,7 @@ func (a *AvatarCacheServer) getAvatarForHash(hash string, baseUrl string) *Avata
 		avatar = a.notFound
 	} else if !exists {
 		if err := a.cache.Add(hash, avatar, gocache.DefaultExpiration); err != nil {
-			alog.Debug("add avatar to cache", "err", err)
+			alog.Debug("Add avatar to cache", "err", err)
 		}
 	}
 	return avatar
@@ -266,7 +266,7 @@ var client = &http.Client{
 func (a *thunderTask) fetch() error {
 	a.Avatar.timestamp = time.Now()
 
-	alog.Debug("avatar.fetch(fetch new avatar)", "url", a.BaseUrl)
+	alog.Debug("Avatar.fetch(fetch new avatar)", "url", a.BaseUrl)
 	// First do the fetch to get the Gravatar with a retro icon fallback
 	err := performGet(a.BaseUrl+gravatarReqParams, a.Avatar, getGravatarHandler)
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -516,7 +516,7 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 		}
 
 		if liveerr != nil {
-			hs.log.Warn("unable to broadcast save event", "uid", dashboard.UID, "error", liveerr)
+			hs.log.Warn("Unable to broadcast save event", "uid", dashboard.UID, "error", liveerr)
 		}
 	}
 

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -367,7 +367,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, g guardian.Dash
 	parents, err := hs.folderService.GetParents(ctx, folder.GetParentsQuery{UID: f.UID, OrgID: f.OrgID})
 	if err != nil {
 		// log the error instead of failing
-		hs.log.Error("failed to fetch folder parents", "folder", f.UID, "org", f.OrgID, "error", err)
+		hs.log.Error("Failed to fetch folder parents", "folder", f.UID, "org", f.OrgID, "error", err)
 	}
 
 	folderDTO.Parents = make([]dtos.Folder, 0, len(parents))

--- a/pkg/api/frontend_logging.go
+++ b/pkg/api/frontend_logging.go
@@ -24,7 +24,7 @@ func GrafanaJavascriptAgentLogMessageHandler(store *frontendlogging.SourceMapSto
 			c.Resp.WriteHeader(http.StatusBadRequest)
 			_, err = c.Resp.Write([]byte("bad request data"))
 			if err != nil {
-				hs.log.Error("could not write to response", "err", err)
+				hs.log.Error("Could not write to response", "err", err)
 			}
 		}
 
@@ -89,7 +89,7 @@ func GrafanaJavascriptAgentLogMessageHandler(store *frontendlogging.SourceMapSto
 		c.Resp.WriteHeader(http.StatusAccepted)
 		_, err := c.Resp.Write([]byte("OK"))
 		if err != nil {
-			hs.log.Error("could not write to response", "err", err)
+			hs.log.Error("Could not write to response", "err", err)
 		}
 	}
 }
@@ -105,7 +105,7 @@ func (hs *HTTPServer) frontendLogEndpoints() web.Handler {
 				ctx.Resp.WriteHeader(http.StatusAccepted)
 				_, err := ctx.Resp.Write([]byte("OK"))
 				if err != nil {
-					hs.log.Error("could not write to response", "err", err)
+					hs.log.Error("Could not write to response", "err", err)
 				}
 			}
 		}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -421,7 +421,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	case setting.HTTPScheme, setting.SocketScheme:
 		if err := hs.httpSrv.Serve(listener); err != nil {
 			if errors.Is(err, http.ErrServerClosed) {
-				hs.log.Debug("server was shutdown gracefully")
+				hs.log.Debug("Server was shutdown gracefully")
 				return nil
 			}
 			return err
@@ -429,7 +429,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	case setting.HTTP2Scheme, setting.HTTPSScheme:
 		if err := hs.httpSrv.ServeTLS(listener, hs.Cfg.CertFile, hs.Cfg.KeyFile); err != nil {
 			if errors.Is(err, http.ErrServerClosed) {
-				hs.log.Debug("server was shutdown gracefully")
+				hs.log.Debug("Server was shutdown gracefully")
 				return nil
 			}
 			return err
@@ -660,7 +660,7 @@ func (hs *HTTPServer) healthzHandler(ctx *web.Context) {
 
 	ctx.Resp.WriteHeader(http.StatusOK)
 	if _, err := ctx.Resp.Write([]byte("Ok")); err != nil {
-		hs.log.Error("could not write to response", "err", err)
+		hs.log.Error("Could not write to response", "err", err)
 	}
 }
 

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -266,13 +266,13 @@ func (hs *HTTPServer) Logout(c *contextmodel.ReqContext) {
 		}
 
 		if err := hs.oauthTokenService.InvalidateOAuthTokens(c.Req.Context(), entry); err != nil {
-			hs.log.Warn("failed to invalidate oauth tokens for user", "userId", c.UserID, "error", err)
+			hs.log.Warn("Failed to invalidate oauth tokens for user", "userId", c.UserID, "error", err)
 		}
 	}
 
 	err := hs.AuthTokenService.RevokeToken(c.Req.Context(), c.UserToken, false)
 	if err != nil && !errors.Is(err, auth.ErrUserTokenNotFound) {
-		hs.log.Error("failed to revoke auth token", "error", err)
+		hs.log.Error("Failed to revoke auth token", "error", err)
 	}
 
 	authn.DeleteSessionCookie(c.Resp, hs.Cfg)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -20,7 +20,7 @@ func (hs *HTTPServer) OAuthLogin(reqCtx *contextmodel.ReqContext) {
 
 	if errorParam := reqCtx.Query("error"); errorParam != "" {
 		errorDesc := reqCtx.Query("error_description")
-		hs.log.Error("failed to login ", "error", errorParam, "errorDesc", errorDesc)
+		hs.log.Error("Failed to login ", "error", errorParam, "errorDesc", errorDesc)
 
 		hs.redirectWithError(reqCtx, errors.New("login provider denied login request"), "error", errorParam, "errorDesc", errorDesc)
 		return

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -306,7 +306,7 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 	})
 
 	if err != nil {
-		hs.log.Warn("failed to retrieve users IDP label", err)
+		hs.log.Warn("Failed to retrieve users IDP label", err)
 	}
 
 	// Get accesscontrol metadata and IPD labels for users in the target org
@@ -497,14 +497,14 @@ func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *org.RemoveOr
 	if cmd.UserWasDeleted {
 		// This should be called from appropriate service when moved
 		if err := hs.accesscontrolService.DeleteUserPermissions(ctx, accesscontrol.GlobalOrgID, cmd.UserID); err != nil {
-			hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", accesscontrol.GlobalOrgID, "err", err)
+			hs.log.Warn("Failed to delete permissions for user", "userID", cmd.UserID, "orgID", accesscontrol.GlobalOrgID, "err", err)
 		}
 		return response.Success("User deleted")
 	}
 
 	// This should be called from appropriate service when moved
 	if err := hs.accesscontrolService.DeleteUserPermissions(ctx, cmd.OrgID, cmd.UserID); err != nil {
-		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", cmd.OrgID, "err", err)
+		hs.log.Warn("Failed to delete permissions for user", "userID", cmd.UserID, "orgID", cmd.OrgID, "err", err)
 	}
 
 	return response.Success("User removed from organization")

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -99,7 +99,7 @@ func (hs *HTTPServer) ResetPassword(c *contextmodel.ReqContext) response.Respons
 	}
 
 	if err := hs.loginAttemptService.Reset(c.Req.Context(), username); err != nil {
-		c.Logger.Warn("could not reset login attempts", "err", err, "username", username)
+		c.Logger.Warn("Could not reset login attempts", "err", err, "username", username)
 	}
 
 	return response.Success("User password changed")

--- a/pkg/cmd/grafana-cli/commands/ls_command.go
+++ b/pkg/cmd/grafana-cli/commands/ls_command.go
@@ -19,7 +19,7 @@ var validateLsCommand = func(pluginDir string) error {
 		return errMissingPathFlag
 	}
 
-	logger.Debug("plugindir: " + pluginDir + "\n")
+	logger.Debug("Plugindir: " + pluginDir + "\n")
 	pluginDirInfo, err := services.IoHelper.Stat(pluginDir)
 	if err != nil {
 		return err
@@ -41,9 +41,9 @@ func lsCommand(c utils.CommandLine) error {
 	plugins := services.GetLocalPlugins(pluginDir)
 
 	if len(plugins) > 0 {
-		logger.Info("installed plugins:\n")
+		logger.Info("Installed plugins:\n")
 	} else {
-		logger.Info("no installed plugins found\n")
+		logger.Info("No installed plugins found\n")
 	}
 
 	for _, plugin := range plugins {

--- a/pkg/components/loki/lokihttp/client.go
+++ b/pkg/components/loki/lokihttp/client.go
@@ -290,7 +290,7 @@ func (c *client) Chan() chan<- Entry {
 func (c *client) sendBatch(tenantID string, batch *batch) {
 	buf, entriesCount, err := batch.encode()
 	if err != nil {
-		c.logger.Error("error encoding batch", "error", err)
+		c.logger.Error("Error encoding batch", "error", err)
 		return
 	}
 	bufBytes := float64(len(buf))
@@ -310,7 +310,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 			break
 		}
 
-		c.logger.Warn("error sending batch, will retry", "status", status, "error", err)
+		c.logger.Warn("Error sending batch, will retry", "status", status, "error", err)
 		c.metrics.batchRetries.WithLabelValues(c.cfg.URL.Host).Inc()
 		backoff.Wait()
 
@@ -321,7 +321,7 @@ func (c *client) sendBatch(tenantID string, batch *batch) {
 	}
 
 	if err != nil {
-		c.logger.Error("final error sendnig batch", "status", status, "error")
+		c.logger.Error("Final error sendnig batch", "status", status, "error")
 		c.metrics.droppedBytes.WithLabelValues(c.cfg.URL.Host).Add(bufBytes)
 		c.metrics.droppedEntries.WithLabelValues(c.cfg.URL.Host).Add(float64(entriesCount))
 	}
@@ -351,7 +351,7 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
-			c.logger.Error("closing response body", "error", err)
+			c.logger.Error("Closing response body", "error", err)
 		}
 	}()
 

--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -27,15 +27,15 @@ func (kv *kvStoreSQL) Get(ctx context.Context, orgId int64, namespace string, ke
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error getting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "err", err)
+			kv.log.Debug("Error getting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "err", err)
 			return err
 		}
 		if !has {
-			kv.log.Debug("kvstore value not found", "orgId", orgId, "namespace", namespace, "key", key)
+			kv.log.Debug("Kvstore value not found", "orgId", orgId, "namespace", namespace, "key", key)
 			return nil
 		}
 		itemFound = true
-		kv.log.Debug("got kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", item.Value)
+		kv.log.Debug("Got kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", item.Value)
 		return nil
 	})
 
@@ -53,12 +53,12 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error checking kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+			kv.log.Debug("Error checking kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
 			return err
 		}
 
 		if has && item.Value == value {
-			kv.log.Debug("kvstore value not changed", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+			kv.log.Debug("Kvstore value not changed", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
 			return nil
 		}
 
@@ -68,9 +68,9 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 		if has {
 			_, err = dbSession.Exec("UPDATE kv_store SET value = ?, updated = ? WHERE id = ?", item.Value, item.Updated, item.Id)
 			if err != nil {
-				kv.log.Debug("error updating kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+				kv.log.Debug("Error updating kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
 			} else {
-				kv.log.Debug("kvstore value updated", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+				kv.log.Debug("Kvstore value updated", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
 			}
 			return err
 		}
@@ -78,9 +78,9 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 		item.Created = item.Updated
 		_, err = dbSession.Insert(&item)
 		if err != nil {
-			kv.log.Debug("error inserting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+			kv.log.Debug("Error inserting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
 		} else {
-			kv.log.Debug("kvstore value inserted", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+			kv.log.Debug("Kvstore value inserted", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
 		}
 		return err
 	})

--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -15,8 +15,8 @@ type logWrapper struct {
 	logger log.Logger
 }
 
-func (lw *logWrapper) Println(v ...any) {
-	lw.logger.Info("graphite metric bridge", v...)
+func (lw *logWrapper) Println(v ...interface{}) {
+	lw.logger.Info("Graphite metric bridge", v...)
 }
 
 func init() {
@@ -43,7 +43,7 @@ func (im *InternalMetricsService) Run(ctx context.Context) error {
 	if im.graphiteCfg != nil {
 		bridge, err := graphitebridge.NewBridge(im.graphiteCfg)
 		if err != nil {
-			metricsLogger.Error("failed to create graphite bridge", "error", err)
+			metricsLogger.Error("Failed to create graphite bridge", "error", err)
 		} else {
 			go bridge.Run(ctx)
 		}

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -48,7 +48,7 @@ func (dc *databaseCache) internalRunGC() {
 	})
 
 	if err != nil {
-		dc.log.Error("failed to run garbage collect", "error", err)
+		dc.log.Error("Failed to run garbage collect", "error", err)
 	}
 }
 

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -268,10 +268,10 @@ func (ots *Opentelemetry) initJaegerTracerProvider() (*tracesdk.TracerProvider, 
 	var ep jaeger.EndpointOption
 	// Create the Jaeger exporter: address can be either agent address (host:port) or collector URL
 	if strings.HasPrefix(ots.Address, "http://") || strings.HasPrefix(ots.Address, "https://") {
-		ots.log.Debug("using jaeger collector", "address", ots.Address)
+		ots.log.Debug("Using jaeger collector", "address", ots.Address)
 		ep = jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(ots.Address))
 	} else if host, port, err := net.SplitHostPort(ots.Address); err == nil {
-		ots.log.Debug("using jaeger agent", "host", host, "port", port)
+		ots.log.Debug("Using jaeger agent", "host", host, "port", port)
 		ep = jaeger.WithAgentEndpoint(jaeger.WithAgentHost(host), jaeger.WithAgentPort(port), jaeger.WithMaxPacketSize(64000))
 	} else {
 		return nil, fmt.Errorf("invalid tracer address: %s", ots.Address)

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -92,14 +92,14 @@ func ProvideService(
 
 // RegisterProviders is called only once - during Grafana start up
 func (s *Service) RegisterProviders(usageStatProviders []registry.ProvidesUsageStats) {
-	s.log.Info("registering usage stat providers", "usageStatsProvidersLen", len(usageStatProviders))
+	s.log.Info("Registering usage stat providers", "usageStatsProvidersLen", len(usageStatProviders))
 	s.usageStatProviders = usageStatProviders
 }
 
 func (s *Service) Run(ctx context.Context) error {
 	sendInterval := time.Second * time.Duration(s.cfg.MetricsTotalStatsIntervalSeconds)
 	nextSendInterval := time.Duration(rand.Intn(MAX_DELAY-MIN_DELAY)+MIN_DELAY) * time.Second
-	s.log.Debug("usage stats collector started", "sendInterval", sendInterval, "nextSendInterval", nextSendInterval)
+	s.log.Debug("Usage stats collector started", "sendInterval", sendInterval, "nextSendInterval", nextSendInterval)
 	updateStatsTicker := time.NewTicker(nextSendInterval)
 	defer updateStatsTicker.Stop()
 

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -74,7 +74,7 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 				} else {
 					// log requests where we could not identify handler so we can register them.
 					if features.IsEnabled(featuremgmt.FlagLogRequestsInstrumentedAsUnknown) {
-						log.Warn("request instrumented as unknown", "path", r.URL.Path, "status_code", status)
+						log.Warn("Request instrumented as unknown", "path", r.URL.Path, "status_code", status)
 					}
 				}
 			}

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -437,7 +437,7 @@ func (r *xormRepositoryImpl) Delete(ctx context.Context, params *annotations.Del
 			annoTagSQL string
 		)
 
-		r.log.Info("delete", "orgId", params.OrgID)
+		r.log.Info("Delete", "orgId", params.OrgID)
 		if params.ID != 0 {
 			annoTagSQL = "DELETE FROM annotation_tag WHERE annotation_id IN (SELECT id FROM annotation WHERE id = ? AND org_id = ?)"
 			sql = "DELETE FROM annotation WHERE id = ? AND org_id = ?"

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -124,7 +124,7 @@ func (srv *CleanUpService) cleanUpOldAnnotations(ctx context.Context) {
 	logger := srv.log.FromContext(ctx)
 	affected, affectedTags, err := srv.annotationCleaner.Run(ctx, srv.Cfg)
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-		logger.Error("failed to clean up old annotations", "error", err)
+		logger.Error("Failed to clean up old annotations", "error", err)
 	} else {
 		logger.Debug("Deleted excess annotations", "annotations affected", affected, "annotation tags affected", affectedTags)
 	}

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -135,10 +135,10 @@ func (s *Service) getDashUIDMaybeEmpty(ctx context.Context, id int64) (string, e
 	result, err := s.dashSvc.GetDashboardUIDByID(ctx, &q)
 	if err != nil {
 		if errors.Is(err, dashboards.ErrDashboardNotFound) {
-			s.log.Debug("dashboard not found")
+			s.log.Debug("Dashboard not found")
 			return "", nil
 		} else {
-			s.log.Error("error getting dashboard", err)
+			s.log.Error("Error getting dashboard", err)
 			return "", err
 		}
 	}
@@ -152,10 +152,10 @@ func (s *Service) getDashIDMaybeEmpty(ctx context.Context, uid string) (int64, e
 	result, err := s.dashSvc.GetDashboard(ctx, &q)
 	if err != nil {
 		if errors.Is(err, dashboards.ErrDashboardNotFound) {
-			s.log.Debug("dashboard not found")
+			s.log.Debug("Dashboard not found")
 			return -1, nil
 		} else {
-			s.log.Error("error getting dashboard", err)
+			s.log.Error("Error getting dashboard", err)
 			return -1, err
 		}
 	}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -198,7 +198,7 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		// fetch folder from dashboard store
 		dashFolder, ok := dashFolders[f.UID]
 		if !ok {
-			s.log.Error("failed to fetch folder by UID from dashboard store", "uid", f.UID)
+			s.log.Error("Failed to fetch folder by UID from dashboard store", "uid", f.UID)
 			continue
 		}
 
@@ -336,13 +336,13 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		if err != nil {
 			// We'll log the error and also roll back the previously-created
 			// (legacy) folder.
-			logger.Error("error saving folder to nested folder store", "error", err)
+			logger.Error("Error saving folder to nested folder store", "error", err)
 			// do not shallow create error if the legacy folder delete fails
 			if deleteErr := s.dashboardStore.DeleteDashboard(ctx, &dashboards.DeleteDashboardCommand{
 				ID:    createdFolder.ID,
 				OrgID: createdFolder.OrgID,
 			}); deleteErr != nil {
-				logger.Error("error deleting folder after failed save to nested folder store", "error", err)
+				logger.Error("Error deleting folder after failed save to nested folder store", "error", err)
 			}
 			return dashboards.FromDashboard(dash), err
 		}
@@ -451,7 +451,7 @@ func (s *Service) legacyUpdate(ctx context.Context, cmd *folder.UpdateFolderComm
 			UID:       dash.UID,
 			OrgID:     cmd.OrgID,
 		}); err != nil {
-			logger.Error("failed to publish FolderTitleUpdated event", "folder", foldr.Title, "user", user.UserID, "error", err)
+			logger.Error("Failed to publish FolderTitleUpdated event", "folder", foldr.Title, "user", user.UserID, "error", err)
 		}
 	}
 	return foldr, nil
@@ -513,7 +513,7 @@ func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) e
 			subfolders, err := s.nestedFolderDelete(ctx, cmd)
 
 			if err != nil {
-				logger.Error("the delete folder on folder table failed with err: ", "error", err)
+				logger.Error("The delete folder on folder table failed with err: ", "error", err)
 				return err
 			}
 			result = append(result, subfolders...)
@@ -646,19 +646,19 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 	}
 	for _, f := range folders {
 		result = append(result, f.UID)
-		logger.Info("deleting subfolder", "org_id", f.OrgID, "uid", f.UID)
+		logger.Info("Deleting subfolder", "org_id", f.OrgID, "uid", f.UID)
 		subfolders, err := s.nestedFolderDelete(ctx, &folder.DeleteFolderCommand{UID: f.UID, OrgID: f.OrgID, ForceDeleteRules: cmd.ForceDeleteRules, SignedInUser: cmd.SignedInUser})
 		if err != nil {
-			logger.Error("failed deleting subfolder", "org_id", f.OrgID, "uid", f.UID, "error", err)
+			logger.Error("Failed deleting subfolder", "org_id", f.OrgID, "uid", f.UID, "error", err)
 			return result, err
 		}
 		result = append(result, subfolders...)
 	}
 
-	logger.Info("deleting folder and its contents", "org_id", cmd.OrgID, "uid", cmd.UID)
+	logger.Info("Deleting folder and its contents", "org_id", cmd.OrgID, "uid", cmd.UID)
 	err = s.store.Delete(ctx, cmd.UID, cmd.OrgID)
 	if err != nil {
-		logger.Info("failed deleting folder", "org_id", cmd.OrgID, "uid", cmd.UID, "err", err)
+		logger.Info("Failed deleting folder", "org_id", cmd.OrgID, "uid", cmd.UID, "err", err)
 		return result, err
 	}
 	return result, nil
@@ -681,7 +681,7 @@ func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescen
 	if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
 		subfolders, err := s.getNestedFolders(ctx, cmd.OrgID, *cmd.UID)
 		if err != nil {
-			logger.Error("failed to get subfolders", "error", err)
+			logger.Error("Failed to get subfolders", "error", err)
 			return nil, err
 		}
 		result = append(result, subfolders...)
@@ -692,7 +692,7 @@ func (s *Service) GetDescendantCounts(ctx context.Context, cmd *folder.GetDescen
 		for _, folder := range result {
 			c, err := v.CountInFolder(ctx, cmd.OrgID, folder, cmd.SignedInUser)
 			if err != nil {
-				logger.Error("failed to count folder descendants", "error", err)
+				logger.Error("Failed to count folder descendants", "error", err)
 				return nil, err
 			}
 			countsMap[v.Kind()] += c

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -221,10 +221,10 @@ func (ss *sqlStore) GetParents(ctx context.Context, q folder.GetParentsQuery) ([
 			folders[idx].WithURL()
 			return nil
 		}); err != nil {
-			ss.log.Debug("failed to set URL to folders", "err", err)
+			ss.log.Debug("Failed to set URL to folders", "err", err)
 		}
 	default:
-		ss.log.Debug("recursive CTE subquery is not supported; it fallbacks to the iterative implementation")
+		ss.log.Debug("Recursive CTE subquery is not supported; it fallbacks to the iterative implementation")
 		return ss.getParentsMySQL(ctx, q)
 	}
 
@@ -267,7 +267,7 @@ func (ss *sqlStore) GetChildren(ctx context.Context, q folder.GetChildrenQuery) 
 			folders[idx].WithURL()
 			return nil
 		}); err != nil {
-			ss.log.Debug("failed to set URL to folders", "err", err)
+			ss.log.Debug("Failed to set URL to folders", "err", err)
 		}
 		return nil
 	})
@@ -327,7 +327,7 @@ func (ss *sqlStore) GetHeight(ctx context.Context, foldrUID string, orgID int64,
 		}
 	}
 	if height > folder.MaxNestedFolderDepth {
-		ss.log.Warn("folder height exceeds the maximum allowed depth, You might have a circular reference", "uid", foldrUID, "orgId", orgID, "maxDepth", folder.MaxNestedFolderDepth)
+		ss.log.Warn("Folder height exceeds the maximum allowed depth, You might have a circular reference", "uid", foldrUID, "orgId", orgID, "maxDepth", folder.MaxNestedFolderDepth)
 	}
 	return height, nil
 }

--- a/pkg/services/grpcserver/interceptors/auth.go
+++ b/pkg/services/grpcserver/interceptors/auth.go
@@ -69,7 +69,7 @@ func (a *authenticator) tokenAuth(ctx context.Context) (context.Context, error) 
 
 	signedInUser, err := a.getSignedInUser(ctx, token)
 	if err != nil {
-		a.logger.Warn("request with invalid token", "error", err, "token", token)
+		a.logger.Warn("Request with invalid token", "error", err, "token", token)
 		return ctx, status.Error(codes.Unauthenticated, "invalid token")
 	}
 
@@ -124,7 +124,7 @@ func (a *authenticator) getSignedInUser(ctx context.Context, token string) (*use
 	if signedInUser.Permissions[signedInUser.OrgID] == nil {
 		permissions, err := a.AccessControlService.GetUserPermissions(ctx, signedInUser, accesscontrol.Options{})
 		if err != nil {
-			a.logger.Error("failed fetching permissions for user", "userID", signedInUser.UserID, "error", err)
+			a.logger.Error("Failed fetching permissions for user", "userID", signedInUser.UserID, "error", err)
 		}
 		signedInUser.Permissions[signedInUser.OrgID] = accesscontrol.GroupScopesByAction(permissions)
 	}

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -239,7 +239,7 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 	return func(include *plugins.Includes) bool {
 		useRBAC := s.features.IsEnabled(featuremgmt.FlagAccessControlOnCall) && include.RequiresRBACAction()
 		if useRBAC && !hasAccess(ac.EvalPermission(include.Action)) {
-			s.log.Debug("plugin include is covered by RBAC, user doesn't have access",
+			s.log.Debug("Plugin include is covered by RBAC, user doesn't have access",
 				"plugin", pluginID,
 				"include", include.Name)
 			return false

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -74,7 +74,7 @@ func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer, store TempUser
 		if len(invalidTemplates) == len(ns.Cfg.Smtp.TemplatesPatterns) {
 			return nil, fmt.Errorf("provided html/template filepaths matched no files: %s", is)
 		}
-		ns.log.Warn("some provided html/template filepaths matched no files: %s", is)
+		ns.log.Warn("Some provided html/template filepaths matched no files: %s", is)
 	}
 
 	if !util.IsEmail(ns.Cfg.Smtp.FromAddress) {

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -76,9 +76,9 @@ func (o *Service) GetCurrentOAuthToken(ctx context.Context, usr identity.Request
 	if err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
 			// Not necessarily an error.  User may be logged in another way.
-			logger.Debug("no oauth token for user found", "userId", userID, "username", usr.GetLogin())
+			logger.Debug("no oauth token for user found", "userId", usr.UserID, "username", usr.Login)
 		} else {
-			logger.Error("failed to get oauth token for user", "userId", userID, "username", usr.GetLogin(), "error", err)
+			logger.Error("failed to get oauth token for user", "userId", usr.UserID, "username", usr.Login, "error", err)
 		}
 		return nil
 	}
@@ -125,7 +125,7 @@ func (o *Service) HasOAuthEntry(ctx context.Context, usr identity.Requester) (*l
 			// Not necessarily an error.  User may be logged in another way.
 			return nil, false, nil
 		}
-		logger.Error("failed to fetch oauth token for user", "userId", userID, "username", usr.GetLogin(), "error", err)
+		logger.Error("failed to fetch oauth token for user", "userId", usr.UserID, "username", usr.Login, "error", err)
 		return nil, false, err
 	}
 	if !strings.Contains(authInfo.AuthModule, "oauth") {
@@ -138,7 +138,7 @@ func (o *Service) HasOAuthEntry(ctx context.Context, usr identity.Requester) (*l
 // It uses a singleflight.Group to prevent getting the Refresh Token multiple times for a given User
 func (o *Service) TryTokenRefresh(ctx context.Context, usr *login.UserAuth) error {
 	lockKey := fmt.Sprintf("oauth-refresh-token-%d", usr.UserId)
-	_, err, _ := o.singleFlightGroup.Do(lockKey, func() (any, error) {
+	_, err, _ := o.singleFlightGroup.Do(lockKey, func() (interface{}, error) {
 		logger.Debug("singleflight request for getting a new access token", "key", lockKey)
 
 		return o.tryGetOrRefreshAccessToken(ctx, usr)

--- a/pkg/services/provisioning/alerting/config_reader.go
+++ b/pkg/services/provisioning/alerting/config_reader.go
@@ -25,16 +25,16 @@ func newRulesConfigReader(logger log.Logger) rulesConfigReader {
 
 func (cr *rulesConfigReader) readConfig(ctx context.Context, path string) ([]*AlertingFile, error) {
 	var alertFiles []*AlertingFile
-	cr.log.Debug("looking for alerting provisioning files", "path", path)
+	cr.log.Debug("Looking for alerting provisioning files", "path", path)
 
 	files, err := os.ReadDir(path)
 	if err != nil {
-		cr.log.Error("can't read alerting provisioning files from directory", "path", path, "error", err)
+		cr.log.Error("Can't read alerting provisioning files from directory", "path", path, "error", err)
 		return alertFiles, nil
 	}
 
 	for _, file := range files {
-		cr.log.Debug("parsing alerting provisioning file", "path", path, "file.Name", file.Name())
+		cr.log.Debug("Parsing alerting provisioning file", "path", path, "file.Name", file.Name())
 		if !cr.isYAML(file.Name()) && !cr.isJSON(file.Name()) {
 			cr.log.Warn(fmt.Sprintf("file has invalid suffix '%s' (.yaml,.yml,.json accepted), skipping", file.Name()))
 			continue

--- a/pkg/services/provisioning/alerting/provisioner.go
+++ b/pkg/services/provisioning/alerting/provisioner.go
@@ -27,8 +27,8 @@ func Provision(ctx context.Context, cfg ProvisionerConfig) error {
 	if err != nil {
 		return err
 	}
-	logger.Info("starting to provision alerting")
-	logger.Debug("read all alerting files", "file_count", len(files))
+	logger.Info("Starting to provision alerting")
+	logger.Debug("Read all alerting files", "file_count", len(files))
 	ruleProvisioner := NewAlertRuleProvisioner(
 		logger,
 		cfg.DashboardService,
@@ -74,6 +74,6 @@ func Provision(ctx context.Context, cfg ProvisionerConfig) error {
 	if err != nil {
 		return fmt.Errorf("text templates: %w", err)
 	}
-	logger.Info("finished to provision alerting")
+	logger.Info("Finished to provision alerting")
 	return nil
 }

--- a/pkg/services/provisioning/alerting/rules_provisioner.go
+++ b/pkg/services/provisioning/alerting/rules_provisioner.go
@@ -44,7 +44,7 @@ func (prov *defaultAlertRuleProvisioner) Provision(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			prov.logger.Debug("provisioning alert rule group",
+			prov.logger.Debug("Provisioning alert rule group",
 				"org", group.OrgID,
 				"folder", group.FolderTitle,
 				"folderUID", folderUID,
@@ -77,17 +77,17 @@ func (prov *defaultAlertRuleProvisioner) provisionRule(
 	ctx context.Context,
 	orgID int64,
 	rule alert_models.AlertRule) error {
-	prov.logger.Debug("provisioning alert rule", "uid", rule.UID, "org", rule.OrgID)
+	prov.logger.Debug("Provisioning alert rule", "uid", rule.UID, "org", rule.OrgID)
 	_, _, err := prov.ruleService.GetAlertRule(ctx, orgID, rule.UID)
 	if err != nil && !errors.Is(err, alert_models.ErrAlertRuleNotFound) {
 		return err
 	} else if err != nil {
-		prov.logger.Debug("creating rule", "uid", rule.UID, "org", rule.OrgID)
+		prov.logger.Debug("Creating rule", "uid", rule.UID, "org", rule.OrgID)
 		// 0 is passed as userID as then the quota logic will only check for
 		// the organization quota, as we don't have any user scope here.
 		_, err = prov.ruleService.CreateAlertRule(ctx, rule, alert_models.ProvenanceFile, 0)
 	} else {
-		prov.logger.Debug("updating rule", "uid", rule.UID, "org", rule.OrgID)
+		prov.logger.Debug("Updating rule", "uid", rule.UID, "org", rule.OrgID)
 		_, err = prov.ruleService.UpdateAlertRule(ctx, rule, alert_models.ProvenanceFile)
 	}
 	return err

--- a/pkg/services/provisioning/dashboards/config_reader.go
+++ b/pkg/services/provisioning/dashboards/config_reader.go
@@ -71,7 +71,7 @@ func (cr *configReader) readConfig(ctx context.Context) ([]*config, error) {
 
 	files, err := os.ReadDir(cr.path)
 	if err != nil {
-		cr.log.Error("can't read dashboard provisioning files from directory", "path", cr.path, "error", err)
+		cr.log.Error("Can't read dashboard provisioning files from directory", "path", cr.path, "error", err)
 		return dashboards, nil
 	}
 
@@ -114,7 +114,7 @@ func (cr *configReader) readConfig(ctx context.Context) ([]*config, error) {
 
 	for uid, times := range uidUsage {
 		if times > 1 {
-			cr.log.Error("the same folder UID is used more than once", "folderUid", uid)
+			cr.log.Error("The same folder UID is used more than once", "folderUid", uid)
 		}
 	}
 

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -76,7 +76,7 @@ func (fr *FileReader) pollChanges(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := fr.walkDisk(ctx); err != nil {
-				fr.log.Error("failed to search for dashboards", "error", err)
+				fr.log.Error("Failed to search for dashboards", "error", err)
 			}
 		case <-ctx.Done():
 			return
@@ -149,7 +149,7 @@ func (fr *FileReader) storeDashboardsInFolder(ctx context.Context, filesFoundOnD
 	for path, fileInfo := range filesFoundOnDisk {
 		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, fileInfo, dashboardRefs)
 		if err != nil {
-			fr.log.Error("failed to save dashboard", "file", path, "error", err)
+			fr.log.Error("Failed to save dashboard", "file", path, "error", err)
 			continue
 		}
 
@@ -178,7 +178,7 @@ func (fr *FileReader) storeDashboardsInFoldersFromFileStructure(ctx context.Cont
 		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, fileInfo, dashboardRefs)
 		usageTracker.track(provisioningMetadata)
 		if err != nil {
-			fr.log.Error("failed to save dashboard", "file", path, "error", err)
+			fr.log.Error("Failed to save dashboard", "file", path, "error", err)
 		}
 	}
 	return nil
@@ -200,19 +200,19 @@ func (fr *FileReader) handleMissingDashboardFiles(ctx context.Context, provision
 		// If deletion is disabled for the provisioner we just remove provisioning metadata about the dashboard
 		// so afterwards the dashboard is considered unprovisioned.
 		for _, dashboardID := range dashboardsToDelete {
-			fr.log.Debug("unprovisioning provisioned dashboard. missing on disk", "id", dashboardID)
+			fr.log.Debug("Unprovisioning provisioned dashboard. missing on disk", "id", dashboardID)
 			err := fr.dashboardProvisioningService.UnprovisionDashboard(ctx, dashboardID)
 			if err != nil {
-				fr.log.Error("failed to unprovision dashboard", "dashboard_id", dashboardID, "error", err)
+				fr.log.Error("Failed to unprovision dashboard", "dashboard_id", dashboardID, "error", err)
 			}
 		}
 	} else {
 		// delete dashboards missing JSON file
 		for _, dashboardID := range dashboardsToDelete {
-			fr.log.Debug("deleting provisioned dashboard, missing on disk", "id", dashboardID)
+			fr.log.Debug("Deleting provisioned dashboard, missing on disk", "id", dashboardID)
 			err := fr.dashboardProvisioningService.DeleteProvisionedDashboard(ctx, dashboardID, fr.Cfg.OrgID)
 			if err != nil {
-				fr.log.Error("failed to delete dashboard", "id", dashboardID, "error", err)
+				fr.log.Error("Failed to delete dashboard", "id", dashboardID, "error", err)
 			}
 		}
 	}
@@ -231,7 +231,7 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 
 	jsonFile, err := fr.readDashboardFromFile(path, resolvedFileInfo.ModTime(), folderID)
 	if err != nil {
-		fr.log.Error("failed to load dashboard from ", "file", path, "error", err)
+		fr.log.Error("Failed to load dashboard from ", "file", path, "error", err)
 		return provisioningMetadata, nil
 	}
 
@@ -259,7 +259,7 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 	}
 
 	if !fr.isDatabaseAccessRestricted() {
-		fr.log.Debug("saving new dashboard", "provisioner", fr.Cfg.Name, "file", path, "folderId", dash.Dashboard.FolderID)
+		fr.log.Debug("Saving new dashboard", "provisioner", fr.Cfg.Name, "file", path, "folderId", dash.Dashboard.FolderID)
 		dp := &dashboards.DashboardProvisioning{
 			ExternalID: path,
 			Name:       fr.Cfg.Name,
@@ -444,7 +444,7 @@ func (fr *FileReader) resolvedPath() string {
 
 	if path == "" {
 		path = fr.Path
-		fr.log.Info("falling back to original path due to EvalSymlink/Abs failure")
+		fr.log.Info("Falling back to original path due to EvalSymlink/Abs failure")
 	}
 	return path
 }

--- a/pkg/services/provisioning/dashboards/file_reader_symlink_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_symlink_test.go
@@ -28,7 +28,7 @@ func TestProvisionedSymlinkedFolder(t *testing.T) {
 
 	reader, err := NewDashboardFileReader(cfg, log.New("test-logger"), nil, nil)
 	if err != nil {
-		t.Error("expected err to be nil")
+		t.Error("Expected err to be nil")
 	}
 
 	want, err := filepath.Abs(containingID)

--- a/pkg/services/provisioning/dashboards/validator.go
+++ b/pkg/services/provisioning/dashboards/validator.go
@@ -95,14 +95,14 @@ func (c *duplicateValidator) logWarnings(duplicatesByOrg map[int64]duplicateEntr
 	for orgID, duplicates := range duplicatesByOrg {
 		for uid, usage := range duplicates.UIDs {
 			if usage.Sum > 1 {
-				c.logger.Warn("the same UID is used more than once", "orgId", orgID, "uid", uid, "times", usage.Sum, "providers",
+				c.logger.Warn("The same UID is used more than once", "orgId", orgID, "uid", uid, "times", usage.Sum, "providers",
 					keysToSlice(usage.InvolvedReaders))
 			}
 		}
 
 		for id, usage := range duplicates.Titles {
 			if usage.Sum > 1 {
-				c.logger.Warn("dashboard title is not unique in folder", "orgId", orgID, "title", id.title, "folderID", id.folderID, "times",
+				c.logger.Warn("Dashboard title is not unique in folder", "orgId", orgID, "title", id.title, "folderID", id.folderID, "times",
 					usage.Sum, "providers", keysToSlice(usage.InvolvedReaders))
 			}
 		}
@@ -123,7 +123,7 @@ func (c *duplicateValidator) takeAwayWritePermissions(duplicatesByOrg map[int64]
 			if exists {
 				// We restrict reader permissions to write to the database here to prevent overloading
 				reader.changeWritePermissions(true)
-				c.logger.Warn("dashboards provisioning provider has no database write permissions because of duplicates", "provider", reader.Cfg.Name, "orgId", orgID)
+				c.logger.Warn("Dashboards provisioning provider has no database write permissions because of duplicates", "provider", reader.Cfg.Name, "orgId", orgID)
 			}
 		}
 	}

--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -26,7 +26,7 @@ func (cr *configReader) readConfig(ctx context.Context, path string) ([]*configs
 
 	files, err := os.ReadDir(path)
 	if err != nil {
-		cr.log.Error("can't read datasource provisioning files from directory", "path", path, "error", err)
+		cr.log.Error("Can't read datasource provisioning files from directory", "path", path, "error", err)
 		return datasources, nil
 	}
 
@@ -140,7 +140,7 @@ func (cr *configReader) validateAccessAndOrgID(ctx context.Context, ds *upsertDa
 	}
 
 	if ds.Access != datasources.DS_ACCESS_DIRECT && ds.Access != datasources.DS_ACCESS_PROXY {
-		cr.log.Warn("invalid access value, will use 'proxy' instead", "value", ds.Access)
+		cr.log.Warn("Invalid access value, will use 'proxy' instead", "value", ds.Access)
 		ds.Access = datasources.DS_ACCESS_PROXY
 	}
 	return nil

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -73,7 +73,7 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 
 		if errors.Is(err, datasources.ErrDataSourceNotFound) {
 			insertCmd := createInsertCommand(ds)
-			dc.log.Info("inserting datasource from configuration ", "name", insertCmd.Name, "uid", insertCmd.UID)
+			dc.log.Info("Inserting datasource from configuration ", "name", insertCmd.Name, "uid", insertCmd.UID)
 			dataSource, err := dc.store.AddDataSource(ctx, insertCmd)
 			if err != nil {
 				return err
@@ -83,13 +83,13 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 				if insertCorrelationCmd, err := makeCreateCorrelationCommand(correlation, dataSource.UID, insertCmd.OrgID); err == nil {
 					correlationsToInsert = append(correlationsToInsert, insertCorrelationCmd)
 				} else {
-					dc.log.Error("failed to parse correlation", "correlation", correlation)
+					dc.log.Error("Failed to parse correlation", "correlation", correlation)
 					return err
 				}
 			}
 		} else {
 			updateCmd := createUpdateCommand(ds, dataSource.ID)
-			dc.log.Debug("updating datasource from configuration", "name", updateCmd.Name, "uid", updateCmd.UID)
+			dc.log.Debug("Updating datasource from configuration", "name", updateCmd.Name, "uid", updateCmd.UID)
 			if _, err := dc.store.UpdateDataSource(ctx, updateCmd); err != nil {
 				return err
 			}
@@ -107,7 +107,7 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 				if insertCorrelationCmd, err := makeCreateCorrelationCommand(correlation, dataSource.UID, updateCmd.OrgID); err == nil {
 					correlationsToInsert = append(correlationsToInsert, insertCorrelationCmd)
 				} else {
-					dc.log.Error("failed to parse correlation", "correlation", correlation)
+					dc.log.Error("Failed to parse correlation", "correlation", correlation)
 					return err
 				}
 			}
@@ -210,11 +210,11 @@ func (dc *DatasourceProvisioner) deleteDatasources(ctx context.Context, dsToDele
 				return err
 			}
 
-			dc.log.Info("deleted correlations based on configuration", "ds_name", ds.Name)
+			dc.log.Info("Deleted correlations based on configuration", "ds_name", ds.Name)
 		}
 
 		if cmd.DeletedDatasourcesCount > 0 {
-			dc.log.Info("deleted datasource based on configuration", "name", ds.Name)
+			dc.log.Info("Deleted datasource based on configuration", "name", ds.Name)
 		}
 	}
 

--- a/pkg/services/provisioning/notifiers/alert_notifications.go
+++ b/pkg/services/provisioning/notifiers/alert_notifications.go
@@ -118,7 +118,7 @@ func (dc *NotificationProvisioner) mergeNotifications(ctx context.Context, notif
 		}
 
 		if res == nil {
-			dc.log.Debug("inserting alert notification from configuration", "name", notification.Name, "uid", notification.UID)
+			dc.log.Debug("Inserting alert notification from configuration", "name", notification.Name, "uid", notification.UID)
 			insertCmd := &models.CreateAlertNotificationCommand{
 				UID:                   notification.UID,
 				Name:                  notification.Name,
@@ -137,7 +137,7 @@ func (dc *NotificationProvisioner) mergeNotifications(ctx context.Context, notif
 				return err
 			}
 		} else {
-			dc.log.Debug("updating alert notification from configuration", "name", notification.Name)
+			dc.log.Debug("Updating alert notification from configuration", "name", notification.Name)
 			updateCmd := &models.UpdateAlertNotificationWithUidCommand{
 				UID:                   notification.UID,
 				Name:                  notification.Name,

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -120,7 +120,7 @@ func (s *ServiceImpl) executeConcurrentQueries(ctx context.Context, user identit
 	recoveryFn := func(queries []*simplejson.Json) {
 		if r := recover(); r != nil {
 			var err error
-			s.log.Error("query datasource panic", "error", r, "stack", log.Stack(1))
+			s.log.Error("Query datasource panic", "error", r, "stack", log.Stack(1))
 			if theErr, ok := r.(error); ok {
 				err = theErr
 			} else if theErrString, ok := r.(string); ok {
@@ -176,7 +176,7 @@ func (s *ServiceImpl) executeConcurrentQueries(ctx context.Context, user identit
 					if !slices.Contains(reqCtx.Resp.Header().Values(k), val) {
 						reqCtx.Resp.Header().Add(k, val)
 					} else {
-						s.log.Warn("skipped duplicate response header", "header", k, "value", val)
+						s.log.Warn("Skipped duplicate response header", "header", k, "value", val)
 					}
 				}
 			}

--- a/pkg/services/quota/quotaimpl/store.go
+++ b/pkg/services/quota/quotaimpl/store.go
@@ -96,7 +96,7 @@ func (ss *sqlStore) getUserScopeQuota(ctx quota.Context, userID int64) (*quota.M
 		for _, q := range quotas {
 			srv, ok := ctx.TargetToSrv.Get(quota.Target(q.Target))
 			if !ok {
-				ss.logger.Info("failed to get service for target", "target", q.Target)
+				ss.logger.Info("Failed to get service for target", "target", q.Target)
 			}
 			tag, err := quota.NewTag(srv, quota.Target(q.Target), quota.UserScope)
 			if err != nil {
@@ -120,7 +120,7 @@ func (ss *sqlStore) getOrgScopeQuota(ctx quota.Context, OrgID int64) (*quota.Map
 		for _, q := range quotas {
 			srv, ok := ctx.TargetToSrv.Get(quota.Target(q.Target))
 			if !ok {
-				ss.logger.Info("failed to get service for target", "target", q.Target)
+				ss.logger.Info("Failed to get service for target", "target", q.Target)
 			}
 			tag, err := quota.NewTag(srv, quota.Target(q.Target), quota.OrgScope)
 			if err != nil {

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -149,7 +149,7 @@ func (rs *RenderingService) doRequest(ctx context.Context, u *url.URL, headers m
 		req.Header[k] = v
 	}
 
-	rs.log.Debug("calling remote rendering service", "url", u)
+	rs.log.Debug("Calling remote rendering service", "url", u)
 
 	// make request to renderer server
 	resp, err := netClient.Do(req)

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -329,7 +329,7 @@ func (rs *RenderingService) SanitizeSVG(ctx context.Context, req *SanitizeSVGReq
 	start := time.Now()
 
 	action, err := rs.sanitizeSVGAction(ctx, req)
-	rs.log.Info("svg sanitization finished", "duration", time.Since(start), "filename", req.Filename, "isError", err != nil)
+	rs.log.Info("Svg sanitization finished", "duration", time.Since(start), "filename", req.Filename, "isError", err != nil)
 
 	return action, err
 }

--- a/pkg/services/secrets/kvstore/cache.go
+++ b/pkg/services/secrets/kvstore/cache.go
@@ -29,7 +29,7 @@ func WithCache(store SecretsKVStore, defaultExpiration time.Duration, cleanupInt
 func (kv *CachedKVStore) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
 	key := fmt.Sprint(orgId, namespace, typ)
 	if value, ok := kv.cache.Get(key); ok {
-		kv.log.Debug("got secret value from cache", "orgId", orgId, "type", typ, "namespace", namespace)
+		kv.log.Debug("Got secret value from cache", "orgId", orgId, "type", typ, "namespace", namespace)
 		return fmt.Sprint(value), true, nil
 	}
 	value, ok, err := kv.store.Get(ctx, orgId, namespace, typ)

--- a/pkg/services/secrets/kvstore/kvstore.go
+++ b/pkg/services/secrets/kvstore/kvstore.go
@@ -33,17 +33,17 @@ func ProvideService(
 	store = NewSQLSecretsKVStore(sqlStore, secretsService, logger)
 	err := EvaluateRemoteSecretsPlugin(ctx, pluginsManager, cfg)
 	if err != nil {
-		logger.Debug("secrets manager evaluator returned false", "reason", err.Error())
+		logger.Debug("Secrets manager evaluator returned false", "reason", err.Error())
 	} else {
 		// Attempt to start the plugin
 		var secretsPlugin secretsmanagerplugin.SecretsManagerPlugin
 		secretsPlugin, err = StartAndReturnPlugin(pluginsManager, ctx)
 		namespacedKVStore := GetNamespacedKVStore(kvstore)
 		if err != nil || secretsPlugin == nil {
-			logger.Error("failed to start remote secrets management plugin")
+			logger.Error("Failed to start remote secrets management plugin")
 			if isFatal, readErr := IsPluginStartupErrorFatal(ctx, namespacedKVStore); isFatal || readErr != nil {
 				// plugin error was fatal or there was an error determining if the error was fatal
-				logger.Error("secrets management plugin is required to start -- exiting app")
+				logger.Error("Secrets management plugin is required to start -- exiting app")
 				if readErr != nil {
 					return nil, readErr
 				}
@@ -58,7 +58,7 @@ func ProvideService(
 	}
 
 	if err != nil {
-		logger.Debug("secrets kvstore is using the default (SQL) implementation for secrets management")
+		logger.Debug("Secrets kvstore is using the default (SQL) implementation for secrets management")
 	}
 
 	return WithCache(store, 5*time.Second, 5*time.Minute), nil

--- a/pkg/services/secrets/kvstore/migrations/datasource_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig.go
@@ -53,7 +53,7 @@ func (s *DataSourceSecretMigrationService) Migrate(ctx context.Context) error {
 	needMigration := migrationStatus != completeSecretMigrationValue && disableSecretsCompatibility
 
 	if needCompatibility || needMigration {
-		logger.Debug("performing secret migration", "needs migration", needMigration, "needs compatibility", needCompatibility)
+		logger.Debug("Performing secret migration", "needs migration", needMigration, "needs compatibility", needCompatibility)
 		query := &datasources.GetAllDataSourcesQuery{}
 		dsList, err := s.dataSourcesService.GetAllDataSources(ctx, query)
 		if err != nil {

--- a/pkg/services/secrets/kvstore/migrations/from_plugin_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/from_plugin_mig.go
@@ -43,7 +43,7 @@ func ProvideMigrateFromPluginService(
 }
 
 func (s *MigrateFromPluginService) Migrate(ctx context.Context) error {
-	logger.Debug("starting migration of plugin secrets to unified secrets")
+	logger.Debug("Starting migration of plugin secrets to unified secrets")
 	// access the plugin directly
 	plugin, err := secretskvs.StartAndReturnPlugin(s.manager, context.Background())
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *MigrateFromPluginService) Migrate(ctx context.Context) error {
 		return err
 	}
 	totalSecrets := len(res.Items)
-	logger.Debug("retrieved all secrets from plugin", "num secrets", totalSecrets)
+	logger.Debug("Retrieved all secrets from plugin", "num secrets", totalSecrets)
 	// create a secret sql store manually
 	secretsSql := secretskvs.NewSQLSecretsKVStore(s.sqlStore, s.secretsService, logger)
 	for i, item := range res.Items {

--- a/pkg/services/secrets/kvstore/migrations/to_plugin_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/to_plugin_mig.go
@@ -48,12 +48,12 @@ func (s *MigrateToPluginService) Migrate(ctx context.Context) error {
 	err := secretskvs.EvaluateRemoteSecretsPlugin(ctx, s.manager, s.cfg)
 	hasStarted := secretskvs.HasPluginStarted(ctx, s.manager)
 	if err == nil && hasStarted {
-		logger.Debug("starting migration of unified secrets to the plugin")
+		logger.Debug("Starting migration of unified secrets to the plugin")
 		// we need to get the fallback store since in this scenario the secrets store would be the plugin.
 		tmpStore, err := secretskvs.GetUnwrappedStoreFromCache(s.secretsStore)
 		if err != nil {
 			tmpStore = s.secretsStore
-			logger.Warn("secret store is not cached, this is unexpected - continuing migration anyway.")
+			logger.Warn("Secret store is not cached, this is unexpected - continuing migration anyway.")
 		}
 		pluginStore, ok := tmpStore.(*secretskvs.SecretsKVStorePlugin)
 		if !ok {
@@ -65,7 +65,7 @@ func (s *MigrateToPluginService) Migrate(ctx context.Context) error {
 		namespacedKVStore := secretskvs.GetNamespacedKVStore(s.kvstore)
 		wasFatal, err := secretskvs.IsPluginStartupErrorFatal(ctx, namespacedKVStore)
 		if err != nil {
-			logger.Warn("unable to determine whether plugin startup failures are fatal - continuing migration anyway.")
+			logger.Warn("Unable to determine whether plugin startup failures are fatal - continuing migration anyway.")
 		}
 
 		var allSec []secretskvs.Item
@@ -95,26 +95,26 @@ func (s *MigrateToPluginService) Migrate(ctx context.Context) error {
 		}
 
 		// as no err was returned, when we delete all the secrets from the sql store
-		logger.Debug("migrated unified secrets to plugin", "number of secrets", totalSec)
+		logger.Debug("Migrated unified secrets to plugin", "number of secrets", totalSec)
 		for index, sec := range allSec {
 			logger.Debug(fmt.Sprintf("Cleaning secret %d of %d", index+1, totalSec), "current", index+1, "secretCount", totalSec)
 
 			err = fallbackStore.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
 			if err != nil {
-				logger.Error("plugin migrator encountered error while deleting unified secrets")
+				logger.Error("Plugin migrator encountered error while deleting unified secrets")
 				if index == 0 && !wasFatal {
 					// old unified secrets still exists, so plugin startup errors are still not fatal, unless they were before we started
 					err := secretskvs.SetPluginStartupErrorFatal(ctx, namespacedKVStore, false)
 					if err != nil {
-						logger.Error("error reverting plugin failure fatal status", "error", err.Error())
+						logger.Error("Error reverting plugin failure fatal status", "error", err.Error())
 					} else {
-						logger.Debug("application will continue to function without the secrets plugin")
+						logger.Debug("Application will continue to function without the secrets plugin")
 					}
 				}
 				return err
 			}
 		}
-		logger.Debug("deleted unified secrets after migration", "number of secrets", totalSec)
+		logger.Debug("Deleted unified secrets after migration", "number of secrets", totalSec)
 	}
 	return nil
 }

--- a/pkg/services/secrets/kvstore/plugin.go
+++ b/pkg/services/secrets/kvstore/plugin.go
@@ -227,7 +227,7 @@ func updateFatalFlag(ctx context.Context, skv *SecretsKVStorePlugin) {
 			err = SetPluginStartupErrorFatal(ctx, skv.kvstore, false)
 		}
 		if err != nil {
-			skv.log.Error("failed to set plugin error fatal flag", err.Error())
+			skv.log.Error("Failed to set plugin error fatal flag", err.Error())
 		}
 	})
 }

--- a/pkg/services/secrets/kvstore/sql.go
+++ b/pkg/services/secrets/kvstore/sql.go
@@ -55,11 +55,11 @@ func (kv *SecretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Error("error getting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("Error getting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 		if !has {
-			kv.log.Debug("secret value not found", "orgId", orgId, "type", typ, "namespace", namespace)
+			kv.log.Debug("Secret value not found", "orgId", orgId, "type", typ, "namespace", namespace)
 			return nil
 		}
 		isFound = true
@@ -69,12 +69,12 @@ func (kv *SecretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 	if err == nil && isFound {
 		decryptedValue, err = kv.getDecryptedValue(ctx, item)
 		if err != nil {
-			kv.log.Error("error decrypting secret value", "orgId", item.OrgId, "type", item.Type, "namespace", item.Namespace, "err", err)
+			kv.log.Error("Error decrypting secret value", "orgId", item.OrgId, "type", item.Type, "namespace", item.Namespace, "err", err)
 			return string(decryptedValue), isFound, err
 		}
 	}
 
-	kv.log.Debug("got secret value", "orgId", orgId, "type", typ, "namespace", namespace)
+	kv.log.Debug("Got secret value", "orgId", orgId, "type", typ, "namespace", namespace)
 	return string(decryptedValue), isFound, err
 }
 
@@ -82,7 +82,7 @@ func (kv *SecretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 func (kv *SecretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {
 	encryptedValue, err := kv.secretsService.Encrypt(ctx, []byte(value), secrets.WithoutScope())
 	if err != nil {
-		kv.log.Error("error encrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+		kv.log.Error("Error encrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 		return err
 	}
 	encodedValue := b64.EncodeToString(encryptedValue)
@@ -95,12 +95,12 @@ func (kv *SecretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("Error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
 		if has && item.Value == encodedValue {
-			kv.log.Debug("secret value not changed", "orgId", orgId, "type", typ, "namespace", namespace)
+			kv.log.Debug("Secret value not changed", "orgId", orgId, "type", typ, "namespace", namespace)
 			return nil
 		}
 
@@ -111,7 +111,7 @@ func (kv *SecretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 			// if item already exists we update it
 			_, err = dbSession.ID(item.Id).Update(&item)
 			if err != nil {
-				kv.log.Error("error updating secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("Error updating secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
 				kv.decryptionCache.Lock()
 				defer kv.decryptionCache.Unlock()
@@ -119,7 +119,7 @@ func (kv *SecretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 					updated: item.Updated,
 					value:   value,
 				}
-				kv.log.Debug("secret value updated", "orgId", orgId, "type", typ, "namespace", namespace)
+				kv.log.Debug("Secret value updated", "orgId", orgId, "type", typ, "namespace", namespace)
 			}
 			return err
 		}
@@ -128,9 +128,9 @@ func (kv *SecretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 		item.Created = item.Updated
 		_, err = dbSession.Insert(&item)
 		if err != nil {
-			kv.log.Error("error inserting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("Error inserting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 		} else {
-			kv.log.Debug("secret value inserted", "orgId", orgId, "type", typ, "namespace", namespace)
+			kv.log.Debug("Secret value inserted", "orgId", orgId, "type", typ, "namespace", namespace)
 		}
 		return err
 	})
@@ -147,7 +147,7 @@ func (kv *SecretsKVStoreSQL) Del(ctx context.Context, orgId int64, namespace str
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("Error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
@@ -155,12 +155,12 @@ func (kv *SecretsKVStoreSQL) Del(ctx context.Context, orgId int64, namespace str
 			// if item exists we delete it
 			_, err = dbSession.ID(item.Id).Delete(&item)
 			if err != nil {
-				kv.log.Error("error deleting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("Error deleting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
 				kv.decryptionCache.Lock()
 				defer kv.decryptionCache.Unlock()
 				delete(kv.decryptionCache.cache, item.Id)
-				kv.log.Debug("secret value deleted", "orgId", orgId, "type", typ, "namespace", namespace)
+				kv.log.Debug("Secret value deleted", "orgId", orgId, "type", typ, "namespace", namespace)
 			}
 			return err
 		}
@@ -194,7 +194,7 @@ func (kv *SecretsKVStoreSQL) Rename(ctx context.Context, orgId int64, namespace 
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("Error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
@@ -205,9 +205,9 @@ func (kv *SecretsKVStoreSQL) Rename(ctx context.Context, orgId int64, namespace 
 			// if item already exists we update it
 			_, err = dbSession.ID(item.Id).Update(&item)
 			if err != nil {
-				kv.log.Error("error updating secret namespace", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("Error updating secret namespace", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
-				kv.log.Debug("secret namespace updated", "orgId", orgId, "type", typ, "namespace", namespace)
+				kv.log.Debug("Secret namespace updated", "orgId", orgId, "type", typ, "namespace", namespace)
 			}
 			return err
 		}
@@ -224,7 +224,7 @@ func (kv *SecretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
 		return dbSession.Find(&items)
 	})
 	if err != nil {
-		kv.log.Error("error getting all the items", "err", err)
+		kv.log.Error("Error getting all the items", "err", err)
 		return nil, err
 	}
 
@@ -233,7 +233,7 @@ func (kv *SecretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
 		value, err := kv.getDecryptedValue(ctx, items[i])
 		items[i].Value = string(value)
 		if err != nil {
-			kv.log.Error("error decrypting secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
+			kv.log.Error("Error decrypting secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
 		}
 	}
 

--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -107,7 +107,7 @@ func (h *databaseQueryWrapper) instrument(ctx context.Context, status string, qu
 	}
 
 	ctxLogger := h.log.FromContext(ctx)
-	ctxLogger.Debug("query finished", "status", status, "elapsed time", elapsed, "sql", query, "error", err)
+	ctxLogger.Debug("Query finished", "status", status, "elapsed time", elapsed, "sql", query, "error", err)
 }
 
 // OnError will be called if any error happens

--- a/pkg/services/sqlstore/migrations/accesscontrol/disabled_migration.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/disabled_migration.go
@@ -47,7 +47,7 @@ func (m *DisabledMigrator) Exec(sess *xorm.Session, mg *migrator.Migrator) error
 	enabled := mg.Cfg.Raw.Section("rbac").Key("enabled").MustBool(true)
 	if enabled {
 		// if the flag is enabled we skip the reset of data migrations
-		mg.Logger.Debug("skip reset of rbac data migrations")
+		mg.Logger.Debug("Skip reset of rbac data migrations")
 		return nil
 	}
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -54,7 +54,7 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 	INNER JOIN role AS r ON p.role_id = r.id
 	WHERE r.name LIKE ?`, "managed:builtins%").
 		Find(&managedPermissions); errFindPermissions != nil {
-		logger.Error("could not get the managed permissions", "error", errFindPermissions)
+		logger.Error("Could not get the managed permissions", "error", errFindPermissions)
 		return errFindPermissions
 	}
 

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -232,7 +232,7 @@ func (mg *Migrator) run() (err error) {
 		}
 	}
 
-	mg.Logger.Info("migrations completed", "performed", migrationsPerformed, "skipped", migrationsSkipped, "duration", time.Since(start))
+	mg.Logger.Info("Migrations completed", "performed", migrationsPerformed, "skipped", migrationsSkipped, "duration", time.Since(start))
 
 	// Make sure migrations are synced
 	return mg.DBEngine.Sync2()

--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -44,7 +44,7 @@ func startSessionOrUseExisting(ctx context.Context, engine *xorm.Engine, beginTr
 
 	if ok {
 		ctxLogger := sessionLogger.FromContext(ctx)
-		ctxLogger.Debug("reusing existing session", "transaction", sess.transactionOpen)
+		ctxLogger.Debug("Reusing existing session", "transaction", sess.transactionOpen)
 		sess.Session = sess.Session.Context(ctx)
 		return sess, false, nil, nil
 	}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -443,7 +443,7 @@ func (ss *SQLStore) ensureTransactionIsolationCompatibility(engine *xorm.Engine,
 	if errors.As(err, &mysqlError) {
 		// if there was an error due to transaction isolation
 		if strings.Contains(mysqlError.Message, "Unknown system variable 'transaction_isolation'") {
-			ss.log.Debug("transaction_isolation system var is unknown, overriding in connection string with tx_isolation instead")
+			ss.log.Debug("Transaction_isolation system var is unknown, overriding in connection string with tx_isolation instead")
 			// replace with compatible system var for transaction isolation
 			connectionString = strings.Replace(connectionString, "&transaction_isolation", "&tx_isolation", -1)
 			// recreate the xorm engine with new connection string that is compatible

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -58,7 +58,7 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 	ctxLogger := tsclogger.FromContext(ctx)
 
 	if !isNew {
-		ctxLogger.Debug("skip committing the transaction because it belongs to a session created in the outer scope")
+		ctxLogger.Debug("Skip committing the transaction because it belongs to a session created in the outer scope")
 		// Do not commit the transaction if the session was reused.
 		return err
 	}

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -155,7 +155,7 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 		if has {
 			return org.ID, nil
 		}
-		ss.log.Debug("auto assigned organization not found")
+		ss.log.Debug("Auto assigned organization not found")
 
 		if ss.Cfg.AutoAssignOrgId != 1 {
 			ss.log.Error("Could not create user: organization ID does not exist", "orgID",
@@ -169,7 +169,7 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 		org.Updated = org.Created
 		org.ID = int64(ss.Cfg.AutoAssignOrgId)
 		if err := sess.InsertId(&org, ss.Dialect); err != nil {
-			ss.log.Error("failed to insert organization with provided id", "org_id", org.ID, "err", err)
+			ss.log.Error("Failed to insert organization with provided id", "org_id", org.ID, "err", err)
 			// ignore failure if for some reason the organization exists
 			if ss.GetDialect().IsUniqueConstraintViolation(err) {
 				return org.ID, nil

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1186,11 +1186,11 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	if err != nil {
 		// if the proxy is misconfigured, disable it rather than crashing
 		cfg.SecureSocksDSProxy.Enabled = false
-		cfg.Logger.Error("secure_socks_datasource_proxy unable to start up", "err", err.Error())
+		cfg.Logger.Error("Secure_socks_datasource_proxy unable to start up", "err", err.Error())
 	}
 
 	if VerifyEmailEnabled && !cfg.Smtp.Enabled {
-		cfg.Logger.Warn("require_email_validation is enabled but smtp is disabled")
+		cfg.Logger.Warn("Require_email_validation is enabled but smtp is disabled")
 	}
 
 	// check old key name

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -150,7 +150,7 @@ func (cfg *Cfg) readUnifiedAlertingEnabledSetting(section *ini.Section) (*bool, 
 	if !hasEnabled {
 		// TODO: Remove in Grafana v10
 		if cfg.IsFeatureToggleEnabled("ngalert") {
-			cfg.Logger.Warn("ngalert feature flag is deprecated: use unified alerting enabled setting instead")
+			cfg.Logger.Warn("Ngalert feature flag is deprecated: use unified alerting enabled setting instead")
 			// feature flag overrides the legacy alerting setting
 			legacyAlerting := false
 			AlertingEnabled = &legacyAlerting
@@ -261,7 +261,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if uaExecuteAlerts { // unified option equals the default (true)
 		legacyExecuteAlerts := alerting.Key("execute_alerts").MustBool(schedulereDefaultExecuteAlerts)
 		if !legacyExecuteAlerts {
-			cfg.Logger.Warn("falling back to legacy setting of 'execute_alerts'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
+			cfg.Logger.Warn("Falling back to legacy setting of 'execute_alerts'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
 		}
 		uaExecuteAlerts = legacyExecuteAlerts
 	}
@@ -272,7 +272,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if err != nil || uaEvaluationTimeout == evaluatorDefaultEvaluationTimeout { // unified option is invalid duration or equals the default
 		legaceEvaluationTimeout := time.Duration(alerting.Key("evaluation_timeout_seconds").MustInt64(int64(evaluatorDefaultEvaluationTimeout.Seconds()))) * time.Second
 		if legaceEvaluationTimeout != evaluatorDefaultEvaluationTimeout {
-			cfg.Logger.Warn("falling back to legacy setting of 'evaluation_timeout_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
+			cfg.Logger.Warn("Falling back to legacy setting of 'evaluation_timeout_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
 		}
 		uaEvaluationTimeout = legaceEvaluationTimeout
 	}
@@ -282,7 +282,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if uaMaxAttempts == schedulerDefaultMaxAttempts { // unified option or equals the default
 		legacyMaxAttempts := alerting.Key("max_attempts").MustInt64(schedulerDefaultMaxAttempts)
 		if legacyMaxAttempts != schedulerDefaultMaxAttempts {
-			cfg.Logger.Warn("falling back to legacy setting of 'max_attempts'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
+			cfg.Logger.Warn("Falling back to legacy setting of 'max_attempts'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
 		}
 		uaMaxAttempts = legacyMaxAttempts
 	}
@@ -316,7 +316,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		// if the legacy option is invalid, fallback to 10 (unified alerting min interval default)
 		legacyMinInterval := time.Duration(alerting.Key("min_interval_seconds").MustInt64(int64(uaCfg.BaseInterval.Seconds()))) * time.Second
 		if legacyMinInterval > uaCfg.BaseInterval {
-			cfg.Logger.Warn("falling back to legacy setting of 'min_interval_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
+			cfg.Logger.Warn("Falling back to legacy setting of 'min_interval_seconds'; please use the configuration option in the `unified_alerting` section if Grafana 8 alerts are enabled.")
 			uaMinInterval = legacyMinInterval
 		} else {
 			// if legacy interval is smaller than the base interval, adjust it to the base interval

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -289,7 +289,9 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 
 	defer func() {
 		err := res.Body.Close()
-		backend.Logger.Error("Failed to close response body", "err", err)
+		if err != nil {
+			logger.Warn("failed to close response body", "error", err)
+		}
 	}()
 
 	logResponse, err := e.unmarshalResponse(res)
@@ -562,8 +564,9 @@ func getCorrelationWorkspaces(ctx context.Context, baseResource string, resource
 		}
 
 		defer func() {
-			if err := res.Body.Close(); err != nil {
-				backend.Logger.Error("Failed to close response body", "err", err)
+			err := res.Body.Close()
+			if err != nil {
+				logger.Warn("failed to close response body", "error", err)
 			}
 		}()
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1535,8 +1535,11 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 		TimeRange: backend.TimeRange{},
 	}
 	tracer := tracing.InitializeTracerForTest()
-	_, err := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
-	if !strings.Contains(err.Error(), "credentials for Log Analytics are no longer supported") {
+	res := ds.executeQuery(ctx, logger, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
+	if res.Error == nil {
+		t.Fatal("expecting an error")
+	}
+	if !strings.Contains(res.Error.Error(), "credentials for Log Analytics are no longer supported") {
 		t.Error("expecting the error to inform of bad credentials")
 	}
 }

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -265,8 +265,9 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 	}
 
 	defer func() {
-		err := res.Body.Close()
-		backend.Logger.Error("Failed to close response body", "err", err)
+		if err := res.Body.Close(); err != nil {
+			logger.Warn("failed to close response body", "err", err)
+		}
 	}()
 
 	body, err := io.ReadAll(res.Body)
@@ -317,8 +318,9 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *types.
 	}
 
 	defer func() {
-		err := res.Body.Close()
-		backend.Logger.Error("Failed to close response body", "err", err)
+		if err := res.Body.Close(); err != nil {
+			logger.Warn("failed to close response body", "err", err)
+		}
 	}()
 
 	data, err := e.unmarshalResponse(res)
@@ -348,6 +350,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *types.
 func (e *AzureMonitorDatasource) createRequest(ctx context.Context, url string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
+		logger.Debug("failed to create request", "error", err)
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -368,6 +371,7 @@ func (e *AzureMonitorDatasource) unmarshalResponse(res *http.Response) (types.Az
 	var data types.AzureMonitorResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
+		logger.Debug("failed to unmarshal AzureMonitor response", "error", err, "status", res.Status, "body", string(body))
 		return types.AzureMonitorResponse{}, err
 	}
 

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -168,7 +168,9 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *
 
 	defer func() {
 		err := res.Body.Close()
-		backend.Logger.Error("Failed to close response body", "err", err)
+		if err != nil {
+			logger.Warn("failed to close response body", "error", err)
+		}
 	}()
 
 	argResponse, err := e.unmarshalResponse(res)

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -94,6 +94,17 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo) (*b
 		return getHealthCheckMessage(logger, "error performing influxQL query", err)
 	}
 
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Warn("failed to close response body", "err", err)
+		}
+	}()
+
+	resp := s.responseParser.Parse(res.Body, res.StatusCode, []Query{{
+		RefID:       refID,
+		UseRawQuery: true,
+		RawQuery:    queryString,
+	}})
 	if res, ok := resp.Responses[refID]; ok {
 		if res.Error != nil {
 			return getHealthCheckMessage(logger, "error reading influxDB", res.Error)

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -101,7 +101,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	defer func() {
 		err := res.Body.Close()
 		if err != nil {
-			logger.Warn("failed to close response body", "error", err)
+			logger.Warn("Failed to close response body", "error", err)
 		}
 	}()
 

--- a/pkg/util/errutil/errhttp/writer.go
+++ b/pkg/util/errutil/errhttp/writer.go
@@ -48,7 +48,7 @@ func Write(ctx context.Context, err error, w http.ResponseWriter, opts ...func(E
 	w.WriteHeader(pub.StatusCode)
 	err = json.NewEncoder(w).Encode(pub)
 	if err != nil {
-		defaultLogger.FromContext(ctx).Error("error while writing error", "error", err)
+		defaultLogger.FromContext(ctx).Error("Error while writing error", "error", err)
 	}
 }
 

--- a/pkg/util/ticker/ticker.go
+++ b/pkg/util/ticker/ticker.go
@@ -48,7 +48,7 @@ func getStartTick(clk clock.Clock, interval time.Duration) time.Time {
 
 func (t *T) run() {
 	logger := log.New("ticker")
-	logger.Info("starting", "first_tick", t.last.Add(t.interval))
+	logger.Info("Starting", "first_tick", t.last.Add(t.interval))
 LOOP:
 	for {
 		next := t.last.Add(t.interval) // calculate the time of the next tick
@@ -72,7 +72,7 @@ LOOP:
 			break LOOP
 		}
 	}
-	logger.Info("stopped", "last_tick", t.last)
+	logger.Info("Stopped", "last_tick", t.last)
 }
 
 // Stop stops the ticker. It does not close the C channel


### PR DESCRIPTION
Hello everyone,

It's been a while since I bothered you with such large diffs. This time we discussed with @svennergr whether logs should be capitalised or lower-case. Seems like most Go projects (k8s, prometheus, minio, ...) use capitalised logs. Also https://google.github.io/styleguide/go/decisions.html#error-strings suggests to use capitalised logs. Finally, original Grafana logs were all capitalised.

This PR was generated by a terribly hacky script:

```bash
#!/bin/sh
fix_logs() {
	gsed -i -E -e 's#\.(Info|Debug|Warn|Error)\("(.)#.\1("\U\2#' "$1"
}
find ./pkg -name "*.go" | while read f ; do
	fix_logs "$f"
done
```

Please make sure that your logs still look proper, and if needed - feel free to suggest fixes. Thank you for your patience while reviewing this obese PR!

P.S. This PR would be followed by a number of smaller PRs, one per team.

P.P.S. We've documented how the messages should look like in our [docs](https://github.com/grafana/grafana/blob/main/contribute/backend/instrumentation.md#naming-conventions)

- [ ] Backend Platform (this PR)
- [x] AuthNZ - https://github.com/grafana/grafana/pull/74332
- [x] Alerting - https://github.com/grafana/grafana/pull/74335
- [x] AppPlatform - https://github.com/grafana/grafana/pull/74336
- [x] Other teams - https://github.com/grafana/grafana/pull/74344
- [ ] Linter check