### PR TITLE
[v9.5.x] Nightlies: Bring back windows installers for main builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1946,6 +1946,25 @@ steps:
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: windows-init
+- commands:
+  - $$gcpKey = $$env:GCP_KEY
+  - '[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($$gcpKey))
+    > gcpkey.json'
+  - dos2unix gcpkey.json
+  - gcloud auth activate-service-account --key-file=gcpkey.json
+  - rm gcpkey.json
+  - cp C:\App\nssm-2.24.zip .
+  depends_on:
+  - windows-init
+  environment:
+    GCP_KEY:
+      from_secret: gcp_grafanauploads_base64
+    GITHUB_TOKEN:
+      from_secret: github_token
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+  image: grafana/ci-wix:0.1.1
+  name: build-windows-installer
 trigger:
   branch: main
   event:
@@ -4207,6 +4226,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 6d2e51d46e164cdb897b3bdd308d020b95fd01703a912daf25d3e97797705d00
+hmac: 4f7dcf8944d20c6f4fbdb0b099969871f4f07d40d44106594f82617ec199e963
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1224,6 +1224,7 @@ def get_windows_steps(ver_mode, bucket = "%PRERELEASE_BUCKET%"):
     if ver_mode in (
         "release",
         "release-branch",
+        "main",
     ):
         gcp_bucket = "{}/artifacts/downloads".format(bucket)
         if ver_mode == "release":


### PR DESCRIPTION
Backport 36728dd671c6dcc368ca2f3ce2d259e52cab46bb from #74698

---

**What is this feature?**

Windows installers (`msi`) seized to be published after https://github.com/grafana/grafana/pull/70815, for `main` builds.

It's not a huge deal since there are not widely used at all, but it blocks the nightly builds publishing.
