### PR TITLE
Auth: Fix set basicrole to the previous role in UI on error from backend

### DIFF
--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -51,7 +51,7 @@ export const RolePicker = ({
   useEffect(() => {
     setSelectedBuiltInRole(basicRole);
     setSelectedRoles(appliedRoles);
-  }, [appliedRoles, basicRole]);
+  }, [appliedRoles, basicRole, onBasicRoleChange]);
 
   useEffect(() => {
     const dimensions = ref?.current?.getBoundingClientRect();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
- Fix for setting updated basic role in UI when update from backend fails, due to is missing permissions

**Why do we need this feature?**
Came from original request from a user having Grafana as a frontend for a proxy




**notes**:

previously: Changed role from Viewer -> Editor, and Editor stays even when backend fails.

https://github.com/grafana/grafana/assets/7727602/0caad20b-8a36-4dbc-ac06-12edf849009a




new: Changed role from Viewer -> Editor, Viewer stays

https://github.com/grafana/grafana/assets/7727602/2efc60a3-ce11-41aa-af3f-6bcc06e80e21



