### PR TITLE
web: add slo group to request meta

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -77,7 +77,6 @@ Some features are enabled by default. You can disable these feature by setting t
 | `splitScopes`                    | Support faster dashboard and folder search by splitting permission scopes into parts                                                                                                         |
 | `reportingRetries`               | Enables rendering retries for the reporting feature                                                                                                                                          |
 | `newBrowseDashboards`            | New browse/manage dashboards UI                                                                                                                                                              |
-| `httpSLOLevels`                  | Adds SLO level to http request metrics                                                                                                                                                       |
 
 ## Experimental feature toggles
 
@@ -138,6 +137,7 @@ Experimental features might be changed or removed without prior notice.
 | `wargamesTesting`                           | Placeholder feature flag for internal testing                                                                |
 | `alertingInsights`                          | Show the new alerting insights landing page                                                                  |
 | `pluginsAPIMetrics`                         | Sends metrics of public grafana packages usage by plugins                                                    |
+| `httpSLOLevels`                             | Adds SLO level to http request metrics                                                                       |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -77,6 +77,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `splitScopes`                    | Support faster dashboard and folder search by splitting permission scopes into parts                                                                                                         |
 | `reportingRetries`               | Enables rendering retries for the reporting feature                                                                                                                                          |
 | `newBrowseDashboards`            | New browse/manage dashboards UI                                                                                                                                                              |
+| `httpSLOLevels`                  | Adds SLO level to http request metrics                                                                                                                                                       |
 
 ## Experimental feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -128,4 +128,5 @@ export interface FeatureToggles {
   wargamesTesting?: boolean;
   alertingInsights?: boolean;
   pluginsAPIMetrics?: boolean;
