### PR TITLE
Plugins: Show deprecated plugins

### DIFF
--- a/public/app/features/plugins/admin/__mocks__/catalogPlugin.mock.ts
+++ b/public/app/features/plugins/admin/__mocks__/catalogPlugin.mock.ts
@@ -17,6 +17,7 @@ export default {
   isEnterprise: false,
   isInstalled: false,
   isDisabled: false,
+  isDeprecated: false,
   isPublished: true,
   name: 'Zabbix',
   orgName: 'Alexander Zobnin',

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -19,17 +19,25 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
   const local = localPlugins.find((p) => p.id === id);
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
-  return {
+  const a = {
+    isDeprecated: remote?.status === 'deprecated',
     grafanaDependency: dependencies?.grafanaDependency ?? dependencies?.grafanaVersion ?? '',
     pluginDependencies: dependencies?.plugins || [],
     links: local?.info.links || remote?.json?.info.links || [],
     readme: localReadme || remote?.readme,
     versions,
   };
+
+  console.log('***', a);
+  return a;
 }
 
 export async function getRemotePlugins(): Promise<RemotePlugin[]> {
-  const { items: remotePlugins }: { items: RemotePlugin[] } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins`);
+  // We are also fetching deprecated plugins, because we would like to be able to label plugins in the list that are both installed and deprecated.
+  // (We won't show not installed deprecated plugins in the list)
+  const { items: remotePlugins }: { items: RemotePlugin[] } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins`, {
+    includeDeprecated: true,
+  });
 
   return remotePlugins.filter(isRemotePluginVisible);
 }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -20,7 +20,6 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
   return {
-    isDeprecated: remote?.status === 'deprecated',
     grafanaDependency: dependencies?.grafanaDependency ?? dependencies?.grafanaVersion ?? '',
     pluginDependencies: dependencies?.plugins || [],
     links: local?.info.links || remote?.json?.info.links || [],

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -19,7 +19,7 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
   const local = localPlugins.find((p) => p.id === id);
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
-  const a = {
+  return {
     isDeprecated: remote?.status === 'deprecated',
     grafanaDependency: dependencies?.grafanaDependency ?? dependencies?.grafanaVersion ?? '',
     pluginDependencies: dependencies?.plugins || [],
@@ -27,9 +27,6 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     readme: localReadme || remote?.readme,
     versions,
   };
-
-  console.log('***', a);
-  return a;
 }
 
 export async function getRemotePlugins(): Promise<RemotePlugin[]> {

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -3,7 +3,7 @@ import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 
 import { API_ROOT, GCOM_API_ROOT } from './constants';
-import { isLocalPluginVisible, isRemotePluginVisible } from './helpers';
+import { isLocalPluginVisibleByConfig, isRemotePluginVisibleByConfig } from './helpers';
 import { LocalPlugin, RemotePlugin, CatalogPluginDetails, Version, PluginVersion } from './types';
 
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
@@ -39,7 +39,7 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     includeDeprecated: true,
   });
 
