### PR TITLE
SQLStore: Fix race condition in RecursiveQueriesAreSupported

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -55,6 +55,7 @@ type SQLStore struct {
 	migrations                   registry.DatabaseMigrator
 	tracer                       tracing.Tracer
 	recursiveQueriesAreSupported *bool
+	recursiveQueriesMu           sync.Mutex
 }
 
 func ProvideService(cfg *setting.Cfg, cacheService *localcache.CacheService, migrations registry.DatabaseMigrator, bus bus.Bus, tracer tracing.Tracer) (*SQLStore, error) {
@@ -524,6 +525,8 @@ func (ss *SQLStore) GetMigrationLockAttemptTimeout() int {
 }
 
 func (ss *SQLStore) RecursiveQueriesAreSupported() (bool, error) {
+	ss.recursiveQueriesMu.Lock()
+	defer ss.recursiveQueriesMu.Unlock()
 	if ss.recursiveQueriesAreSupported != nil {
 		return *ss.recursiveQueriesAreSupported, nil
 	}


### PR DESCRIPTION
**What is this feature?**

This commit fixes a race condition in `RecursiveQueriesAreSupported`:

```
WARNING: DATA RACE
Read at 0x00c0022aa520 by goroutine 15652:
  github.com/grafana/grafana/pkg/services/sqlstore.(*SQLStore).RecursiveQueriesAreSupported()
      /Users/grobinson/go/src/github.com/grafana/grafana/pkg/services/sqlstore/sqlstore.go:527 +0x34
  github.com/grafana/grafana/pkg/services/dashboards/database.(*dashboardStore).FindDashboards()
      /Users/grobinson/go/src/github.com/grafana/grafana/pkg/services/dashboards/database/database.go:963 +0x54

Previous write at 0x00c0022aa520 by goroutine 15648:
  github.com/grafana/grafana/pkg/services/sqlstore.(*SQLStore).RecursiveQueriesAreSupported()
      /Users/grobinson/go/src/github.com/grafana/grafana/pkg/services/sqlstore/sqlstore.go:559 +0xa0
  github.com/grafana/grafana/pkg/services/dashboards/database.(*dashboardStore).FindDashboards()
      /Users/grobinson/go/src/github.com/grafana/grafana/pkg/services/dashboards/database/database.go:963 +0x54
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
