### PR TITLE
postgres/sql: fix imports

### DIFF
--- a/public/app/features/plugins/sql/ResponseParser.ts
+++ b/public/app/features/plugins/sql/ResponseParser.ts
@@ -1,7 +1,8 @@
 import { uniqBy } from 'lodash';
 
 import { DataFrame, MetricFindValue } from '@grafana/data';
-import { ResponseParser as ResponseParserType } from 'app/features/plugins/sql/types';
+
+import { ResponseParser as ResponseParserType } from './types';
 
 export class ResponseParser implements ResponseParserType {
   transformMetricFindResponse(frame: DataFrame): MetricFindValue[] {

--- a/public/app/features/plugins/sql/ResponseParser.ts
+++ b/public/app/features/plugins/sql/ResponseParser.ts
@@ -2,7 +2,7 @@ import { uniqBy } from 'lodash';
 
 import { DataFrame, MetricFindValue } from '@grafana/data';
 
-import { ResponseParser as ResponseParserType } from './types';
+import type { ResponseParser as ResponseParserType } from './types';
 
 export class ResponseParser implements ResponseParserType {
   transformMetricFindResponse(frame: DataFrame): MetricFindValue[] {

--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -14,6 +14,7 @@ import {
   CoreApp,
   getSearchFilterScopedVar,
   LegacyMetricFindQueryOptions,
+  VariableWithMultiSupport,
 } from '@grafana/data';
 import { EditorMode } from '@grafana/experimental';
 import {
@@ -22,13 +23,12 @@ import {
   FetchResponse,
   getBackendSrv,
   getTemplateSrv,
+  toDataQueryResponse,
   TemplateSrv,
   reportInteraction,
 } from '@grafana/runtime';
-import { toDataQueryResponse } from '@grafana/runtime/src/utils/queryResponse';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
-import { VariableWithMultiSupport } from '../../../variables/types';
 import { ResponseParser } from '../ResponseParser';
 import { SqlQueryEditor } from '../components/QueryEditor';
 import { MACRO_NAMES } from '../constants';

--- a/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
@@ -8,6 +8,7 @@ import {
   updateDatasourcePluginJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import {
   Alert,
   InlineSwitch,
@@ -19,7 +20,6 @@ import {
   SecretInput,
   Link,
 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { ConnectionLimits } from 'app/features/plugins/sql/components/configuration/ConnectionLimits';
 import { TLSSecretsConfig } from 'app/features/plugins/sql/components/configuration/TLSSecretsConfig';
 import { useMigrateDatabaseFields } from 'app/features/plugins/sql/components/configuration/useMigrateDatabaseFields';

--- a/public/app/plugins/datasource/postgres/configuration/useAutoDetectFeatures.ts
+++ b/public/app/plugins/datasource/postgres/configuration/useAutoDetectFeatures.ts
@@ -8,8 +8,7 @@ import {
   updateDatasourcePluginJsonDataOption,
   updateDatasourcePluginOption,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
+import { getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 
 import { PostgresDatasource } from '../datasource';
 import { PostgresOptions, PostgresTLSModes, SecureJsonData } from '../types';
@@ -38,7 +37,7 @@ export function useAutoDetectFeatures({ props, setVersionOptions }: Options) {
         // This is needed or else we get an error when we try to save the datasource.
         updateDatasourcePluginOption({ options, onOptionsChange }, 'version', result.datasource.version);
       } else {
-        const datasource = await getDatasourceSrv().loadDatasource(options.name);
+        const datasource = await getDataSourceSrv().get(options.name);
 
         if (datasource instanceof PostgresDatasource) {
           const version = await datasource.getVersion();

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -1,9 +1,9 @@
 import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { LanguageDefinition } from '@grafana/experimental';
+import { TemplateSrv } from '@grafana/runtime';
 import { SqlDatasource } from 'app/features/plugins/sql/datasource/SqlDatasource';
 import { DB, SQLQuery, SQLSelectableValue } from 'app/features/plugins/sql/types';
 import { formatSQL } from 'app/features/plugins/sql/utils/formatSQL';
-import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { PostgresQueryModel } from './PostgresQueryModel';
 import { getSchema, getTimescaleDBVersion, getVersion, showTables } from './postgresMetaQuery';


### PR DESCRIPTION
i adjusted the imports in the code, so that we do not import from core-grafana, only from `@grafana/*` packages. i only fixed the easy imports, some still remain that will need a more complex fix.

how to test:
- use the postgres datasource, create a new one, verify it works