### PR TITLE
Rename Group By Metrics to Aggregate by

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
@@ -70,7 +70,7 @@ export const GroupByField = (props: Props) => {
 
   return (
     <InlineSearchField
-      label="Group By Metrics"
+      label="Aggregate by"
       tooltip="Select one or more tags to see the metrics summary. Note: the metrics summary API only considers spans of kind = server."
     >
       <>

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.test.tsx
@@ -124,7 +124,7 @@ describe('TraceQLSearch', () => {
   it('should not render group by when feature toggle is not enabled', async () => {
     await waitFor(() => {
       render(<TraceQLSearch datasource={datasource} query={query} onChange={onChange} />);
-      const groupBy = screen.queryByText('Group By Metrics');
+      const groupBy = screen.queryByText('Aggregate by');
       expect(groupBy).toBeNull();
       expect(groupBy).not.toBeInTheDocument();
     });
@@ -134,7 +134,7 @@ describe('TraceQLSearch', () => {
     config.featureToggles.metricsSummary = true;
     await waitFor(() => {
       render(<TraceQLSearch datasource={datasource} query={query} onChange={onChange} />);
-      const groupBy = screen.queryByText('Group By Metrics');
+      const groupBy = screen.queryByText('Aggregate by');
       expect(groupBy).not.toBeNull();
       expect(groupBy).toBeInTheDocument();
     });


### PR DESCRIPTION
**What is this feature?**

It's a rename.

**Why do we need this feature?**

More accurately describes the feature.

**Who is this feature for?**

Users of the metrics summary.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
