### PR TITLE
TimeSeries: Old graph migration fix for series override lines: true

### DIFF
--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -623,6 +623,51 @@ describe('Graph Migrations', () => {
       expect(panel.fieldConfig.defaults.custom.spanNulls).toBeTruthy();
     });
   });
+
+  describe('seriesOverride lines: true', () => {
+    test('Should set displayMode', () => {
+      const old = {
+        angular: {
+          bars: true,
+          lines: false,
+          seriesOverrides: [
+            {
+              alias: 'A-series',
+              lines: true,
+            },
+          ],
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.fieldConfig.overrides[0]).toEqual({
+        matcher: { id: 'byName', options: 'A-series' },
+        properties: [{ id: 'custom.drawStyle', value: 'line' }],
+      });
+    });
+  });
+
+  describe('seriesOverride lines: false', () => {
+    test('Should set lineWidth 0', () => {
+      const old = {
+        angular: {
+          lines: true,
+          seriesOverrides: [
+            {
+              alias: 'A-series',
+              lines: false,
+            },
+          ],
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.fieldConfig.overrides[0]).toEqual({
+        matcher: { id: 'byName', options: 'A-series' },
+        properties: [{ id: 'custom.lineWidth', value: 0 }],
+      });
+    });
+  });
 });
 
 const customColor = {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -222,10 +222,17 @@ export function graphToTimeseriesOptions(angular: any): {
             }
             break;
           case 'lines':
-            rule.properties.push({
-              id: 'custom.lineWidth',
-              value: 0, // don't show lines
-            });
+            if (v) {
+              rule.properties.push({
+                id: 'custom.drawStyle',
+                value: 'line',
+              });
+            } else {
+              rule.properties.push({
+                id: 'custom.lineWidth',
+                value: 0,
+              });
+            }
             break;
           case 'linewidth':
             rule.properties.push({


### PR DESCRIPTION
Noticed this panel http://localhost:3000/d/000000003/testdata-demo-dashboard?orgId=1&showCategory=Graph%20styles&editPanel=4

did not migrate correctly. The CPU series has seriesOverride lines: true which was migrated to an override with lineWidth: 0,
which is not correct :)
