### PR TITLE
Prometheus: Fix creation of invalid dataframes with exemplars

### DIFF
--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -387,6 +387,7 @@ l1Fields:
 			frame.Meta = &data.FrameMeta{
 				Custom: resultTypeToCustomMeta("exemplar"),
 			}
+			exCount := 0
 			for more, err := iter.ReadArray(); more; more, err = iter.ReadArray() {
 				if err != nil {
 					return nil, nil, err
@@ -417,7 +418,6 @@ l1Fields:
 						timeField.Append(ts)
 
 					case "labels":
-						max := 0
 						pairs, err := readLabelsAsPairs(iter)
 						if err != nil {
 							return nil, nil, err
@@ -427,20 +427,17 @@ l1Fields:
 							v := pair[1]
 							f, ok := lookup[k]
 							if !ok {
-								f = data.NewFieldFromFieldType(data.FieldTypeString, 0)
+								f = data.NewFieldFromFieldType(data.FieldTypeString, exCount)
 								f.Name = k
 								lookup[k] = f
 								frame.Fields = append(frame.Fields, f)
 							}
 							f.Append(v)
-							if f.Len() > max {
-								max = f.Len()
-							}
 						}
 
 						// Make sure all fields have equal length
 						for _, f := range lookup {
-							diff := max - f.Len()
+							diff := exCount + 1 - f.Len()
 							if diff > 0 {
 								f.Extend(diff)
 							}
@@ -457,6 +454,7 @@ l1Fields:
 						})
 					}
 				}
+				exCount++
 			}
 		case "":
 			if err != nil {

--- a/pkg/util/converter/prom_test.go
+++ b/pkg/util/converter/prom_test.go
@@ -32,6 +32,7 @@ var files = []string{
 	"prom-error",
 	"prom-exemplars-a",
 	"prom-exemplars-b",
+	"prom-exemplars-diff-labels",
 	"loki-streams-a",
 	"loki-streams-b",
 	"loki-streams-c",

--- a/pkg/util/converter/testdata/prom-exemplars-diff-labels-frame.jsonc
+++ b/pkg/util/converter/testdata/prom-exemplars-diff-labels-frame.jsonc
@@ -1,0 +1,93 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "custom": {
+//          "resultType": "exemplar"
+//      }
+//  }
+//  Name: 
+//  Dimensions: 4 Fields by 2 Rows
+//  +-----------------------------------+-----------------+------------------+------------------+
+//  | Name: Time                        | Name: Value     | Name: traceID    | Name: ztraceID   |
+//  | Labels:                           | Labels:         | Labels:          | Labels:          |
+//  | Type: []time.Time                 | Type: []float64 | Type: []string   | Type: []string   |
+//  +-----------------------------------+-----------------+------------------+------------------+
+//  | 2020-09-14 15:22:35.479 +0000 UTC | 19              | Olp9XHlq763ccsfa |                  |
+//  | 2020-09-14 15:22:45.489 +0000 UTC | 20              |                  | hCtjygkIHwAN9vs4 |
+//  +-----------------------------------+-----------------+------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "custom": {
+            "resultType": "exemplar"
+          }
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "labels": {}
+          },
+          {
+            "name": "traceID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "ztraceID",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1600096955479,
+            1600096965489
+          ],
+          [
+            19,
+            20
+          ],
+          [
+            "Olp9XHlq763ccsfa",
+            ""
+          ],
+          [
+            "",
+            "hCtjygkIHwAN9vs4"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/util/converter/testdata/prom-exemplars-diff-labels.json
+++ b/pkg/util/converter/testdata/prom-exemplars-diff-labels.json
@@ -1,0 +1,23 @@
+{
+    "status": "success",
+    "data": [
+        {
+            "exemplars": [
+                {
+                    "labels": {
+                        "traceID": "Olp9XHlq763ccsfa"
+                    },
+                    "value": "19",
+                    "timestamp": 1600096955.479
+                },
+                {
+                    "labels": {
+                        "ztraceID": "hCtjygkIHwAN9vs4"
+                    },
+                    "value": "20",
+                    "timestamp": 1600096965.489
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
With different labels for examplars, the prom response parser would create invalid frames (different field lengths). The prom datasource would then panic processing these frames.

This adds a test case for it and addresses the issue.

**Which issue(s) does this PR fix?**:

Fixes #73654

**Special notes for your reviewer:**

It was creating something like the following:

```
(*data.Frame)(0xc000b3f7c0)({
 Name: (string) "",
 Fields: ([]*data.Field) (len=4 cap=4) {
  (*data.Field)(0xc000aadaa0)({
   Name: (string) (len=4) "Time",
   Labels: (data.Labels) ,
   Config: (*data.FieldConfig)(<nil>),
   vector: (*data.timeTimeVector)(0xc0002018d8)((len=2 cap=2) {
    (time.Time) 2022-06-01 12:28:36.81 +0000 UTC,
    (time.Time) 2031-12-03 17:48:36.81 +0000 UTC
   })
  }),
  (*data.Field)(0xc000aadad0)({
   Name: (string) (len=5) "Value",
   Labels: (data.Labels) (len=9) __name__=traces_spanmetrics_duration_seconds_bucket, group=mythical, instance=f1c32fe505c3, le=0.256, service=mythical-requester, source=tempo, span_kind=SPAN_KIND_CLIENT, span_name=requester, span_status=STATUS_CODE_OK,
   Config: (*data.FieldConfig)(<nil>),
   vector: (*data.float64Vector)(0xc0002018f0)((len=2 cap=2) {
    (float64) 1.134971,
    (float64) 1.134971
   })
  }),
  (*data.Field)(0xc000aadb30)({
   Name: (string) (len=7) "traceID",
   Labels: (data.Labels) ,
   Config: (*data.FieldConfig)(<nil>),
   vector: (*data.stringVector)(0xc000201908)((len=1 cap=1) {
    (string) (len=32) "46e15ae41852149068aeb26c64643c29"
   })
  }),
  (*data.Field)(0xc000aadb60)({
   Name: (string) (len=8) "ztraceID",
   Labels: (data.Labels) ,
   Config: (*data.FieldConfig)(<nil>),
   vector: (*data.stringVector)(0xc000201950)((len=1 cap=1) {
    (string) (len=32) "46e15ae41852149068aeb26c64643c29"
   })
  })
 },
```

Which wouldn't marshal to JSON, so if we had the test case the existing tests would have failed.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
