### PR TITLE
Loki Query Builder: Add support for new logfmt features

### DIFF
--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -264,7 +264,7 @@ describe('LogContextProvider', () => {
         {
           expr: '{bar="baz"} | logfmt | line_format "foo"',
           refId: 'A',
-        } 
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
@@ -279,7 +279,7 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | line_format "foo" |= "bar"',
-          refId: 'A'
+          refId: 'A',
         }
       );
 
@@ -483,24 +483,24 @@ describe('LogContextProvider', () => {
   describe('queryContainsValidPipelineStages', () => {
     it('should return true if query contains a line_format stage', () => {
       expect(
-        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | line_format "foo"', refId: 'A', })
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | line_format "foo"', refId: 'A' })
       ).toBe(true);
     });
 
     it('should return true if query contains a label_format stage', () => {
       expect(
-        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | label_format a="foo"', refId: 'A', })
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | label_format a="foo"', refId: 'A' })
       ).toBe(true);
     });
 
     it('should return false if query contains a parser', () => {
-      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | json', refId: 'A', })).toBe(
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | json', refId: 'A' })).toBe(
         false
       );
     });
 
     it('should return false if query contains a line filter', () => {
-      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} |= "test"', refId: 'A', })).toBe(
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} |= "test"', refId: 'A' })).toBe(
         false
       );
     });

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -77,12 +77,13 @@ describe('LogContextProvider', () => {
         },
         {
           expr: '{bar="baz"}',
-        } as LokiQuery
+          refId: 'A',
+        }
       );
       expect(logContextProvider.getInitContextFilters).toBeCalled();
       expect(logContextProvider.getInitContextFilters).toHaveBeenCalledWith(
         { bar: 'baz', foo: 'uniqueParsedLabel', xyz: 'abc' },
-        { expr: '{bar="baz"}' }
+        { expr: '{bar="baz"}', refId: 'A' }
       );
       expect(logContextProvider.appliedContextFilters).toHaveLength(1);
     });
