### PR TITLE
Plugin Extensions: Add context prop to PluginExtensionComponentConfig.component

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -85,7 +85,7 @@ export type PluginExtensionComponentConfig<Context extends object = object> = {
   // The React component that will be rendered as the extension
   // (This component receives the context as a prop when it is rendered. You can just return `null` from the component to hide for certain contexts)
   component: React.ComponentType<{
-    context: Context;
+    context?: Context;
   }>;
 
   // The unique identifier of the Extension Point

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -84,7 +84,9 @@ export type PluginExtensionComponentConfig<Context extends object = object> = {
 
   // The React component that will be rendered as the extension
   // (This component receives the context as a prop when it is rendered. You can just return `null` from the component to hide for certain contexts)
-  component: React.ComponentType;
+  component: React.ComponentType<{
+    context: Context;
+  }>;
 
   // The unique identifier of the Extension Point
   // (Core Grafana extension point ids are available in the `PluginExtensionPoints` enum)


### PR DESCRIPTION
**What changed?**

This PR adds an optional `context: Context` prop to the `PluginExtensionComponentConfig` as it is sent when using the `grafana/datasources/config` extension point. 
