### PR TITLE
[v10.1.x] Loki: Remove `distinct` operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "@grafana/faro-core": "1.1.0",
     "@grafana/faro-web-sdk": "1.1.0",
     "@grafana/google-sdk": "0.1.1",
-    "@grafana/lezer-logql": "0.1.8",
+    "@grafana/lezer-logql": "0.1.11",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "0.22.0",

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -124,12 +124,6 @@ const afterSelectorCompletions = [
     type: 'PIPE_OPERATION',
     documentation: 'Operator docs',
   },
-  {
-    documentation: 'Operator docs',
-    insertText: '| distinct',
-    label: 'distinct',
-    type: 'PIPE_OPERATION',
-  },
 ];
 
 function buildAfterSelectorCompletions(
@@ -387,32 +381,6 @@ describe('getCompletions', () => {
       },
     ]);
     expect(functionCompletions).toHaveLength(3);
-  });
-
-  test('Returns completion options when the situation is AFTER_DISTINCT', async () => {
-    const situation: Situation = { type: 'AFTER_DISTINCT', logQuery: '{label="value"}' };
-    const completions = await getCompletions(situation, completionProvider);
-
-    expect(completions).toEqual([
-      {
-        insertText: 'extracted',
-        label: 'extracted',
-        triggerOnInsert: false,
-        type: 'LABEL_NAME',
-      },
-      {
-        insertText: 'place',
-        label: 'place',
-        triggerOnInsert: false,
-        type: 'LABEL_NAME',
-      },
-      {
-        insertText: 'source',
-        label: 'source',
-        triggerOnInsert: false,
-        type: 'LABEL_NAME',
-      },
-    ]);
   });
 });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -288,13 +288,6 @@ export async function getAfterSelectorCompletions(
     documentation: explainOperator(LokiOperationId.Decolorize),
   });
 
-  completions.push({
-    type: 'PIPE_OPERATION',
-    label: 'distinct',
-    insertText: `${prefix}distinct`,
-    documentation: explainOperator(LokiOperationId.Distinct),
-  });
-
   // Let's show label options only if query has parser
   if (hasQueryParser) {
     extractedLabelKeys.forEach((key) => {
@@ -347,18 +340,6 @@ async function getAfterUnwrapCompletions(
   return [...labelCompletions, ...UNWRAP_FUNCTION_COMPLETIONS];
 }
 
-async function getAfterDistinctCompletions(logQuery: string, dataProvider: CompletionDataProvider) {
-  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(logQuery);
-  const labelCompletions: Completion[] = extractedLabelKeys.map((label) => ({
-    type: 'LABEL_NAME',
-    label,
-    insertText: label,
-    triggerOnInsert: false,
-  }));
-
-  return [...labelCompletions];
-}
-
 export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
@@ -393,8 +374,6 @@ export async function getCompletions(
       return getAfterUnwrapCompletions(situation.logQuery, dataProvider);
     case 'IN_AGGREGATION':
       return [...FUNCTION_COMPLETIONS, ...AGGREGATION_COMPLETIONS];
-    case 'AFTER_DISTINCT':
-      return getAfterDistinctCompletions(situation.logQuery, dataProvider);
     default:
       throw new NeverCaseError(situation);
   }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -264,16 +264,4 @@ describe('situation', () => {
       ],
     });
   });
-
-  it('identifies AFTER_DISTINCT autocomplete situations', () => {
-    assertSituation('{label="value"} | logfmt | distinct^', {
-      type: 'AFTER_DISTINCT',
-      logQuery: '{label="value"} | logfmt ',
-    });
-
-    assertSituation('{label="value"} | logfmt | distinct id,^', {
-      type: 'AFTER_DISTINCT',
-      logQuery: '{label="value"} | logfmt ',
-    });
-  });
 });

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -340,19 +340,6 @@ describe('runSplitQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(1);
       });
     });
