### PR TITLE
Currency: Add Malaysian Ringgit (RM)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -28,11 +28,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_4",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -115,11 +111,7 @@
       },
       "id": 4,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -1186,11 +1178,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_5",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -1273,11 +1261,7 @@
       },
       "id": 5,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -1619,6 +1603,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -2309,11 +2297,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_2",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -2396,11 +2380,7 @@
       },
       "id": 2,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -2722,6 +2702,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -3399,10 +3383,7 @@
     }
   ],
   "schemaVersion": 16,
-  "tags": [
-    "panel-test",
-    "gdev"
-  ],
+  "tags": ["panel-test", "gdev"],
   "templating": {
     "list": []
   },
@@ -3411,29 +3392,8 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
   "title": "Panel Tests - Polystat",

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -28,7 +28,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_4",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -111,7 +115,11 @@
       },
       "id": 4,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -444,6 +452,10 @@
             {
               "text": "Turkish Lira (₺)",
               "value": "currencyTRY"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -1174,7 +1186,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_5",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -1257,7 +1273,11 @@
       },
       "id": 5,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -2289,7 +2309,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_2",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -2372,7 +2396,11 @@
       },
       "id": 2,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -3371,7 +3399,10 @@
     }
   ],
   "schemaVersion": 16,
-  "tags": ["panel-test", "gdev"],
+  "tags": [
+    "panel-test",
+    "gdev"
+  ],
   "templating": {
     "list": []
   },
@@ -3380,8 +3411,29 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Panel Tests - Polystat",

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -28,7 +28,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_4",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -111,7 +115,11 @@
       },
       "id": 4,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -444,6 +452,10 @@
             {
               "text": "Turkish Lira (₺)",
               "value": "currencyTRY"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -1174,7 +1186,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_5",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -1257,7 +1273,11 @@
       },
       "id": 5,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -2285,7 +2305,11 @@
           "value": "triggered"
         }
       ],
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "d3DivId": "d3_svg_2",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -2368,7 +2392,11 @@
       },
       "id": 2,
       "links": [],
-      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "notcolors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -3371,7 +3399,11 @@
     }
   ],
   "schemaVersion": 16,
-  "tags": ["panel-test", "gdev", "polystat"],
+  "tags": [
+    "panel-test",
+    "gdev",
+    "polystat"
+  ],
   "templating": {
     "list": []
   },
@@ -3380,8 +3412,29 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Panel Tests - Polystat",

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -28,11 +28,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_4",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -115,11 +111,7 @@
       },
       "id": 4,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -1186,11 +1178,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_5",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -1273,11 +1261,7 @@
       },
       "id": 5,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -1619,6 +1603,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -2305,11 +2293,7 @@
           "value": "triggered"
         }
       ],
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
+      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
       "d3DivId": "d3_svg_2",
       "datasource": "gdev-testdata",
       "decimals": 2,
@@ -2392,11 +2376,7 @@
       },
       "id": 2,
       "links": [],
-      "notcolors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
+      "notcolors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
       "operatorName": "avg",
       "operatorOptions": [
         {
@@ -2718,6 +2698,10 @@
             {
               "text": "Vietnamese Dong (VND)",
               "value": "currencyVND"
+            },
+            {
+              "text": "Malaysian Ringgit (RM)",
+              "value": "currencyMYR"
             }
           ],
           "text": "currency"
@@ -3399,11 +3383,7 @@
     }
   ],
   "schemaVersion": 16,
-  "tags": [
-    "panel-test",
-    "gdev",
-    "polystat"
-  ],
+  "tags": ["panel-test", "gdev", "polystat"],
   "templating": {
     "list": []
   },
@@ -3412,29 +3392,8 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
   "title": "Panel Tests - Polystat",

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -142,6 +142,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Philippine Peso (PHP)', id: 'currencyPHP', fn: currency('PHP') },
       { name: 'Vietnamese Dong (VND)', id: 'currencyVND', fn: currency('đ', true) },
       { name: 'Turkish Lira (₺)', id: 'currencyTRY', fn: currency('₺', true) },
+      { name: 'Malaysian Ringgit (RM)', id: 'currencyMYR', fn: currency('RM') },
     ],
   },
   {


### PR DESCRIPTION
Why is this component needed:
The addition of the Malaysian Ringgit (RM) as a currency formatting option is needed to facilitate users in Malaysia or those dealing with the Malaysian Ringgit in their data visualizations. 

[x] Is/could it be used in more than one place in Grafana?

Where is/could it be used?:
The Malaysian Ringgit (RM) formatting option could be used anywhere in Grafana where currency formatting options are provided.

[x] It has a single use case.
[x] It is/could be used in multiple places.

Thanks!