### PR TITLE
[v9.4.x] CI: Use new release eng managed grafanacom api key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4027,8 +4027,8 @@ kind: secret
 name: gcp_grafanauploads_base64
 ---
 get:
-  name: grafana_api_key
-  path: infra/data/ci/drone-plugins
+  name: api_key
+  path: infra/data/ci/grafana-release-eng/grafanacom
 kind: secret
 name: grafana_api_key
 ---
@@ -4207,6 +4207,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 8b1c797ceda46adc56f3c8545d1a185d98c2ebda15985ef2c67bf7f8a3cc7e73
+hmac: 924953dafba945a96a86eb6c7b7f278c7c47a0e83da6f15f980c15bfbf130b43
 
 ...

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -36,7 +36,7 @@ def secrets():
     return [
         vault_secret(gcp_grafanauploads, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials.json"),
         vault_secret(gcp_grafanauploads_base64, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials_base64"),
-        vault_secret("grafana_api_key", "infra/data/ci/drone-plugins", "grafana_api_key"),
+        vault_secret("grafana_api_key", "infra/data/ci/grafana-release-eng/grafanacom", "api_key"),
         vault_secret(pull_secret, "secret/data/common/gcr", ".dockerconfigjson"),
         vault_secret("github_token", "infra/data/ci/github/grafanabot", "pat"),
         vault_secret(drone_token, "infra/data/ci/drone", "machine-user-token"),


### PR DESCRIPTION
Backport ab7e655737a239cb30528b9313b26cab49041a49 from #74017