### PR TITLE
Chore: uPlot v1.6.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
     "tween-functions": "^1.2.0",
-    "uplot": "1.6.25",
+    "uplot": "1.6.26",
     "uuid": "9.0.0",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
     "tween-functions": "^1.2.0",
-    "uplot": "1.6.24",
+    "uplot": "1.6.25",
     "uuid": "9.0.0",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -58,7 +58,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
-    "uplot": "1.6.24",
+    "uplot": "1.6.25",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -58,7 +58,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
-    "uplot": "1.6.25",
+    "uplot": "1.6.26",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -111,7 +111,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
-    "uplot": "1.6.25",
+    "uplot": "1.6.26",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -111,7 +111,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.0",
-    "uplot": "1.6.24",
+    "uplot": "1.6.25",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -90,6 +90,7 @@ export function getConfig(opts: TimelineCoreOptions) {
       mark.classList.add('bar-mark');
       mark.style.position = 'absolute';
       mark.style.background = 'rgba(255,255,255,0.2)';
+      mark.style.pointerEvents = 'none';
       return mark;
     });
 

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -167,13 +167,13 @@ export const ContextMenuPlugin = ({
 
   return (
     <>
-      <Global
+      {/* <Global
         styles={cssCore`
         .uplot .u-cursor-pt {
           pointer-events: auto !important;
         }
       `}
-      />
+      /> */}
       {isOpen && coords && (
         <ContextMenuView
           data={data}

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -1,4 +1,3 @@
-import { css as cssCore, Global } from '@emotion/react';
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useClickAway } from 'react-use';
 
@@ -167,13 +166,6 @@ export const ContextMenuPlugin = ({
 
   return (
     <>
-      {/* <Global
-        styles={cssCore`
-        .uplot .u-cursor-pt {
-          pointer-events: auto !important;
-        }
-      `}
-      /> */}
       {isOpen && coords && (
         <ContextMenuView
           data={data}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,7 +3708,7 @@ __metadata:
     tinycolor2: 1.6.0
     tslib: 2.6.0
     typescript: 4.8.4
-    uplot: 1.6.24
+    uplot: 1.6.25
     xss: ^1.0.14
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
@@ -4202,7 +4202,7 @@ __metadata:
     tinycolor2: 1.6.0
     tslib: 2.6.0
     typescript: 4.8.4
-    uplot: 1.6.24
+    uplot: 1.6.25
     uuid: 9.0.0
     webpack: 5.88.1
   peerDependencies:
@@ -19999,7 +19999,7 @@ __metadata:
     tslib: 2.6.0
     tween-functions: ^1.2.0
     typescript: 4.8.4
-    uplot: 1.6.24
+    uplot: 1.6.25
     uuid: 9.0.0
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -32973,10 +32973,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.24":
-  version: 1.6.24
-  resolution: "uplot@npm:1.6.24"
-  checksum: 253e389dc6db40e1231d1c63913dea1e6987856cfde985da036e70786ef0077afc40f3ed6883c54d95a97ecedc3ea52a7fa815e88f3c3d381b61c15e745f8a40
+"uplot@npm:1.6.25":
+  version: 1.6.25
+  resolution: "uplot@npm:1.6.25"
+  checksum: c47275821ace942a16d89df6b5f4e18cfc9821f8288aee0e43d976ee1d40e8ecd27a3b9b4cf84f87bb0192a426fd727b27fbb1763c902ae7c68af75bf80672fd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,7 +3708,7 @@ __metadata:
     tinycolor2: 1.6.0
     tslib: 2.6.0
     typescript: 4.8.4
-    uplot: 1.6.25
+    uplot: 1.6.26
     xss: ^1.0.14
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
@@ -4202,7 +4202,7 @@ __metadata:
     tinycolor2: 1.6.0
     tslib: 2.6.0
     typescript: 4.8.4
-    uplot: 1.6.25
+    uplot: 1.6.26
     uuid: 9.0.0
     webpack: 5.88.1
   peerDependencies:
@@ -19999,7 +19999,7 @@ __metadata:
     tslib: 2.6.0
     tween-functions: ^1.2.0
     typescript: 4.8.4
-    uplot: 1.6.25
+    uplot: 1.6.26
     uuid: 9.0.0
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -32973,10 +32973,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.25":
-  version: 1.6.25
-  resolution: "uplot@npm:1.6.25"
-  checksum: c47275821ace942a16d89df6b5f4e18cfc9821f8288aee0e43d976ee1d40e8ecd27a3b9b4cf84f87bb0192a426fd727b27fbb1763c902ae7c68af75bf80672fd
+"uplot@npm:1.6.26":
+  version: 1.6.26
+  resolution: "uplot@npm:1.6.26"
+  checksum: 873b5b049b0b2e00534e4a02bfcab7df6972099a2cedec0cd8b1ba949b318628a7d59b988e0f45fd3f8ed4eb6cc5a84d59f83a15b702c21f7396c664dc41a124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bunch of internal & api adjustments to unblock tooltip rework in:
https://github.com/grafana/grafana/pull/70872
https://github.com/grafana/grafana/pull/71603

Fixes https://github.com/grafana/support-escalations/issues/6671

Fixes https://github.com/grafana/grafana/issues/69610
Fixes https://github.com/grafana/grafana/issues/65581
Fixes https://github.com/grafana/grafana/issues/63840

<details><summary>log-ticks-collision-uplot-fixes.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 630,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 2,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "bytes"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 11,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "2,2e9"
        }
      ],
      "title": "Log 2",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "bars",
            "fillOpacity": 100,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "never",
            "spanNulls": 3600000,
            "stacking": {
              "group": "A",
              "mode": "normal"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              }
            ]
          },
          "unit": "reqps"
        },
        "overrides": [
          {
            "matcher": {
              "id": "byRegexp",
              "options": "2.."
            },
            "properties": [
              {
                "id": "color",
                "value": {
                  "fixedColor": "green",
                  "mode": "fixed"
                }
              }
            ]
          },
          {
            "matcher": {
              "id": "byRegexp",
              "options": "3.."
            },
            "properties": [
              {
                "id": "color",
                "value": {
                  "fixedColor": "yellow",
                  "mode": "fixed"
                }
              }
            ]
          },
          {
            "matcher": {
              "id": "byRegexp",
              "options": "4.."
            },
            "properties": [
              {
                "id": "color",
                "value": {
                  "fixedColor": "orange",
                  "mode": "fixed"
                }
              }
            ]
          },
          {
            "matcher": {
              "id": "byRegexp",
              "options": "5.."
            },
            "properties": [
              {
                "id": "color",
                "value": {
                  "fixedColor": "red",
                  "mode": "fixed"
                }
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 27,
        "w": 3,
        "x": 11,
        "y": 0
      },
      "id": 5,
      "interval": "1m",
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"Responses\",\n      \"meta\": {\n        \"executedQueryString\": \"Expr: sum by (res_statusCode) (rate ({hostname=\\\"portal-staging.golem.network\\\", user_unit=\\\"gp-portal-api.service\\\"} |= \\\"request completed\\\" | json [1m]))\\nStep: 1m0s\",\n        \"preferredVisualisationType\": \"graph\",\n        \"stats\": [\n          {\n            \"displayName\": \"Summary: bytes processed per second\",\n            \"unit\": \"Bps\",\n            \"value\": 6839691\n          },\n          {\n            \"displayName\": \"Summary: lines processed per second\",\n            \"value\": 43670\n          },\n          {\n            \"displayName\": \"Summary: total bytes processed\",\n            \"unit\": \"decbytes\",\n            \"value\": 441513\n          },\n          {\n            \"displayName\": \"Summary: total lines processed\",\n            \"value\": 2819\n          },\n          {\n            \"displayName\": \"Summary: exec time\",\n            \"unit\": \"s\",\n            \"value\": 0.064551595\n          },\n          {\n            \"displayName\": \"Ingester: total reached\",\n            \"value\": 112\n          },\n          {\n            \"displayName\": \"Ingester: total chunks matched\",\n            \"value\": 2\n          },\n          {\n            \"displayName\": \"Ingester: total batches\",\n            \"value\": 7\n          },\n          {\n            \"displayName\": \"Ingester: total lines sent\",\n            \"value\": 38\n          },\n          {\n            \"displayName\": \"Ingester: head chunk bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: head chunk lines\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: decompressed bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: decompressed lines\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: compressed bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: total duplicates\",\n            \"value\": 0\n          }\n        ],\n        \"type\": \"timeseries-multi\",\n        \"typeVersion\": [\n          0,\n          0\n        ]\n      },\n      \"name\": \"200\",\n      \"fields\": [\n        {\n          \"config\": {\n            \"interval\": 60000\n          },\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"200\"\n          },\n          \"labels\": {\n            \"res_statusCode\": \"200\"\n          },\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1686017160000,\n          1686017460000,\n          1686017580000,\n          1686017760000,\n          1686018060000,\n          1686018360000,\n          1686018420000,\n          1686018660000,\n          1686018900000,\n          1686018960000,\n          1686019260000,\n          1686019560000,\n          1686019860000,\n          1686020040000,\n          1686020160000,\n          1686020460000,\n          1686020760000,\n          1686021060000,\n          1686021360000,\n          1686021660000,\n          1686021840000,\n          1686021960000,\n          1686022260000,\n          1686022560000,\n          1686022800000,\n          1686022860000,\n          1686023160000,\n          1686023460000,\n          1686023760000,\n          1686024060000,\n          1686024360000,\n          1686024660000,\n          1686024720000,\n          1686024900000,\n          1686024960000,\n          1686025140000,\n          1686025260000,\n          1686025560000,\n          1686025860000,\n          1686026160000,\n          1686026460000,\n          1686026760000,\n          1686027060000,\n          1686027120000,\n          1686027360000,\n          1686027660000,\n          1686027960000,\n          1686028260000,\n          1686028560000,\n          1686028860000,\n          1686029160000,\n          1686029460000,\n          1686029760000,\n          1686030060000,\n          1686030360000,\n          1686030660000,\n          1686030960000,\n          1686031260000,\n          1686031560000,\n          1686031860000,\n          1686032160000,\n          1686032460000,\n          1686032760000,\n          1686033060000,\n          1686033360000,\n          1686033660000,\n          1686033960000,\n          1686034260000,\n          1686034560000,\n          1686034860000,\n          1686035160000,\n          1686035460000,\n          1686035760000,\n          1686035820000,\n          1686036060000,\n          1686036360000,\n          1686036420000,\n          1686036660000,\n          1686036960000,\n          1686037260000,\n          1686037560000,\n          1686037860000,\n          1686037980000,\n          1686038160000,\n          1686038460000\n        ],\n        [\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.03333333333333333,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.05,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.03333333333333333,\n          0.05,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.03333333333333333,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666,\n          0.016666666666666666\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"Responses\",\n      \"meta\": {\n        \"executedQueryString\": \"Expr: sum by (res_statusCode) (rate ({hostname=\\\"portal-staging.golem.network\\\", user_unit=\\\"gp-portal-api.service\\\"} |= \\\"request completed\\\" | json [1m]))\\nStep: 1m0s\",\n        \"preferredVisualisationType\": \"graph\",\n        \"type\": \"timeseries-multi\",\n        \"typeVersion\": [\n          0,\n          0\n        ]\n      },\n      \"name\": \"404\",\n      \"fields\": [\n        {\n          \"config\": {\n            \"interval\": 60000\n          },\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"404\"\n          },\n          \"labels\": {\n            \"res_statusCode\": \"404\"\n          },\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1686024300000,\n          1686024600000,\n          1686024720000,\n          1686024900000,\n          1686029160000,\n          1686036420000\n        ],\n        [\n          0.06666666666666667,\n          0.03333333333333333,\n          0.03333333333333333,\n          0.06666666666666667,\n          0.016666666666666666,\n          0.016666666666666666\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Bleed",
      "transformations": [],
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "bytes"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 11,
        "x": 0,
        "y": 9
      },
      "id": 3,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "2,2e9"
        }
      ],
      "title": "Log 10",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "sci"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 11,
        "x": 0,
        "y": 18
      },
      "id": 4,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "1e-14,1e-2"
        }
      ],
      "title": "Log 10",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 38,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2023-06-06T02:03:26.181Z",
    "to": "2023-06-06T08:02:53.069Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "log-ticks-collision-uplot-fixes",
  "uid": "cac9ea66-d7eb-404e-b74a-8fec69ab3909",
  "version": 8,
  "weekStart": ""
}
```
</details>

before:
![image](https://github.com/grafana/grafana/assets/43234/652cee8f-60ec-442c-a78d-1b98b0d17e7f)

after:
![image](https://github.com/grafana/grafana/assets/43234/19db637f-74cd-4cf4-9940-667dbb015fe2)

Also fixes an issue with the cursor being visible at 0,0 during initial panel load. i've seen this in many screenshots but found it hard to reproduce locally. finally did tho: https://github.com/leeoniya/uPlot/issues/834

![image](https://github.com/grafana/grafana/assets/43234/1246024b-f89d-4127-bd13-72e6895b6875)

Also fixes a clipping bug when explicitly-set axis min or max matches the data min or max:

before:
![image](https://github.com/grafana/grafana/assets/43234/281d4573-a304-4339-94ed-1f96bab26035) 

after:
![image](https://github.com/grafana/grafana/assets/43234/eecce213-eac8-4417-be7d-645604ad54fa)