### PR TITLE
Transformations: Force QueryOperationRow to expand on showHelp click

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { useUpdateEffect } from 'react-use';
 
@@ -30,6 +30,7 @@ export interface QueryOperationRowRenderProps {
   isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
+  // onOptionClick?: (option: any) => void;
 }
 
 export function QueryOperationRow({
@@ -51,6 +52,12 @@ export function QueryOperationRow({
   const onRowToggle = useCallback(() => {
     setIsContentVisible(!isContentVisible);
   }, [isContentVisible, setIsContentVisible]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsContentVisible(true);
+    }
+  }, [isOpen]);
 
   const reportDragMousePosition = useCallback((e: React.MouseEvent) => {
     // When drag detected react-beautiful-dnd will preventDefault the event

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -30,7 +30,6 @@ export interface QueryOperationRowRenderProps {
   isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
-  // onOptionClick?: (option: any) => void;
 }
 
 export function QueryOperationRow({
@@ -53,6 +52,7 @@ export function QueryOperationRow({
     setIsContentVisible(!isContentVisible);
   }, [isContentVisible, setIsContentVisible]);
 
+  // Force open when isOpen prop changes in parent.
   useEffect(() => {
     if (isOpen) {
       setIsContentVisible(true);

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -53,6 +53,7 @@ export function QueryOperationRow({
   }, [isContentVisible, setIsContentVisible]);
 
   // Force QueryOperationRow expansion when `isOpen` prop updates in parent component.
+  // `undefined` is a possible intentionally passed value here, which should not trigger the effect.
   useEffect(() => {
     if (typeof isOpen === 'boolean') {
       setIsContentVisible(isOpen);

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -52,7 +52,7 @@ export function QueryOperationRow({
     setIsContentVisible(!isContentVisible);
   }, [isContentVisible, setIsContentVisible]);
 
-  // Force open when isOpen prop changes in parent.
+  // Force QueryOperationRow expansion when `isOpen` prop updates in parent component.
   useEffect(() => {
     if (isOpen) {
       setIsContentVisible(true);

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -53,7 +53,7 @@ export function QueryOperationRow({
   }, [isContentVisible, setIsContentVisible]);
 
   // Force QueryOperationRow expansion when `isOpen` prop updates in parent component.
-  // `undefined` is a possible intentionally passed value here, which should not trigger the effect.
+  // `undefined` can be deliberately passed value here, but we only want booleans to trigger the effect.
   useEffect(() => {
     if (typeof isOpen === 'boolean') {
       setIsContentVisible(isOpen);

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -54,8 +54,8 @@ export function QueryOperationRow({
 
   // Force QueryOperationRow expansion when `isOpen` prop updates in parent component.
   useEffect(() => {
-    if (isOpen) {
-      setIsContentVisible(true);
+    if (typeof isOpen === 'boolean') {
+      setIsContentVisible(isOpen);
     }
   }, [isOpen]);
 

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -62,8 +62,8 @@ export const TransformationOperationRow = ({
       return true;
     }
 
-    // We return `undefined` here since the QueryOperationRow component ignores an `undefined` value.
-    // If we returned `false` here, the row would be collapsed when the user toggles off the help, which is not what we want.
+    // We return `undefined` here since the QueryOperationRow component ignores an `undefined` value for the `isOpen` prop.
+    // If we returned `false` here, the row would be collapsed when the user toggles off `showHelp`, which is not what we want.
     return undefined;
   }, [showHelp]);
 

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -62,7 +62,7 @@ export const TransformationOperationRow = ({
       return true;
     }
 
-    // We return undefined here since the QueryOperationRow component ignores an undefined value.
+    // We return `undefined` here since the QueryOperationRow component ignores an `undefined` value.
     // If we returned `false` here, the row would be collapsed when the user toggles off the help, which is not what we want.
     return undefined;
   }, [showHelp]);

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useToggle } from 'react-use';
 
 import { DataFrame, DataTransformerConfig, TransformerRegistryItem, FrameMatcherID } from '@grafana/data';
@@ -40,8 +40,8 @@ export const TransformationOperationRow = ({
   onChange,
 }: TransformationOperationRowProps) => {
   const [showDeleteModal, setShowDeleteModal] = useToggle(false);
-  const [showDebug, toggleDebug] = useToggle(false);
-  const [showHelp, setShowHelp] = useState<boolean | undefined>(undefined);
+  const [showDebug, toggleShowDebug] = useToggle(false);
+  const [showHelp, toggleShowHelp] = useToggle(false);
   const disabled = !!configs[index].transformation.disabled;
   const filter = configs[index].transformation.filter != null;
   const showFilter = filter || data.length > 1;
@@ -56,6 +56,16 @@ export const TransformationOperationRow = ({
     },
     [onChange, configs]
   );
+
+  const toggleExpand = useCallback(() => {
+    if (showHelp) {
+      return true;
+    }
+
+    // We return undefined here since the QueryOperationRow component ignores an undefined value.
+    // If we returned `false` here, the row would be collapsed when the user toggles off the help, which is not what we want.
+    return undefined;
+  }, [showHelp]);
 
   // Adds or removes the frame filter
   const toggleFilter = useCallback(() => {
@@ -99,7 +109,7 @@ export const TransformationOperationRow = ({
           title="Show transform help"
           icon="info-circle"
           // `instrumentToggleCallback` expects a function that takes a MouseEvent, is unused in the state setter. Instead, we simply toggle the state.
-          onClick={instrumentToggleCallback((_e) => setShowHelp(!showHelp), 'help', showHelp)}
+          onClick={instrumentToggleCallback((_e) => toggleShowHelp(!showHelp), 'help', showHelp)}
           active={!!showHelp}
         />
         {showFilter && (
@@ -114,7 +124,7 @@ export const TransformationOperationRow = ({
           title="Debug"
           disabled={!isOpen}
           icon="bug"
-          onClick={instrumentToggleCallback(toggleDebug, 'debug', showDebug)}
+          onClick={instrumentToggleCallback(toggleShowDebug, 'debug', showDebug)}
           active={showDebug}
         />
         <QueryOperationToggleAction
@@ -154,9 +164,9 @@ export const TransformationOperationRow = ({
       draggable
       actions={renderActions}
       disabled={disabled}
-      isOpen={showHelp}
+      isOpen={toggleExpand()}
       // Assure that showHelp is untoggled when the row becomes collapsed.
-      onClose={() => setShowHelp(false)}
+      onClose={() => toggleShowHelp(false)}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}
       {filter && (

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -154,6 +154,7 @@ export const TransformationOperationRow = ({
       actions={renderActions}
       disabled={disabled}
       isOpen={showHelp}
+      // Assure that showHelp is untoggled when the row becomes collapsed.
       onClose={() => toggleHelp(false)}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -153,6 +153,8 @@ export const TransformationOperationRow = ({
       draggable
       actions={renderActions}
       disabled={disabled}
+      isOpen={showHelp}
+      onClose={() => toggleHelp(false)}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}
       {filter && (

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useToggle } from 'react-use';
 
 import { DataFrame, DataTransformerConfig, TransformerRegistryItem, FrameMatcherID } from '@grafana/data';
@@ -39,9 +39,9 @@ export const TransformationOperationRow = ({
   uiConfig,
   onChange,
 }: TransformationOperationRowProps) => {
-  const [showDeleteModal, setShowDeleteModal] = useToggle(false);
+  const [showDeleteModal, setShowDeleteModal] = useToggle(false); // JEV: remove all uses of useToggle?
   const [showDebug, toggleDebug] = useToggle(false);
-  const [showHelp, toggleHelp] = useToggle(false);
+  const [showHelp, setShowHelp] = useState<boolean | undefined>(undefined);
   const disabled = !!configs[index].transformation.disabled;
   const filter = configs[index].transformation.filter != null;
   const showFilter = filter || data.length > 1;
@@ -98,8 +98,9 @@ export const TransformationOperationRow = ({
         <QueryOperationToggleAction
           title="Show transform help"
           icon="info-circle"
-          onClick={instrumentToggleCallback(toggleHelp, 'help', showHelp)}
-          active={showHelp}
+          // `instrumentToggleCallback` expects a function that takes a MouseEvent, is unused in the state setter. Instead, we simply toggle the state.
+          onClick={instrumentToggleCallback((_e) => setShowHelp(!showHelp), 'help', showHelp)}
+          active={!!showHelp}
         />
         {showFilter && (
           <QueryOperationToggleAction
@@ -155,7 +156,7 @@ export const TransformationOperationRow = ({
       disabled={disabled}
       isOpen={showHelp}
       // Assure that showHelp is untoggled when the row becomes collapsed.
-      onClose={() => toggleHelp(false)}
+      onClose={() => setShowHelp(false)}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}
       {filter && (

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -39,7 +39,7 @@ export const TransformationOperationRow = ({
   uiConfig,
   onChange,
 }: TransformationOperationRowProps) => {
-  const [showDeleteModal, setShowDeleteModal] = useToggle(false); // JEV: remove all uses of useToggle?
+  const [showDeleteModal, setShowDeleteModal] = useToggle(false);
   const [showDebug, toggleDebug] = useToggle(false);
   const [showHelp, setShowHelp] = useState<boolean | undefined>(undefined);
   const disabled = !!configs[index].transformation.disabled;


### PR DESCRIPTION
**What is this feature?**

This addresses a quirk in the usage of "show help" button on a Transformation. When clicking the "show help" button, a user would expect a collapsed Transformation Operation Row component to expand. It currently doesn't. This fixes that behavior.

**Why do we need this feature?**

So Transformations are easier and more conspicuous to use.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #73796

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/46619047/7cda67be-dfc1-4bbf-9379-d4260eaf51b1