### PR TITLE
Improve check on Tempo version

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -228,16 +228,8 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     try {
       return semver.gte(actualVersion, featuresToTempoVersion[featureName]);
     } catch {
-      // An error could happen if Tempo is running locally. In that case, the version is not a semantic version
-      // and instead it is in the form `<branch>-<revision>`, possibly with a `-WIP` suffix (e.g., `main-12bdeff-WIP`).
-      // Thus, if the version is in the form `<branch>-<revision>`, assume that we are on the most updated
-      // Tempo version and thus any feature should be considered enabled
-      if (/^.*-[a-zA-Z0-9_]+(-WIP)?$/.test(actualVersion)) {
-        return true;
-      }
-
-      console.error(`Cannot compare ${actualVersion} and ${featuresToTempoVersion[featureName]}`);
-      return false;
+      // We assume we are on a development and recent branch, thus we enable all features
+      return true;
     }
   }
 


### PR DESCRIPTION
In a [previous PR](https://github.com/grafana/grafana/pull/74541), as a quick fix, the regex used to detect if we were on a development branch was relaxed to avoid issues that we noticed in Ops. However, with the new regex, many branches would now match it. As such, it is simply easier to enable all features when the version retrieved from the `api/status/buildinfo` endpoint is not a semantic version, which for instance happens when running Tempo locally from `main`.