### PR TITLE
[v10.0.x] Docs: update visualization naming conventions - 2

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -17,7 +17,7 @@ weight: 75
 
 # Visualizations
 
-Grafana offers a variety of visualizations to support different use cases. This section of the documentation highlights the built-in panels, their options and typical usage.
+Grafana offers a variety of visualizations to support different use cases. This section of the documentation highlights the built-in visualizations, their options and typical usage.
 
 {{% admonition type="note" %}}
 If you are unsure which visualization to pick, Grafana can provide visualization suggestions based on the panel query. When you select a visualization, Grafana will show a preview with that visualization applied.
@@ -38,14 +38,14 @@ If you are unsure which visualization to pick, Grafana can provide visualization
 - Misc
   - [Table]({{< relref "table/" >}}) is the main and only table visualization.
   - [Logs]({{< relref "logs/" >}}) is the main visualization for logs.
-  - [Node Graph]({{< relref "node-graph/" >}}) for directed graphs or networks.
+  - [Node graph]({{< relref "node-graph/" >}}) for directed graphs or networks.
   - [Traces]({{< relref "traces/" >}}) is the main visualization for traces.
-  - [Flame Graph]({{< relref "flame-graph/" >}}) is the main visualization for profiling.
+  - [Flame graph]({{< relref "flame-graph/" >}}) is the main visualization for profiling.
 - Widgets
   - [Dashboard list]({{< relref "dashboard-list/" >}}) can list dashboards.
   - [Alert list]({{< relref "alert-list/" >}}) can list alerts.
-  - [Text panel]({{< relref "text/" >}}) can show markdown and html.
-  - [News panel]({{< relref "news/" >}}) can show RSS feeds.
+  - [Text]({{< relref "text/" >}}) can show markdown and html.
+  - [News]({{< relref "news/" >}}) can show RSS feeds.
 
 ## Get more
 
@@ -57,50 +57,50 @@ Below you can find some good examples for how all the visualizations in Grafana 
 
 ### Graphs
 
-For time based line, area and bar charts we recommend the default [Time series]({{< relref "time-series/" >}}) visualization. [This public demo dashboard](https://play.grafana.org/d/000000016/1-time-series-graphs?orgId=1) contains many different examples for how this visualization can be configured and styled.
+For time based line, area and bar charts we recommend the default [time series]({{< relref "time-series/" >}}) visualization. [This public demo dashboard](https://play.grafana.org/d/000000016/1-time-series-graphs?orgId=1) contains many different examples for how this visualization can be configured and styled.
 
 {{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="700px" caption="Time series" >}}
 
-For categorical data use the [Bar chart]({{< relref "bar-chart/" >}}) visualization.
+For categorical data use a [bar chart]({{< relref "bar-chart/" >}}).
 
 {{< figure src="/static/img/docs/bar-chart-panel/barchart_small_example.png" max-width="700px" caption="Bar chart" >}}
 
 ### Big numbers & stats
 
-The [Stat]({{< relref "stat/" >}}) visualization shows one large stat value with an optional graph sparkline. You can control the background or value color using thresholds or color scales.
+A [stat]({{< relref "stat/" >}}) shows one large stat value with an optional graph sparkline. You can control the background or value color using thresholds or color scales.
 
-{{< figure src="/static/img/docs/v66/stat_panel_dark3.png" max-width="1025px" caption="Stat panel" >}}
+{{< figure src="/static/img/docs/v66/stat_panel_dark3.png" max-width="1025px" caption="Stat" >}}
 
 ### Gauge
 
-If you want to present a value as it relates to a min and max value you have two options. First a standard [Radial Gauge]({{< relref "gauge/" >}}) shown below.
+If you want to present a value as it relates to a min and max value you have two options. First a standard radial [gauge]({{< relref "gauge/" >}}) shown below.
 
 {{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="700px" >}}
 
-Secondly Grafana also has a horizontal or vertical [Bar gauge]({{< relref "bar-gauge/" >}}) with three different distinct display modes.
+Secondly Grafana also has a horizontal or vertical [bar gauge]({{< relref "bar-gauge/" >}}) with three different distinct display modes.
 
 {{< figure src="/static/img/docs/v66/bar_gauge_lcd.png" max-width="700px" >}}
 
 ### Table
 
-To show data in a table layout, use the [Table]({{< relref "table/" >}}) visualization.
+To show data in a table layout, use a [table]({{< relref "table/" >}}).
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="700px" lightbox="true" caption="Table visualization" >}}
 
 ### Pie chart
 
