### PR TITLE
refactor(alerting): save state on a ticker async

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -174,4 +174,5 @@ export interface FeatureToggles {
   enablePluginsTracingByDefault?: boolean;
   cloudRBACRoles?: boolean;
   alertingQueryOptimization?: boolean;
+  alertingSaveStateAsync?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1323,5 +1323,13 @@ var (
 			AllowSelfServe: false,
 			Created:        time.Date(2024, time.January, 10, 12, 0, 0, 0, time.UTC),
 		},
+		{
+			Name:         "alertingSaveStateAsync",
+			Description:  "Writes the state only on a given interval to database",
+			Stage:        FeatureStagePrivatePreview,
+			FrontendOnly: false,
+			Owner:        grafanaAlertingSquad,
+			Created:      time.Date(2024, time.January, 10, 12, 0, 0, 0, time.UTC),
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -155,3 +155,4 @@ alertingPreviewUpgrade,experimental,@grafana/alerting-squad,2024-01-03,false,fal
 enablePluginsTracingByDefault,experimental,@grafana/plugins-platform-backend,2024-01-09,false,false,true,false
 cloudRBACRoles,experimental,@grafana/identity-access-team,2024-01-10,false,false,true,false
 alertingQueryOptimization,GA,@grafana/alerting-squad,2024-01-10,false,false,false,false
+alertingSaveStateAsync,privatePreview,@grafana/alerting-squad,2024-01-10,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -630,4 +630,8 @@ const (
 	// FlagAlertingQueryOptimization
 	// Optimizes eligible queries in order to reduce load on datasources
 	FlagAlertingQueryOptimization = "alertingQueryOptimization"
+
+	// FlagAlertingSaveStateAsync
+	// Writes the state only on a given interval to database
+	FlagAlertingSaveStateAsync = "alertingSaveStateAsync"
 )

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -87,15 +87,15 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	}
 
 	cfg := state.ManagerCfg{
-		Metrics:                 nil,
-		ExternalURL:             srv.appUrl,
-		InstanceStore:           nil,
-		Images:                  &backtesting.NoopImageService{},
-		Clock:                   clock.New(),
-		Historian:               nil,
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  srv.tracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        nil,
+		ExternalURL:    srv.appUrl,
+		InstanceStore:  nil,
+		Images:         &backtesting.NoopImageService{},
+		Clock:          clock.New(),
+		Historian:      nil,
+		Tracer:         srv.tracer,
+		Log:            log.New("ngalert.state.manager"),
+		StatePersister: state.NewNoopPersister(),
 	}
 	manager := state.NewManager(cfg)
 	includeFolder := !srv.cfg.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel)

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -49,15 +49,15 @@ func NewEngine(appUrl *url.URL, evalFactory eval.EvaluatorFactory, tracer tracin
 		evalFactory: evalFactory,
 		createStateManager: func() stateManager {
 			cfg := state.ManagerCfg{
-				Metrics:                 nil,
-				ExternalURL:             appUrl,
-				InstanceStore:           nil,
-				Images:                  &NoopImageService{},
-				Clock:                   clock.New(),
-				Historian:               nil,
-				MaxStateSaveConcurrency: 1,
-				Tracer:                  tracer,
-				Log:                     log.New("ngalert.state.manager"),
+				Metrics:        nil,
+				ExternalURL:    appUrl,
+				InstanceStore:  nil,
+				Images:         &NoopImageService{},
+				Clock:          clock.New(),
+				Historian:      nil,
+				Tracer:         tracer,
+				Log:            log.New("ngalert.state.manager"),
+				StatePersister: state.NewNoopPersister(),
 			}
 			return state.NewManager(cfg)
 		},

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -400,6 +400,10 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 	children, subCtx := errgroup.WithContext(ctx)
 
 	children.Go(func() error {
+		return ng.stateManager.Run(subCtx)
+	})
+
+	children.Go(func() error {
 		return ng.MultiOrgAlertmanager.Run(subCtx)
 	})
 	children.Go(func() error {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -294,6 +294,7 @@ func (ng *AlertNG) init() error {
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoDataErrorExecution),
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),
+		SaveStateAsync:                 ng.FeatureToggles.IsEnabled(featuremgmt.FlagAlertingSaveStateAsync),
 	}
 	stateManager := state.NewManager(cfg)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -82,15 +82,15 @@ func TestProcessTicks(t *testing.T) {
 		Log:              log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
-		Metrics:                 testMetrics.GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           nil,
-		Images:                  &state.NoopImageService{},
-		Clock:                   mockedClock,
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  testTracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        testMetrics.GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  nil,
+		Images:         &state.NoopImageService{},
+		Clock:          mockedClock,
+		Historian:      &state.FakeHistorian{},
+		StatePersister: state.NewNoopPersister(),
+		Tracer:         testTracer,
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 
@@ -899,16 +899,17 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Tracer:           testTracer,
 		Log:              log.New("ngalert.scheduler"),
 	}
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), is, false, 1)
 	managerCfg := state.ManagerCfg{
-		Metrics:                 m.GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           is,
-		Images:                  &state.NoopImageService{},
-		Clock:                   mockedClock,
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  testTracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        m.GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  is,
+		Images:         &state.NoopImageService{},
+		Clock:          mockedClock,
+		Historian:      &state.FakeHistorian{},
+		StatePersister: syncStatePersister,
+		Tracer:         testTracer,
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -140,10 +140,10 @@ func (st *Manager) fullSync(ctx context.Context) error {
 	st.log.Info("Full state sync start")
 	instances := st.cache.asInstances(st.doNotSaveNormalState)
 	if err := st.instanceStore.FullSync(ctx, instances); err != nil {
-		st.log.Error("Full state sync failed", "duration", time.Since(startTime).Seconds(), "instances", len(instances))
+		st.log.Error("Full state sync failed", "duration", time.Since(startTime), "instances", len(instances))
 		return err
 	}
-	st.log.Info("Full state sync done", "duration", time.Since(startTime).Seconds(), "instances", len(instances))
+	st.log.Info("Full state sync done", "duration", time.Since(startTime), "instances", len(instances))
 	return nil
 }
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -138,24 +138,7 @@ func (st *Manager) startSync(ctx context.Context) {
 func (st *Manager) fullSync(ctx context.Context) error {
 	startTime := time.Now()
 	st.log.Info("Full state sync start")
-	var instances []ngModels.AlertInstance
-	for _, state := range st.GetAll(allOrgs) {
-		key, err := state.GetAlertInstanceKey()
-		if err != nil {
-			st.log.Warn("Failed to get alert instance key during full sync, skipping instance", "err", err)
-			continue
-		}
-		instance := ngModels.AlertInstance{
-			AlertInstanceKey:  key,
-			Labels:            ngModels.InstanceLabels(state.Labels),
-			CurrentState:      ngModels.InstanceStateType(state.State.String()),
-			CurrentReason:     state.StateReason,
-			LastEvalTime:      state.LastEvaluationTime,
-			CurrentStateSince: state.StartsAt,
-			CurrentStateEnd:   state.EndsAt,
-		}
-		instances = append(instances, instance)
-	}
+	instances := st.cache.asInstances(st.doNotSaveNormalState)
 	if err := st.instanceStore.FullSync(ctx, instances); err != nil {
 		st.log.Error("Full state sync failed", "duration", time.Since(startTime).Seconds(), "instances", len(instances))
 		return err

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -111,7 +111,7 @@ func NewManager(cfg ManagerCfg) *Manager {
 func (st *Manager) startSync(ctx context.Context) {
 	st.stateRunnerWG.Add(1)
 	go func(ctx context.Context) {
-		ticker := st.clock.Ticker(time.Minute * 5)
+		ticker := st.clock.Ticker(time.Second * 30)
 	infLoop:
 		for {
 			select {
@@ -120,6 +120,7 @@ func (st *Manager) startSync(ctx context.Context) {
 					st.log.Error("Failed to do a full state sync to database", "err", err)
 				}
 			case <-st.stateRunnerShutdown:
+				st.log.Info("Stopping state sync...")
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 				if err := st.fullSync(shutdownCtx); err != nil {
 					st.log.Error("Failed to do a full state sync to database", "err", err)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -114,11 +114,9 @@ infLoop:
 			}
 		case <-ctx.Done():
 			st.log.Info("Stopping state sync...")
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-			if err := st.fullSync(shutdownCtx); err != nil {
+			if err := st.fullSync(context.Background()); err != nil {
 				st.log.Error("Failed to do a full state sync to database", "err", err)
 			}
-			cancel()
 			ticker.Stop()
 			break infLoop
 		}

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -22,8 +22,6 @@ import (
 
 var (
 	ResendDelay = 30 * time.Second
-	MetricsScrapeInterval = 15 * time.Second // TODO: parameterize? // Setting to a reasonable default scrape interval for Prometheus.
-	JPsFF       = true
 )
 
 // AlertInstanceManager defines the interface for querying the current alert instances.

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -26,10 +26,11 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	store := historian.NewAnnotationStore(&as, nil, metrics)
 	hist := historian.NewAnnotationBackend(store, nil, metrics)
 	cfg := state.ManagerCfg{
-		Historian:               hist,
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  tracing.InitializeTracerForTest(),
-		Log:                     log.New("ngalert.state.manager"),
+		Historian: hist,
+		// TODO(JP): replace with sync
+		//MaxStateSaveConcurrency: 1,
+		Tracer: tracing.InitializeTracerForTest(),
+		Log:    log.New("ngalert.state.manager"),
 	}
 	sut := state.NewManager(cfg)
 	now := time.Now().UTC()

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -19,13 +19,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-
-	"github.com/grafana/grafana/pkg/util"
 )
 
 // Not for parallel tests.
@@ -80,84 +77,6 @@ func TestStateIsStale(t *testing.T) {
 			require.Equal(t, tc.expectedResult, stateIsStale(now, tc.lastEvaluation, intervalSeconds))
 		})
 	}
-}
-
-func TestManager_saveAlertStates(t *testing.T) {
-	type stateWithReason struct {
-		State  eval.State
-		Reason string
-	}
-	create := func(s eval.State, r string) stateWithReason {
-		return stateWithReason{
-			State:  s,
-			Reason: r,
-		}
-	}
-	allStates := [...]stateWithReason{
-		create(eval.Normal, ""),
-		create(eval.Normal, eval.NoData.String()),
-		create(eval.Normal, eval.Error.String()),
-		create(eval.Normal, util.GenerateShortUID()),
-		create(eval.Alerting, ""),
-		create(eval.Pending, ""),
-		create(eval.NoData, ""),
-		create(eval.Error, ""),
-	}
-
-	transitionToKey := map[ngmodels.AlertInstanceKey]StateTransition{}
-	transitions := make([]StateTransition, 0)
-	for _, fromState := range allStates {
-		for i, toState := range allStates {
-			tr := StateTransition{
-				State: &State{
-					State:       toState.State,
-					StateReason: toState.Reason,
-					Labels:      ngmodels.GenerateAlertLabels(5, fmt.Sprintf("%d--", i)),
-				},
-				PreviousState:       fromState.State,
-				PreviousStateReason: fromState.Reason,
-			}
-			key, err := tr.GetAlertInstanceKey()
-			require.NoError(t, err)
-			transitionToKey[key] = tr
-			transitions = append(transitions, tr)
-		}
-	}
-
-	t.Run("should save all transitions if doNotSaveNormalState is false", func(t *testing.T) {
-		st := &FakeInstanceStore{}
-		m := Manager{instanceStore: st, doNotSaveNormalState: false, maxStateSaveConcurrency: 1}
-		m.saveAlertStates(context.Background(), &logtest.Fake{}, transitions...)
-
-		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
-		for _, op := range st.RecordedOps {
-			saved := op.(ngmodels.AlertInstance)
-			savedKeys[saved.AlertInstanceKey] = saved
-		}
-		assert.Len(t, transitionToKey, len(savedKeys))
-
-		for key, tr := range transitionToKey {
-			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
-		}
-	})
-
-	t.Run("should not save Normal->Normal if doNotSaveNormalState is true", func(t *testing.T) {
-		st := &FakeInstanceStore{}
-		m := Manager{instanceStore: st, doNotSaveNormalState: true, maxStateSaveConcurrency: 1}
-		m.saveAlertStates(context.Background(), &logtest.Fake{}, transitions...)
-
-		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
-		for _, op := range st.RecordedOps {
-			saved := op.(ngmodels.AlertInstance)
-			savedKeys[saved.AlertInstanceKey] = saved
-		}
-		for key, tr := range transitionToKey {
-			if tr.State.State == eval.Normal && tr.StateReason == "" && tr.PreviousState == eval.Normal && tr.PreviousStateReason == "" {
-				continue
-			}
-			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
-		}
-	})
 }
 
 // TestProcessEvalResults_StateTransitions tests how state.Manager's ProcessEvalResults processes results and creates or changes states.
@@ -327,16 +246,18 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 		clk := clock.NewMock()
 
 		testMetrics := metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics()
+		store := &FakeInstanceStore{}
+		syncStatePersister := NewSyncStatePerisiter(log.New("ngalert.state.manager.persister"), store, false, 1)
 		cfg := ManagerCfg{
-			Metrics:                 testMetrics,
-			Tracer:                  tracing.InitializeTracerForTest(),
-			Log:                     log.New("ngalert.state.manager"),
-			ExternalURL:             nil,
-			InstanceStore:           &FakeInstanceStore{},
-			Images:                  &NotAvailableImageService{},
-			Clock:                   clk,
-			Historian:               &FakeHistorian{},
-			MaxStateSaveConcurrency: 1,
+			Metrics:        testMetrics,
+			Tracer:         tracing.InitializeTracerForTest(),
+			Log:            log.New("ngalert.state.manager"),
+			ExternalURL:    nil,
+			InstanceStore:  store,
+			Images:         &NotAvailableImageService{},
+			Clock:          clk,
+			Historian:      &FakeHistorian{},
+			StatePersister: syncStatePersister,
 
 			ApplyNoDataAndErrorToAllStates: applyNoDataErrorToAllStates,
 		}

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -204,15 +204,16 @@ func TestWarmStateCache(t *testing.T) {
 	}
 
 	cfg := state.ManagerCfg{
-		Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           dbstore,
-		Images:                  &state.NoopImageService{},
-		Clock:                   clock.NewMock(),
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  tracing.InitializeTracerForTest(),
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+		ExternalURL:   nil,
+		InstanceStore: dbstore,
+		Images:        &state.NoopImageService{},
+		Clock:         clock.NewMock(),
+		Historian:     &state.FakeHistorian{},
+		// TODO(JP): replace with sync
+		// MaxStateSaveConcurrency: 1,
+		Tracer: tracing.InitializeTracerForTest(),
+		Log:    log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 	st.Warm(ctx, dbstore)
@@ -241,16 +242,17 @@ func TestDashboardAnnotations(t *testing.T) {
 	historianMetrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 	store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, historianMetrics)
 	hist := historian.NewAnnotationBackend(store, nil, historianMetrics)
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), dbstore, false, 1)
 	cfg := state.ManagerCfg{
-		Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           dbstore,
-		Images:                  &state.NoopImageService{},
-		Clock:                   clock.New(),
-		Historian:               hist,
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  tracing.InitializeTracerForTest(),
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  dbstore,
+		Images:         &state.NoopImageService{},
+		Clock:          clock.New(),
+		Historian:      hist,
+		StatePersister: syncStatePersister,
+		Tracer:         tracing.InitializeTracerForTest(),
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 
@@ -1256,16 +1258,18 @@ func TestProcessEvalResults(t *testing.T) {
 			store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, m)
 			hist := historian.NewAnnotationBackend(store, nil, m)
 			clk := clock.NewMock()
+			is := &state.FakeInstanceStore{}
+			syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), is, false, 1)
 			cfg := state.ManagerCfg{
-				Metrics:                 stateMetrics,
-				ExternalURL:             nil,
-				InstanceStore:           &state.FakeInstanceStore{},
-				Images:                  &state.NotAvailableImageService{},
-				Clock:                   clk,
-				Historian:               hist,
-				MaxStateSaveConcurrency: 1,
-				Tracer:                  tracing.InitializeTracerForTest(),
-				Log:                     log.New("ngalert.state.manager"),
+				Metrics:        stateMetrics,
+				ExternalURL:    nil,
+				InstanceStore:  is,
+				Images:         &state.NotAvailableImageService{},
+				Clock:          clk,
+				Historian:      hist,
+				StatePersister: syncStatePersister,
+				Tracer:         tracing.InitializeTracerForTest(),
+				Log:            log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 
@@ -1357,16 +1361,17 @@ func TestProcessEvalResults(t *testing.T) {
 	t.Run("should save state to database", func(t *testing.T) {
 		instanceStore := &state.FakeInstanceStore{}
 		clk := clock.New()
+		syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), instanceStore, false, 1)
 		cfg := state.ManagerCfg{
-			Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-			ExternalURL:             nil,
-			InstanceStore:           instanceStore,
-			Images:                  &state.NotAvailableImageService{},
-			Clock:                   clk,
-			Historian:               &state.FakeHistorian{},
-			MaxStateSaveConcurrency: 1,
-			Tracer:                  tracing.InitializeTracerForTest(),
-			Log:                     log.New("ngalert.state.manager"),
+			Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+			ExternalURL:    nil,
+			InstanceStore:  instanceStore,
+			Images:         &state.NotAvailableImageService{},
+			Clock:          clk,
+			Historian:      &state.FakeHistorian{},
+			StatePersister: syncStatePersister,
+			Tracer:         tracing.InitializeTracerForTest(),
+			Log:            log.New("ngalert.state.manager"),
 		}
 		st := state.NewManager(cfg)
 		rule := models.AlertRuleGen()()
@@ -1510,16 +1515,17 @@ func TestStaleResultsHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		ctx := context.Background()
+		syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), dbstore, false, 1)
 		cfg := state.ManagerCfg{
-			Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-			ExternalURL:             nil,
-			InstanceStore:           dbstore,
-			Images:                  &state.NoopImageService{},
-			Clock:                   clock.New(),
-			Historian:               &state.FakeHistorian{},
-			MaxStateSaveConcurrency: 1,
-			Tracer:                  tracing.InitializeTracerForTest(),
-			Log:                     log.New("ngalert.state.manager"),
+			Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+			ExternalURL:    nil,
+			InstanceStore:  dbstore,
+			Images:         &state.NoopImageService{},
+			Clock:          clock.New(),
+			Historian:      &state.FakeHistorian{},
+			StatePersister: syncStatePersister,
+			Tracer:         tracing.InitializeTracerForTest(),
+			Log:            log.New("ngalert.state.manager"),
 		}
 		st := state.NewManager(cfg)
 		st.Warm(ctx, dbstore)
@@ -1592,17 +1598,17 @@ func TestStaleResults(t *testing.T) {
 	clk := clock.NewMock()
 
 	store := &state.FakeInstanceStore{}
-
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), store, false, 1)
 	cfg := state.ManagerCfg{
-		Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           store,
-		Images:                  &state.NoopImageService{},
-		Clock:                   clk,
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  tracing.InitializeTracerForTest(),
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  store,
+		Images:         &state.NoopImageService{},
+		Clock:          clk,
+		Historian:      &state.FakeHistorian{},
+		StatePersister: syncStatePersister,
+		Tracer:         tracing.InitializeTracerForTest(),
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 
@@ -1767,16 +1773,17 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 			ctx := context.Background()
 			clk := clock.NewMock()
 			clk.Set(time.Now())
+			syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), dbstore, false, 1)
 			cfg := state.ManagerCfg{
-				Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-				ExternalURL:             nil,
-				InstanceStore:           dbstore,
-				Images:                  &state.NoopImageService{},
-				Clock:                   clk,
-				Historian:               &state.FakeHistorian{},
-				MaxStateSaveConcurrency: 1,
-				Tracer:                  tracing.InitializeTracerForTest(),
-				Log:                     log.New("ngalert.state.manager"),
+				Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+				ExternalURL:    nil,
+				InstanceStore:  dbstore,
+				Images:         &state.NoopImageService{},
+				Clock:          clk,
+				Historian:      &state.FakeHistorian{},
+				StatePersister: syncStatePersister,
+				Tracer:         tracing.InitializeTracerForTest(),
+				Log:            log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 			st.Warm(ctx, dbstore)
@@ -1907,18 +1914,19 @@ func TestResetStateByRuleUID(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
 			fakeHistorian := &state.FakeHistorian{StateTransitions: make([]state.StateTransition, 0)}
+			syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), dbstore, false, 1)
 			clk := clock.NewMock()
 			clk.Set(time.Now())
 			cfg := state.ManagerCfg{
-				Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-				ExternalURL:             nil,
-				InstanceStore:           dbstore,
-				Images:                  &state.NoopImageService{},
-				Clock:                   clk,
-				Historian:               fakeHistorian,
-				MaxStateSaveConcurrency: 1,
-				Tracer:                  tracing.InitializeTracerForTest(),
-				Log:                     log.New("ngalert.state.manager"),
+				Metrics:        metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+				ExternalURL:    nil,
+				InstanceStore:  dbstore,
+				Images:         &state.NoopImageService{},
+				Clock:          clk,
+				Historian:      fakeHistorian,
+				StatePersister: syncStatePersister,
+				Tracer:         tracing.InitializeTracerForTest(),
+				Log:            log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 			st.Warm(ctx, dbstore)

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -14,6 +14,7 @@ type InstanceStore interface {
 	SaveAlertInstance(ctx context.Context, instance models.AlertInstance) error
 	DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error
+	FullSync(ctx context.Context, instances []models.AlertInstance) error
 }
 
 // RuleReader represents the ability to fetch alert rules.

--- a/pkg/services/ngalert/state/state_persister.go
+++ b/pkg/services/ngalert/state/state_persister.go
@@ -1,0 +1,183 @@
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/dskit/concurrency"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type StatePersister interface {
+	Async(ctx context.Context, ticker *clock.Ticker, cache *cache)
+	Sync(ctx context.Context, span trace.Span, states, staleStates []StateTransition)
+}
+
+type NoopPersister struct{}
+
+func (n *NoopPersister) Async(_ context.Context, _ *clock.Ticker, _ *cache) {
+	return
+}
+func (n *NoopPersister) Sync(_ context.Context, _ trace.Span, _, _ []StateTransition) {
+	return
+}
+
+func NewNoopPersister() StatePersister {
+	return &NoopPersister{}
+}
+
+type AsyncStatePersister struct {
+	log log.Logger
+	// doNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods.
+	doNotSaveNormalState bool
+	store                InstanceStore
+}
+
+func NewAsyncStatePerisiter(log log.Logger, store InstanceStore, doNotSaveNormalState bool) StatePersister {
+	return &AsyncStatePersister{
+		log:                  log,
+		store:                store,
+		doNotSaveNormalState: doNotSaveNormalState,
+	}
+}
+
+func (a *AsyncStatePersister) Async(ctx context.Context, ticker *clock.Ticker, cache *cache) {
+
+infLoop:
+	for {
+		select {
+		case <-ticker.C:
+			if err := a.fullSync(ctx, cache); err != nil {
+				a.log.Error("Failed to do a full state sync to database", "err", err)
+			}
+		case <-ctx.Done():
+			a.log.Info("Stopping state sync...")
+			if err := a.fullSync(context.Background(), cache); err != nil {
+				a.log.Error("Failed to do a full state sync to database", "err", err)
+			}
+			ticker.Stop()
+			break infLoop
+		}
+	}
+	a.log.Info("State sync shut down")
+	return
+}
+
+func (a *AsyncStatePersister) fullSync(ctx context.Context, cache *cache) error {
+	startTime := time.Now()
+	a.log.Info("Full state sync start")
+	instances := cache.asInstances(a.doNotSaveNormalState)
+	if err := a.store.FullSync(ctx, instances); err != nil {
+		a.log.Error("Full state sync failed", "duration", time.Since(startTime), "instances", len(instances))
+		return err
+	}
+	a.log.Info("Full state sync done", "duration", time.Since(startTime), "instances", len(instances))
+	return nil
+}
+
+func (a *AsyncStatePersister) Sync(_ context.Context, _ trace.Span, _, _ []StateTransition) {
+	a.log.Debug("Sync: No-Op")
+}
+
+type SyncStatePersister struct {
+	log   log.Logger
+	store InstanceStore
+	// doNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods.
+	doNotSaveNormalState bool
+	// maxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
+	maxStateSaveConcurrency int
+}
+
+func NewSyncStatePerisiter(log log.Logger, store InstanceStore, doNotSaveNormalState bool, maxStateSaveConcurrency int) StatePersister {
+	return &SyncStatePersister{
+		log:                     log,
+		store:                   store,
+		doNotSaveNormalState:    doNotSaveNormalState,
+		maxStateSaveConcurrency: maxStateSaveConcurrency,
+	}
+}
+
+func (a *SyncStatePersister) Async(_ context.Context, _ *clock.Ticker, _ *cache) {
+	a.log.Debug("Async: No-Op")
+	return
+}
+func (a *SyncStatePersister) Sync(ctx context.Context, span trace.Span, states, staleStates []StateTransition) {
+	a.deleteAlertStates(ctx, staleStates)
+	if len(staleStates) > 0 {
+		span.AddEvent("deleted stale states", trace.WithAttributes(
+			attribute.Int64("state_transitions", int64(len(staleStates))),
+		))
+	}
+
+	a.saveAlertStates(ctx, states...)
+	span.AddEvent("updated database")
+}
+
+func (a *SyncStatePersister) deleteAlertStates(ctx context.Context, states []StateTransition) {
+	if a.store == nil || len(states) == 0 {
+		return
+	}
+
+	a.log.Debug("Deleting alert states", "count", len(states))
+	toDelete := make([]ngModels.AlertInstanceKey, 0, len(states))
+
+	for _, s := range states {
+		key, err := s.GetAlertInstanceKey()
+		if err != nil {
+			a.log.Error("Failed to delete alert instance with invalid labels", "cacheID", s.CacheID, "error", err)
+			continue
+		}
+		toDelete = append(toDelete, key)
+	}
+
+	err := a.store.DeleteAlertInstances(ctx, toDelete...)
+	if err != nil {
+		a.log.Error("Failed to delete stale states", "error", err)
+	}
+}
+
+func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...StateTransition) {
+	if a.store == nil || len(states) == 0 {
+		return
+	}
+
+	saveState := func(ctx context.Context, idx int) error {
+		s := states[idx]
+		// Do not save normal state to database and remove transition to Normal state but keep mapped states
+		if a.doNotSaveNormalState && IsNormalStateWithNoReason(s.State) && !s.Changed() {
+			return nil
+		}
+
+		key, err := s.GetAlertInstanceKey()
+		if err != nil {
+			a.log.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
+			return nil
+		}
+		instance := ngModels.AlertInstance{
+			AlertInstanceKey:  key,
+			Labels:            ngModels.InstanceLabels(s.Labels),
+			CurrentState:      ngModels.InstanceStateType(s.State.State.String()),
+			CurrentReason:     s.StateReason,
+			LastEvalTime:      s.LastEvaluationTime,
+			CurrentStateSince: s.StartsAt,
+			CurrentStateEnd:   s.EndsAt,
+		}
+
+		err = a.store.SaveAlertInstance(ctx, instance)
+		if err != nil {
+			a.log.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
+			return nil
+		}
+		return nil
+	}
+
+	start := time.Now()
+	a.log.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency)
+	_ = concurrency.ForEachJob(ctx, len(states), a.maxStateSaveConcurrency, saveState)
+	a.log.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency, "duration", time.Since(start))
+}

