### PR TITLE
Alerting: Pass loggers into SchedulerCfg and ManagerCfg.

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -89,6 +89,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 		Historian:               nil,
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  srv.tracer,
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	manager := state.NewManager(cfg)
 	includeFolder := !srv.cfg.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel)

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -54,6 +54,7 @@ func NewEngine(appUrl *url.URL, evalFactory eval.EvaluatorFactory, tracer tracin
 				Historian:               nil,
 				MaxStateSaveConcurrency: 1,
 				Tracer:                  tracer,
+				Log:                     log.New("ngalert.state.manager"),
 			}
 			return state.NewManager(cfg)
 		},

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -202,6 +202,7 @@ func (ng *AlertNG) init() error {
 		Metrics:              ng.Metrics.GetSchedulerMetrics(),
 		AlertSender:          alertsRouter,
 		Tracer:               ng.tracer,
+		Log:                  log.New("ngalert.scheduler"),
 	}
 
 	// There are a set of feature toggles available that act as short-circuits for common configurations.
@@ -222,6 +223,7 @@ func (ng *AlertNG) init() error {
 		MaxStateSaveConcurrency:        ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabled(featuremgmt.FlagAlertingNoDataErrorExecution),
 		Tracer:                         ng.tracer,
+		Log:                            log.New("ngalert.state.manager"),
 	}
 	stateManager := state.NewManager(cfg)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -104,6 +104,7 @@ type SchedulerCfg struct {
 	Metrics              *metrics.Scheduler
 	AlertSender          AlertsSender
 	Tracer               tracing.Tracer
+	Log                  log.Logger
 }
 
 // NewScheduler returns a new schedule.
@@ -113,7 +114,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		maxAttempts:           cfg.MaxAttempts,
 		clock:                 cfg.C,
 		baseInterval:          cfg.BaseInterval,
-		log:                   log.New("ngalert.scheduler"),
+		log:                   cfg.Log,
 		evaluatorFactory:      cfg.EvaluatorFactory,
 		ruleStore:             cfg.RuleStore,
 		metrics:               cfg.Metrics,

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -73,6 +74,7 @@ func TestProcessTicks(t *testing.T) {
 		Metrics:      testMetrics.GetSchedulerMetrics(),
 		AlertSender:  notifier,
 		Tracer:       testTracer,
+		Log:          log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
 		Metrics:                 testMetrics.GetStateMetrics(),
@@ -83,6 +85,7 @@ func TestProcessTicks(t *testing.T) {
 		Historian:               &state.FakeHistorian{},
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  testTracer,
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 
@@ -888,6 +891,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Metrics:          m.GetSchedulerMetrics(),
 		AlertSender:      senderMock,
 		Tracer:           testTracer,
+		Log:              log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
 		Metrics:                 m.GetStateMetrics(),
@@ -898,6 +902,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Historian:               &state.FakeHistorian{},
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  testTracer,
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -65,13 +65,14 @@ type ManagerCfg struct {
 	ApplyNoDataAndErrorToAllStates bool
 
 	Tracer tracing.Tracer
+	Log    log.Logger
 }
 
 func NewManager(cfg ManagerCfg) *Manager {
 	return &Manager{
 		cache:                          newCache(),
 		ResendDelay:                    ResendDelay, // TODO: make this configurable
-		log:                            log.New("ngalert.state.manager"),
+		log:                            cfg.Log,
 		metrics:                        cfg.Metrics,
 		instanceStore:                  cfg.InstanceStore,
 		images:                         cfg.Images,

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -28,6 +29,7 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 		Historian:               hist,
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  tracing.InitializeTracerForTest(),
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	sut := state.NewManager(cfg)
 	now := time.Now().UTC()

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -313,6 +314,7 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 		cfg := ManagerCfg{
 			Metrics:                 testMetrics,
 			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.New("ngalert.state.manager"),
 			ExternalURL:             nil,
 			InstanceStore:           &FakeInstanceStore{},
 			Images:                  &NotAvailableImageService{},

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
@@ -202,6 +203,7 @@ func TestWarmStateCache(t *testing.T) {
 		Historian:               &state.FakeHistorian{},
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  tracing.InitializeTracerForTest(),
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 	st.Warm(ctx, dbstore)
@@ -239,6 +241,7 @@ func TestDashboardAnnotations(t *testing.T) {
 		Historian:               hist,
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  tracing.InitializeTracerForTest(),
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 
@@ -1218,6 +1221,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Historian:               hist,
 				MaxStateSaveConcurrency: 1,
 				Tracer:                  tracing.InitializeTracerForTest(),
+				Log:                     log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 
@@ -1318,6 +1322,7 @@ func TestProcessEvalResults(t *testing.T) {
 			Historian:               &state.FakeHistorian{},
 			MaxStateSaveConcurrency: 1,
 			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.New("ngalert.state.manager"),
 		}
 		st := state.NewManager(cfg)
 		rule := models.AlertRuleGen()()
@@ -1469,6 +1474,7 @@ func TestStaleResultsHandler(t *testing.T) {
 			Historian:               &state.FakeHistorian{},
 			MaxStateSaveConcurrency: 1,
 			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.New("ngalert.state.manager"),
 		}
 		st := state.NewManager(cfg)
 		st.Warm(ctx, dbstore)
@@ -1551,6 +1557,7 @@ func TestStaleResults(t *testing.T) {
 		Historian:               &state.FakeHistorian{},
 		MaxStateSaveConcurrency: 1,
 		Tracer:                  tracing.InitializeTracerForTest(),
+		Log:                     log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(cfg)
 
@@ -1724,6 +1731,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 				Historian:               &state.FakeHistorian{},
 				MaxStateSaveConcurrency: 1,
 				Tracer:                  tracing.InitializeTracerForTest(),
+				Log:                     log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 			st.Warm(ctx, dbstore)
@@ -1865,6 +1873,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 				Historian:               fakeHistorian,
 				MaxStateSaveConcurrency: 1,
 				Tracer:                  tracing.InitializeTracerForTest(),
+				Log:                     log.New("ngalert.state.manager"),
 			}
 			st := state.NewManager(cfg)
 			st.Warm(ctx, dbstore)


### PR DESCRIPTION
In some upcoming work, we want to customize the labels attached to these log lines, so let the logger be passed in.