### PR TITLE
Tempo: Fix metricSummary sorting in spanCount and errorPercentage

### DIFF
--- a/public/app/plugins/datasource/tempo/metricsSummary.test.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.test.ts
@@ -120,7 +120,7 @@ describe('MetricsSummary', () => {
                 "name": "spanCount",
                 "type": "number",
                 "values": [
-                  "10",
+                  10,
                 ],
               },
               {
@@ -134,7 +134,7 @@ describe('MetricsSummary', () => {
                 "name": "errorPercentage",
                 "type": "number",
                 "values": [
-                  "10",
+                  10,
                 ],
               },
               {
@@ -148,7 +148,7 @@ describe('MetricsSummary', () => {
                 "name": "p50",
                 "type": "number",
                 "values": [
-                  "1",
+                  1,
                 ],
               },
               {
@@ -162,7 +162,7 @@ describe('MetricsSummary', () => {
                 "name": "p90",
                 "type": "number",
                 "values": [
-                  "2",
+                  2,
                 ],
               },
               {
@@ -176,7 +176,7 @@ describe('MetricsSummary', () => {
                 "name": "p95",
                 "type": "number",
                 "values": [
-                  "3",
+                  3,
                 ],
               },
               {
@@ -190,7 +190,7 @@ describe('MetricsSummary', () => {
                 "name": "p99",
                 "type": "number",
                 "values": [
-                  "4",
+                  4,
                 ],
               },
             ],
@@ -219,15 +219,15 @@ describe('MetricsSummary', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "contains_sink": "true",
-          "errorPercentage": "10",
+          "errorPercentage": 10,
           "kind": "server",
-          "p50": "1",
-          "p90": "2",
-          "p95": "3",
-          "p99": "4",
+          "p50": 1,
+          "p90": 2,
+          "p95": 3,
+          "p99": 4,
           "room": "kitchen",
           "span.http.status_code": 208,
-          "spanCount": "10",
+          "spanCount": 10,
           "spanKind": "server",
           "spanStatus": "ok",
           "temperature": 38.1,

--- a/public/app/plugins/datasource/tempo/metricsSummary.test.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.test.ts
@@ -118,7 +118,7 @@ describe('MetricsSummary', () => {
                   "displayNameFromDS": "Span count",
                 },
                 "name": "spanCount",
-                "type": "string",
+                "type": "number",
                 "values": [
                   "10",
                 ],
@@ -132,7 +132,7 @@ describe('MetricsSummary', () => {
                   "unit": "percent",
                 },
                 "name": "errorPercentage",
-                "type": "string",
+                "type": "number",
                 "values": [
                   "10",
                 ],

--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -108,7 +108,7 @@ export function createTableFrameFromMetricsSummaryQuery(
 
 export const transformToMetricsData = (data: MetricsSummary) => {
   const errorPercentage = data.errorSpanCount
-    ? (parseInt(data.errorSpanCount, 10) / parseInt(data.spanCount, 10)) * 100
+    ? (getNumberForMetric(data.errorSpanCount) / getNumberForMetric(data.spanCount)) * 100
     : '0%';
 
   const metricsData: MetricsData = {

--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -76,12 +76,12 @@ export function createTableFrameFromMetricsSummaryQuery(
       },
       {
         name: 'spanCount',
-        type: FieldType.string,
+        type: FieldType.number,
         config: { displayNameFromDS: 'Span count', custom: { width: 150 } },
       },
       {
         name: 'errorPercentage',
-        type: FieldType.string,
+        type: FieldType.number,
         config: { displayNameFromDS: 'Error', unit: 'percent', custom: { width: 150 } },
       },
       getPercentileRow('p50'),

--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -32,12 +32,12 @@ type Series = {
 };
 
 type MetricsData = {
-  spanCount: string;
-  errorPercentage: string;
-  p50: string;
-  p90: string;
-  p95: string;
-  p99: string;
+  spanCount: number;
+  errorPercentage: number | string;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
   [key: string]: string | number;
 };
 
@@ -108,17 +108,17 @@ export function createTableFrameFromMetricsSummaryQuery(
 
 export const transformToMetricsData = (data: MetricsSummary) => {
   const errorPercentage = data.errorSpanCount
-    ? ((parseInt(data.errorSpanCount, 10) / parseInt(data.spanCount, 10)) * 100).toString()
+    ? (parseInt(data.errorSpanCount, 10) / parseInt(data.spanCount, 10)) * 100
     : '0%';
 
   const metricsData: MetricsData = {
     kind: 'server', // so the user knows all results are of kind = server
-    spanCount: data.spanCount,
+    spanCount: getNumerForMetric(data.spanCount),
     errorPercentage,
-    p50: data.p50,
-    p90: data.p90,
-    p95: data.p95,
-    p99: data.p99,
+    p50: getNumerForMetric(data.p50),
+    p90: getNumerForMetric(data.p90),
+    p95: getNumerForMetric(data.p95),
+    p99: getNumerForMetric(data.p99),
   };
 
   data.series.forEach((series: Series) => {
@@ -260,6 +260,11 @@ const getPercentileRow = (name: string) => {
       },
     },
   };
+};
+
+const getNumerForMetric = (metric: string) => {
+  const number = parseInt(metric, 10);
+  return isNaN(number) ? 0 : number;
 };
 
 export const emptyResponse = new MutableDataFrame({

--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -113,12 +113,12 @@ export const transformToMetricsData = (data: MetricsSummary) => {
 
   const metricsData: MetricsData = {
     kind: 'server', // so the user knows all results are of kind = server
-    spanCount: getNumerForMetric(data.spanCount),
+    spanCount: getNumberForMetric(data.spanCount),
     errorPercentage,
-    p50: getNumerForMetric(data.p50),
-    p90: getNumerForMetric(data.p90),
-    p95: getNumerForMetric(data.p95),
-    p99: getNumerForMetric(data.p99),
+    p50: getNumberForMetric(data.p50),
+    p90: getNumberForMetric(data.p90),
+    p95: getNumberForMetric(data.p95),
+    p99: getNumberForMetric(data.p99),
   };
 
   data.series.forEach((series: Series) => {
@@ -262,7 +262,7 @@ const getPercentileRow = (name: string) => {
   };
 };
 
-const getNumerForMetric = (metric: string) => {
+const getNumberForMetric = (metric: string) => {
   const number = parseInt(metric, 10);
   return isNaN(number) ? 0 : number;
 };


### PR DESCRIPTION
**What is this feature?**

Fixes the sorting of the `spanCount` & `errorPercentage` columns in the metrics summary.

**Why do we need this feature?**

So we properly sort by numbers.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