--- a/pkg/services/ngalert/state/state_persister_test.go
+++ b/pkg/services/ngalert/state/state_persister_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/component-base/tracing"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func TestSyncPersister_saveAlertStates(t *testing.T) {
+	type stateWithReason struct {
+		State  eval.State
+		Reason string
+	}
+	create := func(s eval.State, r string) stateWithReason {
+		return stateWithReason{
+			State:  s,
+			Reason: r,
+		}
+	}
+	allStates := [...]stateWithReason{
+		create(eval.Normal, ""),
+		create(eval.Normal, eval.NoData.String()),
+		create(eval.Normal, eval.Error.String()),
+		create(eval.Normal, util.GenerateShortUID()),
+		create(eval.Alerting, ""),
+		create(eval.Pending, ""),
+		create(eval.NoData, ""),
+		create(eval.Error, ""),
+	}
+
+	transitionToKey := map[ngmodels.AlertInstanceKey]StateTransition{}
+	transitions := make([]StateTransition, 0)
+	for _, fromState := range allStates {
+		for i, toState := range allStates {
+			tr := StateTransition{
+				State: &State{
+					State:       toState.State,
+					StateReason: toState.Reason,
+					Labels:      ngmodels.GenerateAlertLabels(5, fmt.Sprintf("%d--", i)),
+				},
+				PreviousState:       fromState.State,
+				PreviousStateReason: fromState.Reason,
+			}
+			key, err := tr.GetAlertInstanceKey()
+			require.NoError(t, err)
+			transitionToKey[key] = tr
+			transitions = append(transitions, tr)
+		}
+	}
+
+	t.Run("should save all transitions if doNotSaveNormalState is false", func(t *testing.T) {
+		trace := tracing.NewNoopTracerProvider().Tracer("test")
+		_, span := trace.Start(context.Background(), "")
+		st := &FakeInstanceStore{}
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister.Sync(context.Background(), span, transitions, nil)
+		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
+		for _, op := range st.RecordedOps {
+			saved := op.(ngmodels.AlertInstance)
+			savedKeys[saved.AlertInstanceKey] = saved
+		}
+		assert.Len(t, transitionToKey, len(savedKeys))
+
+		for key, tr := range transitionToKey {
+			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
+		}
+	})
+
+	t.Run("should not save Normal->Normal if doNotSaveNormalState is true", func(t *testing.T) {
+		trace := tracing.NewNoopTracerProvider().Tracer("test")
+		_, span := trace.Start(context.Background(), "")
+		st := &FakeInstanceStore{}
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister.Sync(context.Background(), span, transitions, nil)
+
+		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
+		for _, op := range st.RecordedOps {
+			saved := op.(ngmodels.AlertInstance)
+			savedKeys[saved.AlertInstanceKey] = saved
+		}
+		for key, tr := range transitionToKey {
+			if tr.State.State == eval.Normal && tr.StateReason == "" && tr.PreviousState == eval.Normal && tr.PreviousStateReason == "" {
+				continue
+			}
+			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
+		}
+	})
+}

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -53,6 +53,16 @@ func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key 
 	return nil
 }
 
