### PR TITLE
[v9.3.x] Nightlies: Bring back windows installers for main builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1962,6 +1962,25 @@ steps:
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: windows-init
+- commands:
+  - $$gcpKey = $$env:GCP_KEY
+  - '[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($$gcpKey))
+    > gcpkey.json'
+  - dos2unix gcpkey.json
+  - gcloud auth activate-service-account --key-file=gcpkey.json
+  - rm gcpkey.json
+  - cp C:\App\nssm-2.24.zip .
+  depends_on:
+  - windows-init
+  environment:
+    GCP_KEY:
+      from_secret: gcp_grafanauploads_base64
+    GITHUB_TOKEN:
+      from_secret: github_token
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+  image: grafana/ci-wix:0.1.1
+  name: build-windows-installer
 trigger:
   branch: main
   event:
@@ -4223,6 +4242,6 @@ kind: secret
 name: github_token
 ---
 kind: signature
-hmac: f4fd6163320bd9c1e3929373fce0802358c8e3eb1a50315d2270e3ff2b78b5ac
+hmac: 1f58a357d66fc52801b4e6cc63ea5977b6f7929aa396ae889af6f572b8edfd65
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1227,6 +1227,7 @@ def get_windows_steps(ver_mode, bucket = "%PRERELEASE_BUCKET%"):
     if ver_mode in (
         "release",
         "release-branch",
+        "main",
     ):
         gcp_bucket = "{}/artifacts/downloads".format(bucket)
         if ver_mode == "release":


### PR DESCRIPTION
Backport 36728dd671c6dcc368ca2f3ce2d259e52cab46bb from #74698

---

**What is this feature?**

Windows installers (`msi`) seized to be published after https://github.com/grafana/grafana/pull/70815, for `main` builds.

It's not a huge deal since there are not widely used at all, but it blocks the nightly builds publishing.
