### PR TITLE
add feature tracking for regex and null metadata

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/state/helpers.ts
@@ -206,6 +206,8 @@ export function tracking(event: string, state?: MetricsModalState | null, metric
         fuzzySearchQuery: state?.fuzzySearchQuery,
         fullMetaSearch: state?.fullMetaSearch,
         selectedTypes: state?.selectedTypes,
+        useRegexSearch: state?.useBackend,
+        includeResultsWithoutMetadata: state?.includeNullMetadata,
       });
     case 'grafana_prom_metric_encycopedia_disable_text_wrap_interaction':
       reportInteraction(event, {


### PR DESCRIPTION
**What is this feature?**
Add rudderstack event measures for the metrics explorer to measure the options

1. regex search 
2. including results without metadata 

**Why do we need this feature?**
Rudderstack events are used to measure how people are interacting with features. We want to know how people are using the regex feature and the filtering options to include metrics without metadata in metrics explorer results.

**Who is this feature for?**
Prometheus query builder users and for @catherineymgui and @bohandley and our ops feature tracking dashboard seen [here](https://ops.grafana-ops.net/d/Guq9HihVz/metrics?orgId=1) (have to be a member of the org to see the dashboard)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
