### PR TITLE
Access Permission Issue: Teams are not getting added to dashboards/folders after deletion and recreation

### DIFF
--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -140,6 +140,7 @@ func (ss *xormStore) Delete(ctx context.Context, cmd *team.DeleteTeamCommand) er
 			"DELETE FROM team WHERE org_id=? and id = ?",
 			"DELETE FROM dashboard_acl WHERE org_id=? and team_id = ?",
 			"DELETE FROM team_role WHERE org_id=? and team_id = ?",
+			"DELETE FROM role WHERE org_id=? and name = 'managed:teams:' || ? || ':permissions'",
 		}
 
 		for _, sql := range deletes {


### PR DESCRIPTION
**What happened?**
It appears that the team's re-addition with the same ID after deletion is not successfully granted as a permission to dashboards/folders, despite receiving a success message. - related issue #74900

**What did you expect to happen?**
Team to be added as a permission to dashboards/folders.

**Which issue(s) does this PR fix?**:
This will delete orphan team roles

**Environment (with versions)?**
Grafana: 9.5.4 / 10.2.0
OS: Windows/Linux
Browser: N/A