### PR TITLE
Add version lookup to `docs/shared` usage in Tempo

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/index.md
+++ b/docs/sources/datasources/tempo/query-editor/index.md
@@ -81,7 +81,7 @@ You can create TraceQL queries using the Query editor or using **Search** query 
 
 [//]: # 'Include content for preview of Search tab featuring TraceQL query builder'
 
-{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" >}}
+{{< docs/shared source="grafana" lookup="datasources/tempo-search-traceql.md" leveloffset="+1" version="<GRAFANA VERSION>" >}}
 
 ## Query Loki for traces
 


### PR DESCRIPTION
It was somehow missed in my initial PR but has been included in the other branches.
