### PR TITLE
Browse Dashboards: Better logic for showing selection checkboxes

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -101,9 +101,10 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
   let server: SetupServer;
   const mockPermissions = {
     canCreateDashboards: true,
-    canCreateFolder: true,
-    canDeleteFolder: true,
-    canEditFolder: true,
+    canEditDashboards: true,
+    canCreateFolders: true,
+    canDeleteFolders: true,
+    canEditFolders: true,
     canViewPermissions: true,
     canSetPermissions: true,
   };
@@ -173,7 +174,7 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
         return {
           ...mockPermissions,
           canCreateDashboards: false,
-          canCreateFolder: false,
+          canCreateFolders: false,
         };
       });
       render(<BrowseDashboardsPage {...props} />);
@@ -277,7 +278,7 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
         return {
           ...mockPermissions,
           canCreateDashboards: false,
-          canCreateFolder: false,
+          canCreateFolders: false,
         };
       });
       render(<BrowseDashboardsPage {...props} />);
@@ -294,8 +295,8 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canDeleteFolder: false,
-          canEditFolder: false,
+          canDeleteFolders: false,
+          canEditFolders: false,
           canSetPermissions: false,
           canViewPermissions: false,
         };
@@ -314,7 +315,7 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canEditFolder: false,
+          canEditFolders: false,
         };
       });
       render(<BrowseDashboardsPage {...props} />);

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -78,9 +78,10 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
 
   const hasSelection = useHasSelection();
 
-  const { canEditFolder, canCreateDashboards, canCreateFolder } = getFolderPermissions(folderDTO);
+  const { canEditFolders, canEditDashboards, canCreateDashboards, canCreateFolders } = getFolderPermissions(folderDTO);
 
