### PR TITLE
Alerting: Fix flakey test in CloneRuleEditor

### DIFF
--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -164,7 +164,9 @@ describe('CloneRuleEditor', function () {
       });
 
       await waitForElementToBeRemoved(ui.loadingIndicator.query());
-      await waitForElementToBeRemoved(within(ui.inputs.group.get()).getByTestId('Spinner'));
+      await waitFor(() => {
+        expect(within(ui.inputs.group.get()).queryByTestId('Spinner')).not.toBeInTheDocument();
+      });
 
       await waitFor(() => {
         expect(ui.inputs.name.get()).toHaveValue('First Grafana Rule (copy)');


### PR DESCRIPTION
**What is this feature?**

This PR fixes a flakey test in `CloneRuleEditor.test.tsx`. We believe that what's happening is that both loading elements can get removed in the same render cycle, making one of the loading checks fail.