### PR TITLE
Docs:  Fix Tempo link errors

### DIFF
--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -26,7 +26,7 @@ For instructions on how to add a data source to Grafana, refer to the [administr
 Only users with the organization administrator role can add data sources.
 Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-Once you've added the data source, you can [configure it](<{{ relref "./configure-tempo-data-source" }}>) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
+Once you've added the data source, you can [configure it]({{< relref "./configure-tempo-data-source/" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards][build-dashboards] and use [Explore][explore].
 
 {{< section withDescriptions="true">}}
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -135,7 +135,7 @@ Each linked query consists of:
 
 ## Service Graph
 
-The **Service Graph** setting configures the [Service Graph](/docs/tempo/latest/metrics-generator/service-graphs/) feature.
+The **Service Graph** setting configures the [Service Graph](/docs/tempo/latest/metrics-generator/service_graphs/enable-service-graphs/) feature.
 
 Configure the **Data source** setting to define in which Prometheus instance the Service Graph data is stored.
 

--- a/docs/sources/datasources/tempo/service-graph.md
+++ b/docs/sources/datasources/tempo/service-graph.md
@@ -26,7 +26,7 @@ You use the Service Graph to detect performance issues; track increases in error
 
 ## Display the Service Graph
 
-1. [Configure Grafana Agent](/docs/tempo/latest/grafana-agent/service-graphs/#quickstart) or [Tempo or GET](/docs/tempo/latest/metrics-generator/service_graphs/#tempo) to generate Service Graph data.
+1. [Configure Grafana Agent](/docs/tempo/latest/configuration/grafana-agent/) or [Tempo or GET](/docs/tempo/latest/metrics-generator/service_graphs/#tempo) to generate Service Graph data.
 1. Link a Prometheus data source in the Tempo data source's [Service Graph]({{< relref "./configure-tempo-data-source#configure-service-graph" >}}) settings.
 1. Navigate to [Explore][explore].
 1. Select the Tempo data source.


### PR DESCRIPTION
Fixed the following 404 link errors:

configure it

Configure Grafana Agent

Service Graph
