### PR TITLE
[v9.5.x] LDAP: FIX Enable users on successfull login 

### DIFF
--- a/pkg/services/authn/clients/ldap.go
+++ b/pkg/services/authn/clients/ldap.go
@@ -107,7 +107,7 @@ func (c *LDAP) disableUser(ctx context.Context, username string) (*authn.Identit
 }
 
 func (c *LDAP) identityFromLDAPInfo(orgID int64, info *login.ExternalUserInfo) *authn.Identity {
-	return &authn.Identity{
+	id := &authn.Identity{
 		OrgID:          orgID,
 		OrgRoles:       info.OrgRoles,
 		Login:          info.Login,
@@ -131,4 +131,12 @@ func (c *LDAP) identityFromLDAPInfo(orgID int64, info *login.ExternalUserInfo) *
 			},
 		},
 	}
+
+	// The ldap service is not aware of the internal state of the user. Fetching the user
+	// from the store to know if that user is disabled or not, is almost as costly as
+	// running an update systematically. We are setting IsDisabled to true so that the
+	// EnableDisabledUserHook force-enable that user.
+	id.IsDisabled = true
+
+	return id
 }

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -60,6 +60,7 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 				AuthModule: login.LDAPAuthModule,
 				AuthID:     "123",
 				Groups:     []string{"1", "2"},
+				IsDisabled: true, // Users are marked as disabled to force enablement on successful login
 				ClientParams: authn.ClientParams{
 					SyncUser:            true,
 					SyncTeams:           true,
@@ -129,6 +130,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 				AuthModule: login.LDAPAuthModule,
 				AuthID:     "123",
 				Groups:     []string{"1", "2"},
+				IsDisabled: true, // Users are marked as disabled to force enablement on successful login
 				ClientParams: authn.ClientParams{
 					SyncUser:            true,
 					SyncTeams:           true,


### PR DESCRIPTION
Backport c8149d50f964fd6a5b35ae89ca8bcaf657e39a9d from #75073

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In previous versions, before the new `auth broker service` was introduced, we used to enable users upon successful ldap login.
We had a regression when switching to the `auth broker service`.
This PR intends to fix this issue.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
