### PR TITLE
BrowseDashboards: Only remember the most recent expanded folder

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -82,6 +82,7 @@ import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
 import { initWindowRuntime } from './features/runtime/init';
+import { cleanupOldExpandedFolders } from './features/search/utils';
 import { variableAdapters } from './features/variables/adapters';
 import { createAdHocVariableAdapter } from './features/variables/adhoc/adapter';
 import { createConstantVariableAdapter } from './features/variables/constant/adapter';
@@ -214,6 +215,13 @@ export class GrafanaApp {
 
       // Read initial kiosk mode from url at app startup
       chromeService.setKioskModeFromUrl(queryParams.kiosk);
+
+      // Clean up old search local storage values
+      try {
+        cleanupOldExpandedFolders();
+      } catch (err) {
+        console.warn('Failed to clean up old expanded folders', err);
+      }
 
       this.context = {
         backend: backendSrv,

--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -6,6 +6,7 @@ export const SEARCH_ITEM_HEIGHT = 58;
 export const SEARCH_ITEM_MARGIN = 8;
 export const DEFAULT_SORT = { label: 'A\u2013Z', value: 'alpha-asc' };
 export const SECTION_STORAGE_KEY = 'search.sections';
+export const SEARCH_EXPANDED_FOLDER_STORAGE_KEY = 'grafana.search.expanded-folder';
 export const GENERAL_FOLDER_ID = 0;
 export const GENERAL_FOLDER_UID = 'general';
 export const GENERAL_FOLDER_TITLE = 'General';

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -62,7 +62,6 @@ export const FolderSection = ({
   const styles = useStyles2(useCallback((theme: GrafanaTheme2) => getSectionHeaderStyles(theme, editable), [editable]));
   const [expandedFolder, setExpandedFolder] = useLocalStorage<string | null>(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, null);
   const [sectionExpanded, setSectionExpanded] = useState(uid === expandedFolder);
-  // const sectionExpanded = uid === expandedFolder;
 
   const results = useAsync(async () => {
     if (!sectionExpanded && !renderStandaloneBody) {

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -60,8 +60,10 @@ export const FolderSection = ({
   const editable = selectionToggle != null;
 
   const styles = useStyles2(useCallback((theme: GrafanaTheme2) => getSectionHeaderStyles(theme, editable), [editable]));
-  const [expandedFolder, setExpandedFolder] = useLocalStorage<string | null>(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, null);
-  const [sectionExpanded, setSectionExpanded] = useState(uid === expandedFolder);
+  const [sectionExpanded, setSectionExpanded] = useState(() => {
+    const lastExpandedFolder = window.localStorage.getItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
+    return lastExpandedFolder === uid;
+  });
 
   const results = useAsync(async () => {
     if (!sectionExpanded && !renderStandaloneBody) {
@@ -74,9 +76,15 @@ export const FolderSection = ({
   }, [sectionExpanded, tags]);
 
   const onSectionExpand = () => {
-    // useLocalStorage will bail out on updating if you set the value to undefined,
-    // so we must set to null instead
-    setExpandedFolder(sectionExpanded ? null : uid);
+    const lastExpandedFolder = window.localStorage.getItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
+
+    if (sectionExpanded) {
+      if (lastExpandedFolder === uid) {
+        window.localStorage.removeItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
+      }
+    } else {
+      window.localStorage.setItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, uid);
+    }
 
     setSectionExpanded(!sectionExpanded);
   };

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useId } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { useAsync, useLocalStorage } from 'react-use';
 
 import { GrafanaTheme2, toIconName } from '@grafana/data';
@@ -7,10 +7,9 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Card, Checkbox, CollapsableSection, Icon, Spinner, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { t } from 'app/core/internationalization';
-import { getSectionStorageKey } from 'app/features/search/utils';
 
 import { SearchItem } from '../..';
-import { GENERAL_FOLDER_UID } from '../../constants';
+import { GENERAL_FOLDER_UID, SEARCH_EXPANDED_FOLDER_STORAGE_KEY } from '../../constants';
 import { getGrafanaSearcher } from '../../service';
 import { getFolderChildren } from '../../service/folders';
 import { queryResultToViewItem } from '../../service/utils';
@@ -57,9 +56,13 @@ export const FolderSection = ({
   renderStandaloneBody,
   tags,
 }: SectionHeaderProps) => {
+  const uid = section.uid;
   const editable = selectionToggle != null;
+
   const styles = useStyles2(useCallback((theme: GrafanaTheme2) => getSectionHeaderStyles(theme, editable), [editable]));
-  const [sectionExpanded, setSectionExpanded] = useLocalStorage(getSectionStorageKey(section.title), false);
+  const [expandedFolder, setExpandedFolder] = useLocalStorage<string>(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, undefined);
+  const [sectionExpanded, setSectionExpanded] = useState(uid === expandedFolder);
+  // const sectionExpanded = uid === expandedFolder;
 
   const results = useAsync(async () => {
     if (!sectionExpanded && !renderStandaloneBody) {
@@ -72,6 +75,7 @@ export const FolderSection = ({
   }, [sectionExpanded, tags]);
 
   const onSectionExpand = () => {
+    setExpandedFolder(sectionExpanded ? undefined : uid);
     setSectionExpanded(!sectionExpanded);
   };
 

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import React, { useCallback, useId, useState } from 'react';
-import { useAsync, useLocalStorage } from 'react-use';
+import { useAsync } from 'react-use';
 
 import { GrafanaTheme2, toIconName } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -76,17 +76,20 @@ export const FolderSection = ({
   }, [sectionExpanded, tags]);
 
   const onSectionExpand = () => {
-    const lastExpandedFolder = window.localStorage.getItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
+    const newExpandedValue = !sectionExpanded;
 
-    if (sectionExpanded) {
+    if (newExpandedValue) {
+      // If we've just expanded the section, remember it to local storage
+      window.localStorage.setItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, uid);
+    } else {
+      // Else, when closing a section, remove it from local storage only if this folder was the most recently opened
+      const lastExpandedFolder = window.localStorage.getItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
       if (lastExpandedFolder === uid) {
         window.localStorage.removeItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY);
       }
-    } else {
-      window.localStorage.setItem(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, uid);
     }
 
-    setSectionExpanded(!sectionExpanded);
+    setSectionExpanded(newExpandedValue);
   };
 
   const onToggleFolder = (evt: React.FormEvent) => {

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -60,7 +60,7 @@ export const FolderSection = ({
   const editable = selectionToggle != null;
 
   const styles = useStyles2(useCallback((theme: GrafanaTheme2) => getSectionHeaderStyles(theme, editable), [editable]));
-  const [expandedFolder, setExpandedFolder] = useLocalStorage<string>(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, undefined);
+  const [expandedFolder, setExpandedFolder] = useLocalStorage<string | null>(SEARCH_EXPANDED_FOLDER_STORAGE_KEY, null);
   const [sectionExpanded, setSectionExpanded] = useState(uid === expandedFolder);
   // const sectionExpanded = uid === expandedFolder;
 
@@ -75,7 +75,10 @@ export const FolderSection = ({
   }, [sectionExpanded, tags]);
 
   const onSectionExpand = () => {
-    setExpandedFolder(sectionExpanded ? undefined : uid);
+    // useLocalStorage will bail out on updating if you set the value to undefined,
+    // so we must set to null instead
+    setExpandedFolder(sectionExpanded ? null : uid);
+
     setSectionExpanded(!sectionExpanded);
   };
 

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -14,6 +14,19 @@ export const hasFilters = (query: SearchState) => {
   return Boolean(query.query || query.tag?.length > 0 || query.starred || query.sort);
 };
 
+/** Cleans up old local storage values that remembered many open folders */
+export const cleanupOldExpandedFolders = () => {
+  const keyPrefix = SECTION_STORAGE_KEY + '.';
+
+  for (let index = 0; index < window.localStorage.length; index++) {
+    const lsKey = window.localStorage.key(index);
+    if (lsKey?.startsWith(keyPrefix)) {
+      console.log('removing', lsKey);
+      window.localStorage.removeItem(lsKey);
+    }
+  }
+};
+
 /**
  * Get storage key for a dashboard folder by its title
  * @param title

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -21,7 +21,6 @@ export const cleanupOldExpandedFolders = () => {
   for (let index = 0; index < window.localStorage.length; index++) {
     const lsKey = window.localStorage.key(index);
     if (lsKey?.startsWith(keyPrefix)) {
-      console.log('removing', lsKey);
       window.localStorage.removeItem(lsKey);
     }
   }


### PR DESCRIPTION
**What is this feature?**

The old Browse Dashboards UI remembers opened folders and automatically loads their children when Browse or Search is opened. If the user has opened many folders, this can saturate the requests the frontend makes and prevents new requests (such as one for the user's search) from completing quickly.

This PR changers the old Browse Dashboards UI to only remember the last folder opened.

**Why do we need this feature?**

So the old Browse Dashboards UI performance does not get worse the more someone uses it.

**Who is this feature for?**

Everyone who isn't using new Browse Dashboards UI

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/59543

**Special notes for your reviewer:**

Becuase this is in the old UI which we no longer dog food, we must manually test this throughly.

This is intended to be backported.