### PR TITLE
Nightlies: Remove `pre` suffix from GetLatestMainBuild regexp

### DIFF
--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -418,7 +418,7 @@ func GetLatestMainBuild(ctx context.Context, bucket *storage.BucketHandle, path 
 
 	var latestVersion string
 	for i := 0; i < len(files); i++ {
-		captureVersion := regexp.MustCompile(`(\d+\.\d+\.\d+-\d+pre)`)
+		captureVersion := regexp.MustCompile(`(\d+\.\d+\.\d+-\d+)`)
 		if captureVersion.MatchString(files[i]) {
 			latestVersion = captureVersion.FindString(files[i])
 			break


### PR DESCRIPTION
**What is this feature?**

Leftover from https://github.com/grafana/grafana-delivery/issues/204 

**Why do we need this feature?**

Nightly builds are failing https://drone.grafana.net/grafana/grafana/132283/1/3 