### PR TITLE
Breadcrumbs: Remove logic that is no longer needed

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -120,31 +120,6 @@ describe('breadcrumb utils', () => {
       ]);
     });
 
-    it('does not match the home nav if the editview param is different', () => {
-      const pageNav: NavModelItem = {
-        text: 'My page',
-        url: '/my-page',
-        parentItem: {
-          text: 'My parent page',
-          url: '/home?orgId=1&editview=settings',
-        },
-      };
-      const sectionNav: NavModelItem = {
-        text: 'My section',
-        url: '/my-section',
-        parentItem: {
-          text: 'My parent section',
-          url: '/my-parent-section',
-        },
-      };
-      expect(buildBreadcrumbs(sectionNav, pageNav, mockHomeNav)).toEqual([
-        { text: 'My parent section', href: '/my-parent-section' },
-        { text: 'My section', href: '/my-section' },
-        { text: 'My parent page', href: '/home?orgId=1&editview=settings' },
-        { text: 'My page', href: '/my-page' },
-      ]);
-    });
-
     it('does ignore duplicates', () => {
       const pageNav: NavModelItem = {
         text: 'My page',

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -13,20 +13,8 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     }
 
     // construct the URL to match
-    // we want to ignore query params except for the editview query param
     const urlParts = node.url?.split('?') ?? ['', ''];
     let urlToMatch = urlParts[0];
-
-    const urlSearchParams = new URLSearchParams(urlParts[1]);
-
-    if (urlSearchParams.has('editview')) {
-      urlToMatch += `?editview=${urlSearchParams.get('editview')}`;
-    }
-
-    // This enabled app plugins to control breadcrumbs of their root pages
-    const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
-    // Remember this path for the next breadcrumb
-    lastPath = urlToMatch;
 
     // Check if we found home/root if if so return early
     if (homeNav && urlToMatch === homeNav.url) {
@@ -34,6 +22,11 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
       foundHome = true;
       return;
     }
+
+    // This enabled app plugins to control breadcrumbs of their root pages
+    const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
+    // Remember this path for the next breadcrumb
+    lastPath = urlToMatch;
 
     if (!node.hideFromBreadcrumbs && !isSamePathAsLastBreadcrumb) {
       crumbs.unshift({ text: node.text, href: node.url ?? '' });


### PR DESCRIPTION
Merged https://github.com/grafana/grafana/pull/75218 pushing my final
change.

I removed the special logic for "editPanel?" that was added when we had special Home
breadcrumb for home dashboard. A change we later removed but this logic that
was added for that case was never removed.

