### PR TITLE
Internationalization: Set lang of HTML page to user language preference

### DIFF
--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="[[.User.Language]]">
   <head>
     [[ if and .CSPEnabled .IsDevelopmentEnv ]]
     <!-- Cypress overwrites CSP headers in HTTP requests, so this is required for e2e tests-->


### PR DESCRIPTION
**What is this feature?**

Set "lang" attribute of `<html>` element to the user language setting.

**Why do we need this feature?**

HTML "lang" attribute should reflect the actual language used in texts.
It is important for accessibility functions (screen readers), but also usable in CSS.
Panel plugins can also read the lang attribute for i18n.

**Who is this feature for?**

International users.
