### PR TITLE
[v10.1.x] CI: Mount /root/.docker/ dir in authenticate-gcr step 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4176,6 +4176,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest
   depends_on:
@@ -4230,6 +4232,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main
   depends_on:
@@ -4284,6 +4288,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:latest-ubuntu
   depends_on:
@@ -4339,6 +4345,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana:main-ubuntu
   depends_on:
@@ -4394,6 +4402,8 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  - name: config
+    path: /root/.docker/
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/build-container:1.7.5
@@ -4676,6 +4686,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 280ee66e6098947962df5b5536040c7d732aecfb3f2651183e6fb2b3d45e489e
+hmac: aeae9ce425a35443ceb460a7bd475d151fbb74465ff121c6302817c1a10a0f37
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -32,7 +32,7 @@ def authenticate_gcr_step():
         "environment": {
             "GCR_CREDENTIALS": from_secret("gcr_credentials"),
         },
-        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
+        "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}, {"name": "config", "path": "/root/.docker/"}],
     }
 
 def cron_job_pipeline(cronName, name, steps):


### PR DESCRIPTION
Backport eea4adea292db94c38ea78d8963988530d0274a9 from #73977

---

**What is this feature?**

We need to mount `/root/.docker/` when we authenticate using docker login, so the config.json can be passed from the container to the filesystem. 

**Why do we need this feature?**

Trivy scans are broken.

