### PR TITLE
sql: do not use the unexported getTimeSrv function

### DIFF
--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -27,13 +27,13 @@ import {
   TemplateSrv,
   reportInteraction,
 } from '@grafana/runtime';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { ResponseParser } from '../ResponseParser';
 import { SqlQueryEditor } from '../components/QueryEditor';
 import { MACRO_NAMES } from '../constants';
 import { DB, SQLQuery, SQLOptions, SqlQueryModel, QueryFormat } from '../types';
 import migrateAnnotation from '../utils/migration';
+import { getCurrentTimeRange } from '../utils/time';
 
 import { isSqlDatasourceDatabaseSelectionFeatureFlagEnabled } from './../components/QueryEditorFeatureFlag.utils';
 
@@ -211,7 +211,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   }
 
   private runMetaQuery(request: Partial<SQLQuery>, options?: LegacyMetricFindQueryOptions): Promise<DataFrame> {
-    const range = getTimeSrv().timeRange();
+    const range = getCurrentTimeRange(this.templateSrv);
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 

--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -211,7 +211,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   }
 
   private runMetaQuery(request: Partial<SQLQuery>, options?: LegacyMetricFindQueryOptions): Promise<DataFrame> {
-    const range = getCurrentTimeRange(this.templateSrv);
+    const range = options?.range ?? getCurrentTimeRange(this.templateSrv);
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
@@ -222,8 +222,8 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
           method: 'POST',
           headers: this.getRequestHeaders(),
           data: {
-            from: options?.range?.from.valueOf().toString() || range.from.valueOf().toString(),
-            to: options?.range?.to.valueOf().toString() || range.to.valueOf().toString(),
+            from: range.from.valueOf().toString(),
+            to: range.to.valueOf().toString(),
             queries,
           },
           requestId: refId,

--- a/public/app/features/plugins/sql/utils/time.test.ts
+++ b/public/app/features/plugins/sql/utils/time.test.ts
@@ -1,0 +1,39 @@
+import { TemplateSrv } from '@grafana/runtime';
+
+import { getCurrentTimeRange } from './time';
+
+function getFakeTemplateSrv(text: string): TemplateSrv {
+  return {
+    replace: () => text,
+    getVariables: () => [],
+    containsTemplate: () => false,
+    updateTimeRange: () => undefined,
+  };
+}
+
+describe('getCurrentTimeRange', () => {
+  it('should parse valid values', () => {
+    const templateSrv = getFakeTemplateSrv('1694503944572 1694504244572');
+    const range = getCurrentTimeRange(templateSrv);
+    expect(range.from.valueOf()).toBe(1694503944572);
+    expect(range.to.valueOf()).toBe(1694504244572);
+  });
+
+  it('should reject empty string', () => {
+    const templateSrv = getFakeTemplateSrv('');
+    const getRange = () => getCurrentTimeRange(templateSrv);
+    expect(getRange).toThrow('time range info unavailable');
+  });
+
+  it('should reject single space', () => {
+    const templateSrv = getFakeTemplateSrv(' ');
+    const getRange = () => getCurrentTimeRange(templateSrv);
+    expect(getRange).toThrow('time range info unavailable');
+  });
+
+  it('should reject not-numbers', () => {
+    const templateSrv = getFakeTemplateSrv('asdf');
+    const getRange = () => getCurrentTimeRange(templateSrv);
+    expect(getRange).toThrow('time range info unavailable');
+  });
+});

--- a/public/app/features/plugins/sql/utils/time.ts
+++ b/public/app/features/plugins/sql/utils/time.ts
@@ -1,0 +1,24 @@
+import { dateTime, rangeUtil, TimeRange } from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
+
+const RANGE_RE = /^(\d+) (\d+)$/; // find digits, then a space, then digits again.
+
+// there is no exported "getTimeSrv" functionality,
+// so we use the template server to access the current time range.
+export function getCurrentTimeRange(templateSrv: TemplateSrv): TimeRange {
+  const text = templateSrv.replace('$__from $__to');
+
+  // this is a "string based API", so we try to be sure
+  // that the returned data is correct.
+  const match = text.match(RANGE_RE);
+  if (match == null) {
+    throw new Error('time range info unavailable');
+  }
+
+  const fromText = match[1];
+  const toText = match[2];
+  const from = dateTime(Number(fromText));
+  const to = dateTime(Number(toText));
+
+  return rangeUtil.convertRawToRange({ from, to });
+}


### PR DESCRIPTION
the shared sql functionality codebase in grafana uses the following import:
```ts
import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
```

as working on making the core sql datasources external-ish, we cannot import unexported code from grafana.

this PR uses a workaround where we use the exported `getTemplateSrv()` to get the time range using `getTemplateSrv().replace('$__from $__to')`.

long term it would be better to completely avoid relying on a singleton-based get-time-range approach, because there may be places where there are multiple time-ranges "current" at the same time. i investigated this approach here, but it is not easy:
1. we would need to migrate from `.metricFindQuery()` to `this.variables`
2. the API for `.runSql()` would have to get a time-range param, so the callers would have to calculate it "somehow".


how to test:
1. open devtools in the browser, we will look at the `query` ajax requests
2. create a dashboard query variable for one of the core sql datasources, for example postgres, you can use a "dummy" sql query like "SELECT 42". save the query variable.
3. go back to the dashboard, reload the page
4. check the ajax requests. find the one doing the SELECT 42. verify that the "from" and "to" json attributes in the request-body match the currently selected time range in the dashboard.