### PR TITLE
BarChart: Axes centered zero, borders, and colors

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -297,7 +297,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
       const axisDisplayOptions = {
         border: {
           show: customConfig.axisBorderShow || false,
-          width: 1,
+          width: 1 / devicePixelRatio,
           stroke: axisColor || theme.colors.text.primary,
         },
         ticks: {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -163,7 +163,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       ticks: Object.assign(
         {
           show: true,
-          stroke: gridColor,
+          stroke: border?.show ? color ?? theme.colors.text.primary : gridColor,
           width: 1 / devicePixelRatio,
           size: 4,
         },

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -27,13 +27,13 @@ import {
   VizLegendOptions,
 } from '@grafana/schema';
 import { FIXED_UNIT, measureText, UPlotConfigBuilder, UPlotConfigPrepFn, UPLOT_AXIS_FONT_SIZE } from '@grafana/ui';
+import { AxisProps } from '@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder';
 import { getStackingGroups } from '@grafana/ui/src/components/uPlot/utils';
 import { findField } from 'app/features/dimensions';
 
 import { BarsOptions, getConfig } from './bars';
 import { FieldConfig, Options, defaultFieldConfig } from './panelcfg.gen';
 import { BarChartDisplayValues, BarChartDisplayWarning } from './types';
-import { AxisProps } from '@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder';
 
 function getBarCharScaleOrientation(orientation: VizOrientation) {
   if (orientation === VizOrientation.Vertical) {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -16,6 +16,7 @@ import {
 } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import {
+  AxisColorMode,
   AxisPlacement,
   GraphTransform,
   GraphTresholdsStyleMode,
@@ -32,6 +33,7 @@ import { findField } from 'app/features/dimensions';
 import { BarsOptions, getConfig } from './bars';
 import { FieldConfig, Options, defaultFieldConfig } from './panelcfg.gen';
 import { BarChartDisplayValues, BarChartDisplayWarning } from './types';
+import { AxisProps } from '@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder';
 
 function getBarCharScaleOrientation(orientation: VizOrientation) {
   if (orientation === VizOrientation.Vertical) {
@@ -256,6 +258,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
       max: field.config.max,
       softMin,
       softMax,
+      centeredZero: customConfig.axisCenteredZero,
       orientation: vizOrientation.yOri,
       direction: vizOrientation.yDir,
       distribution: customConfig.scaleDistribution?.type,
@@ -276,7 +279,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
         }
       }
 
-      builder.addAxis({
+      let axisOpts: AxisProps = {
         scaleKey,
         label: customConfig.axisLabel,
         size: customConfig.axisWidth,
@@ -286,7 +289,19 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
         tickLabelRotation: vizOrientation.xOri === 1 ? xTickLabelRotation * -1 : 0,
         theme,
         grid: { show: customConfig.axisGridShow },
-      });
+      };
+
+      if (customConfig.axisBorderShow) {
+        axisOpts.border = {
+          show: customConfig?.axisBorderShow
+        };
+      }
+
+      if (customConfig.axisColorMode === AxisColorMode.Series) {
+        axisOpts.color = seriesColor;
+      }
+
+      builder.addAxis(axisOpts);
     }
   }
 

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -293,7 +293,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
 
       if (customConfig.axisBorderShow) {
         axisOpts.border = {
-          show: customConfig?.axisBorderShow
+          show: true
         };
       }
 

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -293,7 +293,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
 
       if (customConfig.axisBorderShow) {
         axisOpts.border = {
-          show: true
+          show: true,
         };
       }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/75132

look! the options work now!

<details><summary>BarChart-axes.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 757,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": true,
            "axisCenteredZero": true,
            "axisColorMode": "series",
            "axisLabel": "",
            "axisPlacement": "auto",
            "axisSoftMin": 0,
            "fillOpacity": 80,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 0,
            "scaleDistribution": {
              "type": "linear"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "Stat2"
            },
            "properties": [
              {
                "id": "unit",
                "value": "short"
              },
              {
                "id": "custom.axisPlacement",
                "value": "right"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 18,
        "w": 17,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "barRadius": 0,
        "barWidth": 1,
        "fullHighlight": false,
        "groupWidth": 0.82,
        "legend": {
          "calcs": [
            "max"
          ],
          "displayMode": "list",
          "placement": "right",
          "showLegend": true
        },
        "orientation": "auto",
        "showValue": "auto",
        "stacking": "none",
        "text": {},
        "tooltip": {
          "mode": "single",
          "sort": "none"
        },
        "xTickLabelRotation": 0,
        "xTickLabelSpacing": 0
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Name\",\n          \"type\": \"string\",\n          \"typeInfo\": {\n            \"frame\": \"string\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Stat1\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Stat2\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1577836800000,\n          1577836800000,\n          1577836800000,\n          1577836800000,\n          1577836800000\n        ],\n        [\n          \"Stockholm\",\n          \"New York\",\n          \"London\",\n          \"Negative\",\n          \"Long value\"\n        ],\n        [\n          10,\n          19,\n          10,\n          15,\n          15\n        ],\n        [\n          150,\n          50,\n          10,\n          -50,\n          100\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Reproduced with embedded data",
      "type": "barchart"
    }
  ],
  "refresh": "",
  "schemaVersion": 38,
  "tags": [
    "debug",
    "debug-barchart"
  ],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2023-09-20T01:35:48.231Z",
    "to": "2023-09-20T01:40:48.231Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "BarChart-axes",
  "uid": "e0722bd7-ebad-40c0-b520-57c9e03646c4",
  "version": 4,
  "weekStart": ""
}
```
</details>

![image](https://github.com/grafana/grafana/assets/43234/b002d8ea-0fe1-4a49-acbd-f48b9b5f2fd6)