### PR TITLE
[v10.1.x] Loki: Fix filters not being added with multiple expressions and parsers

### DIFF
--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -59,6 +59,7 @@ describe('addLabelToQuery()', () => {
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser with escaped value and regex operator'}                   | ${'bar'} | ${'~='}  | ${'\\"baz\\"'} | ${'{foo="bar"} | logfmt | bar~=`"baz"`'}
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser, > operator and number value'}                            | ${'bar'} | ${'>'}   | ${'5'}         | ${'{foo="bar"} | logfmt | bar>5'}
     ${'{foo="bar"} | logfmt'}                                                                                                         | ${'query with parser, < operator and non-number value'}                        | ${'bar'} | ${'<'}   | ${'5KiB'}      | ${'{foo="bar"} | logfmt | bar<`5KiB`'}
+    ${'sum(rate({x="y"} | logfmt [5m])) + sum(rate({x="z"} | logfmt [5m]))'}                                                          | ${'metric query with non empty selectors and parsers'}                         | ${'bar'} | ${'='}   | ${'baz'}       | ${'sum(rate({x="y"} | logfmt | bar=`baz` [5m])) + sum(rate({x="z"} | logfmt | bar=`baz` [5m]))'}
   `(
     'should add label to query:  $query, description: $description',
     ({ query, description, label, operator, value, expectedResult }) => {


### PR DESCRIPTION
Backport 480aa1ccca03f267907c685a0f2358a9793ff677 from #75152

---

**What is this feature?**

When using a dashboard with adhoc filters and a loki query containing two metric queries and label filters, the ad hoc filter is only added to the last label filter. Previously we determined the last positions of parsers or label filters in the whole query, however we need to do that per sub expression.

**Which issue(s) does this PR fix?**:

Fixes #75101

**How do we reproduce it?**
1. Create a dashboard with a `sum(rate({place="luna"} | logfmt [$__auto])) / sum(rate({place="moon"} |json [$__auto]))` query.
2. Add a Loki ad hoc filter.
3. Apply the ad hoc filter and observe that it is only added to the last subexpression of a query.
