### PR TITLE
Change plugin installation on managed instance

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -490,6 +490,9 @@ user_invite_max_lifetime_duration = 24h
 # Enter a comma-separated list of usernames to hide them in the Grafana UI. These users are shown to Grafana admins and to themselves.
 hidden_users =
 
+# Grafana instance id
+instance_id =
+
 [secretscan]
 # Enable secretscan feature
 enabled = false
@@ -828,7 +831,7 @@ assume_role_enabled = true
 list_metrics_page_limit = 500
 
 # Experimental, for use in Grafana Cloud only. Please do not set.
-external_id = 
+external_id =
 
 #################################### Azure ###############################
 [azure]
@@ -1436,7 +1439,7 @@ app_tls_skip_verify_insecure = false
 allow_loading_unsigned_plugins =
 # Enable or disable installing / uninstalling / updating plugins directly from within Grafana.
 plugin_admin_enabled = true
-plugin_admin_external_manage_enabled = false
+plugin_admin_external_manage_enabled = true
 plugin_catalog_url = https://grafana.com/grafana/plugins/
 # Enter a comma-separated list of plugin identifiers to hide in the plugin catalog.
 plugin_catalog_hidden_plugins =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1439,7 +1439,7 @@ app_tls_skip_verify_insecure = false
 allow_loading_unsigned_plugins =
 # Enable or disable installing / uninstalling / updating plugins directly from within Grafana.
 plugin_admin_enabled = true
