### PR TITLE
Cloudwatch: Bump grafana-aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "@emotion/react": "11.11.1",
     "@fingerprintjs/fingerprintjs": "^3.4.2",
     "@glideapps/glide-data-grid": "^5.2.1",
-    "@grafana/aws-sdk": "0.1.2",
+    "@grafana/aws-sdk": "0.1.3",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,13 +3613,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.1.2":
-  version: 0.1.2
-  resolution: "@grafana/aws-sdk@npm:0.1.2"
+"@grafana/aws-sdk@npm:0.1.3":
+  version: 0.1.3
+  resolution: "@grafana/aws-sdk@npm:0.1.3"
   dependencies:
     "@grafana/async-query-data": 0.1.4
     "@grafana/experimental": 1.1.0
-  checksum: ea0248c8458caeccfb5326db60fba36692868bf71ed17cb9aa9c6797e6acb9a90687cceaa274416841935b2f2ba362f80dec22f603351f180724f56bf2ed0450
+  checksum: 9126354c52722c029ed3d597576577502e17566375e711aa64e8df39277092a3269aa45b1c66d0873736276535decdcbb4618b7afde21418dc0a60268f2e69c8
   languageName: node
   linkType: hard
 
@@ -19215,7 +19215,7 @@ __metadata:
     "@emotion/react": 11.11.1
     "@fingerprintjs/fingerprintjs": ^3.4.2
     "@glideapps/glide-data-grid": ^5.2.1
-    "@grafana/aws-sdk": 0.1.2
+    "@grafana/aws-sdk": 0.1.3
     "@grafana/data": "workspace:*"
     "@grafana/e2e": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Bumps to the latest grafana-aws-sdk npm package to fix a small style bug, in which an instruction box was overly wide: https://github.com/grafana/grafana-aws-sdk-react/pull/59

**Why do we need this feature?**

To improve UI

**Who is this feature for?**

Users of new temporary credentials feature (in private beta) 

**Which issue(s) does this PR fix?**:

Relates to: https://github.com/grafana/oss-plugin-partnerships/issues/224

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
