### PR TITLE
LDAP: Disable removed users on login

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -97,7 +97,7 @@ func ProvideService(
 	var proxyClients []authn.ProxyClient
 	var passwordClients []authn.PasswordClient
 	if s.cfg.LDAPAuthEnabled {
-		ldap := clients.ProvideLDAP(cfg, ldapService)
+		ldap := clients.ProvideLDAP(cfg, ldapService, userService, authInfoService)
 		proxyClients = append(proxyClients, ldap)
 		passwordClients = append(passwordClients, ldap)
 	}

--- a/pkg/services/authn/clients/ldap.go
+++ b/pkg/services/authn/clients/ldap.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/ldap/multildap"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -18,13 +20,16 @@ type ldapService interface {
 	User(username string) (*login.ExternalUserInfo, error)
 }
 
-func ProvideLDAP(cfg *setting.Cfg, ldapService ldapService) *LDAP {
-	return &LDAP{cfg, ldapService}
+func ProvideLDAP(cfg *setting.Cfg, ldapService ldapService, userService user.Service, authInfoService login.AuthInfoService) *LDAP {
+	return &LDAP{cfg, log.New("authn.ldap"), ldapService, userService, authInfoService}
 }
 
 type LDAP struct {
-	cfg     *setting.Cfg
-	service ldapService
+	cfg             *setting.Cfg
+	logger          log.Logger
+	service         ldapService
+	userService     user.Service
+	authInfoService login.AuthInfoService
 }
 
 func (c *LDAP) String() string {
@@ -51,8 +56,7 @@ func (c *LDAP) AuthenticatePassword(ctx context.Context, r *authn.Request, usern
 	})
 
 	if errors.Is(err, multildap.ErrCouldNotFindUser) {
-		// FIXME: disable user in grafana if not found
-		return nil, errIdentityNotFound.Errorf("no user found: %w", err)
+		return c.disableUser(ctx, err, username)
 	}
 
 	// user was found so set auth module in req metadata
@@ -67,6 +71,40 @@ func (c *LDAP) AuthenticatePassword(ctx context.Context, r *authn.Request, usern
 	}
 
 	return c.identityFromLDAPInfo(r.OrgID, info), nil
+}
+
+// disableUser will disable users if they logged in via LDAP previously
+func (c *LDAP) disableUser(ctx context.Context, err error, username string) (*authn.Identity, error) {
+	c.logger.Debug("user was not found in the LDAP directory tree", "username", username)
+	retErr := errIdentityNotFound.Errorf("no user found: %w", err)
+
+	// Retrieve the user from store based on the login
+	dbUser, errGet := c.userService.GetByLogin(ctx, &user.GetUserByLoginQuery{
+		LoginOrEmail: username,
+	})
+	if errors.Is(errGet, user.ErrUserNotFound) {
+		return nil, retErr
+	} else if errGet != nil {
+		return nil, err
+	}
+
+	// Check if the user logged in via LDAP
+	query := &login.GetAuthInfoQuery{UserId: dbUser.ID, AuthModule: login.LDAPAuthModule}
+	authinfo, errGetAuthInfo := c.authInfoService.GetAuthInfo(ctx, query)
+	if errors.Is(errGetAuthInfo, user.ErrUserNotFound) {
+		return nil, retErr
+	} else if errGetAuthInfo != nil {
+		return nil, errGetAuthInfo
+	}
+
+	// Disable the user
+	c.logger.Debug("user was removed from the LDAP directory tree, disabling it", "username", username, "authID", authinfo.AuthId)
+	errDisable := c.userService.Disable(ctx, &user.DisableUserCommand{UserID: dbUser.ID, IsDisabled: true})
+	if errDisable != nil {
+		return nil, errDisable
+	}
+
+	return nil, retErr
 }
 
 func (c *LDAP) identityFromLDAPInfo(orgID int64, info *login.ExternalUserInfo) *authn.Identity {

--- a/pkg/services/authn/clients/ldap.go
+++ b/pkg/services/authn/clients/ldap.go
@@ -99,8 +99,7 @@ func (c *LDAP) disableUser(ctx context.Context, username string) (*authn.Identit
 
 	// Disable the user
 	c.logger.Debug("user was removed from the LDAP directory tree, disabling it", "username", username, "authID", authinfo.AuthId)
-	errDisable := c.userService.Disable(ctx, &user.DisableUserCommand{UserID: dbUser.ID, IsDisabled: true})
-	if errDisable != nil {
+	if errDisable := c.userService.Disable(ctx, &user.DisableUserCommand{UserID: dbUser.ID, IsDisabled: true}); errDisable != nil {
 		return nil, errDisable
 	}
 

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,10 +100,7 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username, nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
-
-			if tt.expectDisable {
-				assert.True(t, tt.disableCalled)
-			}
+			assert.Equal(t, tt.expectDisable, tt.disableCalled)
 		})
 	}
 }
@@ -182,9 +178,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
-			if tt.expectDisable {
-				assert.True(t, tt.disableCalled)
-			}
+			assert.Equal(t, tt.expectDisable, tt.disableCalled)
 		})
 	}
 }
@@ -194,11 +188,8 @@ func setupLDAPTestCase(tt *ldapTestCase) *LDAP {
 		ExpectedError: tt.expectedUserErr,
 		ExpectedUser:  &tt.expectedUser,
 		DisableFn: func(ctx context.Context, cmd *user.DisableUserCommand) error {
-			if tt.expectDisable {
-				tt.disableCalled = true
-				return nil
-			}
-			return errors.New("unexpected call")
+			tt.disableCalled = true
+			return nil
 		},
 	}
 	authInfoService := &logintest.AuthInfoServiceFake{

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -96,7 +96,7 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
-			c := setupTestCase(&tt)
+			c := setupLDAPTestCase(&tt)
 
 			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username, nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -177,7 +177,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
-			c := setupTestCase(&tt)
+			c := setupLDAPTestCase(&tt)
 
 			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -189,7 +189,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 	}
 }
 
-func setupTestCase(tt *ldapTestCase) *LDAP {
+func setupLDAPTestCase(tt *ldapTestCase) *LDAP {
 	userService := &usertest.FakeUserService{
 		ExpectedError: tt.expectedUserErr,
 		ExpectedUser:  &tt.expectedUser,

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -93,7 +93,8 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
 			c := setupTestCase(&tt)
 
@@ -173,7 +174,8 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
 			c := setupTestCase(&tt)
 


### PR DESCRIPTION
**What is this feature?**

In v9.x releases, LDAP users used to be disabled on login if they had been removed from the LDAP directory tree.
In v10.x releases, with the move to the `AuthBroker`, we changed the approach and even if it's still impossible to log in with a removed LDAP user, we do not disable the user anymore.
This PR intends to restore the previous behavior. 

Before the fix:
![login-ko](https://github.com/grafana/support-escalations/assets/5232696/0ef89e1f-347c-4666-8818-3e7c7c0d1020)

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