-    test('Groups queries using distinct', async () => {
-      const request = getQueryOptions<LokiQuery>({
-        targets: [
-          { expr: '{a="b"} | distinct field', refId: 'A' },
-          { expr: 'count_over_time({c="d"} | distinct something [1m])', refId: 'B' },
-        ],
-        range,
-      });
-      await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
-        // Queries using distinct are omitted from splitting
-        expect(datasource.runQuery).toHaveBeenCalledTimes(1);
-      });
-    });
     test('Respects maxLines of logs queries', async () => {
       const { logFrameA } = getMockFrames();
       const request = getQueryOptions<LokiQuery>({
@@ -370,18 +357,17 @@ describe('runSplitQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(4);
       });
     });
-    test('Groups multiple queries into logs, queries, instant, and distinct', async () => {
+    test('Groups multiple queries into logs, queries, instant', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [
           { expr: 'count_over_time({a="b"}[1m])', refId: 'A', queryType: LokiQueryType.Instant },
           { expr: '{c="d"}', refId: 'B' },
           { expr: 'count_over_time({c="d"}[1m])', refId: 'C' },
-          { expr: 'count_over_time({c="d"} | distinct id [1m])', refId: 'D' },
         ],
         range,
       });
       await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
-        // 3 days, 3 chunks, 3x Logs + 3x Metric + (1x Instant | Distinct), 7 requests.
+        // 3 days, 3 chunks, 3x Logs + 3x Metric + (1x Instant), 7 requests.
         expect(datasource.runQuery).toHaveBeenCalledTimes(7);
       });
     });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -18,7 +18,7 @@ import { LoadingState } from '@grafana/schema';
 import { LokiDatasource } from './datasource';
 import { splitTimeRange as splitLogsTimeRange } from './logsTimeSplitting';
 import { splitTimeRange as splitMetricTimeRange } from './metricTimeSplitting';
-import { isLogsQuery, isQueryWithDistinct, isQueryWithRangeVariable } from './queryUtils';
+import { isLogsQuery, isQueryWithRangeVariable } from './queryUtils';
 import { combineResponses } from './responseUtils';
 import { trackGroupedQueries } from './tracking';
 import { LokiGroupedRequest, LokiQuery, LokiQueryType } from './types';
