### PR TITLE
Cloudwatch: Backport 73524 Bring Back Legacy Log Group Picker

### DIFF
--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -26,6 +26,10 @@ func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/accounts", routes.ResourceRequestMiddleware(routes.AccountsHandler, logger, e.getRequestContext))
 	mux.HandleFunc("/namespaces", routes.ResourceRequestMiddleware(routes.NamespacesHandler, logger, e.getRequestContext))
 	mux.HandleFunc("/log-group-fields", routes.ResourceRequestMiddleware(routes.LogGroupFieldsHandler, logger, e.getRequestContext))
+
+	// remove this once AWS's Cross Account Observability is supported in GovCloud
+	mux.HandleFunc("/legacy-log-groups", handleResourceReq(e.handleGetLogGroups))
+
 	return mux
 }
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
@@ -25,12 +25,23 @@ jest.mock('./XrayLinkConfig', () => ({
 
 const putMock = jest.fn();
 const getMock = jest.fn();
+const mockAppEvents = {
+  subscribe: () => ({ unsubscribe: jest.fn() }),
+};
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => ({
     put: putMock,
     get: getMock,
   }),
+  getAppEvents: () => mockAppEvents,
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    awsAssumeRoleEnabled: true,
+    featureToggles: {
+      cloudWatchCrossAccountQuerying: true,
+    },
+  },
 }));
 
 const props: Props = {
@@ -150,7 +161,7 @@ describe('Render', () => {
 
   it('should display log group selector field', async () => {
     setup();
-    await waitFor(async () => expect(await screen.getByText('Select log groups')).toBeInTheDocument());
+    await waitFor(async () => expect(screen.getByText('Select log groups')).toBeInTheDocument());
   });
 
   it('should only display the first two default log groups and show all of them when clicking "Show all" button', async () => {
@@ -204,17 +215,7 @@ describe('Render', () => {
   });
 
   it('should show error message if Select log group button is clicked when data source is never saved', async () => {
-    const SAVED_VERSION = undefined;
-    const newProps = {
-      ...props,
-      options: {
-        ...props.options,
-        version: SAVED_VERSION,
-      },
-    };
-
-    render(<ConfigEditor {...newProps} />);
-
+    setup({ version: 1 });
     await waitFor(() => expect(screen.getByText('Select log groups')).toBeInTheDocument());
     await userEvent.click(screen.getByText('Select log groups'));
     await waitFor(() =>
@@ -256,12 +257,11 @@ describe('Render', () => {
   });
 
   it('should open log group selector if Select log group button is clicked when data source has saved changes', async () => {
-    const SAVED_VERSION = undefined;
     const newProps = {
       ...props,
       options: {
         ...props.options,
-        version: SAVED_VERSION,
+        version: 1,
       },
     };
     const { rerender } = render(<ConfigEditor {...newProps} />);
@@ -270,7 +270,7 @@ describe('Render', () => {
       ...newProps,
       options: {
         ...newProps.options,
-        version: 1,
+        version: 2,
       },
     };
     rerender(<ConfigEditor {...rerenderProps} />);

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -19,7 +19,7 @@ import { CloudWatchDatasource } from '../datasource';
 import { SelectableResourceValue } from '../resources/types';
 import { CloudWatchJsonData, CloudWatchSecureJsonData } from '../types';
 
-import { LogGroupsField } from './LogGroups/LogGroupsField';
+import { LogGroupsFieldWrapper } from './LogGroups/LogGroupsField';
 import { XrayLinkConfig } from './XrayLinkConfig';
 
 export type Props = DataSourcePluginOptionsEditorProps<CloudWatchJsonData, CloudWatchSecureJsonData>;
@@ -94,39 +94,47 @@ export const ConfigEditor = (props: Props) => {
           shrink={true}
           {...logGroupFieldState}
         >
-          <LogGroupsField
-            region={defaultRegion ?? ''}
-            datasource={datasource}
-            onBeforeOpen={() => {
-              if (saved) {
-                return;
-              }
+          {datasource ? (
+            <LogGroupsFieldWrapper
+              region={defaultRegion ?? ''}
+              datasource={datasource}
+              onBeforeOpen={() => {
+                if (saved) {
+                  return;
+                }
 
-              let error = 'You need to save the data source before adding log groups.';
-              if (props.options.version && props.options.version > 1) {
-                error =
-                  'You have unsaved connection detail changes. You need to save the data source before adding log groups.';
-              }
-              setLogGroupFieldState({
-                invalid: true,
-                error,
-              });
-              throw new Error(error);
-            }}
-            legacyLogGroupNames={defaultLogGroups}
-            logGroups={logGroups}
-            onChange={(updatedLogGroups) => {
-              onOptionsChange({
-                ...props.options,
-                jsonData: {
-                  ...props.options.jsonData,
-                  logGroups: updatedLogGroups,
-                  defaultLogGroups: undefined,
-                },
-              });
-            }}
-            maxNoOfVisibleLogGroups={2}
-          />
+                let error = 'You need to save the data source before adding log groups.';
+                if (props.options.version && props.options.version > 1) {
+                  error =
+                    'You have unsaved connection detail changes. You need to save the data source before adding log groups.';
+                }
+                setLogGroupFieldState({
+                  invalid: true,
+                  error,
+                });
+                throw new Error(error);
+              }}
+              legacyLogGroupNames={defaultLogGroups}
+              logGroups={logGroups}
+              onChange={(updatedLogGroups) => {
+                onOptionsChange({
+                  ...props.options,
+                  jsonData: {
+                    ...props.options.jsonData,
+                    logGroups: updatedLogGroups,
+                    defaultLogGroups: undefined,
+                  },
+                });
+              }}
+              maxNoOfVisibleLogGroups={2}
+              //legacy props
+              legacyOnChange={(logGroups) => {
+                updateDatasourcePluginJsonDataOption(props, 'defaultLogGroups', logGroups);
+              }}
+            />
+          ) : (
+            <></>
+          )}
         </InlineField>
       </div>
       <XrayLinkConfig
@@ -212,7 +220,7 @@ function useDataSourceSavedState(props: Props) {
   ]);
 
   useEffect(() => {
-    props.options.version && setSaved(true);
+    props.options.version && props.options.version > 1 && setSaved(true);
   }, [props.options.version]);
 
   return saved;

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupNamesSelection.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupNamesSelection.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { CloudWatchDatasource } from '../../datasource';
+
+import { LogGroupSelector } from './LegacyLogGroupSelector';
+
+type Props = {
+  datasource: CloudWatchDatasource;
+  onChange: (logGroups: string[]) => void;
+  region: string;
+  legacyLogGroupNames: string[];
+};
+
+const rowGap = css`
+  gap: 3px;
+`;
+
+export const LegacyLogGroupSelection = ({ datasource, region, legacyLogGroupNames, onChange }: Props) => {
+  return (
+    <div className={`gf-form gf-form--grow flex-grow-1 ${rowGap}`}>
+      <LogGroupSelector
+        region={region}
+        selectedLogGroups={legacyLogGroupNames}
+        datasource={datasource}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupSelector.tsx
@@ -1,0 +1,144 @@
+import { debounce, unionBy } from 'lodash';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { SelectableValue, toOption } from '@grafana/data';
+import { MultiSelect } from '@grafana/ui';
+import { InputActionMeta } from '@grafana/ui/src/components/Select/types';
+import { notifyApp } from 'app/core/actions';
+import { createErrorNotification } from 'app/core/copy/appNotification';
+import { dispatch } from 'app/store/store';
+
+import { CloudWatchDatasource } from '../../../datasource';
+import { appendTemplateVariables } from '../../../utils/utils';
+
+const MAX_LOG_GROUPS = 20;
+const MAX_VISIBLE_LOG_GROUPS = 4;
+const DEBOUNCE_TIMER = 300;
+
+export interface LogGroupSelectorProps {
+  region: string;
+  selectedLogGroups: string[];
+  onChange: (logGroups: string[]) => void;
+
+  datasource?: CloudWatchDatasource;
+  onOpenMenu?: () => Promise<void>;
+  width?: number | 'auto';
+  saved?: boolean; // is only used in the config editor
+}
+
+export const LogGroupSelector: React.FC<LogGroupSelectorProps> = ({
+  region,
+  selectedLogGroups,
+  onChange,
+  datasource,
+  onOpenMenu,
+  width,
+  saved = true,
+}) => {
+  const [loadingLogGroups, setLoadingLogGroups] = useState(false);
+  const [availableLogGroups, setAvailableLogGroups] = useState<Array<SelectableValue<string>>>([]);
+  const logGroupOptions = useMemo(
+    () => unionBy(availableLogGroups, selectedLogGroups?.map(toOption), 'value'),
+    [availableLogGroups, selectedLogGroups]
+  );
+
+  const fetchLogGroupOptions = useCallback(
+    async (region: string, logGroupNamePrefix?: string) => {
+      if (!datasource) {
+        return [];
+      }
+      try {
+        const logGroups = await datasource.resources.legacyDescribeLogGroups(region, logGroupNamePrefix);
+        return logGroups;
+      } catch (err) {
+        dispatch(notifyApp(createErrorNotification(typeof err === 'string' ? err : JSON.stringify(err))));
+        return [];
+      }
+    },
+    [datasource]
+  );
+
+  const onLogGroupSearch = async (searchTerm: string, region: string, actionMeta: InputActionMeta) => {
+    if (actionMeta.action !== 'input-change' || !datasource) {
+      return;
+    }
+
+    // No need to fetch matching log groups if the search term isn't valid
+    // This is also useful for preventing searches when a user is typing out a log group with template vars
+    // See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_LogGroup.html for the source of the pattern below
+    const logGroupNamePattern = /^[\.\-_/#A-Za-z0-9]+$/;
+    if (!logGroupNamePattern.test(searchTerm)) {
+      if (searchTerm !== '') {
+        dispatch(notifyApp(createErrorNotification('Invalid Log Group name: ' + searchTerm)));
+      }
+      return;
+    }
+
+    setLoadingLogGroups(true);
+    const matchingLogGroups = await fetchLogGroupOptions(region, searchTerm);
+    setAvailableLogGroups(unionBy(availableLogGroups, matchingLogGroups, 'value'));
+    setLoadingLogGroups(false);
+  };
+
+  // Reset the log group options if the datasource or region change and are saved
+  useEffect(() => {
+    async function getAvailableLogGroupOptions() {
+      // Don't call describeLogGroups if datasource or region is undefined
+      if (!datasource || !datasource.getActualRegion(region)) {
+        setAvailableLogGroups([]);
+        return;
+      }
+
+      setLoadingLogGroups(true);
+      return fetchLogGroupOptions(datasource.getActualRegion(region))
+        .then((logGroups) => {
+          setAvailableLogGroups(logGroups);
+        })
+        .finally(() => {
+          setLoadingLogGroups(false);
+        });
+    }
+
+    // Config editor does not fetch new log group options unless changes have been saved
+    saved && getAvailableLogGroupOptions();
+
+    // if component unmounts in the middle of setting state, we reset state and unsubscribe from fetchLogGroupOptions
+    return () => {
+      setAvailableLogGroups([]);
+      setLoadingLogGroups(false);
+    };
+    // this hook shouldn't get called every time selectedLogGroups or onChange updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasource, region, saved]);
+
+  const onOpenLogGroupMenu = async () => {
+    if (onOpenMenu) {
+      await onOpenMenu();
+    }
+  };
+
+  const onLogGroupSearchDebounced = debounce(onLogGroupSearch, DEBOUNCE_TIMER);
+
+  return (
+    <MultiSelect
+      inputId="default-log-groups"
+      aria-label="Log Groups"
+      allowCustomValue
+      options={datasource ? appendTemplateVariables(datasource, logGroupOptions) : logGroupOptions}
+      value={selectedLogGroups}
+      onChange={(v) => onChange(v.filter(({ value }) => value).map(({ value }) => value))}
+      closeMenuOnSelect={false}
+      isClearable
+      isOptionDisabled={() => selectedLogGroups.length >= MAX_LOG_GROUPS}
+      placeholder="Choose Log Groups"
+      maxVisibleValues={MAX_VISIBLE_LOG_GROUPS}
+      noOptionsMessage="No log groups available"
+      isLoading={loadingLogGroups}
+      onOpenMenu={onOpenLogGroupMenu}
+      onInputChange={(value, actionMeta) => {
+        onLogGroupSearchDebounced(value, region, actionMeta);
+      }}
+      width={width}
+    />
+  );
+};

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LegacyLogGroupSelector.tsx
@@ -8,8 +8,8 @@ import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { dispatch } from 'app/store/store';
 
-import { CloudWatchDatasource } from '../../../datasource';
-import { appendTemplateVariables } from '../../../utils/utils';
+import { CloudWatchDatasource } from '../../datasource';
+import { appendTemplateVariables } from '../../utils/utils';
 
 const MAX_LOG_GROUPS = 20;
 const MAX_VISIBLE_LOG_GROUPS = 4;

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsField.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 
+import { config } from '@grafana/runtime';
+
 import { CloudWatchDatasource } from '../../datasource';
 import { useAccountOptions } from '../../hooks';
 import { DescribeLogGroupsRequest } from '../../resources/types';

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsField.tsx
@@ -7,11 +7,12 @@ import { DescribeLogGroupsRequest } from '../../resources/types';
 import { LogGroup } from '../../types';
 import { isTemplateVariable } from '../../utils/templateVariableUtils';
 
+import { LegacyLogGroupSelection } from './LegacyLogGroupNamesSelection';
 import { LogGroupsSelector } from './LogGroupsSelector';
 import { SelectedLogGroups } from './SelectedLogGroups';
 
 type Props = {
-  datasource?: CloudWatchDatasource;
+  datasource: CloudWatchDatasource;
   onChange: (logGroups: LogGroup[]) => void;
   legacyLogGroupNames?: string[];
   logGroups?: LogGroup[];
@@ -88,4 +89,33 @@ export const LogGroupsField = ({
       ></SelectedLogGroups>
     </div>
   );
+};
+
+// We had to bring back the Legacy Log Group selector to support due to an issue where GovClouds do not support the new Log Group API
+// when that is fixed we can get rid of this wrapper component and just export the LogGroupsField
+type WrapperProps = {
+  datasource: CloudWatchDatasource;
+  onChange: (logGroups: LogGroup[]) => void;
+  legacyLogGroupNames?: string[]; // will need this for a while for migration purposes
+  logGroups?: LogGroup[];
+  region: string;
+  maxNoOfVisibleLogGroups?: number;
+  onBeforeOpen?: () => void;
+
+  // Legacy Props, can remove once we remove support for Legacy Log Group Selector
+  legacyOnChange: (logGroups: string[]) => void;
+};
+
+export const LogGroupsFieldWrapper = (props: WrapperProps) => {
+  if (!config.featureToggles.cloudWatchCrossAccountQuerying) {
+    return (
+      <LegacyLogGroupSelection
+        {...props}
+        onChange={props.legacyOnChange}
+        legacyLogGroupNames={props.legacyLogGroupNames || []}
+      />
+    );
+  }
+
+  return <LogGroupsField {...props} />;
 };

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -21,7 +21,7 @@ import syntax from '../language/cloudwatch-logs/syntax';
 import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../types';
 import { getStatsGroups } from '../utils/query/getStatsGroups';
 
-import { LogGroupsField } from './LogGroups/LogGroupsField';
+import { LogGroupsFieldWrapper } from './LogGroups/LogGroupsField';
 
 export interface CloudWatchLogsQueryFieldProps
   extends QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>,
@@ -82,13 +82,17 @@ export const CloudWatchLogsQueryField = (props: CloudWatchLogsQueryFieldProps) =
 
   return (
     <>
-      <LogGroupsField
+      <LogGroupsFieldWrapper
         region={query.region}
         datasource={datasource}
         legacyLogGroupNames={query.logGroupNames}
         logGroups={query.logGroups}
-        onChange={(logGroups) => {
+        onChange={(logGroups: LogGroup[]) => {
           onChange({ ...query, logGroups, logGroupNames: undefined });
+        }}
+        //legacy props can be removed once we remove support for Legacy Log Group Selector
+        legacyOnChange={(logGroups: string[]) => {
+          onChange({ ...query, logGroupNames: logGroups });
         }}
       />
       <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -18,7 +18,7 @@ import {
 // dom also includes Element polyfills
 import { CloudWatchDatasource } from '../datasource';
 import syntax from '../language/cloudwatch-logs/syntax';
-import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery, LogGroup } from '../types';
 import { getStatsGroups } from '../utils/query/getStatsGroups';
 
 import { LogGroupsFieldWrapper } from './LogGroups/LogGroupsField';

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField/LogsQueryField.tsx
@@ -11,8 +11,7 @@ import { registerLanguage } from '../../language/monarch/register';
 import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../../types';
 import { getStatsGroups } from '../../utils/query/getStatsGroups';
 
-import { LogGroupsField } from './../LogGroups/LogGroupsField';
-
+import { LogGroupsFieldWrapper } from './../LogGroups/LogGroupsField';
 export interface CloudWatchLogsQueryFieldProps
   extends QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>,
     Themeable2 {
@@ -48,13 +47,17 @@ export const CloudWatchLogsQueryFieldMonaco = (props: CloudWatchLogsQueryFieldPr
 
   return (
     <>
-      <LogGroupsField
+      <LogGroupsFieldWrapper
         region={query.region}
         datasource={datasource}
         legacyLogGroupNames={query.logGroupNames}
         logGroups={query.logGroups}
         onChange={(logGroups) => {
           onChange({ ...query, logGroups, logGroupNames: undefined });
+        }}
+        //legacy props
+        legacyOnChange={(logGroupNames) => {
+          onChange({ ...query, logGroupNames });
         }}
       />
       <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
@@ -46,6 +46,15 @@ jest.mock('./SQLCodeEditor', () => ({
 }));
 
 export { SQLCodeEditor } from './SQLCodeEditor';
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      cloudWatchCrossAccountQuerying: true,
+    },
+  },
+}));
 
 describe('QueryEditor should render right editor', () => {
   describe('when using grafana 6.3.0 metric query', () => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -72,6 +72,7 @@ export class CloudWatchDatasource
     this.annotationQueryRunner = new CloudWatchAnnotationQueryRunner(instanceSettings, templateSrv);
     this.variables = new CloudWatchVariableSupport(this.resources);
     this.annotations = CloudWatchAnnotationSupport;
+    this.defaultLogGroups = instanceSettings.jsonData.defaultLogGroups;
   }
 
   filterQuery(query: CloudWatchQuery) {

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -160,4 +160,11 @@ export class ResourcesAPI extends CloudWatchRequest {
       tags: JSON.stringify(this.convertMultiFilterFormat(tags, 'tag name')),
     });
   }
+
+  legacyDescribeLogGroups(region: string, logGroupNamePrefix?: string) {
+    return this.memoizedGetRequest<SelectableResourceValue[]>('legacy-log-groups', {
+      region: this.templateSrv.replace(this.getActualRegion(region)),
+      logGroupNamePrefix: logGroupNamePrefix || '',
+    });
+  }
 }


### PR DESCRIPTION
Manual Backport of https://github.com/grafana/grafana/pull/73524

We had an issue with AWS GovCloud where users were unable to use some newer APIs related to log groups, so we've brought back some older ui that used older APIs for existing GovCloud users until AWS is able to improve their api so that all users have access to it. 

We had originally decided not to the backport this work because despite fixing a regression, it is arguably introducing new functionality and there's some room for risk that this will introduce additional bugs, however after some discussion, we've decided to backport as we hope the benefits outweigh the risks here. 

That said would appreciate another set of eyes/manual testing in case I may have missed something. 