### PR TITLE
sql: do not use the getTimeSrv call

### DIFF
--- a/public/app/plugins/datasource/mssql/datasource.test.ts
+++ b/public/app/plugins/datasource/mssql/datasource.test.ts
@@ -3,6 +3,7 @@ import { createFetchResponse } from 'test/helpers/createFetchResponse';
 
 import {
   dataFrameToJSON,
+  getDefaultTimeRange,
   DataSourceInstanceSettings,
   dateTime,
   FieldType,
@@ -33,6 +34,7 @@ const instanceSettings = {
 } as DataSourceInstanceSettings<MssqlOptions>;
 
 describe('MSSQLDatasource', () => {
+  const defaultRange = getDefaultTimeRange(); // it does not matter what value this has
   const fetchMock = jest.spyOn(backendSrv, 'fetch');
 
   const ctx = {
@@ -69,7 +71,7 @@ describe('MSSQLDatasource', () => {
     beforeEach(() => {
       fetchMock.mockImplementation(() => of(createFetchResponse(response)));
 
-      return ctx.ds.metricFindQuery(query).then((data: MetricFindValue[]) => {
+      return ctx.ds.metricFindQuery(query, { range: defaultRange }).then((data: MetricFindValue[]) => {
         results = data;
       });
     });
@@ -97,7 +99,7 @@ describe('MSSQLDatasource', () => {
 
     it('should return an empty array when metricFindQuery is called', async () => {
       const query = 'select * from atable';
-      const results = await ctx.ds.metricFindQuery(query);
+      const results = await ctx.ds.metricFindQuery(query, { range: defaultRange });
       expect(results.length).toBe(0);
     });
 
@@ -231,7 +233,7 @@ describe('MSSQLDatasource', () => {
     beforeEach(() => {
       fetchMock.mockImplementation(() => of(createFetchResponse(response)));
 
-      return ctx.ds.metricFindQuery(query).then((data) => {
+      return ctx.ds.metricFindQuery(query, { range: defaultRange }).then((data) => {
         results = data;
       });
     });
@@ -272,7 +274,7 @@ describe('MSSQLDatasource', () => {
     beforeEach(() => {
       fetchMock.mockImplementation(() => of(createFetchResponse(response)));
 
-      return ctx.ds.metricFindQuery(query).then((data) => {
+      return ctx.ds.metricFindQuery(query, { range: defaultRange }).then((data) => {
         results = data;
       });
     });
@@ -311,7 +313,7 @@ describe('MSSQLDatasource', () => {
 
     beforeEach(() => {
       fetchMock.mockImplementation(() => of(createFetchResponse(response)));
-      return ctx.ds.metricFindQuery(query).then((data) => {
+      return ctx.ds.metricFindQuery(query, { range: defaultRange }).then((data) => {
         results = data;
       });
     });

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 
 import {
   dataFrameToJSON,
+  getDefaultTimeRange,
   DataQueryRequest,
   DataSourceInstanceSettings,
   dateTime,
@@ -18,6 +19,7 @@ import { MySqlDatasource } from '../MySqlDatasource';
 import { MySQLOptions } from '../types';
 
 describe('MySQLDatasource', () => {
+  const defaultRange = getDefaultTimeRange(); // it does not matter what value this has
   const setupTestContext = (response: unknown) => {
     jest.clearAllMocks();
     setBackendSrv(backendSrv);
@@ -82,7 +84,7 @@ describe('MySQLDatasource', () => {
 
     it('should return an empty array when metricFindQuery is called', async () => {
       const query = 'select * from atable';
-      const results = await ds.metricFindQuery(query);
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
       expect(results.length).toBe(0);
     });
 
@@ -216,7 +218,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of all string field values', async () => {
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results.length).toBe(6);
       expect(results[0].text).toBe('aTitle');
@@ -249,7 +251,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of all column values', async () => {
       const { ds, fetchMock } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, { searchFilter: 'aTit' });
+      const results = await ds.metricFindQuery(query, { range: defaultRange, searchFilter: 'aTit' });
 
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe(
@@ -284,7 +286,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of all column values', async () => {
       const { ds, fetchMock } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
@@ -317,7 +319,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of as text, value', async () => {
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results.length).toBe(3);
       expect(results[0].text).toBe('aTitle');
@@ -352,7 +354,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of all field values as text', async () => {
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results).toEqual([
         { text: 1 },
@@ -390,7 +392,7 @@ describe('MySQLDatasource', () => {
 
     it('should return list of unique keys', async () => {
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results.length).toBe(1);
       expect(results[0].text).toBe('aTitle');

--- a/public/app/plugins/datasource/postgres/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/datasource.test.ts
@@ -2,6 +2,7 @@ import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import {
+  getDefaultTimeRange,
   dataFrameToJSON,
   DataQueryRequest,
   DataQueryResponse,
@@ -37,6 +38,7 @@ jest.mock('@grafana/runtime/src/services', () => ({
 }));
 
 describe('PostgreSQLDatasource', () => {
+  const defaultRange = getDefaultTimeRange(); // it does not matter what value this has
   const fetchMock = jest.spyOn(backendSrv, 'fetch');
   const setupTestContext = (data: unknown, mock?: Observable<FetchResponse<unknown>>) => {
     jest.clearAllMocks();
@@ -311,7 +313,7 @@ describe('PostgreSQLDatasource', () => {
 
     it('should return an empty array when metricFindQuery is called', async () => {
       const query = 'select * from atable';
-      const results = await ds.metricFindQuery(query);
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
       expect(results.length).toBe(0);
     });
 
@@ -474,7 +476,7 @@ describe('PostgreSQLDatasource', () => {
       };
 
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results.length).toBe(6);
       expect(results[0].text).toBe('aTitle');
@@ -507,7 +509,7 @@ describe('PostgreSQLDatasource', () => {
       };
 
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, { searchFilter: 'aTit' });
+      const results = await ds.metricFindQuery(query, { range: defaultRange, searchFilter: 'aTit' });
 
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe(
@@ -549,7 +551,7 @@ describe('PostgreSQLDatasource', () => {
       };
 
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(fetchMock).toBeCalledTimes(1);
       expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
@@ -588,7 +590,7 @@ describe('PostgreSQLDatasource', () => {
         },
       };
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results).toEqual([
         { text: 'aTitle', value: 'value1' },
@@ -622,7 +624,7 @@ describe('PostgreSQLDatasource', () => {
         },
       };
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results).toEqual([
         { text: 1 },
@@ -659,7 +661,7 @@ describe('PostgreSQLDatasource', () => {
         },
       };
       const { ds } = setupTestContext(response);
-      const results = await ds.metricFindQuery(query, {});
+      const results = await ds.metricFindQuery(query, { range: defaultRange });
 
       expect(results).toEqual([{ text: 'aTitle', value: 'same' }]);
     });


### PR DESCRIPTION
(NOTE: this is an alternative to https://github.com/grafana/grafana/pull/74699 , with a less "creative" approach 😄 )

the shared sql functionality codebase in grafana uses the following import:
```ts
import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
```

as working on making the core sql datasources external-ish, we cannot import unexported code from grafana.

this PR achieves this, with two changes:


1. in the `this.metricFindQuery` method of the datasource, we get an optional `options` object, which has an optional `.range` attribute. based on my tests it is always set. so i adjusted the code to simply use `options.range`, and, if it is not there ( i cannot create such a scenario, but just to be sure), we return an empty-array of values.
    - (i did some digging, and the only way to not have it set seems to be to set the variable's when-to-refresh attribute to `never`, which you cannot do in the UI. but even if i hacked it happen, in that case the `.metricFindQuery` is just never called. so all in all, whenever `this.metricFindQuery` is called, the `options.range` always seems to be here. )


3. in: `this.runSql`
  - is changed a little:
    - before: this was running with the "current time range", as returned by `getTimeSrv`
    - after: this will run with the fixed "default time range" given by `@grafana/data/getDefaultTimeRange` (last 6 hours)
  - based on checks i did, `this.runSQL` is used to run metadata-queries (what tables do we have, what fields do we have etc.), and  those queries do not rely on time-ranges, so i think the change is ok. i checked all the places that call `runSql`, and they all seem to be ok.

how to test:
1. make a dashboard query variable, verify that it works.
2. use the query editor, choose a database, choose a field, verify that it still works.

(part of https://github.com/grafana/grafana/issues/72892)