-  return remotePlugins.filter(isRemotePluginVisible);
+  return remotePlugins.filter(isRemotePluginVisibleByConfig);
 }
 
 export async function getPluginErrors(): Promise<PluginError[]> {
@@ -105,7 +105,7 @@ export async function getLocalPlugins(): Promise<LocalPlugin[]> {
     accessControlQueryParam({ embedded: 0 })
   );
 
-  return localPlugins.filter(isLocalPluginVisible);
+  return localPlugins.filter(isLocalPluginVisibleByConfig);
 }
 
 export async function installPlugin(id: string) {

--- a/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import { Badge } from '@grafana/ui';
 
 export function PluginDeprecatedBadge(): React.ReactElement {
-  return <Badge icon="exclamation-triangle" text="Deprecated" color="orange" />;
+  return <Badge icon="exclamation-triangle" text="Deprecated" color="orange" tooltip='This plugin is deprecated and no longer receives updates.' />;
 }

--- a/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { Badge } from '@grafana/ui';
+
+export function PluginDeprecatedBadge(): React.ReactElement {
+  return <Badge icon="exclamation-triangle" text="Deprecated" color="orange" />;
+}

--- a/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginDeprecatedBadge.tsx
@@ -3,5 +3,12 @@ import React from 'react';
 import { Badge } from '@grafana/ui';
 
 export function PluginDeprecatedBadge(): React.ReactElement {
-  return <Badge icon="exclamation-triangle" text="Deprecated" color="orange" tooltip='This plugin is deprecated and no longer receives updates.' />;
+  return (
+    <Badge
+      icon="exclamation-triangle"
+      text="Deprecated"
+      color="orange"
+      tooltip="This plugin is deprecated and no longer receives updates."
+    />
+  );
 }

--- a/public/app/features/plugins/admin/components/Badges/index.ts
+++ b/public/app/features/plugins/admin/components/Badges/index.ts
@@ -3,3 +3,4 @@ export { PluginInstalledBadge } from './PluginInstallBadge';
 export { PluginEnterpriseBadge } from './PluginEnterpriseBadge';
 export { PluginUpdateAvailableBadge } from './PluginUpdateAvailableBadge';
 export { PluginAngularBadge } from './PluginAngularBadge';
+export { PluginDeprecatedBadge } from './PluginDeprecatedBadge';

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -28,6 +28,7 @@ const plugin: CatalogPlugin = {
   isDev: false,
   isEnterprise: false,
   isDisabled: false,
+  isDeprecated: false,
   isPublished: true,
 };
 

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -16,7 +16,10 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
 
   return isWarningVisible ? (
     <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>
-      <p>This {plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the plugin.</p>
+      <p>
+        This {plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the
+        plugin.
+      </p>
     </Alert>
   ) : null;
 }

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+
+import { Alert } from '@grafana/ui';
+
+import { CatalogPlugin } from '../types';
+
+type Props = {
+  className?: string;
+  plugin: CatalogPlugin;
+};
+
+export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement | null {
+  const { className, plugin } = props;
+  const [dismissed, setDismissed] = useState(false);
+  const isWarningVisible = plugin.isDeprecated && !dismissed;
+
+  return isWarningVisible ? (
+    <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>
+      <p>This {plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the plugin.</p>
+    </Alert>
+  ) : null;
+}

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -19,6 +19,8 @@ import { usePluginPageExtensions } from '../hooks/usePluginPageExtensions';
 import { useGetSingle, useFetchStatus, useFetchDetailsStatus } from '../state/hooks';
 import { PluginTabIds } from '../types';
 
+import { PluginDetailsDeprecatedWarning } from './PluginDetailsDeprecatedWarning';
+
 export type Props = {
   // The ID of the plugin
   pluginId: string;
@@ -87,6 +89,7 @@ export function PluginDetailsPage({
           )}
           <PluginDetailsSignature plugin={plugin} className={styles.alert} />
           <PluginDetailsDisabledError plugin={plugin} className={styles.alert} />
+          <PluginDetailsDeprecatedWarning plugin={plugin} className={styles.alert} />
           <PluginDetailsBody queryParams={Object.fromEntries(queryParams)} plugin={plugin} pageId={activePageId} />
         </TabContent>
       </Page.Contents>

--- a/public/app/features/plugins/admin/components/PluginList.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginList.test.tsx
@@ -45,6 +45,7 @@ const getMockPlugin = (id: string): CatalogPlugin => {
     isDev: false,
     isEnterprise: false,
     isDisabled: false,
+    isDeprecated: false,
     isPublished: true,
   };
 };

--- a/public/app/features/plugins/admin/components/PluginListItem.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.test.tsx
@@ -55,6 +55,7 @@ describe('PluginListItem', () => {
     isDev: false,
     isEnterprise: false,
     isDisabled: false,
+    isDeprecated: false,
     isPublished: true,
   };
 

--- a/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
@@ -31,6 +31,7 @@ describe('PluginListItemBadges', () => {
     isDev: false,
     isEnterprise: false,
     isDisabled: false,
+    isDeprecated: false,
     isPublished: true,
   };
 

--- a/public/app/features/plugins/admin/components/PluginListItemBadges.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItemBadges.tsx
@@ -11,6 +11,7 @@ import {
   PluginInstalledBadge,
   PluginUpdateAvailableBadge,
   PluginAngularBadge,
+  PluginDeprecatedBadge,
 } from './Badges';
 
 type PluginBadgeType = {
@@ -35,6 +36,7 @@ export function PluginListItemBadges({ plugin }: PluginBadgeType) {
     <HorizontalGroup height="auto" wrap>
       <PluginSignatureBadge status={plugin.signature} />
       {plugin.isDisabled && <PluginDisabledBadge error={plugin.error} />}
+      {plugin.isDeprecated && <PluginDeprecatedBadge />}
       {plugin.isInstalled && <PluginInstalledBadge />}
       {hasUpdate && <PluginUpdateAvailableBadge plugin={plugin} />}
       {plugin.angularDetected && <PluginAngularBadge />}

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -13,7 +13,7 @@ import {
   isLocalPluginVisibleByConfig,
   isRemotePluginVisibleByConfig,
 } from './helpers';
-import { RemotePlugin, LocalPlugin } from './types';
+import { RemotePlugin, LocalPlugin, RemotePluginStatus } from './types';
 
 describe('Plugins/Helpers', () => {
   let remotePlugin: RemotePlugin;
@@ -69,7 +69,7 @@ describe('Plugins/Helpers', () => {
     test('skips deprecated plugins unless they have a local - installed - counterpart', () => {
       const merged = mergeLocalsAndRemotes(localPlugins, [
         ...remotePlugins,
-        getRemotePluginMock({ slug: 'plugin-5', status: 'deprecated' }),
+        getRemotePluginMock({ slug: 'plugin-5', status: RemotePluginStatus.Deprecated }),
       ]);
       const findMerged = (mergedId: string) => merged.find(({ id }) => id === mergedId);
 
@@ -80,7 +80,7 @@ describe('Plugins/Helpers', () => {
     test('keeps deprecated plugins in case they have a local counterpart', () => {
       const merged = mergeLocalsAndRemotes(
         [...localPlugins, getLocalPluginMock({ id: 'plugin-5' })],
-        [...remotePlugins, getRemotePluginMock({ slug: 'plugin-5', status: 'deprecated' })]
+        [...remotePlugins, getRemotePluginMock({ slug: 'plugin-5', status: RemotePluginStatus.Deprecated })]
       );
       const findMerged = (mergedId: string) => merged.find(({ id }) => id === mergedId);
 
@@ -163,8 +163,8 @@ describe('Plugins/Helpers', () => {
     });
 
     test('adds an "isEnterprise" field', () => {
-      const enterprisePlugin = { ...remotePlugin, status: 'enterprise' } as RemotePlugin;
-      const notEnterprisePlugin = { ...remotePlugin, status: 'unknown' } as RemotePlugin;
+      const enterprisePlugin = { ...remotePlugin, status: RemotePluginStatus.Enterprise } as RemotePlugin;
+      const notEnterprisePlugin = { ...remotePlugin, status: RemotePluginStatus.Active } as RemotePlugin;
 
       expect(mapRemoteToCatalog(enterprisePlugin).isEnterprise).toBe(true);
       expect(mapRemoteToCatalog(notEnterprisePlugin).isEnterprise).toBe(false);
@@ -345,15 +345,17 @@ describe('Plugins/Helpers', () => {
 
     test('`.isEnterprise` - prefers the remote', () => {
       // Local & Remote
-      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: 'enterprise' })).toMatchObject({
-        isEnterprise: true,
-      });
-      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: 'unknown' })).toMatchObject({
+      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: RemotePluginStatus.Enterprise })).toMatchObject(
+        {
+          isEnterprise: true,
+        }
+      );
+      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: RemotePluginStatus.Active })).toMatchObject({
         isEnterprise: false,
       });
 
       // Remote only
-      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: 'enterprise' })).toMatchObject({
+      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: RemotePluginStatus.Enterprise })).toMatchObject({
         isEnterprise: true,
       });
 
@@ -366,18 +368,22 @@ describe('Plugins/Helpers', () => {
 
     test('`.isDeprecated` - comes from the remote', () => {
       // Local & Remote
-      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: 'deprecated' })).toMatchObject({
-        isDeprecated: true,
-      });
-      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: 'enterprise' })).toMatchObject({
-        isDeprecated: false,
-      });
+      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: RemotePluginStatus.Deprecated })).toMatchObject(
+        {
+          isDeprecated: true,
+        }
+      );
+      expect(mapToCatalogPlugin(localPlugin, { ...remotePlugin, status: RemotePluginStatus.Enterprise })).toMatchObject(
+        {
+          isDeprecated: false,
+        }
+      );
 
       // Remote only
-      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: 'deprecated' })).toMatchObject({
+      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: RemotePluginStatus.Deprecated })).toMatchObject({
         isDeprecated: true,
       });
