### PR TITLE
Prometheus: Add flag to SigV4 auth for styles in auth component

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -59,7 +59,9 @@ export const ConfigEditor = (props: Props) => {
             onOptionsChange={onOptionsChange}
             azureAuthSettings={azureAuthSettings}
             sigV4AuthToggleEnabled={config.sigV4AuthEnabled}
-            renderSigV4Editor={<SIGV4ConnectionConfig {...props}></SIGV4ConnectionConfig>}
+            renderSigV4Editor={
+              <SIGV4ConnectionConfig inExperimentalAuthComponent={true} {...props}></SIGV4ConnectionConfig>
+            }
             secureSocksDSProxyEnabled={config.secureSocksDSProxyEnabled}
           />
         </>


### PR DESCRIPTION
**What is this feature?**
Fix width for inputs for SigV4 auth component in the new config auth component.

**Why do we need this feature?**
The new auth component in Prometheus config can be seen when the feature toggle `prometheusConfigOverhaulAuth` is enabled. The SigV4 auth (feature toggle `sigv4_auth_enabled`) in grafana-aws-sdk-react input widths needed to be adjusted to fit correctly in the component. This fixes the widths. (the fix in the sdk is here https://github.com/grafana/grafana-aws-sdk-react/pull/52)

**Who is this feature for?**
People configuring Prometheus with SigV4

**Which issue(s) does this PR fix?**:
Part of https://github.com/grafana/grafana/issues/65877

![Screenshot 2023-08-28 at 1 24 38 PM](https://github.com/grafana/grafana/assets/25674746/b73c3d9d-634d-4462-8a37-fca8b0e722c4)

**Special notes for your reviewer:**
Use the `sigv4_auth_enabled` feature toggle to enable the sigv4 auth

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