+  httpSLOLevels?: boolean;
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -436,19 +436,19 @@ func (hs *HTTPServer) registerRoutes() {
 		}
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
-		apiRoute.Any("/datasources/proxy/:id/*", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
-		apiRoute.Any("/datasources/proxy/uid/:uid/*", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
-		apiRoute.Any("/datasources/proxy/:id", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
-		apiRoute.Any("/datasources/proxy/uid/:uid", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
+		apiRoute.Any("/datasources/proxy/:id/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
+		apiRoute.Any("/datasources/proxy/uid/:uid/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
+		apiRoute.Any("/datasources/proxy/:id", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
+		apiRoute.Any("/datasources/proxy/uid/:uid", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
 		// Deprecated: use /datasources/uid/:uid/resources API instead.
-		apiRoute.Any("/datasources/:id/resources", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
-		apiRoute.Any("/datasources/uid/:uid/resources", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
+		apiRoute.Any("/datasources/:id/resources", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
+		apiRoute.Any("/datasources/uid/:uid/resources", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
 		// Deprecated: use /datasources/uid/:uid/resources/* API instead.
-		apiRoute.Any("/datasources/:id/resources/*", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
-		apiRoute.Any("/datasources/uid/:uid/resources/*", authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
+		apiRoute.Any("/datasources/:id/resources/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
+		apiRoute.Any("/datasources/uid/:uid/resources/*", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResourceWithUID)
 		// Deprecated: use /datasources/uid/:uid/health API instead.
-		apiRoute.Any("/datasources/:id/health", authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealth))
-		apiRoute.Any("/datasources/uid/:uid/health", authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealthWithUID))
+		apiRoute.Any("/datasources/:id/health", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealth))
+		apiRoute.Any("/datasources/uid/:uid/health", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealthWithUID))
 
 		// Folders
 		apiRoute.Group("/folders", func(folderRoute routing.RouteRegister) {
@@ -532,7 +532,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// metrics
 		// DataSource w/ expressions
-		apiRoute.Post("/ds/query", authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.QueryMetricsV2))
+		apiRoute.Post("/ds/query", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.QueryMetricsV2))
 
 		apiRoute.Group("/alerts", func(alertsRoute routing.RouteRegister) {
 			alertsRoute.Post("/test", routing.Wrap(hs.AlertTest))
@@ -597,7 +597,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 			// Some channels may have info
 			liveRoute.Get("/info/*", routing.Wrap(hs.Live.HandleInfoHTTP))
-		})
+		}, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
 
 		// short urls
 		apiRoute.Post("/short-urls", routing.Wrap(hs.createShortURL))

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -45,6 +45,10 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 		histogramLabels = append(histogramLabels, "team")
 	}
 
+	if features.IsEnabled(featuremgmt.FlagHttpSLOLevels) {
+		histogramLabels = append(histogramLabels, "slo_group")
+	}
+
 	httpRequestDurationHistogram := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "grafana",
@@ -93,6 +97,10 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 
 			if cfg.MetricsIncludeTeamLabel {
 				labelValues = append(labelValues, rmd.Team)
+			}
+
+			if features.IsEnabled(featuremgmt.FlagHttpSLOLevels) {
+				labelValues = append(labelValues, string(rmd.SLOGroup))
 			}
 
 			// avoiding the sanitize functions for in the new instrumentation

--- a/pkg/middleware/requestmeta/request_metadata.go
+++ b/pkg/middleware/requestmeta/request_metadata.go
@@ -20,12 +20,37 @@ const (
 	StatusSourceDownstream StatusSource = "downstream"
 )
 
-type rMDContextKey struct{}
-
 type RequestMetaData struct {
 	Team         string
 	StatusSource StatusSource
+	SLOGroup     SLOGroup
 }
+
+type SLOGroup string
+
+const (
+	// SLOGroupHighFast is the default slo group for handlers in Grafana
+	// Most handlers should respond quickly
+	SLOGroupHighFast SLOGroup = "high-fast"
+
+	// SLOGroupHighMedium is used for handlers that might take some
+	// time to respond.
+	SLOGroupHighMedium SLOGroup = "high-medium"
+
+	// SLOGroupHighSlow is used by handlers that proxies requests downstream.
+	// We expect an high successrate but without latency garantess
+	SLOGroupHighSlow SLOGroup = "high-slow"
+
+	// SLOGroupLow should only be used for experimental features
+	// that might not be stable enough for our normal SLO
+	SLOGroupLow SLOGroup = "low"
+
+	// SLOGroupNone means that errors are expect for this handler and
+	// it should not be included in the SLO.
+	SLOGroupNone SLOGroup = "none"
+)
+
+type rMDContextKey struct{}
 
 var requestMetaDataContextKey = rMDContextKey{}
 
@@ -96,5 +121,14 @@ func defaultRequestMetadata() RequestMetaData {
 	return RequestMetaData{
 		Team:         TeamCore,
 		StatusSource: StatusSourceServer,
+		SLOGroup:     SLOGroupHighFast,
+	}
+}
+
+// SetSLOGroup creates an middleware that sets the SLOGroup for the request
+func SetSLOGroup(lvl SLOGroup) web.Handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		v := GetRequestMetaData(r.Context())
+		v.SLOGroup = lvl
 	}
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -769,7 +769,7 @@ var (
 		{
 			Name:            "httpSLOLevels",
 			Description:     "Adds SLO level to http request metrics",
-			Stage:           FeatureStagePublicPreview,
+			Stage:           FeatureStageExperimental,
 			FrontendOnly:    false,
 			Owner:           hostedGrafanaTeam,
 			RequiresRestart: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -766,5 +766,13 @@ var (
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaPluginsPlatformSquad,
 		},
+		{
+			Name:            "httpSLOLevels",
+			Description:     "Adds SLO level to http request metrics",
+			Stage:           FeatureStagePublicPreview,
+			FrontendOnly:    false,
+			Owner:           hostedGrafanaTeam,
+			RequiresRestart: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -109,3 +109,4 @@ lokiRunQueriesInParallel,privatePreview,@grafana/observability-logs,false,false,
 wargamesTesting,experimental,@grafana/hosted-grafana-team,false,false,false,false
 alertingInsights,experimental,@grafana/alerting-squad,false,false,false,true
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,false,false,false,true
+httpSLOLevels,preview,@grafana/hosted-grafana-team,false,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -109,4 +109,4 @@ lokiRunQueriesInParallel,privatePreview,@grafana/observability-logs,false,false,
 wargamesTesting,experimental,@grafana/hosted-grafana-team,false,false,false,false
 alertingInsights,experimental,@grafana/alerting-squad,false,false,false,true
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,false,false,false,true
-httpSLOLevels,preview,@grafana/hosted-grafana-team,false,false,true,false
+httpSLOLevels,experimental,@grafana/hosted-grafana-team,false,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -446,4 +446,8 @@ const (
 	// FlagPluginsAPIMetrics
 	// Sends metrics of public grafana packages usage by plugins
 	FlagPluginsAPIMetrics = "pluginsAPIMetrics"
+
+	// FlagHttpSLOLevels
+	// Adds SLO level to http request metrics
+	FlagHttpSLOLevels = "httpSLOLevels"
 )


### PR DESCRIPTION
With the labels we can drastically improve our latency monitoring by having different expecatations based SloGroup. 

Ex Datasource querydata handlers does not have any latency requirements while we expect the get dashboard endpoint to be fast. The actual thresholds for the different SloGroups will be in our internal docs. 

Ex alert for `high-fast`
```
sum(rate(grafana_http_request_duration_seconds_bucket{le="0.1", slo_group="high-fast"}[1m]))
/ 
sum(rate(grafana_http_request_duration_seconds_count{slo_group="high-fast"}[1m]))
```

and for `high-medium`
```
sum(rate(grafana_http_request_duration_seconds_bucket{le="0.2", slo_group="high-medium"}[1m]))
/ 
sum(rate(grafana_http_request_duration_seconds_count{slo_group="high-medium"}[1m]))
```

Since we don't have any latency requirements for `high-slow` we don't have to create an alert rule for that group. This way our alert rules stays the same and we can control the expected latency categorisation in Grafana instead. 

Once this is running internally we can inspect different routes and see if we need to categorize them differently. 

Based on https://sre.google/workbook/alerting-on-slos/#alerting_at_scale
