### PR TITLE
Chore: Add test for anonymous access

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -91,21 +91,21 @@ func TestGetHomeDashboard(t *testing.T) {
 		req                   *contextmodel.ReqContext
 	}{
 		{
-			name:                  "using default config",
+			name:                  "using default configuration settings",
 			defaultSetting:        "",
 			expectedDashboardPath: "../../public/dashboards/home.json",
 			req:                   &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}},
 		},
 		{
-			name:                  "custom path",
+			name:                  "using custom path for configuration settings",
 			defaultSetting:        "../../public/dashboards/default.json",
 			expectedDashboardPath: "../../public/dashboards/default.json",
 			req:                   &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}},
 		},
 		{
-			name:                  "custom path",
-			defaultSetting:        "../../public/dashboards/default.json",
-			expectedDashboardPath: "../../public/dashboards/default.json",
+			name:                  "using anonymous user with default configuration settings",
+			defaultSetting:        "",
+			expectedDashboardPath: "../../public/dashboards/home.json",
 			req: &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{
 				IsAnonymous: true,
 			}, Context: &web.Context{Req: httpReq}},

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -68,7 +68,7 @@ func TestGetHomeDashboard(t *testing.T) {
 	httpReq, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
 	httpReq.Header.Add("Content-Type", "application/json")
-	req := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+
 	cfg := setting.NewCfg()
 	cfg.StaticRootPath = "../../public/"
 	prefService := preftest.NewPreferenceServiceFake()
@@ -88,9 +88,28 @@ func TestGetHomeDashboard(t *testing.T) {
 		name                  string
 		defaultSetting        string
 		expectedDashboardPath string
+		req                   *contextmodel.ReqContext
 	}{
-		{name: "using default config", defaultSetting: "", expectedDashboardPath: "../../public/dashboards/home.json"},
-		{name: "custom path", defaultSetting: "../../public/dashboards/default.json", expectedDashboardPath: "../../public/dashboards/default.json"},
+		{
+			name:                  "using default config",
+			defaultSetting:        "",
+			expectedDashboardPath: "../../public/dashboards/home.json",
+			req:                   &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}},
+		},
+		{
+			name:                  "custom path",
+			defaultSetting:        "../../public/dashboards/default.json",
+			expectedDashboardPath: "../../public/dashboards/default.json",
+			req:                   &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}},
+		},
+		{
+			name:                  "custom path",
+			defaultSetting:        "../../public/dashboards/default.json",
+			expectedDashboardPath: "../../public/dashboards/default.json",
+			req: &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{
+				IsAnonymous: true,
+			}, Context: &web.Context{Req: httpReq}},
+		},
 	}
 
 	for _, tc := range tests {
@@ -111,7 +130,7 @@ func TestGetHomeDashboard(t *testing.T) {
 			b, err := json.Marshal(dash)
 			require.NoError(t, err, "must be able to marshal object to JSON")
 
-			res := hs.GetHomeDashboard(req)
+			res := hs.GetHomeDashboard(tc.req)
 			nr, ok := res.(*response.NormalResponse)
 			require.True(t, ok, "should return *NormalResponse")
 			require.Equal(t, b, nr.Body(), "default home dashboard should equal content on disk")


### PR DESCRIPTION

**What is this feature?**

Adds a test for anonymous access.

**Why do we need this feature?**

During the implementation of the `identity.Requester` interface, the anonymous feature was broken and affected some instances. While this has been fixed already, a test was missing for this feature.

**Who is this feature for?**

This test will avoid this issues from arising again. Anonymous access affects dashboards and live features.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
