### PR TITLE
[v9.4.x] Search: Improvements for starred dashboard search

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -1052,10 +1052,6 @@ func (d *DashboardStore) FindDashboards(ctx context.Context, query *dashboards.F
 		filters = append(filters, searchstore.DashboardIDFilter{IDs: query.DashboardIds})
 	}
 
-	if query.IsStarred {
-		filters = append(filters, searchstore.StarredFilter{UserId: query.SignedInUser.UserID})
-	}
-
 	if len(query.Title) > 0 {
 		filters = append(filters, searchstore.TitleFilter{Dialect: d.store.GetDialect(), Title: query.Title})
 	}

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -417,7 +417,6 @@ type FindPersistedDashboardsQuery struct {
 	Title         string
 	OrgId         int64
 	SignedInUser  *user.SignedInUser
-	IsStarred     bool
 	DashboardIds  []int64
 	DashboardUIDs []string
 	Type          string

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -224,11 +224,19 @@ func (a *AccessControlDashboardGuardian) CanCreate(folderID int64, isFolder bool
 func (a *AccessControlDashboardGuardian) evaluate(evaluator accesscontrol.Evaluator) (bool, error) {
 	ok, err := a.ac.Evaluate(a.ctx, a.user, evaluator)
 	if err != nil {
-		a.log.Debug("Failed to evaluate access control to folder or dashboard", "error", err, "userId", a.user.UserID, "id", a.dashboard.ID)
+		id := 0
+		if a.dashboard != nil {
+			id = int(a.dashboard.ID)
+		}
+		a.log.Debug("Failed to evaluate access control to folder or dashboard", "error", err, "userId", a.user.UserID, "id", id)
 	}
 
 	if !ok && err == nil {
-		a.log.Debug("Access denied to folder or dashboard", "userId", a.user.UserID, "id", a.dashboard.ID, "permissions", evaluator.GoString())
+		id := 0
+		if a.dashboard != nil {
+			id = int(a.dashboard.ID)
+		}
+		a.log.Debug("Access denied to folder or dashboard", "userId", a.user.UserID, "id", id, "permissions", evaluator.GoString())
 	}
 
 	return ok, err

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -58,10 +58,30 @@ type SearchService struct {
 }
 
 func (s *SearchService) SearchHandler(ctx context.Context, query *Query) error {
+	starredQuery := star.GetUserStarsQuery{
+		UserID: query.SignedInUser.UserID,
+	}
+	staredDashIDs, err := s.starService.GetByUser(ctx, &starredQuery)
+	if err != nil {
+		return err
+	}
+
+	// No starred dashboards will be found
+	if query.IsStarred && len(staredDashIDs.UserStars) == 0 {
+		query.Result = models.HitList{}
+		return nil
+	}
+
+	// filter by starred dashboard IDs when starred dashboards are requested and no UID or ID filters are specified to improve query performance
+	if query.IsStarred && len(query.DashboardIds) == 0 && len(query.DashboardUIDs) == 0 {
+		for id := range staredDashIDs.UserStars {
+			query.DashboardIds = append(query.DashboardIds, id)
+		}
+	}
+
 	dashboardQuery := dashboards.FindPersistedDashboardsQuery{
 		Title:         query.Title,
 		SignedInUser:  query.SignedInUser,
-		IsStarred:     query.IsStarred,
 		DashboardUIDs: query.DashboardUIDs,
 		DashboardIds:  query.DashboardIds,
 		Type:          query.Type,
@@ -85,11 +105,24 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) error {
 		hits = sortedHits(hits)
 	}
 
-	if err := s.setStarredDashboards(ctx, query.SignedInUser.UserID, hits); err != nil {
-		return err
+	// set starred dashboards
+	for _, dashboard := range hits {
+		if _, ok := staredDashIDs.UserStars[dashboard.ID]; ok {
+			dashboard.IsStarred = true
+		}
 	}
 
-	query.Result = hits
+	// filter for starred dashboards if requested
+	if !query.IsStarred {
+		query.Result = hits
+	} else {
+		query.Result = models.HitList{}
+		for _, dashboard := range hits {
+			if dashboard.IsStarred {
+				query.Result = append(query.Result, dashboard)
+			}
+		}
+	}
 
 	return nil
 }
@@ -105,23 +138,4 @@ func sortedHits(unsorted models.HitList) models.HitList {
 	}
 
 	return hits
-}
-
-func (s *SearchService) setStarredDashboards(ctx context.Context, userID int64, hits []*models.Hit) error {
-	query := star.GetUserStarsQuery{
-		UserID: userID,
-	}
-
-	res, err := s.starService.GetByUser(ctx, &query)
-	if err != nil {
-		return err
-	}
-	iuserstars := res.UserStars
-	for _, dashboard := range hits {
-		if _, ok := iuserstars[dashboard.ID]; ok {
-			dashboard.IsStarred = true
-		}
-	}
-
-	return nil
 }

--- a/pkg/services/search/service_test.go
+++ b/pkg/services/search/service_test.go
@@ -70,10 +70,10 @@ func TestSearch_StarredResults(t *testing.T) {
 	ds := dashboards.NewFakeDashboardService(t)
 	ds.On("SearchDashboards", mock.Anything, mock.AnythingOfType("*dashboards.FindPersistedDashboardsQuery")).Run(func(args mock.Arguments) {
 		q := args.Get(1).(*dashboards.FindPersistedDashboardsQuery)
-		q.Result = model.HitList{
-			&model.Hit{ID: 1, Title: "A", Type: "dash-db"},
-			&model.Hit{ID: 2, Title: "B", Type: "dash-db"},
-			&model.Hit{ID: 3, Title: "C", Type: "dash-db"},
+		q.Result = models.HitList{
+			&models.Hit{ID: 1, Title: "A", Type: "dash-db"},
+			&models.Hit{ID: 2, Title: "B", Type: "dash-db"},
+			&models.Hit{ID: 3, Title: "C", Type: "dash-db"},
 		}
 	}).Return(nil)
 	us.ExpectedSignedInUser = &user.SignedInUser{}

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -68,16 +68,6 @@ func (f OrgFilter) Where() (string, []interface{}) {
 	return "dashboard.org_id=?", []interface{}{f.OrgId}
 }
 
-type StarredFilter struct {
-	UserId int64
-}
-
-func (f StarredFilter) Where() (string, []interface{}) {
-	return `(SELECT count(*)
-			 FROM star
-			 WHERE star.dashboard_id = dashboard.id AND star.user_id = ?) > 0`, []interface{}{f.UserId}
-}
-
 type TitleFilter struct {
 	Dialect migrator.Dialect
 	Title   string

--- a/pkg/services/star/api/api.go
+++ b/pkg/services/star/api/api.go
@@ -52,22 +52,26 @@ func (api *API) GetStars(c *contextmodel.ReqContext) response.Response {
 
 	iuserstars, err := api.starService.GetByUser(c.Req.Context(), &query)
 	if err != nil {
-		return response.Error(500, "Failed to get user stars", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user stars", err)
 	}
 
 	uids := []string{}
-	for dashboardId := range iuserstars.UserStars {
-		query := &dashboards.GetDashboardQuery{
-			ID:    dashboardId,
-			OrgID: c.OrgID,
+	if len(iuserstars.UserStars) > 0 {
+		var ids []int64
+		for id := range iuserstars.UserStars {
+			ids = append(ids, id)
 		}
-		queryResult, err := api.dashboardService.GetDashboard(c.Req.Context(), query)
+		starredDashboards, err := api.dashboardService.GetDashboards(c.Req.Context(), &dashboards.GetDashboardsQuery{DashboardIDs: ids, OrgID: c.OrgID})
+		if err != nil {
+			return response.ErrOrFallback(http.StatusInternalServerError, "Failed to fetch dashboards", err)
+		}
 
-		// Grafana admin users may have starred dashboards in multiple orgs.  This will avoid returning errors when the dashboard is in another org
-		if err == nil {
-			uids = append(uids, queryResult.UID)
+		uids = make([]string, len(starredDashboards))
+		for i, dash := range starredDashboards {
+			uids[i] = dash.UID
 		}
 	}
+
 	return response.JSON(200, uids)
 }
 


### PR DESCRIPTION
Backport f966045129146cf0f69cdf9b849b4c930fccfc51 from #64758

---

**What is this feature?**

Several improvements related to starred dashboards:
* when searching for starred dashboards, pass dashboard IDs into the search to optimise search performance (it's way faster if dashboard IDs are specified);
* when using starred dashboards, fetch them all in one query rather than issuing one query per dashboard.

**Why do we need this feature?**

We've had reports of starred dashboard queries being slow.

**Special notes for your reviewer**:

I've tested with 20 starred dashboards and it performed fine. However, it might not work well if the user has a really large number of starred dashboards. I'm working with the assumption that a typical user will not have more than 20 starred dashboards.
