### PR TITLE
sql: add more tests

### DIFF
--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -87,7 +87,25 @@ describe('SQLWhereRow', () => {
     expect(exp.whereString).toBe('hostname IN (${multiHost})');
   });
 
-  it('should not remove quotes in a where clause not including a multi-value variable', () => {
+  it('should not remove quotes in a where clause including a non-multi variable', () => {
+    const exp: SQLExpression = {
+      whereString: "hostname IN ('${host}')",
+    };
+
+    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
+    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
+
+    multiVar.multi = true;
+    nonMultiVar.multi = false;
+
+    const variables = [multiVar, nonMultiVar];
+
+    removeQuotesForMultiVariables(exp, variables);
+
+    expect(exp.whereString).toBe("hostname IN ('${host}')");
+  });
+
+  it('should not remove quotes in a where clause not including any known variables', () => {
     const exp: SQLExpression = {
       whereString: "hostname IN ('${nonMultiHost}')",
     };


### PR DESCRIPTION
as part of externalizing the sql datasources, we have to adjust this test-file, but before i do it, i'd like to add one more test-case.

these test-cases test the situation where a multi-value variable is in the `WHERE` clause. in such a case, it should remove certain quote characters.
the test covers 2 scenarios:
- the variable is a multi-variable => remove quotes
- the variable does not exist => do not remove quotes

i added a third one:
- the variable is a single-variable => do not remove quotes