+func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = []any{}
+	for _, instance := range instances {
+		f.RecordedOps = append(f.RecordedOps, instance)
+	}
+	return nil
+}
+
 type FakeRuleReader struct{}
 
 func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -46,15 +46,15 @@ func (st DBstore) ListAlertInstances(ctx context.Context, cmd *models.ListAlertI
 }
 
 func (st DBstore) FullSync(ctx context.Context, instances []models.AlertInstance) error {
+	st.Logger.Info("Doing a full state sync", "count", len(instances))
 	if len(instances) == 0 {
 		return nil
 	}
-	st.Logger.Info("Doing a full state sync", "count", len(instances))
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		startTime := time.Now()
 		// First we delete all records from the table
 		// TODO: could we have multiple orgs? Not sure if the scheduler is isolated by org.
-		if _, err := sess.Exec("DELETE * FROM alert_instance WHERE rule_org_id = ?", instances[0].RuleOrgID); err != nil {
+		if _, err := sess.Exec("DELETE FROM alert_instance WHERE rule_org_id = ?", instances[0].RuleOrgID); err != nil {
 			return err
 		}
 		for _, alertInstance := range instances {


### PR DESCRIPTION
What is this PR about?

This PR adds the possibility to save the state of alert instances periodically using a ticker instead of saving them on each evaluation. This will help us to scale beyond what is possible today, as Grafana servers with a lot of alert instances run into write amplification problems over time.

What does this PR change?

- A new feature flag `alertSaveStateAsync` is introduced which controls if the state is saved on evaluation or periodically.
- The state manager is changed so that it can return all states for all orgs at once.
- The instance store gets a new function `FullSync`, that deletes all entries and then rewrites the current ones.
- The state manager gets a worker that is activated by the `alertSaveStateAsync` flag and is saving the known state async using the new `FullSync` function periodically and on shutdown.


Here is some data from our internal testing with about 2,000 alert instances using a MySQL database (avg. 1s~):

```
  |   | 2023-09-21 12:29:29.279 | logger=ngalert.state.manager t=2023-09-21T12:29:29.278928789Z level=info msg="Full state sync done" duration=1.132681424 instances=2010 |  
  |   | 2023-09-21 12:29:28.146 | logger=ngalert.state.manager t=2023-09-21T12:29:28.146249027Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:28:59.751 | logger=ngalert.state.manager t=2023-09-21T12:28:59.751001955Z level=info msg="Full state sync done" duration=1.605229503 instances=2010 |  
  |   | 2023-09-21 12:28:58.145 | logger=ngalert.state.manager t=2023-09-21T12:28:58.145776341Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:28:29.257 | logger=ngalert.state.manager t=2023-09-21T12:28:29.257195956Z level=info msg="Full state sync done" duration=1.110941519 instances=2010 |  
  |   | 2023-09-21 12:28:28.146 | logger=ngalert.state.manager t=2023-09-21T12:28:28.146257007Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:27:59.875 | logger=ngalert.state.manager t=2023-09-21T12:27:59.87488557Z level=info msg="Full state sync done" duration=1.728377432 instances=2010 |  
  |   | 2023-09-21 12:27:58.146 | logger=ngalert.state.manager t=2023-09-21T12:27:58.146510653Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:27:29.202 | logger=ngalert.state.manager t=2023-09-21T12:27:29.202502461Z level=info msg="Full state sync done" duration=1.055931185 instances=2010 |  
  |   | 2023-09-21 12:27:28.146 | logger=ngalert.state.manager t=2023-09-21T12:27:28.146580763Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:26:59.176 | logger=ngalert.state.manager t=2023-09-21T12:26:59.176088277Z level=info msg="Full state sync done" duration=1.029645845 instances=2010 |  
  |   | 2023-09-21 12:26:58.146 | logger=ngalert.state.manager t=2023-09-21T12:26:58.146444542Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:26:29.272 | logger=ngalert.state.manager t=2023-09-21T12:26:29.272804284Z level=info msg="Full state sync done" duration=1.126469543 instances=2010 |  
  |   | 2023-09-21 12:26:28.146 | logger=ngalert.state.manager t=2023-09-21T12:26:28.146337673Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:25:59.180 | logger=ngalert.state.manager t=2023-09-21T12:25:59.18035847Z level=info msg="Full state sync done" duration=1.033644594 instances=2010 |  
  |   | 2023-09-21 12:25:58.146 | logger=ngalert.state.manager t=2023-09-21T12:25:58.146717714Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:25:29.224 | logger=ngalert.state.manager t=2023-09-21T12:25:29.224706263Z level=info msg="Full state sync done" duration=1.078505144 instances=2010 |  
  |   | 2023-09-21 12:25:28.146 | logger=ngalert.state.manager t=2023-09-21T12:25:28.146206143Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:24:59.188 | logger=ngalert.state.manager t=2023-09-21T12:24:59.188804811Z level=info msg="Full state sync done" duration=1.042937874 instances=2010 |  
  |   | 2023-09-21 12:24:58.146 | logger=ngalert.state.manager t=2023-09-21T12:24:58.145871608Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:24:29.254 | logger=ngalert.state.manager t=2023-09-21T12:24:29.253950463Z level=info msg="Full state sync done" duration=1.107840243 instances=2010 |  
  |   | 2023-09-21 12:24:28.146 | logger=ngalert.state.manager t=2023-09-21T12:24:28.146112117Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:23:59.194 | logger=ngalert.state.manager t=2023-09-21T12:23:59.193895703Z level=info msg="Full state sync done" duration=1.048131248 instances=2010 |  
  |   | 2023-09-21 12:23:58.145 | logger=ngalert.state.manager t=2023-09-21T12:23:58.14576674Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:23:29.285 | logger=ngalert.state.manager t=2023-09-21T12:23:29.285068971Z level=info msg="Full state sync done" duration=1.139391789 instances=2010 |  
  |   | 2023-09-21 12:23:28.145 | logger=ngalert.state.manager t=2023-09-21T12:23:28.145677084Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:22:59.293 | logger=ngalert.state.manager t=2023-09-21T12:22:59.29306789Z level=info msg="Full state sync done" duration=1.146974358 instances=2010 |  
  |   | 2023-09-21 12:22:58.146 | logger=ngalert.state.manager t=2023-09-21T12:22:58.146091113Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:22:29.318 | logger=ngalert.state.manager t=2023-09-21T12:22:29.318789181Z level=info msg="Full state sync done" duration=1.172158923 instances=2010 |  
  |   | 2023-09-21 12:22:28.146 | logger=ngalert.state.manager t=2023-09-21T12:22:28.146625887Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:21:59.269 | logger=ngalert.state.manager t=2023-09-21T12:21:59.269776291Z level=info msg="Full state sync done" duration=1.123887287 instances=2010 |  
  |   | 2023-09-21 12:21:58.146 | logger=ngalert.state.manager t=2023-09-21T12:21:58.145901591Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:21:29.450 | logger=ngalert.state.manager t=2023-09-21T12:21:29.450415953Z level=info msg="Full state sync done" duration=1.304008013 instances=2010 |  
  |   | 2023-09-21 12:21:28.146 | logger=ngalert.state.manager t=2023-09-21T12:21:28.146407462Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:20:59.258 | logger=ngalert.state.manager t=2023-09-21T12:20:59.257942503Z level=info msg="Full state sync done" duration=1.111548905 instances=2010 |  
  |   | 2023-09-21 12:20:58.146 | logger=ngalert.state.manager t=2023-09-21T12:20:58.146395432Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:20:29.458 | logger=ngalert.state.manager t=2023-09-21T12:20:29.458446859Z level=info msg="Full state sync done" duration=1.3125832069999999 instances=2010 |  
  |   | 2023-09-21 12:20:28.146 | logger=ngalert.state.manager t=2023-09-21T12:20:28.145860166Z level=info msg="Full state sync start" |  
  |   | 2023-09-21 12:19:59.217 | logger=ngalert.state.manager t=2023-09-21T12:19:59.217108962Z level=info msg="Full state sync done" duration=1.071075782 instances=1910 |  
  |   | 2023-09-21 12:19:58.146 | logger=ngalert.state.manager t=2023-09-21T12:19:58.146036842Z level=info msg="Full state sync start"

```
