### PR TITLE
CI: fix docker tag format on `main` branch and missing dependency on `ci-frontend-metrics.sh`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1878,6 +1878,7 @@ steps:
     repo:
     - grafana/grafana
 - commands:
+  - apk add --update bash
   - ./scripts/ci-frontend-metrics.sh | ./bin/build publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   depends_on:
   - test-a11y-frontend
@@ -4163,6 +4164,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 9ba7dbe63cfa156c8895c9d575c79e7399c048d67315332f64cbcbfa3c56e448
+hmac: d3a519d45aa8abd7424ede359c024e5212341bcbc1a51e27cda1922a4e42877a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1893,8 +1893,8 @@ steps:
 - commands:
   - /src/grafana-build docker --package=$(cat packages.txt | grep tar.gz | grep -v
     docker | grep -v sha256) --ubuntu-base=ubuntu:22.10 --alpine-base=alpine:3.17.1
-    --tag-format='{{ .version }}-{{ .arch }}' --ubuntu-tag-format='{{ .version }}-ubuntu-{{
-    .arch }}' > docker.txt
+    --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
+    .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' > docker.txt
   - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
   depends_on:
   - rgm-package
@@ -4163,6 +4163,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 5ccdc60b94e3d992613fc1e978057a285d1858ea7db4f9daf87213f91212f1f3
+hmac: 9ba7dbe63cfa156c8895c9d575c79e7399c048d67315332f64cbcbfa3c56e448
 
 ...

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -98,7 +98,13 @@ def build_e2e(trigger, ver_mode):
             [
                 store_storybook_step(trigger = trigger_oss, ver_mode = ver_mode),
                 frontend_metrics_step(trigger = trigger_oss),
-                rgm_build_docker_step("packages.txt", images["ubuntu"], images["alpine"]),
+                rgm_build_docker_step(
+                    "packages.txt",
+                    images["ubuntu"],
+                    images["alpine"],
+                    tag_format = "{{ .version_base }}-{{ .buildID }}-{{ .arch }}",
+                    ubuntu_tag_format = "{{ .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}",
+                ),
                 publish_images_step(
                     docker_repo = "grafana",
                     trigger = trigger_oss,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -633,6 +633,7 @@ def frontend_metrics_step(trigger = None):
         },
         "failure": "ignore",
         "commands": [
+            "apk add --update bash",
             "./scripts/ci-frontend-metrics.sh | ./bin/build publish-metrics $${GRAFANA_MISC_STATS_API_KEY}",
         ],
     }


### PR DESCRIPTION
* Missing `bash` dependency on `ci-frontend-metrics.sh`.
* The docker format did not match what was attempting to be published.