### PR TITLE
Tempo: Metrics summary no value

### DIFF
--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -101,7 +101,7 @@ export function createTableFrameFromMetricsSummaryQuery(
       field.values.push(trace[field.name]);
     }
   }
-  frame = sortDataFrame(frame, 0);
+  frame = sortDataFrame(frame, 0, true);
 
   return [frame];
 }
@@ -183,7 +183,7 @@ const getConfig = (series: Series, query: string, instanceSettings: DataSourceIn
   return { ...commonConfig };
 };
 
-const NO_VALUE = '';
+const NO_VALUE = '<no value>';
 
 const getMetricValue = (series: Series) => {
   if (!series.value.type) {


### PR DESCRIPTION
**What is this feature?**

Updates showing an empty string to `<no value>` when we don't have any value to display in the metrics summary.

**Why do we need this feature?**

Makes it clearer to the user that we don't have a value.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

This is the result of a Slack convo with Jen, Marty and Heds.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
