### PR TITLE
Navigation: enable third level on the `DockedMegaMenu`

### DIFF
--- a/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
@@ -17,7 +18,12 @@ const setup = () => {
       id: 'section',
       url: 'section',
       children: [
-        { text: 'Child1', id: 'child1', url: 'section/child1' },
+        {
+          text: 'Child1',
+          id: 'child1',
+          url: 'section/child1',
+          children: [{ text: 'Grandchild1', id: 'grandchild1', url: 'section/child1/grandchild1' }],
+        },
         { text: 'Child2', id: 'child2', url: 'section/child2' },
       ],
     },
@@ -46,6 +52,22 @@ describe('MegaMenu', () => {
 
     expect(await screen.findByTestId('navbarmenu')).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Section name' })).toBeInTheDocument();
+  });
+
+  it('should render children', async () => {
+    setup();
+    userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
+    expect(await screen.findByRole('link', { name: 'Child1' })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'Child2' })).toBeInTheDocument();
+  });
+
+  it('should render grandchildren', async () => {
+    setup();
+    userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
+    expect(await screen.findByRole('link', { name: 'Child1' })).toBeInTheDocument();
+    userEvent.click(await screen.findByRole('button', { name: 'Expand section Child1' }));
+    expect(await screen.findByRole('link', { name: 'Grandchild1' })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'Child2' })).toBeInTheDocument();
   });
 
   it('should filter out profile', async () => {

--- a/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
@@ -47,6 +47,9 @@ const setup = () => {
 };
 
 describe('MegaMenu', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
   it('should render component', async () => {
     setup();
 
@@ -56,16 +59,16 @@ describe('MegaMenu', () => {
 
   it('should render children', async () => {
     setup();
-    userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
     expect(await screen.findByRole('link', { name: 'Child1' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Child2' })).toBeInTheDocument();
   });
 
   it('should render grandchildren', async () => {
     setup();
-    userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Expand section Section name' }));
     expect(await screen.findByRole('link', { name: 'Child1' })).toBeInTheDocument();
-    userEvent.click(await screen.findByRole('button', { name: 'Expand section Child1' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Expand section Child1' }));
     expect(await screen.findByRole('link', { name: 'Grandchild1' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Child2' })).toBeInTheDocument();
   });

--- a/public/app/core/components/AppChrome/DockedMegaMenu/NavBarMenuItemWrapper.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/NavBarMenuItemWrapper.tsx
@@ -34,7 +34,14 @@ export function NavBarMenuItemWrapper({
       {linkHasChildren(link) && (
         <ul className={styles.children}>
           {link.children.map((childLink) => {
-            return (
+            return linkHasChildren(childLink) ? (
+              <NavBarMenuItemWrapper
+                key={`${link.text}-${childLink.text}`}
+                link={childLink}
+                activeItem={activeItem}
+                onClose={onClose}
+              />
+            ) : (
               !childLink.isCreateAction && (
                 <NavBarMenuItem
                   key={`${link.text}-${childLink.text}`}


### PR DESCRIPTION
**What is this feature?**

To be able to see a third level in the `DockedMegaMenu`.

**Why do we need this feature?**

It enables the third level on the `DockedMegaMenu`.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:
Fixes #75125 

**Special notes for your reviewer:**
You should enable the feature toggle `dockedMegaMenu`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
