### PR TITLE
Fix migrating alerts aliases

### DIFF
--- a/docs/sources/alerting/difference-old-new.md
+++ b/docs/sources/alerting/difference-old-new.md
@@ -2,7 +2,7 @@
 _build:
   list: false
 aliases:
-  - unified-alerting/difference-old-new/
+  - ./unified-alerting/difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/alerting/unified-alerting/difference-old-new/
 canonical: https://grafana.com/docs/grafana/latest/alerting/difference-old-new/
 description: Compare new unified alerting compared to legacy dashboard alerting
 keywords:

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - alerting/migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/
+  - ../migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
 description: Upgrade Grafana alerts
 labels:

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/alerting/difference-old-new/
   - unified-alerting/ # /docs/grafana/<GRAFANA VERSION>/alerting/unified-alerting/
   - unified-alerting/difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/unified-alerting/difference-old-new/
   - alerting/migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -1,9 +1,9 @@
 ---
 aliases:
-  - difference-old-new/
-  - unified-alerting/
-  - unified-alerting/difference-old-new/
-  - alerting/migrating-alerts/
+  - difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/alerting/difference-old-new/
+  - unified-alerting/ # /docs/grafana/<GRAFANA VERSION>/alerting/unified-alerting/
+  - unified-alerting/difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/unified-alerting/difference-old-new/
+  - alerting/migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
 description: Upgrade Grafana alerts
 labels:

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - unified-alerting/ # /docs/grafana/<GRAFANA VERSION>/alerting/unified-alerting/
   - alerting/migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
 description: Upgrade Grafana alerts

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - unified-alerting/ # /docs/grafana/<GRAFANA VERSION>/alerting/unified-alerting/
-  - unified-alerting/difference-old-new/ # /docs/grafana/<GRAFANA VERSION>/unified-alerting/difference-old-new/
   - alerting/migrating-alerts/ # /docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
 description: Upgrade Grafana alerts


### PR DESCRIPTION
Please review individual commits.

- [Add comments to indicate which page I believe each alias is intending to redirect](https://github.com/grafana/grafana/pull/74898/commits/bfd38c2196da5b6bdbfb74379da96af4a553efb2)
- [Remove difference-old-new redirect from migrating-alerts page since an alternative page exists](https://github.com/grafana/grafana/pull/74898/commits/740167f597e5d70a580102bee7f39b050590159b)
- [Add comment to show intended absolute path redirect](https://github.com/grafana/grafana/pull/74898/commits/6615699418a64c3d02e8ca7fd524515bd68d8356)
- [Remove `unified-alerting/difference-old-new/` redirect because it already exists in `docs/sources/alerting/difference-old-new.md`](https://github.com/grafana/grafana/pull/74898/commits/0ade47a3ddc0bb6e6891e730974ea203ba1803a5)
- [Remove `unified-alerting/` alias since the absolute URL already redirects to `/docs/grafana/latest/alerting/`](https://github.com/grafana/grafana/pull/74898/commits/46d16d28a5b392ba9d588b1123b2f8379ae724f7)
- [Fix `/docs/grafana/<GRAFANA VERSION>/alerting/migrating-alerts/` redirect](https://github.com/grafana/grafana/pull/74898/commits/da1af2b8d38c16063f71cd425c1092b0a62b47ba)

The following example uses `latest` as _`GRAFANA VERSION`_ for simplicity and readability.

The desire is the following redirect:

```
src: /docs/grafana/latest/alerting/migrating-alerts/
dst: /docs/grafana/latest/alerting/set-up/migrating-alerts/
```

`dst` is the Hugo pretty URL for the current page (`docs/sources/alerting/set-up/migrating-alerts/_index.md`).

When constructing Hugo aliases we are working from the page's containing directory and not the page itself.
The path element `.` represents that directory.
For example:

```
 page: /docs/grafana/latest/alerting/set-up/migrating-alerts/
alias: ./
  dst: /docs/grafana/latest/alerting/set-up/
```

The path element `..` represents the parent directory of the page's containing directory.
For example:

```
 page: /docs/grafana/latest/alerting/set-up/migrating-alerts/
alias: ../
  dst: /docs/grafana/latest/alerting/
```
