### PR TITLE
Tempo: Update default editor to TraceQL tab

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -31,7 +31,9 @@ interface State {
   uploadModalOpen: boolean;
 }
 
-const DEFAULT_QUERY_TYPE: TempoQueryType = 'traceqlSearch';
+// This needs to default to traceql for data sources like Splunk, where clicking on a
+// data link should open the traceql tab and run a search based on the configured query.
+const DEFAULT_QUERY_TYPE: TempoQueryType = 'traceql';
 
 class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
   constructor(props: Props) {


### PR DESCRIPTION
**What is this feature?**

Updates the default editor that is opened to the TraceQL tab.

**Why do we need this feature?**

Users that for example are clicking on a data link in a logs data source need to be brought to the TraceQL tab so they can visualise their linked query.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
