### PR TITLE
Explore: Fix interpolating external data link in Explore table

### DIFF
--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, TimeZone } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime/src';
+import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import { Collapse, RadioButtonGroup, Table, AdHocFilterItem } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { PANEL_BORDER } from 'app/core/constants';
@@ -120,7 +120,7 @@ export class RawPrometheusContainer extends PureComponent<Props, PrometheusConta
         data: dataFrames,
         timeZone,
         theme: config.theme2,
-        replaceVariables: (v: string) => v,
+        replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
         fieldConfig: {
           defaults: {},
           overrides: [],

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { applyFieldOverrides, TimeZone, SplitOpen, DataFrame, LoadingState, FieldType } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { Table, AdHocFilterItem, PanelChrome } from '@grafana/ui';
 import { config } from 'app/core/config';
 import {
@@ -62,7 +63,7 @@ export class TableContainer extends PureComponent<Props> {
         data: dataFrames,
         timeZone,
         theme: config.theme2,
-        replaceVariables: (v: string) => v,
+        replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
         fieldConfig: {
           defaults: {},
           overrides: [],


### PR DESCRIPTION
Fixes #74333 (check the issue for reproduction steps)

Info:

* #71811 introduced support for **internal** data links in Graph (external links are still not interpolated)
* As part of the refactor, external links for Graph, Table and RawPromethues started to be routed through [generic links supplier](https://github.com/grafana/grafana/blob/v10.1.1/packages/grafana-data/src/field/fieldOverrides.ts#L201), that can [handle external data links with interpolation](https://github.com/grafana/grafana/blob/v10.1.1/packages/grafana-data/src/field/fieldOverrides.ts#L425)
* However, `applyFieldOverrides` for the above components had a no-op replace function (indeed it was not needed before the refactor, as external links were routed through `getFieldLinksForExplore` (which bounds TemplateSrv)
* Other components are not affected because they still use `getFieldLinksForExplore` (to be changed in #74353)

This PR ensures that the replace function is provided to Table and RawPrometheus components. The Graph still needs to be revisited because PanelRenderer overrides replace function. Though not sure if external data links on a graph are used at all). To be done in #74354.

This is just a fix for #74333. The code needs a follow-up to ensure all components use generic `getFieldLinks` for external data links and use `dataLinksSupplier` for internal links in Explore. To be done in #74353.