### PR TITLE
Logging: Add `WithContextualAttributes` to pass log params based on the given context

### DIFF
--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -51,6 +51,14 @@ func init() {
 	}
 	logger := level.NewFilter(format(os.Stderr), level.AllowInfo())
 	root = newManager(logger)
+
+	RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
+		pFromCtx := ctx.Value(logParamsContextKey{})
+		if pFromCtx != nil {
+			return pFromCtx.([]any), true
+		}
+		return nil, false
+	})
 }
 
 // logManager manage loggers
@@ -270,10 +278,10 @@ func RegisterContextualLogProvider(mw ContextualLogProviderFunc) {
 	ctxLogProviders = append(ctxLogProviders, mw)
 }
 
-type LogParamsContextKey struct{}
+type logParamsContextKey struct{}
 
 func WithContextualAttributes(ctx context.Context, logParams []any) context.Context {
-	return context.WithValue(ctx, LogParamsContextKey{}, logParams)
+	return context.WithValue(ctx, logParamsContextKey{}, logParams)
 }
 
 var logLevels = map[string]level.Option{

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -280,8 +280,14 @@ func RegisterContextualLogProvider(mw ContextualLogProviderFunc) {
 
 type logParamsContextKey struct{}
 
+// WithContextualAttributes adds contextual attributes to the logger based on the given context.
+// That allows loggers further down the chain to automatically log those attributes.
 func WithContextualAttributes(ctx context.Context, logParams []any) context.Context {
-	return context.WithValue(ctx, logParamsContextKey{}, logParams)
+	p := logParams
+	if ctx.Value(logParamsContextKey{}) != nil {
+		p = append(ctx.Value(logParamsContextKey{}).([]any), logParams...)
+	}
+	return context.WithValue(ctx, logParamsContextKey{}, p)
 }
 
 var logLevels = map[string]level.Option{

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -18,7 +18,6 @@ import (
 	gokitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/go-stack/stack"
-	"github.com/google/uuid"
 	"github.com/mattn/go-isatty"
 	"gopkg.in/ini.v1"
 
@@ -33,7 +32,7 @@ var (
 	root            *logManager
 	now             = time.Now
 	logTimeFormat   = time.RFC3339Nano
-	ctxLogProviders = []contextualLogProviderFuncStruct{}
+	ctxLogProviders = []ContextualLogProviderFunc{}
 )
 
 const (
@@ -197,7 +196,7 @@ func (cl *ConcreteLogger) FromContext(ctx context.Context) Logger {
 	args := []any{}
 
 	for _, p := range ctxLogProviders {
-		if pArgs, exists := p.fun(ctx); exists {
+		if pArgs, exists := p(ctx); exists {
 			args = append(args, pArgs...)
 		}
 	}
@@ -265,24 +264,16 @@ func WithSuffix(ctxLogger *ConcreteLogger, ctx ...any) *ConcreteLogger {
 // ContextualLogProviderFunc contextual log provider function definition.
 type ContextualLogProviderFunc func(ctx context.Context) ([]any, bool)
 
-type contextualLogProviderFuncStruct struct {
-	fun func(ctx context.Context) ([]any, bool)
-	idx string
-}
-
 // RegisterContextualLogProvider registers a ContextualLogProviderFunc
 // that will be used to provide context when Logger.FromContext is called.
-func RegisterContextualLogProvider(mw ContextualLogProviderFunc) func() {
-	idx := uuid.NewString()
-	ctxLogProviders = append(ctxLogProviders, contextualLogProviderFuncStruct{fun: mw, idx: idx})
-	return func() {
-		for i, c := range ctxLogProviders {
-			if c.idx == idx {
-				ctxLogProviders = append(ctxLogProviders[:i], ctxLogProviders[i+1:]...)
-				return
-			}
-		}
-	}
+func RegisterContextualLogProvider(mw ContextualLogProviderFunc) {
+	ctxLogProviders = append(ctxLogProviders, mw)
+}
+
+type LogParamsContextKey struct{}
+
+func WithContextualAttributes(ctx context.Context, logParams []any) context.Context {
+	return context.WithValue(ctx, LogParamsContextKey{}, logParams)
 }
 
 var logLevels = map[string]level.Option{

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -325,7 +325,6 @@ func TestWithContextualAttributes_appendsContext(t *testing.T) {
 	t.Run("Appends arguments set previously", func(t *testing.T) {
 		scenario := newLoggerScenario(t, false)
 
-		// logs `"k1", "v1"` with the first context
 		ctx := context.Background()
 		ctx = WithContextualAttributes(ctx, []any{"k1", "v1"})
 		ctx = WithContextualAttributes(ctx, []any{"k2", "v2"})

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -322,7 +322,7 @@ func TestWithContextualAttributes_appendsContext(t *testing.T) {
 			"k2", "v2",
 		})
 	})
-	t.Run("Appends arguments set in previously", func(t *testing.T) {
+	t.Run("Appends arguments set previously", func(t *testing.T) {
 		scenario := newLoggerScenario(t, false)
 
 		// logs `"k1", "v1"` with the first context

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -61,13 +61,14 @@ const (
 var logger = plog.New("plugin.instrumentation")
 
 // instrumentPluginRequest instruments success rate and latency of `fn`
-func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.PluginContext, endpoint string, fn func() error) error {
+func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.PluginContext, endpoint string, fn func(ctx context.Context) error) error {
 	status := statusOK
 
 	start := time.Now()
 	timeBeforePluginRequest := log.TimeSinceStart(ctx, start)
 
-	err := fn()
+	ctx = instrumentContext(ctx, endpoint, *pluginCtx)
+	err := fn(ctx)
 	if err != nil {
 		status = statusError
 		if errors.Is(err, context.Canceled) {
@@ -129,23 +130,27 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	return err
 }
 
+func instrumentContext(ctx context.Context, endpoint string, pCtx backend.PluginContext) context.Context {
+	return log.WithContextualAttributes(ctx, []any{"endpoint", endpoint, "dsName", pCtx.DataSourceInstanceSettings.Name, "dsUID", pCtx.DataSourceInstanceSettings.UID, "pluginId", pCtx.PluginID})
+}
+
 type Cfg struct {
 	LogDatasourceRequests bool
 	Target                backendplugin.Target
 }
 
 // InstrumentCollectMetrics instruments collectMetrics.
-func InstrumentCollectMetrics(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func() error) error {
+func InstrumentCollectMetrics(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func(ctx context.Context) error) error {
 	return instrumentPluginRequest(ctx, cfg, req, EndpointCollectMetrics, fn)
 }
 
 // InstrumentCheckHealthRequest instruments checkHealth.
-func InstrumentCheckHealthRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func() error) error {
+func InstrumentCheckHealthRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func(ctx context.Context) error) error {
 	return instrumentPluginRequest(ctx, cfg, req, EndpointCheckHealth, fn)
 }
 
 // InstrumentCallResourceRequest instruments callResource.
-func InstrumentCallResourceRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, requestSize float64, fn func() error) error {
+func InstrumentCallResourceRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, requestSize float64, fn func(ctx context.Context) error) error {
 	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointCallResource,
 		string(cfg.Target)).Observe(requestSize)
 	return instrumentPluginRequest(ctx, cfg, req, EndpointCallResource, fn)
@@ -153,7 +158,7 @@ func InstrumentCallResourceRequest(ctx context.Context, req *backend.PluginConte
 
 // InstrumentQueryDataRequest instruments success rate and latency of query data requests.
 func InstrumentQueryDataRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg,
-	requestSize float64, fn func() error) error {
+	requestSize float64, fn func(ctx context.Context) error) error {
 	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointQueryData,
 		string(cfg.Target)).Observe(requestSize)
 	return instrumentPluginRequest(ctx, cfg, req, EndpointQueryData, fn)

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -67,6 +67,11 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	start := time.Now()
 	timeBeforePluginRequest := log.TimeSinceStart(ctx, start)
 
+	unregisterContextLog := log.RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
+		return []any{"endpoint", endpoint, "dsName", pluginCtx.DataSourceInstanceSettings.Name, "dsUID", pluginCtx.DataSourceInstanceSettings.UID}, true
+	})
+	defer unregisterContextLog()
+
 	err := fn()
 	if err != nil {
 		status = statusError

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -68,7 +68,7 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	timeBeforePluginRequest := log.TimeSinceStart(ctx, start)
 
 	unregisterContextLog := log.RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
-		return []any{"endpoint", endpoint, "dsName", pluginCtx.DataSourceInstanceSettings.Name, "dsUID", pluginCtx.DataSourceInstanceSettings.UID}, true
+		return []any{"endpoint", endpoint, "dsName", pluginCtx.DataSourceInstanceSettings.Name, "dsUID", pluginCtx.DataSourceInstanceSettings.UID, "pluginId", pluginCtx.PluginID}, true
 	})
 	defer unregisterContextLog()
 

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -52,10 +52,10 @@ const (
 	statusError     = "error"
 	statusCancelled = "cancelled"
 
-	EndpointCallResource   = "callResource"
-	EndpointCheckHealth    = "checkHealth"
-	EndpointCollectMetrics = "collectMetrics"
-	EndpointQueryData      = "queryData"
+	endpointCallResource   = "callResource"
+	endpointCheckHealth    = "checkHealth"
+	endpointCollectMetrics = "collectMetrics"
+	endpointQueryData      = "queryData"
 )
 
 var logger = plog.New("plugin.instrumentation")
@@ -141,25 +141,25 @@ type Cfg struct {
 
 // InstrumentCollectMetrics instruments collectMetrics.
 func InstrumentCollectMetrics(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func(ctx context.Context) error) error {
-	return instrumentPluginRequest(ctx, cfg, req, EndpointCollectMetrics, fn)
+	return instrumentPluginRequest(ctx, cfg, req, endpointCollectMetrics, fn)
 }
 
 // InstrumentCheckHealthRequest instruments checkHealth.
 func InstrumentCheckHealthRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func(ctx context.Context) error) error {
-	return instrumentPluginRequest(ctx, cfg, req, EndpointCheckHealth, fn)
+	return instrumentPluginRequest(ctx, cfg, req, endpointCheckHealth, fn)
 }
 
 // InstrumentCallResourceRequest instruments callResource.
 func InstrumentCallResourceRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, requestSize float64, fn func(ctx context.Context) error) error {
-	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointCallResource,
+	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, endpointCallResource,
 		string(cfg.Target)).Observe(requestSize)
-	return instrumentPluginRequest(ctx, cfg, req, EndpointCallResource, fn)
+	return instrumentPluginRequest(ctx, cfg, req, endpointCallResource, fn)
 }
 
 // InstrumentQueryDataRequest instruments success rate and latency of query data requests.
 func InstrumentQueryDataRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg,
 	requestSize float64, fn func(ctx context.Context) error) error {
-	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointQueryData,
+	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, endpointQueryData,
 		string(cfg.Target)).Observe(requestSize)
-	return instrumentPluginRequest(ctx, cfg, req, EndpointQueryData, fn)
+	return instrumentPluginRequest(ctx, cfg, req, endpointQueryData, fn)
 }

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -52,10 +52,10 @@ const (
 	statusError     = "error"
 	statusCancelled = "cancelled"
 
-	endpointCallResource   = "callResource"
-	endpointCheckHealth    = "checkHealth"
-	endpointCollectMetrics = "collectMetrics"
-	endpointQueryData      = "queryData"
+	EndpointCallResource   = "callResource"
+	EndpointCheckHealth    = "checkHealth"
+	EndpointCollectMetrics = "collectMetrics"
+	EndpointQueryData      = "queryData"
 )
 
 var logger = plog.New("plugin.instrumentation")
@@ -66,11 +66,6 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 
 	start := time.Now()
 	timeBeforePluginRequest := log.TimeSinceStart(ctx, start)
-
-	unregisterContextLog := log.RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
-		return []any{"endpoint", endpoint, "dsName", pluginCtx.DataSourceInstanceSettings.Name, "dsUID", pluginCtx.DataSourceInstanceSettings.UID, "pluginId", pluginCtx.PluginID}, true
-	})
-	defer unregisterContextLog()
 
 	err := fn()
 	if err != nil {
@@ -141,25 +136,25 @@ type Cfg struct {
 
 // InstrumentCollectMetrics instruments collectMetrics.
 func InstrumentCollectMetrics(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func() error) error {
-	return instrumentPluginRequest(ctx, cfg, req, endpointCollectMetrics, fn)
+	return instrumentPluginRequest(ctx, cfg, req, EndpointCollectMetrics, fn)
 }
 
 // InstrumentCheckHealthRequest instruments checkHealth.
 func InstrumentCheckHealthRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, fn func() error) error {
-	return instrumentPluginRequest(ctx, cfg, req, endpointCheckHealth, fn)
+	return instrumentPluginRequest(ctx, cfg, req, EndpointCheckHealth, fn)
 }
 
 // InstrumentCallResourceRequest instruments callResource.
 func InstrumentCallResourceRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg, requestSize float64, fn func() error) error {
-	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, endpointCallResource,
+	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointCallResource,
 		string(cfg.Target)).Observe(requestSize)
-	return instrumentPluginRequest(ctx, cfg, req, endpointCallResource, fn)
+	return instrumentPluginRequest(ctx, cfg, req, EndpointCallResource, fn)
 }
 
 // InstrumentQueryDataRequest instruments success rate and latency of query data requests.
 func InstrumentQueryDataRequest(ctx context.Context, req *backend.PluginContext, cfg Cfg,
 	requestSize float64, fn func() error) error {
-	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, endpointQueryData,
+	pluginRequestSizeHistogram.WithLabelValues("grafana-backend", req.PluginID, EndpointQueryData,
 		string(cfg.Target)).Observe(requestSize)
-	return instrumentPluginRequest(ctx, cfg, req, endpointQueryData, fn)
+	return instrumentPluginRequest(ctx, cfg, req, EndpointQueryData, fn)
 }

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -131,7 +131,12 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 }
 
 func instrumentContext(ctx context.Context, endpoint string, pCtx backend.PluginContext) context.Context {
-	return log.WithContextualAttributes(ctx, []any{"endpoint", endpoint, "dsName", pCtx.DataSourceInstanceSettings.Name, "dsUID", pCtx.DataSourceInstanceSettings.UID, "pluginId", pCtx.PluginID})
+	p := []any{"endpoint", endpoint, "pluginId", pCtx.PluginID}
+	if pCtx.DataSourceInstanceSettings != nil {
+		p = append(p, "dsName", pCtx.DataSourceInstanceSettings.Name)
+		p = append(p, "dsUID", pCtx.DataSourceInstanceSettings.UID)
+	}
+	return log.WithContextualAttributes(ctx, p)
 }
 
 type Cfg struct {

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -61,7 +61,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	err := instrumentation.InstrumentQueryDataRequest(ctx, &req.PluginContext, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
-	}, totalBytes, func() (innerErr error) {
+	}, totalBytes, func(ctx context.Context) (innerErr error) {
 		resp, innerErr = p.QueryData(ctx, req)
 		return
 	})
@@ -108,7 +108,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	err := instrumentation.InstrumentCallResourceRequest(ctx, &req.PluginContext, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
-	}, totalBytes, func() error {
+	}, totalBytes, func(ctx context.Context) error {
 		removeConnectionHeaders(req.Headers)
 		removeHopByHopHeaders(req.Headers)
 		removeNonAllowedHeaders(req.Headers)
@@ -157,7 +157,7 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 	err := instrumentation.InstrumentCollectMetrics(ctx, &req.PluginContext, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
-	}, func() (innerErr error) {
+	}, func(ctx context.Context) (innerErr error) {
 		resp, innerErr = p.CollectMetrics(ctx, req)
 		return
 	})
@@ -182,7 +182,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	err := instrumentation.InstrumentCheckHealthRequest(ctx, &req.PluginContext, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
-	}, func() (innerErr error) {
+	}, func(ctx context.Context) (innerErr error) {
 		resp, innerErr = p.CheckHealth(ctx, req)
 		return
 	})

--- a/pkg/plugins/manager/client/decorator.go
+++ b/pkg/plugins/manager/client/decorator.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/backendplugin/instrumentation"
 )
 
 // Decorator allows a plugins.Client to be decorated with middlewares.
@@ -32,6 +34,8 @@ func (d *Decorator) QueryData(ctx context.Context, req *backend.QueryDataRequest
 	}
 
 	client := clientFromMiddlewares(d.middlewares, d.client)
+
+	ctx = instrumentContext(ctx, instrumentation.EndpointQueryData, req.PluginContext)
 	return client.QueryData(ctx, req)
 }
 
@@ -44,6 +48,7 @@ func (d *Decorator) CallResource(ctx context.Context, req *backend.CallResourceR
 		return errors.New("sender cannot be nil")
 	}
 
+	ctx = instrumentContext(ctx, instrumentation.EndpointCallResource, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CallResource(ctx, req, sender)
 }
@@ -53,6 +58,7 @@ func (d *Decorator) CollectMetrics(ctx context.Context, req *backend.CollectMetr
 		return nil, errNilRequest
 	}
 
+	ctx = instrumentContext(ctx, instrumentation.EndpointCollectMetrics, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CollectMetrics(ctx, req)
 }
@@ -62,6 +68,7 @@ func (d *Decorator) CheckHealth(ctx context.Context, req *backend.CheckHealthReq
 		return nil, errNilRequest
 	}
 
+	ctx = instrumentContext(ctx, instrumentation.EndpointCheckHealth, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CheckHealth(ctx, req)
 }
@@ -121,6 +128,11 @@ func reverseMiddlewares(middlewares []plugins.ClientMiddleware) []plugins.Client
 	}
 
 	return reversed
