### PR TITLE
Chore: Add additional debug info to live websocket pushes

### DIFF
--- a/pkg/services/live/pushws/push_stream.go
+++ b/pkg/services/live/pushws/push_stream.go
@@ -2,6 +2,7 @@ package pushws
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
 	liveDto "github.com/grafana/grafana-plugin-sdk-go/live"
@@ -60,6 +61,8 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	defer func() { _ = conn.Close() }()
 	setupWSConn(r.Context(), conn, s.config)
 
+	started := time.Now()
+
 	for {
 		_, body, err := conn.ReadMessage()
 		if err != nil {
@@ -78,10 +81,11 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		frameFormat := pushurl.FrameFormatFromValues(urlValues)
 
 		logger.Debug("Live Push request",
-			"protocol", "http",
+			"protocol", "ws",
 			"streamId", streamID,
 			"bodyLength", len(body),
 			"frameFormat", frameFormat,
+			"duration", time.Since(started).String(),
 		)
 
 		metricFrames, err := s.converter.Convert(body, frameFormat)

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -171,14 +171,14 @@ export class LiveDataStream<T = unknown> {
 
     const liveChannelStatusEvent = isLiveChannelStatusEvent(evt);
     if (liveChannelStatusEvent && evt.error) {
+      const err = toDataQueryError(evt.error);
       this.stream.next({
         type: InternalStreamMessageType.Error,
         error: {
-          ...toDataQueryError(evt.error),
-          message: `Streaming channel error: ${evt.error.message}`,
+          ...err,
+          message: `Streaming channel error: ${err.message}`,
         },
       });
-      return;
     }
 
     if (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds additional logging to help debug live push issues.

**Why do we need this feature?**

Websocket live pushes were incorrectly logged as HTTP

**Who is this feature for?**

@grafana/grafana-app-platform-squad 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
