### PR TITLE
Feature Toggles API: Trigger webhook call when updating

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1678,6 +1678,9 @@ allow_editing = false
 # Allow customization of URL for the controller that manages feature toggles
 update_controller_url =
 
+# Allow configuring an auth token for feature management update requests
+update_controller_token =
+
 # Hides specific feature toggles from the feature management page
 hidden_toggles =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1676,10 +1676,10 @@ show_ui = true
 allow_editing = false
 
 # Allow customization of URL for the controller that manages feature toggles
-update_controller_url =
+update_webhook =
 
 # Allow configuring an auth token for feature management update requests
-update_controller_token =
+update_webhook_token =
 
 # Hides specific feature toggles from the feature management page
 hidden_toggles =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1545,9 +1545,9 @@
 # Allow editing of feature toggles in the feature management page
 ;allow_editing = false
 # Allow customization of URL for the controller that manages feature toggles
-;update_controller_url =
+;update_webhook =
 # Allow configuring an auth token for feature management update requests
-;update_controller_token =
+;update_webhook_token =
 # Hide specific feature toggles from the feature management page
 ;hidden_toggles =
 # Disable updating specific feature toggles in the feature management page

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1546,6 +1546,8 @@
 ;allow_editing = false
 # Allow customization of URL for the controller that manages feature toggles
 ;update_controller_url =
+# Allow configuring an auth token for feature management update requests
+;update_controller_token =
 # Hide specific feature toggles from the feature management page
 ;hidden_toggles =
 # Disable updating specific feature toggles in the feature management page

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2319,7 +2319,7 @@ Please see [Configure feature toggles]({{< relref "./feature-toggles" >}}) for m
 
 Lets you switch the feature toggle state in the feature management page. The default is `false`.
 
-### update_controller_url
+### update_webhook
 
 Set the URL of the controller that manages the feature toggle updates. If not set, feature toggles in the feature management page will be read-only.
 

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -46,8 +46,8 @@ func (hs *HTTPServer) UpdateFeatureToggle(ctx *contextmodel.ReqContext) response
 		return response.Error(http.StatusForbidden, "feature toggles are read-only", fmt.Errorf("feature toggles are configured to be read-only"))
 	}
 
