### PR TITLE
InfluxDB SQL: Provide raw query preview for query history

### DIFF
--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -50,6 +50,7 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 			continue
 		}
 
+		logger.Info(fmt.Sprintf("InfluxDB executing SQL: %s", qm.RawSQL))
 		info, err := r.client.Execute(ctx, qm.RawSQL)
 		if err != nil {
 			tRes.Responses[q.RefID] = backend.ErrDataResponse(backend.StatusInternal, fmt.Sprintf("flightsql: %s", err))

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -34,6 +34,7 @@ import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_sr
 import { AnnotationEditor } from './components/editor/annotation/AnnotationEditor';
 import { FluxQueryEditor } from './components/editor/query/flux/FluxQueryEditor';
 import { BROWSER_MODE_DISABLED_MESSAGE } from './constants';
+import { toRawSql } from './fsql/sqlUtil';
 import InfluxQueryModel from './influx_query_model';
 import InfluxSeries from './influx_series';
 import { buildMetadataQuery } from './influxql_query_builder';
@@ -183,10 +184,16 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   }
 
   getQueryDisplayText(query: InfluxQuery) {
-    if (this.version === InfluxVersion.Flux) {
-      return query.query;
+    switch (this.version) {
+      case InfluxVersion.Flux:
+        return query.query;
+      case InfluxVersion.SQL:
+        return toRawSql(query);
+      case InfluxVersion.InfluxQL:
+        return new InfluxQueryModel(query).render(false);
+      default:
+        return '';
     }
-    return new InfluxQueryModel(query).render(false);
   }
 
   /**

--- a/public/app/plugins/datasource/influxdb/fsql/sqlUtil.test.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/sqlUtil.test.ts
@@ -1,0 +1,32 @@
+import { SQLQuery } from 'app/features/plugins/sql/types';
+
+import { QueryEditorExpressionType } from '../../../../features/plugins/sql/expressions';
+
+import { toRawSql } from './sqlUtil';
+
+describe('toRawSql', () => {
+  it('should render sql properly', () => {
+    const expected = 'SELECT host FROM iox.value1 LIMIT 50';
+    const testQuery: SQLQuery = {
+      refId: 'A',
+      sql: {
+        limit: 50,
+        columns: [
+          {
+            parameters: [
+              {
+                name: 'host',
+                type: QueryEditorExpressionType.FunctionParameter,
+              },
+            ],
+            type: QueryEditorExpressionType.Function,
+          },
+        ],
+      },
+      dataset: 'iox',
+      table: 'value1',
+    };
+    const result = toRawSql(testQuery);
+    expect(result).toEqual(expected);
+  });
+});

--- a/public/app/plugins/datasource/influxdb/fsql/sqlUtil.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/sqlUtil.ts
@@ -36,7 +36,7 @@ export function toRawSql({ sql, dataset, table }: SQLQuery): string {
 
   // Although LIMIT 0 doesn't make sense, it is still possible to have LIMIT 0
   if (isLimit(sql.limit)) {
-    rawQuery += `LIMIT ${sql.limit} `;
+    rawQuery += `LIMIT ${sql.limit}`;
   }
 
   return rawQuery;

--- a/public/app/plugins/datasource/influxdb/fsql/sqlUtil.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/sqlUtil.ts
@@ -1,0 +1,57 @@
+import { isEmpty } from 'lodash';
+
+import { SQLExpression, SQLQuery } from 'app/features/plugins/sql/types';
+import { haveColumns } from 'app/features/plugins/sql/utils/sql.utils';
+
+export function toRawSql({ sql, dataset, table }: SQLQuery): string {
+  let rawQuery = '';
+
+  // Return early with empty string if there is no sql column
+  if (!sql || !haveColumns(sql.columns)) {
+    return rawQuery;
+  }
+
+  rawQuery += createSelectClause(sql.columns, sql.limit);
+
+  if (dataset && table) {
+    rawQuery += `FROM ${dataset}.${table} `;
+  }
+
+  if (sql.whereString) {
+    rawQuery += `WHERE ${sql.whereString} `;
+  }
+
+  if (sql.groupBy?.[0]?.property.name) {
+    const groupBy = sql.groupBy.map((g) => g.property.name).filter((g) => !isEmpty(g));
+    rawQuery += `GROUP BY ${groupBy.join(', ')} `;
+  }
+
+  if (sql.orderBy?.property.name) {
+    rawQuery += `ORDER BY ${sql.orderBy.property.name} `;
+  }
+
+  if (sql.orderBy?.property.name && sql.orderByDirection) {
+    rawQuery += `${sql.orderByDirection} `;
+  }
+
+  return rawQuery;
+}
+
+function createSelectClause(sqlColumns: NonNullable<SQLExpression['columns']>, limit?: number): string {
+  const columns = sqlColumns.map((c) => {
+    let rawColumn = '';
+    if (c.name && c.alias) {
+      rawColumn += `${c.name}(${c.parameters?.map((p) => `${p.name}`)}) AS ${c.alias}`;
+    } else if (c.name) {
+      rawColumn += `${c.name}(${c.parameters?.map((p) => `${p.name}`)})`;
+    } else if (c.alias) {
+      rawColumn += `${c.parameters?.map((p) => `${p.name}`)} AS ${c.alias}`;
+    } else {
+      rawColumn += `${c.parameters?.map((p) => `${p.name}`)}`;
+    }
+    return rawColumn;
+  });
+  return `SELECT ${isLimit(limit) ? 'TOP(' + limit + ')' : ''} ${columns.join(', ')} `;
+}
+
+const isLimit = (limit: number | undefined): boolean => limit !== undefined && limit >= 0;


### PR DESCRIPTION
**What is this feature?**

Support `getQueryDisplayText` for InfluxDB SQL variant. 

![image](https://github.com/grafana/grafana/assets/820946/9b41a16a-04d9-4250-8052-006bd9041d69)


**Why do we need this feature?**

To be able to show the query in the query history panel

**Who is this feature for?**

InfluxDB SQL query language users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/74987

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
