### PR TITLE
Folders: Show folders available for user at the root level

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -312,5 +312,5 @@ func setUpRBACGuardian(t *testing.T) {
 		guardian.New = origNewGuardian
 	})
 
-	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanEditValue: true})
+	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanEditValue: true, CanViewValue: true})
 }

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -377,6 +377,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, g guardian.Dash
 		parentGuardian, err := guardian.NewByFolder(ctx, f, f.OrgID, c.SignedInUser)
 		if err != nil {
 			hs.log.Error("failed to check folder permissions", "folder", f.UID, "org", f.OrgID, "error", err)
+			continue
 		}
 		if canView, _ := parentGuardian.CanView(); canView {
 			folderDTO.Parents = append(folderDTO.Parents, toDTO(f))

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -49,7 +49,6 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 			UID:          c.Query("parentUid"),
 			SignedInUser: c.SignedInUser,
 		})
-
 	} else {
 		folders, err = hs.searchFolders(c)
 	}

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -49,6 +49,7 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 			UID:          c.Query("parentUid"),
 			SignedInUser: c.SignedInUser,
 		})
+
 	} else {
 		folders, err = hs.searchFolders(c)
 	}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"strings"
 	"sync"
 
@@ -188,12 +189,59 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		childrenUIDs = append(childrenUIDs, f.UID)
 	}
 
+	availableNonRootFolderUIDs := make([]string, 0)
+	if cmd.UID == "" {
+		availableNonRootFolderUIDs = GetAvailableNonRootFolders(cmd.SignedInUser)
+		s.log.Debug("Non root folders", "folders", availableNonRootFolderUIDs)
+
+		nonRootFolderUIDs := make([]string, 0)
+		for _, uid := range availableNonRootFolderUIDs {
+			if !slices.Contains(childrenUIDs, uid) {
+				childrenUIDs = append(childrenUIDs, uid)
+				nonRootFolderUIDs = append(nonRootFolderUIDs, uid)
+			}
+		}
+		availableNonRootFolderUIDs = nonRootFolderUIDs
+	}
+
 	dashFolders, err := s.dashboardFolderStore.GetFolders(ctx, cmd.OrgID, childrenUIDs)
 	if err != nil {
 		return nil, folder.ErrInternal.Errorf("failed to fetch subfolders from dashboard store: %w", err)
 	}
 
-	filtered := make([]*folder.Folder, 0, len(children))
+	if cmd.UID == "" {
+		availableNonRootFolders := make([]*folder.Folder, 0)
+		for _, uid := range availableNonRootFolderUIDs {
+			availableNonRootFolders = append(availableNonRootFolders, dashFolders[uid])
+		}
+
+		availableNonRootFoldersDedup := make([]*folder.Folder, 0)
+		for _, f := range availableNonRootFolders {
+			parents, err := s.GetParents(ctx, folder.GetParentsQuery{UID: f.UID, OrgID: f.OrgID})
+			if err != nil {
+				s.log.Error("failed to fetch folder parents", "uid", f.UID, "error", err)
+				continue
+			}
+
+			isSubfolder := false
+			for _, parent := range parents {
+				contains := slices.ContainsFunc(availableNonRootFolders, func(f *folder.Folder) bool {
+					return f.UID == parent.UID
+				})
+				if contains {
+					isSubfolder = true
+					break
+				}
+			}
+			if !isSubfolder {
+				availableNonRootFoldersDedup = append(availableNonRootFoldersDedup, f)
+			}
+		}
+
+		children = append(children, availableNonRootFoldersDedup...)
+	}
+
+	filtered := make([]*folder.Folder, 0, len(childrenUIDs))
 	for _, f := range children {
 		// fetch folder from dashboard store
 		dashFolder, ok := dashFolders[f.UID]
@@ -226,6 +274,18 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 	}
 
 	return filtered, nil
+}
+
+func GetAvailableNonRootFolders(user identity.Requester) []string {
+	permissions := user.GetPermissions()
+	folderPermissions := permissions["dashboards:read"]
+	folderUids := make([]string, 0)
+	for _, p := range folderPermissions {
+		if folderUid, found := strings.CutPrefix(p, "folders:uid:"); found {
+			folderUids = append(folderUids, folderUid)
+		}
+	}
+	return folderUids
 }
 
 func (s *Service) GetParents(ctx context.Context, q folder.GetParentsQuery) ([]*folder.Folder, error) {

--- a/pkg/services/folder/folderimpl/store.go
+++ b/pkg/services/folder/folderimpl/store.go
@@ -33,4 +33,7 @@ type store interface {
 	// GetHeight returns the height of the folder tree. When parentUID is set, the function would
 	// verify in the meanwhile that parentUID is not present in the subtree of the folder with the given UID.
 	GetHeight(ctx context.Context, foldrUID string, orgID int64, parentUID *string) (int, error)
+
+	// GetFolders returns folders with given uids
+	GetFolders(ctx context.Context, orgID int64, uids []string) ([]*folder.Folder, error)
 }

--- a/pkg/services/folder/folderimpl/store_fake.go
+++ b/pkg/services/folder/folderimpl/store_fake.go
@@ -9,6 +9,7 @@ import (
 type fakeStore struct {
 	ExpectedChildFolders  []*folder.Folder
 	ExpectedParentFolders []*folder.Folder
+	ExpectedFolders       []*folder.Folder
 	ExpectedFolder        *folder.Folder
 	ExpectedError         error
 	ExpectedFolderHeight  int
@@ -54,4 +55,8 @@ func (f *fakeStore) GetChildren(ctx context.Context, cmd folder.GetChildrenQuery
 
 func (f *fakeStore) GetHeight(ctx context.Context, folderUID string, orgID int64, parentUID *string) (int, error) {
 	return f.ExpectedFolderHeight, f.ExpectedError
+}
+
+func (f *fakeStore) GetFolders(ctx context.Context, orgID int64, uids []string) ([]*folder.Folder, error) {
+	return f.ExpectedFolders, f.ExpectedError
 }


### PR DESCRIPTION
**What is this feature?**

This is POC for #71425
It allows to find folders that user has access to and show that folders in the root.

**Why do we need this feature?**

This PR solves an issue with nested folders when user has permissions to access a folder, but without permissions for the parent folder. In this case folder can be found in search, however it's no shown in the folders tree.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #71425

**Special notes for your reviewer:**

![Untitled-2023-08-30-1615](https://github.com/grafana/grafana/assets/4932851/ded32634-89a5-421e-8faa-62101fdd7119)

The most performance-demanding part of this approach is checking the parent-child structure of available non-root folders. For example, let's say user has access to _Team A_, _Team B_ and _Folder B1_ which is subfolder of _Team B_. In this case only first two folders should be attached to the root since _Folder B1_ is accessible through the _Folder B1_. To avoid this situation, parents for each folder should be fetched and then checked if it's in the list already. Because of current nested folders implementation, this operation is performance expensive.

![nf-07](https://github.com/grafana/grafana/assets/4932851/f8db17a9-da26-4bc5-9439-1e034ac91d0b)


