### PR TITLE
[v10.0.x] Nightlies: Bring back windows installers for main builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2013,6 +2013,25 @@ steps:
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: windows-init
+- commands:
+  - $$gcpKey = $$env:GCP_KEY
+  - '[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($$gcpKey))
+    > gcpkey.json'
+  - dos2unix gcpkey.json
+  - gcloud auth activate-service-account --key-file=gcpkey.json
+  - rm gcpkey.json
+  - cp C:\App\nssm-2.24.zip .
+  depends_on:
+  - windows-init
+  environment:
+    GCP_KEY:
+      from_secret: gcp_grafanauploads_base64
+    GITHUB_TOKEN:
+      from_secret: github_token
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+  image: grafana/ci-wix:0.1.1
+  name: build-windows-installer
 trigger:
   branch: main
   event:
@@ -4336,6 +4355,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 51b260e286757673bae50d8b9320fe2f613e8690e0876563688f819fd4f749c1
+hmac: bcbe7170dd04ca1254d651b454f451c5da4082de9a90c4f474478b3e685b361d
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1234,6 +1234,7 @@ def get_windows_steps(ver_mode, bucket = "%PRERELEASE_BUCKET%"):
     if ver_mode in (
         "release",
         "release-branch",
+        "main",
     ):
         gcp_bucket = "{}/artifacts/downloads".format(bucket)
         if ver_mode == "release":


### PR DESCRIPTION
Backport 36728dd671c6dcc368ca2f3ce2d259e52cab46bb from #74698

---

**What is this feature?**

Windows installers (`msi`) seized to be published after https://github.com/grafana/grafana/pull/70815, for `main` builds.

It's not a huge deal since there are not widely used at all, but it blocks the nightly builds publishing.
