### PR TITLE
Alerting: Do not exit if Redis ping fails when using redis-based Alertmanager clustering

### DIFF
--- a/pkg/services/ngalert/notifier/redis_peer.go
+++ b/pkg/services/ngalert/notifier/redis_peer.go
@@ -2,7 +2,6 @@ package notifier
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -100,8 +99,9 @@ func newRedisPeer(cfg redisConfig, logger log.Logger, reg prometheus.Registerer,
 	})
 	cmd := rdb.Ping(context.Background())
 	if cmd.Err() != nil {
-		return nil, fmt.Errorf("failed to ping redis: %w", cmd.Err())
+		logger.Error("Failed to ping redis - redis-based alertmanager clustering may not be available", "err", cmd.Err())
 	}
+
 	// Make sure that the prefix uses a colon at the end as deliminator.
 	if cfg.prefix != "" && cfg.prefix[len(cfg.prefix)-1] != ':' {
 		cfg.prefix = cfg.prefix + ":"


### PR DESCRIPTION
**What is this feature?**

The normal gossip-based alertmanager clustering is tolerant to network problems. The peers might not be able to reach each other, but Grafana will still run, albeit without deduplication for high-availability alerts.
https://github.com/grafana/grafana/blob/64652a981c6b590cbc64b34fcef6799ae181374f/pkg/services/ngalert/notifier/multiorg_alertmanager.go#L130-L133
(note the error is ignored)

Most of the Redis-based clustering also works this way most of the time - one exception is the ping that happens when the connection is first created. Failure to ping causes the Grafana process to exit.

Given we heavily favor availability for notifications, this PR fixes the Redis implementation to follow the same failure semantics as gossip.

The trade-off is that genuinely bad redis configurations are now harder to discover. It's consistent with other HA configurations, though.

**Why do we need this feature?**

Prevents a failure mode of the system in favor of allowing duplicate notifications.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