-Grafana now ships with an included [Pie chart]({{< relref "pie-chart/" >}}) visualization.
+To display reduced series, or values in a series, from one or more queries, as they relate to each other, use a [pie chart]({{< relref "pie-chart/" >}}).
 
-{{< figure src="/static/img/docs/pie-chart-panel/pie-chart-example.png" max-width="700px" lightbox="true" caption="Pie chart visualization" >}}
+{{< figure src="/static/img/docs/pie-chart-panel/pie-chart-example.png" max-width="700px" lightbox="true" caption="Pie chart" >}}
 
 ### Heatmaps
 
-To show value distribution over, time use the [heatmap]({{< relref "heatmap/" >}}) visualization.
+To show value distribution over, time use a [heatmap]({{< relref "heatmap/" >}}).
 
 {{< figure src="/static/img/docs/v43/heatmap_panel_cover.jpg" max-width="1000px" lightbox="true" caption="Heatmap" >}}
 
 ### State timeline
 
-The state timeline panel visualization shows discrete state changes over time. When used with time series, the thresholds are used to turn the numerical values into discrete state regions.
+A state timeline shows discrete state changes over time. When used with time series, the thresholds are used to turn the numerical values into discrete state regions.
 
 {{< figure src="/static/img/docs/v8/state_timeline_strings.png" max-width="700px" caption="state timeline with string states" >}}

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -21,11 +21,11 @@ weight: 100
 
 # Candlestick
 
-The Candlestick panel allows you to visualize data that includes a number of consistent dimensions focused on price movement. The Candlestick panel includes an Open-High-Low-Close (OHLC) mode, as well as support for additional dimensions based on time series data.
+The candlestick visualization allows you to visualize data that includes a number of consistent dimensions focused on price movement. The candlestick visualization includes an Open-High-Low-Close (OHLC) mode, as well as support for additional dimensions based on time series data.
 
-{{< figure src="/static/img/docs/candlestick-panel/candlestick-panel-8-3.png" max-width="1200px" caption="Candlestick panel" >}}
+{{< figure src="/static/img/docs/candlestick-panel/candlestick-panel-8-3.png" max-width="1200px" caption="Candlestick visualization" >}}
 
-The Candlestick panel builds upon the foundation of the [time series]({{< relref "time-series/" >}}) panel and includes many common configuration settings.
+Candlestick visualizations build upon the foundation of the [time series visualization]({{< relref "time-series/" >}}) and include many common configuration settings.
 
 ## Mode
 
@@ -33,7 +33,7 @@ The mode options allow you to toggle which dimensions are used for the visualiza
 
 - **Candles** limits the panel dimensions to the open, high, low, and close dimensions used by candlestick visualizations.
 - **Volume** limits the panel dimension to the volume dimension.
-- **Both** is the default behavior for the candlestick panel. It includes both candlestick and volume visualizations.
+- **Both** is the default behavior for the candlestick visualization. It includes both candlestick and volume visualizations.
 
 ## Candle style
 
@@ -51,7 +51,7 @@ The **Up color** and **Down color** options select which colors are used when th
 
 ## Open, High, Low, Close
 