+}
+
+func instrumentContext(ctx context.Context, endpoint string, pCtx backend.PluginContext) context.Context {
+	ctx = log.WithContextualAttributes(ctx, []any{"endpoint", endpoint, "dsName", pCtx.DataSourceInstanceSettings.Name, "dsUID", pCtx.DataSourceInstanceSettings.UID, "pluginId", pCtx.PluginID})
+	return ctx
 }
 
 var _ plugins.Client = &Decorator{}

--- a/pkg/plugins/manager/client/decorator.go
+++ b/pkg/plugins/manager/client/decorator.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/plugins/backendplugin/instrumentation"
 )
 
 // Decorator allows a plugins.Client to be decorated with middlewares.
@@ -35,7 +33,6 @@ func (d *Decorator) QueryData(ctx context.Context, req *backend.QueryDataRequest
 
 	client := clientFromMiddlewares(d.middlewares, d.client)
 
-	ctx = instrumentContext(ctx, instrumentation.EndpointQueryData, req.PluginContext)
 	return client.QueryData(ctx, req)
 }
 
@@ -48,7 +45,6 @@ func (d *Decorator) CallResource(ctx context.Context, req *backend.CallResourceR
 		return errors.New("sender cannot be nil")
 	}
 
-	ctx = instrumentContext(ctx, instrumentation.EndpointCallResource, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CallResource(ctx, req, sender)
 }
