### PR TITLE
Chore: AuthN/IdentitySynchronizer interface/impl compatibility wire fix

### DIFF
--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -42,7 +42,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
-	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authnimpl"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -348,8 +347,8 @@ var wireBasicSet = wire.NewSet(
 	tagimpl.ProvideService,
 	wire.Bind(new(tag.Service), new(*tagimpl.Service)),
 	authnimpl.ProvideService,
-	wire.Bind(new(authn.Service), new(*authnimpl.Service)),
-	wire.Bind(new(authn.IdentitySynchronizer), new(*authnimpl.Service)),
+	authnimpl.ProvideIdentitySynchronizer,
+	authnimpl.ProvideAuthnService,
 	supportbundlesimpl.ProvideService,
 	oasimpl.ProvideService,
 	wire.Bind(new(oauthserver.OAuth2Server), new(*oasimpl.OAuth2ServiceImpl)),

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -48,10 +48,14 @@ var (
 )
 
 // make sure service implements authn.Service interface
-var _ authn.Service = new(Service)
+func ProvideAuthnService(s *Service) authn.Service {
+	return s
+}
 
 // make sure service implements authn.IdentitySynchronizer interface
-var _ authn.IdentitySynchronizer = new(Service)
+func ProvideIdentitySynchronizer(s *Service) authn.IdentitySynchronizer {
+	return s
+}
 
 func ProvideService(
 	cfg *setting.Cfg, tracer tracing.Tracer,


### PR DESCRIPTION
This change resolves the following error in my fresh local checkout:

```
wire: /Users/artur/projects/grafana/grafana/pkg/server/wire.go:351:2: *github.com/grafana/grafana/pkg/services/authn/authnimpl.Service does not implement github.com/grafana/grafana/pkg/services/authn.Service
wire: /Users/artur/projects/grafana/grafana/pkg/server/wire.go:352:2: *github.com/grafana/grafana/pkg/services/authn/authnimpl.Service does not implement github.com/grafana/grafana/pkg/services/authn.IdentitySynchronizer
```