-The candlestick panel will attempt to map fields to the appropriate dimension. The **Open**, **High**, **Low**, and **Close** options allow you to map your data to these dimensions if the panel is unable to do so.
+The candlestick visualization will attempt to map fields to the appropriate dimension. The **Open**, **High**, **Low**, and **Close** options allow you to map your data to these dimensions if the panel is unable to do so.
 
 {{% admonition type="note" %}}
 These values are hidden from the legend.
@@ -65,4 +65,4 @@ These values are hidden from the legend.
 
 ## Additional fields
 
-The candlestick panel is based on the time series panel. It can visualization additional data dimensions beyond open, high, low, close, and volume The **Include** and **Ignore** options allow the panel to visualize other included data such as simple moving averages, Bollinger bands and more, using the same styles and configurations available in the [time series]({{< relref "time-series/" >}}) panel.
+The candlestick visualization is based on the time series visualization. It can visualize additional data dimensions beyond open, high, low, close, and volume The **Include** and **Ignore** options allow it to visualize other included data such as simple moving averages, Bollinger bands and more, using the same styles and configurations available in the [time series]({{< relref "time-series/" >}}) visualization.

--- a/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
@@ -18,9 +18,9 @@ weight: 100
 
 # Flame graph panel
 
-The flame graph takes advantage of the hierarchical nature of profiling data. It condenses data into a format that allows you to easily see which code paths are consuming the most system resources.
+A flame graph takes advantage of the hierarchical nature of profiling data. It condenses data into a format that allows you to easily see which code paths are consuming the most system resources.
 
-These resources are measured through profiles which aggregate that information into a format which is then sent to the flame graph visualization. For example, allocated objects or space when measuring memory.
+These resources are measured through profiles which aggregate that information into a format which is then sent to the flame graph. For example, allocated objects or space when measuring memory.
 
 ![Figure 1 - Flame graph](/static/img/docs/flame-graph-panel/flame-graph.png 'Figure 1 - Flame graph')
 

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -18,9 +18,9 @@ weight: 100
 
 # Trend
 
-The trend panel should be used for datasets that have a sequential, numeric X that is not time. Some examples are function graphs, rpm/torque curves, supply/demand relationships, and elevation or heart rate plots along a race course (with x as distance or duration from start).
+Trend visualizations should be used for datasets that have a sequential, numeric X that is not time. Some examples are function graphs, rpm/torque curves, supply/demand relationships, and elevation or heart rate plots along a race course (with x as distance or duration from start).
 
-The trend panel supports all visual styles and options available in the [Time series panel]({{< relref "../time-series" >}}) with these exceptions:
+Trend visualizations support all visual styles and options available in the [time series visualization]({{< relref "../time-series" >}}) with these exceptions:
 
 - No annotations or time regions
 - No shared cursor/crosshair


### PR DESCRIPTION
Backport 7cbca0dfa433f02d48e314846c65a56d07bef4c2 from #74954

---

Updating visualization docs with following changes:

- Make visualization names common nouns rather than proper nouns (lower case, add an article)
- Replace adjective form of visualization with noun form
- Replace the word "panel" with "visualization" where appropriate
- Fix titles to match with name of visualization in the UI
- This is the second of two PRs doing this work. This PR covers the visualizations for was a bit trickier and updates the Visualizations index page.

**Justifications for treatment**

- **Candlestick** - the individual markers in this visualization is called a "candlestick" so it doesn't work to call the whole visualization a candlestick. Thus this gets the adjective treatment and we use "candlestick visualization."
- **Flame graph** - I had to look at this one a bit longer because this visualization can have flame graph mode or table mode. But when we talk about those, we use the word "mode" so the noun version for this visualization is still fine. Thus "flame graph(s)".
- **Trend** - Like "text" this one seems like it might be confusing, and so I went with the adjective version, but I'm not 100% on this. Maybe this one is fine as a noun in context.

**Note for reviewers**: All you need to do is ensure that the new way we refer to the visualization doesn't sound confusing or just weird. 
