### PR TITLE
Loki Query Builder: Better numeric support

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -20,7 +20,8 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
 
   renderLabels(labels: QueryBuilderLabelFilter[]) {
     if (labels.length === 0) {
-      return '{}';
+      // We can have operations without labels
+      // return '{}';
     }
 
     return super.renderLabels(labels);

--- a/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
@@ -82,12 +82,12 @@ export const binaryScalarOperations: QueryBuilderOperationDef[] = binaryScalarDe
   const params: QueryBuilderOperationParamDef[] = [{ name: 'Value', type: 'number' }];
   const defaultParams: any[] = [2];
   if (opDef.comparison) {
-    params.unshift({
+    params.push({
       name: 'Bool',
       type: 'boolean',
       description: 'If checked comparison will return 0 or 1 for the value rather than filtering.',
     });
-    defaultParams.unshift(false);
+    defaultParams.push(false);
   }
 
   return {
@@ -107,8 +107,7 @@ function getSimpleBinaryRenderer(operator: string) {
     let param = model.params[0];
     let bool = '';
     if (model.params.length === 2) {
-      param = model.params[1];
-      bool = model.params[0] ? ' bool' : '';
+      bool = model.params[1] ? ' bool' : '';
     }
 
     return `${innerExpr} ${operator}${bool} ${param}`;

--- a/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts
@@ -9,6 +9,11 @@ import { LokiOperationId, LokiVisualQueryOperationCategory } from './types';
 
 export const binaryScalarDefs = [
   {
+    id: LokiOperationId.Scalar,
+    name: 'Scalar value',
+    sign: '',
+  },
+  {
     id: LokiOperationId.Addition,
     name: 'Add scalar',
     sign: '+',

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -11,6 +11,59 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses simple binary comparison', () => {
+    expect(buildVisualQueryFromString('count_over_time({app="aggregator"} [$__auto]) == 11')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        operations: [
+          {
+            id: LokiOperationId.CountOverTime,
+            params: ['$__auto'],
+          },
+          {
+            id: LokiOperationId.EqualTo,
+            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            params: [false, 11],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
+  // This still fails because loki doesn't properly parse the bool operator
+  it('parses simple query with label-values with boolean operator', () => {
+    expect(buildVisualQueryFromString('count_over_time({app="aggregator"} [$__auto]) == bool 12')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        operations: [
+          {
+            id: LokiOperationId.CountOverTime,
+            params: ['$__auto'],
+          },
+          {
+            id: LokiOperationId.EqualTo,
+            // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
+            params: [true, 12],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
   it('parses simple query with label-values', () => {
     expect(buildVisualQueryFromString('{app="frontend"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -29,7 +29,7 @@ describe('buildVisualQueryFromString', () => {
           {
             id: LokiOperationId.EqualTo,
             // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
-            params: [false, 11],
+            params: [11, false],
           },
         ],
       },
@@ -56,7 +56,7 @@ describe('buildVisualQueryFromString', () => {
           {
             id: LokiOperationId.EqualTo,
             // defined in getSimpleBinaryRenderer, the first argument is the bool parameter, and the second is the value
-            params: [true, 12],
+            params: [12, true],
           },
         ],
       },

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -54,7 +54,6 @@ import {
   getAllByType,
   getLeftMostChild,
   getString,
-  makeBinOp,
   makeError,
   replaceVariables,
 } from '../../prometheus/querybuilder/shared/parsingUtils';
@@ -684,5 +683,23 @@ function handleKeepFilter(expr: string, node: SyntaxNode, context: Context): Que
   return {
     id: LokiOperationId.Keep,
     params: labels,
+  };
+}
+
+export function makeBinOp(
+  opDef: { id: string; comparison?: boolean },
+  expr: string,
+  numberNode: SyntaxNode,
+  hasBool: boolean
+): QueryBuilderOperation {
+  // params are backwards in loki for some reason?
+  const params: QueryBuilderOperationParamValue[] = [];
+  if (opDef.comparison) {
+    params.push(hasBool);
+  }
+  params.push(parseFloat(getString(expr, numberNode)));
+  return {
+    id: opDef.id,
+    params,
   };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -144,6 +144,12 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       break;
     }
 
+    case NumberLezer: {
+      // debugger;
+      visQuery.operations.push(getNumberParser(expr));
+      break;
+    }
+
     case LabelFilter: {
       const { operation, error } = getLabelFilter(expr, node);
       if (operation) {
@@ -275,6 +281,16 @@ function getLineFilter(expr: string, node: SyntaxNode): { operation?: QueryBuild
       id: mapFilter[filter],
       params: [filterExpr],
     },
+  };
+}
+
+function getNumberParser(expr: string): QueryBuilderOperation {
+  const funcName = LokiOperationId.Addition;
+  let params = [expr];
+
+  return {
+    id: funcName,
+    params,
   };
 }
 
@@ -533,7 +549,8 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context) {
 
   if (leftNumber) {
     // TODO: this should be already handled in case parent is binary expression as it has to be added to parent
-    //  if query starts with a number that isn't handled now.
+    // If we have a number on the lhs we can add it as a scalar operation
+    visQuery.operations.push(makeBinOp(opDef, expr, left, !!binModifier?.isBool));
   } else {
     // If this is binary we don't really know if there is a query or just chained scalars. So
     // we have to traverse a bit deeper to know

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -94,6 +94,8 @@ export enum LokiOperationId {
   LessThan = '__less_than',
   GreaterOrEqual = '__greater_or_equal',
   LessOrEqual = '__less_or_equal',
+  // Scalar values, can only be used on left side of binary operations
+  Scalar = '__scalar',
 }
 
 export enum LokiOperationOrder {

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -1,5 +1,5 @@
 import { buildVisualQueryFromString } from './parsing';
-import { PromVisualQuery } from './types';
+import { PromOperationId, PromVisualQuery } from './types';
 
 describe('buildVisualQueryFromString', () => {
   it('creates no errors for empty query', () => {
@@ -10,6 +10,50 @@ describe('buildVisualQueryFromString', () => {
         metric: '',
       })
     );
+  });
+  it('parses simple binary comparison', () => {
+    expect(buildVisualQueryFromString('{app="aggregator"} == 11')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        metric: '',
+        operations: [
+          {
+            id: PromOperationId.EqualTo,
+            params: [11, false],
+          },
+        ],
+      },
+      errors: [],
+    });
+  });
+
+  // This still fails because loki doesn't properly parse the bool operator
+  it('parses simple query with with boolean operator', () => {
+    expect(buildVisualQueryFromString('{app="aggregator"} == bool 12')).toEqual({
+      query: {
+        labels: [
+          {
+            label: 'app',
+            op: '=',
+            value: 'aggregator',
+          },
+        ],
+        metric: '',
+        operations: [
+          {
+            id: PromOperationId.EqualTo,
+            params: [12, true],
+          },
+        ],
+      },
+      errors: [],
+    });
   });
   it('parses simple query', () => {
     expect(buildVisualQueryFromString('counters_logins{app="frontend"}')).toEqual(

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -86,6 +86,7 @@ export function getString(expr: string, node: SyntaxNode | TreeCursor | null | u
 
 /**
  * Create simple scalar binary op object.
+ * Implementation in loki is backwards?
  * @param opDef - definition of the op to be created
  * @param expr
  * @param numberNode - the node for the scalar


### PR DESCRIPTION
**What is this feature?**
WIP!

Numeric operations are parsed oddly by the query builder:
 * Any numeric on the left hand side is stripped out i.e. `count_over_time({app="aggregator"}[$__auto]) == 2` vs `2 == count_over_time({app="aggregator"}[$__auto])`
 * Valid loki queries can be converted to broken logQL in the query builder
 * * e.g. <img width="1710" alt="image" src="https://github.com/grafana/grafana/assets/109082771/c0b1d733-e05d-4611-8740-0853d548db22">
* * parses into this <img width="1686" alt="image" src="https://github.com/grafana/grafana/assets/109082771/8a181bf0-01bf-4aca-b57c-a70a85ffd8da">
* * On Change of anything in querybuilder, we get this invalid insert of '{}' on the left.
<img width="1685" alt="image" src="https://github.com/grafana/grafana/assets/109082771/2aa9cd36-a390-4635-9162-71c0efbada4c">

**Why do we need this feature?**
Improves UX/DX of query builder

**Who is this feature for?**
Users of loki query builder

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/72334, potentially

**Special notes for your reviewer:**
Need to understand what I'm doing a bit more on this one and write some tests before this is ready for review.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
