### PR TITLE
Explorer: Collapse logs which are multiple lines and expand them on us…

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -118,6 +118,7 @@ interface State {
   tableFrame?: DataFrame;
   visualisationType?: VisualisationType;
   logsContainer?: HTMLDivElement;
+  expandAllLogs: boolean;
 }
 
 const scrollableLogsContainer = config.featureToggles.exploreScrollableLogsContainer;
@@ -161,6 +162,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     contextRow: undefined,
     tableFrame: undefined,
     visualisationType: 'logs',
+    expandAllLogs: store.getBool(SETTINGS_KEYS.expandAllLogs, true),
     logsContainer: undefined,
   };
 
@@ -251,6 +253,17 @@ class UnthemedLogs extends PureComponent<Props, State> {
         showLabels,
       });
       store.set(SETTINGS_KEYS.showLabels, showLabels);
+    }
+  };
+
+  onChangeExpandAllLogs = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { target } = event;
+    if (target) {
+      const expandAllLogs = target.checked;
+      this.setState({
+        expandAllLogs,
+      });
+      store.set(SETTINGS_KEYS.expandAllLogs, expandAllLogs);
     }
   };
 
@@ -513,6 +526,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
       displayedFields,
       forceEscape,
       contextOpen,
+      expandAllLogs,
       contextRow,
     } = this.state;
 
