### PR TITLE
Analytics: Add option to pass destSDKBaseURL to rudderstack load method

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -279,6 +279,9 @@ rudderstack_sdk_url =
 # Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
 rudderstack_config_url =
 
+# Rudderstack Integrations URL, optional. Only valid if you pass the SDK version 1.1 or higher
+rudderstack_integrations_url =
+
 # Intercom secret, optional, used to hash user_id before passing to Intercom via Rudderstack
 intercom_secret =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -286,6 +286,9 @@
 # Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
 ;rudderstack_config_url =
 
+# Rudderstack Integrations URL, optional. Only valid if you pass the SDK version 1.1 or higher
+;rudderstack_integrations_url =
+
 # Intercom secret, optional, used to hash user_id before passing to Intercom via Rudderstack
 ;intercom_secret =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -575,6 +575,12 @@ URL to load the Rudderstack SDK.
 Optional. If tracking with Rudderstack is enabled, you can provide a custom
 URL to load the Rudderstack config.
 
+### rudderstack_integrations_url
+
+Optional. If tracking with Rudderstack is enabled, you can provide a custom
+URL to load the SDK for destinations running in device mode. Only valid for
+Rudderstack version 1.1 or newer.
+
 ### application_insights_connection_string
 
 If you want to track Grafana usage via Azure Application Insights, then specify _your_ Application Insights connection string. Since the connection string contains semicolons, you need to wrap it in backticks (`). By default, tracking usage is disabled.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -578,7 +578,7 @@ URL to load the Rudderstack config.
 ### rudderstack_integrations_url
 
 Optional. If tracking with Rudderstack is enabled, you can provide a custom
-URL to load the SDK for destinations running in device mode. Only valid for
+URL to load the SDK for destinations running in device mode. This setting is only valid for
 Rudderstack version 1.1 and higher.
 
 ### application_insights_connection_string

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -579,7 +579,7 @@ URL to load the Rudderstack config.
 
 Optional. If tracking with Rudderstack is enabled, you can provide a custom
 URL to load the SDK for destinations running in device mode. Only valid for
-Rudderstack version 1.1 or newer.
+Rudderstack version 1.1 and higher.
 
 ### application_insights_connection_string
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -218,6 +218,7 @@ export interface GrafanaConfig {
   rudderstackDataPlaneUrl: string | undefined;
   rudderstackSdkUrl: string | undefined;
   rudderstackConfigUrl: string | undefined;
+  rudderstackIntegrationsUrl: string | undefined;
   sqlConnectionLimits: SqlConnectionLimits;
 }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -155,6 +155,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   rudderstackDataPlaneUrl: undefined;
   rudderstackSdkUrl: undefined;
   rudderstackConfigUrl: undefined;
+  rudderstackIntegrationsUrl: undefined;
   sqlConnectionLimits = {
     maxOpenConns: 100,
     maxIdleConns: 100,

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -155,10 +155,11 @@ type FrontendSettingsDTO struct {
 	GoogleAnalytics4Id                  string `json:"googleAnalytics4Id"`
 	GoogleAnalytics4SendManualPageViews bool   `json:"GoogleAnalytics4SendManualPageViews"`
 
-	RudderstackWriteKey     string `json:"rudderstackWriteKey"`
-	RudderstackDataPlaneUrl string `json:"rudderstackDataPlaneUrl"`
-	RudderstackSdkUrl       string `json:"rudderstackSdkUrl"`
-	RudderstackConfigUrl    string `json:"rudderstackConfigUrl"`
+	RudderstackWriteKey        string `json:"rudderstackWriteKey"`
+	RudderstackDataPlaneUrl    string `json:"rudderstackDataPlaneUrl"`
+	RudderstackSdkUrl          string `json:"rudderstackSdkUrl"`
+	RudderstackConfigUrl       string `json:"rudderstackConfigUrl"`
+	RudderstackIntegrationsUrl string `json:"rudderstackIntegrationsUrl"`
 
 	FeedbackLinksEnabled                bool     `json:"feedbackLinksEnabled"`
 	ApplicationInsightsConnectionString string   `json:"applicationInsightsConnectionString"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -134,6 +134,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		RudderstackDataPlaneUrl:             hs.Cfg.RudderstackDataPlaneURL,
 		RudderstackSdkUrl:                   hs.Cfg.RudderstackSDKURL,
 		RudderstackConfigUrl:                hs.Cfg.RudderstackConfigURL,
+		RudderstackIntegrationsUrl:          hs.Cfg.RudderstackIntegrationsURL,
 		FeedbackLinksEnabled:                hs.Cfg.FeedbackLinksEnabled,
 		ApplicationInsightsConnectionString: hs.Cfg.ApplicationInsightsConnectionString,
 		ApplicationInsightsEndpointUrl:      hs.Cfg.ApplicationInsightsEndpointUrl,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -429,6 +429,7 @@ type Cfg struct {
 	RudderstackWriteKey                 string
 	RudderstackSDKURL                   string
 	RudderstackConfigURL                string
+	RudderstackIntegrationsURL          string
 	IntercomSecret                      string
 
 	// AzureAD
@@ -1106,6 +1107,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cfg.RudderstackDataPlaneURL = analytics.Key("rudderstack_data_plane_url").String()
 	cfg.RudderstackSDKURL = analytics.Key("rudderstack_sdk_url").String()
 	cfg.RudderstackConfigURL = analytics.Key("rudderstack_config_url").String()
+	cfg.RudderstackIntegrationsURL = analytics.Key("rudderstack_integrations_url").String()
 	cfg.IntercomSecret = analytics.Key("intercom_secret").String()
 
 	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -323,6 +323,7 @@ function initEchoSrv() {
         user: config.bootData.user,
         sdkUrl: config.rudderstackSdkUrl,
         configUrl: config.rudderstackConfigUrl,
+        integrationsUrl: config.rudderstackIntegrationsUrl,
         buildInfo: config.buildInfo,
       })
     );

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -34,6 +34,7 @@ export interface RudderstackBackendOptions {
   user?: CurrentUserDTO;
   sdkUrl?: string;
   configUrl?: string;
+  integrationsUrl?: string;
 }
 
 export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, RudderstackBackendOptions> {
@@ -68,7 +69,10 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
       })(method);
     }
 
-    window.rudderanalytics?.load?.(options.writeKey, options.dataPlaneUrl, { configUrl: options.configUrl });
+    window.rudderanalytics?.load?.(options.writeKey, options.dataPlaneUrl, {
+      configUrl: options.configUrl,
+      destSDKBaseURL: options.integrationsUrl,
+    });
 
     if (options.user) {
       const { identifier, intercomIdentifier } = options.user.analytics;


### PR DESCRIPTION
**What is this feature?**

Adds an option to pass `destSDKBaseURL` to the Rudderstack SDK. 

**Why do we need this feature?**

When loading the Rudderstack SDK version 1.1 or newer, this option can be passed to override the URL used to load SDK

**Who is this feature for?**

Any person that wants to override this option, and is using Rudderstack SDK version 1.1 or newer.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