-      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: 'enterprise' })).toMatchObject({
+      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, status: RemotePluginStatus.Enterprise })).toMatchObject({
         isDeprecated: false,
       });
 

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -302,11 +302,11 @@ export const hasInstallControlWarning = (
   );
 };
 
-export const isLocalPluginVisible = (p: LocalPlugin) => isPluginVisible(p.id);
+export const isLocalPluginVisibleByConfig = (p: LocalPlugin) => isNotHiddenByConfig(p.id);
 
-export const isRemotePluginVisible = (p: RemotePlugin) => isPluginVisible(p.slug);
+export const isRemotePluginVisibleByConfig = (p: RemotePlugin) => isNotHiddenByConfig(p.slug);
 
-function isPluginVisible(id: string) {
+function isNotHiddenByConfig(id: string) {
   const { pluginCatalogHiddenPlugins }: { pluginCatalogHiddenPlugins: string[] } = config;
 
   return !pluginCatalogHiddenPlugins.includes(id);

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -5,7 +5,7 @@ import { contextSrv } from 'app/core/core';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { AccessControlAction } from 'app/types';
 
-import { CatalogPlugin, LocalPlugin, RemotePlugin, Version } from './types';
+import { CatalogPlugin, LocalPlugin, RemotePlugin, RemotePluginStatus, Version } from './types';
 
 export function mergeLocalsAndRemotes(
   local: LocalPlugin[] = [],
@@ -29,7 +29,7 @@ export function mergeLocalsAndRemotes(
   remote.forEach((remotePlugin) => {
     const localCounterpart = local.find((l) => l.id === remotePlugin.slug);
     const error = errorByPluginId[remotePlugin.slug];
-    const shouldSkip = remotePlugin.status === 'deprecated' && !localCounterpart; // We are only listing deprecated plugins in case they are installed.
+    const shouldSkip = remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart; // We are only listing deprecated plugins in case they are installed.
 
     if (!shouldSkip) {
       catalogPlugins.push(mergeLocalAndRemote(localCounterpart, remotePlugin, error));
@@ -88,10 +88,10 @@ export function mapRemoteToCatalog(plugin: RemotePlugin, error?: PluginError): C
     isPublished: true,
     isInstalled: isDisabled,
     isDisabled: isDisabled,
-    isDeprecated: status === 'deprecated',
+    isDeprecated: status === RemotePluginStatus.Deprecated,
     isCore: plugin.internal,
     isDev: false,
-    isEnterprise: status === 'enterprise',
+    isEnterprise: status === RemotePluginStatus.Enterprise,
     type: typeCode,
     error: error?.errorCode,
     angularDetected,
@@ -174,10 +174,10 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     },
     isCore: Boolean(remote?.internal || local?.signature === PluginSignatureStatus.internal),
     isDev: Boolean(local?.dev),
-    isEnterprise: remote?.status === 'enterprise',
+    isEnterprise: remote?.status === RemotePluginStatus.Enterprise,
     isInstalled: Boolean(local) || isDisabled,
     isDisabled: isDisabled,
-    isDeprecated: remote?.status === 'deprecated',
+    isDeprecated: remote?.status === RemotePluginStatus.Deprecated,
     isPublished: true,
     // TODO<check if we would like to keep preferring the remote version>
     name: remote?.name || local?.name || '',

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -751,7 +751,9 @@ describe('Plugin details page', () => {
         isDeprecated: true,
       });
 
-      await waitFor(() => expect(queryByText(/plugin is deprecated and removed from the catalog/i)).toBeInTheDocument());
+      await waitFor(() =>
+        expect(queryByText(/plugin is deprecated and removed from the catalog/i)).toBeInTheDocument()
+      );
     });
 
     it('should not display a deprecation warning in the plugin is not deprecated', async () => {
@@ -761,7 +763,9 @@ describe('Plugin details page', () => {
         isDeprecated: false,
       });
 
-      await waitFor(() => expect(queryByText(/plugin is deprecated and removed from the catalog/i)).not.toBeInTheDocument());
+      await waitFor(() =>
+        expect(queryByText(/plugin is deprecated and removed from the catalog/i)).not.toBeInTheDocument()
+      );
     });
   });
 

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -743,7 +743,7 @@ describe('Plugin details page', () => {
 
       await waitFor(() => expect(queryByText(/angular plugin/i)).not.toBeInTheDocument);
     });
-    
+
     it('should display a deprecation warning if the plugin is deprecated', async () => {
       const { queryByText } = renderPluginDetails({
         id,

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -743,6 +743,26 @@ describe('Plugin details page', () => {
 
       await waitFor(() => expect(queryByText(/angular plugin/i)).not.toBeInTheDocument);
     });
+    
+    it('should display a deprecation warning if the plugin is deprecated', async () => {
+      const { queryByText } = renderPluginDetails({
+        id,
+        isInstalled: true,
+        isDeprecated: true,
+      });
+
+      await waitFor(() => expect(queryByText(/plugin is deprecated and removed from the catalog/i)).toBeInTheDocument());
+    });
+
+    it('should not display a deprecation warning in the plugin is not deprecated', async () => {
+      const { queryByText } = renderPluginDetails({
+        id,
+        isInstalled: true,
+        isDeprecated: false,
+      });
+
+      await waitFor(() => expect(queryByText(/plugin is deprecated and removed from the catalog/i)).not.toBeInTheDocument());
+    });
   });
 
   describe('viewed as user without grafana admin permissions', () => {

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -43,6 +43,7 @@ export interface CatalogPlugin extends WithAccessControlMetadata {
   isEnterprise: boolean;
   isInstalled: boolean;
   isDisabled: boolean;
+  isDeprecated: boolean;
   // `isPublished` is TRUE if the plugin is published to grafana.com
   isPublished: boolean;
   name: string;
@@ -69,6 +70,7 @@ export interface CatalogPluginDetails {
   }>;
   grafanaDependency?: string;
   pluginDependencies?: PluginDependencies['plugins'];
+  isDeprecated?: boolean;
 }
 
 export interface CatalogPluginInfo {

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -112,7 +112,7 @@ export type RemotePlugin = {
   readme?: string;
   signatureType: PluginSignatureType | '';
   slug: string;
-  status: string;
+  status: RemotePluginStatus;
   typeCode: PluginType;
   typeId: number;
   typeName: string;
@@ -127,6 +127,16 @@ export type RemotePlugin = {
   versionStatus: string;
   angularDetected?: boolean;
 };
+
+// The available status codes on GCOM are available here:
+// https://github.com/grafana/grafana-com/blob/main/packages/grafana-com-plugins-api/src/plugins/plugin.model.js#L74
+export enum RemotePluginStatus {
+  Deleted = 'deleted',
+  Active = 'active',
+  Pending = 'pending',
+  Deprecated = 'deprecated',
+  Enterprise = 'enterprise',
+}
 
 export type LocalPlugin = WithAccessControlMetadata & {
   category: string;

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -70,7 +70,6 @@ export interface CatalogPluginDetails {
   }>;
   grafanaDependency?: string;
   pluginDependencies?: PluginDependencies['plugins'];
-  isDeprecated?: boolean;
 }
 
 export interface CatalogPluginInfo {


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/grafana/issues/71528

The goal of this PR is to show a warning (both in the list and on the details page) if a plugin is deprecated.

### What changed?
- [x] Introduce a `isDeprecated` field to `CatalogPlugin`
- [x] Fetch deprecated plugins from GCOM and set the `isDeprecated` field in locally installed plugins
- [x] Hide not installed deprecated plugins from the list
- [x] Show a "deprecated label" in the plugins list
- [x]  Show a warning message in the plugin details page
- [x] Update the tests

### Note for the reviewer
Right now there can be cases when a plugin is both using Angular and is deprecated, which can result in somewhat overlapping warning labels and messages. This is something that we would like to improve as a next step, and something that we will bring to the UX Feedback sessions.

### Screenshots
![Screenshot 2023-09-11 at 12 27 58](https://github.com/grafana/grafana/assets/9974811/36f682f5-10b9-4b9f-947b-6bcc93141046)
![Screenshot 2023-09-11 at 12 27 46](https://github.com/grafana/grafana/assets/9974811/d7010999-647b-45ee-b88d-6b79121392c6)
![Screenshot 2023-09-11 at 12 28 18](https://github.com/grafana/grafana/assets/9974811/44456027-038b-4151-af74-9dc199870886)