@@ -135,7 +136,8 @@ describe('LogContextProvider', () => {
     describe('query with no parser', () => {
       const query = {
         expr: '{bar="baz"}',
-      } as LokiQuery;
+        refId: 'A',
+      };
       it('returns empty expression if no appliedContextFilters', async () => {
         logContextProvider.appliedContextFilters = [];
         const result = await logContextProvider.prepareLogRowContextQueryTarget(
@@ -176,7 +178,8 @@ describe('LogContextProvider', () => {
           LogRowContextQueryDirection.Backward,
           {
             expr: '{bar="baz"} | logfmt',
-          } as LokiQuery
+            refId: 'A',
+          }
         );
 
         expect(contextQuery.query.expr).toEqual('{bar="baz",xyz="abc"} | logfmt');
@@ -194,7 +197,8 @@ describe('LogContextProvider', () => {
           LogRowContextQueryDirection.Backward,
           {
             expr: '{bar="baz"} | logfmt',
-          } as LokiQuery
+            refId: 'A',
+          }
         );
 
         expect(contextQuery.query.expr).toEqual('{bar="baz",xyz="abc"} | logfmt | foo=`uniqueParsedLabel`');
@@ -212,7 +216,8 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | json',
-        } as unknown as LokiQuery
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"}`);
@@ -225,8 +230,9 @@ describe('LogContextProvider', () => {
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo"',
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt`);
@@ -240,8 +246,9 @@ describe('LogContextProvider', () => {
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt  | line_format = "foo"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt  | line_format "foo"',
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt`);
@@ -255,11 +262,12 @@ describe('LogContextProvider', () => {
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo"',
+          refId: 'A',
+        } 
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
     });
 
     it('should not apply line filters if flag is set', async () => {
@@ -270,44 +278,48 @@ describe('LogContextProvider', () => {
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo" |= "bar"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo" |= "bar"',
+          refId: 'A'
+        }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
 
       contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo" |~ "bar"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo" |~ "bar"',
+          refId: 'A',
+        }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
 
       contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo" !~ "bar"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo" !~ "bar"',
+          refId: 'A',
+        }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
 
       contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
         LogRowContextQueryDirection.Backward,
         {
-          expr: '{bar="baz"} | logfmt | line_format = "foo" != "bar"',
-        } as unknown as LokiQuery
+          expr: '{bar="baz"} | logfmt | line_format "foo" != "bar"',
+          refId: 'A',
+        }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format = "foo"`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo"`);
     });
 
     it('should not apply line filters if nested between two operations', async () => {
@@ -319,7 +331,8 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | line_format "foo" |= "bar" | label_format a="baz"',
-        } as unknown as LokiQuery
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo" | label_format a="baz"`);
@@ -334,7 +347,8 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | line_format "foo" | bar > 1 | label_format a="baz"',
-        } as unknown as LokiQuery
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"} | logfmt | line_format "foo" | label_format a="baz"`);
@@ -349,7 +363,8 @@ describe('LogContextProvider', () => {
         LogRowContextQueryDirection.Backward,
         {
           expr: '{bar="baz"} | logfmt | line_format "foo" | json | label_format a="baz"',
-        } as unknown as LokiQuery
+          refId: 'A',
+        }
       );
 
       expect(contextQuery.query.expr).toEqual(`{bar="baz"}`);
@@ -358,9 +373,10 @@ describe('LogContextProvider', () => {
 
   describe('getInitContextFiltersFromLabels', () => {
     describe('query with no parser', () => {
-      const queryWithoutParser = {
+      const queryWithoutParser: LokiQuery = {
         expr: '{bar="baz"}',
-      } as LokiQuery;
+        refId: 'A',
+      };
 
       it('should correctly create contextFilters', async () => {
         const filters = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithoutParser);
@@ -383,9 +399,10 @@ describe('LogContextProvider', () => {
     });
 
     describe('query with parser', () => {
-      const queryWithParser = {
+      const queryWithParser: LokiQuery = {
         expr: '{bar="baz"} | logfmt',
-      } as LokiQuery;
+        refId: 'A',
+      };
 
       it('should correctly create contextFilters', async () => {
         const filters = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithParser);
@@ -408,9 +425,10 @@ describe('LogContextProvider', () => {
     });
 
     describe('with preserved labels', () => {
-      const queryWithParser = {
+      const queryWithParser: LokiQuery = {
         expr: '{bar="baz"} | logfmt',
-      } as LokiQuery;
+        refId: 'A',
+      };
 
       it('should correctly apply preserved labels', async () => {
         window.localStorage.setItem(
@@ -465,24 +483,24 @@ describe('LogContextProvider', () => {
   describe('queryContainsValidPipelineStages', () => {
     it('should return true if query contains a line_format stage', () => {
       expect(
-        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | line_format "foo"' } as LokiQuery)
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | line_format "foo"', refId: 'A', })
       ).toBe(true);
     });
 
     it('should return true if query contains a label_format stage', () => {
       expect(
-        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | label_format a="foo"' } as LokiQuery)
+        logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | label_format a="foo"', refId: 'A', })
       ).toBe(true);
     });
 
     it('should return false if query contains a parser', () => {
-      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | json' } as LokiQuery)).toBe(
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} | json', refId: 'A', })).toBe(
         false
       );
     });
 
     it('should return false if query contains a line filter', () => {
-      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} |= "test"' } as LokiQuery)).toBe(
+      expect(logContextProvider.queryContainsValidPipelineStages({ expr: '{foo="bar"} |= "test"', refId: 'A', })).toBe(
         false
       );
     });
@@ -491,7 +509,8 @@ describe('LogContextProvider', () => {
       expect(
         logContextProvider.queryContainsValidPipelineStages({
           expr: '{foo="bar"} |= "test" | label_format a="foo"',
-        } as LokiQuery)
+          refId: 'A',
+        })
       ).toBe(true);
     });
   });

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -14,7 +14,7 @@ import {
   LogRowContextQueryDirection,
   LogRowContextOptions,
 } from '@grafana/data';
-import { LabelParser, LabelFilter, LineFilters, PipelineStage } from '@grafana/lezer-logql';
+import { LabelParser, LabelFilter, LineFilters, PipelineStage, Logfmt, Json } from '@grafana/lezer-logql';
 import { Labels } from '@grafana/schema';
 import { notifyApp } from 'app/core/actions';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
@@ -249,6 +249,8 @@ export class LogContextProvider {
     const allNodePositions = getNodePositionsFromQuery(origExpr, [
       PipelineStage,
       LabelParser,
+      Logfmt,
+      Json,
       LineFilters,
       LabelFilter,
     ]);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -539,7 +539,7 @@ describe('IN_LOGFMT completions', () => {
       flags: false,
       otherLabels: [],
     };
-    
+
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {
@@ -645,7 +645,7 @@ describe('IN_LOGFMT completions', () => {
       flags: true,
       otherLabels: [],
     };
-    
+
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {
@@ -739,7 +739,7 @@ describe('IN_LOGFMT completions', () => {
       flags: true,
       otherLabels: ['label1', 'label2'],
     };
-    
+
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {
@@ -821,7 +821,7 @@ describe('IN_LOGFMT completions', () => {
       flags: false,
       otherLabels: ['label1'],
     };
-    
+
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {
@@ -841,7 +841,7 @@ describe('IN_LOGFMT completions', () => {
       flags: true,
       otherLabels: ['label1'],
     };
-    
+
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -102,13 +102,15 @@ const LOGFMT_ARGUMENT_COMPLETIONS: Completion[] = [
   {
     type: 'FUNCTION',
     label: 'strict',
-    documentation: 'Strict parsing. The logfmt parser stops scanning the log line and returns early with an error when it encounters any poorly formatted key/value pair.',
+    documentation:
+      'Strict parsing. The logfmt parser stops scanning the log line and returns early with an error when it encounters any poorly formatted key/value pair.',
     insertText: '--strict',
   },
   {
     type: 'FUNCTION',
     label: 'keep empty',
-    documentation: 'Retain standalone keys with empty value. The logfmt parser retains standalone keys (keys without a value) as labels with value set to empty string.',
+    documentation:
+      'Retain standalone keys with empty value. The logfmt parser retains standalone keys (keys without a value) as labels with value set to empty string.',
     insertText: '--keep-empty',
   },
 ];
@@ -311,7 +313,7 @@ export async function getAfterSelectorCompletions(
   const hasQueryParser = isQueryWithParser(query).queryWithParser;
 
   const prefix = `${hasSpace ? '' : ' '}${afterPipe ? '' : '| '}`;
-  
+
   const parserCompletions = await getParserCompletions(
     prefix,
     hasJSON,
@@ -355,7 +357,7 @@ export async function getLogfmtCompletions(
   const trailingComma = logQuery.trimEnd().endsWith(',');
   if (trailingComma) {
     // The user is typing a new label, so we remove the last comma
-    logQuery = trimEnd(logQuery, ', '); 
+    logQuery = trimEnd(logQuery, ', ');
   }
   const { extractedLabelKeys, hasJSON, hasLogfmt, hasPack } = await dataProvider.getParserAndLabelKeys(logQuery);
   const hasQueryParser = isQueryWithParser(logQuery).queryWithParser;
@@ -373,13 +375,13 @@ export async function getLogfmtCompletions(
   const pipeOperations = getPipeOperationsCompletions('| ');
 
   if (!flags && !trailingComma) {
-    completions = [...completions, ...LOGFMT_ARGUMENT_COMPLETIONS, ...parserCompletions, ...pipeOperations]
+    completions = [...completions, ...LOGFMT_ARGUMENT_COMPLETIONS, ...parserCompletions, ...pipeOperations];
   } else if (!trailingComma) {
     completions = [...completions, ...parserCompletions, ...pipeOperations];
   }
 
   const labelPrefix = otherLabels.length === 0 || trailingComma ? '' : ', ';
-  const labels = extractedLabelKeys.filter(label => !otherLabels.includes(label));
+  const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
   const labelCompletions: Completion[] = labels.map((label) => ({
     type: 'LABEL_NAME',
     label,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -27,7 +27,7 @@ import {
   KeepLabels,
   ParserFlag,
   LabelExtractionExpression,
-  LabelExtractionExpressionList
+  LabelExtractionExpressionList,
 } from '@grafana/lezer-logql';
 
 import { getLogQueryFromMetricsQuery, getNodesFromQuery } from '../../../queryUtils';
@@ -105,11 +105,11 @@ export type Situation =
       type: 'AT_ROOT';
     }
   | {
-    type: 'IN_LOGFMT',
-    otherLabels: string[],
-    flags: boolean,
-    logQuery: string;
-  }
+      type: 'IN_LOGFMT';
+      otherLabels: string[];
+      flags: boolean;
+      logQuery: string;
+    }
   | {
       type: 'IN_RANGE';
     }
@@ -214,10 +214,7 @@ const RESOLVERS: Resolver[] = [
     fun: resolvePipeError,
   },
   {
-    paths: [
-      [ERROR_NODE_ID, UnwrapExpr],
-      [UnwrapExpr]
-    ],
+    paths: [[ERROR_NODE_ID, UnwrapExpr], [UnwrapExpr]],
     fun: resolveAfterUnwrap,
   },
   {
@@ -438,7 +435,7 @@ function resolveLogfmtParser(_: SyntaxNode, text: string, cursorPosition: number
 
   const cursor = tree.cursorAt(position);
 
-  const expectedNodes = [Logfmt, ParserFlag, LabelExtractionExpression, LabelExtractionExpressionList]
+  const expectedNodes = [Logfmt, ParserFlag, LabelExtractionExpression, LabelExtractionExpressionList];
   let inLogfmt = false;
   do {
     const { node } = cursor;
@@ -467,7 +464,7 @@ function resolveLogfmtParser(_: SyntaxNode, text: string, cursorPosition: number
     otherLabels,
     flags,
     logQuery: getLogQueryFromMetricsQuery(text).trim(),
-  }
+  };
 }
 
 function resolveTopLevel(node: SyntaxNode, text: string, pos: number): Situation | null {

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -3,7 +3,6 @@ import { sortBy } from 'lodash';
 
 import {
   Identifier,
-  JsonExpressionParser,
   LabelFilter,
   LabelParser,
   LineComment,
@@ -17,6 +16,9 @@ import {
   UnwrapExpr,
   String,
   PipelineStage,
+  LogfmtParser,
+  JsonExpressionParser,
+  LogfmtExpressionParser,
 } from '@grafana/lezer-logql';
 
 import { QueryBuilderLabelFilter } from '../prometheus/querybuilder/shared/types';
@@ -301,9 +303,10 @@ function getMatcherInStreamPositions(query: string): NodePosition[] {
 export function getParserPositions(query: string): NodePosition[] {
   const tree = parser.parse(query);
   const positions: NodePosition[] = [];
+  const parserNodeTypes = [LabelParser, JsonExpressionParser, LogfmtParser, LogfmtExpressionParser];
   tree.iterate({
     enter: ({ type, from, to }): false | void => {
-      if (type.id === LabelParser || type.id === JsonExpressionParser) {
+      if (parserNodeTypes.includes(type.id)) {
         positions.push(new NodePosition(from, to, type));
         return false;
       }

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -358,7 +358,9 @@ describe('getParserFromQuery', () => {
     expect(getParserFromQuery('{job="grafana"} | logfmt field="otherField"')).toBe('logfmt');
     expect(getParserFromQuery('{job="grafana"} | logfmt field="otherField", label')).toBe('logfmt');
     expect(getParserFromQuery('{job="grafana"} | logfmt --strict field="otherField"')).toBe('logfmt');
-    expect(getParserFromQuery('{job="grafana"} | logfmt --strict --keep-empty field="otherField", label="field2"')).toBe('logfmt');
+    expect(
+      getParserFromQuery('{job="grafana"} | logfmt --strict --keep-empty field="otherField", label="field2"')
+    ).toBe('logfmt');
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -342,6 +342,24 @@ describe('getParserFromQuery', () => {
       parser
     );
   });
+
+  it('supports json parser with arguments', () => {
+    // Redundant, but gives us a baseline
+    expect(getParserFromQuery('{job="grafana"} | json')).toBe('json');
+    expect(getParserFromQuery('{job="grafana"} | json field="otherField"')).toBe('json');
+    expect(getParserFromQuery('{job="grafana"} | json field="otherField", label="field2"')).toBe('json');
+  });
+
+  it('supports logfmt parser with arguments and flags', () => {
+    // Redundant, but gives us a baseline
+    expect(getParserFromQuery('{job="grafana"} | logfmt')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt --strict')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt --strict --keep-empty')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt field="otherField"')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt field="otherField", label')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt --strict field="otherField"')).toBe('logfmt');
+    expect(getParserFromQuery('{job="grafana"} | logfmt --strict --keep-empty field="otherField", label="field2"')).toBe('logfmt');
+  });
 });
 
 describe('requestSupportsSplitting', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -20,6 +20,7 @@ import {
   Range,
   formatLokiQuery,
   Logfmt,
+  Json,
 } from '@grafana/lezer-logql';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -200,7 +201,7 @@ export function isQueryWithParser(query: string): { queryWithParser: boolean; pa
 }
 
 export function getParserFromQuery(query: string): string | undefined {
-  const parsers = getNodesFromQuery(query, [LabelParser, JsonExpressionParser]);
+  const parsers = getNodesFromQuery(query, [LabelParser, Json, Logfmt]);
   return parsers.length > 0 ? query.substring(parsers[0].from, parsers[0].to).trim() : undefined;
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -49,6 +49,51 @@ describe('LokiQueryModeller', () => {
     ).toBe('{app="grafana"} | logfmt');
   });
 
+  it('Models a logfmt query with strict flag', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.Logfmt, params: [true] }],
+      })
+    ).toBe('{app="grafana"} | logfmt --strict');
+  });
+
+  it('Models a logfmt query with keep empty flag', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.Logfmt, params: [false, true] }],
+      })
+    ).toBe('{app="grafana"} | logfmt --keep-empty');
+  });
+
+  it('Models a logfmt query with multiple flags', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.Logfmt, params: [true, true] }],
+      })
+    ).toBe('{app="grafana"} | logfmt --strict --keep-empty');
+  });
+
+  it('Models a logfmt query with multiple flags and labels', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.Logfmt, params: [true, true, 'label', 'label2="label3'] }],
+      })
+    ).toBe("{app=\"grafana\"} | logfmt --strict --keep-empty label, label2=\"label3");
+  });
+
+  it('Models a logfmt query with labels', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.Logfmt, params: [false, false, 'label', 'label2="label3'] }],
+      })
+    ).toBe("{app=\"grafana\"} | logfmt label, label2=\"label3");
+  });
+
   it('Can query with pipeline operation regexp', () => {
     expect(
       modeller.renderQuery({

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -82,7 +82,7 @@ describe('LokiQueryModeller', () => {
         labels: [{ label: 'app', op: '=', value: 'grafana' }],
         operations: [{ id: LokiOperationId.Logfmt, params: [true, true, 'label', 'label2="label3'] }],
       })
-    ).toBe("{app=\"grafana\"} | logfmt --strict --keep-empty label, label2=\"label3");
+    ).toBe('{app="grafana"} | logfmt --strict --keep-empty label, label2="label3');
   });
 
   it('Models a logfmt query with labels', () => {
@@ -91,7 +91,7 @@ describe('LokiQueryModeller', () => {
         labels: [{ label: 'app', op: '=', value: 'grafana' }],
         operations: [{ id: LokiOperationId.Logfmt, params: [false, false, 'label', 'label2="label3'] }],
       })
-    ).toBe("{app=\"grafana\"} | logfmt label, label2=\"label3");
+    ).toBe('{app="grafana"} | logfmt label, label2="label3');
   });
 
   it('Can query with pipeline operation regexp', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -1,4 +1,5 @@
-import { QueryBuilderOperationDef } from '../../prometheus/querybuilder/shared/types';
+import { QueryBuilderOperation, QueryBuilderOperationDef } from '../../prometheus/querybuilder/shared/types';
+import { getOperationDefinitions } from './operations';
 
 import {
   createRangeOperation,
@@ -6,8 +7,9 @@ import {
   getLineFilterRenderer,
   isConflictingFilter,
   labelFilterRenderer,
+  pipelineRenderer,
 } from './operationUtils';
-import { LokiVisualQueryOperationCategory } from './types';
+import { LokiOperationId, LokiVisualQueryOperationCategory } from './types';
 
 describe('createRangeOperation', () => {
   it('should create basic range operation without possible grouping', () => {
@@ -203,5 +205,21 @@ describe('isConflictingFilter', () => {
       { id: '__label_filter', params: ['abc', '=', '123'] },
     ];
     expect(isConflictingFilter(operation, queryOperations)).toBe(false);
+  });
+});
+
+describe('pipelineRenderer', () => {
+  let definitions: QueryBuilderOperationDef[];
+  beforeEach(() => {
+    definitions = getOperationDefinitions();
+  })
+
+  it('Correctly renders unpack expressions', () => {
+    const model: QueryBuilderOperation = {
+      id: LokiOperationId.Unpack,
+      params: [],
+    }
+    const definition = definitions.find(def => def.id === LokiOperationId.Unpack);
+    expect(pipelineRenderer(model, definition!, '{}')).toBe('{} | unpack');
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -1,5 +1,4 @@
 import { QueryBuilderOperation, QueryBuilderOperationDef } from '../../prometheus/querybuilder/shared/types';
-import { getOperationDefinitions } from './operations';
 
 import {
   createRangeOperation,
@@ -9,6 +8,7 @@ import {
   labelFilterRenderer,
   pipelineRenderer,
 } from './operationUtils';
+import { getOperationDefinitions } from './operations';
 import { LokiOperationId, LokiVisualQueryOperationCategory } from './types';
 
 describe('createRangeOperation', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -212,14 +212,14 @@ describe('pipelineRenderer', () => {
   let definitions: QueryBuilderOperationDef[];
   beforeEach(() => {
     definitions = getOperationDefinitions();
-  })
+  });
 
   it('Correctly renders unpack expressions', () => {
     const model: QueryBuilderOperation = {
       id: LokiOperationId.Unpack,
       params: [],
-    }
-    const definition = definitions.find(def => def.id === LokiOperationId.Unpack);
+    };
+    const definition = definitions.find((def) => def.id === LokiOperationId.Unpack);
     expect(pipelineRenderer(model, definition!, '{}')).toBe('{} | unpack');
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -187,7 +187,7 @@ export function pipelineRenderer(model: QueryBuilderOperation, def: QueryBuilder
   switch (model.id) {
     case LokiOperationId.Logfmt:
       const [strict = false, keepEmpty = false, ...labels] = model.params;
-      return `${innerExpr} | logfmt ${strict ? '--strict' : ''} ${keepEmpty ? '--keep-empty' : ''} ${labels.join(', ')}`;
+      return `${innerExpr} | logfmt${strict ? ' --strict' : ''}${keepEmpty ? ' --keep-empty' : ''} ${labels.join(', ')}`.trim();
     default:
       return `${innerExpr} | ${model.id}`;
   }

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -184,7 +184,13 @@ export function isConflictingFilter(
 }
 
 export function pipelineRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-  return `${innerExpr} | ${model.id}`;
+  switch (model.id) {
+    case LokiOperationId.Logfmt:
+      const [strict = false, keepEmpty = false, ...labels] = model.params;
+      return `${innerExpr} | logfmt ${strict ? '--strict' : ''} ${keepEmpty ? '--keep-empty' : ''} ${labels.join(', ')})`;
+    default:
+      return `${innerExpr} | ${model.id}`;
+  }
 }
 
 function isRangeVectorFunction(def: QueryBuilderOperationDef) {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -187,7 +187,7 @@ export function pipelineRenderer(model: QueryBuilderOperation, def: QueryBuilder
   switch (model.id) {
     case LokiOperationId.Logfmt:
       const [strict = false, keepEmpty = false, ...labels] = model.params;
-      return `${innerExpr} | logfmt ${strict ? '--strict' : ''} ${keepEmpty ? '--keep-empty' : ''} ${labels.join(', ')})`;
+      return `${innerExpr} | logfmt ${strict ? '--strict' : ''} ${keepEmpty ? '--keep-empty' : ''} ${labels.join(', ')}`;
     default:
       return `${innerExpr} | ${model.id}`;
   }

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -187,7 +187,9 @@ export function pipelineRenderer(model: QueryBuilderOperation, def: QueryBuilder
   switch (model.id) {
     case LokiOperationId.Logfmt:
       const [strict = false, keepEmpty = false, ...labels] = model.params;
-      return `${innerExpr} | logfmt${strict ? ' --strict' : ''}${keepEmpty ? ' --keep-empty' : ''} ${labels.join(', ')}`.trim();
+      return `${innerExpr} | logfmt${strict ? ' --strict' : ''}${keepEmpty ? ' --keep-empty' : ''} ${labels.join(
+        ', '
+      )}`.trim();
     default:
       return `${innerExpr} | ${model.id}`;
   }

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -128,7 +128,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
             'Using expressions with your logfmt parser will extract and rename (if provided) only the specified fields to labels. You can specify one or more expressions in this way.',
         },
       ],
-      defaultParams: [],
+      defaultParams: [false, false],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
       orderRank: LokiOperationOrder.Parsers,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -100,7 +100,34 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
     {
       id: LokiOperationId.Logfmt,
       name: 'Logfmt',
-      params: [],
+      params: [
+        {
+          name: 'Strict',
+          type: 'boolean',
+          optional: true,
+          restParam: true,
+          description:
+            'With strict parsing enabled, the logfmt parser immediately stops scanning the log line and returns early with an error when it encounters any poorly formatted key/value pair.',
+        },
+        {
+          name: 'Keep empty',
+          type: 'boolean',
+          optional: true,
+          restParam: true,
+          description:
+            'The logfmt parser retains standalone keys (keys without a value) as labels with its value set to empty string. ',
+        },
+        {
+          name: 'Expression',
+          type: 'string',
+          optional: true,
+          restParam: true,
+          minWidth: 18,
+          placeholder: 'field_name',
+          description:
+            'Using expressions with your logfmt parser will extract and rename (if provided) only the specified fields to labels. You can specify one or more expressions in this way.',
+        },
+      ],
       defaultParams: [],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -105,7 +105,6 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
           name: 'Strict',
           type: 'boolean',
           optional: true,
-          restParam: true,
           description:
             'With strict parsing enabled, the logfmt parser immediately stops scanning the log line and returns early with an error when it encounters any poorly formatted key/value pair.',
         },
@@ -113,7 +112,6 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
           name: 'Keep empty',
           type: 'boolean',
           optional: true,
-          restParam: true,
           description:
             'The logfmt parser retains standalone keys (keys without a value) as labels with its value set to empty string. ',
         },

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -119,7 +119,7 @@ describe('buildVisualQueryFromString', () => {
         ],
         operations: [
           { id: LokiOperationId.LineFilterIpMatches, params: ['|=', '192.168.4.5/16'] },
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
         ],
       })
     );
@@ -209,7 +209,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.LabelFilterIpMatches, params: ['address', '=', '192.168.4.5/16'] },
         ],
       })
@@ -260,7 +260,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.Unwrap, params: ['bytes_processed', ''] },
           { id: LokiOperationId.SumOverTime, params: ['1m'] },
         ],
@@ -281,7 +281,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.Unwrap, params: ['duration', ''] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
           { id: LokiOperationId.SumOverTime, params: ['1m'] },
@@ -303,7 +303,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.Unwrap, params: ['duration', ''] },
           { id: LokiOperationId.LabelFilter, params: ['label', '=', 'value'] },
           { id: LokiOperationId.SumOverTime, params: ['1m'] },
@@ -326,7 +326,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.Unwrap, params: ['label', 'duration'] },
           { id: LokiOperationId.SumOverTime, params: ['5m'] },
         ],
@@ -360,7 +360,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.Decolorize, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
         ],
@@ -477,7 +477,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [] },
+          { id: LokiOperationId.Logfmt, params: [false, false] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
           { id: LokiOperationId.CountOverTime, params: ['5m'] },
           { id: LokiOperationId.Sum, params: [] },
@@ -833,6 +833,63 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [{ id: LokiOperationId.Keep, params: ['id', 'email', 'test="test1"'] }],
+      })
+    );
+  });
+
+  it('parses query with logfmt parser', () => {
+    expect(
+      buildVisualQueryFromString('{label="value"} | logfmt')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'value',
+            label: 'label',
+          },
+        ],
+        operations: [
+          { id: LokiOperationId.Logfmt, params: [false, false] },
+        ],
+      })
+    );
+  });
+
+  it('parses query with logfmt parser and flags', () => {
+    expect(
+      buildVisualQueryFromString('{label="value"} | logfmt --keep-empty --strict')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'value',
+            label: 'label',
+          },
+        ],
+        operations: [
+          { id: LokiOperationId.Logfmt, params: [true, true] },
+        ],
+      })
+    );
+  });
+
+  it('parses query with logfmt parser, flags, and labels', () => {
+    expect(
+      buildVisualQueryFromString('{label="value"} | logfmt --keep-empty --strict label1, label2, label3="label4"')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'value',
+            label: 'label',
+          },
+        ],
+        operations: [
+          { id: LokiOperationId.Logfmt, params: [true, true, 'label1', 'label2', "label3=\"label4"] },
+        ],
       })
     );
   });

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -888,7 +888,7 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: LokiOperationId.Logfmt, params: [true, true, 'label1', 'label2', "label3=\"label4"] },
+          { id: LokiOperationId.Logfmt, params: [true, true, 'label1', 'label2', "label3=\"label4\""] },
         ],
       })
     );

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -838,9 +838,7 @@ describe('buildVisualQueryFromString', () => {
   });
 
   it('parses query with logfmt parser', () => {
-    expect(
-      buildVisualQueryFromString('{label="value"} | logfmt')
-    ).toEqual(
+    expect(buildVisualQueryFromString('{label="value"} | logfmt')).toEqual(
       noErrors({
         labels: [
           {
@@ -849,17 +847,13 @@ describe('buildVisualQueryFromString', () => {
             label: 'label',
           },
         ],
-        operations: [
-          { id: LokiOperationId.Logfmt, params: [false, false] },
-        ],
+        operations: [{ id: LokiOperationId.Logfmt, params: [false, false] }],
       })
     );
   });
 
   it('parses query with logfmt parser and flags', () => {
-    expect(
-      buildVisualQueryFromString('{label="value"} | logfmt --keep-empty --strict')
-    ).toEqual(
+    expect(buildVisualQueryFromString('{label="value"} | logfmt --keep-empty --strict')).toEqual(
       noErrors({
         labels: [
           {
@@ -868,9 +862,7 @@ describe('buildVisualQueryFromString', () => {
             label: 'label',
           },
         ],
-        operations: [
-          { id: LokiOperationId.Logfmt, params: [true, true] },
-        ],
+        operations: [{ id: LokiOperationId.Logfmt, params: [true, true] }],
       })
     );
   });
@@ -887,9 +879,7 @@ describe('buildVisualQueryFromString', () => {
             label: 'label',
           },
         ],
-        operations: [
-          { id: LokiOperationId.Logfmt, params: [true, true, 'label1', 'label2', "label3=\"label4\""] },
-        ],
+        operations: [{ id: LokiOperationId.Logfmt, params: [true, true, 'label1', 'label2', 'label3="label4"'] }],
       })
     );
   });

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -87,7 +87,6 @@ interface ParsingError {
 interface GetOperationResult { operation?: QueryBuilderOperation; error?: string };
 
 export function buildVisualQueryFromString(expr: string): Context {
-  console.log(expr);
   const replacedExpr = replaceVariables(expr);
   const tree = parser.parse(replacedExpr);
   const node = tree.topNode;

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -173,6 +173,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       if (error) {
         context.errors.push(createNotSupportedError(expr, node, error));
       }
+      break;
     }
 
     case LogfmtExpressionParser: {
@@ -183,6 +184,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       if (error) {
         context.errors.push(createNotSupportedError(expr, node, error));
       }
+      break;
     }
 
     case LineFormatExpr: {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -333,7 +333,6 @@ function getJsonExpressionParser(expr: string, node: SyntaxNode): QueryBuilderOp
 }
 
 function getLogfmtParser(expr: string, node: SyntaxNode): GetOperationResult {
-  const params: QueryBuilderOperationParamValue[] = [];
   const flags: string[] = [];
   const labels: string[] = [];
   let error: string | undefined = undefined;

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -25,7 +25,6 @@ import {
   KeepLabels,
   KeepLabelsExpr,
   LabelExtractionExpression,
-  LabelExtractionExpressionList,
   LabelFilter,
   LabelFormatMatcher,
   LabelParser,
@@ -325,7 +324,7 @@ function getJsonExpressionParser(expr: string, node: SyntaxNode): QueryBuilderOp
   const parserNode = node.getChild(Json);
   const parser = getString(expr, parserNode);
 
-  const params = [...getAllByType(expr, node, LabelExtractionExpressionList)];
+  const params = [...getAllByType(expr, node, LabelExtractionExpression)];
   return {
     id: parser,
     params,

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -20,11 +20,11 @@ import {
   Ip,
   IpLabelFilter,
   Json,
-  JsonExpression,
   JsonExpressionParser,
   KeepLabel,
   KeepLabels,
   KeepLabelsExpr,
+  LabelExtractionExpressionList,
   LabelFilter,
   LabelFormatMatcher,
   LabelParser,
@@ -299,7 +299,7 @@ function getJsonExpressionParser(expr: string, node: SyntaxNode): QueryBuilderOp
   const parserNode = node.getChild(Json);
   const parser = getString(expr, parserNode);
 
-  const params = [...getAllByType(expr, node, JsonExpression)];
+  const params = [...getAllByType(expr, node, LabelExtractionExpressionList)];
   return {
     id: parser,
     params,

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -83,7 +83,10 @@ interface ParsingError {
   parentType?: string;
 }
 
-interface GetOperationResult { operation?: QueryBuilderOperation; error?: string };
+interface GetOperationResult {
+  operation?: QueryBuilderOperation;
+  error?: string;
+}
 
 export function buildVisualQueryFromString(expr: string): Context {
   const replacedExpr = replaceVariables(expr);
@@ -335,8 +338,7 @@ function getLogfmtParser(expr: string, node: SyntaxNode): GetOperationResult {
         flags.push(expr.substring(subNode.from + offset, subNode.to + offset));
       } else if (subNode.type.id === LabelExtractionExpression) {
         labels.push(expr.substring(subNode.from + offset, subNode.to + offset));
-      }
-      else if (subNode.type.id === ErrorId) {
+      } else if (subNode.type.id === ErrorId) {
         error = `Unexpected string "${expr.substring(subNode.from + offset, subNode.to + offset)}"`;
       }
     },
@@ -446,11 +448,7 @@ function getDecolorize(): QueryBuilderOperation {
   };
 }
 
-function handleUnwrapExpr(
-  expr: string,
-  node: SyntaxNode,
-  context: Context
-): GetOperationResult {
+function handleUnwrapExpr(expr: string, node: SyntaxNode, context: Context): GetOperationResult {
   const unwrapExprChild = node.getChild(UnwrapExpr);
   const labelFilterChild = node.getChild(LabelFilter);
   const unwrapChild = node.getChild(Unwrap);

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -165,17 +165,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       break;
     }
 
-    case LogfmtParser: {
-      const { operation, error } = getLogfmtParser(expr, node);
-      if (operation) {
-        visQuery.operations.push(operation);
-      }
-      if (error) {
-        context.errors.push(createNotSupportedError(expr, node, error));
-      }
-      break;
-    }
-
+    case LogfmtParser:
     case LogfmtExpressionParser: {
       const { operation, error } = getLogfmtParser(expr, node);
       if (operation) {


### PR DESCRIPTION
This PR adds support for new Loki LogQL features to the Query Builder:

- --strict flag
- --keep-empty flag
- Support for parameters (labels)

Additional changes:
- JsonExpression nodes don't exist anymore. We now generate [LabelExtractionExpressionList](https://github.com/grafana/loki/blob/main/pkg/logql/syntax/expr.y#L324).

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71121

**Special notes for your reviewer:**

No special steps to follow. Just install the updated dependencies and:

- From a LogQL query, switch modes and see that nothing was lost or misrepresented.
- Use the Query Builder to build logs and metric queries with `logfmt` parser and double check that the generated query is correct.

Examples:

Query: 

![imagen](https://github.com/grafana/grafana/assets/1069378/059c4140-1892-4596-8eae-6fac10af45f9)

Visual query: 

![imagen](https://github.com/grafana/grafana/assets/1069378/6b801d36-4b0a-48c8-8d44-759515d49c9f)

Metric visual query:

![imagen](https://github.com/grafana/grafana/assets/1069378/f98d22b1-5cae-4ebc-850d-9f777dcbac06)
