### PR TITLE
Plugins: Unset annotation editor variables

### DIFF
--- a/public/app/features/annotations/components/AnnotationResultMapper.tsx
+++ b/public/app/features/annotations/components/AnnotationResultMapper.tsx
@@ -126,14 +126,11 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
     let picker = [...fieldNames];
     const current = mapping.value;
     let currentValue = fieldNames.find((f) => current === f.value);
-    if (current) {
-      picker = [...fieldNames];
-      if (!currentValue) {
-        picker.push({
-          label: current,
-          value: current,
-        });
-      }
+    if (current && !currentValue) {
+      picker.push({
+        label: current,
+        value: current,
+      });
     }
 
     let value = first ? first[row.key] : '';

--- a/public/app/features/annotations/components/AnnotationResultMapper.tsx
+++ b/public/app/features/annotations/components/AnnotationResultMapper.tsx
@@ -99,6 +99,15 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
 
   onFieldNameChange = (k: keyof AnnotationEvent, v: SelectableValue<string>) => {
     const mappings = this.props.mappings || {};
+
+    // in case of clearing the value
+    if (!v) {
+      const newMappings = { ...this.props.mappings };
+      delete newMappings[k];
+      this.props.change(newMappings);
+      return;
+    }
+
     const mapping = mappings[k] || {};
 
     this.props.change({
@@ -114,7 +123,7 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
   renderRow(row: AnnotationFieldInfo, mapping: AnnotationEventFieldMapping, first?: AnnotationEvent) {
     const { fieldNames } = this.state;
 
-    let picker = fieldNames;
+    let picker = [...fieldNames];
     const current = mapping.value;
     let currentValue = fieldNames.find((f) => current === f.value);
     if (current) {
@@ -139,7 +148,7 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
     return (
       <tr key={row.key}>
         <td>
-          {row.key}{' '}
+          {row.label || row.key}{' '}
           {row.help && (
             <Tooltip content={row.help}>
               <Icon name="info-circle" />
@@ -166,6 +175,7 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
             }}
             noOptionsMessage="Unknown field names"
             allowCustomValue={true}
+            isClearable
           />
         </td>
         <td>{`${value}`}</td>

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -103,7 +103,7 @@ export const annotationEventNames: AnnotationFieldInfo[] = [
     field: (frame: DataFrame) => frame.fields.find((f) => f.type === FieldType.time),
     placeholder: 'time, or the first time field',
   },
-  { key: 'timeEnd', label: 'end time',  help: 'When this field is defined, the annotation will be treated as a range' },
+  { key: 'timeEnd', label: 'end time', help: 'When this field is defined, the annotation will be treated as a range' },
   {
     key: 'title',
   },

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -89,7 +89,7 @@ interface AnnotationEventFieldSetter {
 
 export interface AnnotationFieldInfo {
   key: keyof AnnotationEvent;
-
+  label?: string;
   split?: string;
   field?: (frame: DataFrame) => Field | undefined;
   placeholder?: string;
@@ -103,7 +103,7 @@ export const annotationEventNames: AnnotationFieldInfo[] = [
     field: (frame: DataFrame) => frame.fields.find((f) => f.type === FieldType.time),
     placeholder: 'time, or the first time field',
   },
-  { key: 'timeEnd', help: 'When this field is defined, the annotation will be treated as a range' },
+  { key: 'timeEnd', label: 'end time',  help: 'When this field is defined, the annotation will be treated as a range' },
   {
     key: 'title',
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Unset annotation editor variables in the default annotation form provided for datasource plugins which have an annotation property.
- Change one of the variables label from "timeEnd" to "end time"

**Why do we need this feature?**

This feature is needed so the editor variables can be reset to their original state.

**Who is this feature for?**

Query Annotation users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/47452

**Special notes for your reviewer:**

![2023-09-07_11-27](https://github.com/grafana/grafana/assets/5558280/fd4975ce-c69f-4f91-860d-424423e769d2)

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
