### PR TITLE
[v10.1.x] Docs: add deep links info

### DIFF
--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -37,7 +37,9 @@ To see a list of available variables, type `$` in the data link **URL** field to
 These variables changed in 6.4 so if you have an older version of Grafana, then use the version picker to select docs for an older version of Grafana.
 {{% /admonition %}}
 
-You can also use template variables in your data links URLs, refer to [Templates and variables]({{< relref "../../dashboards/variables/" >}}) for more information on template variables.
+Azure Monitor, [CloudWatch]({{< relref "../../datasources/aws-cloudwatch/query-editor/#deep-link-grafana-panels-to-the-cloudwatch-console-1" >}}), and [Google Cloud Monitoring]({{< relref "../../datasources/google-cloud-monitoring/query-editor/#deep-link-from-grafana-panels-to-the-google-cloud-console-metrics-explorer" >}}) have pre-configured data links called _deep links_.
+
+You can also use template variables in your data links URLs, refer to [Templates and variables][] for more information on template variables.
 
 ## Time range panel variables
 


### PR DESCRIPTION
Backport 025979df75f049e4365930a50045e747e50c29dc from #75017

---

Replaces PR #72540 that couldn't be completed (unsigned CLA).
