### PR TITLE
[v10.1.x] Security: Authenticate to GCR for trivy scans

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4167,13 +4167,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4187,6 +4207,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4197,13 +4221,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4217,6 +4261,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4227,13 +4275,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4248,6 +4316,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4258,13 +4330,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4279,6 +4371,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4288,6 +4384,16 @@ platform:
   arch: amd64
   os: linux
 steps:
+- commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
@@ -4308,8 +4414,13 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.5
@@ -4330,8 +4441,13 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 1 --severity HIGH,CRITICAL us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -4345,6 +4461,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -4376,6 +4496,10 @@ trigger:
   cron: grafana-com-nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 get:
   name: credentials.json
@@ -4545,7 +4669,13 @@ get:
 kind: secret
 name: delivery-bot-app-private-key
 ---
+get:
+  name: service-account
+  path: secret/data/common/gcr
+kind: secret
+name: gcr_credentials
+---
 kind: signature
-hmac: 607c9baedb5ccffbd36a8819187ee80c4205356d89a3468bff4911c6ae7ab1ee
+hmac: e8e6a8afa4a8a115117e3203cd8a7b55418f0305c432a7b347640ac95f845ae2
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -24,6 +24,17 @@ def cronjobs():
         grafana_com_nightly_pipeline(),
     ]
 
+def authenticate_gcr_step():
+    return {
+        "name": "authenticate-gcr",
+        "image": "docker:dind",
+        "commands": ["echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io"],
+        "environment": {
+            "GCR_CREDENTIALS": from_secret("gcr_credentials"),
+        },
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+    }
+
 def cron_job_pipeline(cronName, name, steps):
     return {
         "kind": "pipeline",
@@ -41,6 +52,14 @@ def cron_job_pipeline(cronName, name, steps):
             "retries": 3,
         },
         "steps": steps,
+        "volumes": [
+            {
+                "name": "docker",
+                "host": {
+                    "path": "/var/run/docker.sock",
+                },
+            },
+        ],
     }
 
 def scan_docker_image_pipeline(tag):
@@ -58,6 +77,7 @@ def scan_docker_image_pipeline(tag):
         cronName = "nightly",
         name = "scan-" + docker_image + "-image",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image),
             scan_docker_image_high_critical_vulnerabilities_step(docker_image),
             slack_job_failed_step("grafana-backend-ops", docker_image),
@@ -75,6 +95,7 @@ def scan_build_test_publish_docker_image_pipeline():
         cronName = "nightly",
         name = "scan-build-test-and-publish-docker-images",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step("all"),
             scan_docker_image_high_critical_vulnerabilities_step("all"),
             slack_job_failed_step("grafana-backend-ops", "build-images"),
@@ -101,6 +122,8 @@ def scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image):
         "name": "scan-unknown-low-medium-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
@@ -123,6 +146,8 @@ def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
         "name": "scan-high-critical-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def slack_job_failed_step(channel, image):

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -148,4 +148,9 @@ def secrets():
             "infra/data/ci/grafana-release-eng/grafana-delivery-bot",
             "app-private-key",
         ),
+        vault_secret(
+            "gcr_credentials",
+            "secret/data/common/gcr",
+            "service-account",
+        ),
     ]


### PR DESCRIPTION
Backport e100fc927ec00ae3df7ee1420374b10b834c277c from #72658

---

**What is this feature?**

Our nightly trivy scans fail for GCR images, because of the lack of authentication. This PR should fix this issue by authenticating to GCR using a service account secret. 

Small note - `http://us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest` needs dev SA authentication so it'll be excluded for now until we move it to `us.gcr.io/kubernetes-dev`.

Also updates `google/cloud-sdk`, to `444.0.0`. 

