### PR TITLE
Chore: Refactoring to absolute imports in components

### DIFF
--- a/public/app/core/actions/cleanUp.ts
+++ b/public/app/core/actions/cleanUp.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { StoreState } from '../../types';
+import { StoreState } from 'app/types';
 
 export type CleanUpAction = (state: StoreState) => void;
 

--- a/public/app/core/actions/index.ts
+++ b/public/app/core/actions/index.ts
@@ -1,3 +1,4 @@
-import { hideAppNotification, notifyApp } from '../reducers/appNotification';
-import { updateNavIndex, updateConfigurationSubtitle } from '../reducers/navModel';
+import { hideAppNotification, notifyApp } from 'app/core/reducers/appNotification';
+import { updateNavIndex, updateConfigurationSubtitle } from 'app/core/reducers/navModel';
+
 export { updateNavIndex, updateConfigurationSubtitle, notifyApp, hideAppNotification };

--- a/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/DockedMegaMenu.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Router } from 'react-router-dom';
+import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 
-import { TestProvider } from '../../../../../test/helpers/TestProvider';
 
 import { DockedMegaMenu } from './DockedMegaMenu';
 

--- a/public/app/core/components/AppChrome/DockedMegaMenu/NavBarItemIcon.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/NavBarItemIcon.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Icon, toIconName, useTheme2 } from '@grafana/ui';
-
-import { Branding } from '../../Branding/Branding';
+import { Branding } from 'app/core/components/Branding/Branding';
 
 interface NavBarItemIconProps {
   link: NavModelItem;

--- a/public/app/core/components/AppChrome/DockedMegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/utils.ts
@@ -1,11 +1,10 @@
 import { locationUtil, NavModelItem } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import appEvents from 'app/core/app_events';
+import { getFooterLinks } from 'app/core/components/Footer/Footer';
+import { HelpModal } from 'app/core/components/help/HelpModal';
 import { t } from 'app/core/internationalization';
-
-import { ShowModalReactEvent } from '../../../../types/events';
-import appEvents from '../../../app_events';
-import { getFooterLinks } from '../../Footer/Footer';
-import { HelpModal } from '../../help/HelpModal';
+import { ShowModalReactEvent } from 'app/types/events';
 
 export const enrichHelpItem = (helpItem: NavModelItem) => {
   let menuItems = helpItem.children || [];

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Router } from 'react-router-dom';
+import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 
-import { TestProvider } from '../../../../../test/helpers/TestProvider';
 
 import { MegaMenu } from './MegaMenu';
 

--- a/public/app/core/components/AppChrome/MegaMenu/NavBarItemIcon.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/NavBarItemIcon.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Icon, toIconName, useTheme2 } from '@grafana/ui';
-
-import { Branding } from '../../Branding/Branding';
+import { Branding } from 'app/core/components/Branding/Branding';
 
 interface NavBarItemIconProps {
   link: NavModelItem;

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -1,11 +1,10 @@
 import { locationUtil, NavModelItem } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import appEvents from 'app/core/app_events';
+import { getFooterLinks } from 'app/core/components/Footer/Footer';
+import { HelpModal } from 'app/core/components/help/HelpModal';
 import { t } from 'app/core/internationalization';
-
-import { ShowModalReactEvent } from '../../../../types/events';
-import appEvents from '../../../app_events';
-import { getFooterLinks } from '../../Footer/Footer';
-import { HelpModal } from '../../help/HelpModal';
+import { ShowModalReactEvent } from 'app/types/events';
 
 export const enrichHelpItem = (helpItem: NavModelItem) => {
   let menuItems = helpItem.children || [];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Absolute imports are configured in tsconfig file.

If we are looking to maintain standard absolute imports throughout the public/app directory then followup PRs might come in future too.

**Why do we need this feature?**

To make code clean and standard.

**Who is this feature for?**

Typescript coders.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
