### PR TITLE
Transformations: Fix group by field transformation field name text-overflow

### DIFF
--- a/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
@@ -83,7 +83,7 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
   );
 
   return (
-    <InlineField label={fieldName} labelWidth={32} grow shrink>
+    <InlineField className={styles.label} label={fieldName} grow shrink>
       <Stack gap={0.5} direction="row" wrap={false}>
         <div className={styles.operation}>
           <Select options={options} value={config?.operation} placeholder="Ignored" onChange={onChange} isClearable />
@@ -107,6 +107,11 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    label: css`
+      label {
+        min-width: ${theme.spacing(32)};
+      }
+    `,
     operation: css`
       flex-shrink: 0;
       height: 100%;


### PR DESCRIPTION
**What is this feature?**

This fixes an issue where a very long field name would be hard to read due to text overflowing.
Before:
![image](https://github.com/grafana/grafana/assets/468940/eee34aec-9d9d-4511-8487-203551293b5b)

After:
![image](https://github.com/grafana/grafana/assets/468940/5ed58f6e-ad3f-4fc8-a30b-cc25c0cc9963)

In the event that there is a very long field name, the label will grow to accommodate the whole name. Optimally the other labels would grow to the same length as the longest field, but this would require a new solution to how we tackle forms. Since this problem should be an outlier, this solution seems good enough for now.

Fixes: https://github.com/grafana/support-escalations/issues/7266

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
