### PR TITLE
[v9.5.x] Docs: reorder visualizations pages (#74047)

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/annotations/index.md
+++ b/docs/sources/panels-visualizations/visualizations/annotations/index.md
@@ -10,7 +10,7 @@ keywords:
   - panel
   - documentation
 title: Annotations
-weight: 105
+weight: 100
 ---
 
 # Annotations

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -10,7 +10,7 @@ keywords:
   - panel
   - barchart
 title: Bar chart
-weight: 170
+weight: 100
 ---
 
 # Bar chart

--- a/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
@@ -9,7 +9,7 @@ keywords:
   - bar
   - bar gauge
 title: Bar gauge
-weight: 200
+weight: 100
 ---
 
 # Bar gauge

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -11,7 +11,7 @@ keywords:
   - panel
   - documentation
 title: Candlestick
-weight: 600
+weight: 100
 ---
 
 # Candlestick

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -9,7 +9,7 @@ keywords:
   - panel
   - documentation
 title: Canvas
-weight: 600
+weight: 100
 ---
 
 # Canvas

--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -11,7 +11,7 @@ keywords:
   - panel
   - dashlist
 title: Dashboard list
-weight: 300
+weight: 100
 ---
 
 # Dashboard list

--- a/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
@@ -8,7 +8,7 @@ keywords:
   - panels
   - flame graph
 title: Flame graph
-weight: 850
+weight: 100
 ---
 
 # Flame graph panel

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -9,7 +9,7 @@ keywords:
   - gauge
   - gauge panel
 title: Gauge
-weight: 400
+weight: 100
 ---
 
 # Gauge

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -28,7 +28,7 @@ keywords:
   - panel
   - documentation
 title: Geomap
-weight: 600
+weight: 100
 ---
 
 # Geomap

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -9,7 +9,7 @@ keywords:
   - panel
   - documentation
 title: Heatmap
-weight: 600
+weight: 100
 ---
 
 # Heatmap

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -11,7 +11,7 @@ keywords:
   - panel
   - barchart
 title: Histogram
-weight: 605
+weight: 100
 ---
 
 # Histogram

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -11,7 +11,7 @@ keywords:
   - panels
   - logs panel
 title: Logs panel
-weight: 700
+weight: 100
 ---
 
 # Logs panel

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -9,7 +9,7 @@ keywords:
   - panels
   - news panel
 title: News
-weight: 800
+weight: 100
 ---
 
 ## News

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -10,7 +10,7 @@ keywords:
   - node graph
   - directed graph
 title: Node graph
-weight: 850
+weight: 100
 ---
 
 # Node graph panel

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -6,7 +6,7 @@ keywords:
   - grafana
   - pie chart
 title: Pie chart
-weight: 850
+weight: 100
 ---
 
 # Pie chart

--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -11,7 +11,7 @@ keywords:
   - docs
   - stat panel
 title: Stat
-weight: 900
+weight: 100
 ---
 
 # Stat

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -9,7 +9,7 @@ keywords:
   - state timeline
   - panel
 title: State timeline
-weight: 900
+weight: 100
 ---
 
 # State timeline

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -9,7 +9,7 @@ keywords:
   - status history
   - panel
 title: Status history
-weight: 900
+weight: 100
 ---
 
 # Status history

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -18,7 +18,7 @@ keywords:
   - filter columns
 menuTitle: Table
 title: Table
-weight: 1000
+weight: 100
 ---
 
 # Table

--- a/docs/sources/panels-visualizations/visualizations/text/index.md
+++ b/docs/sources/panels-visualizations/visualizations/text/index.md
@@ -10,7 +10,7 @@ keywords:
   - documentation
   - panel
 title: Text
-weight: 1100
+weight: 100
 ---
 
 # Text

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -25,7 +25,7 @@ keywords:
   - guide
   - graph
 title: Time series
-weight: 90
+weight: 10
 ---
 
 # Time series

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -8,7 +8,7 @@ keywords:
   - panels
   - traces
 title: Traces
-weight: 850
+weight: 100
 ---
 
 # Traces panel


### PR DESCRIPTION
Reordering pages to be in alphabetical order except Time series, which remains the first page.
Set Time series page weight to 10 to force it to the top.
Set all other page weights to same number (100) to force them to follow default alphabetical ordering.

* Changed order of visualization docs

* Fixed weight of missed page

(cherry picked from commit 27c4362135a0435709ff36205e081237f4ec5112)

