### PR TITLE
Docs: Improve levels of headings in logs plugin documentation

### DIFF
--- a/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-logs-data-source-plugin.md
@@ -102,15 +102,13 @@ const result = createDataFrame({
 
 ## Enhance your logs data source plugin with optional features
 
-You can use the following optional features to enhance your logs data source plugin.
-
-### Implement features that enhance log querying experience in Explore
+You can use the following optional features to enhance your logs data source plugin. With optional features, you are going to enhance log querying experience in Explore.
 
 [Explore]({{< relref "../../../../explore" >}}) provides a useful interface for investigating incidents and troubleshooting logs. If the data source produces log results, we highly recommend implementing the following APIs to allow your users to get the most out of the logs UI and its features within Explore.
 
 The following steps show the process for adding support for Explore features in a data source plugin through a seamless integration. Implement these APIs to enhance the user experience and take advantage of Explore's powerful log investigation capabilities.
 
-#### Show log results in Explore's Logs view
+### Show log results in Explore's Logs view
 
 To ensure that your log results are displayed in an interactive Logs view, you must add a `meta` attribute to `preferredVisualisationType` in your log result data frame.
 
@@ -135,7 +133,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Highlight searched words
+### Highlight searched words
 
 {{% admonition type="note" %}} This feature must be implemented in the data frame as a meta attribute. {{%
 /admonition %}}
@@ -167,7 +165,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Log result `meta` information
+### Log result `meta` information
 
 {{% admonition type="note" %}} This feature must be implemented in the data frame as a meta attribute, or in the data frame as a field. {{%
 /admonition %}}
@@ -235,7 +233,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Color-coded log levels
+### Color-coded log levels
 
 {{% admonition type="note" %}} This feature must be implemented in the data frame as a field. {{%
 /admonition %}}
@@ -244,7 +242,7 @@ Color-coded [log levels]({{< relref "../../../../explore/logs-integration/#log-l
 
 Refer to [Logs data frame format](#logs-data-frame-format) for more information.
 
-#### Copy link to log line
+### Copy link to log line
 
 {{% admonition type="note" %}} This feature must be implemented in the data frame as a field. {{%
 /admonition %}}
@@ -255,7 +253,7 @@ If the underlying database doesn't return an `id` field, you can implement one w
 
 Refer to [Logs data frame format](#logs-data-frame-format) for more information.
 
-#### Filter fields using Log details
+### Filter fields using Log details
 
 {{% admonition type="note" %}} Implement this feature through the data source method. {{%
 /admonition %}}
@@ -290,7 +288,7 @@ export class ExampleDatasource extends DataSourceApi<ExampleQuery, ExampleOption
 }
 ```
 
-#### Live tailing
+### Live tailing
 
 {{% admonition type="note" %}} Implement this feature data source method and enabled in `plugin.json` {{%
 /admonition %}}
@@ -323,7 +321,7 @@ export class ExampleDatasource extends DataSourceApi<ExampleQuery, ExampleOption
 }
 ```
 
-#### Log context
+### Log context
 
 {{% admonition type="note" %}} Implement this feature through the `DataSourceWithXXXSupport` interface{{%
 /admonition %}}


### PR DESCRIPTION
In [Build a logs data source plugin](https://grafana.com/docs/grafana/next/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-logs-data-source-plugin/#implement-features-that-enhance-log-querying-experience-in-explore) documentation, we have a redundant heading that hides list of features in navigation:

<img width="413" alt="image" src="https://github.com/grafana/grafana/assets/30407135/6d84cb02-e979-4eac-ac1d-3db4fa50dd9a">

This heading doesn't bring any value as all of the features are accessible in Explore.

With this change, list of features to implement will be listed in right navigation, in the same way as it is in [APIs under development](https://grafana.com/docs/grafana/next/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-logs-data-source-plugin/#apis-under-development) part