### PR TITLE
[Alerting] - Display scenes using SceneAppPage for caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@grafana/lezer-traceql": "0.0.5",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
-    "@grafana/scenes": "^1.1.1",
+    "@grafana/scenes": "^1.3.1",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -259,6 +259,14 @@ const unifiedRoutes: RouteDescriptor[] = [
       () => import(/* webpackChunkName: "AlertingAdmin" */ 'app/features/alerting/unified/Admin')
     ),
   },
+
+  {
+    path: '/alerting/insights',
+    exact: false,
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingHome" */ 'app/features/alerting/unified/home/Home')
+    ),
+  },
 ];
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -89,6 +89,12 @@ const unifiedRoutes: RouteDescriptor[] = [
   ...commonRoutes,
   {
     path: '/alerting',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingHome" */ 'app/features/alerting/unified/home/Home')
+    ),
+  },
+  {
+    path: '/alerting/home',
     exact: false,
     component: SafeDynamicImport(
       () => import(/* webpackChunkName: "AlertingHome" */ 'app/features/alerting/unified/home/Home')

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -89,6 +89,7 @@ const unifiedRoutes: RouteDescriptor[] = [
   ...commonRoutes,
   {
     path: '/alerting',
+    exact: false,
     component: SafeDynamicImport(
       () => import(/* webpackChunkName: "AlertingHome" */ 'app/features/alerting/unified/home/Home')
     ),
@@ -257,14 +258,6 @@ const unifiedRoutes: RouteDescriptor[] = [
     roles: () => ['Admin'],
     component: SafeDynamicImport(
       () => import(/* webpackChunkName: "AlertingAdmin" */ 'app/features/alerting/unified/Admin')
-    ),
-  },
-
-  {
-    path: '/alerting/insights',
-    exact: false,
-    component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "AlertingHome" */ 'app/features/alerting/unified/home/Home')
     ),
   },
 ];

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -130,32 +130,43 @@ export function WelcomeHeader({ className }: { className?: string }) {
   const styles = useStyles2(getWelcomeHeaderStyles);
 
   return (
-    <ContentBox className={cx(styles.ctaContainer, className)}>
-      <WelcomeCTABox
-        title="Alert rules"
-        description="Define the condition that must be met before an alert rule fires"
-        href="/alerting/list"
-        hrefText="Manage alert rules"
-      />
-      <div className={styles.separator} />
-      <WelcomeCTABox
-        title="Contact points"
-        description="Configure who receives notifications and how they are sent"
-        href="/alerting/notifications"
-        hrefText="Manage contact points"
-      />
-      <div className={styles.separator} />
-      <WelcomeCTABox
-        title="Notification policies"
-        description="Configure how firing alert instances are routed to contact points"
-        href="/alerting/routes"
-        hrefText="Manage notification policies"
-      />
-    </ContentBox>
+    <div className={styles.welcomeHeaderWrapper}>
+      <div className={styles.subtitle}>Learn about problems in your systems moments after they occur</div>
+
+      <ContentBox className={cx(styles.ctaContainer, className)}>
+        <WelcomeCTABox
+          title="Alert rules"
+          description="Define the condition that must be met before an alert rule fires"
+          href="/alerting/list"
+          hrefText="Manage alert rules"
+        />
+        <div className={styles.separator} />
+        <WelcomeCTABox
+          title="Contact points"
+          description="Configure who receives notifications and how they are sent"
+          href="/alerting/notifications"
+          hrefText="Manage contact points"
+        />
+        <div className={styles.separator} />
+        <WelcomeCTABox
+          title="Notification policies"
+          description="Configure how firing alert instances are routed to contact points"
+          href="/alerting/routes"
+          hrefText="Manage notification policies"
+        />
+      </ContentBox>
+    </div>
   );
 }
 
 const getWelcomeHeaderStyles = (theme: GrafanaTheme2) => ({
+  welcomeHeaderWrapper: css({
+    color: theme.colors.text.primary,
+  }),
+  subtitle: css({
+    color: theme.colors.text.secondary,
+    paddingBottom: theme.spacing(2),
+  }),
   ctaContainer: css`
     padding: ${theme.spacing(4, 2)};
     display: flex;

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -4,7 +4,22 @@ import SVG from 'react-inlinesvg';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
+import { EmbeddedScene, SceneFlexLayout, SceneFlexItem, SceneReactObject } from '@grafana/scenes';
 import { Icon, useStyles2, useTheme2 } from '@grafana/ui';
+
+export const getOverviewScene = () => {
+  return new EmbeddedScene({
+    body: new SceneFlexLayout({
+      children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: GettingStarted,
+          }),
+        }),
+      ],
+    }),
+  });
+};
 
 export default function GettingStarted({ showWelcomeHeader }: { showWelcomeHeader?: boolean }) {
   const theme = useTheme2();

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -1,50 +1,90 @@
 import React, { useState } from 'react';
 
 import { config } from '@grafana/runtime';
-import { Tab, TabContent, TabsBar } from '@grafana/ui';
-
-import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
+import {
+  EmbeddedScene,
+  SceneApp,
+  SceneAppPage,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneReactObject,
+} from '@grafana/scenes';
+import { usePageNav } from 'app/core/components/Page/usePageNav';
+import { PluginPageContext, PluginPageContextType } from 'app/features/plugins/components/PluginPageContext';
 
 import GettingStarted, { WelcomeHeader } from './GettingStarted';
-import Insights from './Insights';
+import { getGrafanaScenes } from './Insights';
 
-type HomeTabs = 'insights' | 'gettingStarted';
+let homeApp: SceneApp | undefined;
+
+export function getHomeApp() {
+  if (homeApp) {
+    return homeApp;
+  }
+
+  homeApp = new SceneApp({
+    pages: [
+      new SceneAppPage({
+        title: 'Alerting',
+        subTitle: <WelcomeHeader />,
+        url: '/alerting',
+        hideFromBreadcrumbs: true,
+        tabs: [
+          new SceneAppPage({
+            title: 'Grafana',
+            url: '/alerting/insights',
+            getScene: getGrafanaScenes,
+          }),
+          new SceneAppPage({
+            title: 'Overview',
+            url: '/alerting/overview',
+            getScene: () => {
+              return new EmbeddedScene({
+                body: new SceneFlexLayout({
+                  children: [
+                    new SceneFlexItem({
+                      body: new SceneReactObject({
+                        component: GettingStarted,
+                      }),
+                    }),
+                  ],
+                }),
+              });
+            },
+          }),
+          // new SceneAppPage({
+          //   title: 'Mimir alertmanager',
+          //   url: '/alerting/insights/mimir-alertmanager',
+          //   getScene: getCloudScenes,
+          // }),
+          // new SceneAppPage({
+          //   title: 'Mimir-managed rules',
+          //   url: '/alerting/insights/mimir-rules',
+          //   getScene: getMimirManagedRulesScenes,
+          // }),
+          // new SceneAppPage({
+          //   title: 'Mimir-managed Rules - Per Rule Group',
+          //   url: '/alerting/insights/mimir-rules-per-group',
+          //   getScene: getMimirManagedRulesPerGroupScenes,
+          // }),
+        ],
+      }),
+    ],
+  });
+
+  return homeApp;
+}
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState<HomeTabs>('insights');
+  const appScene = getHomeApp();
+
+  const sectionNav = usePageNav('alerting')!;
+  const [pluginContext] = useState<PluginPageContextType>({ sectionNav });
 
   const alertingInsightsEnabled = config.featureToggles.alertingInsights;
   return (
-    <AlertingPageWrapper pageId={'alerting'}>
-      {alertingInsightsEnabled && (
-        <>
-          <WelcomeHeader />
-          <TabsBar>
-            <Tab
-              key={'insights'}
-              label={'Insights'}
-              active={activeTab === 'insights'}
-              onChangeTab={() => {
-                setActiveTab('insights');
-              }}
-            />
-            <Tab
-              key={'gettingStarted'}
-              label={'Overview'}
-              active={activeTab === 'gettingStarted'}
-              onChangeTab={() => {
-                setActiveTab('gettingStarted');
-              }}
-            />
-          </TabsBar>
-          <TabContent>
-            {activeTab === 'insights' && <Insights />}
-            {activeTab === 'gettingStarted' && <GettingStarted />}
-          </TabContent>
-        </>
-      )}
-
-      {!alertingInsightsEnabled && <GettingStarted showWelcomeHeader={true} />}
-    </AlertingPageWrapper>
+    <PluginPageContext.Provider value={pluginContext}>
+      <appScene.Component model={appScene} />
+    </PluginPageContext.Provider>
   );
 }

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -32,12 +32,12 @@ export function getHomeApp() {
         tabs: [
           new SceneAppPage({
             title: 'Grafana',
-            url: '/alerting/insights',
+            url: '/alerting/home/insights',
             getScene: getGrafanaScenes,
           }),
           new SceneAppPage({
             title: 'Overview',
-            url: '/alerting/overview',
+            url: '/alerting/home/overview',
             getScene: () => {
               return new EmbeddedScene({
                 body: new SceneFlexLayout({

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,19 +1,4 @@
-import React, { useMemo, useState } from 'react';
-
-import {
-  EmbeddedScene,
-  NestedScene,
-  QueryVariable,
-  SceneApp,
-  SceneAppPage,
-  SceneFlexItem,
-  SceneFlexLayout,
-  SceneTimeRange,
-  SceneVariableSet,
-  VariableValueSelectors,
-} from '@grafana/scenes';
-import { usePageNav } from 'app/core/components/Page/usePageNav';
-import { PluginPageContext, PluginPageContextType } from 'app/features/plugins/components/PluginPageContext';
+import { EmbeddedScene, NestedScene, SceneFlexItem, SceneFlexLayout, SceneTimeRange } from '@grafana/scenes';
 
 import { getFiringAlertsScene } from '../insights/grafana/FiringAlertsPercentage';
 import { getFiringAlertsRateScene } from '../insights/grafana/FiringAlertsRate';

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -32,7 +32,6 @@ import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIteratio
 import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
 
-
 const ashDs = {
   type: 'loki',
   uid: 'grafanacloud-alert-state-history',

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,4 +1,13 @@
-import { EmbeddedScene, NestedScene, SceneFlexItem, SceneFlexLayout, SceneTimeRange } from '@grafana/scenes';
+import {
+  EmbeddedScene,
+  NestedScene,
+  QueryVariable,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneTimeRange,
+  SceneVariableSet,
+  VariableValueSelectors,
+} from '@grafana/scenes';
 
 import { getFiringAlertsScene } from '../insights/grafana/FiringAlertsPercentage';
 import { getFiringAlertsRateScene } from '../insights/grafana/FiringAlertsRate';
@@ -110,14 +119,13 @@ function getMimirManagedRulesScenes() {
   });
 }
 
-//@todo: enable query variables after https://github.com/grafana/scenes/pull/335 is merged
 function getMimirManagedRulesPerGroupScenes() {
-  // const ruleGroupHandler = new QueryVariable({
-  //   label: 'Rule Group',
-  //   name: 'rule_group',
-  //   datasource: cloudUsageDs,
-  //   query: 'label_values(grafanacloud_instance_rule_group_rules,rule_group)',
-  // });
+  const ruleGroupHandler = new QueryVariable({
+    label: 'Rule Group',
+    name: 'rule_group',
+    datasource: cloudUsageDs,
+    query: 'label_values(grafanacloud_instance_rule_group_rules,rule_group)',
+  });
 
   return new NestedScene({
     title: 'Mimir-managed Rules - Per Rule Group',
@@ -132,9 +140,9 @@ function getMimirManagedRulesPerGroupScenes() {
         getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per Group'),
       ],
     }),
-    // $variables: new SceneVariableSet({
-    //   variables: [ruleGroupHandler],
-    // }),
-    //controls: [new VariableValueSelectors({})],
+    $variables: new SceneVariableSet({
+      variables: [ruleGroupHandler],
+    }),
+    controls: [new VariableValueSelectors({})],
   });
 }

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -110,6 +110,7 @@ function getMimirManagedRulesScenes() {
   });
 }
 
+//@todo: enable query variables after https://github.com/grafana/scenes/pull/335 is merged
 function getMimirManagedRulesPerGroupScenes() {
   // const ruleGroupHandler = new QueryVariable({
   //   label: 'Rule Group',

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
@@ -61,8 +61,7 @@ export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: Data
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.stat().setTitle(panelTitle).setData(transformation).setUnit('percent').build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
@@ -18,8 +18,8 @@ export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
+    minWidth: '40%',
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
@@ -19,7 +19,6 @@ export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: 
 
   return new SceneFlexItem({
     minHeight: 300,
-    minWidth: '40%',
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -103,8 +103,8 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
+    minWidth: '40%',
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -104,7 +104,6 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
 
   return new SceneFlexItem({
     minHeight: 300,
-    minWidth: '40%',
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
@@ -54,8 +54,7 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
@@ -49,8 +49,7 @@ export function getMostFiredLabelsScene(timeRange: SceneTimeRange, datasource: D
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 8px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.table().setTitle(panelTitle).setData(query).build(),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,9 +4010,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@grafana/scenes@npm:1.1.1"
+"@grafana/scenes@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@grafana/scenes@npm:1.3.1"
   dependencies:
     "@grafana/e2e-selectors": 10.0.2
     react-grid-layout: 1.3.4
@@ -4024,7 +4024,7 @@ __metadata:
     "@grafana/runtime": 10.0.3
     "@grafana/schema": 10.0.3
     "@grafana/ui": 10.0.3
-  checksum: 6405998a40e38f088443f5d4b1f5ea1f73e5bc0d08216e4aaccf8ff0b68ec4c3d691430857f357d3eed335dee0dc2e24c41c5c2f286fc7fdd32375382ad3eafe
+  checksum: fe348e4eaaa3604d0d1ec745b14ae1c0752ce1aa481e5f05a10cdf9392448386e600c2a94f2ae23af83f59daf34cd11fb7a336da863b8624b98c8d3c2732b3c3
   languageName: node
   linkType: hard
 
@@ -19702,7 +19702,7 @@ __metadata:
     "@grafana/lezer-traceql": 0.0.5
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
-    "@grafana/scenes": ^1.1.1
+    "@grafana/scenes": ^1.3.1
     "@grafana/schema": "workspace:*"
     "@grafana/tsconfig": ^1.3.0-rc1
     "@grafana/ui": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Wraps the scenes displayed in the alerting insights page in a `SceneApp`  and `SceneAppPage` which takes care of the inner scenes caching plus url sync with variables (rule group in this case). 

This also allows us to display them using tabs preventing users to having to scroll too much (see https://github.com/grafana/grafana/pull/72407#discussion_r1322732902)

**Why do we need this feature?**

To take advantage of the features from `SceneApp` and `SceneAppPage` in regards to caching. 

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/615

It can be seen in https://ephemeral1511182174767vikacep.grafana-dev.net/ after enabling the feature flag with `window.localStorage.setItem('grafana.featureToggles', 'alertingInsights=true')` (and reloading the page)

![2023-09-14 16 43 07](https://github.com/grafana/grafana/assets/6271380/fc0676f0-ff72-4a81-96f3-cdee2746d7b2)
