### PR TITLE
Instrumentation: Add label to HTTP request metrics/logs that defines the source of the error

### DIFF
--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -108,11 +108,14 @@ func (r *NormalResponse) writeLogLine(c *contextmodel.ReqContext) {
 	}
 
 	logger := c.Logger.Error
+	source := errutil.SourceServer
 	var gfErr errutil.Error
 	if errors.As(r.err, &gfErr) {
 		logger = gfErr.LogLevel.LogFunc(c.Logger)
+		source = gfErr.Source
 	}
-	logger(r.errMessage, "error", r.err, "remote_addr", c.RemoteAddr(), "traceID", traceID)
+	// TODO: feature toggle for errorSource
+	logger(r.errMessage, "error", r.err, "errorSource", string(source), "remote_addr", c.RemoteAddr(), "traceID", traceID)
 }
 
 func (r *NormalResponse) SetHeader(key, value string) *NormalResponse {

--- a/pkg/api/response/response_test.go
+++ b/pkg/api/response/response_test.go
@@ -64,7 +64,7 @@ func TestErrors(t *testing.T) {
 				errMessage: genericErrorMessage,
 			},
 			newResponse: &NormalResponse{
-				status:     http.StatusGatewayTimeout,
+				status:     http.StatusRequestTimeout,
 				errMessage: errutil.StatusTimeout.String(),
 			},
 			fallbackUseNew: true,

--- a/pkg/middleware/loggermw/logger.go
+++ b/pkg/middleware/loggermw/logger.go
@@ -142,9 +142,11 @@ func errorLogParams(err error) []any {
 		return []any{"error", err.Error()}
 	}
 
+	// TODO: feature toggle for errorSource
 	return []any{
 		"errorReason", gfErr.Reason,
 		"errorMessageID", gfErr.MessageID,
+		"errorSource", gfErr.Source,
 		"error", gfErr.LogMessage,
 	}
 }

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -13,5 +13,6 @@ var (
 	ErrMethodNotImplemented = errutil.NotImplemented("plugin.notImplemented")
 	// ErrPluginDownstreamError error returned when a plugin method is not implemented.
 	ErrPluginDownstreamError = errutil.Internal("plugin.downstreamError",
-		errutil.WithPublicMessage("An error occurred within the plugin"))
+		errutil.WithPublicMessage("An error occurred within the plugin"),
+		errutil.WithDownstream())
 )

--- a/pkg/util/errutil/errhttp/writer_test.go
+++ b/pkg/util/errutil/errhttp/writer_test.go
@@ -24,6 +24,6 @@ func TestWrite(t *testing.T) {
 
 	handler(recorder, req)
 
-	assert.Equal(t, http.StatusGatewayTimeout, recorder.Code)
-	assert.JSONEq(t, `{"message": "Timeout", "messageId": "test.thisIsExpected", "statusCode": 504}`, recorder.Body.String())
+	assert.Equal(t, http.StatusRequestTimeout, recorder.Code)
+	assert.JSONEq(t, `{"message": "Timeout", "messageId": "test.thisIsExpected", "statusCode": 408}`, recorder.Body.String())
 }

--- a/pkg/util/errutil/source.go
+++ b/pkg/util/errutil/source.go
@@ -1,0 +1,22 @@
+package errutil
+
+// Source identifies from where an error originates.
+type Source string
+
+const (
+	// SourceServer implies error originates from within the server, i.e. this application.
+	SourceServer Source = "server"
+
+	// SourceDownstream implies error originates from downstream services, i.e. from outgoing connections/requests.
+	SourceDownstream Source = "downstream"
+)
+
+// IsServer checks if Source is SourceServer.
+func (s Source) IsServer() bool {
+	return s == SourceServer
+}
+
+// IsDownstream checks if Source is SourceDownstream.
+func (s Source) IsDownstream() bool {
+	return s == SourceDownstream
+}

--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -39,14 +39,38 @@ const (
 	StatusInternal CoreStatus = "Internal server error"
 	// StatusTimeout means that the server did not complete the request
 	// within the required time and aborted the action.
-	// HTTP status code 504.
+	// HTTP status code 408.
 	StatusTimeout CoreStatus = "Timeout"
 	// StatusNotImplemented means that the server does not support the
 	// requested action. Typically used during development of new
 	// features.
 	// HTTP status code 501.
 	StatusNotImplemented CoreStatus = "Not implemented"
+
+	// StatusBadGateway means that the server, while acting as a proxy,
+	// received an invalid response from the downstream server.
+	// HTTP status code 502.
+	StatusBadGateway CoreStatus = "Bad gateway"
+
+	// StatusClientClosedRequest means that a client closes the connection
+	// while the server is processing the request.
+	//
+	// This is a non-standard HTTP status code introduced by nginx, see
+	// https://httpstatus.in/499/ for more information.
+	// HTTP status code 499.
+	StatusClientClosedRequest CoreStatus = "Request cancelled by client"
+
+	// StatusGatewayTimeout means that the server, while acting as a proxy,
+	// did not receive a timely response from a downstream server it needed
+	// to access in order to complete the request.
+	// HTTP status code 504.
+	StatusGatewayTimeout CoreStatus = "Gateway timeout"
 )
