### PR TITLE
ClientTokenRotation: Rotate only expired tokens

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -389,7 +389,12 @@ export class BackendSrv implements BackendService {
                   return throwError(() => error);
                 }
 
-                let authChecker = config.featureToggles.clientTokenRotation ? this.rotateToken() : this.loginPing();
+                let authChecker = this.loginPing();
+
+                const expired = contextSrv.getSessionExpiry() * 1000 < Date.now();
+                if (config.featureToggles.clientTokenRotation && expired) {
+                  authChecker = this.rotateToken();
+                }
 
                 return from(authChecker).pipe(
                   catchError((err) => {

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -20,6 +20,7 @@ import { GrafanaEdition } from '@grafana/data/src/types/config';
 import { BackendSrv as BackendService, BackendSrvRequest, config, FetchError, FetchResponse } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
+import { getSessionExpiry } from 'app/core/utils/auth';
 import { loadUrlToken } from 'app/core/utils/urlToken';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { DashboardSearchItem } from 'app/features/search/types';
@@ -391,7 +392,7 @@ export class BackendSrv implements BackendService {
 
                 let authChecker = this.loginPing();
 
-                const expired = contextSrv.getSessionExpiry() * 1000 < Date.now();
+                const expired = getSessionExpiry() * 1000 < Date.now();
                 if (config.featureToggles.clientTokenRotation && expired) {
                   authChecker = this.rotateToken();
                 }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -2,6 +2,7 @@ import { extend } from 'lodash';
 
 import { AnalyticsSettings, OrgRole, rangeUtil, WithAccessControlMetadata } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { getSessionExpiry } from 'app/core/utils/auth';
 import { AccessControlAction, UserPermission } from 'app/types';
 import { CurrentUserInternal } from 'app/types/config';
 
@@ -209,7 +210,7 @@ export class ContextSrv {
     // check if we can schedula the token rotation job
     if (this.canScheduleRotation()) {
       // get the time token is going to expire
-      let expires = this.getSessionExpiry();
+      let expires = getSessionExpiry();
 
       // because this job is scheduled for every tab we have open that shares a session we try
       // to distribute the scheduling of the job. For now this can be between 1 and 20 seconds
@@ -222,7 +223,7 @@ export class ContextSrv {
       this.tokenRotationJobId = setTimeout(() => {
         // if we have a new expiry time from the expiry cookie another tab have already performed the rotation
         // so the only thing we need to do is reschedule the job and exit
-        if (this.getSessionExpiry() > expires) {
+        if (getSessionExpiry() > expires) {
           this.scheduleTokenRotationJob();
           return;
         }
@@ -247,7 +248,7 @@ export class ContextSrv {
     // from an older version of grafana, we never schedule the job and the fallback logic
     // in backend_srv will take care of rotations until first rotation has been made and
     // page has been reloaded.
-    if (this.getSessionExpiry() === 0) {
+    if (getSessionExpiry() === 0) {
       return false;
     }
 
@@ -277,20 +278,6 @@ export class ContextSrv {
       .catch((e) => {
         console.error(e);
       });
-  }
-
-  getSessionExpiry() {
-    const expiryCookie = document.cookie.split('; ').find((row) => row.startsWith('grafana_session_expiry='));
-    if (!expiryCookie) {
-      return 0;
-    }
-
-    let expiresStr = expiryCookie.split('=').at(1);
-    if (!expiresStr) {
-      return 0;
-    }
-
-    return parseInt(expiresStr, 10);
   }
 }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -279,7 +279,7 @@ export class ContextSrv {
       });
   }
 
-  private getSessionExpiry() {
+  getSessionExpiry() {
     const expiryCookie = document.cookie.split('; ').find((row) => row.startsWith('grafana_session_expiry='));
     if (!expiryCookie) {
       return 0;

--- a/public/app/core/utils/auth.ts
+++ b/public/app/core/utils/auth.ts
@@ -1,0 +1,13 @@
+export function getSessionExpiry() {
+  const expiryCookie = document.cookie.split('; ').find((row) => row.startsWith('grafana_session_expiry='));
+  if (!expiryCookie) {
+    return 0;
+  }
+
+  let expiresStr = expiryCookie.split('=').at(1);
+  if (!expiresStr) {
+    return 0;
+  }
+
+  return parseInt(expiresStr, 10);
+}


### PR DESCRIPTION
**What is this feature?**

This PR fixes unnecessary token rotation in some cases (ie, plugin responds with 401).

**Why do we need this feature?**

We should only rotate tokens that expired.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#](https://github.com/grafana/identity-access-team/issues/259)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
