### PR TITLE
Nightly scans: Remove `cloud_datasources_e2e_image` from images to scan

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4457,7 +4457,6 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docker-puppeteer:1.1.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
   depends_on:
   - authenticate-gcr
   image: aquasec/trivy:0.21.0
@@ -4486,7 +4485,6 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docker-puppeteer:1.1.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
-  - trivy --exit-code 1 --severity HIGH,CRITICAL us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest
   depends_on:
   - authenticate-gcr
   environment:
@@ -4731,6 +4729,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: fe74c275ebfa4c5fc190b08d9b452abb3dd35120a5e3616231bcbcd7d1f5e614
+hmac: 883d9f0e14f52a0b773040eeb476f3081b8122b34d5c14ad4f81219ceb754299
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -892,7 +892,7 @@ def cloud_plugins_e2e_tests_step(suite, cloud, trigger = None):
     branch = "${DRONE_SOURCE_BRANCH}".replace("/", "-")
     step = {
         "name": "end-to-end-tests-{}-{}".format(suite, cloud),
-        "image": images["cloud_datasources_e2e_image"],
+        "image": "us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest",
         "depends_on": [
             "grafana-server",
         ],

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -21,5 +21,4 @@ images = {
     "docker_puppeteer_image": "grafana/docker-puppeteer:1.1.0",
     "docs_image": "grafana/docs-base:dbd975af06",
     "cypress_image": "cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97",
-    "cloud_datasources_e2e_image": "us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest",
 }


### PR DESCRIPTION
**What is this feature?**

Removes `us-docker.pkg.dev/grafanalabs-dev/cloud-data-sources/e2e:latest` from trivy scan list, until we move it to. "prod" gcr.

Related: https://github.com/grafana/oss-plugin-partnerships/issues/241