### PR TITLE
[v9.4.x] SSE: Fix DSNode to not panic when response has empty response

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -314,7 +314,11 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 
 	if len(filtered) == 0 {
 		responseType = "no data"
-		return mathexp.Results{Values: mathexp.Values{mathexp.NoData{Frame: response.Frames[0]}}}, nil
+		noData := mathexp.NewNoData()
+		if len(response.Frames) > 0 {
+			noData.Frame = response.Frames[0]
+		}
+		return mathexp.Results{Values: mathexp.Values{noData}}, nil
 	}
 
 	maybeFixerFn := checkIfSeriesNeedToBeFixed(filtered, dataSource)

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -201,6 +201,11 @@ func TestConvertDataFramesToResults(t *testing.T) {
 		return dsNode.Execute(context.Background(), time.Now(), nil, s)
 	}
 
+	t.Run("should return NoData if no frames", func(t *testing.T) {
+		result, err := execute(nil, "test")
+		require.NoError(t, err)
+		require.Equal(t, mathexp.NewNoData(), result.Values[0].Value())
+	})
 	t.Run("should add name label if no labels and specific data source", func(t *testing.T) {
 		supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}
 		t.Run("when only field name is specified", func(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/commit/a374ae875c0e8eefe6d31950d9757b1ddb4d009c to 9.4.x