### PR TITLE
Secure socks proxy: Allow overriding socks username

### DIFF
--- a/pkg/tsdb/sqleng/proxyutil/proxy_util.go
+++ b/pkg/tsdb/sqleng/proxyutil/proxy_util.go
@@ -6,10 +6,14 @@ import (
 )
 
 func GetSQLProxyOptions(dsInfo sqleng.DataSourceInfo) *sdkproxy.Options {
-	return &sdkproxy.Options{
+	opts := &sdkproxy.Options{
 		Enabled: dsInfo.JsonData.SecureDSProxy,
 		Auth: &sdkproxy.AuthOptions{
 			Username: dsInfo.UID,
 		},
 	}
+	if dsInfo.JsonData.SecureDSProxyUsername != "" {
+		opts.Auth.Username = dsInfo.JsonData.SecureDSProxyUsername
+	}
+	return opts
 }

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -73,6 +73,7 @@ type JsonData struct {
 	TimeInterval            string `json:"timeInterval"`
 	Database                string `json:"database"`
 	SecureDSProxy           bool   `json:"enableSecureSocksProxy"`
+	SecureDSProxyUsername   string `json:"secureSocksProxyUsername"`
 	AllowCleartextPasswords bool   `json:"allowCleartextPasswords"`
 	AuthenticationType      string `json:"authenticationType"`
 }


### PR DESCRIPTION
**What is this feature?**

This PR allows for the SQL datasources to override the socks username used in the secure socks proxy by setting `secureSocksProxyUsername` in the json data. This is the same functionality used by the other datasources via the [plugin sdk](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/common.go#L224). However, since the SQL datasources don't use `DataSourceInstanceSettings`, it needs to be done in the proxy util.

**Which issue(s) does this PR fix?**:

Unblocks https://github.com/grafana/hosted-grafana/issues/4487
