### PR TITLE
Tempo: Improve autocompletion for TraceQL editor

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4180,6 +4180,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "public/app/plugins/datasource/tempo/traceql/autocomplete.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/plugins/datasource/testdata/ConfigEditor.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.1",
     "@grafana/lezer-logql": "0.1.11",
-    "@grafana/lezer-traceql": "0.0.5",
+    "@grafana/lezer-traceql": "0.0.6",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^1.1.1",

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -200,13 +200,18 @@ describe('CompletionProvider', () => {
   ])(
     'suggests operators that go after `|` (aggregators, selectorts, ...) - %s, %i',
     async (input: string, offset: number) => {
-      const { provider, model } = setup(input, offset);
+      const { provider, model } = setup(input, offset, undefined, v2Tags);
       const result = await provider.provideCompletionItems(model, emptyPosition);
-      expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
-        CompletionProvider.functions.map((s) =>
+      expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual([
+        ...CompletionProvider.functions.map((s) =>
           expect.objectContaining({ label: s.label, insertText: s.insertText, documentation: s.documentation })
-        )
-      );
+        ),
+        ...scopes.map((s) => expect.objectContaining({ label: s, insertText: s })),
+        ...intrinsics.map((s) => expect.objectContaining({ label: s, insertText: s })),
+        expect.objectContaining({ label: 'cluster', insertText: '.cluster' }),
+        expect.objectContaining({ label: 'container', insertText: '.container' }),
+        expect.objectContaining({ label: 'db', insertText: '.db' }),
+      ]);
     }
   );
 

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -337,11 +337,15 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
           type: 'OPERATOR',
         }));
       case 'SPANSET_PIPELINE_AFTER_OPERATOR':
-        return CompletionProvider.functions.map((key) => ({
+        const functions = CompletionProvider.functions.map((key) => ({
           ...key,
           insertTextRules: this.monaco?.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
-          type: 'FUNCTION',
+          type: 'FUNCTION' as CompletionType,
         }));
+        const tags = this.getScopesCompletions()
+          .concat(this.getIntrinsicsCompletions())
+          .concat(this.getTagsCompletions('.'));
+        return [...functions, ...tags];
       case 'SPANSET_COMPARISON_OPERATORS':
         return CompletionProvider.comparisonOps.map((key) => ({
           ...key,

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -11,6 +11,7 @@ import {
   IntrinsicField,
   Or,
   parser,
+  Pipe,
   ScalarFilter,
   SelectArgs,
   SpansetFilter,
@@ -206,10 +207,6 @@ const RESOLVERS: Resolver[] = [
     }),
   },
   {
-    path: [ERROR_NODE_ID, SpansetPipeline],
-    fun: resolveSpansetPipeline,
-  },
-  {
     path: [ERROR_NODE_ID, Aggregate],
     fun: resolveAttributeForFunction,
   },
@@ -219,11 +216,7 @@ const RESOLVERS: Resolver[] = [
   },
   {
     path: [ERROR_NODE_ID, SpansetPipelineExpression],
-    fun: () => {
-      return {
-        type: 'NEW_SPANSET',
-      };
-    },
+    fun: resolveSpansetPipeline,
   },
   {
     path: [ERROR_NODE_ID, ScalarFilter, SpansetPipeline],
@@ -386,8 +379,13 @@ function resolveAttributeForFunction(node: SyntaxNode, _0: string, _1: number): 
   };
 }
 
-function resolveSpansetPipeline(_0: SyntaxNode, _1: string, _2: number): SituationType {
+function resolveSpansetPipeline(node: SyntaxNode, _1: string, _2: number): SituationType {
+  if (node.prevSibling?.type.id === Pipe) {
+    return {
+      type: 'SPANSET_PIPELINE_AFTER_OPERATOR',
+    };
+  }
   return {
-    type: 'SPANSET_PIPELINE_AFTER_OPERATOR',
+    type: 'NEW_SPANSET',
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3948,12 +3948,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@grafana/lezer-traceql@npm:0.0.5"
+"@grafana/lezer-traceql@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@grafana/lezer-traceql@npm:0.0.6"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 6fcf48acde1e444c155a4b4009f4c7211843b07960713821a2649b1db0e0ef819fd1062eec101173c2e6b8249b253faf0b6052e96f551663618fd2fe0d17e3c9
+  checksum: 166a30c38f4f78e1768e80f724176b71becf3fa51414bc8bea4c2c5288a92d1f8b7872280a06c0d3f7f7608b174e5fc930e1af39339b2c2fdf627fb7ac14c6b4
   languageName: node
   linkType: hard
 
@@ -19698,7 +19698,7 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": 0.1.1
     "@grafana/lezer-logql": 0.1.11
-    "@grafana/lezer-traceql": 0.0.5
+    "@grafana/lezer-traceql": 0.0.6
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": ^1.1.1


### PR DESCRIPTION
This PR:
- bumps the version of `lezer-traceql` and addresses the associated breaking changes
- improve the autocomplete suggestions after `|`.

Fixes https://github.com/grafana/grafana/issues/74786