### PR TITLE
AdHocFilters: Clean-up unused prop from type

### DIFF
--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -48,7 +48,8 @@ export interface AdHocVariableFilter {
   key: string;
   operator: string;
   value: string;
-  condition: string;
+  /** @deprecated  */
+  condition?: string;
 }
 
 export interface AdHocVariableModel extends BaseVariableModel {

--- a/public/app/features/variables/adhoc/actions.test.ts
+++ b/public/app/features/variables/adhoc/actions.test.ts
@@ -59,7 +59,6 @@ describe('adhoc actions', () => {
         key: 'filter-key',
         value: 'filter-existing',
         operator: '!=',
-        condition: '',
       };
 
       const variable = adHocBuilder()
@@ -76,7 +75,7 @@ describe('adhoc actions', () => {
         .whenAsyncActionIsDispatched(applyFilterFromTable(options), true);
 
       const expectedQuery = { 'var-Filters': ['filter-key|!=|filter-existing', 'filter-key|=|filter-value'] };
-      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
+      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=' };
 
       tester.thenDispatchedActionsShouldEqual(
         toKeyedAction(key, filterAdded(toVariablePayload(variable, expectedFilter)))
@@ -108,7 +107,7 @@ describe('adhoc actions', () => {
         .build();
 
       const expectedQuery = { 'var-Filters': ['filter-key|=|filter-value'] };
-      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
+      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=' };
 
       tester.thenDispatchedActionsShouldEqual(
         createAddVariableAction(variable),
@@ -142,7 +141,7 @@ describe('adhoc actions', () => {
         .whenActionIsDispatched(createAddVariableAction(variable))
         .whenAsyncActionIsDispatched(applyFilterFromTable(options), true);
 
-      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
+      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=' };
       const expectedQuery = { 'var-Filters': ['filter-key|=|filter-value'] };
 
       tester.thenDispatchedActionsShouldEqual(
@@ -181,7 +180,7 @@ describe('adhoc actions', () => {
         .whenActionIsDispatched(createAddVariableAction(existing))
         .whenAsyncActionIsDispatched(applyFilterFromTable(options), true);
 
-      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
+      const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=' };
       const expectedQuery = { 'var-elastic-filter': [] as string[], 'var-Filters': ['filter-key|=|filter-value'] };
 
       tester.thenDispatchedActionsShouldEqual(
@@ -200,7 +199,6 @@ describe('adhoc actions', () => {
         key: 'key',
         value: 'value',
         operator: '=',
-        condition: '',
       };
 
       const updated = {
@@ -241,7 +239,6 @@ describe('adhoc actions', () => {
         key: 'key',
         value: 'value',
         operator: '=',
-        condition: '',
       };
 
       const adding = {
@@ -263,7 +260,7 @@ describe('adhoc actions', () => {
         .whenAsyncActionIsDispatched(addFilter(toKeyedVariableIdentifier(variable), adding), true);
 
       const expectedQuery = { 'var-elastic-filter': ['key|=|value', 'key|!=|value'] };
-      const expectedFilter = { key: 'key', value: 'value', operator: '!=', condition: '' };
+      const expectedFilter = { key: 'key', value: 'value', operator: '!=' };
 
       tester.thenDispatchedActionsShouldEqual(
         toKeyedAction(key, filterAdded(toVariablePayload(variable, expectedFilter)))
@@ -279,7 +276,6 @@ describe('adhoc actions', () => {
         key: 'key',
         value: 'value',
         operator: '=',
-        condition: '',
       };
 
       const variable = adHocBuilder()
@@ -332,7 +328,6 @@ describe('adhoc actions', () => {
         key: 'key',
         value: 'value',
         operator: '=',
-        condition: '',
       };
 
       const variable = adHocBuilder()
@@ -362,7 +357,6 @@ describe('adhoc actions', () => {
         key: 'key',
         value: 'value',
         operator: '=',
-        condition: '',
       };
 
       const variable = adHocBuilder()
@@ -373,10 +367,7 @@ describe('adhoc actions', () => {
         .withDatasource({ uid: 'elasticsearch' })
         .build();
 
-      const fromUrl = [
-        { ...existing, condition: '>' },
-        { ...existing, name: 'value-2' },
-      ];
+      const fromUrl = [{ ...existing, name: 'value-2' }];
 
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
@@ -384,10 +375,7 @@ describe('adhoc actions', () => {
         .whenAsyncActionIsDispatched(setFiltersFromUrl(toKeyedVariableIdentifier(variable), fromUrl), true);
 
       const expectedQuery = { 'var-elastic-filter': ['key|=|value', 'key|=|value'] };
-      const expectedFilters = [
-        { key: 'key', value: 'value', operator: '=', condition: '>' },
-        { key: 'key', value: 'value', operator: '=', condition: '', name: 'value-2' },
-      ];
+      const expectedFilters = [{ key: 'key', value: 'value', operator: '=', name: 'value-2' }];
 
       tester.thenDispatchedActionsShouldEqual(
         toKeyedAction(key, filtersRestored(toVariablePayload(variable, expectedFilters)))

--- a/public/app/features/variables/adhoc/actions.test.ts
+++ b/public/app/features/variables/adhoc/actions.test.ts
@@ -374,7 +374,7 @@ describe('adhoc actions', () => {
         .whenActionIsDispatched(createAddVariableAction(variable))
         .whenAsyncActionIsDispatched(setFiltersFromUrl(toKeyedVariableIdentifier(variable), fromUrl), true);
 
-      const expectedQuery = { 'var-elastic-filter': ['key|=|value', 'key|=|value'] };
+      const expectedQuery = { 'var-elastic-filter': ['key|=|value'] };
       const expectedFilters = [{ key: 'key', value: 'value', operator: '=', name: 'value-2' }];
 
       tester.thenDispatchedActionsShouldEqual(

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -48,7 +48,7 @@ export const applyFilterFromTable = (options: AdHocTableOptions): ThunkResult<vo
 
     if (index === -1) {
       const { value, key, operator } = options;
-      const filter = { value, key, operator, condition: '' };
+      const filter = { value, key, operator };
       return await dispatch(addFilter(toKeyedVariableIdentifier(variable), filter));
     }
 

--- a/public/app/features/variables/adhoc/picker/AdHocFilter.test.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilter.test.tsx
@@ -84,13 +84,11 @@ function setup() {
       key: 'key1',
       operator: '=',
       value: 'val1',
-      condition: '',
     },
     {
       key: 'key2',
       operator: '=',
       value: 'val2',
-      condition: '',
     },
   ];
   const addFilter = jest.fn();

--- a/public/app/features/variables/adhoc/picker/AdHocFilterBuilder.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilterBuilder.tsx
@@ -39,7 +39,6 @@ export const AdHocFilterBuilder = ({ datasource, appendBefore, onCompleted, getT
       onCompleted({
         value: item.value ?? '',
         operator: operator,
-        condition: '',
         key: key!,
       });
       setKey(null);
@@ -64,7 +63,7 @@ export const AdHocFilterBuilder = ({ datasource, appendBefore, onCompleted, getT
       {appendBefore}
       <AdHocFilterRenderer
         datasource={datasource}
-        filter={{ key, value: '', operator, condition: '' }}
+        filter={{ key, value: '', operator }}
         placeHolder={t('variable.adhoc.placeholder', 'Select value')}
         onKeyChange={onKeyChanged}
         onOperatorChange={onOperatorChanged}

--- a/public/app/features/variables/adhoc/reducer.test.ts
+++ b/public/app/features/variables/adhoc/reducer.test.ts
@@ -25,7 +25,7 @@ describe('adHocVariableReducer', () => {
         .thenStateShouldEqual({
           [id]: {
             ...initialState[id],
-            filters: [{ value: 'a', operator: '=', condition: '', key: 'a' }],
+            filters: [{ value: 'a', operator: '=', key: 'a' }],
           } as AdHocVariableModel,
         });
     });
@@ -46,8 +46,8 @@ describe('adHocVariableReducer', () => {
           [id]: {
             ...initialState[id],
             filters: [
-              { value: 'a', operator: '=', condition: '', key: 'a' },
-              { value: 'b', operator: '=', condition: '', key: 'b' },
+              { value: 'a', operator: '=', key: 'a' },
+              { value: 'b', operator: '=', key: 'b' },
             ],
           } as AdHocVariableModel,
         });
@@ -69,7 +69,7 @@ describe('adHocVariableReducer', () => {
         .thenStateShouldEqual({
           [id]: {
             ...initialState[id],
-            filters: [{ value: 'a', operator: '=', condition: '', key: 'a' }],
+            filters: [{ value: 'a', operator: '=', key: 'a' }],
           } as AdHocVariableModel,
         });
     });
@@ -90,7 +90,7 @@ describe('adHocVariableReducer', () => {
         .thenStateShouldEqual({
           [id]: {
             ...initialState[id],
-            filters: [{ value: 'b', operator: '=', condition: '', key: 'b' }],
+            filters: [{ value: 'b', operator: '=', key: 'b' }],
           } as AdHocVariableModel,
         });
     });
@@ -133,8 +133,8 @@ describe('adHocVariableReducer', () => {
           [id]: {
             ...initialState[id],
             filters: [
-              { value: 'b', operator: '=', condition: '', key: 'b' },
-              { value: 'aa', operator: '=', condition: '', key: 'aa' },
+              { value: 'b', operator: '=', key: 'b' },
+              { value: 'aa', operator: '=', key: 'aa' },
             ],
           } as AdHocVariableModel,
         });
@@ -158,8 +158,8 @@ describe('adHocVariableReducer', () => {
           [id]: {
             ...initialState[id],
             filters: [
-              { value: 'b', operator: '=', condition: '', key: 'b' },
-              { value: 'aa', operator: '>', condition: '', key: 'aa' },
+              { value: 'b', operator: '=', key: 'b' },
+              { value: 'aa', operator: '>', key: 'aa' },
             ],
           } as AdHocVariableModel,
         });
@@ -181,8 +181,8 @@ describe('adHocVariableReducer', () => {
           [id]: {
             ...initialState[id],
             filters: [
-              { value: 'aa', operator: '=', condition: '', key: 'aa' },
-              { value: 'bb', operator: '=', condition: '', key: 'bb' },
+              { value: 'aa', operator: '=', key: 'aa' },
+              { value: 'bb', operator: '=', key: 'bb' },
             ],
           } as AdHocVariableModel,
         });
@@ -203,8 +203,8 @@ describe('adHocVariableReducer', () => {
           [id]: {
             ...initialState[id],
             filters: [
-              { value: 'aa', operator: '=', condition: '', key: 'aa' },
-              { value: 'bb', operator: '=', condition: '', key: 'bb' },
+              { value: 'aa', operator: '=', key: 'aa' },
+              { value: 'bb', operator: '=', key: 'bb' },
             ],
           } as AdHocVariableModel,
         });
@@ -216,7 +216,7 @@ function createFilter(value: string, operator = '='): AdHocVariableFilter {
   return {
     value,
     operator,
-    condition: '',
+
     key: value,
   };
 }

--- a/public/app/features/variables/adhoc/urlParser.test.ts
+++ b/public/app/features/variables/adhoc/urlParser.test.ts
@@ -49,7 +49,6 @@ describe('urlParser', () => {
         value: '',
         key: 'key',
         operator: '',
-        condition: '',
       };
 
       const filters: AdHocVariableFilter[] = [a];
@@ -67,7 +66,6 @@ describe('urlParser', () => {
         value: undefined,
         key: 'key',
         operator: undefined,
-        condition: '',
       } as unknown as AdHocVariableFilter;
 
       const filters: AdHocVariableFilter[] = [a];
@@ -85,7 +83,6 @@ describe('urlParser', () => {
         value: 1974,
         key: 'key',
         operator: '=',
-        condition: '',
       } as unknown as AdHocVariableFilter;
 
       const filters: AdHocVariableFilter[] = [a];
@@ -103,7 +100,6 @@ describe('urlParser', () => {
         value: false,
         key: 'key',
         operator: '=',
-        condition: '',
       } as unknown as AdHocVariableFilter;
 
       const filters: AdHocVariableFilter[] = [a];
@@ -171,7 +167,6 @@ describe('urlParser', () => {
           value: '',
           key: 'key',
           operator: '',
-          condition: '',
         },
       ];
 
@@ -193,6 +188,5 @@ function createFilter(value: string, operator = '='): AdHocVariableFilter {
     value: `${value}-value`,
     key: `${value}-key`,
     operator: operator,
-    condition: '',
   };
 }

--- a/public/app/features/variables/adhoc/urlParser.ts
+++ b/public/app/features/variables/adhoc/urlParser.ts
@@ -48,7 +48,6 @@ function toFilter(value: string | number | boolean | undefined | null): AdHocVar
     key: parts[0],
     operator: parts[1],
     value: parts[2],
-    condition: '',
   };
 }
 


### PR DESCRIPTION
Removes an unused prop from the AdHocVariableFilter type. Not sure why it was ever there we
have never had a condition prop, it was always hard coded to AND in the interface (so could never be changed.)

