### PR TITLE
Pyroscope: add public catalog description

### DIFF
--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -30,7 +30,7 @@ const (
 	defaultPassword  = "password"
 )
 
-var updateSnapshotFlag = false
+var updateSnapshotFlag = true
 
 func TestIntegrationPlugins(t *testing.T) {
 	if testing.Short() {

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -30,7 +30,7 @@ const (
 	defaultPassword  = "password"
 )
 
-var updateSnapshotFlag = true
+var updateSnapshotFlag = false
 
 func TestIntegrationPlugins(t *testing.T) {
 	if testing.Short() {

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -675,7 +675,7 @@
       "links": [
         {
           "name": "GitHub Project",
-          "url": "https://github.com/grafana/phlare"
+          "url": "https://github.com/grafana/pyroscope"
         }
       ],
       "logos": {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
@@ -14,7 +14,6 @@ Grafana Pyroscope is an open source continuous profiling platform. It will help 
 
 ## [Live Demo](https://demo.pyroscope.io/)
 
-[![Pyroscope GIF Demo](https://user-images.githubusercontent.com/23323466/143324845-16ff72df-231e-412d-bd0a-38ef2e09cba8.gif)](https://demo.pyroscope.io/)
 
 ## Features
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
@@ -15,7 +15,6 @@ Grafana Pyroscope is an open source continuous profiling platform. It will help 
 
 ## [Live Demo](https://demo.pyroscope.io/)
 
-
 ## Features
 
 - Minimal CPU overhead

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
@@ -5,12 +5,13 @@ Grafana ships with **built in** support for Grafana Pyroscope, an open source co
 ## What is Grafana Pyroscope?
 
 Grafana Pyroscope is an open source continuous profiling platform. It will help you:
-* Find performance issues and bottlenecks in your code
-* Use high-cardinality tags/labels to analyze your application
-* Resolve issues with high CPU utilization
-* Track down memory leaks
-* Understand the call tree of your application
-* Auto-instrument your code to link profiling data to traces
+
+- Find performance issues and bottlenecks in your code
+- Use high-cardinality tags/labels to analyze your application
+- Resolve issues with high CPU utilization
+- Track down memory leaks
+- Understand the call tree of your application
+- Auto-instrument your code to link profiling data to traces
 
 ## [Live Demo](https://demo.pyroscope.io/)
 
@@ -18,11 +19,11 @@ Grafana Pyroscope is an open source continuous profiling platform. It will help 
 
 ## Features
 
-* Minimal CPU overhead
-* Horizontally scalable
-* Efficient compression, low disk space requirements
-* Can handle high-cardinality tags/labels
-* Calculate the performance "diff" between various tags/labels and time periods
-* Advanced analysis UI
+- Minimal CPU overhead
+- Horizontally scalable
+- Efficient compression, low disk space requirements
+- Can handle high-cardinality tags/labels
+- Calculate the performance "diff" between various tags/labels and time periods
+- Advanced analysis UI
 
 Read more [here](https://grafana.com/docs/grafana/latest/datasources/grafana-pyroscope/).

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/README.md
@@ -1,0 +1,28 @@
+# Grafana Pyroscope Data Source - Native Plugin
+
+Grafana ships with **built in** support for Grafana Pyroscope, an open source continuous profiling platform.
+
+## What is Grafana Pyroscope?
+
+Grafana Pyroscope is an open source continuous profiling platform. It will help you:
+* Find performance issues and bottlenecks in your code
+* Use high-cardinality tags/labels to analyze your application
+* Resolve issues with high CPU utilization
+* Track down memory leaks
+* Understand the call tree of your application
+* Auto-instrument your code to link profiling data to traces
+
+## [Live Demo](https://demo.pyroscope.io/)
+
+[![Pyroscope GIF Demo](https://user-images.githubusercontent.com/23323466/143324845-16ff72df-231e-412d-bd0a-38ef2e09cba8.gif)](https://demo.pyroscope.io/)
+
+## Features
+
+* Minimal CPU overhead
+* Horizontally scalable
+* Efficient compression, low disk space requirements
+* Can handle high-cardinality tags/labels
+* Calculate the performance "diff" between various tags/labels and time periods
+* Advanced analysis UI
+
+Read more [here](https://grafana.com/docs/grafana/latest/datasources/grafana-pyroscope/).

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/plugin.json
@@ -26,7 +26,7 @@
     "links": [
       {
         "name": "GitHub Project",
-        "url": "https://github.com/grafana/phlare"
+        "url": "https://github.com/grafana/pyroscope"
       }
     ]
   }


### PR DESCRIPTION
**What is this feature?**

Adds a README to the Pyroscope data source.

**Why do we need this feature?**

When searching the public catalog, it's important to show the Pyroscope data source since it's a built-in data source. ([slack](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1692201366642309))
