### PR TITLE
[v10.1.x] CI: Run auto-milestone workflow also on reopened pull-requests

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -2,6 +2,8 @@ name: Auto-milestone
 on:
   pull_request:
     types:
+      - opened
+      - reopened
       - closed
 
 jobs:


### PR DESCRIPTION
Backport 94c9bee18196c9b03e9bcd9ebc60a2d9423fa1c0 from #74390

---

When someone closes a PR and then reopens it, auto-milestoning should happen again as the milestone was removed when the PR was originally closed.
