### PR TITLE
Navigation: hide `sectionNav` when the `dockedMegaMenu` feature toggle is enabled

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -4,6 +4,7 @@ import React, { PropsWithChildren } from 'react';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { useStyles2, LinkButton } from '@grafana/ui';
+import config from 'app/core/config';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
 import { KioskMode } from 'app/types';
@@ -61,7 +62,9 @@ export function AppChrome({ children }: Props) {
       )}
       <main className={contentClass} id="pageContent">
         <div className={styles.panes}>
-          {state.layout === PageLayoutType.Standard && state.sectionNav && <SectionNav model={state.sectionNav} />}
+          {state.layout === PageLayoutType.Standard && state.sectionNav && !config.featureToggles.dockedMegaMenu && (
+            <SectionNav model={state.sectionNav} />
+          )}
           <div className={styles.pageContainer}>{children}</div>
         </div>
       </main>

--- a/public/app/core/components/AppChrome/SectionNav/SectionNav.tsx
+++ b/public/app/core/components/AppChrome/SectionNav/SectionNav.tsx
@@ -4,6 +4,7 @@ import { useLocalStorage } from 'react-use';
 
 import { NavModel, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, CustomScrollbar, useTheme2 } from '@grafana/ui';
+import config from 'app/core/config';
 
 import { SectionNavItem } from './SectionNavItem';
 import { SectionNavToggle } from './SectionNavToggle';
@@ -15,6 +16,10 @@ export interface Props {
 export function SectionNav({ model }: Props) {
   const styles = useStyles2(getStyles);
   const { isExpanded, onToggleSectionNav } = useSectionNavState();
+
+  if (config.featureToggles.dockedMegaMenu) {
+    return null;
+  }
 
   if (!Boolean(model.main?.children?.length)) {
     return null;

--- a/public/app/core/components/AppChrome/SectionNav/SectionNav.tsx
+++ b/public/app/core/components/AppChrome/SectionNav/SectionNav.tsx
@@ -4,7 +4,6 @@ import { useLocalStorage } from 'react-use';
 
 import { NavModel, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, CustomScrollbar, useTheme2 } from '@grafana/ui';
-import config from 'app/core/config';
 
 import { SectionNavItem } from './SectionNavItem';
 import { SectionNavToggle } from './SectionNavToggle';
@@ -16,10 +15,6 @@ export interface Props {
 export function SectionNav({ model }: Props) {
   const styles = useStyles2(getStyles);
   const { isExpanded, onToggleSectionNav } = useSectionNavState();
-
-  if (config.featureToggles.dockedMegaMenu) {
-    return null;
-  }
 
   if (!Boolean(model.main?.children?.length)) {
     return null;


### PR DESCRIPTION
**What is this feature?**
We hide `sectionNav` when the `dockedMegaMenu` feature toggle is enabled.

**Why do we need this feature?**
To hide the section nav when the navigation menu is persistent.

**Who is this feature for?**
Everybody with the dockedMegaMenu` feature toggle enabled.

**Which issue(s) does this PR fix?**:
Fixes #75025 