### PR TITLE
Sandbox: Make `window.monaco` and `window.Prism` available for plugins inside the sandbox

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -86,7 +86,7 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
           return Reflect.get(window, 'monaco');
         },
         get Prism() {
-          // Similar to `window.monaco`, window.Prism` may be undefined when invoked.
+          // Similar to `window.monaco`, `window.Prism` may be undefined when invoked.
           return Reflect.get(window, 'Prism');
         },
         // Plugins builds use the AMD module system. Their code consists

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -80,6 +80,11 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
         // window.locationSandbox. In the future `window.location` could be a proxy if we
         // want to intercept calls to it.
         locationSandbox: window.location,
+        get monaco() {
+          // `window.monaco` may be undefined when invoked. However, plugins have long
+          // accessed it directly, aware of this possibility.
+          return Reflect.get(window, 'monaco');
+        },
         // Plugins builds use the AMD module system. Their code consists
         // of a single function call to `define()` that internally contains all the plugin code.
         // This is that `define` function the plugin will call.

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -85,6 +85,10 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
           // accessed it directly, aware of this possibility.
           return Reflect.get(window, 'monaco');
         },
+        get Prism() {
+          // Similar to `window.monaco`, window.Prism` may be undefined when invoked.
+          return Reflect.get(window, 'Prism');
+        },
         // Plugins builds use the AMD module system. Their code consists
         // of a single function call to `define()` that internally contains all the plugin code.
         // This is that `define` function the plugin will call.


### PR DESCRIPTION
**What is this feature?**

Makes `window.monaco` and `window.Prism` accessible inside the sandbox.

**Why do we need this feature?**

Several plugins use monaco and Prism directly from the `window` object. Those plugins have broken functionality because monaco or Prism was not accessible in the sandbox until this PR.

**Who is this feature for?**

Plugins using monaco or Prism directly from the `window` object

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
