### PR TITLE
Add minimal vector DB sync background service

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1650,3 +1650,19 @@ hidden_toggles =
 
 # Disables updating specific feature toggles in the feature management page
 read_only_toggles =
+
+################################## Vector Store ##############################################
+
+[vector]
+embedding_engine =
+store_engine =
+
+[vector.sync]
+enabled = false
+interval = "15m"
+
+[vector.qdrant]
+address =
+
+[vector.openai]
+api_key =

--- a/go.mod
+++ b/go.mod
@@ -375,6 +375,7 @@ require (
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
+	github.com/qdrant/go-client v1.4.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2570,6 +2570,8 @@ github.com/prometheus/prometheus v0.43.0/go.mod h1:2BA14LgBeqlPuzObSEbh+Y+JwLH2G
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b h1:zd/2RNzIRkoGGMjE+YIsZ85CnDIz672JK2F3Zl4vux4=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b/go.mod h1:KjY0wibdYKc4DYkerHSbguaf3JeIPGhNJBp2BNiFH78=
+github.com/qdrant/go-client v1.4.1 h1:kh5B4yWjrd5BcynJoA4014mZlI/j6++inCMMQoKUOtI=
+github.com/qdrant/go-client v1.4.1/go.mod h1:680gkxNAsVtre0Z8hAQmtPzJtz1xFAyCu2TUxULtnoE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.0.2 h1:BA426Zqe/7r56kCcvxYLWe1mkaz71LKF77GwgFzSxfE=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=

--- a/pkg/registry/backgroundsvcs/background_services.go
+++ b/pkg/registry/backgroundsvcs/background_services.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/store/sanitizer"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlesimpl"
 	"github.com/grafana/grafana/pkg/services/updatechecker"
+	"github.com/grafana/grafana/pkg/services/vector/sync"
 )
 
 func ProvideBackgroundServiceRegistry(
@@ -59,6 +60,7 @@ func ProvideBackgroundServiceRegistry(
 	_ serviceaccounts.Service, _ *guardian.Provider,
 	_ *plugindashboardsservice.DashboardUpdater, _ *sanitizer.Provider,
 	_ *grpcserver.HealthService, _ entity.EntityStoreServer, _ *grpcserver.ReflectionService, _ *ldapapi.Service,
+	syncService *sync.Service,
 ) *BackgroundServiceRegistry {
 	return NewBackgroundServiceRegistry(
 		httpServer,
@@ -92,6 +94,7 @@ func ProvideBackgroundServiceRegistry(
 		publicDashboardsMetric,
 		keyRetriever,
 		dynamicAngularDetectorsProvider,
+		syncService,
 	)
 }
 

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -138,6 +138,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/temp_user/tempuserimpl"
 	"github.com/grafana/grafana/pkg/services/updatechecker"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/services/vector/sync"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor"
 	cloudmonitoring "github.com/grafana/grafana/pkg/tsdb/cloud-monitoring"
@@ -356,6 +357,7 @@ var wireBasicSet = wire.NewSet(
 	loggermw.Provide,
 	signingkeysimpl.ProvideEmbeddedSigningKeysService,
 	wire.Bind(new(signingkeys.Service), new(*signingkeysimpl.Service)),
+	sync.ProvideService,
 )
 
 var wireSet = wire.NewSet(

--- a/pkg/services/vector/embedding/client.go
+++ b/pkg/services/vector/embedding/client.go
@@ -1,0 +1,24 @@
+package embedding
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type EmbeddingEngineType string
+
+const (
+	EmbeddingEngineOpenAI EmbeddingEngineType = "openai"
+)
+
+// Client is a client for interacting with an embedding engine.
+type Client interface {
+	Embeddings(ctx context.Context, text string) ([]float32, error)
+}
+
+// NewClient creates a new embedding engine client.
+func NewClient(cfg setting.EmbeddingEngineSettings) Client {
+	// TODO: dispatch based on cfg.Type.
+	return nil
+}

--- a/pkg/services/vector/embedding/client.go
+++ b/pkg/services/vector/embedding/client.go
@@ -19,6 +19,9 @@ type Client interface {
 
 // NewClient creates a new embedding engine client.
 func NewClient(cfg setting.EmbeddingEngineSettings) Client {
-	// TODO: dispatch based on cfg.Type.
+	switch EmbeddingEngineType(cfg.Type) {
+	case EmbeddingEngineOpenAI:
+		return newOpenAILLMClient(cfg.OpenAI)
+	}
 	return nil
 }

--- a/pkg/services/vector/embedding/openai.go
+++ b/pkg/services/vector/embedding/openai.go
@@ -1,0 +1,89 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type openAILLMClient struct {
+	client *http.Client
+	url    string
+	apiKey string
+	model  string
+}
+
+type openAIEmbeddingsRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+type openAIEmbeddingsResponse struct {
+	Data []openAIEmbeddingData `json:"data"`
+}
+
+type openAIEmbeddingData struct {
+	Embedding []float32 `json:"embedding"`
+}
+
+func (o *openAILLMClient) Embeddings(ctx context.Context, payload string) ([]float32, error) {
+	// TODO: ensure payload is under 8191 tokens, somehow.
+	url := o.url
+	if url == "" {
+		url = "https://api.openai.com"
+	}
+	url = strings.TrimSuffix(url, "/")
+	url = url + "/v1/embeddings"
+	model := o.model
+	if model == "" {
+		model = "text-embedding-ada-002"
+	}
+	reqBody := openAIEmbeddingsRequest{
+		Model: model,
+		Input: payload,
+	}
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("make request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("got non-2xx status from OpenAI: %s", resp.Status)
+	}
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024*2))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	var body openAIEmbeddingsResponse
+	err = json.Unmarshal(respBody, &body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal response body: %w", err)
+	}
+	return body.Data[0].Embedding, nil
+}
+
+// newOpenAILLMClient creates a new LLMClient using OpenAI's API.
+func newOpenAILLMClient(cfg setting.OpenAIEngineSettings) Client {
+	impl := openAILLMClient{
+		client: &http.Client{},
+		url:    cfg.URL,
+		apiKey: cfg.APIKey,
+	}
+	return &impl
+}

--- a/pkg/services/vector/store/client.go
+++ b/pkg/services/vector/store/client.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// Client is a client for interacting with a vector store.
+type Client interface {
+	Collections(ctx context.Context) ([]string, error)
+	CollectionExists(ctx context.Context, collection string) (bool, error)
+	CreateCollection(ctx context.Context, collection string, size uint64) error
+	PointExists(ctx context.Context, collection string, id uint64) (bool, error)
+	UpsertColumnar(ctx context.Context, collection string, ids []uint64, embeddings [][]float32, payloadJSONs []string) error
+	Search(ctx context.Context, collection string, vector []float32, limit uint64) ([]string, error)
+}
+
+// NewClient creates a new vector store client.
+func NewClient(cfg setting.VectorStoreSettings) (Client, context.CancelFunc, error) {
+	// TODO: dispatch based on cfg.Type.
+	return nil, nil, nil
+}

--- a/pkg/services/vector/store/client.go
+++ b/pkg/services/vector/store/client.go
@@ -6,6 +6,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+type VectorStoreType string
+
+const (
+	VectorStoreTypeQdrant VectorStoreType = "qdrant"
+)
+
 // Client is a client for interacting with a vector store.
 // The methods of this interface are named after the qdrant API but
 // can probably be renamed to be more generic.
@@ -20,6 +26,9 @@ type Client interface {
 
 // NewClient creates a new vector store client.
 func NewClient(cfg setting.VectorStoreSettings) (Client, context.CancelFunc, error) {
-	// TODO: dispatch based on cfg.Type.
+	switch VectorStoreType(cfg.Type) {
+	case VectorStoreTypeQdrant:
+		return newQdrantClient(cfg.Qdrant)
+	}
 	return nil, nil, nil
 }

--- a/pkg/services/vector/store/client.go
+++ b/pkg/services/vector/store/client.go
@@ -7,6 +7,8 @@ import (
 )
 
 // Client is a client for interacting with a vector store.
+// The methods of this interface are named after the qdrant API but
+// can probably be renamed to be more generic.
 type Client interface {
 	Collections(ctx context.Context) ([]string, error)
 	CollectionExists(ctx context.Context, collection string) (bool, error)

--- a/pkg/services/vector/store/qdrant.go
+++ b/pkg/services/vector/store/qdrant.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/setting"
 	qdrant "github.com/qdrant/go-client/qdrant"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -16,8 +17,8 @@ type qdrantClient struct {
 	pointsClient      qdrant.PointsClient
 }
 
-func newQdrantClient(addr string) (Client, func(), error) {
-	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func newQdrantClient(cfg setting.QdrantVectorDBSettings) (Client, func(), error) {
+	conn, err := grpc.DialContext(context.Background(), cfg.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/services/vector/store/qdrant.go
+++ b/pkg/services/vector/store/qdrant.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+
+	qdrant "github.com/qdrant/go-client/qdrant"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type qdrantClient struct {
+	conn              *grpc.ClientConn
+	collectionsClient qdrant.CollectionsClient
+	pointsClient      qdrant.PointsClient
+}
+
+func newQdrantClient(addr string) (Client, func(), error) {
+	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, err
+	}
+	cancel := func() {
+		defer conn.Close()
+	}
+	return &qdrantClient{
+		conn:              conn,
+		collectionsClient: qdrant.NewCollectionsClient(conn),
+		pointsClient:      qdrant.NewPointsClient(conn),
+	}, cancel, nil
+}
+
+func (q *qdrantClient) Collections(ctx context.Context) ([]string, error) {
+	collections, err := q.collectionsClient.List(ctx, &qdrant.ListCollectionsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(collections.Collections))
+	for _, c := range collections.Collections {
+		names = append(names, c.Name)
+	}
+	return names, nil
+}
+
+func (q *qdrantClient) CollectionExists(ctx context.Context, collection string) (bool, error) {
+	_, err := q.collectionsClient.Get(ctx, &qdrant.GetCollectionInfoRequest{
+		CollectionName: collection,
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		st, ok := status.FromError(err)
+		if !ok {
+			return false, err
+			// Error was not a status error
+		}
+		if st.Code() == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (q *qdrantClient) CreateCollection(ctx context.Context, collection string, size uint64) error {
+	_, err := q.collectionsClient.Create(ctx, &qdrant.CreateCollection{
+		CollectionName: collection,
+		VectorsConfig: &qdrant.VectorsConfig{
+			Config: &qdrant.VectorsConfig_Params{
+				Params: &qdrant.VectorParams{
+					Size: size,
+					// TODO: make this customizable
+					Distance: qdrant.Distance_Cosine,
+				},
+			},
+		},
+	})
+	return err
+}
+
+func (q *qdrantClient) PointExists(ctx context.Context, collection string, id uint64) (bool, error) {
+	point, err := q.pointsClient.Get(ctx, &qdrant.GetPoints{
+		CollectionName: collection,
+		Ids: []*qdrant.PointId{
+			{PointIdOptions: &qdrant.PointId_Num{Num: id}},
+		},
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		st, ok := status.FromError(err)
+		if !ok {
+			return false, err
+			// Error was not a status error
+		}
+		if st.Code() == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	if point.Result == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (q *qdrantClient) UpsertColumnar(ctx context.Context, collection string, ids []uint64, embeddings [][]float32, payloadJSONs []string) error {
+	waitUpsert := false
+	upsertPoints := make([]*qdrant.PointStruct, 0, len(ids))
+	for i, id := range ids {
+		point := &qdrant.PointStruct{
+			Id: &qdrant.PointId{
+				PointIdOptions: &qdrant.PointId_Num{Num: id},
+			},
+			Vectors: &qdrant.Vectors{VectorsOptions: &qdrant.Vectors_Vector{Vector: &qdrant.Vector{Data: embeddings[i]}}},
+			Payload: map[string]*qdrant.Value{
+				"metadata": {
+					Kind: &qdrant.Value_StringValue{StringValue: payloadJSONs[i]},
+				},
+			},
+		}
+		upsertPoints = append(upsertPoints, point)
+	}
+	_, err := q.pointsClient.Upsert(ctx, &qdrant.UpsertPoints{
+		CollectionName: collection,
+		Points:         upsertPoints,
+		Wait:           &waitUpsert,
+	}, grpc.WaitForReady(true))
+	return err
+}
+
+func (q *qdrantClient) Search(ctx context.Context, collection string, vector []float32, limit uint64) ([]string, error) {
+	result, err := q.pointsClient.Search(ctx, &qdrant.SearchPoints{
+		CollectionName: collection,
+		Vector:         vector,
+		Limit:          limit,
+		// Include all payloads in the search result
+		WithVectors: &qdrant.WithVectorsSelector{SelectorOptions: &qdrant.WithVectorsSelector_Enable{Enable: false}},
+		WithPayload: &qdrant.WithPayloadSelector{SelectorOptions: &qdrant.WithPayloadSelector_Enable{Enable: true}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	payloads := make([]string, 0, len(result.GetResult()))
+	for _, v := range result.GetResult() {
+		payload := v.Payload["metadata"]
+		// TODO: handle non-strings, in case they get there
+		payloads = append(payloads, payload.GetStringValue())
+	}
+	return payloads, nil
+}

--- a/pkg/services/vector/sync/sync.go
+++ b/pkg/services/vector/sync/sync.go
@@ -1,0 +1,223 @@
+// package sync provides a background service to sync metadata from
+// Grafana and supported datasources to a configured vector database.
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/vector"
+	"github.com/grafana/grafana/pkg/services/vector/embedding"
+	"github.com/grafana/grafana/pkg/services/vector/store"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var (
+	logger = log.New("vector.sync")
+)
+
+type Service struct {
+	dashboardService  dashboards.DashboardService
+	dataSourceService datasources.DataSourceService
+	features          *featuremgmt.FeatureManager
+
+	embeddingClient embedding.Client
+
+	cfg *setting.Cfg
+}
+
+func ProvideService(
+	dashboardService dashboards.DashboardService,
+	dataSourceService datasources.DataSourceService,
+	features *featuremgmt.FeatureManager,
+	cfg *setting.Cfg,
+) *Service {
+	ec := embedding.NewClient(cfg.Vector.Embedding)
+	return &Service{
+		dashboardService:  dashboardService,
+		dataSourceService: dataSourceService,
+		features:          features,
+		embeddingClient:   ec,
+		cfg:               cfg,
+	}
+}
+
+// IsDisabled returns true if the service is disabled.
+//
+// Satisfies the registry.CanBeDisabled interface which will guarantee
+// that Run() is not called if the service is disabled.
+func (s *Service) IsDisabled() bool {
+	return !s.features.IsEnabled(featuremgmt.FlagVectorSync) || !s.cfg.Vector.SyncEnabled || s.cfg.Vector.Embedding.Type == "" || s.cfg.Vector.Store.Type == ""
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	s.syncVectorStore(ctx)
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			s.syncVectorStore(ctx)
+		}
+	}
+}
+
+// syncVectorStore syncs the vector store with the latest metadata from Grafana
+// and datasources.
+//
+// Currently only syncs core Grafana metadata.
+func (s *Service) syncVectorStore(ctx context.Context) error {
+	client, cancel, err := store.NewClient(s.cfg.Vector.Store)
+	if err != nil {
+		return fmt.Errorf("create vector store client: %s", err)
+	}
+	defer cancel()
+
+	if err := s.syncCoreMetadataToVectorStore(ctx, client); err != nil {
+		logger.Warn("error syncing core Grafana metadata to vector store", "err", err)
+	}
+
+	return nil
+}
+
+func (s *Service) syncCoreMetadataToVectorStore(ctx context.Context, client store.Client) error {
+	// TODO: improve error handling, this is horrible.
+
+	// Dashboards
+	// This doesn't work correctly because searching dashboards using the dashboardService requires a signed in user,
+	// but we just want _all_ dashboards. Right now it finds zero dashboards.
+	dashboards, dashboardsErr := s.dashboardService.SearchDashboards(ctx, &dashboards.FindPersistedDashboardsQuery{Type: "dash-db", SignedInUser: &user.SignedInUser{}})
+	if dashboardsErr == nil {
+		metadata := make([]string, 0, len(dashboards))
+		for _, dashboard := range dashboards {
+			jdoc, err := json.Marshal(dashboard)
+			if err != nil {
+				logger.Warn("error marshalling dashboard", "dashboardUID", dashboard.UID, "err", err)
+				continue
+			}
+			metadata = append(metadata, string(jdoc))
+		}
+		dashboardsErr = s.createCollectionIfNotExists(ctx, client, vector.CoreCollectionDashboards)
+		if dashboardsErr != nil {
+			dashboardsErr = fmt.Errorf("create collection: %w", dashboardsErr)
+		}
+		if dashboardsErr == nil {
+			dashboardsErr = s.addNewMetadata(ctx, client, vector.CoreCollectionDashboards, metadata)
+			if dashboardsErr != nil {
+				dashboardsErr = fmt.Errorf("add new metadata: %w", dashboardsErr)
+			}
+		}
+	}
+	// Datasources
+	datasources, datasourcesErr := s.dataSourceService.GetAllDataSources(ctx, &datasources.GetAllDataSourcesQuery{})
+	if datasourcesErr == nil {
+		metadata := make([]string, 0, len(datasources))
+		for _, datasource := range datasources {
+			jdoc, err := json.Marshal(datasource)
+			if err != nil {
+				logger.Warn("error marshalling datasource", "datasourceUID", datasource.UID, "err", err)
+				continue
+			}
+			metadata = append(metadata, string(jdoc))
+		}
+		datasourcesErr = s.createCollectionIfNotExists(ctx, client, vector.CoreCollectionDatasources)
+		if datasourcesErr != nil {
+			datasourcesErr = fmt.Errorf("create collection: %w", datasourcesErr)
+		}
+		if datasourcesErr == nil {
+			datasourcesErr = s.addNewMetadata(ctx, client, vector.CoreCollectionDatasources, metadata)
+		}
+		if datasourcesErr != nil {
+			datasourcesErr = fmt.Errorf("add new metadata: %w", datasourcesErr)
+		}
+	}
+	// TODO: add alert rules, folders, annotations, ...
+	return errors.Join(dashboardsErr, datasourcesErr)
+}
+
+func (s *Service) createCollectionIfNotExists(ctx context.Context, client store.Client, collection string) error {
+	if exists, err := client.CollectionExists(ctx, collection); err != nil {
+		return fmt.Errorf("check if collection exists: %w", err)
+	} else if exists {
+		logger.Debug("collection already exists", "collection", collection)
+		return nil
+	}
+	logger.Debug("creating collection", "collection", collection)
+	// TODO: make size customizable in config
+	return client.CreateCollection(ctx, collection, 1536)
+}
+
+// addNewMetadata adds any new metadata to the vector store.
+//
+// It takes _all_ metadata as an argument, then checks against the vector store
+// whether each piece of metadata exists. If it doesn't, it adds it by first
+// computing the embedding using the configured embedding engine, then inserting it
+// into the configured vector store.
+//
+// Each piece of metadata is hashed to create a unique ID so we can avoid recomputing
+// embeddings for existing metadata.
+func (s *Service) addNewMetadata(ctx context.Context, client store.Client, collection string, allMetadata []string) error {
+	// IDs are just hashes of the payload
+	logger.Debug("adding metadata", "collection", collection, "count", len(allMetadata))
+	chunkSize := 100
+	if len(allMetadata) == 0 {
+		logger.Debug("no new embeddings to add")
+		return nil
+	}
+	for i := 0; i < len(allMetadata); i += chunkSize {
+		chunk := allMetadata[i:int(math.Min(float64(i+chunkSize), float64(len(allMetadata))))]
+		ids := make([]uint64, 0)
+		embeddings := make([][]float32, 0)
+		payloads := make([]string, 0)
+		for j, metadata := range chunk {
+			hash := fnv.New64a()
+			hash.Write([]byte(metadata))
+			id := hash.Sum64()
+			// TODO: can we do this call in a batch?
+			// or does it return 404 if _any_ don't exist?
+			// Answer: looks like we can for qdrant at least, the returned array
+			// just returns any found IDs.
+			if exists, err := client.PointExists(ctx, collection, id); err != nil {
+				logger.Warn("check vector exists", "collection", collection, "id", id, "err", err)
+				continue
+			} else if exists {
+				logger.Debug("vector already exists, skipping", "collection", collection, "id", id, "err", err)
+				continue
+			}
+			// If we're here, we have some new metadata to add.
+			logger.Debug("getting embeddings for metadata", "collection", collection, "metadata", metadata, "index", i+j, "count", len(allMetadata))
+			// TODO: we could batch this as well.
+			e, err := s.embeddingClient.Embeddings(ctx, metadata)
+			if err != nil {
+				logger.Warn("get embeddings", "collection", collection, "err", err)
+				continue
+			}
+			ids = append(ids, id)
+			embeddings = append(embeddings, e)
+			payloads = append(payloads, metadata)
+
+		}
+		if len(ids) == 0 {
+			logger.Debug("no new embeddings to add")
+			continue
+		}
+		logger.Debug("adding embeddings to vector DB", "collection", collection, "count", len(embeddings))
+		err := client.UpsertColumnar(ctx, collection, ids, embeddings, payloads)
+		if err != nil {
+			return fmt.Errorf("upsert columnar: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/services/vector/sync/sync.go
+++ b/pkg/services/vector/sync/sync.go
@@ -57,7 +57,7 @@ func ProvideService(
 // Satisfies the registry.CanBeDisabled interface which will guarantee
 // that Run() is not called if the service is disabled.
 func (s *Service) IsDisabled() bool {
-	return !s.features.IsEnabled(featuremgmt.FlagVectorSync) || !s.cfg.Vector.SyncEnabled || s.cfg.Vector.Embedding.Type == "" || s.cfg.Vector.Store.Type == ""
+	return !s.features.IsEnabled(featuremgmt.FlagVectorSync) || !s.cfg.Vector.Sync.Enabled || s.cfg.Vector.Embedding.Type == "" || s.cfg.Vector.Store.Type == "" || s.embeddingClient == nil
 }
 
 func (s *Service) Run(ctx context.Context) error {
@@ -82,6 +82,9 @@ func (s *Service) syncVectorStore(ctx context.Context) error {
 	client, cancel, err := store.NewClient(s.cfg.Vector.Store)
 	if err != nil {
 		return fmt.Errorf("create vector store client: %s", err)
+	}
+	if client == nil {
+		return fmt.Errorf("got nil vector store client")
 	}
 	defer cancel()
 

--- a/pkg/services/vector/vector.go
+++ b/pkg/services/vector/vector.go
@@ -1,0 +1,11 @@
+package vector
+
+import "fmt"
+
+var (
+	CoreCollectionPrefix      = "grafana-core-"
+	CoreCollectionAlertRules  = fmt.Sprintf("%salert-rules", CoreCollectionPrefix)
+	CoreCollectionDashboards  = fmt.Sprintf("%sdashboards", CoreCollectionPrefix)
+	CoreCollectionDatasources = fmt.Sprintf("%sdatasources", CoreCollectionPrefix)
+	CoreCollectionFolders     = fmt.Sprintf("%sfolders", CoreCollectionPrefix)
+)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -561,6 +561,9 @@ type Cfg struct {
 
 	// Feature Management Settings
 	FeatureManagement FeatureMgmtSettings
+
+	// Vector settings
+	Vector VectorSettings
 }
 
 // AddChangePasswordLink returns if login form is disabled or not since

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1255,6 +1255,8 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	cfg.readFeatureManagementConfig()
 
+	cfg.readVectorSettings()
+
 	return nil
 }
 

--- a/pkg/setting/setting_vector.go
+++ b/pkg/setting/setting_vector.go
@@ -1,0 +1,68 @@
+package setting
+
+import (
+	"gopkg.in/ini.v1"
+)
+
+func (cfg *Cfg) readVectorSettings(iniFile *ini.File) {
+	syncSection := cfg.SectionWithEnvOverrides("vector.sync")
+	cfg.Vector = VectorSettings{
+		SyncEnabled: syncSection.Key("enabled").MustBool(false),
+		Store:       cfg.readVectorStoreSettings(iniFile),
+		Embedding:   cfg.readVectorEmbeddingSettings(iniFile),
+	}
+}
+
+type VectorSettings struct {
+	SyncEnabled bool
+	Store       VectorStoreSettings
+	Embedding   EmbeddingEngineSettings
+}
+
+type VectorStoreSettings struct {
+	Type string
+
+	Qdrant QdrantVectorDBSettings
+}
+
+type QdrantVectorDBSettings struct {
+	Address string
+}
+
+func (cfg *Cfg) readVectorStoreSettings(iniFile *ini.File) VectorStoreSettings {
+	section := cfg.SectionWithEnvOverrides("vector.store")
+	settings := VectorStoreSettings{}
+	switch section.Key("type").MustString("") {
+	case "qdrant":
+		settings.Type = "qdrant"
+		settings.Qdrant = QdrantVectorDBSettings{
+			Address: section.Key("address").MustString("localhost:6333"),
+		}
+	}
+	return settings
+}
+
+type EmbeddingEngineSettings struct {
+	Type string
+
+	OpenAI OpenAIEngineSettings
+}
+
+func (cfg *Cfg) readVectorEmbeddingSettings(iniFile *ini.File) EmbeddingEngineSettings {
+	section := cfg.SectionWithEnvOverrides("vector.embedding")
+	settings := EmbeddingEngineSettings{}
+	switch section.Key("type").MustString("") {
+	case "openai":
+		settings.Type = "openai"
+		settings.OpenAI = OpenAIEngineSettings{
+			URL:    section.Key("url").MustString("https://api.openai.com"),
+			APIKey: section.Key("api_key").String(),
+		}
+	}
+	return settings
+}
+
+type OpenAIEngineSettings struct {
+	URL    string
+	APIKey string
+}


### PR DESCRIPTION
**What is this feature?**

This is a version of #69915 with only the background sync service. It allows the embedding engine and vector DB to be selected using config, and currently only supports OpenAI as the embedding engine and Qdrant as the vector DB.

The background service periodically queries for metadata from Grafana (datasources, dashboards, etc) and synchronises them to a configured vector DB for semantic search.

Later we will need a 'vector query' service which provides an API for searching for similar items using the vector DB.

**Why do we need this feature?**

TODO (see also [this design doc](https://docs.google.com/document/d/1fId22vv_Ow3DHpbPLrTVIO0b9IaID5_idmT1D1dKBIs/edit#heading=h.xbi0mej5qx7r))

**Who is this feature for?**

This will eventually enable Grafana and plugin developers to add more sophisticated LLM-driven features.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**


To get this working you'll need to add this to conf/custom.ini:

```ini
[feature_toggles]
enable = vectorSync

[vector]
embedding_engine = openai
store_engine = qdrant

[vector.sync]
enabled = true
interval = 15m

[vector.qdrant]
address = localhost:6334
```

Run this before make run:

```sh
export GF_VECTOR_OPENAI_API_KEY=$OPENAI_API_KEY
```

And start qdrant in a separate shell:

```sh
docker run -p 6333:6333 -p 6334:6334 --rm \
    -v $(pwd)/qdrant_storage:/qdrant/storage \
    qdrant/qdrant
```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
