### PR TITLE
Docs: add missing shared files to upgrade guides 8-9.4

### DIFF
--- a/docs/sources/upgrade-guide/upgrade-v8.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.0/index.md
@@ -16,6 +16,10 @@ weight: 2900
 
 # Upgrade to Grafana v8.0
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v8.1/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.1/index.md
@@ -16,6 +16,10 @@ weight: 2800
 
 # Upgrade to Grafana v8.1
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v8.2/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.2/index.md
@@ -16,6 +16,10 @@ weight: 2700
 
 # Upgrade to Grafana v8.2
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v8.3/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.3/index.md
@@ -16,6 +16,10 @@ weight: 2600
 
 # Upgrade to Grafana v8.3
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v8.4/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.4/index.md
@@ -16,6 +16,10 @@ weight: 2500
 
 # Upgrade to Grafana v8.4
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v8.5/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v8.5/index.md
@@ -16,6 +16,10 @@ weight: 2400
 
 # Upgrade to Grafana v8.5
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v9.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.0/index.md
@@ -16,6 +16,10 @@ weight: 2300
 
 # Upgrade to Grafana v9.0
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v9.1/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.1/index.md
@@ -16,6 +16,10 @@ weight: 2200
 
 # Upgrade to Grafana v9.1
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v9.2/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.2/index.md
@@ -16,6 +16,10 @@ weight: 2100
 
 # Upgrade to Grafana v9.2
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v9.3/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.3/index.md
@@ -16,6 +16,10 @@ weight: 2000
 
 # Upgrade to Grafana v9.3
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes

--- a/docs/sources/upgrade-guide/upgrade-v9.4/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v9.4/index.md
@@ -16,6 +16,10 @@ weight: 1995
 
 # Upgrade to Grafana v9.4
 
+{{< docs/shared lookup="upgrade/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
+
+{{< docs/shared lookup="back-up/back-up-grafana.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+1" >}}
+
 {{< docs/shared lookup="upgrade/upgrade-common-tasks.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Technical notes


### PR DESCRIPTION
Related to PR #74754 - added new shared files to remaining upgrade guides
