### PR TITLE
Tempo: Fix flaky test

### DIFF
--- a/public/app/features/explore/TraceView/components/demo/trace-generators.ts
+++ b/public/app/features/explore/TraceView/components/demo/trace-generators.ts
@@ -148,7 +148,7 @@ export default chance.mixin({
           chance.normal({ mean: 45, dev: 15 }), // average case
         ])
       ),
-      1 // `pickone` might pick a negative number (or zero) from one of the normal distributions, but we want to have at least one span
+      1 // `pickone` might pick a negative number (or zero) from one of the normal distributions, but we need to have at least one span
     ),
     numberOfProcesses = chance.integer({ min: 1, max: 10 }),
     maxDepth = chance.integer({ min: 1, max: 10 }),
@@ -194,8 +194,6 @@ export default chance.mixin({
     traceEndTime = 0,
     operations = OPERATIONS_LIST,
   }: ChanceSpanOptions) {
-    console.log('span');
-
     // Set default values for trace start/end time.
     traceStartTime = traceStartTime || chance.timestamp() * 1000 * 1000;
     traceEndTime = traceEndTime || traceStartTime + 100000;

--- a/public/app/features/explore/TraceView/components/demo/trace-generators.ts
+++ b/public/app/features/explore/TraceView/components/demo/trace-generators.ts
@@ -140,14 +140,16 @@ function attachReferences(spans: TraceSpanData[], depth: number, spansPerLevel: 
 
 export default chance.mixin({
   trace({
-    // long trace
-    // very short trace
-    // average case
-    numberOfSpans = chance.pickone([
-      Math.ceil(chance.normal({ mean: 200, dev: 10 })) + 1,
-      Math.ceil(chance.integer({ min: 3, max: 10 })),
-      Math.ceil(chance.normal({ mean: 45, dev: 15 })) + 1,
-    ]),
+    numberOfSpans = Math.max(
+      Math.ceil(
+        chance.pickone([
+          chance.normal({ mean: 200, dev: 10 }), // long trace
+          chance.integer({ min: 3, max: 10 }), // very short trace
+          chance.normal({ mean: 45, dev: 15 }), // average case
+        ])
+      ),
+      1 // `pickone` might pick a negative number (or zero) from one of the normal distributions, but we want to have at least one span
+    ),
     numberOfProcesses = chance.integer({ min: 1, max: 10 }),
     maxDepth = chance.integer({ min: 1, max: 10 }),
     spansPerLevel = null,
@@ -192,6 +194,8 @@ export default chance.mixin({
     traceEndTime = 0,
     operations = OPERATIONS_LIST,
   }: ChanceSpanOptions) {
+    console.log('span');
+
     // Set default values for trace start/end time.
     traceStartTime = traceStartTime || chance.timestamp() * 1000 * 1000;
     traceEndTime = traceEndTime || traceStartTime + 100000;


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/73888

A test in `public/app/features/explore/TraceView/components/TraceTimelineViewer/index.test.tsx` is flaky because sometimes we do not generate any span. This is a problem since later in the code we try to get the ID of the first span (with something similar to `spans[0].spanID`), thus causing an access to an `undefined` object.

More in details: the number of spans (length of the `spans` array) is chosen either by sampling a value from some normal distributions or from a uniform distribution. When choosing it from one of the normal distributions, the picked value might be negative or zero. Note that the current code already sums 1 to the value if sampled from a normal distribution, but since the original value might be negative and we want to have a value strictly greater than zero, just adding 1 isn't enough. I tried with some dummy runs and I managed to generate non-positive values, in fact.
