### PR TITLE
Bug: Allow to uninstall a deprecated plugin

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -69,4 +69,24 @@ describe('InstallControlsButton', () => {
       });
     }
   );
+
+  it("should allow to uninstall a plugin even if it's unpublished", () => {
+    render(
+      <TestProvider>
+        <InstallControlsButton plugin={{ ...plugin, isPublished: false }} pluginStatus={PluginStatus.UNINSTALL} />
+      </TestProvider>
+    );
+    const el = screen.getByRole('button');
+    expect(el).toHaveTextContent(/uninstall/i);
+    expect(el).toBeVisible();
+  });
+
+  it('should not render install or upgrade buttons if the plugin is unpublished', () => {
+    render(
+      <TestProvider>
+        <InstallControlsButton plugin={{ ...plugin, isPublished: false }} pluginStatus={PluginStatus.INSTALL} />
+      </TestProvider>
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
 });

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -110,6 +110,11 @@ export function InstallControlsButton({
     );
   }
 
+  if (!plugin.isPublished) {
+    // Cannot be updated or installed
+    return null;
+  }
+
   if (pluginStatus === PluginStatus.UPDATE) {
     return (
       <HorizontalGroup align="flex-start" width="auto" height="auto">

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -16,8 +16,8 @@ import { CatalogPlugin, PluginStatus, PluginTabIds, Version } from '../../types'
 type InstallControlsButtonProps = {
   plugin: CatalogPlugin;
   pluginStatus: PluginStatus;
-  hasInstallWarning: boolean;
   latestCompatibleVersion?: Version;
+  hasInstallWarning?: boolean;
   setNeedReload?: (needReload: boolean) => void;
 };
 

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -16,6 +16,7 @@ import { CatalogPlugin, PluginStatus, PluginTabIds, Version } from '../../types'
 type InstallControlsButtonProps = {
   plugin: CatalogPlugin;
   pluginStatus: PluginStatus;
+  hasInstallWarning: boolean;
   latestCompatibleVersion?: Version;
   setNeedReload?: (needReload: boolean) => void;
 };
@@ -24,6 +25,7 @@ export function InstallControlsButton({
   plugin,
   pluginStatus,
   latestCompatibleVersion,
+  hasInstallWarning,
   setNeedReload,
 }: InstallControlsButtonProps) {
   const dispatch = useDispatch();
@@ -110,7 +112,7 @@ export function InstallControlsButton({
     );
   }
 
-  if (!plugin.isPublished) {
+  if (!plugin.isPublished || hasInstallWarning) {
     // Cannot be updated or installed
     return null;
   }

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -33,15 +33,14 @@ export const PluginActions = ({ plugin }: Props) => {
       ? PluginStatus.UPDATE
       : PluginStatus.UNINSTALL
     : PluginStatus.INSTALL;
-  const isInstallControlsDisabled =
-    plugin.isCore || plugin.isDisabled || !isInstallControlsEnabled() || hasInstallWarning;
+  const isInstallControlsDisabled = plugin.isCore || plugin.isDisabled || !isInstallControlsEnabled();
 
   return (
     <VerticalGroup>
       <HorizontalGroup>
         {!isInstallControlsDisabled && (
           <>
-            {isExternallyManaged && plugin.isPublished ? (
+            {isExternallyManaged && !hasInstallWarning ? (
               <ExternallyManagedButton
                 pluginId={plugin.id}
                 pluginStatus={pluginStatus}

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -52,6 +52,7 @@ export const PluginActions = ({ plugin }: Props) => {
                 latestCompatibleVersion={latestCompatibleVersion}
                 pluginStatus={pluginStatus}
                 setNeedReload={setNeedReload}
+                hasInstallWarning={hasInstallWarning}
               />
             )}
           </>

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -41,7 +41,7 @@ export const PluginActions = ({ plugin }: Props) => {
       <HorizontalGroup>
         {!isInstallControlsDisabled && (
           <>
-            {isExternallyManaged ? (
+            {isExternallyManaged && plugin.isPublished ? (
               <ExternallyManagedButton
                 pluginId={plugin.id}
                 pluginStatus={pluginStatus}

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -291,6 +291,7 @@ export const hasInstallControlWarning = (
     (plugin.isEnterprise && !featureEnabled('enterprise.plugins')) ||
     plugin.isDev ||
     (!hasPermission && !isExternallyManaged) ||
+    !plugin.isPublished ||
     !isCompatible ||
     !isRemotePluginsAvailable
   );

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -291,7 +291,6 @@ export const hasInstallControlWarning = (
     (plugin.isEnterprise && !featureEnabled('enterprise.plugins')) ||
     plugin.isDev ||
     (!hasPermission && !isExternallyManaged) ||
-    !plugin.isPublished ||
     !isCompatible ||
     !isRemotePluginsAvailable
   );

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -324,12 +324,13 @@ describe('Plugin details page', () => {
       expect(await queryByRole('button', { name: /install/i })).toBeInTheDocument();
     });
 
-    it('should not display install button for enterprise plugins if license is invalid', async () => {
+    it('should not display install button for enterprise plugins if license is invalid (but allow uninstall)', async () => {
       config.licenseInfo.enabledFeatures = {};
 
       const { queryByRole, queryByText } = renderPluginDetails({ id, isInstalled: true, isEnterprise: true });
 
-      expect(await queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+      expect(await queryByRole('button', { name: /Install/ })).not.toBeInTheDocument();
+      expect(await queryByRole('button', { name: /Uninstall/ })).toBeInTheDocument();
       expect(queryByText(/no valid Grafana Enterprise license detected/i)).toBeInTheDocument();
       expect(queryByRole('link', { name: /learn more/i })).toBeInTheDocument();
     });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allow to uninstall a plugin if it is "not published". Useful when a plugin is deprecated and is no longer published.

![image](https://github.com/grafana/grafana/assets/4025665/e1ab0952-356d-433d-92c6-fe12643f514e)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45281

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
