### PR TITLE
TabsBar: Fix height so that it aligns with grid, and alignItems center 

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -96,7 +96,7 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       width: 57,
     },
     menuTabs: {
-      height: 41,
+      height: 42,
     },
     textHighlight: {
       text: colors.warning.contrastText,

--- a/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
@@ -37,6 +37,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: 'relative',
     display: 'flex',
     height: `${theme.components.menuTabs.height}px`,
+    alignItems: 'center',
   }),
 });
 


### PR DESCRIPTION
Ran into an issue where I wanted to place other other elements in the TabsBar and discovered it does not have alignItems: center. 

But if I add alignItems: center (wich improves centering for the tab text) the height of the individual tabs change to 42px (strange I know). but because the items turn to 42 but the bar is set to 41 we get a scrollbar.  

Bug: 
![image](https://github.com/grafana/grafana/assets/10999/52cf2a43-d42c-4dac-9a93-311f4fa5a71a)

This PR
* Change height to 42
* Add alignItems: center 