### PR TITLE
HealthCheck: show enterprise commit

### DIFF
--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -36,6 +36,29 @@ func TestHealthAPI_Version(t *testing.T) {
 	require.JSONEq(t, expectedBody, rec.Body.String())
 }
 
+func TestHealthAPI_VersionEnterprise(t *testing.T) {
+	m, _ := setupHealthAPITestEnvironment(t, func(cfg *setting.Cfg) {
+		cfg.BuildVersion = "7.4.0"
+		cfg.EnterpriseBuildCommit = "22206ab1be"
+		cfg.BuildCommit = "59906ab1bf"
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+
+	require.Equal(t, 200, rec.Code)
+	expectedBody := `
+		{
+			"database": "ok",
+			"enterpriseCommit": "22206ab1be",
+			"version": "7.4.0",
+			"commit": "59906ab1bf"
+		}
+	`
+	require.JSONEq(t, expectedBody, rec.Body.String())
+}
+
 func TestHealthAPI_AnonymousHideVersion(t *testing.T) {
 	m, hs := setupHealthAPITestEnvironment(t)
 	hs.Cfg.AnonymousHideVersion = true

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -679,6 +679,9 @@ func (hs *HTTPServer) apiHealthHandler(ctx *web.Context) {
 	if !hs.Cfg.AnonymousHideVersion {
 		data.Set("version", hs.Cfg.BuildVersion)
 		data.Set("commit", hs.Cfg.BuildCommit)
+		if hs.Cfg.EnterpriseBuildCommit != "NA" {
+			data.Set("enterpriseCommit", hs.Cfg.EnterpriseBuildCommit)
+		}
 	}
 
 	if !hs.databaseHealthy(ctx.Req.Context()) {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -679,7 +679,7 @@ func (hs *HTTPServer) apiHealthHandler(ctx *web.Context) {
 	if !hs.Cfg.AnonymousHideVersion {
 		data.Set("version", hs.Cfg.BuildVersion)
 		data.Set("commit", hs.Cfg.BuildCommit)
-		if hs.Cfg.EnterpriseBuildCommit != "NA" {
+		if hs.Cfg.EnterpriseBuildCommit != "NA" && hs.Cfg.EnterpriseBuildCommit != "" {
 			data.Set("enterpriseCommit", hs.Cfg.EnterpriseBuildCommit)
 		}
 	}

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -222,15 +222,25 @@ func ldflags(opts BuildOpts) (string, error) {
 		commitSha = v
 	}
 
+	var enterpriseCommitSha string
+	if opts.enterprise {
+		enterpriseCommitSha = getGitEnterpriseSha()
+		if v := os.Getenv("ENTERPRISE_COMMIT_SHA"); v != "" {
+			enterpriseCommitSha = v
+		}
+	}
+
 	buildBranch := getGitBranch()
 	if v := os.Getenv("BUILD_BRANCH"); v != "" {
 		buildBranch = v
 	}
-
 	var b bytes.Buffer
 	b.WriteString("-w")
 	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", commitSha))
+	if enterpriseCommitSha != "" {
+		b.WriteString(fmt.Sprintf(" -X main.enterpriseCommit=%s", enterpriseCommitSha))
+	}
 	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp))
 	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", buildBranch))
 	if v := os.Getenv("LDFLAGS"); v != "" {

--- a/pkg/build/config/revision.go
+++ b/pkg/build/config/revision.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Revision struct {
-	Timestamp int64
-	SHA256    string
-	Branch    string
+	Timestamp        int64
+	SHA256           string
+	EnterpriseCommit string
+	Branch           string
 }
 
 func GrafanaTimestamp(ctx context.Context, dir string) (int64, error) {
@@ -42,14 +43,23 @@ func GrafanaRevision(ctx context.Context, grafanaDir string) (Revision, error) {
 		return Revision{}, err
 	}
 
+	enterpriseCommit, err := executil.OutputAt(ctx, grafanaDir, "git", "-C", "../grafana-enterprise", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		enterpriseCommit, err = executil.OutputAt(ctx, grafanaDir, "git", "-C", "..", "rev-parse", "--short", "HEAD")
+		if err != nil {
+			return Revision{}, err
+		}
+	}
+
 	branch, err := executil.OutputAt(ctx, grafanaDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return Revision{}, err
 	}
 
 	return Revision{
-		SHA256:    sha,
-		Branch:    branch,
-		Timestamp: stamp,
+		SHA256:           sha,
+		EnterpriseCommit: enterpriseCommit,
+		Branch:           branch,
+		Timestamp:        stamp,
 	}, nil
 }

--- a/pkg/build/git.go
+++ b/pkg/build/git.go
@@ -15,3 +15,16 @@ func getGitSha() string {
 	}
 	return string(v)
 }
+
+func getGitEnterpriseSha() string {
+	// supporting the old way of dev setup
+	v, err := runError("git", "-C", "../grafana-enterprise", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		// supporting the new way of dev setup
+		v, err = runError("git", "-C", "..", "rev-parse", "--short", "HEAD")
+		if err != nil {
+			return ""
+		}
+	}
+	return string(v)
+}

--- a/pkg/build/grafana/build.go
+++ b/pkg/build/grafana/build.go
@@ -23,13 +23,19 @@ const (
 )
 
 func GrafanaLDFlags(version string, r config.Revision) []string {
-	return []string{
+	cmd := []string{
 		"-w",
 		fmt.Sprintf("-X main.version=%s", version),
 		fmt.Sprintf("-X main.commit=%s", r.SHA256),
 		fmt.Sprintf("-X main.buildstamp=%d", r.Timestamp),
 		fmt.Sprintf("-X main.buildBranch=%s", r.Branch),
 	}
+
+	if r.EnterpriseCommit != "" {
+		cmd = append(cmd, fmt.Sprintf("-X main.enterpriseCommit=%s", r.EnterpriseCommit))
+	}
+
+	return cmd
 }
 
 // BinaryFolder returns the path to where the Grafana binary is build given the provided arguments.

--- a/pkg/cmd/grafana-server/commands/buildinfo.go
+++ b/pkg/cmd/grafana-server/commands/buildinfo.go
@@ -16,6 +16,7 @@ func setBuildInfo(opts ServerOptions) {
 	}
 	setting.BuildVersion = opts.Version
 	setting.BuildCommit = opts.Commit
+	setting.EnterpriseBuildCommit = opts.EnterpriseCommit
 	setting.BuildStamp = buildstampInt64
 	setting.BuildBranch = opts.BuildBranch
 	setting.IsEnterprise = extensions.IsEnterprise

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -23,25 +23,27 @@ import (
 )
 
 type ServerOptions struct {
-	Version     string
-	Commit      string
-	BuildBranch string
-	BuildStamp  string
-	Context     *cli.Context
+	Version          string
+	Commit           string
+	EnterpriseCommit string
+	BuildBranch      string
+	BuildStamp       string
+	Context          *cli.Context
 }
 
-func ServerCommand(version, commit, buildBranch, buildstamp string) *cli.Command {
+func ServerCommand(version, commit, enterpriseCommit, buildBranch, buildstamp string) *cli.Command {
 	return &cli.Command{
 		Name:  "server",
 		Usage: "run the grafana server",
 		Flags: commonFlags,
 		Action: func(context *cli.Context) error {
 			return RunServer(ServerOptions{
-				Version:     version,
-				Commit:      commit,
-				BuildBranch: buildBranch,
-				BuildStamp:  buildstamp,
-				Context:     context,
+				Version:          version,
+				Commit:           commit,
+				EnterpriseCommit: enterpriseCommit,
+				BuildBranch:      buildBranch,
+				BuildStamp:       buildstamp,
+				Context:          context,
 			})
 		},
 		Subcommands: []*cli.Command{TargetCommand(version, commit, buildBranch, buildstamp)},

--- a/pkg/cmd/grafana/main.go
+++ b/pkg/cmd/grafana/main.go
@@ -14,6 +14,7 @@ import (
 // The following variables cannot be constants, since they can be overridden through the -X link flag
 var version = "9.2.0"
 var commit = "NA"
+var enterpriseCommit = "NA"
 var buildBranch = "main"
 var buildstamp string
 
@@ -30,7 +31,7 @@ func main() {
 		Version: version,
 		Commands: []*cli.Command{
 			gcli.CLICommand(version),
-			gsrv.ServerCommand(version, commit, buildBranch, buildstamp),
+			gsrv.ServerCommand(version, commit, enterpriseCommit, buildBranch, buildstamp),
 		},
 		CommandNotFound:      cmdNotFound,
 		EnableBashCompletion: true,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -63,11 +63,12 @@ var (
 	InstanceName     string
 
 	// build
-	BuildVersion string
-	BuildCommit  string
-	BuildBranch  string
-	BuildStamp   int64
-	IsEnterprise bool
+	BuildVersion          string
+	BuildCommit           string
+	EnterpriseBuildCommit string
+	BuildBranch           string
+	BuildStamp            int64
+	IsEnterprise          bool
 
 	// packaging
 	Packaging = "unknown"
@@ -176,11 +177,12 @@ type Cfg struct {
 	EmailCodeValidMinutes int
 
 	// build
-	BuildVersion string
-	BuildCommit  string
-	BuildBranch  string
-	BuildStamp   int64
-	IsEnterprise bool
+	BuildVersion          string
+	BuildCommit           string
+	EnterpriseBuildCommit string
+	BuildBranch           string
+	BuildStamp            int64
+	IsEnterprise          bool
 
 	// packaging
 	Packaging string
@@ -1021,6 +1023,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	cfg.BuildVersion = BuildVersion
 	cfg.BuildCommit = BuildCommit
+	cfg.EnterpriseBuildCommit = EnterpriseBuildCommit
 	cfg.BuildStamp = BuildStamp
 	cfg.BuildBranch = BuildBranch
 	cfg.IsEnterprise = IsEnterprise


### PR DESCRIPTION
**What is this feature?**

The goal of this PR is to return in the health check the enterprise commit on Enterprise and Pro builds
```
{
"commit": "f229758af0",
"database": "ok",
"enterpriseCommit": "5865e6847",
"version": "10.2.0-pre"
} 
```

**Why do we need this feature?**
We want to use it in some developer tools to quickly know which enterprise commit is running.

**Special notes for your reviewer:**
This is the first attempt to accomplish this task. It won't work with docker images but I will work on it after confirming this is the correct approach.
There are several steps and building files I'm not familiar with, I tested locally and it is working as expected but I probably missed some cases.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