-plugin_admin_external_manage_enabled = true
+plugin_admin_external_manage_enabled = false
 plugin_catalog_url = https://grafana.com/grafana/plugins/
 # Enter a comma-separated list of plugin identifiers to hide in the plugin catalog.
 plugin_catalog_hidden_plugins =

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -192,6 +192,7 @@ export interface GrafanaConfig {
   trustedTypesDefaultPolicyEnabled: boolean;
   cspReportOnlyEnabled: boolean;
   liveEnabled: boolean;
+  instanceId: string;
   /** @deprecated Use `theme2` instead. */
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -86,6 +86,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   trustedTypesDefaultPolicyEnabled = false;
   cspReportOnlyEnabled = false;
   liveEnabled = true;
+  instanceId = '';
   /** @deprecated Use `theme2` instead. */
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -140,6 +140,7 @@ type FrontendSettingsDTO struct {
 	AlertingMinInterval        int64                            `json:"alertingMinInterval"`
 	LiveEnabled                bool                             `json:"liveEnabled"`
 	AutoAssignOrg              bool                             `json:"autoAssignOrg"`
+	InstanceId                 string                           `json:"instanceId"`
 
 	VerifyEmailEnabled  bool `json:"verifyEmailEnabled"`
 	SigV4AuthEnabled    bool `json:"sigV4AuthEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -153,6 +153,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		SecureSocksDSProxyEnabled:           hs.Cfg.SecureSocksDSProxy.Enabled && hs.Cfg.SecureSocksDSProxy.ShowUI,
 		DisableFrontendSandboxForPlugins:    hs.Cfg.DisableFrontendSandboxForPlugins,
 		PublicDashboardAccessToken:          c.PublicDashboardAccessToken,
+		InstanceId:                          setting.InstanceId,
 
 		Auth: dtos.FrontendSettingsAuthDTO{
 			OAuthSkipOrgRoleUpdateSync:  hs.Cfg.OAuthSkipOrgRoleUpdateSync,

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -40,6 +40,8 @@ func ReverseProxyGnetReq(logger log.Logger, proxyPath string, version string, gr
 
 		// send the current Grafana version for each request proxied to GCOM
 		req.Header.Add("grafana-version", version)
+		// TODO authenticate with GCOM
+		req.Header.Add("Authorization", "Bearer <token>")
 	}
 
 	return proxyutil.NewReverseProxy(logger, director)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -101,6 +101,7 @@ var (
 	ExternalUserMngLinkUrl  string
 	ExternalUserMngLinkName string
 	ExternalUserMngInfo     string
+	InstanceId              string
 
 	// HTTP auth
 	SigV4AuthEnabled bool
@@ -1676,6 +1677,7 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	users := iniFile.Section("users")
 	AllowUserSignUp = users.Key("allow_sign_up").MustBool(true)
 	AllowUserOrgCreate = users.Key("allow_org_create").MustBool(true)
+	InstanceId = users.Key("instance_id").MustString("")
 	cfg.AutoAssignOrg = users.Key("auto_assign_org").MustBool(true)
 	cfg.AutoAssignOrgId = users.Key("auto_assign_org_id").MustInt(1)
 	cfg.AutoAssignOrgRole = users.Key("auto_assign_org_role").In(

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -109,6 +109,16 @@ export async function installPlugin(id: string) {
   });
 }
 
+export async function installManagedPlugin(instanceId: string, plugin: string, version?: string)  {
+  return await getBackendSrv().post(`${GCOM_API_ROOT}/instances/${instanceId}/plugins`, {
+    plugin,
+    version,
+  }, {
+    // Error is displayed in the page
+    showErrorAlert: false,
+  });
+}
+
 export async function uninstallPlugin(id: string) {
   return await getBackendSrv().post(`${API_ROOT}/${id}/uninstall`);
 }
@@ -127,5 +137,6 @@ export const api = {
   getRemotePlugins,
   getInstalledPlugins: getLocalPlugins,
   installPlugin,
+  installManagedPlugin,
   uninstallPlugin,
 };

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -7,7 +7,6 @@ import { HorizontalGroup, Icon, useStyles2, VerticalGroup } from '@grafana/ui';
 
 import { GetStartedWithPlugin } from '../components/GetStartedWithPlugin';
 import { InstallControlsButton } from '../components/InstallControls';
-import { ExternallyManagedButton } from '../components/InstallControls/ExternallyManagedButton';
 import { getLatestCompatibleVersion, hasInstallControlWarning, isInstallControlsEnabled } from '../helpers';
 import { useIsRemotePluginsAvailable } from '../state/hooks';
 import { CatalogPlugin, PluginStatus } from '../types';
@@ -40,22 +39,13 @@ export const PluginActions = ({ plugin }: Props) => {
     <VerticalGroup>
       <HorizontalGroup>
         {!isInstallControlsDisabled && (
-          <>
-            {isExternallyManaged ? (
-              <ExternallyManagedButton
-                pluginId={plugin.id}
-                pluginStatus={pluginStatus}
-                angularDetected={plugin.angularDetected}
-              />
-            ) : (
               <InstallControlsButton
                 plugin={plugin}
                 latestCompatibleVersion={latestCompatibleVersion}
                 pluginStatus={pluginStatus}
                 setNeedReload={setNeedReload}
+                isExternallyManaged={isExternallyManaged}
               />
-            )}
-          </>
         )}
         <GetStartedWithPlugin plugin={plugin} />
       </HorizontalGroup>

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'app/types';
 import { sortPlugins, Sorters } from '../helpers';
 import { CatalogPlugin, PluginListDisplayMode } from '../types';
 
-import { fetchAll, fetchDetails, fetchRemotePlugins, install, uninstall, fetchAllLocal, unsetInstall } from './actions';
+import { fetchAll, fetchDetails, fetchRemotePlugins, install, uninstall, fetchAllLocal, unsetInstall, managedInstall } from './actions';
 import { setDisplayMode } from './reducer';
 import {
   selectPlugins,
@@ -55,6 +55,11 @@ export const useGetErrors = (): PluginError[] => {
 export const useInstall = () => {
   const dispatch = useDispatch();
   return (id: string, version?: string, isUpdating?: boolean) => dispatch(install({ id, version, isUpdating }));
+};
+
+export const useManagedInstall = () => {
+  const dispatch = useDispatch();
+  return (id: string, version?: string, isUpdating?: boolean) => dispatch(managedInstall({ id, version, isUpdating }));
 };
 
 export const useUnsetInstall = () => {

--- a/public/app/features/plugins/admin/state/reducer.ts
+++ b/public/app/features/plugins/admin/state/reducer.ts
@@ -13,6 +13,7 @@ import {
   loadPluginDashboards,
   panelPluginLoaded,
   fetchAllLocal,
+  managedInstall,
 } from './actions';
 
 export const pluginsAdapter = createEntityAdapter<CatalogPlugin>();
@@ -72,6 +73,10 @@ const slice = createSlice({
       })
       // Install
       .addCase(install.fulfilled, (state, action) => {
+        pluginsAdapter.updateOne(state.items, action.payload);
+      })
+      // Managed Install
+      .addCase(managedInstall.fulfilled, (state, action) => {
         pluginsAdapter.updateOne(state.items, action.payload);
       })
       // Uninstall


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a draft PR to improve plugin installation for managed instances

**Why do we need this feature?**

This is needed to provide cloud users a better experience, closer to OSS, for plugin installation

**Who is this feature for?**

Cloud users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

https://github.com/grafana/grafana-plugins-platform-team/issues/21

**Special notes for your reviewer:**

To discuss:
- POST /instances/${instanceId}/plugins returns immediately, but the whole installation process takes more time, since the instance needs to be restarted, we need to find a way to give a user feedback about it.
- We need to find a way to make authenticated gcom requests
- In this draft I'm considering that the instance id will be added to users.instance_id settings, which is not a good place at all

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
