### PR TITLE
Chore: Don't run pre-commit hooks on merge commits

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,8 @@ rc: ./lefthook.rc
 
 pre-commit:
   parallel: true
+  skip:
+    - merge
   commands:
     frontend-betterer:
       glob: '*.{ts,tsx}'


### PR DESCRIPTION
When merging, we presume code is already linted, and doesn't need to run. Avoids an issue where out of date deps (coming in from a merge) can cause incorrect formatted code.