### PR TITLE
Alerting: Fix provisioning of contact points when contact point is renamed

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -454,7 +454,7 @@ func stitchReceiver(cfg *apimodels.PostableUserConfig, target *apimodels.Postabl
 	// All receivers in a given receiver group have the same name. We must maintain this across renames.
 	configModified := false
 groupLoop:
-	for _, receiverGroup := range cfg.AlertmanagerConfig.Receivers {
+	for groupIdx, receiverGroup := range cfg.AlertmanagerConfig.Receivers {
 		// Does the current group contain the grafana receiver we're interested in?
 		for i, grafanaReceiver := range receiverGroup.GrafanaManagedReceivers {
 			if grafanaReceiver.UID == target.UID {
@@ -477,8 +477,6 @@ groupLoop:
 					replaceReferences(receiverGroup.Name, target.Name, cfg.AlertmanagerConfig.Route)
 					receiverGroup.Name = target.Name
 					receiverGroup.GrafanaManagedReceivers[i] = target
-					configModified = true
-					break groupLoop
 				}
 
 				// Otherwise, we only want to rename the receiver we are touching... NOT all of them.
@@ -491,6 +489,11 @@ groupLoop:
 						// Add the modified receiver to the new group...
 						candidateExistingGroup.GrafanaManagedReceivers = append(candidateExistingGroup.GrafanaManagedReceivers, target)
 						configModified = true
+
+						// if the receiver group turns out to be empty. Remove it.
+						if len(receiverGroup.GrafanaManagedReceivers) == 0 {
+							cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers[:groupIdx], cfg.AlertmanagerConfig.Receivers[groupIdx+1:]...)
+						}
 						break groupLoop
 					}
 				}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -490,7 +490,7 @@ groupLoop:
 						candidateExistingGroup.GrafanaManagedReceivers = append(candidateExistingGroup.GrafanaManagedReceivers, target)
 						configModified = true
 
-						// if the receiver group turns out to be empty. Remove it.
+						// if the old receiver group turns out to be empty. Remove it.
 						if len(receiverGroup.GrafanaManagedReceivers) == 0 {
 							cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers[:groupIdx], cfg.AlertmanagerConfig.Receivers[groupIdx+1:]...)
 						}

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -992,6 +992,108 @@ func TestStitchReceivers(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single item group rename to existing group",
+			initial: &definitions.PostableUserConfig{
+				AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+					Config: definitions.Config{
+						Route: &definitions.Route{
+							Receiver: "receiver-1",
+							Routes: []*definitions.Route{
+								{
+									Receiver: "receiver-1",
+								},
+								{
+									Receiver: "receiver-2",
+								},
+							},
+						},
+					},
+					Receivers: []*definitions.PostableApiReceiver{
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-1",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "1",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+									{
+										UID:  "2",
+										Name: "receiver-1",
+										Type: "slack",
+									},
+								},
+							},
+						},
+						{
+							Receiver: config.Receiver{
+								Name: "receiver-2",
+							},
+							PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+								GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+									{
+										UID:  "3",
+										Name: "receiver-2",
+										Type: "slack",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			new: &definitions.PostableGrafanaReceiver{
+				UID:  "3",
+				Name: "receiver-1",
+				Type: "slack",
+			},
+			expModified: true,
+			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{
+					{
+						Receiver: config.Receiver{
+							Name: "receiver-1",
+						},
+						PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+							GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+								{
+									UID:  "1",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+								{
+									UID:  "2",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+								{
+									UID:  "3",
+									Name: "receiver-1",
+									Type: "slack",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR fixes a bug when the last contact point in the receiver group gets moved to another existing group. See the video below for a demonstration of the bug

<details><summary> Demonstartion of the bug</summary>

https://github.com/grafana/grafana/assets/25988953/e9c333c3-0389-4bc8-a03f-722a27972c11

</details>


**Why do we need this feature?**
This causes another bug - 2 receivers with the same name are not supported in Alertmanager. The last in the order wins, and the notification policy that before the update sent notifications to "discord", after the update sends __only__ to email.

**Who is this feature for?**
Those who use provisioning API

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/71619

**Special notes for your reviewer:**
The first commit introduces a unit test that demonstrates the bug.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
