### PR TITLE
Legend: Truncate only for table mode

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
@@ -74,7 +74,6 @@ export const VizLegendListItem = <T = unknown,>({
       <button
         disabled={readonly}
         type="button"
-        title={item.label}
         onBlur={onMouseOut}
         onFocus={onMouseOver}
         onMouseOver={onMouseOver}
@@ -101,9 +100,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: 'inherit',
     padding: 0,
     userSelect: 'text',
-    maxWidth: '600px',
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
   }),
   itemDisabled: css({
     label: 'LegendLabelDisabled',


### PR DESCRIPTION
This PR is a partial revert of https://github.com/grafana/grafana/pull/66307 - the legend text should be truncated just in table mode for now (as a temporary response to a customer complaint). We'll work with UX for a better long term solution.


https://github.com/grafana/grafana/assets/88068998/ccc89462-3402-4136-a16a-3d3aad862c71


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
