### PR TITLE
Explore: Fix tracking when log results are shown

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -583,7 +583,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
       newQuerySubscription = newQuerySource.subscribe({
         next(data) {
-          if (data.logsResult !== null) {
+          if (data.logsResult !== null && data.state === LoadingState.Done) {
             reportInteraction('grafana_explore_logs_result_displayed', {
               datasourceType: datasourceInstance.type,
             });


### PR DESCRIPTION
Fixes #74799. Please check the issue for reproduction steps.

This PR ensures the `grafana_explore_logs_result_displayed` event it tracked only after requests are finished, and not while it's still loading. It also removes tracking in Live mode for now, which we may tackle in a separate PR.

After this change only one `grafana_explore_logs_result_displayed` should be tracked when a Loki data source is selected, even in mixed mode with two different Loki data sources:

<img width="940" alt="Screenshot 2023-09-13 at 10 48 25" src="https://github.com/grafana/grafana/assets/745532/4aca0edd-c4d1-4ad3-95a6-0bdfdf282b18">
