### PR TITLE
Use const assertion instead of type assertion

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4164,9 +4164,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/plugins/datasource/tempo/traceql/autocomplete.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/datasource/testdata/ConfigEditor.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -340,7 +340,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
         const functions = CompletionProvider.functions.map((key) => ({
           ...key,
           insertTextRules: this.monaco?.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
-          type: 'FUNCTION' as CompletionType,
+          type: 'FUNCTION' as const,
         }));
         const tags = this.getScopesCompletions()
           .concat(this.getIntrinsicsCompletions())


### PR DESCRIPTION
Small PR to replace a type assertion with a `const` one, as suggested in [this comment](https://github.com/grafana/grafana/pull/74790#discussion_r1331594837).