### PR TITLE
Logging: Add `uname` to context logger for plugins

### DIFF
--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -100,6 +100,9 @@ func instrumentContext(ctx context.Context, endpoint string, pCtx backend.Plugin
 		p = append(p, "dsName", pCtx.DataSourceInstanceSettings.Name)
 		p = append(p, "dsUID", pCtx.DataSourceInstanceSettings.UID)
 	}
+	if pCtx.User != nil {
+		p = append(p, "uname", pCtx.User.Login)
+	}
 	return log.WithContextualAttributes(ctx, p)
 }
 


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/74428 we added contextual attributes for the logger in data sources. This PR just adds the `uname` attribute if present.