### PR TITLE
Alerting: Do not show grouping when grouplabels are empty in email template

### DIFF
--- a/emails/templates/partials/alerting/grouping_labels.mjml
+++ b/emails/templates/partials/alerting/grouping_labels.mjml
@@ -8,9 +8,9 @@
       <h2>📁 {{ .GroupLabels.grafana_folder }} &rsaquo; {{ .GroupLabels.alertname }}</h2>
     </mj-text>
     <mj-raw>
-      {{ else }}
+      {{ else if gt (len .GroupLabels.SortedPairs) 0 }}
     </mj-raw>
-    <!-- non-default grouping labels are just printed verbatim -->
+    <!-- non-default grouping labels are just printed verbatim, if we are grouping at all -->
     <mj-text padding="0" align="left">
       <h2>
         📁 Grouped by&nbsp;

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -193,7 +193,7 @@
                         </div>
                       </td>
                     </tr>
-                    {{ else }}
+                    {{ else if gt (len .GroupLabels.SortedPairs) 0 }}
                     <tr>
                       <td align="left" class="txt" style="font-size:0px;padding:0;word-break:break-word;">
                         <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: left; color: #000000;">


### PR DESCRIPTION
**What is this feature?**

When the notification policy is not grouping by any labels, this change prevents it from showing an empty header in the email template.

Tested locally with grouping / no-grouping notification policies and maildev.

Fixes #72447 