### PR TITLE
SSE: Fix DSNode to not panic when response has empty response

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -333,7 +333,11 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 
 	if len(filtered) == 0 {
 		responseType = "no data"
-		return mathexp.Results{Values: mathexp.Values{mathexp.NoData{Frame: response.Frames[0]}}}, nil
+		noData := mathexp.NewNoData()
+		if len(response.Frames) > 0 {
+			noData.Frame = response.Frames[0]
+		}
+		return mathexp.Results{Values: mathexp.Values{noData}}, nil
 	}
 
 	maybeFixerFn := checkIfSeriesNeedToBeFixed(filtered, dataSource)

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -214,7 +214,6 @@ func TestConvertDataFramesToResults(t *testing.T) {
 		})
 		features = featuremgmt.WithFeatures(featuremgmt.FlagDisableSSEDataplane)
 		t.Run("should return NoData if no frames", func(t *testing.T) {
-
 			result, err := execute(nil, "test")
 			require.NoError(t, err)
 			require.Equal(t, mathexp.NewNoData(), result.Values[0].Value())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes server-side expressions to not panic when the response from the data source does not contain any frames. 

**Why do we need this feature?**
Fixes regression after backport https://github.com/grafana/grafana/pull/73646 was merged. The backport missed a line where the result length was checked:
https://github.com/grafana/grafana/blob/2aaa8741d5490cf9ba4a1b6894eb75f76333f206/pkg/expr/nodes.go#L388-L390
In 10.0.x it happens when the feature flag `disableSSEDataplane` is enabled (disabled by default).

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
