### PR TITLE
[v9.4.x] LDAP: Fix user disabling

### DIFF
--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/loginattempt"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -36,13 +37,18 @@ type AuthenticatorService struct {
 	loginService        login.Service
 	loginAttemptService loginattempt.Service
 	userService         user.Service
+	authInfoService     login.AuthInfoService
+	cfg                 *setting.Cfg
 }
 
-func ProvideService(store db.DB, loginService login.Service, loginAttemptService loginattempt.Service, userService user.Service) *AuthenticatorService {
+func ProvideService(store db.DB, loginService login.Service, loginAttemptService loginattempt.Service,
+	userService user.Service, authInfoService login.AuthInfoService, cfg *setting.Cfg) *AuthenticatorService {
 	a := &AuthenticatorService{
 		loginService:        loginService,
 		loginAttemptService: loginAttemptService,
 		userService:         userService,
+		authInfoService:     authInfoService,
+		cfg:                 cfg,
 	}
 	return a
 }
@@ -73,7 +79,7 @@ func (a *AuthenticatorService) AuthenticateUser(ctx context.Context, query *logi
 		return err
 	}
 
-	ldapEnabled, ldapErr := loginUsingLDAP(ctx, query, a.loginService)
+	ldapEnabled, ldapErr := loginUsingLDAP(ctx, query, a.loginService, a.userService, a.authInfoService, a.cfg)
 	if ldapEnabled {
 		query.AuthModule = login.LDAPAuthModule
 		if ldapErr == nil || !errors.Is(ldapErr, ldap.ErrInvalidCredentials) {

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -38,7 +38,7 @@ func TestAuthenticateUser(t *testing.T) {
 		sc.loginUserQuery.Cfg.DisableLogin = true
 
 		loginAttemptService := &loginattempttest.MockLoginAttemptService{ExpectedValid: true}
-		a := AuthenticatorService{loginAttemptService: loginAttemptService, loginService: &logintest.LoginServiceFake{}}
+		a := AuthenticatorService{loginAttemptService: loginAttemptService, loginService: &logintest.LoginServiceFake{}, cfg: setting.NewCfg()}
 		err := a.AuthenticateUser(context.Background(), sc.loginUserQuery)
 
 		require.EqualError(t, err, ErrNoAuthProvider.Error())

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -195,7 +195,7 @@ func mockLoginUsingGrafanaDB(err error, sc *authScenarioContext) {
 }
 
 func mockLoginUsingLDAP(enabled bool, err error, sc *authScenarioContext) {
-	loginUsingLDAP = func(ctx context.Context, query *login.LoginUserQuery, _ login.Service) (bool, error) {
+	loginUsingLDAP = func(ctx context.Context, query *login.LoginUserQuery, _ login.Service, _ user.Service, _ login.AuthInfoService, _ *setting.Cfg) (bool, error) {
 		sc.ldapLoginWasCalled = true
 		return enabled, err
 	}

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -9,14 +9,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/multildap"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 // getLDAPConfig gets LDAP config
 var getLDAPConfig = multildap.GetConfig
-
-// isLDAPEnabled checks if LDAP is enabled
-var isLDAPEnabled = multildap.IsEnabled
 
 // newLDAP creates multiple LDAP instance
 var newLDAP = multildap.New
@@ -26,10 +24,9 @@ var ldapLogger = log.New("login.ldap")
 
 // loginUsingLDAP logs in user using LDAP. It returns whether LDAP is enabled and optional error and query arg will be
 // populated with the logged in user if successful.
-var loginUsingLDAP = func(ctx context.Context, query *login.LoginUserQuery, loginService login.Service) (bool, error) {
-	enabled := isLDAPEnabled()
-
-	if !enabled {
+var loginUsingLDAP = func(ctx context.Context, query *login.LoginUserQuery,
+	loginService login.Service, userService user.Service, authInfoService login.AuthInfoService, cfg *setting.Cfg) (bool, error) {
+	if !cfg.LDAPAuthEnabled {
 		return false, nil
 	}
 
@@ -41,13 +38,37 @@ var loginUsingLDAP = func(ctx context.Context, query *login.LoginUserQuery, logi
 	externalUser, err := newLDAP(config.Servers).Login(query)
 	if err != nil {
 		if errors.Is(err, ldap.ErrCouldNotFindUser) {
-			// Ignore the error since user might not be present anyway
-			if err := loginService.DisableExternalUser(ctx, query.Username); err != nil {
-				ldapLogger.Debug("Failed to disable external user", "err", err)
+			ldapLogger.Debug("user was not found in the LDAP directory tree", "username", query.Username)
+			retErr := ldap.ErrInvalidCredentials
+
+			// Retrieve the user from store based on the login
+			dbUser, errGet := userService.GetByLogin(ctx, &user.GetUserByLoginQuery{
+				LoginOrEmail: query.Username,
+			})
+			if errors.Is(errGet, user.ErrUserNotFound) {
+				return true, retErr
+			} else if errGet != nil {
+				return true, errGet
+			}
+
+			// Check if the user logged in via LDAP
+			authModuleQuery := &login.GetAuthInfoQuery{UserId: dbUser.ID, AuthModule: login.LDAPAuthModule}
+			errGetAuthInfo := authInfoService.GetAuthInfo(ctx, authModuleQuery)
+			if errors.Is(errGetAuthInfo, user.ErrUserNotFound) {
+				return true, retErr
+			} else if errGetAuthInfo != nil {
+				return true, errGetAuthInfo
+			}
+
+			// Disable the user
+			ldapLogger.Debug("user was removed from the LDAP directory tree, disabling it", "username", query.Username, "authID", authModuleQuery.Result.AuthId)
+			if errDisable := loginService.DisableExternalUser(ctx, query.Username); errDisable != nil {
+				ldapLogger.Debug("Failed to disable external user", "err", errDisable)
+				return true, errDisable
 			}
 
 			// Return invalid credentials if we couldn't find the user anywhere
-			return true, ldap.ErrInvalidCredentials
+			return true, retErr
 		}
 
 		return true, err

--- a/pkg/middleware/middleware_basic_auth_test.go
+++ b/pkg/middleware/middleware_basic_auth_test.go
@@ -67,7 +67,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 
 		sc.userService.ExpectedUser = &user.User{Password: encoded, ID: id, Salt: salt}
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{UserID: id}
-		login.ProvideService(sc.mockSQLStore, &logintest.LoginServiceFake{}, nil, sc.userService)
+		login.ProvideService(sc.mockSQLStore, &logintest.LoginServiceFake{}, nil, sc.userService, sc.authInfoService, sc.cfg)
 
 		authHeader := util.GetBasicAuthHeader("myUser", password)
 		sc.fakeReq("GET", "/").withAuthorizationHeader(authHeader).exec()

--- a/pkg/middleware/testing.go
+++ b/pkg/middleware/testing.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
+	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -49,6 +50,7 @@ type scenarioContext struct {
 	userService          *usertest.FakeUserService
 	oauthTokenService    *authtest.FakeOAuthTokenService
 	orgService           *orgtest.FakeOrgService
+	authInfoService      *logintest.AuthInfoServiceFake
 
 	req *http.Request
 }

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -86,7 +86,7 @@ func ProvideService(
 	var proxyClients []authn.ProxyClient
 	var passwordClients []authn.PasswordClient
 	if s.cfg.LDAPAuthEnabled {
-		ldap := clients.ProvideLDAP(cfg)
+		ldap := clients.ProvideLDAP(cfg, userService, authInfoService)
 		proxyClients = append(proxyClients, ldap)
 		passwordClients = append(passwordClients, ldap)
 	}

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -176,7 +176,7 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 	}
 
 	if needsUpdate {
-		s.log.Debug("Syncing user info", "id", usr.ID, "update", updateCmd)
+		s.log.Debug("Syncing user info", "id", id.ID, "update", fmt.Sprintf("%v", updateCmd))
 		if err := s.userService.Update(ctx, updateCmd); err != nil {
 			return err
 		}

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -6,25 +6,38 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestLDAP_AuthenticateProxy(t *testing.T) {
-	type testCase struct {
-		desc             string
-		username         string
-		expectedLDAPErr  error
-		expectedLDAPInfo *login.ExternalUserInfo
-		expectedErr      error
-		expectedIdentity *authn.Identity
-	}
+type ldapTestCase struct {
+	desc             string
+	username         string
+	password         string
+	expectedErr      error
+	expectedLDAPErr  error
+	expectedLDAPInfo *login.ExternalUserInfo
+	expectedIdentity *authn.Identity
 
-	tests := []testCase{
+	// Disabling User
+	expectedUser        user.User
+	expectedUserErr     error
+	expectedAuthInfo    login.UserAuth
+	expectedAuthInfoErr error
+	disableCalled       bool
+	expectDisable       bool
+}
+
+func TestLDAP_AuthenticateProxy(t *testing.T) {
+	tests := []ldapTestCase{
 		{
 			desc:     "should return valid identity when found by ldap service",
 			username: "test",
@@ -62,32 +75,34 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 			desc:            "should return error when user is not found",
 			username:        "test",
 			expectedLDAPErr: multildap.ErrDidNotFindUser,
+			expectedUserErr: user.ErrUserNotFound,
 			expectedErr:     errIdentityNotFound,
+		},
+		{
+			desc:             "should disable user when user is not found",
+			username:         "test",
+			expectedLDAPErr:  multildap.ErrDidNotFindUser,
+			expectedUser:     user.User{ID: 11, Login: "test"},
+			expectedAuthInfo: login.UserAuth{UserId: 11, AuthId: "cn=test,ou=users,dc=example,dc=org", AuthModule: login.LDAPAuthModule},
+			expectDisable:    true,
+			expectedErr:      errIdentityNotFound,
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
-			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr}}
+			c := setupLDAPTestCase(&tt)
 			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username, nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
+			assert.Equal(t, tt.expectDisable, tt.disableCalled)
 		})
 	}
 }
 
 func TestLDAP_AuthenticatePassword(t *testing.T) {
-	type testCase struct {
-		desc             string
-		username         string
-		password         string
-		expectedErr      error
-		expectedLDAPErr  error
-		expectedLDAPInfo *login.ExternalUserInfo
-		expectedIdentity *authn.Identity
-	}
-
-	tests := []testCase{
+	tests := []ldapTestCase{
 		{
 			desc:     "should successfully authenticate with correct username and password",
 			username: "test",
@@ -135,18 +150,56 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 			password:        "wrong",
 			expectedErr:     errIdentityNotFound,
 			expectedLDAPErr: ldap.ErrCouldNotFindUser,
+			expectedUserErr: user.ErrUserNotFound,
+		},
+		{
+			desc:             "should disable user if not found",
+			username:         "test",
+			password:         "wrong",
+			expectedErr:      errIdentityNotFound,
+			expectedLDAPErr:  ldap.ErrCouldNotFindUser,
+			expectedUser:     user.User{ID: 11, Login: "test"},
+			expectedAuthInfo: login.UserAuth{UserId: 11, AuthId: "cn=test,ou=users,dc=example,dc=org", AuthModule: login.LDAPAuthModule},
+			expectDisable:    true,
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.desc, func(t *testing.T) {
-			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr}}
+			c := setupLDAPTestCase(&tt)
 
 			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
+			assert.Equal(t, tt.expectDisable, tt.disableCalled)
 		})
 	}
+}
+
+func setupLDAPTestCase(tt *ldapTestCase) *LDAP {
+	userService := &usertest.FakeUserService{
+		ExpectedError: tt.expectedUserErr,
+		ExpectedUser:  &tt.expectedUser,
+		DisableFn: func(ctx context.Context, cmd *user.DisableUserCommand) error {
+			tt.disableCalled = true
+			return nil
+		},
+	}
+	authInfoService := &logintest.AuthInfoServiceFake{
+		ExpectedUserAuth: &tt.expectedAuthInfo,
+		ExpectedError:    tt.expectedAuthInfoErr,
+	}
+
+	c := &LDAP{
+		cfg:             setting.NewCfg(),
+		logger:          log.New("authn.ldap.test"),
+		service:         &fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr},
+		userService:     userService,
+		authInfoService: authInfoService,
+	}
+
+	return c
 }
 
 func strPtr(s string) *string {

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -283,8 +283,8 @@ func (server *Server) Users(logins []string) (
 ) {
 	var users [][]*ldap.Entry
 	err := getUsersIteration(logins, func(previous, current int) error {
-		var err error
-		users, err = server.users(logins[previous:current])
+		iterationUsers, err := server.users(logins[previous:current])
+		users = append(users, iterationUsers...)
 		return err
 	})
 	if err != nil {

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -17,6 +17,7 @@ type FakeUserService struct {
 
 	GetSignedInUserFn func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error)
 	CreateFn          func(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error)
+	DisableFn         func(ctx context.Context, cmd *user.DisableUserCommand) error
 
 	counter int
 }
@@ -92,6 +93,10 @@ func (f *FakeUserService) Search(ctx context.Context, query *user.SearchUsersQue
 }
 
 func (f *FakeUserService) Disable(ctx context.Context, cmd *user.DisableUserCommand) error {
+	if f.DisableFn != nil {
+		return f.DisableFn(ctx, cmd)
+	}
+
 	return f.ExpectedError
 }
 


### PR DESCRIPTION
Backport f900098cc9f5771c02b6189ba5138547b4f5e6c2 from #74016
Backport 9e52414a912b0bfa853d16eb538aa7ac4cdd63d1 from #73834

---

**What is this feature?**

In v9.x releases, LDAP users used to be disabled on login if they had been removed from the LDAP directory tree.
**But we had a bug, we'd also disable non-ldap users.**
In v10.x releases, with the move to the `AuthBroker`, we changed the approach and even if it's still impossible to log in with a removed LDAP user, we do not disable the user anymore.
This PR intends to restore the previous behavior in the `AuthBroker` but also fix the disabling to only target users that logged via LDAP. 

Additionally, for large amount of ldap users (>500 users), active sync was only retrieving a single iteration of users (max 500 users) and therefore was disabling every user that wasn't returned considering them as deleted from the LDAP directory tree.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
