### PR TITLE
Templating: Fix cell macro date formatting

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -546,4 +546,12 @@ describe('fixCellTemplateExpressions', () => {
       '${__data.fields[10]} asd ${__data.fields[15]} asd ${__data.fields[20]}'
     );
   });
+
+  it('Should handle date formatting', () => {
+    expect(
+      fixCellTemplateExpressions('$__cell_10:date:iso asd ${__cell_15:date:seconds} asd [[__cell_20:date:YYYY-MM]]')
+    ).toEqual(
+      '${__data.fields[10]:date:iso} asd ${__data.fields[15]:date:seconds} asd ${__data.fields[20]:date:YYYY-MM}'
+    );
+  });
 });

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -373,9 +373,12 @@ function getDisplayText(display: DisplayValue, fallback: string): string {
 }
 
 export function fixCellTemplateExpressions(str: string) {
-  return str.replace(/\${__cell_(\d+)}|\[\[__cell_(\d+)\]\]|\$__cell_(\d+)/g, (match, fmt1, fmt2, fmt3) => {
-    return `\${__data.fields[${fmt1 ?? fmt2 ?? fmt3}]}`;
-  });
+  return str.replace(
+    /\${__cell_(\d+)(.*?)}|\[\[__cell_(\d+)(.*?)\]\]|\$__cell_(\d+)(\S*)/g,
+    (match, cellNum1, fmt1, cellNum2, fmt2, cellNum3, fmt3) => {
+      return `\${__data.fields[${cellNum1 ?? cellNum2 ?? cellNum3}]${fmt1 ?? fmt2 ?? fmt3}}`;
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes date formatting when used with the cell macro which was broken in https://github.com/grafana/grafana/pull/65324 (I think)

Closes #70301