### PR TITLE
Chore: Remove lint exceptions from testdata backend

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -16,21 +16,44 @@ confidence = 3
 [linters-settings.depguard.rules.main]
 allow = [] # allow all
 deny = [
-  {pkg = "io/ioutil", desc = "Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details."},
-  {pkg = "gopkg.in/yaml.v2", desc = "Grafana packages are not allowed to depend on gopkg.in/yaml.v2 as gopkg.in/yaml.v3 is now available"},
-  {pkg = "github.com/pkg/errors", desc = "Deprecated: Go 1.13 supports the functionality provided by pkg/errors in the standard library."},
-  {pkg = "github.com/xorcare/pointer", desc = "Use pkg/util.Pointer instead, which is a generic one-liner alternative"},
-  {pkg = "github.com/gofrs/uuid", desc = "Use github.com/google/uuid instead, which we already depend on."},
+  { pkg = "io/ioutil", desc = "Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details." },
+  { pkg = "gopkg.in/yaml.v2", desc = "Grafana packages are not allowed to depend on gopkg.in/yaml.v2 as gopkg.in/yaml.v3 is now available" },
+  { pkg = "github.com/pkg/errors", desc = "Deprecated: Go 1.13 supports the functionality provided by pkg/errors in the standard library." },
+  { pkg = "github.com/xorcare/pointer", desc = "Use pkg/util.Pointer instead, which is a generic one-liner alternative" },
+  { pkg = "github.com/gofrs/uuid", desc = "Use github.com/google/uuid instead, which we already depend on." },
 ]
 
 [linters-settings.depguard.rules.coreplugins]
 deny = [
-  {pkg = "github.com/grafana/grafana/pkg/", desc = "Core plugins are not allowed to depend on Grafana core packages"},
+  { pkg = "github.com/grafana/grafana/pkg/api", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/cmd", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/cuectx", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/extensions", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/kinds", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/middleware", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/modules", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/registry", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/services", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/build", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/codegen", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/events", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/ifaces", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/kindsysreport", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/mocks", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/plugins", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/setting", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/util", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/bus", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/components", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/expr", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/infra", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/login", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/models", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/server", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/tests", desc = "Core plugins are not allowed to depend on Grafana core packages" },
+  { pkg = "github.com/grafana/grafana/pkg/web", desc = "Core plugins are not allowed to depend on Grafana core packages" },
 ]
-files = [
-  "**/pkg/tsdb/testdatasource/*",
-  "**/pkg/tsdb/testdatasource/**/*",
-]
+files = ["**/pkg/tsdb/testdatasource/*", "**/pkg/tsdb/testdatasource/**/*"]
 
 [linters-settings.gocritic]
 enabled-checks = ["ruleguard"]

--- a/pkg/tsdb/testdatasource/scenarios_test.go
+++ b/pkg/tsdb/testdatasource/scenarios_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	// nolint:depguard // Lint exception can be removed once we move testdata to a separate module
-	"github.com/grafana/grafana/pkg/tsdb/legacydata"
 )
 
 func TestTestdataScenarios(t *testing.T) {
@@ -21,13 +18,14 @@ func TestTestdataScenarios(t *testing.T) {
 
 	t.Run("random walk ", func(t *testing.T) {
 		t.Run("Should start at the requested value", func(t *testing.T) {
-			timeRange := legacydata.DataTimeRange{From: "5m", To: "now", Now: time.Now()}
+			from := time.Now()
+			to := from.Add(5 * time.Minute)
 
 			query := backend.DataQuery{
 				RefID: "A",
 				TimeRange: backend.TimeRange{
-					From: timeRange.MustGetFrom(),
-					To:   timeRange.MustGetTo(),
+					From: from,
+					To:   to,
 				},
 				Interval:      100 * time.Millisecond,
 				MaxDataPoints: 100,
@@ -60,13 +58,14 @@ func TestTestdataScenarios(t *testing.T) {
 
 	t.Run("random walk table", func(t *testing.T) {
 		t.Run("Should return a table that looks like value/min/max", func(t *testing.T) {
-			timeRange := legacydata.DataTimeRange{From: "5m", To: "now", Now: time.Now()}
+			from := time.Now()
+			to := from.Add(5 * time.Minute)
 
 			query := backend.DataQuery{
 				RefID: "A",
 				TimeRange: backend.TimeRange{
-					From: timeRange.MustGetFrom(),
-					To:   timeRange.MustGetTo(),
+					From: from,
+					To:   to,
 				},
 				Interval:      100 * time.Millisecond,
 				MaxDataPoints: 100,
@@ -110,13 +109,14 @@ func TestTestdataScenarios(t *testing.T) {
 		})
 
 		t.Run("Should return a table with some nil values", func(t *testing.T) {
-			timeRange := legacydata.DataTimeRange{From: "5m", To: "now", Now: time.Now()}
+			from := time.Now()
+			to := from.Add(5 * time.Minute)
 
 			query := backend.DataQuery{
 				RefID: "A",
 				TimeRange: backend.TimeRange{
-					From: timeRange.MustGetFrom(),
-					To:   timeRange.MustGetTo(),
+					From: from,
+					To:   to,
 				},
 				Interval:      100 * time.Millisecond,
 				MaxDataPoints: 100,

--- a/pkg/tsdb/testdatasource/testdata.go
+++ b/pkg/tsdb/testdatasource/testdata.go
@@ -9,8 +9,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-
-	// nolint:depguard // Lint exception can be removed once we move testdata to a separate module
 	"github.com/grafana/grafana/pkg/tsdb/testdatasource/sims"
 )
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The original idea was to move decoupled core plugins to a new location (both frontend and backend) but we may not want to move the backend to the same folder than the fronted because that requires to [modify the build process to ignore backend files in the public folder](https://github.com/grafana/grafana/pull/72205/files#diff-220aa9f5b5c1684e7977efc311e7d5ceb54dca93833d9d8c53665b38cf2335faR446-R460).

If we want to avoid that, we have two options:

 - Keep the plugin backend code where it is.
   - Pros: Less changes, well known directory for plugin devs. 
   - Cons: No clear separation between decoupled and non-decoupled plugins (from a directory perspective). More difficult to maintain lint code.
 - Move the plugin backend code to a new location.
   - Pros: Clear differentiation of decoupled plugins. Easier to lint.
   - Cons: Multiple directories with plugins in Grafana. Require [extra work in the CI process to take the new path into account](https://github.com/grafana/grafana/pull/72205/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52).

This PR covers the first option. The second option is what we had in https://github.com/grafana/grafana/pull/72205 (but with a different location from `public/`). Thoughts? 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Ref https://github.com/grafana/grafana/issues/68973

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
