### PR TITLE
Alerting: Add empty remote Alertmanager struct

### DIFF
--- a/pkg/services/ngalert/notifier/external_alertmanager.go
+++ b/pkg/services/ngalert/notifier/external_alertmanager.go
@@ -58,7 +58,7 @@ func newExternalAlertmanager(cfg externalAlertmanagerConfig, orgID int64) (*exte
 	return &externalAlertmanager{
 		amClient:      amclient.New(transport, nil),
 		httpClient:    &client,
-		log:           log.New("ngalert.notifier.external.alertmanager"),
+		log:           log.New("ngalert.notifier.external-alertmanager"),
 		url:           cfg.URL,
 		tenantID:      cfg.TenantID,
 		orgID:         orgID,

--- a/pkg/services/ngalert/notifier/external_alertmanager.go
+++ b/pkg/services/ngalert/notifier/external_alertmanager.go
@@ -1,0 +1,159 @@
+package notifier
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/grafana/grafana/pkg/infra/log"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	amclient "github.com/prometheus/alertmanager/api/v2/client"
+)
+
+type externalAlertmanager struct {
+	log           log.Logger
+	url           string
+	tenantID      string
+	orgID         int64
+	amClient      *amclient.AlertmanagerAPI
+	httpClient    *http.Client
+	defaultConfig string
+}
+
+type externalAlertmanagerConfig struct {
+	URL               string
+	TenantID          string
+	BasicAuthPassword string
+	DefaultConfig     string
+}
+
+func newExternalAlertmanager(cfg externalAlertmanagerConfig, orgID int64) (*externalAlertmanager, error) {
+	client := http.Client{
+		Transport: &roundTripper{
+			tenantID:          cfg.TenantID,
+			basicAuthPassword: cfg.BasicAuthPassword,
+			next:              http.DefaultTransport,
+		},
+	}
+
+	if cfg.URL == "" {
+		return nil, errors.New("empty URL")
+	}
+
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := httptransport.NewWithClient(u.Host, amclient.DefaultBasePath, []string{u.Scheme}, &client)
+
+	_, err = Load([]byte(cfg.DefaultConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	return &externalAlertmanager{
+		amClient:      amclient.New(transport, nil),
+		httpClient:    &client,
+		log:           log.New("ngalert.notifier.external.alertmanager"),
+		url:           cfg.URL,
+		tenantID:      cfg.TenantID,
+		orgID:         orgID,
+		defaultConfig: cfg.DefaultConfig,
+	}, nil
+}
+
+func (am *externalAlertmanager) SaveAndApplyConfig(ctx context.Context, cfg *apimodels.PostableUserConfig) error {
+	return nil
+}
+
+func (am *externalAlertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
+	return nil
+}
+
+func (am *externalAlertmanager) GetStatus() (apimodels.GettableStatus, error) {
+	return apimodels.GettableStatus{}, nil
+}
+
+func (am *externalAlertmanager) CreateSilence(*apimodels.PostableSilence) (string, error) {
+	return "", nil
+}
+
+func (am *externalAlertmanager) DeleteSilence(string) error {
+	return nil
+}
+
+func (am *externalAlertmanager) GetSilence(silenceID string) (apimodels.GettableSilence, error) {
+	return apimodels.GettableSilence{}, nil
+}
+
+func (am *externalAlertmanager) ListSilences([]string) (apimodels.GettableSilences, error) {
+	return apimodels.GettableSilences{}, nil
+}
+
+func (am *externalAlertmanager) GetAlerts(active, silenced, inhibited bool, filter []string, receiver string) (apimodels.GettableAlerts, error) {
+	return apimodels.GettableAlerts{}, nil
+}
+
+func (am *externalAlertmanager) GetAlertGroups(active, silenced, inhibited bool, filter []string, receiver string) (apimodels.AlertGroups, error) {
+	return apimodels.AlertGroups{}, nil
+}
+
+func (am *externalAlertmanager) PutAlerts(postableAlerts apimodels.PostableAlerts) error {
+	return nil
+}
+
+func (am *externalAlertmanager) GetReceivers(ctx context.Context) ([]apimodels.Receiver, error) {
+	return []apimodels.Receiver{}, nil
+}
+
+func (am *externalAlertmanager) ApplyConfig(ctx context.Context, config *models.AlertConfiguration) error {
+	return nil
+}
+
+func (am *externalAlertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*TestReceiversResult, error) {
+	return &TestReceiversResult{}, nil
+}
+
+func (am *externalAlertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*TestTemplatesResults, error) {
+	return &TestTemplatesResults{}, nil
+}
+
+func (am *externalAlertmanager) StopAndWait() {
+}
+
+func (am *externalAlertmanager) Ready() bool {
+	return false
+}
+
+func (am *externalAlertmanager) FileStore() *FileStore {
+	return &FileStore{}
+}
+
+func (am *externalAlertmanager) OrgID() int64 {
+	return am.orgID
+}
+
+func (am *externalAlertmanager) ConfigHash() [16]byte {
+	return [16]byte{}
+}
+
+type roundTripper struct {
+	tenantID          string
+	basicAuthPassword string
+	next              http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface
+// while adding the `X-Scope-OrgID` header and basic auth credentials.
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("X-Scope-OrgID", r.tenantID)
+	if r.tenantID != "" && r.basicAuthPassword != "" {
+		req.SetBasicAuth(r.tenantID, r.basicAuthPassword)
+	}
+
+	return r.next.RoundTrip(req)
+}

--- a/pkg/services/ngalert/notifier/external_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/external_alertmanager_test.go
@@ -1,0 +1,80 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewExternalAlertmanager(t *testing.T) {
+	validConfig := `{"template_files":null,"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"email receiver","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@email.com\u003e"},"secureSettings":null}]}]}}`
+	tests := []struct {
+		name          string
+		url           string
+		tenantID      string
+		password      string
+		orgID         int64
+		defaultConfig string
+		expErr        string
+	}{
+		{
+			name:          "empty URL",
+			url:           "",
+			tenantID:      "1234",
+			password:      "test",
+			defaultConfig: validConfig,
+			orgID:         1,
+			expErr:        "empty URL",
+		},
+		{
+			name:          "empty default config",
+			url:           "http://localhost:8080",
+			tenantID:      "1234",
+			defaultConfig: "",
+			password:      "test",
+			orgID:         1,
+			expErr:        "unable to parse Alertmanager configuration: unexpected end of JSON input",
+		},
+		{
+			name:          "invalid default config",
+			url:           "http://localhost:8080",
+			tenantID:      "1234",
+			defaultConfig: `{"invalid": true}`,
+			password:      "test",
+			orgID:         1,
+			expErr:        "unable to parse Alertmanager configuration: no route provided in config",
+		},
+		{
+			name:          "valid parameters",
+			url:           "http://localhost:8080",
+			tenantID:      "1234",
+			defaultConfig: validConfig,
+			password:      "test",
+			orgID:         1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			cfg := externalAlertmanagerConfig{
+				URL:               test.url,
+				TenantID:          test.tenantID,
+				BasicAuthPassword: test.password,
+				DefaultConfig:     test.defaultConfig,
+			}
+			am, err := newExternalAlertmanager(cfg, test.orgID)
+			if test.expErr != "" {
+				require.EqualError(tt, err, test.expErr)
+				return
+			}
+
+			require.NoError(tt, err)
+			require.Equal(tt, am.tenantID, test.tenantID)
+			require.Equal(tt, am.url, test.url)
+			require.Equal(tt, am.defaultConfig, test.defaultConfig)
+			require.Equal(tt, am.OrgID(), test.orgID)
+			require.NotNil(tt, am.amClient)
+			require.NotNil(tt, am.httpClient)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a struct that implements the `notifier.Alertmanager` interface to connect to an external Alertmanager.

This is part of a series of PRs to include an Alertmanager struct that acts as a proxy to an external Alertmanager (WIP [here](https://github.com/grafana/grafana/pull/74279)). The methods are not yet implemented, just the factory function.