### PR TITLE
Breadcrumbs: Enable plugins to override breadcrumbs that are generated by pages defined in plugin.json

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -144,5 +144,27 @@ describe('breadcrumb utils', () => {
         { text: 'My page', href: '/my-page' },
       ]);
     });
+
+    it('does ignore duplicates', () => {
+      const pageNav: NavModelItem = {
+        text: 'My page',
+        url: '/my-page',
+        parentItem: {
+          text: 'My section',
+          // same url as section nav, but this one should win/overwrite it
+          url: '/my-section?from=1h&to=now',
+        },
+      };
+
+      const sectionNav: NavModelItem = {
+        text: 'My section',
+        url: '/my-section',
+      };
+
+      expect(buildBreadcrumbs(sectionNav, pageNav, mockHomeNav)).toEqual([
+        { text: 'My section', href: '/my-section?from=1h&to=now' },
+        { text: 'My page', href: '/my-page' },
+      ]);
+    });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -5,23 +5,38 @@ import { Breadcrumb } from './types';
 export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelItem, homeNav?: NavModelItem) {
   const crumbs: Breadcrumb[] = [];
   let foundHome = false;
+  let lastPath: string | undefined = undefined;
 
   function addCrumbs(node: NavModelItem) {
+    if (foundHome) {
+      return;
+    }
+
     // construct the URL to match
     // we want to ignore query params except for the editview query param
-    const urlSearchParams = new URLSearchParams(node.url?.split('?')[1]);
-    let urlToMatch = `${node.url?.split('?')[0]}`;
+    const urlParts = node.url?.split('?') ?? ['', ''];
+    let urlToMatch = urlParts[0];
+
+    const urlSearchParams = new URLSearchParams(urlParts[1]);
+
     if (urlSearchParams.has('editview')) {
       urlToMatch += `?editview=${urlSearchParams.get('editview')}`;
     }
 
-    if (!foundHome && !node.hideFromBreadcrumbs) {
-      if (homeNav && urlToMatch === homeNav.url) {
-        crumbs.unshift({ text: homeNav.text, href: node.url ?? '' });
-        foundHome = true;
-      } else {
-        crumbs.unshift({ text: node.text, href: node.url ?? '' });
-      }
+    // This enabled app plugins to control breadcrumbs of their root pages
+    const isSamePathAsLastBreadcrumb = lastPath === urlToMatch;
+    // Remember this path for the next breadcrumb
+    lastPath = urlToMatch;
+
+    // Check if we found home/root if if so return early
+    if (homeNav && urlToMatch === homeNav.url) {
+      crumbs.unshift({ text: homeNav.text, href: node.url ?? '' });
+      foundHome = true;
+      return;
+    }
+
+    if (!node.hideFromBreadcrumbs && !isSamePathAsLastBreadcrumb) {
+      crumbs.unshift({ text: node.text, href: node.url ?? '' });
     }
 
     if (node.parentItem) {

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -24,7 +24,7 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     }
 
     // This enabled app plugins to control breadcrumbs of their root pages
-    const isSamePathAsLastBreadcrumb = lastPath === urlToMatch;
+    const isSamePathAsLastBreadcrumb = lastPath === urlToMatch && node.url !== undefined;
     // Remember this path for the next breadcrumb
     lastPath = urlToMatch;
 

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -24,7 +24,7 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     }
 
     // This enabled app plugins to control breadcrumbs of their root pages
-    const isSamePathAsLastBreadcrumb = lastPath === urlToMatch && node.url !== undefined;
+    const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
     // Remember this path for the next breadcrumb
     lastPath = urlToMatch;
 


### PR DESCRIPTION
This tries to solve 2 problems app plugins have (mostly scene apps). 

* You cannot update the URL of your root breadcrumb pages (as they are defined in plugin.json) 
* SceneApps have usually set their root SceneAppPAges to "hideFromBreadcrumbs: true" in order to not get duplicate breadcrumbs for them (if those pages are also defined in plugin.json as a root page). 

This PR updates the breadcrumbs logic so that it ignores breadcrumb items that have the same URL path as the previous one (breadcrumb generation starts at the leaf and works it's way back). This way the plugin does not need to set hideFromBreadcrums: true on the root pages, as long as the url path part is the same the breadcrumbs builder will ignore the one that would have been added based on section nav (plugin.json). The query params (url state) can be different, only path will be checked. 

So if a plugin.json root page is specified with url `/a/grafana-scenes-app/demos`, then a SceneAppPage can also be specified with the same url and with preserveUrlKeys, and overwrite that breadcrumb item (so no duplicates will be shown). 



