### PR TITLE
Explore: Anchor to 0 in timeseries' stacked displays

### DIFF
--- a/public/app/features/explore/Graph/exploreGraphStyleUtils.ts
+++ b/public/app/features/explore/Graph/exploreGraphStyleUtils.ts
@@ -40,11 +40,13 @@ export function applyGraphStyle(config: FieldConfig, style: ExploreGraphStyle, m
         custom.drawStyle = GraphDrawStyle.Line;
         custom.stacking.mode = StackingMode.Normal;
         custom.fillOpacity = 100;
+        custom.axisSoftMin = 0;
         break;
       case 'stacked_bars':
         custom.drawStyle = GraphDrawStyle.Bars;
         custom.stacking.mode = StackingMode.Normal;
         custom.fillOpacity = 100;
+        custom.axisSoftMin = 0;
         break;
       default: {
         // should never happen


### PR DESCRIPTION
**What is this feature?**

The explore graph was not anchoring to 0 in the two stacked modes for its timeseries graph. This was creating misleading charts.

**Which issue(s) does this PR fix?**:

Fixes a support escalation

**Special notes for your reviewer:**

To replicate
1. Show a prometheus query with one result. Duplicate that query so it shows up twice (the points will be overlaid on each other so you will only be able to see one)
2. Change to stacked lines/stacked bars. See the Y axis does not start at 0

**Before:**
![Screenshot 2023-09-21 at 12 27 58 PM](https://github.com/grafana/grafana/assets/1533128/9261cb97-6a3a-4130-870d-9265184d9173)

**After:**
![Screenshot 2023-09-21 at 12 28 16 PM](https://github.com/grafana/grafana/assets/1533128/d43f4679-ef2e-4aa8-844f-a42313f4ed15)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
