### PR TITLE
XYChart: Fix numerous axis options

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
@@ -32,11 +32,6 @@ exports[`GraphNG utils preparePlotConfigBuilder 1`] = `
       "values": [Function],
     },
     {
-      "border": {
-        "show": false,
-        "stroke": "rgb(204, 204, 220)",
-        "width": 1,
-      },
       "filter": undefined,
       "font": "12px "Inter", "Helvetica", "Arial", sans-serif",
       "gap": 5,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -155,6 +155,11 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
 
       labelGap: 0,
 
+      border: {
+        stroke: color ?? theme.colors.text.primary,
+        width: 1 / devicePixelRatio,
+        ...border,
+      },
       grid: {
         show: grid.show,
         stroke: gridColor,
@@ -179,10 +184,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       filter,
       incrs,
     };
-
-    if (border != null) {
-      config.border = border;
-    }
 
     if (label != null && label.length > 0) {
       config.label = label;

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -155,11 +155,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
 
       labelGap: 0,
 
-      border: {
-        stroke: color ?? theme.colors.text.primary,
-        width: 1 / devicePixelRatio,
-        ...border,
-      },
       grid: {
         show: grid.show,
         stroke: gridColor,
@@ -184,6 +179,14 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       filter,
       incrs,
     };
+
+    if (border?.show) {
+      config.border = {
+        stroke: color ?? theme.colors.text.primary,
+        width: 1 / devicePixelRatio,
+        ...border,
+      };
+    }
 
     if (label != null && label.length > 0) {
       config.label = label;

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -57,9 +57,10 @@ export function addAxisConfig(
       path: 'axisGridShow',
       name: 'Show grid lines',
       category,
-      defaultValue: true,
+      defaultValue: undefined,
       settings: {
         options: [
+          { value: undefined, label: 'Auto' },
           { value: true, label: 'On' },
           { value: false, label: 'Off' },
         ],

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -57,14 +57,14 @@ export function addAxisConfig(
       path: 'axisGridShow',
       name: 'Show grid lines',
       category,
-      defaultValue: undefined,
+      defaultValue: true,
       settings: {
         options: [
-          { value: undefined, label: 'Auto' },
           { value: true, label: 'On' },
           { value: false, label: 'Off' },
         ],
       },
+      showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
     })
     .addRadio({
       path: 'axisColorMode',
@@ -77,12 +77,14 @@ export function addAxisConfig(
           { value: AxisColorMode.Series, label: 'Series' },
         ],
       },
+      showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
     })
     .addBooleanSwitch({
-      path: 'axisShow',
+      path: 'axisShow',  // TODO: rename to axisBorderShow / Show border
       name: 'Show axis',
       category,
       defaultValue: false,
+      showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
     });
 
   // options for scale range

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -81,8 +81,8 @@ export function addAxisConfig(
       showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
     })
     .addBooleanSwitch({
-      path: 'axisShow',  // TODO: rename to axisBorderShow / Show border
-      name: 'Show axis',
+      path: 'axisShow', // TODO: rename to axisBorderShow
+      name: 'Show border',
       category,
       defaultValue: false,
       showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -623,6 +623,7 @@ const prepConfig = (
     placement: customConfig?.axisPlacement !== AxisPlacement.Hidden ? AxisPlacement.Bottom : AxisPlacement.Hidden,
     show: customConfig?.axisPlacement !== AxisPlacement.Hidden,
     grid: { show: customConfig?.axisGridShow },
+    border: { show: customConfig?.axisShow },
     theme,
     label:
       xAxisLabel == null || xAxisLabel === ''
@@ -669,6 +670,8 @@ const prepConfig = (
       placement: customConfig?.axisPlacement === AxisPlacement.Auto ? AxisPlacement.Left : customConfig?.axisPlacement,
       show: customConfig?.axisPlacement !== AxisPlacement.Hidden,
       grid: { show: customConfig?.axisGridShow },
+      border: { show: customConfig?.axisShow },
+      size: customConfig?.axisWidth,
       label:
         yAxisLabel == null || yAxisLabel === ''
           ? getFieldDisplayName(field, scatterSeries[si].frame(frames), frames)

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -659,21 +659,20 @@ const prepConfig = (
       decimals: config.decimals,
     });
 
-    if (customConfig?.axisPlacement !== AxisPlacement.Hidden) {
-      // why does this fall back to '' instead of null or undef?
-      let yAxisLabel = customConfig?.axisLabel;
+    // why does this fall back to '' instead of null or undef?
+    let yAxisLabel = customConfig?.axisLabel;
 
-      builder.addAxis({
-        scaleKey,
-        theme,
-        placement: customConfig?.axisPlacement,
-        label:
-          yAxisLabel == null || yAxisLabel === ''
-            ? getFieldDisplayName(field, scatterSeries[si].frame(frames), frames)
-            : yAxisLabel,
-        formatValue: (v, decimals) => formattedValueToString(field.display!(v, decimals)),
-      });
-    }
+    builder.addAxis({
+      scaleKey,
+      theme,
+      placement: customConfig?.axisPlacement === AxisPlacement.Auto ? AxisPlacement.Left : customConfig?.axisPlacement,
+      show: customConfig?.axisPlacement !== AxisPlacement.Hidden,
+      label:
+        yAxisLabel == null || yAxisLabel === ''
+          ? getFieldDisplayName(field, scatterSeries[si].frame(frames), frames)
+          : yAxisLabel,
+      formatValue: (v, decimals) => formattedValueToString(field.display!(v, decimals)),
+    });
 
     builder.addSeries({
       facets: [

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -622,6 +622,7 @@ const prepConfig = (
     scaleKey: 'x',
     placement: customConfig?.axisPlacement !== AxisPlacement.Hidden ? AxisPlacement.Bottom : AxisPlacement.Hidden,
     show: customConfig?.axisPlacement !== AxisPlacement.Hidden,
+    grid: { show: customConfig?.axisGridShow },
     theme,
     label:
       xAxisLabel == null || xAxisLabel === ''
@@ -667,6 +668,7 @@ const prepConfig = (
       theme,
       placement: customConfig?.axisPlacement === AxisPlacement.Auto ? AxisPlacement.Left : customConfig?.axisPlacement,
       show: customConfig?.axisPlacement !== AxisPlacement.Hidden,
+      grid: { show: customConfig?.axisGridShow },
       label:
         yAxisLabel == null || yAxisLabel === ''
           ? getFieldDisplayName(field, scatterSeries[si].frame(frames), frames)


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/74975

since uPlot will auto-add any missing axes, we have to explicitly add the axis with `show: false` rather than omitting it.