### PR TITLE
Alerting: Prevent showing "Permissions denied" alert when not accurate

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
@@ -1,6 +1,5 @@
 import { AlertmanagerChoice } from '../../../../../../plugins/datasource/alertmanager/types';
 import { alertmanagerApi } from '../../../api/alertmanagerApi';
-import { useExternalDataSourceAlertmanagers } from '../../../hooks/useExternalAmSelector';
 import { getAlertManagerDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 
 export interface AlertManagerNameWithImage {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
@@ -1,6 +1,10 @@
 import { AlertmanagerChoice } from '../../../../../../plugins/datasource/alertmanager/types';
 import { alertmanagerApi } from '../../../api/alertmanagerApi';
-import { getAlertManagerDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
+import {
+  getAlertManagerDataSources,
+  getExternalDsAlertManagers,
+  GRAFANA_RULES_SOURCE_NAME,
+} from '../../../utils/datasource';
 
 export interface AlertManagerNameWithImage {
   name: string;
@@ -11,12 +15,10 @@ export const useGetAlertManagersSourceNamesAndImage = () => {
   //get current alerting config
   const { currentData: amConfigStatus } = alertmanagerApi.useGetAlertmanagerChoiceStatusQuery(undefined);
 
-  const externalDsAlertManagers = getAlertManagerDataSources()
-    .filter((ds) => ds.jsonData.handleGrafanaManagedAlerts)
-    .map((ds) => ({
-      name: ds.name,
-      img: ds.meta.info.logos.small,
-    }));
+  const externalDsAlertManagers = getExternalDsAlertManagers().map((ds) => ({
+    name: ds.name,
+    img: ds.meta.info.logos.small,
+  }));
 
   const alertmanagerChoice = amConfigStatus?.alertmanagersChoice;
   const alertManagerSourceNamesWithImage: AlertManagerNameWithImage[] =

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
@@ -1,7 +1,7 @@
 import { AlertmanagerChoice } from '../../../../../../plugins/datasource/alertmanager/types';
 import { alertmanagerApi } from '../../../api/alertmanagerApi';
 import { useExternalDataSourceAlertmanagers } from '../../../hooks/useExternalAmSelector';
-import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
+import { getAlertManagerDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 
 export interface AlertManagerNameWithImage {
   name: string;
@@ -12,10 +12,13 @@ export const useGetAlertManagersSourceNamesAndImage = () => {
   //get current alerting config
   const { currentData: amConfigStatus } = alertmanagerApi.useGetAlertmanagerChoiceStatusQuery(undefined);
 
-  const externalDsAlertManagers: AlertManagerNameWithImage[] = useExternalDataSourceAlertmanagers().map((ds) => ({
-    name: ds.dataSource.name,
-    img: ds.dataSource.meta.info.logos.small,
-  }));
+  const externalDsAlertManagers = getAlertManagerDataSources()
+    .filter((ds) => ds.jsonData.handleGrafanaManagedAlerts)
+    .map((ds) => ({
+      name: ds.name,
+      img: ds.meta.info.logos.small,
+    }));
+
   const alertmanagerChoice = amConfigStatus?.alertmanagersChoice;
   const alertManagerSourceNamesWithImage: AlertManagerNameWithImage[] =
     alertmanagerChoice === AlertmanagerChoice.Internal

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useGetAlertManagersSourceNamesAndImage.tsx
@@ -1,10 +1,6 @@
 import { AlertmanagerChoice } from '../../../../../../plugins/datasource/alertmanager/types';
 import { alertmanagerApi } from '../../../api/alertmanagerApi';
-import {
-  getAlertManagerDataSources,
-  getExternalDsAlertManagers,
-  GRAFANA_RULES_SOURCE_NAME,
-} from '../../../utils/datasource';
+import { getExternalDsAlertManagers, GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 
 export interface AlertManagerNameWithImage {
   name: string;

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -47,6 +47,10 @@ export function getAlertManagerDataSources() {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+export function getExternalDsAlertManagers() {
+  return getAlertManagerDataSources().filter((ds) => ds.jsonData.handleGrafanaManagedAlerts);
+}
+
 const grafanaAlertManagerDataSource: AlertManagerDataSource = {
   name: GRAFANA_RULES_SOURCE_NAME,
   imgUrl: 'public/img/grafana_icon.svg',


### PR DESCRIPTION
**What is this feature?**

Users without org admin role were shown a "Permissions denied" alert in the creation/edition rule form even though they had access to create/edit the rule. The problem came after the `NotificationPreview` component made a request to `/api/v1/ngalert/alertmanagers` in order to obtain external alertmanagers information which is an endpoint that requires that permission level. 
Turns out we don't actually need to call that endpoint to obtain that information. 

**Why do we need this feature?**

To prevent showing the "Permissions denied" alert which is confusing and inaccurate.

**Who is this feature for?**

All users without org admin access.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/7303

Before
![2023-09-13 19 01 57](https://github.com/grafana/grafana/assets/6271380/872c3657-d088-4f56-b01b-ef161042b6fd)

After
![2023-09-13 19 00 45](https://github.com/grafana/grafana/assets/6271380/421522d0-385a-4188-b8c8-b81d05f0f3f4)
