### PR TITLE
Fix regex for Tempo version

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -232,7 +232,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       // and instead it is in the form `<branch>-<revision>`, possibly with a `-WIP` suffix (e.g., `main-12bdeff-WIP`).
       // Thus, if the version is in the form `<branch>-<revision>`, assume that we are on the most updated
       // Tempo version and thus any feature should be considered enabled
-      if (/^.*-[a-zA-Z0-9_]{7}(-WIP)?$/.test(actualVersion)) {
+      if (/^.*-[a-zA-Z0-9_]+(-WIP)?$/.test(actualVersion)) {
         return true;
       }
 


### PR DESCRIPTION
Fix issue discussed on Slack by relaxing the regular expression to parse the Tempo version.

I was tricked by the following part in Tempo, but apparently the hash can be longer than 7:
![image](https://github.com/grafana/grafana/assets/135109076/2e07323c-6e05-4b89-9d17-e7af58de1f55)

Edit: improved even further in [this PR](https://github.com/grafana/grafana/pull/74547).
