### PR TITLE
Plugins: Ensure service registration occurs in right order

### DIFF
--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -583,3 +583,26 @@ func (p *FakeBackendPlugin) Kill() {
 	defer p.mutex.Unlock()
 	p.Running = false
 }
+
+type FakeFeatureToggles struct {
+	features map[string]bool
+}
+
+func NewFakeFeatureToggles(features ...string) *FakeFeatureToggles {
+	m := make(map[string]bool)
+	for _, f := range features {
+		m[f] = true
+	}
+
+	return &FakeFeatureToggles{
+		features: m,
+	}
+}
+
+func (f *FakeFeatureToggles) GetEnabled(_ context.Context) map[string]bool {
+	return f.features
+}
+
+func (f *FakeFeatureToggles) IsEnabled(feature string) bool {
+	return f.features[feature]
+}

--- a/pkg/plugins/manager/testdata/external-registration/plugin.json
+++ b/pkg/plugins/manager/testdata/external-registration/plugin.json
@@ -1,0 +1,41 @@
+{
+  "id": "grafana-test-datasource",
+  "type": "datasource",
+  "name": "Test",
+  "backend": true,
+  "executable": "gpx_test_datasource",
+  "info": {
+    "author": {
+      "name": "Grafana Labs",
+      "url": "https://grafana.com"
+    },
+    "logos": {
+      "large": "img/ds.svg",
+      "small": "img/ds.svg"
+    },
+    "screenshots": [],
+    "updated": "2023-08-03",
+    "version": "1.0.0"
+  },
+  "externalServiceRegistration": {
+    "impersonation": {
+      "enabled" : true,
+      "groups" : true,
+      "permissions" :  [
+        {
+          "action": "read",
+          "scope": "datasource"
+        }
+      ]
+    },
+    "self": {
+      "enabled" : true,
+      "permissions" :  [
+        {
+          "action": "read",
+          "scope": "datasource"
+        }
+      ]
+    }
+  }
+}

--- a/pkg/plugins/pfs/pfs_test.go
+++ b/pkg/plugins/pfs/pfs_test.go
@@ -131,6 +131,9 @@ func TestParsePluginTestdata(t *testing.T) {
 			rootid:  "grafana-worldmap-panel",
 			subpath: "plugin",
 		},
+		"external-registration": {
+			rootid: "grafana-test-datasource",
+		},
 	}
 
 	staticRootPath, err := filepath.Abs("../manager/testdata")

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -57,10 +57,10 @@ func ProvideInitializationStage(cfg *config.Cfg, pr registry.Service, l plugins.
 	roleRegistry plugins.RoleRegistry) *initialization.Initialize {
 	return initialization.New(cfg, initialization.Opts{
 		InitializeFuncs: []initialization.InitializeFunc{
+			ExternalServiceRegistrationStep(cfg, externalServiceRegistry),
 			initialization.BackendClientInitStep(envvars.NewProvider(cfg, l), bp),
 			initialization.PluginRegistrationStep(pr),
 			initialization.BackendProcessStartStep(pm),
-			ExternalServiceRegistrationStep(cfg, externalServiceRegistry),
 			RegisterPluginRolesStep(roleRegistry),
 			ReportBuildMetrics,
 		},


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where service registration env vars were not being set as the initialization was being called after environment variables were being constructed for the plugin (see changes to [pkg/services/pluginsintegration/pipeline/pipeline.go](https://github.com/grafana/grafana/compare/plugins-oauth-registation-bug?expand=1#diff-b1f170807459adf5d7fcf558b83dc193ad200a5c449ee7a7ec1ff29140868680))

**Why do we need this feature?**

External service registration would not function otherwise.

**Who is this feature for?**

Plugin users.
<!--
**Which issue(s) does this PR fix?**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->
**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
