### PR TITLE
Connections: Make the "Add new Connection" page work without internet access

### DIFF
--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -39,7 +39,7 @@ export function AddNewConnection() {
     setSearchTerm(e.currentTarget.value.toLowerCase());
   };
 
-  const { isLoading, error, plugins } = useGetAll({
+  const { error, plugins, isLoading } = useGetAll({
     keyword: searchTerm,
     type: PluginType.datasource,
   });

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -44,7 +44,10 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
               .pipe(
                 catchError((err) => {
                   thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-                  return throwError(() => new Error('Failed fetching plugins from GCOM.'));
+                  return throwError(
+                    () =>
+                      new Error('Failed to fetch plugins from catalog (default https://grafana.com/grafana/plugins)')
+                  );
                 })
               )
               // Remote plugins loaded after a timeout, updating the store

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -45,8 +45,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
                 catchError((err) => {
                   thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
                   return throwError(
-                    () =>
-                      new Error('Failed to fetch plugins from catalog (default https://grafana.com/grafana/plugins)')
+                    () => new Error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)')
                   );
                 })
               )

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,6 +1,7 @@
 import { createAction, createAsyncThunk, Update } from '@reduxjs/toolkit';
+import { from, forkJoin, timeout, lastValueFrom, catchError, throwError } from 'rxjs';
 
-import { PanelPlugin } from '@grafana/data';
+import { PanelPlugin, PluginError } from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { StoreState, ThunkResult } from 'app/types';
@@ -18,16 +19,74 @@ import { STATE_PREFIX } from '../constants';
 import { mapLocalToCatalog, mergeLocalsAndRemotes, updatePanels } from '../helpers';
 import { CatalogPlugin, RemotePlugin, LocalPlugin } from '../types';
 
+// Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
   try {
-    const { dispatch } = thunkApi;
-    const [localPlugins, pluginErrors, { payload: remotePlugins }] = await Promise.all([
-      getLocalPlugins(),
-      getPluginErrors(),
-      dispatch(fetchRemotePlugins()),
-    ]);
+    thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/pending` });
+    thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/pending` });
 
-    return mergeLocalsAndRemotes(localPlugins, remotePlugins, pluginErrors);
+    const local$ = from(getLocalPlugins());
+    const remote$ = from(getRemotePlugins());
+    const pluginErrors$ = from(getPluginErrors());
+
+    forkJoin({
+      local: local$,
+      remote: remote$,
+      pluginErrors: pluginErrors$,
+    })
+      .pipe(
+        // Fetching the list of plugins from GCOM is slow / errors out
+        timeout({
+          each: 500,
+          with: () => {
+            remote$
+              // The request to fetch remote plugins from GCOM failed
+              .pipe(
+                catchError((err) => {
+                  thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
+                  return throwError(() => new Error('Failed fetching plugins from GCOM.'));
+                })
+              )
+              // Remote plugins loaded after a timeout, updating the store
+              .subscribe(async (remote: RemotePlugin[]) => {
+                thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/fulfilled` });
+
+                if (remote.length > 0) {
+                  const local = await lastValueFrom(local$);
+                  const pluginErrors = await lastValueFrom(pluginErrors$);
+
+                  thunkApi.dispatch(addPlugins(mergeLocalsAndRemotes(local, remote, pluginErrors)));
+                }
+              });
+
+            return forkJoin({ local: local$, pluginErrors: pluginErrors$ });
+          },
+        })
+      )
+      .subscribe(
+        ({
+          local,
+          remote,
+          pluginErrors,
+        }: {
+          local: LocalPlugin[];
+          remote?: RemotePlugin[];
+          pluginErrors: PluginError[];
+        }) => {
+          thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/fulfilled` });
+
+          // Both local and remote plugins are loaded
+          if (local && remote) {
+            thunkApi.dispatch(addPlugins(mergeLocalsAndRemotes(local, remote, pluginErrors)));
+
+            // Only remote plugins are loaded (remote timed out)
+          } else if (local) {
+            thunkApi.dispatch(addPlugins(mergeLocalsAndRemotes(local, [], pluginErrors)));
+          }
+        }
+      );
+
+    return null;
   } catch (e) {
     return thunkApi.rejectWithValue('Unknown error.');
   }
@@ -70,6 +129,24 @@ export const fetchDetails = createAsyncThunk<Update<CatalogPlugin>, string>(
       return thunkApi.rejectWithValue('Unknown error.');
     }
   }
