### PR TITLE
Sandbox: Fix plugins not loading due to wrong plugin module url

### DIFF
--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -52,7 +52,7 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     return pluginCode;
   } else {
     //local plugin loading
-    const response = await fetch('public/' + meta.module + '.js');
+    const response = await fetch(meta.module);
     let pluginCode = await response.text();
     pluginCode = patchPluginSourceMap(meta, pluginCode);
     pluginCode = patchPluginAPIs(pluginCode);
@@ -81,7 +81,7 @@ function patchPluginSourceMap(meta: PluginMeta, pluginCode: string): string {
       replaceWith += `//# sourceURL=module.js\n`;
     }
     // modify the source map url to point to the correct location
-    const sourceCodeMapUrl = `/public/${meta.module}.map`;
+    const sourceCodeMapUrl = meta.module + '.map';
     replaceWith += `//# sourceMappingURL=${sourceCodeMapUrl}`;
 
     return pluginCode.replace('//# sourceMappingURL=module.js.map', replaceWith);


### PR DESCRIPTION
**What is this feature?**

Fixes plugins not loading inside the sandbox.

**Why do we need this feature?**

Plugins are not loading inside the sandbox.

**Who is this feature for?**

Grafana plugin developers and users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
