### PR TITLE
CI: github-release workflow should forward "latest" input

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -24,3 +24,4 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           version: ${{ inputs.version }}
           metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
+          latest: ${{ inputs.latest }}


### PR DESCRIPTION
When trigger a new GitHub Release we recently added a new "latest" input field so that the latest release is also listed as such. That flag was never forwarded which should be fixed with this PR.