+);
+
+export const addPlugins = createAction<CatalogPlugin[]>(`${STATE_PREFIX}/addPlugins`);
+
+// 1. gets remote equivalents from the store (if there are any)
+// 2. merges the remote equivalents with the local plugins
+// 3. updates the the store with the updated CatalogPlugin objects
+export const addLocalPlugins = createAction<LocalPlugin[]>(`${STATE_PREFIX}/addLocalPlugins`);
+
+// 1. gets local equivalents from the store (if there are any)
+// 2. merges the local equivalents with the remote plugins
+// 3. updates the the store with the updated CatalogPlugin objects
+export const addRemotePlugins = createAction<RemotePlugin[]>(`${STATE_PREFIX}/addLocalPlugins`);
+
+// 1. merges the local and remote plugins
+// 2. updates the store with the CatalogPlugin objects
+export const addLocalAndRemotePlugins = createAction<{ local: LocalPlugin[]; remote: RemotePlugin[] }>(
+  `${STATE_PREFIX}/addLocalPlugins`
 );
 
 // We are also using the install API endpoint to update the plugin

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -24,7 +24,9 @@ export const useGetAll = (filters: PluginFilters, sortBy: Sorters = Sorters.name
 
   const selector = useMemo(() => selectPlugins(filters), [filters]);
   const plugins = useSelector(selector);
-  const { isLoading, error } = useFetchStatus();
+  // As the locally installed plugins load quicker than the remote ones, we only show a loading state until these are being loaded
+  // (In case the remote ones are not loaded within a reasonable timeout, we will merge those with the locally installed plugins once they are loaded)
+  const { isLoading, error } = useLocalFetchStatus();
   const sortedPlugins = sortPlugins(plugins, sortBy);
 
   return {
@@ -72,6 +74,13 @@ export const useUninstall = () => {
 export const useIsRemotePluginsAvailable = () => {
   const error = useSelector(selectRequestError(fetchRemotePlugins.typePrefix));
   return error === null;
+};
+
+export const useLocalFetchStatus = () => {
+  const isLoading = useSelector(selectIsRequestPending('plugins/fetchLocal'));
+  const error = useSelector(selectRequestError('plugins/fetchLocal'));
+
+  return { isLoading, error };
 };
 
 export const useFetchStatus = () => {

--- a/public/app/features/plugins/admin/state/reducer.ts
+++ b/public/app/features/plugins/admin/state/reducer.ts
@@ -6,13 +6,13 @@ import { STATE_PREFIX } from '../constants';
 import { CatalogPlugin, PluginListDisplayMode, ReducerState, RequestStatus } from '../types';
 
 import {
-  fetchAll,
   fetchDetails,
   install,
   uninstall,
   loadPluginDashboards,
   panelPluginLoaded,
   fetchAllLocal,
+  addPlugins,
 } from './actions';
 
 export const pluginsAdapter = createEntityAdapter<CatalogPlugin>();
@@ -58,8 +58,7 @@ const slice = createSlice({
   },
   extraReducers: (builder) =>
     builder
-      // Fetch All
-      .addCase(fetchAll.fulfilled, (state, action) => {
+      .addCase(addPlugins, (state, action: PayloadAction<CatalogPlugin[]>) => {
         pluginsAdapter.upsertMany(state.items, action.payload);
       })
       // Fetch All local


### PR DESCRIPTION
**Related issue(s):** https://github.com/grafana/grafana/issues/74267 

### What changed?

Made the "Add new Connection" page and the Plugins Catalog work in case Grafana has no access to the internet, or if the internet connection is slow. 

### The problem

Currently the plugin list used by the frontend is merged from two sources: **locally installed plugins** (can contain plugins not available in our catalog), and **remote plugins** (available in our catalog on GCOM).

As the remote plugins are fetched through the internet (hitting https://grafana.com), it can happen that it takes more time, or even that it times out after 30 seconds if the access is blocked. **_Currently this is causing some of our pages to hang for 30 seconds, even though the instances are only planned to work with locally installed plugins._** 

### The solution
The changes in this PR are trying to solve this in the following way:
1. Start fetching **local** and **remote** plugins
2. In case they both respond in a reasonable amount of time, render the UI
3. In case the remote API times out, continue rendering the UI with the local plugins only
4. When the remote request completes, update the list of plugins with the remote ones  

**1. Add New Connection - Normal behaviour**

https://github.com/grafana/grafana/assets/9974811/927d958b-e541-419e-9eca-2516e06729ea

---

**2. Add New Connection - Slow remote response**

https://github.com/grafana/grafana/assets/9974811/cd2bc9f6-8b85-4e9e-b8ba-7befc1d767f6

---

**3. Add New Connection - Failing remote response**

https://github.com/grafana/grafana/assets/9974811/dea2fa08-94ae-4d4f-9f29-b6c74cb0ccf7

Fixes https://github.com/grafana/grafana/issues/74267.

