### PR TITLE
Trace View: Use number instead of array for last color index

### DIFF
--- a/public/app/features/explore/TraceView/components/utils/color-generator.tsx
+++ b/public/app/features/explore/TraceView/components/utils/color-generator.tsx
@@ -33,12 +33,14 @@ class ColorGenerator {
   colorsHex: string[];
   colorsRgb: Array<[number, number, number]>;
   cache: Map<string, number>;
+  prevCacheColor: number | undefined;
 
   constructor(colorsHex: string[], theme: GrafanaTheme2) {
     const filteredColors = getFilteredColors(colorsHex, theme);
     this.colorsHex = filteredColors;
     this.colorsRgb = filteredColors.map(strToRgb);
     this.cache = new Map();
+    this.prevCacheColor = undefined;
   }
 
   _getColorIndex(key: string): number {
@@ -47,15 +49,14 @@ class ColorGenerator {
       const hash = this.hashCode(key.toLowerCase());
       i = Math.abs(hash % this.colorsHex.length);
 
-      const prevCacheItem = Array.from(this.cache).pop();
-      if (prevCacheItem && prevCacheItem[1]) {
+      if (this.prevCacheColor !== undefined) {
         // disallow a color that is the same as the previous color
-        if (prevCacheItem[1] === i) {
+        if (this.prevCacheColor === i) {
           i = this.getNextIndex(i);
         }
 
         // disallow a color that looks very similar to the previous color
-        const prevColor = this.colorsHex[prevCacheItem[1]];
+        const prevColor = this.colorsHex[this.prevCacheColor];
         if (tinycolor.readability(prevColor, this.colorsHex[i]) < 1.5) {
           let newIndex = i;
           for (let j = 0; j < this.colorsHex.length; j++) {
@@ -70,6 +71,7 @@ class ColorGenerator {
       }
 
       this.cache.set(key, i);
+      this.prevCacheColor = i;
     }
     return i;
   }

--- a/public/app/features/explore/TraceView/components/utils/color-generator.tsx
+++ b/public/app/features/explore/TraceView/components/utils/color-generator.tsx
@@ -33,14 +33,14 @@ class ColorGenerator {
   colorsHex: string[];
   colorsRgb: Array<[number, number, number]>;
   cache: Map<string, number>;
-  prevCacheColor: number | undefined;
+  prevColorIndex: number | undefined;
 
   constructor(colorsHex: string[], theme: GrafanaTheme2) {
     const filteredColors = getFilteredColors(colorsHex, theme);
     this.colorsHex = filteredColors;
     this.colorsRgb = filteredColors.map(strToRgb);
     this.cache = new Map();
-    this.prevCacheColor = undefined;
+    this.prevColorIndex = undefined;
   }
 
   _getColorIndex(key: string): number {
@@ -49,14 +49,14 @@ class ColorGenerator {
       const hash = this.hashCode(key.toLowerCase());
       i = Math.abs(hash % this.colorsHex.length);
 
-      if (this.prevCacheColor !== undefined) {
+      if (this.prevColorIndex !== undefined) {
         // disallow a color that is the same as the previous color
-        if (this.prevCacheColor === i) {
+        if (this.prevColorIndex === i) {
           i = this.getNextIndex(i);
         }
 
         // disallow a color that looks very similar to the previous color
-        const prevColor = this.colorsHex[this.prevCacheColor];
+        const prevColor = this.colorsHex[this.prevColorIndex];
         if (tinycolor.readability(prevColor, this.colorsHex[i]) < 1.5) {
           let newIndex = i;
           for (let j = 0; j < this.colorsHex.length; j++) {
@@ -71,7 +71,7 @@ class ColorGenerator {
       }
 
       this.cache.set(key, i);
-      this.prevCacheColor = i;
+      this.prevColorIndex = i;
     }
     return i;
   }


### PR DESCRIPTION
**What is this feature?**

Gets the last color via a number instead of getting the last index from converting the cache map to an array and then popping the last value.

**Why do we need this feature?**

Simpler and less space.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
