### PR TITLE
[v9.3.x] CI: Use new release eng managed grafanacom api key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4027,8 +4027,8 @@ kind: secret
 name: gcp_grafanauploads_base64
 ---
 get:
-  name: grafana_api_key
-  path: infra/data/ci/drone-plugins
+  name: api_key
+  path: infra/data/ci/grafana-release-eng/grafanacom
 kind: secret
 name: grafana_api_key
 ---
@@ -4207,6 +4207,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: 084053161df2a3e465e559907c73113a29ddeef51aebd39d034701cfcf4dfc19
+hmac: 02b21b9aea12f6dfb6f2d0bd9e47d0d6908c8133a06d5ab382b973c8fe377271
 
 ...

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -36,7 +36,7 @@ def secrets():
     return [
         vault_secret(gcp_grafanauploads, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials.json"),
         vault_secret(gcp_grafanauploads_base64, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials_base64"),
-        vault_secret("grafana_api_key", "infra/data/ci/drone-plugins", "grafana_api_key"),
+        vault_secret("grafana_api_key", "infra/data/ci/grafana-release-eng/grafanacom", "api_key"),
         vault_secret(pull_secret, "secret/data/common/gcr", ".dockerconfigjson"),
         vault_secret("github_token", "infra/data/ci/github/grafanabot", "pat"),
         vault_secret(drone_token, "infra/data/ci/drone", "machine-user-token"),


### PR DESCRIPTION
Backport ab7e655737a239cb30528b9313b26cab49041a49 from #74017