### PR TITLE
InfluxDB: Fix adhoc filter call

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -335,7 +335,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         rawQuery: true,
       },
       this.templateSrv,
-      options.scopedVars
+      options?.scopedVars
     ).render(true);
 
     return lastValueFrom(this._seriesQuery(interpolated, options)).then((resp) => {
@@ -345,12 +345,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   // Used in public/app/features/variables/adhoc/picker/AdHocFilterKey.tsx::fetchFilterKeys
-  getTagKeys(options: InfluxQuery) {
+  getTagKeys(options?: InfluxQuery) {
     const query = buildMetadataQuery({
       type: 'TAG_KEYS',
       templateService: this.templateSrv,
       database: this.database,
-      measurement: options.measurement ?? '',
+      measurement: options?.measurement ?? '',
       tags: [],
     });
     return this.metricFindQuery(query, options);
@@ -361,8 +361,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       type: 'TAG_VALUES',
       templateService: this.templateSrv,
       database: this.database,
-      withKey: options.key,
-      measurement: options.measurement ?? '',
+      withKey: options.key ?? '',
+      measurement: options?.measurement ?? '',
       tags: [],
     });
     return this.metricFindQuery(query, options);

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -1,14 +1,14 @@
-import { lastValueFrom, of } from 'rxjs';
-import { TemplateSrvStub } from 'test/specs/helpers';
+import {lastValueFrom, of} from 'rxjs';
+import {TemplateSrvStub} from 'test/specs/helpers';
 
-import { ScopedVars } from '@grafana/data/src';
-import { FetchResponse } from '@grafana/runtime';
+import {ScopedVars} from '@grafana/data/src';
+import {FetchResponse} from '@grafana/runtime';
 import config from 'app/core/config';
-import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
+import {backendSrv} from 'app/core/services/backend_srv'; // will use the version in __mocks__
 
-import { BROWSER_MODE_DISABLED_MESSAGE } from '../constants';
+import {BROWSER_MODE_DISABLED_MESSAGE} from '../constants';
 import InfluxDatasource from '../datasource';
-import { InfluxQuery, InfluxVersion } from '../types';
+import {InfluxQuery, InfluxVersion} from '../types';
 
 //@ts-ignore
 const templateSrv = new TemplateSrvStub();
@@ -212,11 +212,28 @@ describe('InfluxDataSource', () => {
   // Some functions are required by the parent datasource class to provide functionality
   // such as ad-hoc filters, which requires the definition of the getTagKeys, and getTagValues
   describe('Datasource contract', () => {
+    const metricFindQueryMock = jest.fn();
+    beforeEach(() => {
+      ctx.ds.metricFindQuery = metricFindQueryMock;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('has function called getTagKeys', () => {
       expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ctx.ds))).toContain('getTagKeys');
     });
     it('has function called getTagValues', () => {
       expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ctx.ds))).toContain('getTagValues');
+    });
+    it('should be able to call getTagKeys without specifying any parameter', () => {
+      ctx.ds.getTagKeys();
+      expect(metricFindQueryMock).toHaveBeenCalled();
+    });
+    it('should be able to call getTagValues without specifying anything but key', () => {
+      ctx.ds.getTagValues({ key: 'test' });
+      expect(metricFindQueryMock).toHaveBeenCalled();
     });
   });
 

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -1,14 +1,14 @@
-import {lastValueFrom, of} from 'rxjs';
-import {TemplateSrvStub} from 'test/specs/helpers';
+import { lastValueFrom, of } from 'rxjs';
+import { TemplateSrvStub } from 'test/specs/helpers';
 
-import {ScopedVars} from '@grafana/data/src';
-import {FetchResponse} from '@grafana/runtime';
+import { ScopedVars } from '@grafana/data/src';
+import { FetchResponse } from '@grafana/runtime';
 import config from 'app/core/config';
-import {backendSrv} from 'app/core/services/backend_srv'; // will use the version in __mocks__
+import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 
-import {BROWSER_MODE_DISABLED_MESSAGE} from '../constants';
+import { BROWSER_MODE_DISABLED_MESSAGE } from '../constants';
 import InfluxDatasource from '../datasource';
-import {InfluxQuery, InfluxVersion} from '../types';
+import { InfluxQuery, InfluxVersion } from '../types';
 
 //@ts-ignore
 const templateSrv = new TemplateSrvStub();
@@ -224,13 +224,16 @@ describe('InfluxDataSource', () => {
     it('has function called getTagKeys', () => {
       expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ctx.ds))).toContain('getTagKeys');
     });
+
     it('has function called getTagValues', () => {
       expect(Object.getOwnPropertyNames(Object.getPrototypeOf(ctx.ds))).toContain('getTagValues');
     });
+
     it('should be able to call getTagKeys without specifying any parameter', () => {
       ctx.ds.getTagKeys();
       expect(metricFindQueryMock).toHaveBeenCalled();
     });
+
     it('should be able to call getTagValues without specifying anything but key', () => {
       ctx.ds.getTagValues({ key: 'test' });
       expect(metricFindQueryMock).toHaveBeenCalled();


### PR DESCRIPTION
**What is this feature?**

This fixes to load of the ad-hoc filter keys and values.

**Who is this feature for?**

InfluxDB Users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/74258

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
