### PR TITLE
SSE: Reduce to add warning notice to only the first result

### DIFF
--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -166,6 +166,7 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 	span.SetAttributes("reducer", gr.Reducer, attribute.Key("reducer").String(gr.Reducer))
 
 	newRes := mathexp.Results{}
+	noticeAdded := false
 	for _, val := range vars[gr.VarToReduce].Values {
 		switch v := val.(type) {
 		case mathexp.Series:
@@ -184,11 +185,12 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 			}
 			copyV := mathexp.NewNumber(gr.refID, v.GetLabels())
 			copyV.SetValue(value)
-			if gr.seriesMapper == nil {
+			if gr.seriesMapper == nil && !noticeAdded { // Add notice to only the first result to not multiple them in presentation
 				copyV.AddNotice(data.Notice{
 					Severity: data.NoticeSeverityWarning,
 					Text:     fmt.Sprintf("Reduce operation is not needed. Input query or expression %s is already reduced data.", gr.VarToReduce),
 				})
+				noticeAdded = true
 			}
 			newRes.Values = append(newRes.Values, copyV)
 		case mathexp.NoData:

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -166,8 +166,7 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 	span.SetAttributes("reducer", gr.Reducer, attribute.Key("reducer").String(gr.Reducer))
 
 	newRes := mathexp.Results{}
-	noticeAdded := false
-	for _, val := range vars[gr.VarToReduce].Values {
+	for i, val := range vars[gr.VarToReduce].Values {
 		switch v := val.(type) {
 		case mathexp.Series:
 			num, err := v.Reduce(gr.refID, gr.Reducer, gr.seriesMapper)
@@ -185,12 +184,11 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 			}
 			copyV := mathexp.NewNumber(gr.refID, v.GetLabels())
 			copyV.SetValue(value)
-			if gr.seriesMapper == nil && !noticeAdded { // Add notice to only the first result to not multiple them in presentation
+			if gr.seriesMapper == nil && i == 0 { // Add notice to only the first result to not multiple them in presentation
 				copyV.AddNotice(data.Notice{
 					Severity: data.NoticeSeverityWarning,
 					Text:     fmt.Sprintf("Reduce operation is not needed. Input query or expression %s is already reduced data.", gr.VarToReduce),
 				})
-				noticeAdded = true
 			}
 			newRes.Values = append(newRes.Values, copyV)
 		case mathexp.NoData:

--- a/pkg/expr/commands_test.go
+++ b/pkg/expr/commands_test.go
@@ -133,12 +133,12 @@ func TestReduceExecute(t *testing.T) {
 				require.Equal(t, expectedValue, actualValue)
 			}
 
-			t.Run("should add warn notices to every frame", func(t *testing.T) {
+			t.Run("should add warn notices to the first frame", func(t *testing.T) {
 				frames := execute.Values.AsDataFrames("test")
-				for _, frame := range frames {
-					require.Len(t, frame.Meta.Notices, 1)
-					notice := frame.Meta.Notices[0]
-					require.Equal(t, data.NoticeSeverityWarning, notice.Severity)
+				notice := frames[0].Meta.Notices[0]
+				require.Equal(t, data.NoticeSeverityWarning, notice.Severity)
+				for _, frame := range frames[1:] {
+					require.Empty(t, frame.Meta.Notices)
 				}
 			})
 		})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Currently, the Reduce expression adds a warning notice when a reduced dimension is represented by a number and the expression's mode is Strict. The warning is displayed in the query editor.  The UI squashes all similar warnings for the same query expression, and therefore it does not make sense to duplicate them. This PR changes the expression to add notice to only one result.

**Why do we need this feature?**
To reduce the amount of unnecessary data the API returns back to the user.

**Who is this feature for?**
N/A

**Which issue(s) does this PR fix?**:
Related to a discussion in https://github.com/grafana/grafana/pull/74859#discussion_r1325868361

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
