### PR TITLE
Tempo: Add delay on duration input change

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/DurationInput.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/DurationInput.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import { debounce } from 'lodash';
+import React, { useState, useMemo } from 'react';
 
 import { Select, HorizontalGroup, Input, useStyles2 } from '@grafana/ui';
 
@@ -34,6 +35,16 @@ const DurationInput = ({ filter, operators, updateFilter }: Props) => {
     invalid = filter.value ? !validationRegex.test(filter.value.concat('')) : false;
   }
 
+  const [value, setValue] = useState(filter.value);
+
+  const delayFilter = useMemo(
+    () =>
+      debounce((value: string, filter: TraceqlFilter) => {
+        updateFilter({ ...filter, value: value });
+      }, 500),
+    [updateFilter]
+  );
+
   return (
     <HorizontalGroup spacing={'none'}>
       <Select
@@ -51,9 +62,10 @@ const DurationInput = ({ filter, operators, updateFilter }: Props) => {
       />
       <Input
         className={styles.noBoxShadow}
-        value={filter.value}
+        value={value}
         onChange={(v) => {
-          updateFilter({ ...filter, value: v.currentTarget.value });
+          setValue(v.currentTarget.value);
+          delayFilter(v.currentTarget.value, filter);
         }}
         placeholder="e.g. 100ms, 1.2s"
         aria-label={`select ${filter.id} value`}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Added a debouncing effect when duration input is changed in the Tempo data source

**Why do we need this feature?**

Avoid triggering the search bar loading animation with every keystroke

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #73943 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
