### PR TITLE
Alerting: Add missing scenes for grafana managed alerts

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -13,7 +13,6 @@ import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSu
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/InstancesByState';
 import { getGrafanaInstancesPercentageByStateScene } from '../insights/grafana/InstancesPercentageByState';
-import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
 import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
 import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -17,6 +17,9 @@ import { getGrafanaInstancesPercentageByStateScene } from '../insights/grafana/I
 import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
 import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
+import { getGrafanaAlertmanagerInstancesByStateScene } from '../insights/grafana/alertmanager/AlertsByStateScene';
+import { getGrafanaAlertmanagerNotificationsScene } from '../insights/grafana/alertmanager/NotificationsScene';
+import { getGrafanaAlertmanagerSilencesScene } from '../insights/grafana/alertmanager/SilencesByStateScene';
 import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';
 import { getInvalidConfigScene } from '../insights/mimir/InvalidConfig';
 import { getNotificationsScene } from '../insights/mimir/Notifications';
@@ -32,9 +35,6 @@ import { getInstancesPercentageByStateScene } from '../insights/mimir/rules/Inst
 import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIterationsScene';
 import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
-import { getGrafanaAlertmanagerInstancesByStateScene } from '../insights/grafana/alertmanager/AlertsByStateScene';
-import { getGrafanaAlertmanagerNotificationsScene } from '../insights/grafana/alertmanager/NotificationsScene';
-import { getGrafanaAlertmanagerSilencesScene } from '../insights/grafana/alertmanager/SilencesByStateScene';
 
 const ashDs = {
   type: 'loki',

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -51,6 +51,8 @@ const grafanaCloudPromDs = {
   uid: 'grafanacloud-prom',
 };
 
+export const PANEL_STYLES = { minHeight: 300 };
+
 const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
 const LAST_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-2w', to: 'now-1w' });
 

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -9,10 +9,12 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 
+import { getGrafanaEvalDurationScene } from '../insights/grafana/EvalDurationScene';
 import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/InstancesByState';
 import { getGrafanaInstancesPercentageByStateScene } from '../insights/grafana/InstancesPercentageByState';
+import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
 import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
 import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';
@@ -57,14 +59,28 @@ export function getGrafanaScenes() {
         new SceneFlexLayout({
           children: [
             getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
-            getFiringAlertsRateScene(THIS_WEEK_TIME_RANGE, ashDs, 'Alerts firing per minute'),
+            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing'),
+            getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused'),
           ],
         }),
         new SceneFlexLayout({
           children: [
-            getFiringAlertsScene(THIS_WEEK_TIME_RANGE, ashDs, 'Firing alerts this week'),
-            getFiringAlertsScene(LAST_WEEK_TIME_RANGE, ashDs, 'Firing alerts last week'),
+            getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Count of alert instances by state'),
+            getGrafanaInstancesPercentageByStateScene(
+              THIS_WEEK_TIME_RANGE,
+              cloudUsageDs,
+              '% of Alert Instances by State'
+            ),
           ],
+        }),
+        new SceneFlexLayout({
+          children: [
+            getGrafanaEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Success vs Failures'),
+            getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations Missed'),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Duration')],
         }),
         new SceneFlexItem({
           ySizing: 'content',
@@ -87,14 +103,22 @@ function getCloudScenes() {
   return new NestedScene({
     title: 'Mimir alertmanager',
     canCollapse: true,
-    isCollapsed: true,
+    isCollapsed: false,
     body: new SceneFlexLayout({
-      wrap: 'wrap',
+      direction: 'column',
       children: [
-        getAlertsByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by State'),
-        getNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
-        getSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences'),
-        getInvalidConfigScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Invalid configuration'),
+        new SceneFlexLayout({
+          children: [
+            getAlertsByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by State'),
+            getNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [
+            getSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences'),
+            getInvalidConfigScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Invalid configuration'),
+          ],
+        }),
       ],
     }),
   });
@@ -104,19 +128,33 @@ function getMimirManagedRulesScenes() {
   return new NestedScene({
     title: 'Mimir-managed rules',
     canCollapse: true,
-    isCollapsed: true,
+    isCollapsed: false,
     body: new SceneFlexLayout({
-      wrap: 'wrap',
+      direction: 'column',
       children: [
-        getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
-        getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Firing'),
-        getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending'),
-
-        getInstancesByStateScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Count of alert instances by state'),
-        getInstancesPercentageByStateScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, '% of Alert Instances by State'),
-
-        getEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Success vs Failures'),
-        getMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations Missed'),
+        new SceneFlexLayout({
+          children: [
+            getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
+            getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Firing'),
+            getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending'),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [
+            getInstancesByStateScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Count of alert instances by state'),
+            getInstancesPercentageByStateScene(
+              THIS_WEEK_TIME_RANGE,
+              grafanaCloudPromDs,
+              '% of Alert Instances by State'
+            ),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [
+            getEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Success vs Failures'),
+            getMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations Missed'),
+          ],
+        }),
       ],
     }),
   });
@@ -133,14 +171,22 @@ function getMimirManagedRulesPerGroupScenes() {
   return new NestedScene({
     title: 'Mimir-managed Rules - Per Rule Group',
     canCollapse: true,
-    isCollapsed: true,
+    isCollapsed: false,
     body: new SceneFlexLayout({
-      wrap: 'wrap',
+      direction: 'column',
       children: [
-        getRuleGroupEvaluationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation'),
-        getRuleGroupIntervalScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Interval'),
-        getRuleGroupEvaluationDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation Duration'),
-        getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per Group'),
+        new SceneFlexLayout({
+          children: [
+            getRuleGroupEvaluationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation'),
+            getRuleGroupIntervalScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Interval'),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [
+            getRuleGroupEvaluationDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation Duration'),
+            getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per Group'),
+          ],
+        }),
       ],
     }),
     $variables: new SceneVariableSet({

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -9,9 +9,13 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 
-import { getFiringAlertsScene } from '../insights/grafana/FiringAlertsPercentage';
-import { getFiringAlertsRateScene } from '../insights/grafana/FiringAlertsRate';
+import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
+import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
+import { getGrafanaInstancesByStateScene } from '../insights/grafana/InstancesByState';
+import { getGrafanaInstancesPercentageByStateScene } from '../insights/grafana/InstancesPercentageByState';
+import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
+import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
 import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';
 import { getInvalidConfigScene } from '../insights/mimir/InvalidConfig';
 import { getNotificationsScene } from '../insights/mimir/Notifications';

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -32,6 +32,9 @@ import { getInstancesPercentageByStateScene } from '../insights/mimir/rules/Inst
 import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIterationsScene';
 import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
+import { getGrafanaAlertmanagerInstancesByStateScene } from '../insights/grafana/alertmanager/AlertsByStateScene';
+import { getGrafanaAlertmanagerNotificationsScene } from '../insights/grafana/alertmanager/NotificationsScene';
+import { getGrafanaAlertmanagerSilencesScene } from '../insights/grafana/alertmanager/SilencesByStateScene';
 
 const ashDs = {
   type: 'loki',
@@ -84,6 +87,10 @@ export function getGrafanaScenes() {
         }),
         new SceneFlexItem({
           ySizing: 'content',
+          body: getGrafanaAlertmanagerScenes(),
+        }),
+        new SceneFlexItem({
+          ySizing: 'content',
           body: getCloudScenes(),
         }),
         new SceneFlexItem({
@@ -93,6 +100,28 @@ export function getGrafanaScenes() {
         new SceneFlexItem({
           ySizing: 'content',
           body: getMimirManagedRulesPerGroupScenes(),
+        }),
+      ],
+    }),
+  });
+}
+
+function getGrafanaAlertmanagerScenes() {
+  return new NestedScene({
+    title: 'Grafana Alertmanager',
+    canCollapse: true,
+    isCollapsed: false,
+    body: new SceneFlexLayout({
+      direction: 'column',
+      children: [
+        new SceneFlexLayout({
+          children: [
+            getGrafanaAlertmanagerInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by State'),
+            getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
+          ],
+        }),
+        new SceneFlexLayout({
+          children: [getGrafanaAlertmanagerSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences')],
         }),
       ],
     }),

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -22,7 +24,7 @@ export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasourc
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,9 +1,10 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum by (rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m)';
+const QUERY_A = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
+const QUERY_B = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
 
-export function getGrafanaMissedIterationsScene(
+export function getGrafanaEvalDurationScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
   panelTitle: string
@@ -15,7 +16,13 @@ export function getGrafanaMissedIterationsScene(
         refId: 'A',
         expr: QUERY_A,
         range: true,
-        legendFormat: 'missed',
+        legendFormat: 'success',
+      },
+      {
+        refId: 'B',
+        expr: QUERY_B,
+        range: true,
+        legendFormat: 'failed',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,23 +1,19 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A =
-  'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
-const QUERY_B = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
-
 export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,14 +1,11 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
+const QUERY_A =
+  'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
 const QUERY_B = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
 
-export function getGrafanaEvalDurationScene(
-  timeRange: SceneTimeRange,
-  datasource: DataSourceRef,
-  panelTitle: string
-) {
+export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -31,8 +31,7 @@ export function getGrafanaEvalSuccessVsFailuresScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getGrafanaEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -26,7 +28,7 @@ export function getGrafanaEvalSuccessVsFailuresScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,0 +1,42 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY_A =
+  'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
+
+const QUERY_B = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
+
+export function getGrafanaEvalSuccessVsFailuresScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY_A,
+        range: true,
+        legendFormat: 'success',
+      },
+      {
+        refId: 'B',
+        expr: QUERY_B,
+        range: true,
+        legendFormat: 'failed',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(50% - 4px)',
+    height: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,11 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A =
-  'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
-
-const QUERY_B = 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)';
-
 export function getGrafanaEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -16,13 +11,13 @@ export function getGrafanaEvalSuccessVsFailuresScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -2,8 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active"})';
-
 export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -11,7 +9,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
       {
         refId: 'A',
         instant: true,
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active"})',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -18,8 +18,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
   });
 
   return new SceneFlexItem({
-    width: 'calc(25% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -1,0 +1,41 @@
+import { ThresholdsMode } from '@grafana/data';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema';
+
+const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active"})';
+
+export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        instant: true,
+        expr: QUERY,
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(25% - 4px)',
+    height: 300,
+    body: PanelBuilders.stat()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setThresholds({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      })
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
@@ -1,9 +1,6 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const TOTALS = 'sum(count_over_time({from="state-history"} | json [1w]))';
-const TOTALS_FIRING = 'sum(count_over_time({from="state-history"} | json | current="Alerting"[1w]))';
-
 export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -11,12 +8,12 @@ export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: Data
       {
         refId: 'A',
         instant: true,
-        expr: TOTALS_FIRING,
+        expr: 'sum(count_over_time({from="state-history"} | json | current="Alerting"[1w]))',
       },
       {
         refId: 'B',
         instant: true,
-        expr: TOTALS,
+        expr: 'sum(count_over_time({from="state-history"} | json [1w]))',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -58,7 +60,7 @@ export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: Data
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.stat().setTitle(panelTitle).setData(transformation).setUnit('percent').build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const RATE_FIRING = 'sum(count_over_time({from="state-history"} | json | current="Alerting"[5m]))';
-
 export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: RATE_FIRING,
+        expr: 'sum(count_over_time({from="state-history"} | json | current="Alerting"[5m]))',
         range: true,
         legendFormat: 'Number of fires',
       },

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)';
-
 export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -13,7 +11,7 @@ export function getGrafanaInstancesByStateScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -20,7 +22,7 @@ export function getGrafanaInstancesByStateScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -1,0 +1,29 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)';
+
+export function getGrafanaInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY,
+        range: true,
+        legendFormat: '{{state}}',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(50% - 4px)',
+    height: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -3,7 +3,11 @@ import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
 const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)';
 
-export function getGrafanaInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+export function getGrafanaInstancesByStateScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -22,8 +22,7 @@ export function getGrafanaInstancesByStateScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -2,7 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)';
+const QUERY =
+  'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)';
 
 export function getGrafanaInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getGrafanaInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -21,7 +23,7 @@ export function getGrafanaInstancesPercentageByStateScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -2,9 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY =
-  'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)';
-
 export function getGrafanaInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -15,7 +12,7 @@ export function getGrafanaInstancesPercentageByStateScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)',
         range: true,
         legendFormat: '{{alertstate}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -1,0 +1,50 @@
+import { ThresholdsMode } from '@grafana/data';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)';
+
+export function getGrafanaInstancesPercentageByStateScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY,
+        range: true,
+        legendFormat: '{{alertstate}}',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(50% - 4px)',
+    height: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setCustomFieldConfig('fillOpacity', 45)
+      .setUnit('percentunit')
+      .setMax(1)
+      .setThresholds({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          {
+            color: 'green',
+            value: 0,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      })
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -24,8 +24,7 @@ export function getGrafanaInstancesPercentageByStateScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getGrafanaMissedIterationsScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -20,7 +22,7 @@ export function getGrafanaMissedIterationsScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum by (rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m)';
-
 export function getGrafanaMissedIterationsScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -13,7 +11,7 @@ export function getGrafanaMissedIterationsScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum by (rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m)',
         range: true,
         legendFormat: 'missed',
       },

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,0 +1,29 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY_A = 'sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)';
+
+export function getGrafanaMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY_A,
+        range: true,
+        legendFormat: 'missed',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(50% - 4px)',
+    height: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -22,8 +22,7 @@ export function getGrafanaMissedIterationsScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -3,7 +3,11 @@ import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
 const QUERY_A = 'sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)';
 
-export function getGrafanaMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+export function getGrafanaMissedIterationsScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -13,6 +13,7 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { Icon, Link } from '@grafana/ui';
 
+import { PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
 
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
@@ -100,7 +101,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -15,16 +15,13 @@ import { Icon, Link } from '@grafana/ui';
 
 import { createUrl } from '../../utils/url';
 
-const TOP_FIRING_INSTANCES =
-  'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))';
-
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: TOP_FIRING_INSTANCES,
+        expr: 'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))',
         instant: true,
       },
     ],

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
@@ -1,16 +1,13 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const TOP_5_FIRING_RULES =
-  'topk(5, sum by(group, labels_grafana_folder) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))';
-
 export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: TOP_5_FIRING_RULES,
+        expr: 'topk(5, sum by(group, labels_grafana_folder) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))',
         instant: true,
       },
     ],

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -51,7 +53,7 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
@@ -13,6 +13,8 @@ import {
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export const getLabelsInfo = (from: number, to: number): Observable<DataQueryResponseData> => {
   return getBackendSrv().fetch({
     url: `/api/v1/rules/history`,
@@ -49,7 +51,7 @@ export function getMostFiredLabelsScene(timeRange: SceneTimeRange, datasource: D
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.table().setTitle(panelTitle).setData(query).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -18,8 +18,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
   });
 
   return new SceneFlexItem({
-    width: 'calc(25% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -2,8 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused"})';
-
 export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -11,7 +9,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
       {
         refId: 'A',
         instant: true,
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused"})',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -1,0 +1,41 @@
+import { ThresholdsMode } from '@grafana/data';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema';
+
+const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused"})';
+
+export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        instant: true,
+        expr: QUERY,
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    width: 'calc(25% - 4px)',
+    height: 300,
+    body: PanelBuilders.stat()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setThresholds({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          {
+            color: 'yellow',
+            value: 0,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      })
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getGrafanaAlertmanagerInstancesByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -20,7 +22,7 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_alerts)';
-
 export function getGrafanaAlertmanagerInstancesByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -13,7 +11,7 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_alerts)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -1,0 +1,32 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY = 'sum by (state) (grafanacloud_grafana_instance_alerting_alerts)';
+
+export function getGrafanaAlertmanagerInstancesByStateScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY,
+        range: true,
+        legendFormat: '{{state}}',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    minHeight: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,0 +1,40 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY_A =
+  'grafanacloud_grafana_instance_alerting_notifications_total:rate5m - grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m';
+const QUERY_B = 'grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m';
+
+export function getGrafanaAlertmanagerNotificationsScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY_A,
+        range: true,
+        legendFormat: 'success',
+      },
+      {
+        refId: 'B',
+        expr: QUERY_B,
+        range: true,
+        legendFormat: 'failed',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    minHeight: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,10 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A =
-  'grafanacloud_grafana_instance_alerting_notifications_total:rate5m - grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m';
-const QUERY_B = 'grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m';
-
 export function getGrafanaAlertmanagerNotificationsScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -15,13 +11,13 @@ export function getGrafanaAlertmanagerNotificationsScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'grafanacloud_grafana_instance_alerting_notifications_total:rate5m - grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m',
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: 'grafanacloud_grafana_instance_alerting_notifications_failed_total:rate5m',
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getGrafanaAlertmanagerNotificationsScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -26,7 +28,7 @@ export function getGrafanaAlertmanagerNotificationsScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,0 +1,32 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+
+const QUERY_A = 'sum by (state) (grafanacloud_grafana_instance_alerting_silences)';
+
+export function getGrafanaAlertmanagerSilencesScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: QUERY_A,
+        range: true,
+        legendFormat: '{{state}}',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    minHeight: 300,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setData(query)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getGrafanaAlertmanagerSilencesScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -20,7 +22,7 @@ export function getGrafanaAlertmanagerSilencesScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum by (state) (grafanacloud_grafana_instance_alerting_silences)';
-
 export function getGrafanaAlertmanagerSilencesScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -13,7 +11,7 @@ export function getGrafanaAlertmanagerSilencesScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_silences)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -18,8 +18,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (state) (grafanacloud_instance_alertmanager_alerts)';
-
 export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (state) (grafanacloud_instance_alertmanager_alerts)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config)';
-
 export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config)',
         range: true,
         legendFormat: '{{cluster}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -18,8 +18,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -26,8 +26,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getNotificationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -22,7 +24,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,23 +1,19 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A =
-  'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)';
-const QUERY_B = 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)';
-
 export function getNotificationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
         range: true,
         legendFormat: '{{cluster}} - success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
         range: true,
         legendFormat: '{{cluster}} - failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../home/Insights';
+
 export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum by (state) (grafanacloud_instance_alertmanager_silences)';
-
 export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum by (state) (grafanacloud_instance_alertmanager_silences)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -18,8 +18,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -22,8 +22,7 @@ export function getRuleGroupEvaluationDurationScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getRuleGroupEvaluationDurationScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -20,7 +22,7 @@ export function getRuleGroupEvaluationDurationScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`;
-
 export function getRuleGroupEvaluationDurationScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -13,7 +11,7 @@ export function getRuleGroupEvaluationDurationScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`,
         range: true,
         legendFormat: '{{rule_group}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -22,7 +24,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,22 +1,19 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
-const QUERY_B = `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
-
 export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`,
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`,
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -25,8 +25,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -18,8 +18,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
-
 export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`,
         range: true,
         legendFormat: 'interval',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -18,8 +18,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`;
-
 export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`,
         range: true,
         legendFormat: 'number of rules',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -31,8 +31,7 @@ export function getEvalSuccessVsFailuresScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,11 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A =
-  'sum(grafanacloud_instance_rule_evaluations_total:rate5m) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)';
-
-const QUERY_B = 'sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)';
-
 export function getEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -16,13 +11,13 @@ export function getEvalSuccessVsFailuresScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum(grafanacloud_instance_rule_evaluations_total:rate5m) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: QUERY_B,
+        expr: 'sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)',
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -26,7 +28,7 @@ export function getEvalSuccessVsFailuresScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -18,8 +18,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
   });
 
   return new SceneFlexItem({
-    width: 'calc(25% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -2,8 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const QUERY = 'sum by (alertstate) (ALERTS{alertstate="firing"})';
-
 export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -11,7 +9,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
       {
         refId: 'A',
         instant: true,
-        expr: QUERY,
+        expr: 'sum by (alertstate) (ALERTS{alertstate="firing"})',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (alertstate) (ALERTS)';
-
 export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (alertstate) (ALERTS)',
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -18,8 +18,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -23,8 +23,7 @@ export function getInstancesPercentageByStateScene(
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -21,7 +23,7 @@ export function getInstancesPercentageByStateScene(
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -2,8 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY = 'sum by (alertstate) (ALERTS) / ignoring(alertstate) group_left sum(ALERTS)';
-
 export function getInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -14,7 +12,7 @@ export function getInstancesPercentageByStateScene(
     queries: [
       {
         refId: 'A',
-        expr: QUERY,
+        expr: 'sum by (alertstate) (ALERTS) / ignoring(alertstate) group_left sum(ALERTS)',
         range: true,
         legendFormat: '{{alertstate}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -18,8 +18,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-const QUERY_A = 'sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)';
-
 export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: QUERY_A,
+        expr: 'sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)',
         range: true,
         legendFormat: 'missed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
@@ -39,8 +39,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    width: 'calc(50% - 8px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
@@ -1,15 +1,13 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const TOP_5_FIRING_INSTANCES = 'topk(10, sum by (alertname) (ALERTS))';
-
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: TOP_5_FIRING_INSTANCES,
+        expr: 'topk(10, sum by (alertname) (ALERTS))',
         range: true,
       },
     ],

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
@@ -1,6 +1,8 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -37,7 +39,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -2,8 +2,6 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const QUERY = 'sum by (alertstate) (ALERTS{alertstate="pending"})';
-
 export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -11,7 +9,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
       {
         refId: 'A',
         instant: true,
-        expr: QUERY,
+        expr: 'sum by (alertstate) (ALERTS{alertstate="pending"})',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -2,6 +2,8 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { PANEL_STYLES } from '../../../home/Insights';
+
 export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
@@ -16,7 +18,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    minHeight: 300,
+    ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -18,8 +18,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
   });
 
   return new SceneFlexItem({
-    width: 'calc(25% - 4px)',
-    height: 300,
+    minHeight: 300,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setData(query)


### PR DESCRIPTION
**What is this feature?**

Adds the missing panels from https://virginiacepeda1.grafana.net/d/d3f0a969-67b4-404d-b94b-1b8370c5a20e/grafana-managed-rules?orgId=1&from=now-5m&to=now that were defined in https://github.com/grafana/alerting-squad/issues/602 for grafana managed alerts after the backend added the necessary metrics.

It can be seen in https://ephemeral1511182175100vikacep.grafana-dev.net/ after enabling the feature flag with window.localStorage.setItem('grafana.featureToggles', 'alertingInsights=true') (and reloading the page)

Dashboard:
<img width="1512" alt="image" src="https://github.com/grafana/grafana/assets/6271380/2d8db7fd-b1be-4e8a-b54b-4b286a5bb558">

Landing page:
![2023-09-19 11 28 03](https://github.com/grafana/grafana/assets/6271380/04b38456-f9c2-48c4-83ac-8b29bf128906)


**Why do we need this feature?**

In order to provide useful information for GMA.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/alerting-squad/issues/610
