### PR TITLE
Save dashboard: Fix jsonDiff accessing undefined values

### DIFF
--- a/public/app/features/dashboard/components/VersionHistory/utils.ts
+++ b/public/app/features/dashboard/components/VersionHistory/utils.ts
@@ -28,16 +28,16 @@ export const jsonDiff = (lhs: any, rhs: any): Diffs => {
 
       const path = tail(diff.path.split('/'));
 
-      if (diff.op === 'replace') {
+      if (diff.op === 'replace' && rhsMap.pointers[diff.path]) {
         originalValue = get(lhs, path);
         value = diff.value;
         startLineNumber = rhsMap.pointers[diff.path].value.line;
       }
-      if (diff.op === 'add') {
+      if (diff.op === 'add' && rhsMap.pointers[diff.path]) {
         value = diff.value;
         startLineNumber = rhsMap.pointers[diff.path].value.line;
       }
-      if (diff.op === 'remove') {
+      if (diff.op === 'remove' && lhsMap.pointers[diff.path]) {
         originalValue = get(lhs, path);
         startLineNumber = lhsMap.pointers[diff.path].value.line;
       }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/74372, https://github.com/grafana/support-escalations/issues/7519

This makes sure the diff start line number is calculated against values that exist.

It's easy to repro by creating annotation with CSV Metric values from testdata ds.