### PR TITLE
Adds levitate levignore configuration file to prevent breaking change notifications from expected typescript symbols

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -353,6 +353,7 @@ lerna.json @grafana/frontend-ops
 /lefthook.yml @grafana/frontend-ops
 /lefthook.rc @grafana/frontend-ops
 .husky/pre-commit @grafana/frontend-ops
+.levignore.js @grafana/plugins-platform-frontend
 
 
 # public folder

--- a/.levignore.js
+++ b/.levignore.js
@@ -1,0 +1,3 @@
+module.exports = {
+  removals: [/FeatureToggles\..*\b/],
+};

--- a/.levignore.js
+++ b/.levignore.js
@@ -1,3 +1,3 @@
 module.exports = {
-  removals: [/FeatureToggles\..*\b/],
+  removals: [/FeatureToggles\..*/],
 };

--- a/.levignore.js
+++ b/.levignore.js
@@ -1,3 +1,5 @@
 module.exports = {
   removals: [/FeatureToggles\..*/],
+  additions: [/FeatureToggles\..*/],
+  changes: [/FeatureToggles\..*/],
 };


### PR DESCRIPTION
**What is this feature?**

Adds a levignore file to prevent levitate reporting on FeatureToggles. This TS symbol is expected to constantly introduce breaking changes and we want to reduce the failed pipelines related to it.

**Why do we need this feature?**

Reduce failed pipelines related to FeatureToggles and breaking changes detected by levitate

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
