### PR TITLE
Alerting: Fix annotations for cloud rules and for new rules when comming from panel

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -96,6 +96,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
   const uidFromParams = routeParams.id;
 
   const returnTo: string = (queryParams['returnTo'] as string | undefined) ?? '/alerting/list';
+  const fromPanel = returnTo.startsWith('/d/');
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
   const defaultValues: RuleFormValues = useMemo(() => {
@@ -258,7 +259,11 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
               {/* Step 1 */}
               <AlertRuleNameInput />
               {/* Step 2 */}
-              <QueryAndExpressionsStep editingExistingRule={!!existing} onDataChange={checkAlertCondition} />
+              <QueryAndExpressionsStep
+                editingExistingRule={!!existing}
+                onDataChange={checkAlertCondition}
+                fromPanel={fromPanel}
+              />
               {/* Step 3-4-5 */}
               {showDataSourceDependantStep && (
                 <>

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -15,7 +15,7 @@ import { DashboardDTO } from '../../../../../types';
 import { DashboardSearchItem, DashboardSearchItemType } from '../../../../search/types';
 import { mockStore } from '../../mocks';
 import { mockSearchApiResponse } from '../../mocks/grafanaApi';
-import { RuleFormValues } from '../../types/rule-form';
+import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { Annotation } from '../../utils/constants';
 import { getDefaultFormValues } from '../../utils/rule-form';
 
@@ -60,7 +60,9 @@ afterAll(() => {
 
 function FormWrapper({ formValues }: { formValues?: Partial<RuleFormValues> }) {
   const store = mockStore(() => null);
-  const formApi = useForm<RuleFormValues>({ defaultValues: { ...getDefaultFormValues(), ...formValues } });
+  const formApi = useForm<RuleFormValues>({
+    defaultValues: { ...getDefaultFormValues(), type: RuleFormType.grafana, ...formValues },
+  });
 
   return (
     <TestProvider store={store}>

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -10,7 +10,7 @@ import { Button, Field, Input, TextArea, useStyles2 } from '@grafana/ui';
 import { DashboardDataDTO } from 'app/types';
 
 import { dashboardApi } from '../../api/dashboardApi';
-import { RuleFormValues } from '../../types/rule-form';
+import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationLabels } from '../../utils/constants';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
@@ -31,6 +31,7 @@ const AnnotationsStep = () => {
     setValue,
   } = useFormContext<RuleFormValues>();
   const annotations = watch('annotations');
+  const type = watch('type');
 
   const { fields, append, remove } = useFieldArray({ control, name: 'annotations' });
 
@@ -91,6 +92,8 @@ const AnnotationsStep = () => {
   const handleEditDashboardAnnotation = () => {
     setShowPanelSelector(true);
   };
+  const showDashboardPicker = showPanelSelector && type === RuleFormType.grafana;
+  const showLinkToDashAndPanelButton = type === RuleFormType.grafana && !selectedDashboard;
 
   function getAnnotationsSectionDescription() {
     const docsLink =
@@ -190,14 +193,14 @@ const AnnotationsStep = () => {
             >
               Add custom annotation
             </Button>
-            {!selectedDashboard && (
+            {showLinkToDashAndPanelButton && (
               <Button type="button" variant="secondary" icon="dashboard" onClick={() => setShowPanelSelector(true)}>
                 Link dashboard and panel
               </Button>
             )}
           </div>
         </Stack>
-        {showPanelSelector && (
+        {showDashboardPicker && (
           <DashboardPicker
             isOpen={true}
             dashboardUid={selectedDashboardUid}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
@@ -81,6 +81,7 @@ export interface SmartAlertTypeDetectorProps {
   rulesSourcesWithRuler: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
   queries: AlertQuery[];
   onClickSwitch: () => void;
+  fromPanel: boolean;
 }
 
 const getContentText = (ruleFormType: RuleFormType, isEditing: boolean, dataSourceName: string, canSwitch: boolean) => {
@@ -125,13 +126,14 @@ export function SmartAlertTypeDetector({
   rulesSourcesWithRuler,
   queries,
   onClickSwitch,
+  fromPanel,
 }: SmartAlertTypeDetectorProps) {
   const { getValues } = useFormContext<RuleFormValues>();
 
   const [ruleFormType, dataSourceName] = getValues(['type', 'dataSourceName']);
   const styles = useStyles2(getStyles);
 
-  const canSwitch = getCanSwitch({ queries, ruleFormType, editingExistingRule, rulesSourcesWithRuler });
+  const canSwitch = !fromPanel && getCanSwitch({ queries, ruleFormType, editingExistingRule, rulesSourcesWithRuler });
 
   const typeTitle =
     ruleFormType === RuleFormType.cloudAlerting ? 'Data source-managed alert rule' : 'Grafana-managed alert rule';


### PR DESCRIPTION
**What is this feature?**

Currently we allow users to link a cloud rule to a dashboard&panel. Attempting to link panels to external alerts should be avoided, as it's not supported. Panels can only be linked to Grafana-managed alerts

This PR prevents:

- switching to cloud rule when creating an alert rule from a panel.
- selecting dashboard and panel when editing/creating a cloud rule.

It also restore dashboard and panel annotations selected when switching from cloud to Grafana-managed.

**Why do we need this feature?**

We cannot allow users to link panel to cloud rules if we are not using them for this case.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/33540275/1a87d3da-1b63-4a02-8ff0-8967d970f098



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
