### PR TITLE
DashboardMigrator: Add migration that removes repeats

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -49,6 +49,7 @@ describe('DashboardModel', () => {
     let singlestat: any;
     let table: any;
     let singlestatGauge: any;
+    const panelIdWithRepeatId = 500;
 
     config.panels = {
       stat: getPanelPlugin({ id: 'stat' }).meta,
@@ -116,6 +117,31 @@ describe('DashboardModel', () => {
             styles: [{ thresholds: ['10', '20', '30'] }, { thresholds: ['100', '200', '300'] }],
             targets: [{ refId: 'A' }, {}],
           },
+          // Old left-over repeated panel
+          {
+            type: 'table',
+            id: panelIdWithRepeatId,
+            // @ts-expect-error
+            repeatPanelId: 1,
+          },
+          // Collapsed row with left-over repeated panels
+          {
+            type: 'row',
+            panels: [
+              // @ts-expect-error
+              {
+                id: 501,
+                type: 'table',
+                repeat: 'server',
+              },
+              // Old left-over repeated panel
+              {
+                id: 502,
+                // @ts-expect-error
+                repeatedPanelId: 501,
+              },
+            ],
+          },
         ],
       });
 
@@ -130,7 +156,7 @@ describe('DashboardModel', () => {
     });
 
     it('should have panel id', () => {
-      expect(graph.id).toBe(1);
+      expect(graph.id).toBe(503);
     });
 
     it('should not have style', () => {
@@ -235,6 +261,10 @@ describe('DashboardModel', () => {
       expect(graph.thresholds[0].value).toBe(100);
       expect(graph.thresholds[1].value).toBe(200);
       expect(graph.thresholds[2].value).toBe(400);
+    });
+
+    it('Shoud ignore repeated panels', () => {
+      expect(model.getPanelById(panelIdWithRepeatId)).toBe(null);
     });
   });
 

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -118,10 +118,10 @@ describe('DashboardModel', () => {
             targets: [{ refId: 'A' }, {}],
           },
           // Old left-over repeated panel
+          // @ts-expect-error
           {
             type: 'table',
             id: panelIdWithRepeatId,
-            // @ts-expect-error
             repeatPanelId: 1,
           },
           // Collapsed row with left-over repeated panels

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -627,6 +627,9 @@ export class DashboardMigrator {
     }
 
     if (oldVersion < 27) {
+      // remove old repeated panel left-overs
+      this.removeRepeatedPanels();
+
       this.dashboard.templating.list = this.dashboard.templating.list.map((variable) => {
         if (!isConstant(variable)) {
           return variable;
@@ -861,6 +864,26 @@ export class DashboardMigrator {
         }
       }
     }
+  }
+
+  private removeRepeatedPanels() {
+    const newPanels = [];
+
+    for (const panel of this.dashboard.panels) {
+      // @ts-expect-error
+      if (panel.repeatPanelId || panel.repeatByRow) {
+        continue;
+      }
+
+      // Filter out repeats in collapsed rows
+      if (panel.type === 'row' && Array.isArray(panel.panels)) {
+        panel.panels = panel.panels.filter((x) => !x.repeatPanelId);
+      }
+
+      newPanels.push(panel);
+    }
+
+    this.dashboard.panels = newPanels;
   }
 
   // Migrates metric queries and/or annotation queries that use more than one statistic.


### PR DESCRIPTION
Two years ago we changed so that repeated panel clones and repeated rows are removed from the save model:
https://github.com/grafana/grafana/pull/32436/ 

However we (I) forgot to add a migration for it so some old dashboards still have them when we load a dashboard. This is not a problem for current architecture that cleans the old left over panels before new repeating panels are generated. But it is a problem for new scenes architecture (where repeats are handled differently). 

So figured the best thing here is to have a proper migration for it. 