+
+// HTTPStatusClientClosedRequest A non-standard status code introduced by nginx
+// for the case when a client closes the connection while nginx is processing
+// the request. See https://httpstatus.in/499/ for more information.
+const HTTPStatusClientClosedRequest = 499
 
 // StatusReason allows for wrapping of CoreStatus.
 type StatusReason interface {
@@ -70,13 +94,19 @@ func (s CoreStatus) HTTPStatus() int {
 	case StatusNotFound:
 		return http.StatusNotFound
 	case StatusTimeout:
-		return http.StatusGatewayTimeout
+		return http.StatusRequestTimeout
 	case StatusTooManyRequests:
 		return http.StatusTooManyRequests
 	case StatusBadRequest, StatusValidationFailed:
 		return http.StatusBadRequest
 	case StatusNotImplemented:
 		return http.StatusNotImplemented
+	case StatusClientClosedRequest:
+		return HTTPStatusClientClosedRequest
+	case StatusBadGateway:
+		return http.StatusBadGateway
+	case StatusGatewayTimeout:
+		return http.StatusGatewayTimeout
 	case StatusUnknown, StatusInternal:
 		return http.StatusInternalServerError
 	default:

--- a/pkg/util/proxyutil/reverse_proxy_test.go
+++ b/pkg/util/proxyutil/reverse_proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func TestReverseProxy(t *testing.T) {
@@ -110,7 +111,7 @@ func TestReverseProxy(t *testing.T) {
 			{
 				desc:               "Cancelled request should return 499 Client closed request",
 				transport:          &cancelledRoundTripper{},
-				expectedStatusCode: StatusClientClosedRequest,
+				expectedStatusCode: errutil.HTTPStatusClientClosedRequest,
 			},
 			{
 				desc:               "Timed out request should return 504 Gateway timeout",


### PR DESCRIPTION
**What is this feature?**

POC for exploring how to label metrics and logs with the source of an error. This one uses the errutil package and embeds the error source within an `errutil.Error`. Request errors includes `errorSource` label and metrics `status_source` label because `error_source` doesn't make sense in this context, e.g. when there are a mix of 1xx,2xx,3xx,4xx,5xx status codes where only 5xx refers to an actual error where it would make sense using  `error_source` naming.

Note: Haven't implemented support for plugin call resources or check health right now, only reverse proxy and query data failures.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Ref #68480

**Special notes for your reviewer:**

Logs:
INFO [08-29|16:26:51] Proxying incoming request                logger=data-proxy-log traceID=05f0e1145a8c68b0319704622c3bea2e userid=1 orgid=1 username=admin datasource=alertmanager uri=/api/datasources/proxy/uid/gdev-alertmanager/alertmanager/api/v2/status method=GET body=
ERROR[08-29|16:26:51] Proxy request failed                     logger=data-proxy-log userId=1 orgId=1 uname=admin path=/api/datasources/proxy/uid/gdev-alertmanager/alertmanager/api/v2/status remote_addr=[::1] referer=http://localhost:3000/connections/datasources/edit/gdev-alertmanager traceID=05f0e1145a8c68b0319704622c3bea2e err="dial tcp 127.0.0.1:9093: connect: connection refused"
ERROR[08-29|16:26:51] Request Completed                        logger=context traceID=05f0e1145a8c68b0319704622c3bea2e userId=1 orgId=1 uname=admin method=GET path=/api/datasources/proxy/uid/gdev-alertmanager/alertmanager/api/v2/status status=502 remote_addr=[::1] time_ms=3 duration=3.656093ms size=0 referer=http://localhost:3000/connections/datasources/edit/gdev-alertmanager db_call_count=2 handler=/api/datasources/proxy/uid/:uid/* errorReason="Bad gateway" errorMessageID=proxyutil.badGateway errorSource=downstream error="proxyutil: request failed: dial tcp 127.0.0.1:9093: connect: connection refused"

Metrics:
```
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.005"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.01"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.025"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.05"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.1"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.25"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="0.5"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="1"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="2.5"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="5"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="10"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="25"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/",method="GET",status_code="500",status_source="server",le="+Inf"} 1
grafana_http_request_duration_seconds_sum{handler="/api/datasources/",method="GET",status_code="500",status_source="server"} 5.019833454
grafana_http_request_duration_seconds_count{handler="/api/datasources/",method="GET",status_code="500",status_source="server"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.005"} 2
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.01"} 2
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.025"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.05"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.1"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.25"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="0.5"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="1"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="2.5"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="5"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="10"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="25"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream",le="+Inf"} 3
grafana_http_request_duration_seconds_sum{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream"} 0.031739751
grafana_http_request_duration_seconds_count{handler="/api/datasources/proxy/uid/:uid/*",method="GET",status_code="502",status_source="downstream"} 3
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.005"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.01"} 0
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.025"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.05"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.1"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.25"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="0.5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="1"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="2.5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="10"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="25"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/datasources/uid/:uid",method="GET",status_code="200",status_source="server",le="+Inf"} 1
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
