### PR TITLE
Tracing: Span filters reset show matches only

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx
@@ -64,9 +64,10 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
       search.tags.length > 1 ||
       search.tags.some((tag) => {
         return tag.key;
-      })
+      }) ||
+      showSpanFilterMatchesOnly
     );
-  }, [search.serviceName, search.spanName, search.from, search.to, search.tags]);
+  }, [search.serviceName, search.spanName, search.from, search.to, search.tags, showSpanFilterMatchesOnly]);
 
   return (
     <div className={styles.container}>

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
@@ -214,7 +214,6 @@ describe('SpanFilters', () => {
     const matchesSwitch = screen.getByRole('checkbox', { name: 'Show matches only switch' });
     expect(matchesSwitch).not.toBeChecked();
     await user.click(matchesSwitch);
-    jest.advanceTimersByTime(1000);
     expect(matchesSwitch).toBeChecked();
 
     expect((clearFiltersButton as HTMLButtonElement)['disabled']).toBe(false);

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.test.tsx
@@ -45,12 +45,13 @@ describe('SpanFilters', () => {
   let user: ReturnType<typeof userEvent.setup>;
   const SpanFiltersWithProps = ({ showFilters = true }) => {
     const [search, setSearch] = useState(defaultFilters);
+    const [showSpanFilterMatchesOnly, setShowSpanFilterMatchesOnly] = useState(false);
     const props = {
       trace: trace,
       showSpanFilters: showFilters,
       setShowSpanFilters: jest.fn(),
-      showSpanFilterMatchesOnly: false,
-      setShowSpanFilterMatchesOnly: jest.fn(),
+      showSpanFilterMatchesOnly,
+      setShowSpanFilterMatchesOnly,
       search,
       setSearch,
       spanFilterMatches: undefined,
@@ -210,12 +211,19 @@ describe('SpanFilters', () => {
     await selectAndCheckValue(user, tagKey, 'TagKey0');
     await selectAndCheckValue(user, tagValue, 'TagValue0');
 
+    const matchesSwitch = screen.getByRole('checkbox', { name: 'Show matches only switch' });
+    expect(matchesSwitch).not.toBeChecked();
+    await user.click(matchesSwitch);
+    jest.advanceTimersByTime(1000);
+    expect(matchesSwitch).toBeChecked();
+
     expect((clearFiltersButton as HTMLButtonElement)['disabled']).toBe(false);
     await user.click(clearFiltersButton);
     expect(screen.queryByText('Service0')).not.toBeInTheDocument();
     expect(screen.queryByText('Span0')).not.toBeInTheDocument();
     expect(screen.queryByText('TagKey0')).not.toBeInTheDocument();
     expect(screen.queryByText('TagValue0')).not.toBeInTheDocument();
+    expect(matchesSwitch).not.toBeChecked();
   });
 
   it('renders buttons when span filters is collapsed', async () => {

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -69,7 +69,8 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
     setTagKeys(undefined);
     setTagValues({});
     setSearch(defaultFilters);
-  }, [setSearch]);
+    setShowSpanFilterMatchesOnly(false);
+  }, [setSearch, setShowSpanFilterMatchesOnly]);
 
   useEffect(() => {
     clear();


### PR DESCRIPTION
**What is this feature?**

Resets show matches only toggles when clear button pressed.

**Why do we need this feature?**

It has been brought up internally that the clear should also clear the show matches only toggle.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
