### PR TITLE
Plugins: Make sure feature toggles config value is deterministic

### DIFF
--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -87,7 +87,7 @@ func (s *Service) GetConfigMap(ctx context.Context, _ string, _ *oauth.ExternalS
 
 	if s.cfg.Features != nil {
 		enabledFeatures := s.cfg.Features.GetEnabled(ctx)
-		if len(enabledFeatures) == 0 {
+		if len(enabledFeatures) > 0 {
 			features := make([]string, 0, len(enabledFeatures))
 			for feat := range enabledFeatures {
 				features = append(features, feat)

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -84,15 +85,13 @@ func (s *Service) GetConfigMap(ctx context.Context, _ string, _ *oauth.ExternalS
 	//	m[oauthtokenretriever.AppPrivateKey] = externalService.PrivateKey
 	//}
 
-	if s.cfg.Features != nil {
-		enabledFeatures := s.cfg.Features.GetEnabled(ctx)
-		if len(enabledFeatures) > 0 {
-			features := make([]string, 0, len(enabledFeatures))
-			for feat := range enabledFeatures {
-				features = append(features, feat)
-			}
-			m[featuretoggles.EnabledFeatures] = strings.Join(features, ",")
+	if enabledFeatures := s.cfg.Features.GetEnabled(ctx); len(enabledFeatures) > 0 {
+		features := make([]string, 0, len(enabledFeatures))
+		for feat := range enabledFeatures {
+			features = append(features, feat)
 		}
+		sort.Strings(features)
+		m[featuretoggles.EnabledFeatures] = strings.Join(features, ",")
 	}
 
 	// TODO add support via plugin SDK
@@ -181,16 +180,12 @@ func (s *Service) tracingEnvVars(plugin *plugins.Plugin) []string {
 func (s *Service) featureToggleEnableVar(ctx context.Context) []string {
 	var variables []string // an array is used for consistency and keep the logic simpler for no features case
 
-	if s.cfg.Features != nil {
-		enabledFeatures := s.cfg.Features.GetEnabled(ctx)
-
-		if len(enabledFeatures) > 0 {
-			features := make([]string, 0, len(enabledFeatures))
-			for feat := range enabledFeatures {
-				features = append(features, feat)
-			}
-			variables = append(variables, fmt.Sprintf("GF_INSTANCE_FEATURE_TOGGLES_ENABLE=%s", strings.Join(features, ",")))
+	if enabledFeatures := s.cfg.Features.GetEnabled(ctx); len(enabledFeatures) > 0 {
+		features := make([]string, 0, len(enabledFeatures))
+		for feat := range enabledFeatures {
+			features = append(features, feat)
 		}
+		variables = append(variables, fmt.Sprintf("GF_INSTANCE_FEATURE_TOGGLES_ENABLE=%s", strings.Join(features, ",")))
 	}
 
 	return variables

--- a/pkg/services/store/testdata/public_testdata.golden.jsonc
+++ b/pkg/services/store/testdata/public_testdata.golden.jsonc
@@ -12,14 +12,14 @@
 //  }
 //  Name: 
 //  Dimensions: 3 Fields by 2 Rows
-//  +--------------------+--------------------------+---------------+
-//  | Name: name         | Name: mediaType          | Name: size    |
-//  | Labels:            | Labels:                  | Labels:       |
-//  | Type: []string     | Type: []string           | Type: []int64 |
-//  +--------------------+--------------------------+---------------+
-//  | countries.geojson  | application/octet-stream | 255943        |
-//  | usa-states.geojson | application/octet-stream | 89263         |
-//  +--------------------+--------------------------+---------------+
+//  +--------------------+----------------------+---------------+
+//  | Name: name         | Name: mediaType      | Name: size    |
+//  | Labels:            | Labels:              | Labels:       |
+//  | Type: []string     | Type: []string       | Type: []int64 |
+//  +--------------------+----------------------+---------------+
+//  | countries.geojson  | application/geo+json | 255943        |
+//  | usa-states.geojson | application/geo+json | 89263         |
+//  +--------------------+----------------------+---------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -72,8 +72,8 @@
             "usa-states.geojson"
           ],
           [
-            "application/octet-stream",
-            "application/octet-stream"
+            "application/geo+json",
+            "application/geo+json"
           ],
           [
             255943,

--- a/pkg/services/store/testdata/public_testdata.golden.jsonc
+++ b/pkg/services/store/testdata/public_testdata.golden.jsonc
@@ -12,14 +12,14 @@
 //  }
 //  Name: 
 //  Dimensions: 3 Fields by 2 Rows
-//  +--------------------+----------------------+---------------+
-//  | Name: name         | Name: mediaType      | Name: size    |
-//  | Labels:            | Labels:              | Labels:       |
-//  | Type: []string     | Type: []string       | Type: []int64 |
-//  +--------------------+----------------------+---------------+
-//  | countries.geojson  | application/geo+json | 255943        |
-//  | usa-states.geojson | application/geo+json | 89263         |
-//  +--------------------+----------------------+---------------+
+//  +--------------------+--------------------------+---------------+
+//  | Name: name         | Name: mediaType          | Name: size    |
+//  | Labels:            | Labels:                  | Labels:       |
+//  | Type: []string     | Type: []string           | Type: []int64 |
+//  +--------------------+--------------------------+---------------+
+//  | countries.geojson  | application/octet-stream | 255943        |
+//  | usa-states.geojson | application/octet-stream | 89263         |
+//  +--------------------+--------------------------+---------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -72,8 +72,8 @@
             "usa-states.geojson"
           ],
           [
-            "application/geo+json",
-            "application/geo+json"
+            "application/octet-stream",
+            "application/octet-stream"
           ],
           [
             255943,


### PR DESCRIPTION
**What is this feature?**

A bug fix for ensuring plugin instances are cached appropriately when 2 or more feature toggles are enabled.

**Why do we need this feature?**

Because getting a list of enabled features is not consistent (because it's backed by a Go map), when we send the value in the outgoing plugin request, a different instance can be created each time. This change makes sure we always get the same value, when the same features are enabled.

**Who is this feature for?**

Plugins Platform
<!--
**Which issue(s) does this PR fix?**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #

-->

**Special notes for your reviewer:**
It's probably worth having this in the core feature toggles implementation, but wanted to get this out the door first.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