-  const showEditTitle = canEditFolder && folderUID;
+  const showEditTitle = canEditFolders && folderUID;
+  const canSelect = canEditFolders || canEditDashboards;
   const onEditTitle = async (newValue: string) => {
     if (folderDTO) {
       const result = await saveFolder({
@@ -101,11 +102,11 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
       actions={
         <>
           {folderDTO && <FolderActionsButton folder={folderDTO} />}
-          {(canCreateDashboards || canCreateFolder) && (
+          {(canCreateDashboards || canCreateFolders) && (
             <CreateNewButton
               parentFolder={folderDTO}
               canCreateDashboard={canCreateDashboards}
-              canCreateFolder={canCreateFolder}
+              canCreateFolder={canCreateFolders}
             />
           )}
         </>
@@ -125,9 +126,9 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
           <AutoSizer>
             {({ width, height }) =>
               isSearching ? (
-                <SearchView canSelect={canEditFolder} width={width} height={height} />
+                <SearchView canSelect={canSelect} width={width} height={height} />
               ) : (
-                <BrowseView canSelect={canEditFolder} width={width} height={height} folderUID={folderUID} />
+                <BrowseView canSelect={canSelect} width={width} height={height} folderUID={folderUID} />
               )
             }
           </AutoSizer>

--- a/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
@@ -37,9 +37,10 @@ describe('browse-dashboards BrowseFolderAlertingPage', () => {
   let server: SetupServer;
   const mockPermissions = {
     canCreateDashboards: true,
-    canCreateFolder: true,
-    canDeleteFolder: true,
-    canEditFolder: true,
+    canEditDashboards: true,
+    canCreateFolders: true,
+    canDeleteFolders: true,
+    canEditFolders: true,
     canViewPermissions: true,
     canSetPermissions: true,
   };
@@ -105,8 +106,8 @@ describe('browse-dashboards BrowseFolderAlertingPage', () => {
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
       return {
         ...mockPermissions,
-        canDeleteFolder: false,
-        canEditFolder: false,
+        canDeleteFolders: false,
+        canEditFolders: false,
         canViewPermissions: false,
         canSetPermissions: false,
       };

--- a/public/app/features/browse-dashboards/BrowseFolderLibraryPanelsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderLibraryPanelsPage.test.tsx
@@ -37,9 +37,10 @@ describe('browse-dashboards BrowseFolderLibraryPanelsPage', () => {
   let server: SetupServer;
   const mockPermissions = {
     canCreateDashboards: true,
-    canCreateFolder: true,
-    canDeleteFolder: true,
-    canEditFolder: true,
+    canEditDashboards: true,
+    canCreateFolders: true,
+    canDeleteFolders: true,
+    canEditFolders: true,
     canViewPermissions: true,
     canSetPermissions: true,
   };
@@ -110,8 +111,8 @@ describe('browse-dashboards BrowseFolderLibraryPanelsPage', () => {
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
       return {
         ...mockPermissions,
-        canDeleteFolder: false,
-        canEditFolder: false,
+        canDeleteFolders: false,
+        canEditFolders: false,
         canViewPermissions: false,
         canSetPermissions: false,
       };

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -27,9 +27,10 @@ describe('browse-dashboards FolderActionsButton', () => {
   const mockFolder = mockFolderDTO();
   const mockPermissions = {
     canCreateDashboards: true,
-    canCreateFolder: true,
-    canDeleteFolder: true,
-    canEditFolder: true,
+    canEditDashboards: true,
+    canCreateFolders: true,
+    canDeleteFolders: true,
+    canEditFolders: true,
     canViewPermissions: true,
     canSetPermissions: true,
   };
@@ -55,8 +56,8 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canDeleteFolder: false,
-          canEditFolder: false,
+          canDeleteFolders: false,
+          canEditFolders: false,
           canViewPermissions: false,
           canSetPermissions: false,
         };
@@ -98,7 +99,7 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canEditFolder: false,
+          canEditFolders: false,
         };
       });
       render(<FolderActionsButton folder={mockFolder} />);
@@ -113,7 +114,7 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canDeleteFolder: false,
+          canDeleteFolders: false,
         };
       });
       render(<FolderActionsButton folder={mockFolder} />);
@@ -168,8 +169,8 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canDeleteFolder: false,
-          canEditFolder: false,
+          canDeleteFolders: false,
+          canEditFolders: false,
           canViewPermissions: false,
           canSetPermissions: false,
         };
@@ -216,7 +217,7 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canEditFolder: false,
+          canEditFolders: false,
         };
       });
       render(<FolderActionsButton folder={mockFolder} />);
@@ -230,7 +231,7 @@ describe('browse-dashboards FolderActionsButton', () => {
       jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => {
         return {
           ...mockPermissions,
-          canDeleteFolder: false,
+          canDeleteFolders: false,
         };
       });
       render(<FolderActionsButton folder={mockFolder} />);

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -23,9 +23,9 @@ export function FolderActionsButton({ folder }: Props) {
   const [showPermissionsDrawer, setShowPermissionsDrawer] = useState(false);
   const [moveFolder] = useMoveFolderMutation();
   const [deleteFolder] = useDeleteFolderMutation();
-  const { canEditFolder, canDeleteFolder, canViewPermissions, canSetPermissions } = getFolderPermissions(folder);
+  const { canEditFolders, canDeleteFolders, canViewPermissions, canSetPermissions } = getFolderPermissions(folder);
   // Can only move folders when nestedFolders is enabled
-  const canMoveFolder = config.featureToggles.nestedFolders && canEditFolder;
+  const canMoveFolder = config.featureToggles.nestedFolders && canEditFolders;
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folder, destinationUID });
@@ -94,11 +94,11 @@ export function FolderActionsButton({ folder }: Props) {
     <Menu>
       {canViewPermissions && <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />}
       {canMoveFolder && <MenuItem onClick={showMoveModal} label={moveLabel} />}
-      {canDeleteFolder && <MenuItem destructive onClick={showDeleteModal} label={deleteLabel} />}
+      {canDeleteFolders && <MenuItem destructive onClick={showDeleteModal} label={deleteLabel} />}
     </Menu>
   );
 
-  if (!canViewPermissions && !canMoveFolder && !canDeleteFolder) {
+  if (!canViewPermissions && !canMoveFolder && !canDeleteFolders) {
     return null;
   }
 

--- a/public/app/features/browse-dashboards/permissions.ts
+++ b/public/app/features/browse-dashboards/permissions.ts
@@ -7,21 +7,23 @@ function checkFolderPermission(action: AccessControlAction, folderDTO?: FolderDT
 }
 
 export function getFolderPermissions(folderDTO?: FolderDTO) {
-  const canEditFolder = checkFolderPermission(AccessControlAction.FoldersWrite, folderDTO);
   // Can only create a folder if we have permissions and either we're at root or nestedFolders is enabled
-  const canCreateFolder = Boolean(
+  const canCreateDashboards = checkFolderPermission(AccessControlAction.DashboardsCreate, folderDTO);
+  const canCreateFolders = Boolean(
     (!folderDTO || config.featureToggles.nestedFolders) && checkFolderPermission(AccessControlAction.FoldersCreate)
   );
-  const canCreateDashboards = checkFolderPermission(AccessControlAction.DashboardsCreate, folderDTO);
-  const canDeleteFolder = checkFolderPermission(AccessControlAction.FoldersDelete, folderDTO);
-  const canViewPermissions = checkFolderPermission(AccessControlAction.FoldersPermissionsRead, folderDTO);
+  const canDeleteFolders = checkFolderPermission(AccessControlAction.FoldersDelete, folderDTO);
+  const canEditDashboards = checkFolderPermission(AccessControlAction.DashboardsWrite, folderDTO);
+  const canEditFolders = checkFolderPermission(AccessControlAction.FoldersWrite, folderDTO);
   const canSetPermissions = checkFolderPermission(AccessControlAction.FoldersPermissionsWrite, folderDTO);
+  const canViewPermissions = checkFolderPermission(AccessControlAction.FoldersPermissionsRead, folderDTO);
 
   return {
     canCreateDashboards,
-    canCreateFolder,
-    canDeleteFolder,
-    canEditFolder,
+    canCreateFolders,
+    canDeleteFolders,
+    canEditDashboards,
+    canEditFolders,
     canSetPermissions,
     canViewPermissions,
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- shows selection checkboxes if can edit either folders or dashboards
  - rely on backend handling whether we can *actually* move things
- consistently pluralise permissions returned by `getFolderPermissions`

**Why do we need this feature?**

- so selection checkboxes are shown correctly

**Who is this feature for?**

- everyone restricting permissions of users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
