### PR TITLE
Nested Folders: Fix fetching a folder by title

### DIFF
--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -172,7 +172,15 @@ func (ss *sqlStore) Get(ctx context.Context, q folder.GetFolderQuery) (*folder.F
 		case q.ID != nil:
 			exists, err = sess.SQL("SELECT * FROM folder WHERE id = ?", q.ID).Get(foldr)
 		case q.Title != nil:
-			exists, err = sess.SQL("SELECT * FROM folder WHERE title = ? AND org_id = ?", q.Title, q.OrgID).Get(foldr)
+			args := []any{*q.Title, q.OrgID}
+			s := "SELECT * FROM folder WHERE title = ? AND org_id = ?"
+			if q.ParentUID != nil {
+				s = s + " AND parent_uid = ?"
+				args = append(args, *q.ParentUID)
+			} else {
+				s = s + " AND parent_uid IS NULL"
+			}
+			exists, err = sess.SQL(s, args...).Get(foldr)
 		default:
 			return folder.ErrBadRequest.Errorf("one of ID, UID, or Title must be included in the command")
 		}

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -408,6 +408,17 @@ func TestIntegrationGet(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// create subfolder with same title
+	subfolderUID := util.GenerateShortUID()
+	subfolder, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{
+		Title:       folderTitle,
+		Description: folderDsc,
+		OrgID:       orgID,
+		UID:         subfolderUID,
+		ParentUID:   f.UID,
+	})
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		err := folderStore.Delete(context.Background(), f.UID, orgID)
 		require.NoError(t, err)
@@ -429,15 +440,14 @@ func TestIntegrationGet(t *testing.T) {
 		assert.Equal(t, f.OrgID, ff.OrgID)
 		assert.Equal(t, f.Title, ff.Title)
 		assert.Equal(t, f.Description, ff.Description)
-		//assert.Equal(t, folder.GeneralFolderUID, ff.ParentUID)
 		assert.NotEmpty(t, ff.Created)
 		assert.NotEmpty(t, ff.Updated)
 		assert.NotEmpty(t, ff.URL)
 	})
 
-	t.Run("get folder by title should succeed", func(t *testing.T) {
+	t.Run("get folder by title should return folder under root", func(t *testing.T) {
 		ff, err := folderStore.Get(context.Background(), folder.GetFolderQuery{
-			Title: &f.Title,
+			Title: &folderTitle,
 			OrgID: orgID,
 		})
 		require.NoError(t, err)
@@ -446,13 +456,30 @@ func TestIntegrationGet(t *testing.T) {
 		assert.Equal(t, f.OrgID, ff.OrgID)
 		assert.Equal(t, f.Title, ff.Title)
 		assert.Equal(t, f.Description, ff.Description)
-		//assert.Equal(t, folder.GeneralFolderUID, ff.ParentUID)
 		assert.NotEmpty(t, ff.Created)
 		assert.NotEmpty(t, ff.Updated)
 		assert.NotEmpty(t, ff.URL)
 	})
 
-	t.Run("get folder by title should succeed", func(t *testing.T) {
+	t.Run("get folder by title and parent UID should return subfolder", func(t *testing.T) {
+		ff, err := folderStore.Get(context.Background(), folder.GetFolderQuery{
+			Title:     &folderTitle,
+			OrgID:     orgID,
+			ParentUID: &f.UID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, subfolder.ID, ff.ID)
+		assert.Equal(t, subfolder.UID, ff.UID)
+		assert.Equal(t, subfolder.OrgID, ff.OrgID)
+		assert.Equal(t, subfolder.Title, ff.Title)
+		assert.Equal(t, subfolder.Description, ff.Description)
+		assert.Equal(t, subfolder.ParentUID, ff.ParentUID)
+		assert.NotEmpty(t, subfolder.Created)
+		assert.NotEmpty(t, subfolder.Updated)
+		assert.NotEmpty(t, subfolder.URL)
+	})
+
+	t.Run("get folder by ID should succeed", func(t *testing.T) {
 		ff, err := folderStore.Get(context.Background(), folder.GetFolderQuery{
 			ID: &f.ID,
 		})
@@ -462,7 +489,6 @@ func TestIntegrationGet(t *testing.T) {
 		assert.Equal(t, f.OrgID, ff.OrgID)
 		assert.Equal(t, f.Title, ff.Title)
 		assert.Equal(t, f.Description, ff.Description)
-		//assert.Equal(t, folder.GeneralFolderUID, ff.ParentUID)
 		assert.NotEmpty(t, ff.Created)
 		assert.NotEmpty(t, ff.Updated)
 		assert.NotEmpty(t, ff.URL)

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -130,13 +130,15 @@ type DeleteFolderCommand struct {
 
 // GetFolderQuery is used for all folder Get requests. Only one of UID, ID, or
 // Title should be set; if multiple fields are set by the caller the dashboard
-// service will select the field with the most specificity, in order: ID, UID,
-// Title.
+// service will select the field with the most specificity, in order: UID, ID
+// Title. If Title is set, it will fetch the folder in the root folder.
+// Callers can additionally set the ParentUID field to fetch a folder by title under a specific folder.
 type GetFolderQuery struct {
-	UID   *string
-	ID    *int64
-	Title *string
-	OrgID int64
+	UID       *string
+	ParentUID *string
+	ID        *int64
+	Title     *string
+	OrgID     int64
 
 	SignedInUser identity.Requester `json:"-"`
 }

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -15,7 +15,10 @@ type Service interface {
 	// GetFolder takes a GetFolderCommand and returns a folder matching the
 	// request. One of ID, UID, or Title must be included. If multiple values
 	// are included in the request, Grafana will select one in order of
-	// specificity (ID, UID, Title).
+	// specificity (UID, ID,Title).
+	// If Title is set, it will fetch the folder in the root folder.
+	// If nested folders are enabled, callers can additionally set the ParentUID field
+	// to fetch a folder by title under a specific folder.
 	Get(ctx context.Context, cmd *GetFolderQuery) (*Folder, error)
 
 	// Update is used to update a folder's UID, Title and Description. To change


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Nested folders are [uniquely identified by `org_id`, `parent_uid` and `title`](https://github.com/grafana/grafana/blob/376f9a75dbb8d7b9e2219eb27a58d43f090c51f0/pkg/services/sqlstore/migrations/folder_mig.go#L36). Due to a temporary constrain #63082, currently is not possible for two folders under different folders to have the same title.
This fix modifies that nested folder store [Get()](https://github.com/grafana/grafana/blob/376f9a75dbb8d7b9e2219eb27a58d43f090c51f0/pkg/services/folder/folderimpl/sqlstore.go#L158) method so that it takes parent UID under consideration when fetching a folder by title.
This is required because if we remove the above constrain xorm's [Get()](https://github.com/grafana/grafana/blob/376f9a75dbb8d7b9e2219eb27a58d43f090c51f0/pkg/services/folder/folderimpl/sqlstore.go#L169C100-L169C103) will potentially fail if there are multiple folders with the same title.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
