### PR TITLE
Alerting: Fix returnTo expression being empty when no queryParam found

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -112,7 +112,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
   const ruleType = translateRouteParamToRuleType(routeParams.type);
   const uidFromParams = routeParams.id;
 
-  const returnTo = String(queryParams['returnTo']) ?? '/alerting/list';
+  const returnTo = !queryParams['returnTo'] ? '/alerting/list' : String(queryParams['returnTo']);
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
   const defaultValues: RuleFormValues = useMemo(() => {


### PR DESCRIPTION
This PR fixes returnTo expression being empty when no queryParam found in the AlertRuleForm.

Steps to reproduce the issue:

- click duplicate on an alert rule 
- click save and exit
- result: error is shown

This bug was introduced by this [PR](https://github.com/grafana/grafana/pull/74599)
**Why do we need this feature?**

After duplicating no error should be shown.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

<img width="1677" alt="Screenshot 2023-09-19 at 13 03 13" src="https://github.com/grafana/grafana/assets/33540275/d36bca1b-d502-4023-a889-ce04bcfc8627">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
