### PR TITLE
Requester: Update GetCacheKey

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -143,11 +143,7 @@ func (s *Service) getUserPermissions(ctx context.Context, user identity.Requeste
 }
 
 func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	key, err := permissionCacheKey(user)
-	if err != nil {
-		return nil, err
-	}
-
+	key := permissionCacheKey(user)
 	if !options.ReloadCache {
 		permissions, ok := s.cache.Get(key)
 		if ok {
@@ -169,11 +165,7 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 }
 
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
-	key, err := permissionCacheKey(user)
-	if err != nil {
-		return
-	}
-	s.cache.Delete(key)
+	s.cache.Delete(permissionCacheKey(user))
 }
 
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {
@@ -215,12 +207,8 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 	return nil
 }
 
-func permissionCacheKey(user identity.Requester) (string, error) {
-	key, err := user.GetCacheKey()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("rbac-permissions-%s", key), nil
+func permissionCacheKey(user identity.Requester) string {
+	return fmt.Sprintf("rbac-permissions-%s", user.GetCacheKey())
 }
 
 // DeclarePluginRoles allow the caller to declare, to the service, plugin roles and their assignments
@@ -380,13 +368,9 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 		UserID: searchOptions.UserID,
 		OrgID:  orgID,
 	}
-	key, err := permissionCacheKey(tempUser)
-	if err != nil {
-		s.log.Debug("Could not obtain cache key to search user permissions", "error", err.Error())
-		return nil, false
-	}
 
-	permissions, ok := s.cache.Get(key)
+	key := permissionCacheKey(tempUser)
+	permissions, ok := s.cache.Get((key))
 	if !ok {
 		return nil, false
 	}

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -695,7 +695,6 @@ func TestPermissionCacheKey(t *testing.T) {
 		name         string
 		signedInUser *user.SignedInUser
 		expected     string
-		expectedErr  error
 	}{
 		{
 			name: "should return correct key for user",
@@ -703,8 +702,7 @@ func TestPermissionCacheKey(t *testing.T) {
 				OrgID:  1,
 				UserID: 1,
 			},
-			expected:    "rbac-permissions-1-user-1",
-			expectedErr: nil,
+			expected: "rbac-permissions-1-user-1",
 		},
 		{
 			name: "should return correct key for api key",
@@ -713,8 +711,7 @@ func TestPermissionCacheKey(t *testing.T) {
 				ApiKeyID:         1,
 				IsServiceAccount: false,
 			},
-			expected:    "rbac-permissions-1-apikey-1",
-			expectedErr: nil,
+			expected: "rbac-permissions-1-api-key-1",
 		},
 		{
 			name: "should return correct key for service account",
@@ -723,8 +720,7 @@ func TestPermissionCacheKey(t *testing.T) {
 				UserID:           1,
 				IsServiceAccount: true,
 			},
-			expected:    "rbac-permissions-1-service-1",
-			expectedErr: nil,
+			expected: "rbac-permissions-1-service-account-1",
 		},
 		{
 			name: "should return correct key for matching a service account with userId -1",
@@ -733,24 +729,19 @@ func TestPermissionCacheKey(t *testing.T) {
 				UserID:           -1,
 				IsServiceAccount: true,
 			},
-			expected:    "rbac-permissions-1-service--1",
-			expectedErr: nil,
+			expected: "rbac-permissions-1-service-account--1",
 		},
 		{
-			name: "should return error if not matching any",
+			name: "should fallback to user 0",
 			signedInUser: &user.SignedInUser{
-				OrgID:  1,
-				UserID: -1,
+				OrgID: 1,
 			},
-			expected:    "",
-			expectedErr: user.ErrNoUniqueID,
+			expected: "rbac-permissions-1-user-0",
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			str, err := permissionCacheKey(tc.signedInUser)
-			require.Equal(t, tc.expectedErr, err)
-			assert.Equal(t, tc.expected, str)
+			assert.Equal(t, tc.expected, permissionCacheKey(tc.signedInUser))
 		})
 	}
 }

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -732,11 +733,12 @@ func TestPermissionCacheKey(t *testing.T) {
 			expected: "rbac-permissions-1-service-account--1",
 		},
 		{
-			name: "should fallback to user 0",
+			name: "should use org role if no unique id",
 			signedInUser: &user.SignedInUser{
-				OrgID: 1,
+				OrgID:   1,
+				OrgRole: org.RoleNone,
 			},
-			expected: "rbac-permissions-1-user-0",
+			expected: "rbac-permissions-1-user-None",
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -57,7 +57,7 @@ type Requester interface {
 	HasRole(role roletype.RoleType) bool
 	// GetCacheKey returns a unique key for the entity.
 	// Add an extra prefix to avoid collisions with other caches
-	GetCacheKey() (string, error)
+	GetCacheKey() string
 	// HasUniqueId returns true if the entity has a unique id
 	HasUniqueId() bool
 	// AuthenticatedBy returns the authentication method used to authenticate the entity.

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -180,6 +180,8 @@ const (
 	NamespaceUser           = identity.NamespaceUser
 	NamespaceAPIKey         = identity.NamespaceAPIKey
 	NamespaceServiceAccount = identity.NamespaceServiceAccount
+	NamespaceAnonymous      = identity.NamespaceAnonymous
+	NamespaceRenderService  = identity.NamespaceRenderService
 )
 
 type Identity struct {

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -159,6 +159,9 @@ func (u *SignedInUser) GetTeams() []int64 {
 
 // GetOrgRole returns the role of the active entity in the active organization
 func (u *SignedInUser) GetOrgRole() roletype.RoleType {
+	if u.OrgRole == "" {
+		return roletype.RoleNone
+	}
 	return u.OrgRole
 }
 

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -107,9 +107,9 @@ func (u *SignedInUser) HasUniqueId() bool {
 // Add an extra prefix to avoid collisions with other caches
 func (u *SignedInUser) GetCacheKey() string {
 	namespace, id := u.GetNamespacedID()
-	if namespace == identity.NamespaceRenderService {
-		// Hack use the org role as id for rendering service because it can vary between keys
-		// and we don't have any other unique identifier to go on
+	if !u.HasUniqueId() {
+		// Hack use the org role as id for identities that do not have a unique id
+		// e.g. anonymous and render key.
 		id = string(u.GetOrgRole())
 	}
 


### PR DESCRIPTION
**What is this feature?**
`GetCacheKey` was only available for identities that had a unique id. Those where `users`, `service-account` and `api-key` and used hard coded namespaces.

I have a case when I wan't to be able to generate a cache key for all kinds of identities. So instead of either returning a cache key or an error I propose that we always generate a key using the namespace. In the implementation of `GetCacheKey` I fallback to use org roles as the unique id and this is mostly done to not generate the same key for e.g. render auth. Render auth does not have a unique id but can have different org roles. This should not matter for anonymous because all properties of an anonymous users are taken from config.

Bonus:
Re-export all namespaces in authn package

The only place `GetCacheKey` is used atm is in access control permission cache and is protected by HasUniqueID.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
