### PR TITLE
Tempo: Reset metrics summary tag when scope changes

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.test.tsx
@@ -63,6 +63,7 @@ describe('GroupByField', () => {
       const groupByFilter = query.groupBy?.find((f) => f.id === 'group-by-id');
       expect(groupByFilter).not.toBeNull();
       expect(groupByFilter?.scope).toBe('resource');
+      expect(groupByFilter?.tag).toBe('');
     }
   });
 

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
@@ -78,44 +78,45 @@ export const GroupByField = (props: Props) => {
           <div key={f.id}>
             <HorizontalGroup spacing={'none'} width={'auto'}>
               <Select
-                options={scopeOptions}
-                value={f.scope}
-                onChange={(v) => {
-                  updateFilter({ ...f, scope: v?.value });
-                }}
-                placeholder="Select scope"
                 aria-label={`Select scope for filter ${i + 1}`}
+                onChange={(v) => {
+                  updateFilter({ ...f, scope: v?.value, tag: '' });
+                }}
+                options={scopeOptions}
+                placeholder="Select scope"
+                value={f.scope}
               />
               <Select
+                aria-label={`Select tag for filter ${i + 1}`}
+                isClearable
+                isLoading={isTagsLoading}
+                key={f.tag}
+                onChange={(v) => {
+                  updateFilter({ ...f, tag: v?.value });
+                }}
                 options={getTags(f)?.map((t) => ({
                   label: t,
                   value: t,
                 }))}
-                value={f.tag || ''}
-                onChange={(v) => {
-                  updateFilter({ ...f, tag: v?.value });
-                }}
                 placeholder="Select tag"
-                aria-label={`Select tag for filter ${i + 1}`}
-                isLoading={isTagsLoading}
-                isClearable
+                value={f.tag || ''}
               />
               <AccessoryButton
-                variant="secondary"
+                aria-label={`Remove tag for filter ${i + 1}`}
                 icon="times"
                 onClick={() => removeFilter(f)}
                 tooltip="Remove tag"
-                aria-label={`Remove tag for filter ${i + 1}`}
+                variant="secondary"
               />
 
               {i === (query.groupBy?.length ?? 0) - 1 && (
                 <span className={styles.addFilter}>
                   <AccessoryButton
-                    variant="secondary"
+                    aria-label="Add tag"
                     icon="plus"
                     onClick={() => addFilter()}
                     tooltip="Add tag"
-                    aria-label="Add tag"
+                    variant="secondary"
                   />
                 </span>
               )}


### PR DESCRIPTION
**What is this feature?**

Resets the metrics summary tag when the scope changes.

**Why do we need this feature?**

So that we don't send queries with tag values that don't actually exist in the selected scope.

Also alphabetised props for easier scanning.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
