### PR TITLE
CloudWatch Logs: Fix log query display name when used with expressions

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -543,7 +543,7 @@ func TestGroupingResultsWithNumericField(t *testing.T) {
 	assert.ElementsMatch(t, expectedGroupedFrames, groupedResults)
 }
 
-func TestGroupingResultsWithRemoveNonTimeTrue(t *testing.T) {
+func TestGroupingResultsWithFromSyncQueryTrue(t *testing.T) {
 	logField := data.NewField("@log", data.Labels{}, []*string{
 		aws.String("fakelog-a"),
 		aws.String("fakelog-b"),
@@ -602,6 +602,8 @@ func TestGroupingResultsWithRemoveNonTimeTrue(t *testing.T) {
 			RefID: "",
 		},
 	}
+	expectedGroupedFrames[0].Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: "fakelog-a1"}
+	expectedGroupedFrames[1].Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: "fakelog-b1"}
 
 	groupedResults, err := groupResults(fakeDataFrame, []string{"@log", "stream"}, true)
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Fixes issue where CloudWatch Logs queries with expressions would label it as the name twice:
![image](https://github.com/grafana/grafana/assets/5421859/5a2db938-5e0d-4909-b2da-a28add2f5d21)

now only shows the name once:
![Screenshot 2023-09-06 at 6 05 33 PM](https://github.com/grafana/grafana/assets/5421859/ffac00a2-ee5a-4790-b396-0034e637f73b)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #69002

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
