### PR TITLE
Alerting: Fix default policy timing summary

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -257,4 +257,6 @@ const mockRoutes: RouteWithID = {
     },
   ],
   group_wait: '30s',
+  group_interval: undefined,
+  repeat_interval: undefined,
 };

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { uniqueId, groupBy, upperFirst, sumBy, isArray } from 'lodash';
+import { uniqueId, groupBy, upperFirst, sumBy, isArray, defaults } from 'lodash';
 import pluralize from 'pluralize';
 import React, { FC, Fragment, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
@@ -281,7 +281,7 @@ const Policy: FC<PolicyComponentProps> = ({
                 {timingOptions && (
                   // for the default policy we will also merge the default timings, that way a user can observe what the timing options would be
                   <TimingOptionsMeta
-                    timingOptions={isDefaultPolicy ? { ...timingOptions, ...TIMING_OPTIONS_DEFAULTS } : timingOptions}
+                    timingOptions={isDefaultPolicy ? defaults(timingOptions, TIMING_OPTIONS_DEFAULTS) : timingOptions}
                   />
                 )}
                 {hasInheritedProperties && (


### PR DESCRIPTION
A small fix for incorrect summary of the timing options for the default policy if some timing options were overridden, and update to the tests to catch regression.