### PR TITLE
Sandbox: Set sandbox wrapper to height 100% for panel plugins

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_components.tsx
+++ b/public/app/features/plugins/sandbox/sandbox_components.tsx
@@ -92,7 +92,10 @@ const withSandboxWrapper = <P extends object>(
 ): React.MemoExoticComponent<FC<P>> => {
   const WithWrapper = React.memo((props: P) => {
     return (
-      <div data-plugin-sandbox={pluginMeta.id} style={{ height: pluginMeta.type === PluginType.app ? '100%' : 'auto' }}>
+      <div
+        data-plugin-sandbox={pluginMeta.id}
+        style={{ height: pluginMeta.type === PluginType.app || pluginMeta.type === PluginType.panel ? '100%' : 'auto' }}
+      >
         <WrappedComponent {...props} />
       </div>
     );


### PR DESCRIPTION
**What is this feature?**

It sets the sandbox wrapper for panel plugins to 100% (previously auto).

**Why do we need this feature?**

If set to `auto`, some plugins fail to show some UI elements such as scrollbars and tooltips.

**Who is this feature for?**

plugins running inside the frontend sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
