### PR TITLE
Docs: reorder visualizations pages

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/annotations/index.md
+++ b/docs/sources/panels-visualizations/visualizations/annotations/index.md
@@ -15,7 +15,7 @@ labels:
     - enterprise
     - oss
 title: Annotations
-weight: 105
+weight: 100
 ---
 
 # Annotations

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -15,7 +15,7 @@ labels:
     - enterprise
     - oss
 title: Bar chart
-weight: 170
+weight: 100
 ---
 
 # Bar chart

--- a/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: Bar gauge
-weight: 200
+weight: 100
 ---
 
 # Bar gauge

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -16,7 +16,7 @@ labels:
     - enterprise
     - oss
 title: Candlestick
-weight: 600
+weight: 100
 ---
 
 # Candlestick

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: Canvas
-weight: 600
+weight: 100
 ---
 
 # Canvas

--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -16,7 +16,7 @@ labels:
     - enterprise
     - oss
 title: Dashboard list
-weight: 300
+weight: 100
 ---
 
 # Dashboard list

--- a/docs/sources/panels-visualizations/visualizations/datagrid/index.md
+++ b/docs/sources/panels-visualizations/visualizations/datagrid/index.md
@@ -18,7 +18,7 @@ labels:
     - oss
 menuTitle: Datagrid
 title: Datagrid
-weight: 350
+weight: 100
 ---
 
 # Datagrid

--- a/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
@@ -13,7 +13,7 @@ labels:
     - enterprise
     - oss
 title: Flame graph
-weight: 850
+weight: 100
 ---
 
 # Flame graph

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: Gauge
-weight: 400
+weight: 100
 ---
 
 # Gauge

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -33,7 +33,7 @@ labels:
     - enterprise
     - oss
 title: Geomap
-weight: 600
+weight: 100
 ---
 
 # Geomap

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: Heatmap
-weight: 600
+weight: 100
 ---
 
 # Heatmap

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -16,7 +16,7 @@ labels:
     - enterprise
     - oss
 title: Histogram
-weight: 605
+weight: 100
 ---
 
 # Histogram

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -16,7 +16,7 @@ labels:
     - enterprise
     - oss
 title: Logs panel
-weight: 700
+weight: 100
 ---
 
 # Logs panel

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: News
-weight: 800
+weight: 100
 ---
 
 ## News

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -15,7 +15,7 @@ labels:
     - enterprise
     - oss
 title: Node graph
-weight: 850
+weight: 100
 ---
 
 # Node graph panel

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -11,7 +11,7 @@ labels:
     - enterprise
     - oss
 title: Pie chart
-weight: 850
+weight: 100
 ---
 
 # Pie chart

--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -16,7 +16,7 @@ labels:
     - enterprise
     - oss
 title: Stat
-weight: 900
+weight: 100
 ---
 
 # Stat

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: State timeline
-weight: 900
+weight: 100
 ---
 
 # State timeline

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -14,7 +14,7 @@ labels:
     - enterprise
     - oss
 title: Status history
-weight: 900
+weight: 100
 ---
 
 # Status history

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -23,7 +23,7 @@ labels:
     - oss
 menuTitle: Table
 title: Table
-weight: 1000
+weight: 100
 ---
 
 # Table

--- a/docs/sources/panels-visualizations/visualizations/text/index.md
+++ b/docs/sources/panels-visualizations/visualizations/text/index.md
@@ -15,7 +15,7 @@ labels:
     - enterprise
     - oss
 title: Text
-weight: 1100
+weight: 100
 ---
 
 # Text

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -30,7 +30,7 @@ labels:
     - enterprise
     - oss
 title: Time series
-weight: 90
+weight: 10
 ---
 
 # Time series

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -13,7 +13,7 @@ labels:
     - enterprise
     - oss
 title: Traces
-weight: 850
+weight: 100
 ---
 
 # Traces panel

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -13,7 +13,7 @@ labels:
     - enterprise
     - oss
 title: Trend
-weight: 1200
+weight: 100
 ---
 
 # Trend


### PR DESCRIPTION
Reordering pages to be in alphabetical order except Time series, which remains the first page.
Set Time series page weight to 10 to force it to the top. 
Set all other page weights to same number (100) to force them to follow default alphabetical ordering.