### PR TITLE
Fix panic in legacy alerting after identity.Requester migration

### DIFF
--- a/pkg/services/pluginsintegration/plugincontext/plugincontext.go
+++ b/pkg/services/pluginsintegration/plugincontext/plugincontext.go
@@ -49,7 +49,7 @@ func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Reque
 	pCtx := backend.PluginContext{
 		PluginID: pluginID,
 	}
-	if user != nil {
+	if user != nil && !user.IsNil() {
 		pCtx.OrgID = user.GetOrgID()
 		pCtx.User = adapters.BackendUserFromSignedInUser(user)
 	}
@@ -77,7 +77,7 @@ func (p *Provider) GetWithDataSource(ctx context.Context, pluginID string, user 
 	pCtx := backend.PluginContext{
 		PluginID: pluginID,
 	}
-	if user != nil {
+	if user != nil && !user.IsNil() {
 		pCtx.OrgID = user.GetOrgID()
 		pCtx.User = adapters.BackendUserFromSignedInUser(user)
 	}


### PR DESCRIPTION
**What is this feature?**

Follow up from #74048 which introduced a panic in legacy alerting:
```
ERROR[09-01|11:29:30] Alert Panic                              logger=alerting.engine error="runtime error: invalid memory addr
ess or nil pointer dereference" stack="[engine.go:208 panic.go:884 panic.go:260 signal_unix.go:837 identity.go:130 plugincontex
t.go:81 service.go:77 service.go:35 query.go:202 query.go:51 eval_handler.go:37 engine.go:221]"
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
