### PR TITLE
Chore: Bump systemjs-cjs-extra to latest

### DIFF
--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -45,7 +45,7 @@
     "lodash": "4.17.21",
     "rxjs": "7.8.1",
     "systemjs": "6.14.2",
-    "systemjs-cjs-extra": "0.1.1",
+    "systemjs-cjs-extra": "0.2.0",
     "tslib": "2.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4001,7 +4001,7 @@ __metadata:
     rollup-plugin-terser: 7.0.2
     rxjs: 7.8.1
     systemjs: 6.14.2
-    systemjs-cjs-extra: 0.1.1
+    systemjs-cjs-extra: 0.2.0
     tslib: 2.6.0
     typescript: 4.8.4
   peerDependencies:
@@ -31625,10 +31625,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systemjs-cjs-extra@npm:0.1.1":
-  version: 0.1.1
-  resolution: "systemjs-cjs-extra@npm:0.1.1"
-  checksum: 5b2880a5ec95b995ab3e1396c8c7fb2e089ad768a4843e915ff97e75bd255ef8d1f9cd79869eb1b42d9ee7bdd64d9f8d0385d25d82992d5c11e8cacc3b896417
+"systemjs-cjs-extra@npm:0.2.0":
+  version: 0.2.0
+  resolution: "systemjs-cjs-extra@npm:0.2.0"
+  checksum: c00ea3dba63cbfb6629543cdd4fe5bcf61501cf395d08ca49b622de07fdd5a2c9a4c2c6c3a84ab73648e2da5cc690bdbdf7d5701868b654816ee8df28bd5a891
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Bumps systemjs-cjs-extra to latest which solves problems with finding dependencies in minified cjs module code.

**Why do we need this feature?**

So older plugins continue to load in Grafana.

**Who is this feature for?**

Grafana users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
