### PR TITLE
Dashlist: Fix panel not showing for Viewer users

### DIFF
--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -61,6 +61,7 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
   if (newOptions.folderId !== undefined) {
     const folderId = newOptions.folderId;
 
+    // If converting ID to UID fails, the panel will not be migrated and will show incorrectly
     try {
       const folderUID = await getFolderUID(folderId);
       newOptions.folderUID = folderUID;

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -4,10 +4,17 @@ import { FolderDTO } from 'app/types';
 
 import { Options } from './panelcfg.gen';
 
-function getFolderByID(folderID: number) {
-  return getBackendSrv().get<FolderDTO>(`/api/folders/id/${folderID}`, undefined, undefined, {
+async function getFolderUID(folderID: number): Promise<string> {
+  // folderID 0 is always the fake General/Dashboards folder, which always has a UID of empty string
+  if (folderID === 0) {
+    return '';
+  }
+
+  const folderDTO = await getBackendSrv().get<FolderDTO>(`/api/folders/id/${folderID}`, undefined, undefined, {
     showErrorAlert: false,
   });
+
+  return folderDTO.uid;
 }
 
 export interface AngularModel {
@@ -55,8 +62,8 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
     const folderId = newOptions.folderId;
 
     try {
-      const folderResp = await getFolderByID(folderId);
-      newOptions.folderUID = folderResp.uid;
+      const folderUID = await getFolderUID(folderId);
+      newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
       console.warn('Dashlist: Error migrating folder ID to UID', err);

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -5,7 +5,9 @@ import { FolderDTO } from 'app/types';
 import { Options } from './panelcfg.gen';
 
 function getFolderByID(folderID: number) {
-  return getBackendSrv().get<FolderDTO>(`/api/folders/id/${folderID}`);
+  return getBackendSrv().get<FolderDTO>(`/api/folders/id/${folderID}`, undefined, undefined, {
+    showErrorAlert: false,
+  });
 }
 
 export interface AngularModel {
@@ -51,9 +53,14 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
   // Convert the folderId to folderUID. Uses the API to do the conversion.
   if (newOptions.folderId !== undefined) {
     const folderId = newOptions.folderId;
-    const folderResp = await getFolderByID(folderId);
-    newOptions.folderUID = folderResp.uid;
-    delete newOptions.folderId;
+
+    try {
+      const folderResp = await getFolderByID(folderId);
+      newOptions.folderUID = folderResp.uid;
+      delete newOptions.folderId;
+    } catch (err) {
+      console.warn('Dashlist: Error migrating folder ID to UID', err);
+    }
   }
 
   return newOptions;

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -52,9 +52,9 @@ export const plugin = new PanelPlugin<Options>(DashList)
         defaultValue: defaultOptions.query,
       })
       .addCustomEditor({
-        path: 'folderUid',
+        path: 'folderUID',
         name: 'Folder',
-        id: 'folderUid',
+        id: 'folderUID',
         defaultValue: undefined,
         editor: function RenderFolderPicker({ value, onChange }) {
           return <FolderPicker value={value} onChange={(folderUID) => onChange(folderUID)} />;


### PR DESCRIPTION
 - If the panel migration fails, which is more likely because dashlist migration hits the api, the panel is silently hidden on the dashboard https://github.com/grafana/grafana/issues/73918
 - Dashlist migration for general folder - GET `/api/folders/id/0` - fails due to permission error. This might be a bug with permissions, but it's unclear.


To counter both of these:
 - We don't need to hit the API for folder ID 0, because that can only ever be the fake General folder, which always has uid of `""`
 - if the API call fails, we just don't migrate the folder ID to UID. The panel will potentially show incorrectly in this state.