### PR TITLE
DashboardScene: Inspect / query tab

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -125,7 +125,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       panel_type_changed: panel.state.pluginId !== panelModel.type,
       panel_id_changed: getPanelIdForVizPanel(panel) !== panelModel.id,
       panel_grid_pos_changed: hasGridPosChanged(panel.parent.state, newState),
-      panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(gridItem.state.body)),
+      panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(newState.$data)),
     });
   };
 
@@ -218,7 +218,6 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
 
     case 'data-frames': {
       reportPanelInspectInteraction(InspectTab.JSON, 'dataFrame');
-
       const dataProvider = sceneGraph.getData(panel);
 
       if (dataProvider.state.data) {

--- a/public/app/features/dashboard-scene/inspect/InspectQueryTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectQueryTab.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import {
+  SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneObjectRef,
+  VizPanel,
+} from '@grafana/scenes';
+import { t } from 'app/core/internationalization';
+import { QueryInspector } from 'app/features/inspector/QueryInspector';
+import { InspectTab } from 'app/features/inspector/types';
+
+import { getQueryRunnerFor } from '../utils/utils';
+
+export interface InspectQueryTabState extends SceneObjectState {
+  panelRef: SceneObjectRef<VizPanel>;
+}
+
+export class InspectQueryTab extends SceneObjectBase<InspectQueryTabState> {
+  public getTabLabel() {
+    return t('dashboard.inspect.query-tab', 'Query');
+  }
+
+  public getTabValue() {
+    return InspectTab.Query;
+  }
+
+  public onRefreshQuery = () => {
+    const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
+
+    if (queryRunner) {
+      queryRunner.runQueries();
+    }
+  };
+
+  static Component = ({ model }: SceneComponentProps<InspectQueryTab>) => {
+    const data = sceneGraph.getData(model.state.panelRef.resolve()).useState();
+
+    if (!data.data) {
+      return null;
+    }
+
+    return <QueryInspector data={data.data} onRefreshQuery={model.onRefreshQuery} />;
+  };
+}

--- a/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
+++ b/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
@@ -16,6 +16,7 @@ import { supportsDataQuery } from 'app/features/dashboard/components/PanelEditor
 
 import { InspectDataTab } from './InspectDataTab';
 import { InspectJsonTab } from './InspectJsonTab';
+import { InspectQueryTab } from './InspectQueryTab';
 import { InspectStatsTab } from './InspectStatsTab';
 import { SceneInspectTab } from './types';
 
@@ -56,6 +57,7 @@ export class PanelInspectDrawer extends SceneObjectBase<PanelInspectDrawerState>
     if (supportsDataQuery(plugin)) {
       tabs.push(new InspectDataTab({ panelRef }));
       tabs.push(new InspectStatsTab({ panelRef }));
+      tabs.push(new InspectQueryTab({ panelRef }));
     }
 
     tabs.push(new InspectJsonTab({ panelRef, onClose: this.onClose }));

--- a/public/app/features/dashboard/components/Inspector/InspectContent.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectContent.tsx
@@ -109,9 +109,7 @@ export const InspectContent = ({
       )}
       {activeTab === InspectTab.Error && <InspectErrorTab errors={errors} />}
       {data && activeTab === InspectTab.Stats && <InspectStatsTab data={data} timeZone={dashboard.getTimezone()} />}
-      {data && activeTab === InspectTab.Query && (
-        <QueryInspector panel={panel} data={data.series} onRefreshQuery={() => panel.refresh()} />
-      )}
+      {data && activeTab === InspectTab.Query && <QueryInspector data={data} onRefreshQuery={() => panel.refresh()} />}
     </Drawer>
   );
 };

--- a/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
@@ -34,7 +34,7 @@ const PanelInspectorUnconnected = ({ panel, dashboard, plugin }: Props) => {
   });
 
   const location = useLocation();
-  const { data, isLoading, error } = usePanelLatestData(panel, dataOptions, true);
+  const { data, isLoading, error } = usePanelLatestData(panel, dataOptions, false);
   const metaDs = useDatasourceMetadata(data);
   const tabs = useInspectTabs(panel, dashboard, plugin, error, metaDs);
   const defaultTab = new URLSearchParams(location.search).get('inspectTab') as InspectTab;

--- a/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
+++ b/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
@@ -64,7 +64,7 @@ export const usePanelLatestData = (
   return {
     data: latestData,
     error: latestData && latestData.error,
-    isLoading: latestData ? latestData.state === LoadingState.Loading : true,
+    isLoading: latestData?.state === LoadingState.Loading,
     hasSeries: latestData ? !!latestData.series : false,
   };
 };

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -35,7 +35,6 @@ jest.mock('@grafana/runtime', () => ({
 
 const setup = (propOverrides = {}) => {
   const props: ExploreQueryInspectorProps = {
-    loading: false,
     width: 100,
     exploreId: 'left',
     onClose: jest.fn(),

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { CoreApp, TimeZone } from '@grafana/data';
+import { CoreApp, LoadingState, TimeZone } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime/src';
 import { TabbedContainer, TabConfig } from '@grafana/ui';
 import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
@@ -12,7 +12,7 @@ import { InspectStatsTab } from 'app/features/inspector/InspectStatsTab';
 import { QueryInspector } from 'app/features/inspector/QueryInspector';
 import { StoreState, ExploreItemState } from 'app/types';
 
-import { runQueries, selectIsWaitingForData } from './state/query';
+import { runQueries } from './state/query';
 
 interface DispatchProps {
   width: number;
@@ -24,7 +24,7 @@ interface DispatchProps {
 type Props = DispatchProps & ConnectedProps<typeof connector>;
 
 export function ExploreQueryInspector(props: Props) {
-  const { loading, width, onClose, queryResponse, timeZone } = props;
+  const { width, onClose, queryResponse, timeZone } = props;
   const dataFrames = queryResponse?.series || [];
   let errors = queryResponse?.errors;
   if (!errors?.length && queryResponse?.error) {
@@ -57,7 +57,7 @@ export function ExploreQueryInspector(props: Props) {
       <InspectDataTab
         data={dataFrames}
         dataName={'Explore'}
-        isLoading={loading}
+        isLoading={queryResponse.state === LoadingState.Loading}
         options={{ withTransforms: false, withFieldConfig: false }}
         timeZone={timeZone}
         app={CoreApp.Explore}
@@ -70,7 +70,7 @@ export function ExploreQueryInspector(props: Props) {
     value: 'query',
     icon: 'info-circle',
     content: (
-      <QueryInspector data={dataFrames} onRefreshQuery={() => props.runQueries({ exploreId: props.exploreId })} />
+      <QueryInspector data={queryResponse} onRefreshQuery={() => props.runQueries({ exploreId: props.exploreId })} />
     ),
   };
 
@@ -97,7 +97,6 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
   const { queryResponse } = item;
 
   return {
-    loading: selectIsWaitingForData(exploreId)(state),
     queryResponse,
   };
 }


### PR DESCRIPTION
* [x] Adds a query tab to scene inspect
* [x] Refactor and simplify QueryInspector (now takes in PanelData and reads loading state from PanelData.state) 
* [x] Fix loading state bug in the old arch panel inspector (it can miss the done state because usePanelLatestData true for checkSchema which can ignore updates when the schema is the same (But loading state is different). 