### PR TITLE
Grafana-ui: Get rid of duplicated code in `TimeRangeContent`

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 
 import {
-  dateMath,
   DateTime,
   dateTimeFormat,
   dateTimeParse,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -21,6 +21,7 @@ import { t, Trans } from '../../../utils/i18n';
 import { Button } from '../../Button';
 import { Field } from '../../Forms/Field';
 import { Input } from '../../Input/Input';
+import { isValid } from '../utils';
 
 import TimePickerCalendar from './TimePickerCalendar';
 
@@ -206,19 +207,6 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
     return dateTimeFormat(value, { timeZone });
   }
   return value;
-}
-
-function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
-  if (isDateTime(value)) {
-    return value.isValid();
-  }
-
-  if (dateMath.isMathString(value)) {
-    return dateMath.isValid(value);
-  }
-
-  const parsed = dateTimeParse(value, { roundUp, timeZone });
-  return parsed.isValid();
 }
 
 function getStyles(theme: GrafanaTheme2) {


### PR DESCRIPTION
**What is this feature?**
`TimeRangeContent` uses the `isValid` function that also is in the `utils` file. Instead of having duplicated code, `TimeRangeContent` now imports the `isValid` function.

**Why do we need this feature?**
To get rid of duplicated code.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
