### PR TITLE
sql: improve imports in test

### DIFF
--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -1,8 +1,8 @@
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { CustomVariableModel, LoadingState, VariableHide } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { customBuilder } from 'app/features/variables/shared/testing/builders';
 
 import { SQLExpression } from '../types';
 
@@ -69,16 +69,34 @@ describe('TableSelector', () => {
 });
 
 describe('SQLWhereRow', () => {
+  function makeVariable(id: string, name: string, multi: boolean): CustomVariableModel {
+    return {
+      id,
+      name,
+      multi,
+      type: 'custom',
+      includeAll: false,
+      current: {},
+      options: [],
+      query: '',
+      rootStateKey: null,
+      global: false,
+      hide: VariableHide.dontHide,
+      skipUrlSync: false,
+      index: -1,
+      state: LoadingState.NotStarted,
+      error: null,
+      description: null,
+    };
+  }
+
   it('should remove quotes in a where clause including multi-value variable', () => {
     const exp: SQLExpression = {
       whereString: "hostname IN ('${multiHost}')",
     };
 
-    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
-    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
-
-    multiVar.multi = true;
-    nonMultiVar.multi = false;
+    const multiVar = makeVariable('multiVar', 'multiHost', true);
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
 
     const variables = [multiVar, nonMultiVar];
 
@@ -92,11 +110,8 @@ describe('SQLWhereRow', () => {
       whereString: "hostname IN ('${host}')",
     };
 
-    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
-    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
-
-    multiVar.multi = true;
-    nonMultiVar.multi = false;
+    const multiVar = makeVariable('multiVar', 'multiHost', true);
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
 
     const variables = [multiVar, nonMultiVar];
 
@@ -110,11 +125,8 @@ describe('SQLWhereRow', () => {
       whereString: "hostname IN ('${nonMultiHost}')",
     };
 
-    const multiVar = customBuilder().withId('multiVar').withName('multiHost').build();
-    const nonMultiVar = customBuilder().withId('nonMultiVar').withName('host').build();
-
-    multiVar.multi = true;
-    nonMultiVar.multi = false;
+    const multiVar = makeVariable('multiVar', 'multiHost', true);
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
 
     const variables = [multiVar, nonMultiVar];
 


### PR DESCRIPTION
(NOTE: only a unit-test has changed, no "production" code)

the shared sql-helper-code does the following import:
```ts
import { customBuilder } from 'app/features/variables/shared/testing/builders';
```

we cannot have this if we want to externalize the code one day.

unfortunately there is no exported function to do this, so i built the variable by hand.

there is an alternative approach too. the code we test is only accessing the `.name` and `.multi` attributes of the variable, so we could do something like this:
```ts
  function makeVariable(id: string, name: string, multi: boolean): CustomVariableModel {
    const result = { id, name, multi };
    return result as CustomVariableModel;
  }
```

(if we only fill out `id` & `name` & `multi`, the result is not a valid `CustomVariableModel`, it's missing many mandatory fields... but ` as ` makes typescript happy, and the test goes through)

i personally like the current approach more, but if others prefer the ` as ` way, i can adjust the code.