### PR TITLE
[v10.0.x] BrowseDashboards: Only remember the most recent expanded folder

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -81,6 +81,7 @@ import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
 import { initWindowRuntime } from './features/runtime/init';
+import { cleanupOldExpandedFolders } from './features/search/utils';
 import { variableAdapters } from './features/variables/adapters';
 import { createAdHocVariableAdapter } from './features/variables/adhoc/adapter';
 import { createConstantVariableAdapter } from './features/variables/constant/adapter';
@@ -202,6 +203,13 @@ export class GrafanaApp {
 
       // Read initial kiosk mode from url at app startup
       chromeService.setKioskModeFromUrl(queryParams.kiosk);
+
+      // Clean up old search local storage values
+      try {
+        cleanupOldExpandedFolders();
+      } catch (err) {
+        console.warn('Failed to clean up old expanded folders', err);
+      }
 
       this.context = {
         backend: backendSrv,

--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -6,6 +6,7 @@ export const SEARCH_ITEM_HEIGHT = 58;
 export const SEARCH_ITEM_MARGIN = 8;
 export const DEFAULT_SORT = { label: 'A\u2013Z', value: 'alpha-asc' };
 export const SECTION_STORAGE_KEY = 'search.sections';
+export const SEARCH_EXPANDED_FOLDER_STORAGE_KEY = 'grafana.search.expanded-folder';
 export const GENERAL_FOLDER_ID = 0;
 export const GENERAL_FOLDER_UID = 'general';
 export const GENERAL_FOLDER_TITLE = 'General';

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -14,6 +14,18 @@ export const hasFilters = (query: SearchState) => {
   return Boolean(query.query || query.tag?.length > 0 || query.starred || query.sort);
 };
 
+/** Cleans up old local storage values that remembered many open folders */
+export const cleanupOldExpandedFolders = () => {
+  const keyPrefix = SECTION_STORAGE_KEY + '.';
+
+  for (let index = 0; index < window.localStorage.length; index++) {
+    const lsKey = window.localStorage.key(index);
+    if (lsKey?.startsWith(keyPrefix)) {
+      window.localStorage.removeItem(lsKey);
+    }
+  }
+};
+
 /**
  * Get storage key for a dashboard folder by its title
  * @param title


### PR DESCRIPTION
Backport 5cb7eb588435f699f05b3fe9334cf6cf9bc2e60f from #74617

---

**What is this feature?**

The old Browse Dashboards UI remembers opened folders and automatically loads their children when Browse or Search is opened. If the user has opened many folders, this can saturate the requests the frontend makes and prevents new requests (such as one for the user's search) from completing quickly.

This PR changers the old Browse Dashboards UI to only remember the last folder opened.

**Why do we need this feature?**

So the old Browse Dashboards UI performance does not get worse the more someone uses it.

**Who is this feature for?**

Everyone who isn't using new Browse Dashboards UI

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/59543

**Special notes for your reviewer:**

Becuase this is in the old UI which we no longer dog food, we must manually test this throughly.

This is intended to be backported.
