### PR TITLE
[v10.0.x] Licensing: Pass func to update env variables when starting plugin

### DIFF
--- a/pkg/plugins/backendplugin/backendplugin.go
+++ b/pkg/plugins/backendplugin/backendplugin.go
@@ -6,4 +6,4 @@ import (
 )
 
 // PluginFactoryFunc is a function type for creating a Plugin.
-type PluginFactoryFunc func(pluginID string, logger log.Logger, env []string) (Plugin, error)
+type PluginFactoryFunc func(pluginID string, logger log.Logger, env func() []string) (Plugin, error)

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -21,7 +21,7 @@ type corePlugin struct {
 
 // New returns a new backendplugin.PluginFactoryFunc for creating a core (built-in) backendplugin.Plugin.
 func New(opts backend.ServeOpts) backendplugin.PluginFactoryFunc {
-	return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
+	return func(pluginID string, logger log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 		return &corePlugin{
 			pluginID:            pluginID,
 			logger:              logger,

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -33,12 +33,12 @@ type grpcPlugin struct {
 
 // newPlugin allocates and returns a new gRPC (external) backendplugin.Plugin.
 func newPlugin(descriptor PluginDescriptor) backendplugin.PluginFactoryFunc {
-	return func(pluginID string, logger log.Logger, env []string) (backendplugin.Plugin, error) {
+	return func(pluginID string, logger log.Logger, env func() []string) (backendplugin.Plugin, error) {
 		return &grpcPlugin{
 			descriptor: descriptor,
 			logger:     logger,
 			clientFactory: func() *plugin.Client {
-				return plugin.NewClient(newClientConfig(descriptor.executablePath, env, logger, descriptor.versionedPlugins))
+				return plugin.NewClient(newClientConfig(descriptor.executablePath, env(), logger, descriptor.versionedPlugins))
 			},
 		}, nil
 	}

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -289,7 +289,7 @@ func NewFakeBackendProcessProvider() *FakeBackendProcessProvider {
 	}
 	f.BackendFactoryFunc = func(ctx context.Context, p *plugins.Plugin) backendplugin.PluginFactoryFunc {
 		f.Requested[p.ID]++
-		return func(pluginID string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+		return func(pluginID string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 			f.Invoked[pluginID]++
 			return &FakePluginClient{}, nil
 		}

--- a/pkg/plugins/manager/loader/initializer/initializer.go
+++ b/pkg/plugins/manager/loader/initializer/initializer.go
@@ -39,7 +39,11 @@ func (i *Initializer) Initialize(ctx context.Context, p *plugins.Plugin) error {
 			return fmt.Errorf("could not find backend factory for plugin")
 		}
 
-		if backendClient, err := backendFactory(p.ID, p.Logger(), i.envVars(p)); err != nil {
+		envFunc := func() []string {
+			return i.envVars(p)
+		}
+
+		if backendClient, err := backendFactory(p.ID, p.Logger(), envFunc); err != nil {
 			return err
 		} else {
 			p.RegisterClient(backendClient)

--- a/pkg/plugins/manager/loader/initializer/initializer_test.go
+++ b/pkg/plugins/manager/loader/initializer/initializer_test.go
@@ -465,7 +465,7 @@ type fakeBackendProvider struct {
 }
 
 func (f *fakeBackendProvider) BackendFactory(_ context.Context, _ *plugins.Plugin) backendplugin.PluginFactoryFunc {
-	return func(_ string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+	return func(_ string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 		return f.plugin, nil
 	}
 }

--- a/pkg/plugins/manager/loader/loader_test.go
+++ b/pkg/plugins/manager/loader/loader_test.go
@@ -1045,7 +1045,7 @@ func TestLoader_Load_SkipUninitializedPlugins(t *testing.T) {
 		procPrvdr := fakes.NewFakeBackendProcessProvider()
 		// Cause an initialization error
 		procPrvdr.BackendFactoryFunc = func(ctx context.Context, p *plugins.Plugin) backendplugin.PluginFactoryFunc {
-			return func(pluginID string, _ log.Logger, _ []string) (backendplugin.Plugin, error) {
+			return func(pluginID string, _ log.Logger, _ func() []string) (backendplugin.Plugin, error) {
 				if pluginID == "test-datasource" {
 					return nil, fmt.Errorf("failed to initialize")
 				}


### PR DESCRIPTION
Backport 5e0b20266ec5401203b28f5811ac727cc5426c98 from #74620

---

**What is this feature?**
Updates backendplugin.PluginFactoryFunc to receive a provider func for the env variables to set when starting a Plugin. 
This will update the env variables every time a plugin is started (instead of just snapshotting the variables the first time). 

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana-enterprise/issues/5752