@@ -208,7 +208,6 @@ function getNextRequestPointers(requests: LokiGroupedRequest[], requestGroup: nu
 function querySupportsSplitting(query: LokiQuery) {
   return (
     query.queryType !== LokiQueryType.Instant &&
-    !isQueryWithDistinct(query.expr) &&
     // Queries with $__range variable should not be split because then the interpolated $__range variable is incorrect
     // because it is interpolated on the backend with the split timeRange
     !isQueryWithRangeVariable(query.expr)

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -12,7 +12,6 @@ import {
   getParserFromQuery,
   obfuscate,
   requestSupportsSplitting,
-  isQueryWithDistinct,
   isQueryWithRangeVariable,
   isQueryPipelineErrorFiltering,
   getLogQueryFromMetricsQuery,
@@ -307,18 +306,6 @@ describe('isQueryWithLabelFormat', () => {
 
   it('returns false if metrics query without label format', () => {
     expect(isQueryWithLabelFormat('rate({job="grafana"} [5m])')).toBe(false);
-  });
-});
-
-describe('isQueryWithDistinct', () => {
-  it('identifies queries using distinct', () => {
-    expect(isQueryWithDistinct('{job="grafana"} | distinct id')).toBe(true);
-    expect(isQueryWithDistinct('count_over_time({job="grafana"} | distinct id [1m])')).toBe(true);
-  });
-
-  it('does not return false positives', () => {
-    expect(isQueryWithDistinct('{label="distinct"} | logfmt')).toBe(false);
-    expect(isQueryWithDistinct('count_over_time({job="distinct"} | json [1m])')).toBe(false);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -17,7 +17,6 @@ import {
   MetricExpr,
   Matcher,
   Identifier,
-  Distinct,
   Range,
   formatLokiQuery,
 } from '@grafana/lezer-logql';
@@ -246,10 +245,6 @@ export function isQueryWithLabelFilter(query: string): boolean {
 
 export function isQueryWithLineFilter(query: string): boolean {
   return isQueryWithNode(query, LineFilter);
-}
-
-export function isQueryWithDistinct(query: string): boolean {
-  return isQueryWithNode(query, Distinct);
 }
 
 export function isQueryWithRangeVariable(query: string): boolean {

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -1,4 +1,3 @@
-import { LabelParamEditor } from '../../prometheus/querybuilder/components/LabelParamEditor';
 import {
   createAggregationOperation,
   createAggregationOperationWithParam,
@@ -486,27 +485,6 @@ Example: \`\`error_level=\`level\` \`\`
       renderer: (op, def, innerExpr) => `${innerExpr} | decolorize`,
       addOperationHandler: addLokiOperation,
       explainHandler: () => `This will remove ANSI color codes from log lines.`,
-    },
-    {
-      id: LokiOperationId.Distinct,
-      name: 'Distinct',
-      params: [
-        {
-          name: 'Label',
-          type: 'string',
-          restParam: true,
-          optional: true,
-          editor: LabelParamEditor,
-        },
-      ],
-      defaultParams: [''],
-      alternativesKey: 'format',
-      category: LokiVisualQueryOperationCategory.Formats,
-      orderRank: LokiOperationOrder.Unwrap,
-      renderer: (op, def, innerExpr) => `${innerExpr} | distinct ${op.params.join(',')}`,
-      addOperationHandler: addLokiOperation,
-      explainHandler: () =>
-        'Allows filtering log lines using their original and extracted labels to filter out duplicate label values. The first line occurrence of a distinct value is returned, and the others are dropped.',
     },
     ...binaryScalarOperations,
     {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -746,36 +746,6 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
-
-  it('parses a log query with distinct and no labels', () => {
-    expect(buildVisualQueryFromString('{app="frontend"} | distinct')).toEqual(
-      noErrors({
-        labels: [
-          {
-            op: '=',
-            value: 'frontend',
-            label: 'app',
-          },
-        ],
-        operations: [{ id: LokiOperationId.Distinct, params: [] }],
-      })
-    );
-  });
-
-  it('parses a log query with distinct and labels', () => {
-    expect(buildVisualQueryFromString('{app="frontend"} | distinct id, email')).toEqual(
-      noErrors({
-        labels: [
-          {
-            op: '=',
-            value: 'frontend',
-            label: 'app',
-          },
-        ],
-        operations: [{ id: LokiOperationId.Distinct, params: ['id', 'email'] }],
-      })
-    );
-  });
 });
 
 function noErrors(query: LokiVisualQuery) {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -8,8 +8,6 @@ import {
   By,
   ConvOp,
   Decolorize,
-  DistinctFilter,
-  DistinctLabel,
   Filter,
   FilterOp,
   Grouping,
@@ -204,11 +202,6 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
         break;
       }
       context.errors.push(makeError(expr, node));
-      break;
-    }
-
-    case DistinctFilter: {
-      visQuery.operations.push(handleDistinctFilter(expr, node, context));
       break;
     }
 
@@ -642,21 +635,4 @@ function isEmptyQuery(query: LokiVisualQuery) {
     return true;
   }
   return false;
-}
-
-function handleDistinctFilter(expr: string, node: SyntaxNode, context: Context): QueryBuilderOperation {
-  const labels: string[] = [];
-  let exploringNode = node.getChild(DistinctLabel);
-  while (exploringNode) {
-    const label = getString(expr, exploringNode.getChild(Identifier));
-    if (label) {
-      labels.push(label);
-    }
-    exploringNode = exploringNode?.getChild(DistinctLabel);
-  }
-  labels.reverse();
-  return {
-    id: LokiOperationId.Distinct,
-    params: labels,
-  };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -38,7 +38,6 @@ export enum LokiOperationId {
   Regexp = 'regexp',
   Pattern = 'pattern',
   Unpack = 'unpack',
-  Distinct = 'distinct',
   LineFormat = 'line_format',
   LabelFormat = 'label_format',
   Decolorize = 'decolorize',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,14 +3959,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@grafana/lezer-logql@npm:0.1.8"
-  dependencies:
-    lodash: ^4.17.21
+"@grafana/lezer-logql@npm:0.1.11":
+  version: 0.1.11
+  resolution: "@grafana/lezer-logql@npm:0.1.11"
   peerDependencies:
     "@lezer/lr": ^1.0.0
-  checksum: f0f301b6d4fbd2d79563b5b4e34303257be0ea995b2b9fa1f012648654b4afaa9cea91642bc59eddb70e9fa24ec8804489c161f7065b41eef49db68d3a2ca561
+  checksum: 6a624b9a8d31ff854fcf9708c35e6a7498e78c4bda884639681d0b6d0fffe5527fbaeab1198e5a7694f913181657334345f31156a4a15ff64e3019b30ba6ca2a
   languageName: node
   linkType: hard
 
@@ -19272,7 +19270,7 @@ __metadata:
     "@grafana/faro-core": 1.1.0
     "@grafana/faro-web-sdk": 1.1.0
     "@grafana/google-sdk": 0.1.1
-    "@grafana/lezer-logql": 0.1.8
+    "@grafana/lezer-logql": 0.1.11
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": 0.22.0


### PR DESCRIPTION
Backport 07eb4b1b901eb372e729712a199136975026009b from #73938

---

**What is this feature?**

Loki removed the `distinct` operation, so we need to remove it from Grafana as well.

References:
- https://github.com/grafana/loki/pull/10356
- https://github.com/grafana/lezer-logql/pull/53
