### PR TITLE
Loki Query Builder: binary expression and numeric literal bugs

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
@@ -82,12 +82,12 @@ export const binaryScalarOperations: QueryBuilderOperationDef[] = binaryScalarDe
   const params: QueryBuilderOperationParamDef[] = [{ name: 'Value', type: 'number' }];
   const defaultParams: any[] = [2];
   if (opDef.comparison) {
-    params.unshift({
+    params.push({
       name: 'Bool',
       type: 'boolean',
       description: 'If checked comparison will return 0 or 1 for the value rather than filtering.',
     });
-    defaultParams.unshift(false);
+    defaultParams.push(false);
   }
 
   return {
@@ -107,8 +107,7 @@ function getSimpleBinaryRenderer(operator: string) {
     let param = model.params[0];
     let bool = '';
     if (model.params.length === 2) {
-      param = model.params[1];
-      bool = model.params[0] ? ' bool' : '';
+      bool = model.params[1] ? ' bool' : '';
     }
 
     return `${innerExpr} ${operator}${bool} ${param}`;

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -11,6 +11,59 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses simple binary comparison', () => {
+    expect(buildVisualQueryFromString('count_over_time({app="aggregator"} [$__auto]) == 11')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        operations: [
+          {
+            id: LokiOperationId.CountOverTime,
+            params: ['$__auto'],
+          },
+          {
+            id: LokiOperationId.EqualTo,
+            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            params: [false, 11],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
+  // This still fails because loki doesn't properly parse the bool operator
+  it('parses simple query with label-values with boolean operator', () => {
+    expect(buildVisualQueryFromString('count_over_time({app="aggregator"} [$__auto]) == bool 12')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        operations: [
+          {
+            id: LokiOperationId.CountOverTime,
+            params: ['$__auto'],
+          },
+          {
+            id: LokiOperationId.EqualTo,
+            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            params: [true, 12],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
   it('parses simple query with label-values', () => {
     expect(buildVisualQueryFromString('{app="frontend"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -28,7 +28,7 @@ describe('buildVisualQueryFromString', () => {
           },
           {
             id: LokiOperationId.EqualTo,
-            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            // defined in getSimpleBinaryRenderer, the first argument is the bool value, and the second is the comparison operator
             params: [11, false],
           },
         ],
@@ -55,7 +55,7 @@ describe('buildVisualQueryFromString', () => {
           },
           {
             id: LokiOperationId.EqualTo,
-            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            // defined in getSimpleBinaryRenderer, the first argument is the bool value, and the second is the comparison operator
             params: [12, true],
           },
         ],

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -66,6 +66,7 @@ describe('buildVisualQueryFromString', () => {
 
   it('parses binary operation with query', () => {
     expect(
+      // There is no capability for "bool" in the query builder for (nested) binary operation with query as of now, it will always be stripped out
       buildVisualQueryFromString(
         'max by(stream) (count_over_time({app="aggregator"}[1m])) > bool ignoring(stream) avg(count_over_time({app="aggregator"}[1m]))'
       )

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -29,7 +29,7 @@ describe('buildVisualQueryFromString', () => {
           {
             id: LokiOperationId.EqualTo,
             // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
-            params: [false, 11],
+            params: [11, false],
           },
         ],
       },
@@ -56,7 +56,7 @@ describe('buildVisualQueryFromString', () => {
           {
             id: LokiOperationId.EqualTo,
             // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
-            params: [true, 12],
+            params: [12, true],
           },
         ],
       },

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -64,6 +64,62 @@ describe('buildVisualQueryFromString', () => {
     });
   });
 
+  it('parses binary operation with query', () => {
+    expect(
+      buildVisualQueryFromString(
+        'max by(stream) (count_over_time({app="aggregator"}[1m])) > bool ignoring(stream) avg(count_over_time({app="aggregator"}[1m]))'
+      )
+    ).toEqual({
+      query: {
+        binaryQueries: [
+          {
+            // nested binary operation
+            operator: '>',
+            query: {
+              labels: [
+                {
+                  label: 'app',
+                  op: '=',
+                  value: 'aggregator',
+                },
+              ],
+              operations: [
+                {
+                  id: 'count_over_time',
+                  params: ['1m'],
+                },
+                {
+                  id: 'avg',
+                  params: [],
+                },
+              ],
+            },
+            vectorMatches: 'stream',
+            vectorMatchesType: 'ignoring',
+          },
+        ],
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        operations: [
+          {
+            id: 'count_over_time',
+            params: ['1m'],
+          },
+          {
+            id: '__max_by',
+            params: ['stream'],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
   it('parses simple query with label-values', () => {
     expect(buildVisualQueryFromString('{app="frontend"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -54,7 +54,6 @@ import {
   getAllByType,
   getLeftMostChild,
   getString,
-  makeBinOp,
   makeError,
   replaceVariables,
 } from '../../prometheus/querybuilder/shared/parsingUtils';
@@ -684,5 +683,23 @@ function handleKeepFilter(expr: string, node: SyntaxNode, context: Context): Que
   return {
     id: LokiOperationId.Keep,
     params: labels,
+  };
+}
+
+export function makeBinOp(
+  opDef: { id: string; comparison?: boolean },
+  expr: string,
+  numberNode: SyntaxNode,
+  hasBool: boolean
+): QueryBuilderOperation {
+  // params are backwards in loki for some reason?
+  const params: QueryBuilderOperationParamValue[] = [];
+  if (opDef.comparison) {
+    params.push(hasBool);
+  }
+  params.push(parseFloat(getString(expr, numberNode)));
+  return {
+    id: opDef.id,
+    params,
   };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -588,9 +588,6 @@ function getBinaryModifier(
   const matcher = node.getChild(OnOrIgnoringModifier);
   const boolMatcher = node.getChild(Bool);
 
-  console.log('matcher', matcher);
-  console.log('boolMatcher', boolMatcher);
-
   if (!matcher && boolMatcher) {
     return { isBool: true, isMatcher: false };
   } else {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -55,6 +55,7 @@ import {
   getAllByType,
   getLeftMostChild,
   getString,
+  makeBinOp,
   makeError,
   replaceVariables,
 } from '../../prometheus/querybuilder/shared/parsingUtils';
@@ -684,21 +685,5 @@ function handleKeepFilter(expr: string, node: SyntaxNode, context: Context): Que
   return {
     id: LokiOperationId.Keep,
     params: labels,
-  };
-}
-
-export function makeBinOp(
-  opDef: { id: string; comparison?: boolean },
-  expr: string,
-  numberNode: SyntaxNode,
-  hasBool: boolean
-): QueryBuilderOperation {
-  const params: QueryBuilderOperationParamValue[] = [parseFloat(getString(expr, numberNode))];
-  if (opDef.comparison) {
-    params.push(hasBool);
-  }
-  return {
-    id: opDef.id,
-    params,
   };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -580,15 +580,20 @@ function getBinaryModifier(
   node: SyntaxNode | null
 ):
   | { isBool: true; isMatcher: false }
-  | { isBool: false; isMatcher: true; matches: string; matchType: 'ignoring' | 'on' }
+  | { isBool: boolean; isMatcher: true; matches: string; matchType: 'ignoring' | 'on' }
   | undefined {
   if (!node) {
     return undefined;
   }
-  if (node.getChild(Bool)) {
+  const matcher = node.getChild(OnOrIgnoringModifier);
+  const boolMatcher = node.getChild(Bool);
+
+  console.log('matcher', matcher);
+  console.log('boolMatcher', boolMatcher);
+
+  if (!matcher && boolMatcher) {
     return { isBool: true, isMatcher: false };
   } else {
-    const matcher = node.getChild(OnOrIgnoringModifier);
     if (!matcher) {
       // Not sure what this could be, maybe should be an error.
       return undefined;
@@ -596,7 +601,7 @@ function getBinaryModifier(
     const labels = getString(expr, matcher.getChild(GroupingLabels)?.getChild(GroupingLabelList));
     return {
       isMatcher: true,
-      isBool: false,
+      isBool: !!boolMatcher,
       matches: labels,
       matchType: matcher.getChild(On) ? 'on' : 'ignoring',
     };

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -1,5 +1,5 @@
 import { buildVisualQueryFromString } from './parsing';
-import { PromVisualQuery } from './types';
+import { PromOperationId, PromVisualQuery } from './types';
 
 describe('buildVisualQueryFromString', () => {
   it('creates no errors for empty query', () => {
@@ -10,6 +10,50 @@ describe('buildVisualQueryFromString', () => {
         metric: '',
       })
     );
+  });
+  it('parses simple binary comparison', () => {
+    expect(buildVisualQueryFromString('{app="aggregator"} == 11')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        metric: '',
+        operations: [
+          {
+            id: PromOperationId.EqualTo,
+            params: [11, false],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
+  // This still fails because loki doesn't properly parse the bool operator
+  it('parses simple query with with boolean operator', () => {
+    expect(buildVisualQueryFromString('{app="aggregator"} == bool 12')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        metric: '',
+        operations: [
+          {
+            id: PromOperationId.EqualTo,
+            params: [12, true],
+          },
+        ],
+      },
+      errors: [],
+    });
   });
   it('parses simple query', () => {
     expect(buildVisualQueryFromString('counters_logins{app="frontend"}')).toEqual(

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -86,6 +86,7 @@ export function getString(expr: string, node: SyntaxNode | TreeCursor | null | u
 
 /**
  * Create simple scalar binary op object.
+ * Implementation in loki is backwards?
  * @param opDef - definition of the op to be created
  * @param expr
  * @param numberNode - the node for the scalar

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -86,7 +86,6 @@ export function getString(expr: string, node: SyntaxNode | TreeCursor | null | u
 
 /**
  * Create simple scalar binary op object.
- * Implementation in loki is backwards?
  * @param opDef - definition of the op to be created
  * @param expr
  * @param numberNode - the node for the scalar


### PR DESCRIPTION
This PR fixes bugs in the loki query parser, and adds unit tests for them. 
It does not address any UI issues with the `bool` modifier in boolean comparisons, any use of that modifier will still be stripped out by the query builder (https://github.com/grafana/grafana/issues/75122 aims to introduce UI update to the query builder so users have control over that modifier in the visual query builder).

1. When making any binary comparison with a scalar value (except binary operation with query), the scalar value is ripped out and replaced with the boolean value of false. This bug is only invoked when switching between code and query builders.
Example: `count_over_time({app="aggregator"} [1m]) > 50` (code)
Becomes: `count_over_time({app="aggregator"} [1m]) > bool false` (query builder)
Example2: `count_over_time({app="aggregator"} [1m]) > bool 20` 
Becomes: `count_over_time({app="aggregator"} [1m]) > bool false`

2. Values in the text field for on/ignoring (which are invoked as part of the binary operation with query in the query builder operations) are stripped out when used in conjunction with the "bool" operator.
Example: `max by(stream) (count_over_time({app="aggregator"}[1m])) > bool ignoring(stream) avg(count_over_time({app="aggregator"}[1m]))`, 
Becomes: `max by(stream) (count_over_time({app="aggregator"} [1m])) > avg(count_over_time({app="aggregator"} [1m]))`