### PR TITLE
Dashboards: Show panel load failure error state

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -457,6 +457,9 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       }
     }
 
+    const foo: any = undefined;
+    foo.hello.toString();
+
     this.applyPluginOptionDefaults(plugin, false);
     this.resendLastResult();
   }

--- a/public/app/features/panel/components/PanelPluginError.tsx
+++ b/public/app/features/panel/components/PanelPluginError.tsx
@@ -26,7 +26,7 @@ class PanelPluginError extends PureComponent<Props> {
 
     return (
       <div style={style}>
-        <Alert severity={AppNotificationSeverity.Error} {...this.props} />
+        <Alert severity={AppNotificationSeverity.Error} children={this.props.text} {...this.props} />
       </div>
     );
   }
@@ -46,6 +46,17 @@ export function getPanelPluginLoadError(meta: PanelPluginMeta, err: unknown): Pa
   };
   const plugin = new PanelPlugin(LoadError);
   plugin.meta = meta;
+  plugin.loadError = true;
+  return plugin;
+}
+
+export function getPanelErrorPlugin(title: string, message?: string): PanelPlugin {
+  const LoadError = class LoadError extends PureComponent<PanelProps> {
+    render() {
+      return <PanelPluginError title={title} text={message} />;
+    }
+  };
+  const plugin = new PanelPlugin(LoadError);
   plugin.loadError = true;
   return plugin;
 }


### PR DESCRIPTION
Initial stab at showing errors for when panels fail to initialise

Sharing draft now to see if this is the right way to guard for these errors. Maybe there might be a better place higher in the call stack? Unsure.

![image](https://github.com/grafana/grafana/assets/46142/fdbe78fc-f625-425c-a0d2-e95d38e64e0a)


fixes https://github.com/grafana/grafana/issues/73918