### PR TITLE
Snapshots: Use appUrl on snapshot list page

### DIFF
--- a/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
@@ -1,4 +1,4 @@
-import { locationService } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 
 import { getSnapshots } from './SnapshotListTable';
 
@@ -24,15 +24,7 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('getSnapshots', () => {
-  global.window = Object.create(window);
-  Object.defineProperty(window, 'location', {
-    value: {
-      href: 'http://localhost:3000/grafana/dashboard/snapshots',
-    },
-    writable: true,
-  });
-
-  locationService.push('/dashboard/snapshots');
+  config.appUrl = 'http://snapshots.grafana.com/';
 
   test('returns correct snapshot urls', async () => {
     const results = await getSnapshots();
@@ -44,7 +36,7 @@ describe('getSnapshots', () => {
           "externalUrl": "https://www.externalSnapshotUrl.com",
           "key": "JRXqfKihKZek70FM6Xaq502NxH7OyyEs",
           "name": "Snap 1",
-          "url": "/dashboard/snapshot/JRXqfKihKZek70FM6Xaq502NxH7OyyEs",
+          "url": "http://snapshots.grafana.com/dashboard/snapshot/JRXqfKihKZek70FM6Xaq502NxH7OyyEs",
         },
         {
           "external": false,
@@ -52,7 +44,7 @@ describe('getSnapshots', () => {
           "id": 3,
           "key": "RziRfhlBDTjwyYGoHAjnWyrMNQ1zUg3j",
           "name": "Snap 2",
-          "url": "/dashboard/snapshot/RziRfhlBDTjwyYGoHAjnWyrMNQ1zUg3j",
+          "url": "http://snapshots.grafana.com/dashboard/snapshot/RziRfhlBDTjwyYGoHAjnWyrMNQ1zUg3j",
         },
       ]
     `);

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
-import { getBackendSrv, locationService } from '@grafana/runtime';
+import { getBackendSrv, config } from '@grafana/runtime';
 import { ConfirmModal, Button, LinkButton } from '@grafana/ui';
 
 import { Snapshot } from '../types';
@@ -12,17 +12,13 @@ export function getSnapshots() {
     .then((result: Snapshot[]) => {
       return result.map((snapshot) => ({
         ...snapshot,
-        url: `/dashboard/snapshot/${snapshot.key}`,
+        url: `${config.appUrl}dashboard/snapshot/${snapshot.key}`,
       }));
     });
 }
 export const SnapshotListTable = () => {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [removeSnapshot, setRemoveSnapshot] = useState<Snapshot | undefined>();
-  const currentPath = locationService.getLocation().pathname;
-  const fullUrl = window.location.href;
-  const baseUrl = fullUrl.substring(0, fullUrl.indexOf(currentPath));
-
   useAsync(async () => {
     const response = await getSnapshots();
     setSnapshots(response);
@@ -60,14 +56,13 @@ export const SnapshotListTable = () => {
         <tbody>
           {snapshots.map((snapshot) => {
             const url = snapshot.externalUrl || snapshot.url;
-            const fullUrl = snapshot.externalUrl || `${baseUrl}${snapshot.url}`;
             return (
               <tr key={snapshot.key}>
                 <td>
                   <a href={url}>{snapshot.name}</a>
                 </td>
                 <td>
-                  <a href={url}>{fullUrl}</a>
+                  <a href={url}>{url}</a>
                 </td>
                 <td>{snapshot.external && <span className="query-keyword">External</span>}</td>
                 <td className="text-center">


### PR DESCRIPTION
**What is this feature?**

Build the snapshot URL using the config server app URL in the snapshots list page.

**Why do we need this feature?**

We were using the server app URL on snapshot creation but using the `window.location.href` in the snapshot page list. This PR fixes this inconsistency.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/34687

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
