### PR TITLE
Grafana-UI: Add title in order to read out keyboard shortcuts

### DIFF
--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -166,7 +166,7 @@ export const MenuItem = React.memo(
           <div className={cx(styles.rightWrapper, { [styles.withShortcut]: hasShortcut })}>
             {hasShortcut && (
               <div className={styles.shortcut}>
-                <Icon name="keyboard" aria-hidden />
+                <Icon name="keyboard" title="keyboard shortcut" />
                 {shortcut}
               </div>
             )}


### PR DESCRIPTION
**What is this feature?**
I removed the aria-hidden from the keyboard icon and added a title that the screenreader can read out.

**Why do we need this feature?**
Improve accessibility

**Who is this feature for?**
Users who need to use a screanreader

**Which issue(s) does this PR fix?**:
Fixes #74550

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
