### PR TITLE
Graphite: Use DataSourceWithBackend to support public dashboards

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -9,7 +9,6 @@ import {
   DataFrame,
   DataQueryRequest,
   DataQueryResponse,
-  DataSourceApi,
   DataSourceWithQueryExportSupport,
   dateMath,
   dateTime,
@@ -21,7 +20,7 @@ import {
   toDataFrame,
   getSearchFilterScopedVar,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
@@ -65,7 +64,7 @@ function convertGlobToRegEx(text: string): string {
 }
 
 export class GraphiteDatasource
-  extends DataSourceApi<GraphiteQuery, GraphiteOptions, GraphiteQueryImportConfiguration>
+  extends DataSourceWithBackend<GraphiteQuery, GraphiteOptions>
   implements DataSourceWithQueryExportSupport<GraphiteQuery>
 {
   basicAuth: string;


### PR DESCRIPTION
**What is this feature?**
This changes the implementation of the Graphite data source to use `DataSourceWithBackend` instead of `DataSourceApi` to allow for calling `super.query`. 

Work needed to complete for implementing [`super.query`](https://github.com/grafana/grafana/blob/e7a2c95586b91249c923955d2818dd88b2f0f4d7/public/app/plugins/datasource/graphite/datasource.ts#L194-L247):
- [ ] refactor `buildGraphiteParams` to update options
  - [ ] interpolate scopedVars
  - [ ] handle nested queries
  - [ ] fix interval format
- [ ] handle metric tank data
  - [ ] `params.push('meta=true');`
- [ ]  add tracing headers for dashboard id or panel id
- [ ] check what is implemented in `doGraphiteRequest` compare to backend
  - [ ] auth type sent in options

**Why do we need this feature?**
This is required to support public dashboards.
Context: public dahsboards squad merged this [change](https://github.com/grafana/grafana/pull/73708) to fully support Prometheus datasource in public dashboards. This requires data sources to implement DataSourceWithBackend  and call super.query. Because of this change and because Graphite does not use DataSourceWithBackend nor super.query we have this [escalation](https://github.com/grafana/support-escalations/issues/7340). Graphite which is not working anymore because this DS is not extending DataSourceWithBackend and making a special request to another endpoint https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/graphite/datasource.ts#L233.

**Who is this feature for?**
Public dashboards users.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana/issues/74491

**Special notes for your reviewer:**
To test this, I used explore, dashboards, created variables and annotations and rans the test suite. Everything looks ok but I want to get some more eyes on this.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
