### PR TITLE
Alerting: call rule API using the folder UID instead of title

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -173,7 +173,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
       { rulerConfig: RulerDataSourceConfig; namespace: string; group: string }
     >({
       query: ({ rulerConfig, namespace, group }) => {
-        const { path, params } = rulerUrlBuilder(rulerConfig).namespaceGroup(namespace, group);
+        const { path, params } = rulerUrlBuilder(rulerConfig).namespaceGroup(namespace, group); //@todo change namespace to folder uid
         return { url: path, params };
       },
     }),

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -160,10 +160,11 @@ export interface ModalProps {
   intervalEditOnly?: boolean;
   folderUrl?: string;
   hideFolder?: boolean;
+  folderUid?: string;
 }
 
 export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
-  const { namespace, group, onClose, intervalEditOnly } = props;
+  const { namespace, group, onClose, intervalEditOnly, folderUid } = props;
 
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
@@ -202,6 +203,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
         namespaceName: namespace.name,
         newNamespaceName: values.namespaceName,
         groupInterval: values.groupInterval || undefined,
+        uid: folderUid,
       })
     );
   };

--- a/public/app/features/alerting/unified/components/rules/ReorderRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/ReorderRuleGroupModal.tsx
@@ -25,6 +25,7 @@ import { AlertStateTag } from './AlertStateTag';
 
 interface ModalProps {
   namespace: CombinedRuleNamespace;
+  folderUid?: string;
   group: CombinedRuleGroup;
   onClose: () => void;
 }
@@ -32,7 +33,7 @@ interface ModalProps {
 type CombinedRuleWithUID = { uid: string } & CombinedRule;
 
 export const ReorderCloudGroupModal = (props: ModalProps) => {
-  const { group, namespace, onClose } = props;
+  const { group, namespace, onClose, folderUid } = props;
   const [pending, setPending] = useState<boolean>(false);
   const [rulesList, setRulesList] = useState<CombinedRule[]>(group.rules);
 
@@ -50,6 +51,10 @@ export const ReorderCloudGroupModal = (props: ModalProps) => {
         return;
       }
 
+      if (!folderUid) {
+        return;
+      }
+
       const newOrderedRules = reorder(rulesList, result.source.index, result.destination.index);
       setRulesList(newOrderedRules); // optimistically update the new rules list
 
@@ -63,6 +68,7 @@ export const ReorderCloudGroupModal = (props: ModalProps) => {
           groupName: group.name,
           rulesSourceName: rulesSourceName,
           newRules: rulerRules,
+          folderUid: folderUid,
         })
       )
         .unwrap()

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -248,13 +248,19 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
       {isEditingGroup && (
         <EditCloudGroupModal
           namespace={namespace}
+          folderUid={folderUID}
           group={group}
           onClose={() => closeEditModal()}
           folderUrl={folder?.canEdit ? makeFolderSettingsLink(folder) : undefined}
         />
       )}
       {isReorderingGroup && (
-        <ReorderCloudGroupModal group={group} namespace={namespace} onClose={() => setIsReorderingGroup(false)} />
+        <ReorderCloudGroupModal
+          group={group}
+          folderUid={folderUID}
+          namespace={namespace}
+          onClose={() => setIsReorderingGroup(false)}
+        />
       )}
       <ConfirmModal
         isOpen={isDeletingGroup}

--- a/public/app/features/alerting/unified/utils/rulerClient.ts
+++ b/public/app/features/alerting/unified/utils/rulerClient.ts
@@ -50,7 +50,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
 
     if (isCloudRuleIdentifier(ruleIdentifier)) {
       const { ruleSourceName, namespace, groupName } = ruleIdentifier;
-      const group = await fetchRulerRulesGroup(rulerConfig, namespace, groupName);
+      const group = await fetchRulerRulesGroup(rulerConfig, namespace, groupName); //@todo change namespace to folder uid
 
       if (!group) {
         return null;
@@ -85,11 +85,12 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
 
     // it was the last rule, delete the entire group
     if (group.rules.length === 1) {
-      await deleteRulerRulesGroup(rulerConfig, namespace, group.name);
+      await deleteRulerRulesGroup(rulerConfig, namespace, group.name); //@todo: change namespace to folder uid
       return;
     }
     // post the group with rule removed
     await setRulerRuleGroup(rulerConfig, namespace, {
+      //@todo: change namespace to folder uid
       ...group,
       rules: group.rules.filter((r) => r !== rule),
     });
@@ -122,14 +123,14 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
             ),
             evaluateEvery: evaluateEvery,
           };
-          await setRulerRuleGroup(rulerConfig, namespace, payload);
+          await setRulerRuleGroup(rulerConfig, namespace, payload); //@todo: change namespace to folder uid
           return ruleId.fromRulerRule(dataSourceName, namespace, group, formRule);
         }
       }
 
       // if creating new rule or existing rule was in a different namespace/group, create new rule in target group
 
-      const targetGroup = await fetchRulerRulesGroup(rulerConfig, namespace, group);
+      const targetGroup = await fetchRulerRulesGroup(rulerConfig, namespace, group); //@todo change namespace to folder uid
 
       const payload: RulerRuleGroupDTO = targetGroup
         ? {
@@ -141,7 +142,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
             rules: [formRule],
           };
 
-      await setRulerRuleGroup(rulerConfig, namespace, payload);
+      await setRulerRuleGroup(rulerConfig, namespace, payload); //@todo: change namespace to folder uid
       return ruleId.fromRulerRule(dataSourceName, namespace, group, formRule);
     } else {
       throw new Error('Data source and location must be specified');
@@ -190,7 +191,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
     group: { name: string; interval: string },
     newRule: PostableRuleGrafanaRuleDTO
   ): Promise<RuleIdentifier> => {
-    const existingGroup = await fetchRulerRulesGroup(rulerConfig, namespace, group.name);
+    const existingGroup = await fetchRulerRulesGroup(rulerConfig, namespace, group.name); //@todo change namespace to folder uid
     if (!existingGroup) {
       throw new Error(`No group found with name "${group.name}"`);
     }
@@ -201,7 +202,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
       rules: (existingGroup.rules ?? []).concat(newRule as RulerGrafanaRuleDTO),
     };
 
-    await setRulerRuleGroup(rulerConfig, namespace, payload);
+    await setRulerRuleGroup(rulerConfig, namespace, payload); //@todo: change namespace to folder uid
 
     return { uid: newRule.grafana_alert.uid ?? '', ruleSourceName: GRAFANA_RULES_SOURCE_NAME };
   };
@@ -243,6 +244,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
     });
 
     await setRulerRuleGroup(rulerConfig, existingRule.namespace, {
+      //@todo: change namespace to folder uid
       name: existingRule.group.name,
       interval: interval,
       rules: newRules,


### PR DESCRIPTION
After https://github.com/grafana/grafana/pull/74600, the rule API must be called using the folder UID instead of the folder title as the namespace parameter.

The place where we call this API is https://github.com/grafana/grafana/blob/main/public/app/features/alerting/unified/api/ruler.ts#L39-L46 so all usages of `rulerUrlBuilder(rulerConfig).namespace(namespace);` and `rulerUrlBuilder(rulerConfig).namespaceGroup(namespace, groupName)` should update the `namespace` parameter.

I've marked all places where this needs to be changed with `//@todo: change namespace to folder uid`
