### PR TITLE
LogDetails: Fix copy button visibility

### DIFF
--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -119,8 +119,12 @@ describe('LogDetailsRow', () => {
     expect(screen.getByTestId('logLabelStats')).toHaveTextContent('another value');
   });
 
-  it('should render copy button on hover', async () => {
-    setup({ parsedValues: ['test value'] });
-    expect(screen.getByTitle('Copy value to clipboard')).toHaveStyle('visibility: hidden;');
-  });
+  describe('copy button', () => {
+    it('should be invisible unless mouse is over', async () => {
+      setup({ parsedValues: ['test value'] });
+      // This tests a regression where the button was always visible.
+      expect(screen.getByTitle('Copy value to clipboard')).toHaveStyle('visibility: hidden;');
+      // Asserting visibility on mouse-over is currently not possible.
+    });
+  })
 });

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -122,6 +122,5 @@ describe('LogDetailsRow', () => {
   it('should render copy button on hover', async () => {
     setup({ parsedValues: ['test value'] });
     expect(screen.getByTitle('Copy value to clipboard')).toHaveStyle('visibility: hidden;');
-    
   });
 });

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -121,11 +121,7 @@ describe('LogDetailsRow', () => {
 
   it('should render copy button on hover', async () => {
     setup({ parsedValues: ['test value'] });
-    let copyButtonDiv = screen.getByTitle('Copy value to clipboard').parentElement;
-    expect(copyButtonDiv).toHaveStyle('visibility: hidden;');
-    const value = screen.getByText('test value');
-    await userEvent.hover(value);
-    copyButtonDiv = screen.getByTitle('Copy value to clipboard').parentElement;
-    expect(copyButtonDiv).toHaveStyle('visibility: visible;');
+    expect(screen.getByTitle('Copy value to clipboard')).toHaveStyle('visibility: hidden;');
+    
   });
 });

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
 import { LogRowModel } from '@grafana/data';

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -119,7 +119,7 @@ describe('LogDetailsRow', () => {
   });
 
   describe('copy button', () => {
-    it('should be invisible unless mouse is over', async () => {
+    it('should be invisible unless mouse is over', () => {
       setup({ parsedValues: ['test value'] });
       // This tests a regression where the button was always visible.
       expect(screen.getByTitle('Copy value to clipboard')).not.toBeVisible();

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -125,5 +125,5 @@ describe('LogDetailsRow', () => {
       expect(screen.getByTitle('Copy value to clipboard')).not.toBeVisible();
       // Asserting visibility on mouse-over is currently not possible.
     });
-  })
+  });
 });

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -123,7 +123,7 @@ describe('LogDetailsRow', () => {
     it('should be invisible unless mouse is over', async () => {
       setup({ parsedValues: ['test value'] });
       // This tests a regression where the button was always visible.
-      expect(screen.getByTitle('Copy value to clipboard')).toHaveStyle('visibility: hidden;');
+      expect(screen.getByTitle('Copy value to clipboard')).not.toBeVisible();
       // Asserting visibility on mouse-over is currently not possible.
     });
   })

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -1,4 +1,5 @@
-import { screen, render, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
 import { LogRowModel } from '@grafana/data';
@@ -116,5 +117,15 @@ describe('LogDetailsRow', () => {
     fireEvent.click(adHocStatsButton);
     expect(screen.getByTestId('logLabelStats')).toBeInTheDocument();
     expect(screen.getByTestId('logLabelStats')).toHaveTextContent('another value');
+  });
+
+  it('should render copy button on hover', async () => {
+    setup({ parsedValues: ['test value'] });
+    let copyButtonDiv = screen.getByTitle('Copy value to clipboard').parentElement;
+    expect(copyButtonDiv).toHaveStyle('visibility: hidden;');
+    const value = screen.getByText('test value');
+    await userEvent.hover(value);
+    copyButtonDiv = screen.getByTitle('Copy value to clipboard').parentElement;
+    expect(copyButtonDiv).toHaveStyle('visibility: visible;');
   });
 });

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -77,9 +77,6 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
 
       .log-details-value-copy {
         visibility: hidden;
-        &:hover {
-          visibility: visible;
-        }
       }
       &:hover {
         .log-details-value-copy {

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -75,12 +75,11 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
       align-items: center;
       line-height: 22px;
 
-      .log-details-copy-button-show-on-hover {
-        display: inline;
+      div > button:first-of-type {
         visibility: hidden;
       }
       &:hover {
-        .log-details-copy-button-show-on-hover {
+        div > button:first-of-type {
           visibility: visible;
         }
       }
@@ -206,7 +205,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const styles = getStyles(theme);
 
     return (
-      <div className={cx('log-details-copy-button-show-on-hover', styles.copyButton)}>
+      <div className={styles.copyButton}>
         <ClipboardButton
           getText={() => val}
           title="Copy value to clipboard"

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -75,12 +75,12 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
       align-items: center;
       line-height: 22px;
 
-      .show-on-hover {
+      .log-details-copy-button-show-on-hover {
         display: inline;
         visibility: hidden;
       }
       &:hover {
-        .show-on-hover {
+        .log-details-copy-button-show-on-hover {
           visibility: visible;
         }
       }
@@ -206,7 +206,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const styles = getStyles(theme);
 
     return (
-      <div className={cx('show-on-hover', styles.copyButton)}>
+      <div className={cx('log-details-copy-button-show-on-hover', styles.copyButton)}>
         <ClipboardButton
           getText={() => val}
           title="Copy value to clipboard"

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -272,7 +272,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
 
     return (
       <>
-        <tr className={cx(rowStyles.logDetailsValue)}>
+        <tr className={rowStyles.logDetailsValue}>
           <td className={rowStyles.logsDetailsIcon}>
             <div className={styles.buttonRow}>
               {hasFilteringFunctionality && (

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -75,11 +75,14 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
       align-items: center;
       line-height: 22px;
 
-      div > button:first-of-type {
+      .log-details-value-copy {
         visibility: hidden;
+        &:hover {
+          visibility: visible;
+        }
       }
       &:hover {
-        div > button:first-of-type {
+        .log-details-value-copy {
           visibility: visible;
         }
       }
@@ -205,7 +208,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const styles = getStyles(theme);
 
     return (
-      <div className={styles.copyButton}>
+      <div className={`log-details-value-copy ${styles.copyButton}`}>
         <ClipboardButton
           getText={() => val}
           title="Copy value to clipboard"
@@ -253,7 +256,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
     const styles = getStyles(theme);
-    const style = getLogRowStyles(theme);
+    const rowStyles = getLogRowStyles(theme);
     const singleKey = parsedKeys == null ? false : parsedKeys.length === 1;
     const singleVal = parsedValues == null ? false : parsedValues.length === 1;
     const hasFilteringFunctionality = !disableActions && onClickFilterLabel && onClickFilterOutLabel;
@@ -272,8 +275,8 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
 
     return (
       <>
-        <tr className={cx(style.logDetailsValue)}>
-          <td className={style.logsDetailsIcon}>
+        <tr className={cx(rowStyles.logDetailsValue)}>
+          <td className={rowStyles.logsDetailsIcon}>
             <div className={styles.buttonRow}>
               {hasFilteringFunctionality && (
                 <>
@@ -310,7 +313,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
           </td>
 
           {/* Key - value columns */}
-          <td className={style.logDetailsLabel}>{singleKey ? parsedKeys[0] : this.generateMultiVal(parsedKeys)}</td>
+          <td className={rowStyles.logDetailsLabel}>{singleKey ? parsedKeys[0] : this.generateMultiVal(parsedKeys)}</td>
           <td className={cx(styles.wordBreakAll, wrapLogMessage && styles.wrapLine)}>
             <div className={styles.logDetailsValue}>
               {singleVal ? parsedValues[0] : this.generateMultiVal(parsedValues, true)}


### PR DESCRIPTION
**What is this feature?**
The change to `PanelChrome` in Explore made the CSS class `show-on-hover` not unique, so we are changing the log details classname.

WIP: Test not working.
