### PR TITLE
fix: revert module server initialization from CLI

### DIFF
--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -103,7 +103,7 @@ func RunServer(opts ServerOptions) error {
 		return err
 	}
 
-	s, err := server.InitializeModuleServer(
+	s, err := server.Initialize(
 		cfg,
 		server.Options{
 			PidFile:     PidFile,
@@ -132,7 +132,7 @@ func validPackaging(packaging string) string {
 	return "unknown"
 }
 
-func listenToSystemSignals(ctx context.Context, s *server.ModuleServer) {
+func listenToSystemSignals(ctx context.Context, s *server.Server) {
 	signalChan := make(chan os.Signal, 1)
 	sighupChan := make(chan os.Signal, 1)
 

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/modules"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/grafana-apiserver"
 	"github.com/grafana/grafana/pkg/setting"
 )


### PR DESCRIPTION
This is a "soft" reversion of #74188, going back to the original Initialize method in the CLI. I've left everything (wiresets, including enterprise; module server code, etc) else in place for now so we can continue to work on it, but I'm not opposed to removing more now if folks prefer.
