### PR TITLE
Docs: Add a section about using multiple auth providers in Grafana

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -34,8 +34,10 @@ The following table shows all supported authentication providers and the feature
 
 ## Configuring multiple identity providers
 
-Grafana allows you to configure more than one authentication provider, however it is not possible to configure the same type of authentication provider twice. 
-For example, you can have [SAML]({{< relref "./saml" >}}) (Enterprise only) and [Generic OAuth]({{< relref "./generic-oauth" >}}) configured, but you can not have two different [Generic OAuth]({{< relref "./generic-oauth" >}}) configurations.  
+Grafana allows you to configure more than one authentication provider, however it is not possible to configure the same type of authentication provider twice.
+For example, you can have [SAML]({{< relref "./saml" >}}) (Enterprise only) and [Generic OAuth]({{< relref "./generic-oauth" >}}) configured, but you can not have two different [Generic OAuth]({{< relref "./generic-oauth" >}}) configurations.
+
+> Note: Grafana does not support multiple identity providers resolving the same user. Ensure there are no user account overlaps between the different providers
 
 In scenarios where you have multiple identity providers of the same type, there are a couple of options:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -32,6 +32,17 @@ The following table shows all supported authentication providers and the feature
 | [Okta OAuth]({{< relref "./okta" >}})             |  v7.0+  |    v7.0+     |               v7.0+               |                  -                  |
 | [SAML]({{< relref "./saml" >}}) (Enterprise only) |  v6.3+  |    v7.0+     |               v7.0+               |                  -                  |
 
+## Configuring multiple identity providers
+
+Grafana allows you to configure more than one authentication provider, however it is not possible to configure the same type of authentication provider twice. 
+For example, you can have [SAML]({{< relref "./saml" >}}) (Enterprise only) and [Generic OAuth]({{< relref "./generic-oauth" >}}) configured, but you can not have two different [Generic OAuth]({{< relref "./generic-oauth" >}}) configurations.  
+
+In scenarios where you have multiple identity providers of the same type, there are a couple of options:
+
+- Use different Grafana instances each configured with a given identity provider.
+- Check if the identity provider supports account federation. In such cases, you can configure it once and let your identity provider federate the accounts from different providers.
+- If SAML is supported by the identity provider, you can configure one [Generic OAuth]({{< relref "./generic-oauth" >}}) and one [SAML]({{< relref "./saml" >}}) (Enterprise only).
+
 ## Grafana Auth
 
 Grafana of course has a built in user authentication system with password authentication enabled by default. You can


### PR DESCRIPTION
We often get questions about the possibility of configuring multiple identity providers of the same type. This PR adds a small section to cover this scenario and give alternatives to the users - as Grafana does not support multiple identity provider configuration of the same type.