@@ -58,7 +54,6 @@ func (d *Decorator) CollectMetrics(ctx context.Context, req *backend.CollectMetr
 		return nil, errNilRequest
 	}
 
-	ctx = instrumentContext(ctx, instrumentation.EndpointCollectMetrics, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CollectMetrics(ctx, req)
 }
@@ -68,7 +63,6 @@ func (d *Decorator) CheckHealth(ctx context.Context, req *backend.CheckHealthReq
 		return nil, errNilRequest
 	}
 
-	ctx = instrumentContext(ctx, instrumentation.EndpointCheckHealth, req.PluginContext)
 	client := clientFromMiddlewares(d.middlewares, d.client)
 	return client.CheckHealth(ctx, req)
 }
@@ -128,11 +122,6 @@ func reverseMiddlewares(middlewares []plugins.ClientMiddleware) []plugins.Client
 	}
 
 	return reversed
-}
-
-func instrumentContext(ctx context.Context, endpoint string, pCtx backend.PluginContext) context.Context {
-	ctx = log.WithContextualAttributes(ctx, []any{"endpoint", endpoint, "dsName", pCtx.DataSourceInstanceSettings.Name, "dsUID", pCtx.DataSourceInstanceSettings.UID, "pluginId", pCtx.PluginID})
-	return ctx
 }
 
 var _ plugins.Client = &Decorator{}

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -1,8 +1,11 @@
 package pluginsintegration
 
 import (
+	"context"
+
 	"github.com/google/wire"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
@@ -145,6 +148,14 @@ func NewClientDecorator(
 ) (*client.Decorator, error) {
 	c := client.ProvideService(pluginRegistry, pCfg)
 	middlewares := CreateMiddlewares(cfg, oAuthTokenService, tracer, cachingService, features)
+
+	log.RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
+		pFromCtx := ctx.Value(log.LogParamsContextKey{})
+		if pFromCtx != nil {
+			return pFromCtx.([]any), true
+		}
+		return nil, false
+	})
 
 	return client.NewDecorator(c, middlewares...)
 }

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -1,11 +1,8 @@
 package pluginsintegration
 
 import (
-	"context"
-
 	"github.com/google/wire"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
@@ -148,14 +145,6 @@ func NewClientDecorator(
 ) (*client.Decorator, error) {
 	c := client.ProvideService(pluginRegistry, pCfg)
 	middlewares := CreateMiddlewares(cfg, oAuthTokenService, tracer, cachingService, features)
-
-	log.RegisterContextualLogProvider(func(ctx context.Context) ([]any, bool) {
-		pFromCtx := ctx.Value(log.LogParamsContextKey{})
-		if pFromCtx != nil {
-			return pFromCtx.([]any), true
-		}
-		return nil, false
-	})
 
 	return client.NewDecorator(c, middlewares...)
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds `WithContextualAttributes` method, that will just register some labels/log-parameters on the given context and return a new context with those values. If a new logger is created with `logger.FromContext`, those parameters will automatically be prepended.

This is especially useful for datasource loggers to also include the `endpoint`, `dsName`, `dsUID` and `pluginId`.