### PR TITLE
Docs: Add entry for Tempo query-type template variables

### DIFF
--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -16,3 +16,14 @@ weight: -37
 # What’s new in Grafana Cloud
 
 Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana Cloud.
+
+## Support query-type template variables for Tempo data source
+
+<!-- Fabrizio Casati -->
+<!-- OSS, Enterprise -->
+
+_Generally available in Grafana Cloud_
+
+The Tempo data source now supports query-type template variables. This means that you can define your custom query-type vaiables in the settings of a dashboard and use them in your the TraceQL query builder or query editor.
+
+For more information, please refer to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/).

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -17,15 +17,15 @@ weight: -37
 
 Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana Cloud.
 
-## Support query-type template variables for Tempo data source
+## Query-type template variables for Tempo data source
 
 <!-- Fabrizio Casati -->
 <!-- OSS, Enterprise -->
 
 _Generally available in Grafana Cloud_
 
-The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo.
+The Tempo data source now supports query-type template variables. With this update, you can create variables for which the values are a list of attribute names or attribute values seen on spans received by Tempo.
 
-To learn more, refer to the video demo below as well as to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/) in the Grafana documentation.
+To learn more, refer to the following video demo, as well as the [Grafana Variables documentation](/docs/grafana/latest/dashboards/variables/).
 
 {{< video-embed src="/media/docs/tempo/screen-recording-grafana-10.2-tempo-query-type-template-variables.mp4" >}}

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -24,6 +24,6 @@ Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana C
 
 _Generally available in Grafana Cloud_
 
-The Tempo data source now supports query-type template variables. This means that you can define your custom query-type vaiables in the settings of a dashboard and use them in your the TraceQL query builder or query editor.
+The Tempo data source now supports query-type template variables. This means that you can define your custom query-type variables in the settings of a dashboard and use them in your the TraceQL query builder or query editor.
 
 For more information, please refer to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/).

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -24,6 +24,6 @@ Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana C
 
 _Generally available in Grafana Cloud_
 
-The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo. 
+The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo.
 
 For more information, please refer to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/).

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -26,4 +26,4 @@ _Generally available in Grafana Cloud_
 
 The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo.
 
-For more information, please refer to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/).
+To learn more, refer to this [short video demo]( add link ) as well as to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/) in the Grafana documentation.

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -26,4 +26,6 @@ _Generally available in Grafana Cloud_
 
 The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo.
 
-To learn more, refer to this [short video demo]( add link ) as well as to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/) in the Grafana documentation.
+To learn more, refer to the video demo below as well as to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/) in the Grafana documentation.
+
+{{< video-embed src="/media/docs/tempo/screen-recording-grafana-10.2-tempo-query-type-template-variables.mp4" >}}

--- a/docs/sources/whatsnew/whats-new-next/index.md
+++ b/docs/sources/whatsnew/whats-new-next/index.md
@@ -24,6 +24,6 @@ Welcome to Grafana Cloud! Read on to learn about the newest changes to Grafana C
 
 _Generally available in Grafana Cloud_
 
-The Tempo data source now supports query-type template variables. This means that you can define your custom query-type variables in the settings of a dashboard and use them in your the TraceQL query builder or query editor.
+The Tempo data source now supports query-type template variables. With this, you can now create variables whose values are a list of attribute names or attribute values seen on spans received by Tempo. 
 
 For more information, please refer to the [Variables page](https://grafana.com/docs/grafana/latest/dashboards/variables/).


### PR DESCRIPTION
Add entry for Tempo query-type template variables in "What's New In Grafana" for 10.2.

Trying the new process to update "What's New In Grafana", as discussed on Slack.