### PR TITLE
[v10.0.x] CI: Use new release eng managed grafanacom api key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4140,8 +4140,8 @@ kind: secret
 name: gcp_grafanauploads_base64
 ---
 get:
-  name: grafana_api_key
-  path: infra/data/ci/drone-plugins
+  name: api_key
+  path: infra/data/ci/grafana-release-eng/grafanacom
 kind: secret
 name: grafana_api_key
 ---
@@ -4320,6 +4320,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 39fac391717124335cb454514c2c4757de5b19b17ac051192cd6bb62b89a50fe
+hmac: 22ca4a06107f4704231fc97b61680c3f162aea508696773654b05c91f6683f09
 
 ...

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -36,7 +36,7 @@ def secrets():
     return [
         vault_secret(gcp_grafanauploads, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials.json"),
         vault_secret(gcp_grafanauploads_base64, "infra/data/ci/grafana-release-eng/grafanauploads", "credentials_base64"),
-        vault_secret("grafana_api_key", "infra/data/ci/drone-plugins", "grafana_api_key"),
+        vault_secret("grafana_api_key", "infra/data/ci/grafana-release-eng/grafanacom", "api_key"),
         vault_secret(pull_secret, "secret/data/common/gcr", ".dockerconfigjson"),
         vault_secret("github_token", "infra/data/ci/github/grafanabot", "pat"),
         vault_secret(drone_token, "infra/data/ci/drone", "machine-user-token"),


### PR DESCRIPTION
Backport ab7e655737a239cb30528b9313b26cab49041a49 from #74017