### PR TITLE
Instrumentation: Improve instrumentation for database migrations

### DIFF
--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -239,6 +239,7 @@ func (mg *Migrator) run() (err error) {
 }
 
 func (mg *Migrator) exec(m Migration, sess *xorm.Session) error {
+	start := time.Now()
 	mg.Logger.Info("Executing migration", "id", m.Id())
 
 	condition := m.GetCondition()
@@ -274,6 +275,8 @@ func (mg *Migrator) exec(m Migration, sess *xorm.Session) error {
 		mg.Logger.Error("Executing migration failed", "id", m.Id(), "error", err)
 		return err
 	}
+
+	mg.Logger.Info("Migration successfully executed", "id", m.Id(), "duration", time.Since(start))
 
 	return nil
 }

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -272,7 +272,7 @@ func (mg *Migrator) exec(m Migration, sess *xorm.Session) error {
 	}
 
 	if err != nil {
-		mg.Logger.Error("Executing migration failed", "id", m.Id(), "error", err)
+		mg.Logger.Error("Executing migration failed", "id", m.Id(), "error", err, "duration", time.Since(start))
 		return err
 	}
 


### PR DESCRIPTION
**What is this feature?**

Follow up from #73148. Logs an info message for each migration run and how long it took.

**Why do we need this feature?**

To make it easier for an operator to understand how long time did each migration take, what migrations did run etc.

**Who is this feature for?**

Grafana operators.

**Which issue(s) does this PR fix?**:

Fixes #70987

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