@@ -608,6 +622,15 @@ class UnthemedLogs extends PureComponent<Props, State> {
                     className={styles.horizontalInlineSwitch}
                     transparent
                     id={`unique-labels_${exploreId}`}
+                  />
+                </InlineField>
+                <InlineField label="Expand all logs" className={styles.horizontalInlineLabel} transparent>
+                  <InlineSwitch
+                    value={expandAllLogs}
+                    onChange={this.onChangeExpandAllLogs}
+                    className={styles.horizontalInlineSwitch}
+                    transparent
+                    id={`expand-labels_${exploreId}`}
                   />
                 </InlineField>
                 <InlineField label="Wrap lines" className={styles.horizontalInlineLabel} transparent>
@@ -709,6 +732,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   prettifyLogMessage={prettifyLogMessage}
                   timeZone={timeZone}
                   getFieldLinks={getFieldLinks}
+                  expandAllLogs={expandAllLogs}
                   logsSortOrder={logsSortOrder}
                   displayedFields={displayedFields}
                   onClickShowField={this.showField}

--- a/public/app/features/explore/Logs/utils/logs.ts
+++ b/public/app/features/explore/Logs/utils/logs.ts
@@ -5,4 +5,5 @@ export const SETTINGS_KEYS = {
   prettifyLogMessage: 'grafana.explore.logs.prettifyLogMessage',
   logsSortOrder: 'grafana.explore.logs.sortOrder',
   logContextWrapLogMessage: 'grafana.explore.logs.logContext.wrapLogMessage',
+  expandAllLogs: 'grafana.explore.logs.expandAllLogs',
 };

--- a/public/app/features/logs/components/LogMessage.test.tsx
+++ b/public/app/features/logs/components/LogMessage.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import React, { ComponentProps } from 'react';
+
+import { createTheme } from '@grafana/data';
+
+import { LogMessage } from './LogMessage';
+import { getLogRowStyles } from './getLogRowStyles';
+
+const LOG_MULTILINE_ENTRY = `[2020-12-03 11:36:23] ERROR in app: Exception on /error [GET]
+Traceback (most recent call last):
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
+    response = self.full_dispatch_request()
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
+    rv = self.handle_user_exception(e)
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception
+    reraise(exc_type, exc_value, tb)
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
+    raise value
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
+    rv = self.dispatch_request()
+  File "/home/pallets/.pyenv/versions/3.8.5/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
+    return self.view_functions[rule.endpoint](**req.view_args)
+  File "/home/pallets/src/deployment_tools/hello.py", line 10, in error
+    raise Exception("Sorry, this route always breaks")
+Exception: Sorry, this route always breaks`;
+const LOG_LONG_SINGLE_LINE_ENTRY = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eu nisl varius, hendrerit velit faucibus, dictum nisi. Cras facilisis vestibulum mollis. Curabitur congue suscipit quam. Cras efficitur vitae ligula vitae rhoncus. Integer auctor condimentum ligula eu semper. Pellentesque eleifend lectus nulla, eu auctor nisl vehicula eget. Mauris consectetur dui eu justo placerat, nec consectetur tortor fermentum. Nunc vitae quam vitae ante pretium aliquet eget in lectus.Ut mollis eros vel interdum placerat. Maecenas ultrices arcu risus, eu elementum dui blandit id. Integer lobortis pulvinar dictum. Maecenas quis ipsum faucibus, porta massa vulputate, maximus nibh. Morbi dapibus porta pulvinar. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus non nisl mauris. Interdum et malesuada fames ac ante ipsum primis in faucibus.Integer et vestibulum nulla. Phasellus metus diam, sagittis consequat enim placerat, fermentum sodales ante. Vivamus pretium, odio sagittis laoreet semper, urna diam aliquam magna, a tristique dolor nunc et arcu. Aenean a accumsan turpis, eget ultricies risus. Aenean ut luctus ligula, ornare tincidunt nisi. Aenean a nisl ac lectus ultrices interdum. Pellentesque condimentum dui nec urna dapibus, ornare consequat lorem suscipit.`;
+const LOG_SMALL_SINGLE_LINE_ENTRY = `test123`;
+
+const setup = (entry: string, expandLogMessage: boolean): string => {
+  const theme = createTheme();
+  const styles = getLogRowStyles(theme);
+  const { rerender } = render(
+    <LogMessage hasAnsi={false} highlights={[]} entry={entry} styles={styles} expandLogMessage={expandLogMessage} />
+  );
+  return styles.truncateToOneLine;
+};
+
+const setupHighlightedLogMessage = () => {
+  const theme = createTheme();
+  const styles = getLogRowStyles(theme);
+  const { rerender } = render(
+    <LogMessage
+      hasAnsi={false}
+      highlights={['test', 'yuk']}
+      entry={'asd123 test rty yuk'}
+      styles={styles}
+      expandLogMessage={false}
+    />
+  );
+};
+
+describe('LogMessage must handle correctly highlights', () => {
+  it('Must highlight all matching string in a log message', () => {
+    setupHighlightedLogMessage();
+    expect(screen.queryByText(/.*test*/).tagName.toLowerCase()).toContain('mark');
+    expect(screen.queryByText(/.*test*/).className).toMatch(/.*highlight.*/);
+
+    expect(screen.queryByText(/.*yuk*/).tagName.toLowerCase()).toContain('mark');
+    expect(screen.queryByText(/.*yuk*/).className).toMatch(/.*highlight.*/);
+  });
+  it('Must not highlight text not specified in the highlighs array', () => {
+    setupHighlightedLogMessage();
+    expect(screen.queryByText(/.*asd123*/).tagName.toLowerCase()).not.toContain('mark');
+    expect(screen.queryByText(/.*asd123*/).className).not.toMatch(/.*highlight.*/);
+  });
+});
+
+describe('LogMessage must handle ANSI codes', () => {
+  it('Must render LogMessageAnsi there are ANSI codes in the entry and hasAnsi is true', () => {
+    const theme = createTheme();
+    const styles = getLogRowStyles(theme);
+    const { rerender } = render(
+      <LogMessage
+        hasAnsi={true}
+        highlights={[]}
+        entry={'Lorem \u001B[31mipsum\u001B[0m et dolor'}
+        styles={styles}
+        expandLogMessage={true}
+      />
+    );
+    expect(screen.queryByTestId('ansiLogLine')).toBeInTheDocument();
+  });
+  it('Must not ender LogMessageAnsi there are ANSI codes in the entry and hasAnsi is false', () => {
+    const theme = createTheme();
+    const styles = getLogRowStyles(theme);
+    const { rerender } = render(
+      <LogMessage
+        hasAnsi={false}
+        highlights={[]}
+        entry={'Lorem ipsum et dolor'}
+        styles={styles}
+        expandLogMessage={true}
+      />
+    );
+    expect(screen.queryByTestId('ansiLogLine')).not.toBeInTheDocument();
+  });
+});
+
+describe('LogRowMessage must show only the first line of a message when expandLogMessage is set to false', () => {
+  it('When the message is multiline', () => {
+    const expectedClass = setup(LOG_MULTILINE_ENTRY, false);
+    expect(screen.queryByText(/.*ERROR in app: Exception on \/error.*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*ERROR in app: Exception on \/error.*/)).toHaveClass(expectedClass);
+  });
+  it('When the message is single long line', () => {
+    const expectedClass = setup(LOG_LONG_SINGLE_LINE_ENTRY, false);
+    expect(screen.queryByText(/.*Lorem ipsum dolor sit amet*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*Lorem ipsum dolor sit amet*/)).toHaveClass(expectedClass);
+  });
+  it('When the message is single small line', () => {
+    const expectedClass = setup(LOG_SMALL_SINGLE_LINE_ENTRY, false);
+    expect(screen.queryByText(/.*test123*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*test123*/)).toHaveClass(expectedClass);
+  });
+});
+
+describe('LogMessage must show all lines of a message when expandLogMessage is set to true', () => {
+  it('When the message is multiline', () => {
+    const expectedClass = setup(LOG_MULTILINE_ENTRY, true);
+    expect(screen.queryByText(/.*ERROR in app: Exception on \/error.*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*ERROR in app: Exception on \/error.*/)).not.toHaveClass(expectedClass);
+  });
+  it('When the message is single long line', () => {
+    const expectedClass = setup(LOG_LONG_SINGLE_LINE_ENTRY, true);
+    expect(screen.queryByText(/.*Lorem ipsum dolor sit amet*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*Lorem ipsum dolor sit amet*/)).not.toHaveClass(expectedClass);
+  });
+  it('When the message is single small line', () => {
+    const expectedClass = setup(LOG_SMALL_SINGLE_LINE_ENTRY, true);
+    expect(screen.queryByText(/.*test123*/)).toBeInTheDocument();
+    expect(screen.queryByText(/.*test123*/)).not.toHaveClass(expectedClass);
+  });
+});

--- a/public/app/features/logs/components/LogMessage.tsx
+++ b/public/app/features/logs/components/LogMessage.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import Highlighter from 'react-highlight-words';
+
+import { findHighlightChunksInText } from '@grafana/data';
+
+import { LogMessageAnsi } from './LogMessageAnsi';
+import { LogRowStyles } from './getLogRowStyles';
+
+const EMPTY_STYLE = '';
+export const MAX_CHARACTERS = 100000;
+
+interface LogMessageProps {
+  hasAnsi: boolean;
+  entry: string;
+  highlights: string[] | undefined;
+  styles: LogRowStyles;
+  expandLogMessage: boolean;
+}
+
+const hasHighlightWordsInProps = (highlights: string[] | undefined, entry: string): boolean => {
+  const highlightIsDefined = (highlights: string[] | undefined): boolean => {
+    return typeof highlights !== undefined && highlights !== null;
+  };
+  const highlightHasAtLeastOneString = (highlights: string[]): boolean => {
+    return highlights[0] !== undefined && highlights.length > 0 && highlights[0].length > 0;
+  };
+  const entryLengthIsWithinMax = (entry: string): boolean => {
+    return entry.length < MAX_CHARACTERS;
+  };
+  return (
+    highlightIsDefined(highlights) && highlightHasAtLeastOneString(highlights ?? []) && entryLengthIsWithinMax(entry)
+  );
+};
+const createLogMessageAnsi = (
+  entry: string,
+  styles: LogRowStyles,
+  searchWords: string[],
+  needsHighlighter?: boolean
+) => {
+  const highlight = needsHighlighter ? { searchWords, highlightClassName: styles.logsRowMatchHighLight } : undefined;
+  return <LogMessageAnsi value={entry} highlight={highlight} />;
+};
+
+const createHighliter = (entry: string, highlights: string[], styles: LogRowStyles) => {
+  return (
+    <Highlighter
+      textToHighlight={entry}
+      searchWords={highlights}
+      findChunks={findHighlightChunksInText}
+      highlightClassName={styles.logsRowMatchHighLight}
+    />
+  );
+};
+
+const defaultLogMessage = (entry: string) => {
+  return <>{entry}</>;
+};
+
+const createLogMessageComponent = (hasAnsi: boolean, entry: string, highlights: string[], styles: LogRowStyles) => {
+  if (hasAnsi) {
+    return createLogMessageAnsi(entry, styles, highlights, hasHighlightWordsInProps(highlights, entry));
+  }
+  if (hasHighlightWordsInProps(highlights, entry)) {
+    return createHighliter(entry, highlights, styles);
+  }
+  return defaultLogMessage(entry);
+};
+
+export const LogMessage = ({ expandLogMessage, hasAnsi, entry, highlights, styles }: LogMessageProps) => {
+  return (
+    <div className={expandLogMessage ? EMPTY_STYLE : styles.truncateToOneLine}>
+      {createLogMessageComponent(hasAnsi, entry, highlights ?? [], styles)}
+    </div>
+  );
+};

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -47,6 +47,7 @@ interface Props extends Themeable2 {
   onUnpinLine?: (row: LogRowModel) => void;
   pinned?: boolean;
   containerRendered?: boolean;
+  expandAllLogs?: boolean;
 }
 
 interface State {
@@ -86,7 +87,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     this.setState({ showingContext: true });
     this.props.onOpenContext(row, this.debouncedContextClose);
   };
-
   toggleDetails = () => {
     if (!this.props.enableLogDetails) {
       return;
@@ -265,6 +265,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               pinned={this.props.pinned}
               mouseIsOver={this.state.mouseIsOver}
               onBlur={this.onMouseLeave}
+              expandAllLogs={this.props.expandAllLogs}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -17,6 +17,8 @@ interface Props {
   styles: LogRowStyles;
   mouseIsOver: boolean;
   onBlur: () => void;
+  expandAllLogs?: boolean;
+  expandLogMessage?: (expandLogMessage: (currnet: boolean) => boolean) => void;
 }
 
 export const LogRowMenuCell = React.memo(
@@ -32,11 +34,21 @@ export const LogRowMenuCell = React.memo(
     styles,
     mouseIsOver,
     onBlur,
+    expandLogMessage,
+    expandAllLogs,
   }: Props) => {
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
     const onLogRowClick = useCallback((e: SyntheticEvent) => {
       e.stopPropagation();
     }, []);
+    const onExpandLogClick = () => {
+      if (expandLogMessage !== undefined) {
+        expandLogMessage((current) => {
+          console.log('will become: ' + !current);
+          return !current;
+        });
+      }
+    };
     const onShowContextClick = useCallback(
       (e: SyntheticEvent<HTMLElement, Event>) => {
         e.stopPropagation();
@@ -75,6 +87,17 @@ export const LogRowMenuCell = React.memo(
         )}
         {mouseIsOver && (
           <>
+            {expandAllLogs && (
+              <IconButton
+                size="md"
+                name="expand-arrows"
+                onClick={onExpandLogClick}
+                tooltip="Expand log"
+                tooltipPlacement="top"
+                aria-label="Expand log"
+                tabIndex={0}
+              />
+            )}
             {shouldShowContextToggle && (
               <IconButton
                 size="md"

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -17,6 +17,7 @@ const setup = (propOverrides?: Partial<ComponentProps<typeof LogRowMessage>>, ro
     onOpenContext: () => {},
     prettifyLogMessage: false,
     app: CoreApp.Explore,
+    expandAllLogs: true,
     styles,
     mouseIsOver: true,
     onBlur: jest.fn(),

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -53,6 +53,7 @@ export interface Props extends Themeable2 {
   isFilterLabelActive?: (key: string, value: string) => Promise<boolean>;
   pinnedRowId?: string;
   containerRendered?: boolean;
+  expandAllLogs?: boolean;
 }
 
 interface State {
@@ -168,6 +169,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 onUnpinLine={this.props.onUnpinLine}
                 pinned={this.props.pinnedRowId === row.uid}
                 isFilterLabelActive={this.props.isFilterLabelActive}
+                expandAllLogs={this.props.expandAllLogs}
                 {...rest}
               />
             ))}

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -253,6 +253,13 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
         margin: 0;
       }
     `,
+    truncateToOneLine: css`
+      width: 100%;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+      display: -webkit-box;
+    `,
     logRowMenuCell: css`
       position: sticky;
       z-index: ${theme.zIndex.dropdown};


### PR DESCRIPTION
**What is this feature?**

The feature was inspired by https://github.com/grafana/grafana/discussions/46507. Basically it allows multiline logs to be collapse. This is split in two features - one global, affecting all log lines and one local for each line. 
The global "collapse" is implemented with radio button sitting at the top, together with "wrap lines", "unique labels" and others of this fashion:
![image](https://github.com/grafana/grafana/assets/143441726/2d955216-fee9-4b88-b967-2873cba0716b)
While the local collapse is a button in the context menu:
![image](https://github.com/grafana/grafana/assets/143441726/27fda3f3-97fb-4607-8bfa-45088791433e)

The global collapse is set to "On" meaning all lines are expanded by default. This is so that the change is backward compatible with any automated tests.

If the global is set to "On" the local collapse button is hidden. It doesn't make sense to have it, or to provide capability to overwrite the global one. This is at least as per my understanding.
![image](https://github.com/grafana/grafana/assets/143441726/8f5061a5-5081-4061-9452-4c8cb6816979)

The global expand option is preserved between page reloads, the local one is not. During my testing I discovered this to be the best combination as it provides with means to erase any expanded lines. 

This is how expanded log looks:
![image](https://github.com/grafana/grafana/assets/143441726/5bae3b43-4fa7-4171-9e66-47035b1ebf29)

The local expand option expands single row. By pressing the "expand" button again, it collapses the log again. Its basically flipping between the two states on click.
**Why do we need this feature?**

The feature simplifies reading and reviewing multiline exceptions. Those are common in the Java world. 

**Who is this feature for?**
Developers and infrastructure engineers

Special notes for your reviewer:

- [ ] I refactored the LogRow component since it became too large to handle. I move the refactored code to LogMessage component.
- [ ] I have tested on latest versions of Safari, Chrome and Firefox. I cannot support Edge. 
- [ ] I have create some unit tests related to the component and the refactoring of LogRow in LogMessage.test.tsx
- [ ] Make sure the feature is intuitive to use. I believe such feature doesn't need documentation for our end users. Given such functionality is common in other similar applications.