### PR TITLE
SSE: Put data source query grouping behind feature flag

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -133,6 +133,7 @@ Experimental features might be changed or removed without prior notice.
 | `noBasicRole`                               | Enables a new role that has no permissions by default                                                                                                                                    |
 | `angularDeprecationUI`                      | Display new Angular deprecation-related UI features                                                                                                                                      |
 | `dashgpt`                                   | Enable AI powered features in dashboards                                                                                                                                                 |
+| `sseGroupByDatasource`                      | Send query to the same datasource in a single request when using server side expressions                                                                                                 |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -123,4 +123,5 @@ export interface FeatureToggles {
   dashgpt?: boolean;
   reportingRetries?: boolean;
   newBrowseDashboards?: boolean;
+  sseGroupByDatasource?: boolean;
 }

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -290,8 +290,65 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 // other nodes they must have already been executed and their results must
 // already by in vars.
 func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s *Service) (r mathexp.Results, e error) {
-	panic("Execute called on DSNode and should not be")
-	// Datasource queries are sent as a group to the datasource, see executeDSNodesGrouped.
+	logger := logger.FromContext(ctx).New("datasourceType", dn.datasource.Type, "queryRefId", dn.refID, "datasourceUid", dn.datasource.UID, "datasourceVersion", dn.datasource.Version)
+	ctx, span := s.tracer.Start(ctx, "SSE.ExecuteDatasourceQuery")
+	defer span.End()
+
+	pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, dn.datasource.Type, dn.request.User, dn.datasource)
+	if err != nil {
+		return mathexp.Results{}, err
+	}
+	span.SetAttributes("datasource.type", dn.datasource.Type, attribute.Key("datasource.type").String(dn.datasource.Type))
+	span.SetAttributes("datasource.uid", dn.datasource.UID, attribute.Key("datasource.uid").String(dn.datasource.UID))
+
+	req := &backend.QueryDataRequest{
+		PluginContext: pCtx,
+		Queries: []backend.DataQuery{
+			{
+				RefID:         dn.refID,
+				MaxDataPoints: dn.maxDP,
+				Interval:      time.Duration(int64(time.Millisecond) * dn.intervalMS),
+				JSON:          dn.query,
+				TimeRange:     dn.timeRange.AbsoluteTime(now),
+				QueryType:     dn.queryType,
+			},
+		},
+		Headers: dn.request.Headers,
+	}
+
+	responseType := "unknown"
+	respStatus := "success"
+	defer func() {
+		if e != nil {
+			responseType = "error"
+			respStatus = "failure"
+			span.AddEvents([]string{"error", "message"},
+				[]tracing.EventValue{
+					{Str: fmt.Sprintf("%v", err)},
+					{Str: "failed to query data source"},
+				})
+		}
+		logger.Debug("Data source queried", "responseType", responseType)
+		useDataplane := strings.HasPrefix(responseType, "dataplane-")
+		s.metrics.dsRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane), dn.datasource.Type).Inc()
+	}()
+
+	resp, err := s.dataService.QueryData(ctx, req)
+	if err != nil {
+		return mathexp.Results{}, MakeQueryError(dn.refID, dn.datasource.UID, err)
+	}
+
+	dataFrames, err := getResponseFrame(resp, dn.refID)
+	if err != nil {
+		return mathexp.Results{}, MakeQueryError(dn.refID, dn.datasource.UID, err)
+	}
+
+	var result mathexp.Results
+	responseType, result, err = convertDataFramesToResults(ctx, dataFrames, dn.datasource.Type, s, logger)
+	if err != nil {
+		err = MakeConversionError(dn.refID, err)
+	}
+	return result, err
 }
 
 func getResponseFrame(resp *backend.QueryDataResponse, refID string) (data.Frames, error) {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -731,5 +731,12 @@ var (
 			Owner:        grafanaFrontendPlatformSquad,
 			FrontendOnly: true,
 		},
+		{
+			Name:         "sseGroupByDatasource",
+			Description:  "Send query to the same datasource in a single request when using server side expressions",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaObservabilityMetricsSquad,
+			FrontendOnly: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -732,11 +732,10 @@ var (
 			FrontendOnly: true,
 		},
 		{
-			Name:         "sseGroupByDatasource",
-			Description:  "Send query to the same datasource in a single request when using server side expressions",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaObservabilityMetricsSquad,
-			FrontendOnly: true,
+			Name:        "sseGroupByDatasource",
+			Description: "Send query to the same datasource in a single request when using server side expressions",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaObservabilityMetricsSquad,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -104,4 +104,4 @@ angularDeprecationUI,experimental,@grafana/plugins-platform-backend,false,false,
 dashgpt,experimental,@grafana/dashboards-squad,false,false,false,true
 reportingRetries,preview,@grafana/sharing-squad,false,false,true,false
 newBrowseDashboards,preview,@grafana/grafana-frontend-platform,false,false,false,true
-sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,false,true
+sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -104,3 +104,4 @@ angularDeprecationUI,experimental,@grafana/plugins-platform-backend,false,false,
 dashgpt,experimental,@grafana/dashboards-squad,false,false,false,true
 reportingRetries,preview,@grafana/sharing-squad,false,false,true,false
 newBrowseDashboards,preview,@grafana/grafana-frontend-platform,false,false,false,true
+sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -426,4 +426,8 @@ const (
 	// FlagNewBrowseDashboards
 	// New browse/manage dashboards UI
 	FlagNewBrowseDashboards = "newBrowseDashboards"
+
+	// FlagSseGroupByDatasource
+	// Send query to the same datasource in a single request when using server side expressions
+	FlagSseGroupByDatasource = "sseGroupByDatasource"
 )


### PR DESCRIPTION
Changes this behavior to be off by default as it has created issues with the CW datasource.
was merged in commit: 720d716 via PR: https://github.com/grafana/grafana/pull/72935
flag is: sseGroupByDatasource

**Special notes for your reviewer:**
I should have made this feature flag with the initial commit.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