-	if featureMgmtCfg.UpdateControllerUrl == "" {
-		return response.Error(http.StatusInternalServerError, "feature toggles service is misconfigured", fmt.Errorf("[feature_management]update_controller_url is not set"))
+	if featureMgmtCfg.UpdateWebhook == "" {
+		return response.Error(http.StatusInternalServerError, "feature toggles service is misconfigured", fmt.Errorf("[feature_management]update_webhook is not set"))
 	}
 
 	cmd := featuremgmt.UpdateFeatureTogglesCommand{}
@@ -103,7 +103,7 @@ func isFeatureWriteable(flag featuremgmt.FeatureFlag, readOnlyCfg map[string]str
 
 // isFeatureEditingAllowed checks if the backend is properly configured to allow feature toggle changes from the UI
 func isFeatureEditingAllowed(cfg setting.Cfg) bool {
-	return cfg.FeatureManagement.AllowEditing && cfg.FeatureManagement.UpdateControllerUrl != ""
+	return cfg.FeatureManagement.AllowEditing && cfg.FeatureManagement.UpdateWebhook != ""
 }
 
 type UpdatePayload struct {
@@ -117,13 +117,13 @@ func sendWebhookUpdate(cfg setting.FeatureMgmtSettings, payload UpdatePayload, l
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, cfg.UpdateControllerUrl, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, cfg.UpdateWebhook, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+cfg.UpdateControllerToken)
+	req.Header.Set("Authorization", "Bearer "+cfg.UpdateWebhookToken)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -131,7 +131,7 @@ func sendWebhookUpdate(cfg setting.FeatureMgmtSettings, payload UpdatePayload) e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode >= http.StatusBadRequest {
 		if body, err := io.ReadAll(resp.Body); err != nil {
 			return fmt.Errorf("SendWebhookUpdate failed with status=%d, error: %s", resp.StatusCode, string(body))
 		} else {

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -51,21 +54,29 @@ func (hs *HTTPServer) UpdateFeatureToggle(ctx *contextmodel.ReqContext) response
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
+	payload := UpdatePayload{
+		FeatureToggles: make(map[string]bool, len(cmd.FeatureToggles)),
+		User:           ctx.SignedInUser.Email,
+	}
+
 	for _, t := range cmd.FeatureToggles {
 		// make sure flag exists, and only continue if flag is writeable
 		if f, ok := hs.Features.LookupFlag(t.Name); ok && isFeatureWriteable(f, hs.Cfg.FeatureManagement.ReadOnlyToggles) {
 			hs.log.Info("UpdateFeatureToggle: updating toggle", "toggle_name", t.Name, "enabled", t.Enabled, "username", ctx.SignedInUser.Login)
-			// TODO build payload
+			payload.FeatureToggles[t.Name] = t.Enabled
 		} else {
 			hs.log.Warn("UpdateFeatureToggle: invalid toggle passed in", "toggle_name", t.Name)
 			return response.Error(http.StatusBadRequest, "invalid toggle passed in", fmt.Errorf("invalid toggle passed in: %s", t.Name))
 		}
 	}
 
-	// TODO: post to featureMgmtCfg.UpdateControllerUrl and return response status
-	hs.log.Warn("UpdateFeatureToggle: function is unimplemented")
+	err := sendWebhookUpdate(featureMgmtCfg, payload)
+	if err != nil {
+		hs.log.Error("UpdateFeatureToggle: Failed to perform webhook request", "error", err)
+		return response.Respond(http.StatusBadRequest, "Failed to perform webhook request")
+	}
 
-	return response.Error(http.StatusNotImplemented, "UpdateFeatureToggle is unimplemented", fmt.Errorf("UpdateFeatureToggle is unimplemented"))
+	return response.Respond(http.StatusOK, "feature toggles updated successfully")
 }
 
 // isFeatureHidden returns whether a toggle should be hidden from the admin page.
@@ -92,4 +103,41 @@ func isFeatureWriteable(flag featuremgmt.FeatureFlag, readOnlyCfg map[string]str
 // isFeatureEditingAllowed checks if the backend is properly configured to allow feature toggle changes from the UI
 func isFeatureEditingAllowed(cfg setting.Cfg) bool {
 	return cfg.FeatureManagement.AllowEditing && cfg.FeatureManagement.UpdateControllerUrl != ""
+}
+
+type UpdatePayload struct {
+	FeatureToggles map[string]bool `json:"feature_toggles"`
+	User           string          `json:"user"`
+}
+
+func sendWebhookUpdate(cfg setting.FeatureMgmtSettings, payload UpdatePayload) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, cfg.UpdateControllerUrl, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.UpdateControllerToken)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if body, err := io.ReadAll(resp.Body); err != nil {
+			return fmt.Errorf("SendWebhookUpdate failed with status=%d, error: %s", resp.StatusCode, string(body))
+		} else {
+			return fmt.Errorf("SendWebhookUpdate failed with status=%d, error: %w", resp.StatusCode, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/setting/setting_featuremgmt.go
+++ b/pkg/setting/setting_featuremgmt.go
@@ -5,11 +5,11 @@ import (
 )
 
 type FeatureMgmtSettings struct {
-	HiddenToggles         map[string]struct{}
-	ReadOnlyToggles       map[string]struct{}
-	AllowEditing          bool
-	UpdateControllerUrl   string
-	UpdateControllerToken string
+	HiddenToggles      map[string]struct{}
+	ReadOnlyToggles    map[string]struct{}
+	AllowEditing       bool
+	UpdateWebhook      string
+	UpdateWebhookToken string
 }
 
 func (cfg *Cfg) readFeatureManagementConfig() {
@@ -33,6 +33,6 @@ func (cfg *Cfg) readFeatureManagementConfig() {
 	cfg.FeatureManagement.HiddenToggles = hiddenToggles
 	cfg.FeatureManagement.ReadOnlyToggles = readOnlyToggles
 	cfg.FeatureManagement.AllowEditing = cfg.SectionWithEnvOverrides("feature_management").Key("allow_editing").MustBool(false)
-	cfg.FeatureManagement.UpdateControllerUrl = cfg.SectionWithEnvOverrides("feature_management").Key("update_controller_url").MustString("")
-	cfg.FeatureManagement.UpdateControllerToken = cfg.SectionWithEnvOverrides("feature_management").Key("update_controller_token").MustString("")
+	cfg.FeatureManagement.UpdateWebhook = cfg.SectionWithEnvOverrides("feature_management").Key("update_webhook").MustString("")
+	cfg.FeatureManagement.UpdateWebhookToken = cfg.SectionWithEnvOverrides("feature_management").Key("update_webhook_token").MustString("")
 }

--- a/pkg/setting/setting_featuremgmt.go
+++ b/pkg/setting/setting_featuremgmt.go
@@ -5,10 +5,11 @@ import (
 )
 
 type FeatureMgmtSettings struct {
-	HiddenToggles       map[string]struct{}
-	ReadOnlyToggles     map[string]struct{}
-	AllowEditing        bool
-	UpdateControllerUrl string
+	HiddenToggles         map[string]struct{}
+	ReadOnlyToggles       map[string]struct{}
+	AllowEditing          bool
+	UpdateControllerUrl   string
+	UpdateControllerToken string
 }
 
 func (cfg *Cfg) readFeatureManagementConfig() {
@@ -33,4 +34,5 @@ func (cfg *Cfg) readFeatureManagementConfig() {
 	cfg.FeatureManagement.ReadOnlyToggles = readOnlyToggles
 	cfg.FeatureManagement.AllowEditing = cfg.SectionWithEnvOverrides("feature_management").Key("allow_editing").MustBool(false)
 	cfg.FeatureManagement.UpdateControllerUrl = cfg.SectionWithEnvOverrides("feature_management").Key("update_controller_url").MustString("")
+	cfg.FeatureManagement.UpdateControllerToken = cfg.SectionWithEnvOverrides("feature_management").Key("update_controller_token").MustString("")
 }


### PR DESCRIPTION
Related with https://github.com/grafana/grafana/pull/73022

**What is this feature?**
When updating feature toggles, we need to trigger a webhook request to the grafana operator service.

**Why do we need this feature?**
We want to allow Grafana Cloud users to be able to update GA feature toggles themselves without going through support. 

Fixes #
https://github.com/grafana/grafana/issues/73059
