### PR TITLE
Licensing: Pass func to update env variables when starting plugin

### DIFF
--- a/pkg/plugins/backendplugin/backendplugin.go
+++ b/pkg/plugins/backendplugin/backendplugin.go
@@ -6,4 +6,4 @@ import (
 )
 
 // PluginFactoryFunc is a function type for creating a Plugin.
-type PluginFactoryFunc func(pluginID string, logger log.Logger, env []string) (Plugin, error)
+type PluginFactoryFunc func(pluginID string, logger log.Logger, env func() []string) (Plugin, error)

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -21,7 +21,7 @@ type corePlugin struct {
 
 // New returns a new backendplugin.PluginFactoryFunc for creating a core (built-in) backendplugin.Plugin.
 func New(opts backend.ServeOpts) backendplugin.PluginFactoryFunc {
-	return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
+	return func(pluginID string, logger log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 		return &corePlugin{
 			pluginID:            pluginID,
 			logger:              logger,

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -33,12 +33,12 @@ type grpcPlugin struct {
 
 // newPlugin allocates and returns a new gRPC (external) backendplugin.Plugin.
 func newPlugin(descriptor PluginDescriptor) backendplugin.PluginFactoryFunc {
-	return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
+	return func(pluginID string, logger log.Logger, env func() []string) (backendplugin.Plugin, error) {
 		return &grpcPlugin{
 			descriptor: descriptor,
 			logger:     logger,
 			clientFactory: func() *plugin.Client {
-				return plugin.NewClient(newClientConfig(descriptor.executablePath, env, logger, descriptor.versionedPlugins))
+				return plugin.NewClient(newClientConfig(descriptor.executablePath, env(), logger, descriptor.versionedPlugins))
 			},
 		}, nil
 	}

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -290,7 +290,7 @@ func NewFakeBackendProcessProvider() *FakeBackendProcessProvider {
 	}
 	f.BackendFactoryFunc = func(ctx context.Context, p *plugins.Plugin) backendplugin.PluginFactoryFunc {
 		f.Requested[p.ID]++
-		return func(pluginID string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+		return func(pluginID string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 			f.Invoked[pluginID]++
 			return &FakePluginClient{}, nil
 		}

--- a/pkg/plugins/manager/pipeline/initialization/steps.go
+++ b/pkg/plugins/manager/pipeline/initialization/steps.go
@@ -46,7 +46,10 @@ func (b *BackendClientInit) Initialize(ctx context.Context, p *plugins.Plugin) (
 			return nil, errors.New("could not find backend factory for plugin")
 		}
 
-		if backendClient, err := backendFactory(p.ID, p.Logger(), b.envVarProvider.Get(ctx, p)); err != nil {
+		// this will ensure that the env variables are calculated every time a plugin is started
+		envFunc := func() []string { return b.envVarProvider.Get(ctx, p) }
+
+		if backendClient, err := backendFactory(p.ID, p.Logger(), envFunc); err != nil {
 			return nil, err
 		} else {
 			p.RegisterClient(backendClient)

--- a/pkg/plugins/manager/pipeline/initialization/steps_test.go
+++ b/pkg/plugins/manager/pipeline/initialization/steps_test.go
@@ -115,7 +115,7 @@ type fakeBackendProvider struct {
 }
 
 func (f *fakeBackendProvider) BackendFactory(_ context.Context, _ *plugins.Plugin) backendplugin.PluginFactoryFunc {
-	return func(_ string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+	return func(_ string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 		return f.plugin, nil
 	}
 }

--- a/pkg/services/pluginsintegration/loader/loader_test.go
+++ b/pkg/services/pluginsintegration/loader/loader_test.go
@@ -565,12 +565,12 @@ func TestLoader_Load_ExternalRegistration(t *testing.T) {
 
 		backendFactoryProvider := fakes.NewFakeBackendProcessProvider()
 		backendFactoryProvider.BackendFactoryFunc = func(ctx context.Context, plugin *plugins.Plugin) backendplugin.PluginFactoryFunc {
-			return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
+			return func(pluginID string, logger log.Logger, env func() []string) (backendplugin.Plugin, error) {
 				require.Equal(t, "grafana-test-datasource", pluginID)
 				require.Equal(t, []string{"GF_VERSION=", "GF_EDITION=", "GF_ENTERPRISE_LICENSE_PATH=",
 					"GF_ENTERPRISE_APP_URL=", "GF_ENTERPRISE_LICENSE_TEXT=", "GF_APP_URL=",
 					"GF_PLUGIN_APP_CLIENT_ID=client-id", "GF_PLUGIN_APP_CLIENT_SECRET=secretz",
-					"GF_PLUGIN_APP_PRIVATE_KEY=priv@t3", "GF_INSTANCE_FEATURE_TOGGLES_ENABLE=externalServiceAuth"}, env)
+					"GF_PLUGIN_APP_PRIVATE_KEY=priv@t3", "GF_INSTANCE_FEATURE_TOGGLES_ENABLE=externalServiceAuth"}, env())
 				return &fakes.FakeBackendPlugin{}, nil
 			}
 		}
@@ -1063,7 +1063,7 @@ func TestLoader_Load_SkipUninitializedPlugins(t *testing.T) {
 		procPrvdr := fakes.NewFakeBackendProcessProvider()
 		// Cause an initialization error
 		procPrvdr.BackendFactoryFunc = func(ctx context.Context, p *plugins.Plugin) backendplugin.PluginFactoryFunc {
-			return func(pluginID string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+			return func(pluginID string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 				if pluginID == "test-datasource" {
 					return nil, errors.New("failed to initialize")
 				}


### PR DESCRIPTION
**What is this feature?**
Updates backendplugin.PluginFactoryFunc to receive a provider func for the env variables to set when starting a Plugin. 
This will update the env variables every time a plugin is started (instead of just snapshotting the variables the first time). 

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana-enterprise/issues/5752
