### PR TITLE
CI: Run auto-milestone workflow also on reopened pull-requests

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - closed
 
 jobs:


### PR DESCRIPTION
When someone closes a PR and then reopens it, auto-milestoning should happen again as the milestone was removed when the PR was originally closed.