### PR TITLE
BarChart: Fixes barchart tooltip styling

### DIFF
--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -134,9 +134,15 @@ const getStyles = (theme: GrafanaTheme2) => {
       background: ${theme.components.tooltip.background};
       border-radius: ${theme.shape.borderRadius(2)};
     `,
+    header: css`
+      background: ${theme.colors.background.secondary};
+      align-items: center;
+      align-content: center;
+      display: flex;
+      padding-bottom: ${theme.spacing(1)};
+    `,
     title: css`
       font-weight: ${theme.typography.fontWeightMedium};
-      padding-right: ${theme.spacing(2)};
       overflow: hidden;
       display: inline-block;
       white-space: nowrap;

--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -117,8 +117,8 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
       <table className={styles.infoWrap}>
         <tbody>
           {displayValues.map((displayValue, i) => (
-            <tr key={`${i}/${rowIndex}`} className={displayValue.highlight ? styles.highlight : ''}>
-              <th>{displayValue.name}:</th>
+            <tr key={`${i}/${rowIndex}`}>
+              <th>{displayValue.name}</th>
               <td>{renderValue(displayValue.valueString)}</td>
             </tr>
           ))}
@@ -128,22 +128,11 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
     </div>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => {
-  const bg = theme.isDark ? theme.v1.palette.dark2 : theme.v1.palette.white;
-  const headerBg = theme.isDark ? theme.v1.palette.dark9 : theme.v1.palette.gray5;
-  const tableBgOdd = theme.isDark ? theme.v1.palette.dark3 : theme.v1.palette.gray6;
-
   return {
     wrapper: css`
-      background: ${bg};
-      border: 1px solid ${headerBg};
+      background: ${theme.components.tooltip.background};
       border-radius: ${theme.shape.borderRadius(2)};
-    `,
-    header: css`
-      background: ${headerBg};
-      padding: 6px 10px;
-      display: flex;
     `,
     title: css`
       font-weight: ${theme.typography.fontWeightMedium};
@@ -155,24 +144,24 @@ const getStyles = (theme: GrafanaTheme2) => {
       flex-grow: 1;
     `,
     infoWrap: css`
-      padding: 8px;
+      padding: ${theme.spacing(1)};
+      background: transparent;
+      border: none;
       th {
         font-weight: ${theme.typography.fontWeightMedium};
-        padding: ${theme.spacing(0.25, 2)};
+        padding: ${theme.spacing(0.25, 2, 0.25, 0)};
       }
+
       tr {
-        background-color: ${theme.colors.background.primary};
-        &:nth-child(even) {
-          background-color: ${tableBgOdd};
+        border-bottom: 1px solid ${theme.colors.border.weak};
+        &:last-child {
+          border-bottom: none;
         }
       }
     `,
-    highlight: css`
-      /* !important is required to overwrite default table styles */
-      background: ${theme.colors.action.hover} !important;
-    `,
+    highlight: css``,
     link: css`
-      color: #6e9fff;
+      color: ${theme.colors.text.link};
     `,
   };
 };


### PR DESCRIPTION
The barchart tooltip looks very buggy with internal table border, and striped table, And inconsistent padding (no padding on right side of table)

* Remove table border
* Remove table background
* Align tooltip background with TimeSeriesPanel tooltip (and other dataviz tooltips) 
* Fix padding / spacing issues
* Add border between rows 

Before dark:
![Screenshot from 2023-09-07 08-51-43](https://github.com/grafana/grafana/assets/10999/8e3829a1-849f-425f-afe2-6cdc373d8372)
Before light:
![image](https://github.com/grafana/grafana/assets/10999/0907dd4f-2a2c-4141-a1e7-b18cc3510708)

After dark:
![image](https://github.com/grafana/grafana/assets/10999/d1ecfba6-463d-479b-a9d7-791112d82dfd)

After light:
![image](https://github.com/grafana/grafana/assets/10999/5e86b66b-6aef-473e-909d-f3d69e7b3d7c)


