### PR TITLE
Canvas: Button API Editor support setting content-type

### DIFF
--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -24,6 +24,7 @@ export const defaultApiConfig: APIEditorConfig = {
   endpoint: '',
   method: HttpRequestMethod.POST,
   data: '{}',
+  contentType: 'application/json',
 };
 
 class ButtonDisplay extends PureComponent<CanvasElementProps<ButtonConfig, ButtonData>> {
@@ -80,7 +81,11 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
   prepareData: (ctx: DimensionContext, cfg: ButtonConfig) => {
     const getCfgApi = () => {
       if (cfg?.api) {
-        cfg.api = { ...cfg.api, method: cfg.api.method ?? HttpRequestMethod.POST };
+        cfg.api = {
+          ...cfg.api,
+          method: cfg.api.method ?? defaultApiConfig.method,
+          contentType: cfg.api.contentType ?? defaultApiConfig.contentType,
+        };
         return cfg.api;
       }
 

--- a/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
@@ -209,7 +209,7 @@ export function APIEditor({ value, context, onChange }: Props) {
       )}
       {renderTestAPIButton(value)}
       <br />
-      {value?.method === HttpRequestMethod.POST && renderJSON(value?.data ?? '{}')}
+      {value?.method === HttpRequestMethod.POST && value?.contentType === defaultApiConfig.contentType && renderJSON(value?.data ?? '{}')}
     </>
   ) : (
     <>Must enable disableSanitizeHtml feature flag to access</>

--- a/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
@@ -209,7 +209,9 @@ export function APIEditor({ value, context, onChange }: Props) {
       )}
       {renderTestAPIButton(value)}
       <br />
-      {value?.method === HttpRequestMethod.POST && value?.contentType === defaultApiConfig.contentType && renderJSON(value?.data ?? '{}')}
+      {value?.method === HttpRequestMethod.POST &&
+        value?.contentType === defaultApiConfig.contentType &&
+        renderJSON(value?.data ?? '{}')}
     </>
   ) : (
     <>Must enable disableSanitizeHtml feature flag to access</>


### PR DESCRIPTION
This PR adds the option to select from a list of content types and also set a custom type.
The list could potentially be revisited and improved, currently supports - `text, json, javascript, html, xml, x-www-form-urlencoded`.
The JSON validation section is removed if the content type is not json.



https://github.com/grafana/grafana/assets/88068998/22ed09b2-98ae-414f-9a37-2483aa4a500e


Fixes #74221

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
