### PR TITLE
Notifications: Don't show toasts after refreshing

### DIFF
--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -109,7 +109,9 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
         text: cur.text,
         traceId: cur.traceId,
         timestamp: cur.timestamp,
-        showing: cur.showing,
+        // we don't care about still showing toasts after refreshing
+        // https://github.com/grafana/grafana/issues/71932
+        showing: false,
       };
 
       return prev;


### PR DESCRIPTION
**What is this feature?**

Prevent app notifications/toasts from showing after reloading the page.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/71932

**Special notes for your reviewer:**

Have a nice day 😎 