### PR TITLE
Frontend PanelChrome: Fix header title moving down when collapsing

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -153,7 +153,7 @@ export function PanelChrome({
     cursor: dragClass ? 'move' : 'auto',
   };
 
-  const containerStyles: CSSProperties = { width, height: !collapsed ? height : headerHeight };
+  const containerStyles: CSSProperties = { width, height: collapsed ? undefined : height };
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
 
   /** Old property name now maps to actions */
@@ -163,39 +163,39 @@ export function PanelChrome({
 
   const testid = title ? selectors.components.Panels.Panel.title(title) : 'Panel';
 
-  const collapsibleHeader = (
-    <h6 className={styles.title}>
-      <button
-        type="button"
-        className={styles.clearButtonStyles}
-        onClick={() => {
-          toggleOpen();
-          if (onToggleCollapse) {
-            onToggleCollapse(!collapsed);
-          }
-        }}
-        aria-expanded={!collapsed}
-        aria-controls={!collapsed ? panelContentId : undefined}
-      >
-        <Icon
-          name={!collapsed ? 'angle-down' : 'angle-right'}
-          aria-hidden={!!title}
-          aria-label={!title ? 'toggle collapse panel' : undefined}
-        />
-        {title}
-      </button>
-    </h6>
-  );
-
   const headerContent = (
     <>
-      {collapsible
-        ? collapsibleHeader
-        : title && (
-            <h6 title={title} className={styles.title}>
-              {title}
-            </h6>
-          )}
+      {/* Non collapsible title */}
+      {!collapsible && title && (
+        <h6 title={title} className={styles.title}>
+          {title}
+        </h6>
+      )}
+
+      {/* Collapsible title */}
+      {collapsible && (
+        <h6 className={styles.title}>
+          <button
+            type="button"
+            className={styles.clearButtonStyles}
+            onClick={() => {
+              toggleOpen();
+              if (onToggleCollapse) {
+                onToggleCollapse(!collapsed);
+              }
+            }}
+            aria-expanded={!collapsed}
+            aria-controls={!collapsed ? panelContentId : undefined}
+          >
+            <Icon
+              name={!collapsed ? 'angle-down' : 'angle-right'}
+              aria-hidden={!!title}
+              aria-label={!title ? 'toggle collapse panel' : undefined}
+            />
+            {title}
+          </button>
+        </h6>
+      )}
 
       <div className={cx(styles.titleItems, dragClassCancel)} data-testid="title-items-container">
         <PanelDescription description={description} className={dragClassCancel} />
@@ -476,6 +476,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     clearButtonStyles: css({
       alignItems: 'center',
+      display: 'flex',
+      gap: theme.spacing(0.5),
       background: 'transparent',
       color: theme.colors.text.primary,
       border: 'none',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -139,7 +139,7 @@ export function PanelChrome({
   const isPanelTransparent = displayMode === 'transparent';
 
   const headerHeight = getHeaderHeight(theme, hasHeader);
-  const { contentStyle, innerWidth, innerHeight } = getContentStyle(
+  const { contentStyle, innerWidth, innerHeight, collapsedHeight } = getContentStyle(
     padding,
     theme,
     headerHeight,
@@ -153,7 +153,7 @@ export function PanelChrome({
     cursor: dragClass ? 'move' : 'auto',
   };
 
-  const containerStyles: CSSProperties = { width, height: !collapsed ? height : headerHeight };
+  const containerStyles: CSSProperties = { width, height: !collapsed ? height : collapsedHeight };
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
 
   /** Old property name now maps to actions */
@@ -341,7 +341,9 @@ const getContentStyle = (
     padding: chromePadding,
   };
 
-  return { contentStyle, innerWidth, innerHeight };
+  const collapsedHeight = headerHeight + panelBorder;
+
+  return { contentStyle, innerWidth, innerHeight, collapsedHeight };
 };
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -351,7 +353,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     container: css({
       label: 'panel-container',
       backgroundColor: background,
-      outline: `1px solid ${borderColor}`,
+      border: `1px solid ${borderColor}`,
       position: 'relative',
       borderRadius: theme.shape.radius.default,
       height: '100%',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -351,7 +351,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     container: css({
       label: 'panel-container',
       backgroundColor: background,
-      border: `1px solid ${borderColor}`,
+      outline: `1px solid ${borderColor}`,
       position: 'relative',
       borderRadius: theme.shape.radius.default,
       height: '100%',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -139,7 +139,7 @@ export function PanelChrome({
   const isPanelTransparent = displayMode === 'transparent';
 
   const headerHeight = getHeaderHeight(theme, hasHeader);
-  const { contentStyle, innerWidth, innerHeight, collapsedHeight } = getContentStyle(
+  const { contentStyle, innerWidth, innerHeight } = getContentStyle(
     padding,
     theme,
     headerHeight,
@@ -153,7 +153,7 @@ export function PanelChrome({
     cursor: dragClass ? 'move' : 'auto',
   };
 
-  const containerStyles: CSSProperties = { width, height: !collapsed ? height : collapsedHeight };
+  const containerStyles: CSSProperties = { width, height: collapsed ? undefined : height };
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
 
   /** Old property name now maps to actions */
@@ -341,9 +341,7 @@ const getContentStyle = (
     padding: chromePadding,
   };
 
-  const collapsedHeight = headerHeight + panelBorder;
-
-  return { contentStyle, innerWidth, innerHeight, collapsedHeight };
+  return { contentStyle, innerWidth, innerHeight };
 };
 
 const getStyles = (theme: GrafanaTheme2) => {


### PR DESCRIPTION
Fixed PanelChrome's header title moving down 1px when collapsing.

@torkelo also fixed: 
- Icon placement (alignItems: center did not work as the button did not have display: flex), and corrected the spacing for the icon with a gap property.
- Also a minor refactoring moved the collapsing header into where it's rendered and simplified the conditional logic there

Before:

https://github.com/grafana/grafana/assets/58232930/bac3d925-b56e-49df-b3ea-f2af568ab9bf

After:

https://github.com/grafana/grafana/assets/58232930/5c5e7973-3383-4234-b71d-cc054f3ab9b3

Fixes: https://github.com/grafana/grafana/issues/74120

Please check that:
- [ ] It works as expected from a user's perspective.
