### PR TITLE
Alerting: Change export label

### DIFF
--- a/public/app/features/alerting/unified/MoreActionsRuleButtons.tsx
+++ b/public/app/features/alerting/unified/MoreActionsRuleButtons.tsx
@@ -29,7 +29,7 @@ export function MoreActionsRuleButtons({}: Props) {
             download: 'true',
             format: 'yaml',
           })}
-          label="Export all"
+          label="Export all Grafana-managed rules"
           target="_blank"
         />
       )}


### PR DESCRIPTION
**What is this feature?**

Current export button label is confusing as it says ' Export all' when actually you can only export Grafana-managed alerts.
This PR updates this label to be more clear about this.

**Why do we need this feature?**

Current export button is confusing about what it does.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

After the change: 

<img width="431" alt="Screenshot 2023-09-01 at 16 10 18" src="https://github.com/grafana/grafana/assets/33540275/06485770-87ba-46dd-8be8-68c8e1887cc6">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
