### PR TITLE
[v9.5.x] CI: Mount /root/.docker/ dir in authenticate-gcr step 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3673,6 +3673,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest
   depends_on:
@@ -3727,6 +3729,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main
   depends_on:
@@ -3781,6 +3785,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest-ubuntu
   depends_on:
@@ -3836,6 +3842,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main-ubuntu
   depends_on:
@@ -3891,6 +3899,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
@@ -4191,6 +4201,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 8ea972fb9df645d27b0a827c5bfbf86ab75e08929dfaa49c54e2f999444bab51
+hmac: 1bef926e29226301963706858f23f74822c2d6b09d1d403f9e1787d9521a3f97
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -32,7 +32,7 @@ def authenticate_gcr_step():
         "environment": {
             "GCR_CREDENTIALS": from_secret("gcr_credentials"),
         },
-        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}, {"name": "config", "path": "/root/.docker/"}],
     }
 
 def cron_job_pipeline(cronName, name, steps):


### PR DESCRIPTION
Backport eea4adea292db94c38ea78d8963988530d0274a9 from #73977

---

**What is this feature?**

We need to mount `/root/.docker/` when we authenticate using docker login, so the config.json can be passed from the container to the filesystem. 

**Why do we need this feature?**

Trivy scans are broken.

