### PR TITLE
[v9.5.x] Docs: Add multiple y-axes guidance 

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -183,3 +183,5 @@ Set a **Soft min** or **soft max** option for better control of Y-axis limits. B
 **Soft min** and **soft max** settings can prevent blips from turning into mountains when the data is mostly flat, and hard min or max derived from standard min and max field options can prevent intermittent spikes from flattening useful detail by clipping the spikes past a defined point.
 
 You can set standard min/max options to define hard limits of the Y-axis. For more information, refer to [Standard options definitions]({{< relref "../../configure-standard-options/#max" >}}).
+
+{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+2" >}}

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -74,6 +74,8 @@ This setting configures the axis value.
 
 When selected, the axis appears in reverse order.
 
+{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+2" >}}
+
 ## Colors
 
 The color spectrum controls the mapping between value count (in each bucket) and the color assigned to each bucket. The leftmost color on the spectrum represents the minimum count and the color on the right most side represents the maximum count. Some color schemes are automatically inverted when using the light theme.

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -224,6 +224,8 @@ Use this option to transform the series values without affecting the values show
 
 > **Note:** The transform option is only available as an override.
 
+{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+2" >}}
+
 ## Color options
 
 By default, the graph uses the standard [Color scheme]({{< relref "../../configure-standard-options/#color-scheme" >}}) option to assign series colors. You can also use the legend to open the color picker by clicking the legend series color icon. Setting

--- a/docs/sources/shared/visualizations/multiple-y-axes.md
+++ b/docs/sources/shared/visualizations/multiple-y-axes.md
@@ -1,0 +1,9 @@
+---
+title: Display multiple y-axes
+---
+
+# Display multiple y-axes
+
+In some cases, you may want to display multiple y-axes. For example, if you have a dataset showing both temperature and humidity over time, you may want to show two y-axes with different units for these two series.
+
+You can do this by [adding field overrides]({{< relref "../../panels-visualizations/configure-overrides#add-a-field-override" >}}). Follow the steps as many times as required to add as many y-axes as you need.

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -7,5 +7,3 @@ export DOC_VALIDATOR_IMAGE := $(shell sed -En 's, *image: "(grafana/doc-validato
 # Skip some doc-validator checks.
 export DOC_VALIDATOR_SKIP_CHECKS := ^(?:image.+|canonical-does-not-match-pretty-URL)$
 
-# Use alternative image until make-docs 3.0.0 is rolled out.
-export DOCS_IMAGE := grafana/docs-base:dbd975af06


### PR DESCRIPTION
Backport #74282 to v9.5.x

* Added multiple y axes shared file

* Added shared content to time series page

* Updated shared content and added to heatmap and bar chart pages

(cherry picked from commit 9a389a80d8c83ae5c89850dfc576e3ff94ba89da)

Also removed command from variables.mk file to make version lookup in docs/shared shortcode work properly.