### PR TITLE
sql datasources: shared code: improve API

### DIFF
--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -2,6 +2,7 @@ import { lastValueFrom, Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import {
+  rangeUtil,
   DataFrame,
   DataFrameView,
   DataQuery,
@@ -14,6 +15,7 @@ import {
   CoreApp,
   getSearchFilterScopedVar,
   LegacyMetricFindQueryOptions,
+  TimeRange,
 } from '@grafana/data';
 import { EditorMode } from '@grafana/experimental';
 import {
@@ -25,7 +27,6 @@ import {
   TemplateSrv,
 } from '@grafana/runtime';
 import { toDataQueryResponse } from '@grafana/runtime/src/utils/queryResponse';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { VariableWithMultiSupport } from '../../../variables/types';
 import { ResponseParser } from '../ResponseParser';
@@ -191,17 +192,25 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       format: QueryFormat.Table,
     };
 
-    const response = await this.runMetaQuery(interpolatedQuery, options);
+    // in my experience we get `options.range` here, but the typescript types
+    // claim that it is optional. for that case we will switch to last-6-hours.
+    const range =
+      options?.range ??
+      rangeUtil.convertRawToRange({
+        from: 'now-6h',
+        to: 'now',
+      });
+
+    const response = await this.runMetaQuery(interpolatedQuery, range);
     return this.getResponseParser().transformMetricFindResponse(response);
   }
 
-  async runSql<T>(query: string, options?: RunSQLOptions) {
-    const frame = await this.runMetaQuery({ rawSql: query, format: QueryFormat.Table, refId: options?.refId }, options);
+  async runSql<T>(query: string, range: TimeRange, options?: { refId?: string }) {
+    const frame = await this.runMetaQuery({ rawSql: query, format: QueryFormat.Table, refId: options?.refId }, range);
     return new DataFrameView<T>(frame);
   }
 
-  private runMetaQuery(request: Partial<SQLQuery>, options?: LegacyMetricFindQueryOptions): Promise<DataFrame> {
-    const range = getTimeSrv().timeRange();
+  private runMetaQuery(request: Partial<SQLQuery>, range: TimeRange): Promise<DataFrame> {
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
@@ -212,8 +221,8 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
           method: 'POST',
           headers: this.getRequestHeaders(),
           data: {
-            from: options?.range?.from.valueOf().toString() || range.from.valueOf().toString(),
-            to: options?.range?.to.valueOf().toString() || range.to.valueOf().toString(),
+            from: range.from.valueOf().toString(),
+            to: range.to.valueOf().toString(),
             queries,
           },
           requestId: refId,
@@ -234,8 +243,4 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     });
     return this.templateSrv.containsTemplate(queryWithoutMacros);
   }
-}
-
-interface RunSQLOptions extends LegacyMetricFindQueryOptions {
-  refId?: string;
 }


### PR DESCRIPTION
the shared `SqlDatasource.ts` imports something that it should not:

https://github.com/grafana/grafana/blob/bccb5869a5baa1eceda206f2e2e725114ac6b121/public/app/features/plugins/sql/datasource/SqlDatasource.ts#L28

it's something from core grafana, and if we want to externalize the sql-using datasources, we have to externalize this code too, so it must not import things from core grafana.

there are multiple approaches how to fix this, this PR tries one approach, , another is at https://github.com/grafana/grafana/pull/74325

the problem is twofold:
1. there's no published alternative, `@grafana/runtime` does not provide `getTimeSrv()`
2. in general, `getTimeSrv()` is not a good thing. it's the dashboard's time-range, which is often correct, but in some cases, ,for example, explore with split two panes, there may be two separate "current time range" at the same time.

i'm looking for a solution, and have found that there are two ways to get to the place calling `getTimeSrv()`:
1. `metricFindQuery`. this one receives an optional time-range, so we can use that
2. `runSql`. this does not receive a time-range, but, on the other hand, it seems it's mostly (always?) used to run metadata sql queries, where the time-range is not important.


this PR tries the following solution:
1. move the "bad code" out of the shared sql code.
2. if `metricFindQuery` does not provide a time-range, fallback to "last 6 hours". (it always seem to receive the time-range, i have to check when it does not happen)

as you see, we are not really fixing the problem, we just move it to a different place. though, one could say a `runSql` API taking the timeRange is better, considering it will use a time-range.