### PR TITLE
[v9.4.x] Chore: Remove unused secret enterprise2-cdn-path - Nightlies: Push windows artifacts to GCS on main builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4180,12 +4180,6 @@ kind: secret
 name: static_asset_editions
 ---
 get:
-  name: cdn_path
-  path: infra/data/ci/grafana-release-eng/enterprise2
-kind: secret
-name: enterprise2-cdn-path
----
-get:
   name: gcp_service_account_prod_base64
   path: infra/data/ci/grafana-release-eng/rgm
 kind: secret
@@ -4246,6 +4240,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 12449867a2fad72bbdc91ae4f3d5479747fe12479b1ecbe09068ca5dd168cb0c
+hmac: e34c10286bcbc3d00bee9650adba43e1784cf6c52ec765377ae408a57e4fd022
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1970,6 +1970,10 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
+  - .\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER
+  - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
+  - gsutil cp "$$fname" gs://grafana-downloads/oss/main/
+  - gsutil cp "$$fname.sha256" gs://grafana-downloads/oss/main/
   depends_on:
   - windows-init
   environment:
@@ -2771,7 +2775,7 @@ steps:
   - .\grabpl.exe windows-installer --target gs://grafana-prerelease/artifacts/downloads/${DRONE_TAG}/oss/release/grafana-${DRONE_TAG:1}.windows-amd64.zip
     --edition oss ${DRONE_TAG}
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://grafana-prerelease/artifacts/downloads/${DRONE_TAG}/oss/release/
+  - gsutil cp "$$fname" gs://grafana-prerelease/artifacts/downloads/${DRONE_TAG}/oss/release/
   - gsutil cp "$$fname.sha256" gs://grafana-prerelease/artifacts/downloads/${DRONE_TAG}/oss/release/
   depends_on:
   - windows-init
@@ -4242,6 +4246,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: a35a77092a89461e630b78f16aa8767cb36b3590157f277835c57841a17fc695
+hmac: 12449867a2fad72bbdc91ae4f3d5479747fe12479b1ecbe09068ca5dd168cb0c
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1266,42 +1266,28 @@ def get_windows_steps(ver_mode, bucket = "%PRERELEASE_BUCKET%"):
             "cp C:\\App\\nssm-2.24.zip .",
         ]
 
-        if ver_mode in ("release",):
+        if ver_mode == "release":
             version = "${DRONE_TAG:1}"
             installer_commands.extend(
                 [
-                    ".\\grabpl.exe windows-installer --target {} --edition oss {}".format(
-                        "gs://{}/{}/oss/{}/grafana-{}.windows-amd64.zip".format(gcp_bucket, ver_part, ver_mode, version),
-                        ver_part,
-                    ),
+                    ".\\grabpl.exe windows-installer --target {} --edition oss {}".format("gs://{}/{}/oss/{}/grafana-{}.windows-amd64.zip".format(gcp_bucket, ver_part, ver_mode, version), ver_part),
                     '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
+                    'gsutil cp "$$fname" gs://{}/{}/oss/{}/'.format(gcp_bucket, ver_part, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/{}/oss/{}/'.format(gcp_bucket, ver_part, dir),
                 ],
             )
-            if ver_mode == "main":
-                installer_commands.extend(
-                    [
-                        "gsutil cp $$fname gs://{}/oss/{}/".format(gcp_bucket, dir),
-                        'gsutil cp "$$fname.sha256" gs://{}/oss/{}/'.format(
-                            gcp_bucket,
-                            dir,
-                        ),
-                    ],
-                )
-            else:
-                installer_commands.extend(
-                    [
-                        "gsutil cp $$fname gs://{}/{}/oss/{}/".format(
-                            gcp_bucket,
-                            ver_part,
-                            dir,
-                        ),
-                        'gsutil cp "$$fname.sha256" gs://{}/{}/oss/{}/'.format(
-                            gcp_bucket,
-                            ver_part,
-                            dir,
-                        ),
-                    ],
-                )
+        if ver_mode in ("main"):
+            installer_commands.extend(
+                [
+                    ".\\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER",
+                    '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
+                    'gsutil cp "$$fname" gs://{}/oss/{}/'.format(gcp_bucket, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/oss/{}/'.format(
+                        gcp_bucket,
+                        dir,
+                    ),
+                ],
+            )
         steps.append(
             {
                 "name": "build-windows-installer",

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -113,11 +113,6 @@ def secrets():
             "static_asset_editions",
         ),
         vault_secret(
-            "enterprise2-cdn-path",
-            "infra/data/ci/grafana-release-eng/enterprise2",
-            "cdn_path",
-        ),
-        vault_secret(
             rgm_gcp_key_base64,
             "infra/data/ci/grafana-release-eng/rgm",
             "gcp_service_account_prod_base64",


### PR DESCRIPTION
Backport 49165d35ad09b4368dc2b3f85b681a3f0bd17de5 and 02f617a20d87e4344a6a6d251f77992241fbfa7e from #74709 and #74741

---

**What is this feature?**

Removes `enterprise2-cdn-path` secret, as it's unused.
