### PR TITLE
[v9.3.x] Security: Authenticate to GCR for trivy scans

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3680,13 +3680,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -3700,6 +3720,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -3710,13 +3734,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -3730,6 +3774,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -3740,13 +3788,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:latest-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -3761,6 +3829,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -3771,13 +3843,33 @@ platform:
   os: linux
 steps:
 - commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana:main-ubuntu
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -3792,6 +3884,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -3801,6 +3897,16 @@ platform:
   arch: amd64
   os: linux
 steps:
+- commands:
+  - echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io
+  environment:
+    GCR_CREDENTIALS:
+      from_secret: gcr_credentials
+  image: docker:dind
+  name: authenticate-gcr
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.4
@@ -3821,8 +3927,13 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-unknown-low-medium-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/build-container:1.7.4
@@ -3843,8 +3954,13 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 1 --severity HIGH,CRITICAL us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
+  depends_on:
+  - authenticate-gcr
   image: aquasec/trivy:0.21.0
   name: scan-high-critical-vulnerabilities
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 - image: plugins/slack
   name: slack-notify-failure
   settings:
@@ -3858,6 +3974,10 @@ trigger:
   cron: nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 clone:
   retries: 3
@@ -3889,6 +4009,10 @@ trigger:
   cron: grafana-com-nightly
   event: cron
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 get:
   name: credentials.json
@@ -4017,12 +4141,6 @@ kind: secret
 name: enterprise2-cdn-path
 ---
 get:
-  name: security_prefix
-  path: infra/data/ci/grafana-release-eng/enterprise2
-kind: secret
-name: enterprise2_security_prefix
----
-get:
   name: gcp_service_account_prod_base64
   path: infra/data/ci/grafana-release-eng/rgm
 kind: secret
@@ -4065,6 +4183,12 @@ kind: secret
 name: delivery-bot-app-private-key
 ---
 get:
+  name: service-account
+  path: secret/data/common/gcr
+kind: secret
+name: gcr_credentials
+---
+get:
   name: gcp_service_account_base64
   path: infra/data/ci/grafana-release-eng/rgm
 kind: secret
@@ -4083,6 +4207,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: fc290ffe72cdad8e3d81f5e763aaeb2d370b6a58ae25886edb15837fc1503c79
+hmac: 084053161df2a3e465e559907c73113a29ddeef51aebd39d034701cfcf4dfc19
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -24,6 +24,17 @@ def cronjobs():
         grafana_com_nightly_pipeline(),
     ]
 
+def authenticate_gcr_step():
+    return {
+        "name": "authenticate-gcr",
+        "image": "docker:dind",
+        "commands": ["echo $${GCR_CREDENTIALS} | docker login -u _json_key --password-stdin https://us.gcr.io"],
+        "environment": {
+            "GCR_CREDENTIALS": from_secret("gcr_credentials"),
+        },
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+    }
+
 def cron_job_pipeline(cronName, name, steps):
     return {
         "kind": "pipeline",
@@ -41,6 +52,14 @@ def cron_job_pipeline(cronName, name, steps):
             "retries": 3,
         },
         "steps": steps,
+        "volumes": [
+            {
+                "name": "docker",
+                "host": {
+                    "path": "/var/run/docker.sock",
+                },
+            },
+        ],
     }
 
 def scan_docker_image_pipeline(tag):
@@ -58,6 +77,7 @@ def scan_docker_image_pipeline(tag):
         cronName = "nightly",
         name = "scan-" + docker_image + "-image",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image),
             scan_docker_image_high_critical_vulnerabilities_step(docker_image),
             slack_job_failed_step("grafana-backend-ops", docker_image),
@@ -75,6 +95,7 @@ def scan_build_test_publish_docker_image_pipeline():
         cronName = "nightly",
         name = "scan-build-test-and-publish-docker-images",
         steps = [
+            authenticate_gcr_step(),
             scan_docker_image_unknown_low_medium_vulnerabilities_step("all"),
             scan_docker_image_high_critical_vulnerabilities_step("all"),
             slack_job_failed_step("grafana-backend-ops", "build-images"),
@@ -101,6 +122,8 @@ def scan_docker_image_unknown_low_medium_vulnerabilities_step(docker_image):
         "name": "scan-unknown-low-medium-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
@@ -123,6 +146,8 @@ def scan_docker_image_high_critical_vulnerabilities_step(docker_image):
         "name": "scan-high-critical-vulnerabilities",
         "image": aquasec_trivy_image,
         "commands": cmds,
+        "depends_on": ["authenticate-gcr"],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
 def slack_job_failed_step(channel, image):

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -113,11 +113,6 @@ def secrets():
             "cdn_path",
         ),
         vault_secret(
-            "enterprise2_security_prefix",
-            "infra/data/ci/grafana-release-eng/enterprise2",
-            "security_prefix",
-        ),
-        vault_secret(
             rgm_gcp_key_base64,
             "infra/data/ci/grafana-release-eng/rgm",
             "gcp_service_account_prod_base64",
@@ -152,6 +147,11 @@ def secrets():
             "delivery-bot-app-private-key",
             "infra/data/ci/grafana-release-eng/grafana-delivery-bot",
             "app-private-key",
+        ),
+        vault_secret(
+            "gcr_credentials",
+            "secret/data/common/gcr",
+            "service-account",
         ),
         vault_secret(
             rgm_gcp_key_base64,


### PR DESCRIPTION
Backport e100fc927ec00ae3df7ee1420374b10b834c277c from #72658

---

**What is this feature?**

Our nightly trivy scans fail for GCR images, because of the lack of authentication. This PR should fix this issue by authenticating to GCR using a service account secret. 

Small note - `http://us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest` needs dev SA authentication so it'll be excluded for now until we move it to `us.gcr.io/kubernetes-dev`.

Also updates `google/cloud-sdk`, to `444.0.0`. 

