### PR TITLE
Drawer: Make content scroll by default

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.story.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof Drawer> = {
   },
   args: {
     closeOnMaskClick: true,
-    scrollableContent: false,
     expandable: false,
     subtitle: 'This is a subtitle.',
   },

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -40,7 +40,7 @@ export interface Props {
   size?: 'sm' | 'md' | 'lg';
   /** Tabs */
   tabs?: React.ReactNode;
-  // TODO remove this prop next major version, it doesn't do anything anymore
+  // TODO remove this prop next major version
   /**
    * @deprecated this is now default behaviour. content is always scrollable.
    **/

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -11,7 +11,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '../../themes';
 import { Button } from '../Button';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
-//import { IconButton } from '../IconButton/IconButton';
 import { Text } from '../Text/Text';
 
 export interface Props {
@@ -41,7 +40,10 @@ export interface Props {
   size?: 'sm' | 'md' | 'lg';
   /** Tabs */
   tabs?: React.ReactNode;
-  /** Set to true if the component rendered within in drawer content has its own scroll */
+  // TODO remove this prop next major version, it doesn't do anything anymore
+  /**
+   * @deprecated this is now default behaviour. content is always scrollable.
+   **/
   scrollableContent?: boolean;
   /** Callback for closing the drawer */
   onClose: () => void;
@@ -51,7 +53,6 @@ export function Drawer({
   children,
   onClose,
   closeOnMaskClick = true,
-  scrollableContent = false,
   title,
   subtitle,
   width,
@@ -131,9 +132,7 @@ export function Drawer({
             </div>
           )}
           {typeof title !== 'string' && title}
-          <div className={styles.contentScroll}>
-            {!scrollableContent ? content : <CustomScrollbar autoHeightMin="100%">{content}</CustomScrollbar>}
-          </div>
+          <CustomScrollbar>{content}</CustomScrollbar>
         </div>
       </FocusScope>
     </RcDrawer>

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -53,6 +53,7 @@ export function Drawer({
   children,
   onClose,
   closeOnMaskClick = true,
+  scrollableContent = true,
   title,
   subtitle,
   width,
@@ -132,7 +133,9 @@ export function Drawer({
             </div>
           )}
           {typeof title !== 'string' && title}
-          <CustomScrollbar>{content}</CustomScrollbar>
+          <div className={styles.contentScroll}>
+            {!scrollableContent ? content : <CustomScrollbar autoHeightMin="100%">{content}</CustomScrollbar>}
+          </div>
         </div>
       </FocusScope>
     </RcDrawer>

--- a/public/app/core/components/AppChrome/News/NewsContainer.tsx
+++ b/public/app/core/components/AppChrome/News/NewsContainer.tsx
@@ -46,7 +46,6 @@ export function NewsContainer({ className }: NewsContainerProps) {
               </div>
             </div>
           }
-          scrollableContent
           onClose={onToggleShowNewsDrawer}
           size="md"
         >

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -85,7 +85,6 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
         <Drawer
           title={getNewFolderPhrase()}
           subtitle={parentFolder?.title ? `Location: ${parentFolder.title}` : undefined}
-          scrollableContent
           onClose={() => setShowNewFolderDrawer(false)}
           size="sm"
         >

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -114,7 +114,6 @@ export function FolderActionsButton({ folder }: Props) {
         <Drawer
           title={t('browse-dashboards.action.manage-permissions-button', 'Manage permissions')}
           subtitle={folder.title}
-          scrollableContent
           onClose={() => setShowPermissionsDrawer(false)}
           size="md"
         >

--- a/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
+++ b/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
@@ -102,7 +102,6 @@ function PanelInspectRenderer({ model }: SceneComponentProps<PanelInspectDrawer>
   return (
     <Drawer
       title={model.getDrawerTitle()}
-      scrollableContent
       onClose={model.onClose}
       size="md"
       tabs={

--- a/public/app/features/dashboard-scene/serialization/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard-scene/serialization/SaveDashboardDrawer.tsx
@@ -33,7 +33,7 @@ export class SaveDashboardDrawer extends SceneObjectBase<SaveDashboardDrawerStat
     // }
 
     return (
-      <Drawer title="Save dashboard" subtitle={dashboard.state.title} scrollableContent onClose={model.onClose}>
+      <Drawer title="Save dashboard" subtitle={dashboard.state.title} onClose={model.onClose}>
         <SaveDashboardDiff diff={diff} oldValue={initialSaveModel} newValue={changedSaveModel} />
       </Drawer>
     );

--- a/public/app/features/dashboard/components/EmbeddedDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/EmbeddedDashboard/SaveDashboardDrawer.tsx
@@ -53,7 +53,6 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, dashboardJson, onSav
           )}
         </TabsBar>
       }
-      scrollableContent
     >
       {showDiff ? (
         <SaveDashboardDiff diff={data.diff} oldValue={dashboardJson} newValue={data.clone} />

--- a/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
+++ b/public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx
@@ -73,7 +73,6 @@ export function HelpWizard({ panel, plugin, onClose }: Props) {
       title={`Get help with this panel`}
       size="lg"
       onClose={onClose}
-      scrollableContent
       subtitle={
         <Stack direction="column" gap={1}>
           <Stack direction="row" gap={1}>

--- a/public/app/features/dashboard/components/Inspector/InspectContent.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectContent.tsx
@@ -76,7 +76,6 @@ export const InspectContent = ({
       title={title}
       subtitle={data && formatStats(data)}
       onClose={onClose}
-      scrollableContent
       tabs={
         <TabsBar>
           {tabs.map((tab, index) => {

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -128,7 +128,6 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
           )}
         </TabsBar>
       }
-      scrollableContent
     >
       {renderSaveBody()}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- wraps the drawer content in a scrollbar by default
- deprecates the `scrollableContent` prop and marks it for removal in the next version
- removes all uses of `scrollableContent` in the core grafana codebase

**Why do we need this feature?**

- cleaner interface for the `Drawer` component

**Who is this feature for?**

- everyone! 🙌 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
