### PR TITLE
Alerting: Paginate silences table(s)

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -122,6 +122,7 @@ function SilenceList({
   if (!!items.length) {
     return (
       <DynamicTable
+        pagination={{ itemsPerPage: 25 }}
         items={items}
         cols={columns}
         isExpandable


### PR DESCRIPTION
**What is this feature?**

This PR adds pagination to the silences tables for active and expired silences. This prevents the UI from crashing if (tens of) thousands of silences are rendered in the UI.

<img width="1187" alt="image" src="https://github.com/grafana/grafana/assets/868844/69e6801e-81ad-4d52-9729-44b1ff79d07f">

