### PR TITLE
Prometheus: Fix applying ad-hoc filters to the expression that has a template variable

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -835,6 +835,30 @@ describe('PrometheusDatasource', () => {
       const result = ds.applyTemplateVariables(query, {});
       expect(result).toMatchObject({ expr: 'test{job="bar", k1="v1", k2!="v2"}' });
     });
+
+    it('should add ad-hoc filters only to expr', () => {
+      replaceMock.mockImplementation((a: string) => a?.replace('$A', '99') ?? a);
+      getAdhocFiltersMock.mockReturnValue([
+        {
+          key: 'k1',
+          operator: '=',
+          value: 'v1',
+        },
+        {
+          key: 'k2',
+          operator: '!=',
+          value: 'v2',
+        },
+      ]);
+
+      const query = {
+        expr: 'test{job="bar"} > $A',
+        refId: 'A',
+      };
+
+      const result = ds.applyTemplateVariables(query, {});
+      expect(result).toMatchObject({ expr: 'test{job="bar", k1="v1", k2!="v2"} > 99' });
+    });
   });
 
   describe('metricFindQuery', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -859,6 +859,31 @@ describe('PrometheusDatasource', () => {
       const result = ds.applyTemplateVariables(query, {});
       expect(result).toMatchObject({ expr: 'test{job="bar", k1="v1", k2!="v2"} > 99' });
     });
+
+    it('should add ad-hoc filters only to expr and expression has template variable as label value??', () => {
+      const searchPattern = /\$A/g;
+      replaceMock.mockImplementation((a: string) => a?.replace(searchPattern, '99') ?? a);
+      getAdhocFiltersMock.mockReturnValue([
+        {
+          key: 'k1',
+          operator: '=',
+          value: 'v1',
+        },
+        {
+          key: 'k2',
+          operator: '!=',
+          value: 'v2',
+        },
+      ]);
+
+      const query = {
+        expr: 'test{job="$A"} > $A',
+        refId: 'A',
+      };
+
+      const result = ds.applyTemplateVariables(query, {});
+      expect(result).toMatchObject({ expr: 'test{job="99", k1="v1", k2!="v2"} > 99' });
+    });
   });
 
   describe('metricFindQuery', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -1280,14 +1280,17 @@ export class PrometheusDatasource
     delete variables.__interval;
     delete variables.__interval_ms;
 
-    //Add ad hoc filters
-    const expr = this.enhanceExprWithAdHocFilters(target.expr);
+    // interpolate expression
+    const expr = this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr);
+
+    // Add ad hoc filters
+    const exprWithAdHocFilters = this.enhanceExprWithAdHocFilters(expr);
 
     return {
       ...target,
-      legendFormat: this.templateSrv.replace(target.legendFormat, variables),
-      expr: this.templateSrv.replace(expr, variables, this.interpolateQueryExpr),
+      expr: exprWithAdHocFilters,
       interval: this.templateSrv.replace(target.interval, variables),
+      legendFormat: this.templateSrv.replace(target.legendFormat, variables),
     };
   }
 


### PR DESCRIPTION
**What is this feature?**

Have a dashboard with template variable and ad-hoc filter defined. Have a panel that queries with the template variable you defined. We apply the ad-hoc filters automatically. But when you have a query like following 
```
some_cool_metric > $my_template_var
```
it will be interpolated like this
```
some_cool_metric{adhocKey=adHocVal} > my_template_var_value{adhocKey=adHocVal}
```
So obviously that's not what we want. This PR is fixing this by interpolating the template variables first.

**Who is this feature for?**

Prometheus users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/51743

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
