### PR TITLE
[v9.0.x] Docs: update missing link in whats new 9.0

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -174,7 +174,7 @@ Reporting is all about convenience - getting info to eyeballs as quickly as poss
 
 ## Breaking Changes
 
-This is a partial list of notable breaking changes. For the complete list, see our [Release Notes](LINK-TO-9.0-RELEASE-NOTES).
+This is a partial list of notable breaking changes. For the complete list, see our [Release Notes]({{< relref "../release-notes/release-notes-9-0-0/" >}}).
 
 ### Role-based access control: changes for general release
 

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -174,7 +174,7 @@ Reporting is all about convenience - getting info to eyeballs as quickly as poss
 
 ## Breaking Changes
 
-This is a partial list of notable breaking changes. For the complete list, see our [Release Notes]({{< relref "../release-notes/release-notes-9-0-0/" >}}).
+This is a partial list of notable breaking changes. For the complete list, see our [Release Notes]({{< relref "../release-notes/release-notes-9-0-0#breaking-changes" >}}).
 
 ### Role-based access control: changes for general release
 


### PR DESCRIPTION
Replaced placeholder text with link