### PR TITLE
Alerting: Remove export button in alert form when editing grafana-managed alert

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -251,7 +251,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
         </Button>
       ) : null}
 
-      {existing ? (
+      {existing && isCortexLokiOrRecordingRule(watch) && (
         <Button
           variant="secondary"
           type="button"
@@ -259,9 +259,9 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
           disabled={submitState.loading}
           size="sm"
         >
-          {isCortexLokiOrRecordingRule(watch) ? 'Edit YAML' : 'Export'}
+          {'Edit YAML'}
         </Button>
-      ) : null}
+      )}
     </HorizontalGroup>
   );
 

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -259,7 +259,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
           disabled={submitState.loading}
           size="sm"
         >
-          {'Edit YAML'}
+          Edit YAML
         </Button>
       )}
     </HorizontalGroup>


### PR DESCRIPTION
**What is this feature?**

This PR removes the export button when editing a Grafana-managed alert. We aim to prevent user confusion, as this button doesn't export the updated form data; rather, it exports the data currently stored in the database, which may not reflect the latest changes.

**Why do we need this feature?**

We want to avoid confusion when using export feature.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

Before: 

<img width="484" alt="Screenshot 2023-09-20 at 12 45 47" src="https://github.com/grafana/grafana/assets/33540275/df411ab5-2301-4e9d-b85e-51dd63070060">

After removing the export button:


<img width="624" alt="Screenshot 2023-09-20 at 12 45 26" src="https://github.com/grafana/grafana/assets/33540275/02ef2d0d-0128-46b1-84c4-5c046961d6e8">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
