### PR TITLE
Pyroscope: Change names of the backend-type options

### DIFF
--- a/docs/sources/datasources/grafana-pyroscope.md
+++ b/docs/sources/datasources/grafana-pyroscope.md
@@ -98,8 +98,8 @@ apiVersion: 1
 
 datasources:
   - name: Grafana Pyroscope
-    type: phlare
-    url: http://localhost:4100
+    type: grafana-pyroscope-datasource
+    url: http://localhost:4040
     jsonData:
       minStep: '15s'
       backendType: 'pyroscope'

--- a/pkg/tsdb/grafana-pyroscope-datasource/client.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/client.go
@@ -19,7 +19,7 @@ type ProfileType struct {
 }
 
 func getClient(backendType string, httpClient *http.Client, url string) ProfilingClient {
-	if backendType == "pyroscope" {
+	if backendType == "legacy-pyroscope" || backendType == "pyroscope" {
 		return NewPyroscopeClient(httpClient, url)
 	}
 

--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -192,16 +192,16 @@ func (d *PhlareDatasource) backendType(ctx context.Context, req *backend.CallRes
 	// to test with (like when filling in the confgi page for the first time)
 	url := query["url"][0]
 
-	pyroClient := getClient("pyroscope", d.httpClient, url)
+	pyroClient := getClient("legacy-pyroscope", d.httpClient, url)
 	_, err = pyroClient.ProfileTypes(ctx)
 
 	if err == nil {
-		body.BackendType = "pyroscope"
+		body.BackendType = "legacy-pyroscope"
 	} else {
-		phlareClient := getClient("phlare", d.httpClient, url)
+		phlareClient := getClient("grafana-pyroscope", d.httpClient, url)
 		_, err := phlareClient.ProfileTypes(ctx)
 		if err == nil {
-			body.BackendType = "phlare"
+			body.BackendType = "grafana-pyroscope"
 		}
 	}
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/ConfigEditor.tsx
@@ -7,7 +7,7 @@ import { Alert, DataSourceHttpSettings, EventsWithValidation, LegacyForms, regex
 import { config } from 'app/core/config';
 
 import { PhlareDataSource } from './datasource';
-import { BackendType, PhlareDataSourceOptions } from './types';
+import { BackendType, NewBackendType, PhlareDataSourceOptions } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<PhlareDataSourceOptions> {}
 
@@ -35,7 +35,7 @@ export const ConfigEditor = (props: Props) => {
 
     // If user already has something selected don't overwrite but show warning.
     if (options.jsonData.backendType) {
-      if (backendType !== options.jsonData.backendType) {
+      if (backendType !== getNormalizedBackendType(options.jsonData.backendType)) {
         setMismatchedBackendType(backendType);
       } else {
         setMismatchedBackendType(undefined);
@@ -103,7 +103,11 @@ export const ConfigEditor = (props: Props) => {
               inputEl={
                 <LegacyForms.Select<BackendType>
                   allowCustomValue={false}
-                  value={options.jsonData.backendType ? backendTypeOptions[options.jsonData.backendType] : undefined}
+                  value={
+                    options.jsonData.backendType
+                      ? backendTypeOptions[getNormalizedBackendType(options.jsonData.backendType)]
+                      : undefined
+                  }
                   options={Object.values(backendTypeOptions)}
                   onChange={(option) => {
                     onOptionsChange({
@@ -122,7 +126,7 @@ export const ConfigEditor = (props: Props) => {
         </div>
         {mismatchedBackendType && (
           <Alert
-            title={`"${options.jsonData.backendType}" option is selected but it seems like you are using "${mismatchedBackendType}" backend.`}
+            title={`"${getNormalizedBackendType(options.jsonData.backendType!)}" option is selected but it seems like you are using "${mismatchedBackendType}" backend.`}
             severity="warning"
           />
         )}
@@ -131,13 +135,23 @@ export const ConfigEditor = (props: Props) => {
   );
 };
 
-const backendTypeOptions: Record<BackendType, SelectableValue<BackendType>> = {
-  phlare: {
-    label: 'Phlare',
-    value: 'phlare',
+function getNormalizedBackendType(backendType: BackendType): NewBackendType {
+  if (backendType === 'phlare') {
+    return 'grafana-pyroscope';
+  }
+  if (backendType === 'pyroscope') {
+    return 'legacy-pyroscope';
+  }
+  return backendType;
+}
+
+const backendTypeOptions: Record<NewBackendType, SelectableValue<BackendType>> = {
+  'grafana-pyroscope': {
+    label: 'Grafana Pyroscope',
+    value: 'grafana-pyroscope',
   },
-  pyroscope: {
-    label: 'Pyroscope',
-    value: 'pyroscope',
+  'legacy-pyroscope': {
+    label: 'Legacy Pyroscope',
+    value: 'legacy-pyroscope',
   },
 };

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/types.ts
@@ -19,7 +19,9 @@ export interface PhlareDataSourceOptions extends DataSourceJsonData {
   backendType?: BackendType; // if not set we assume it's phlare
 }
 
-export type BackendType = 'phlare' | 'pyroscope';
+export type OldBackendType = 'phlare' | 'pyroscope';
+export type NewBackendType = 'grafana-pyroscope' | 'legacy-pyroscope';
+export type BackendType = OldBackendType | NewBackendType;
 
 export type ProfileTypeQuery = {
   type: 'profileType';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changing the name of the config options for backend type to be (hopefully) less confusing 

**Why do we need this feature?**

The confusion was that right now the data source is called Grafana Pyroscope but the correct option for the current backend-type was 'phlare'.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
