### PR TITLE
[v10.0.x] Docs: update visualization naming conventions 

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -21,7 +21,7 @@ weight: 100
 
 # Alert list
 
-Use Alert list to display your alerts. You can configure the list to show the current state or recent state changes. You can read more about alerts in [Grafana Alerting overview]({{< relref "../../../alerting/" >}}).
+Use alert lists to display your alerts. You can configure the list to show the current state. You can read more about alerts in [Grafana Alerting overview]({{< relref "../../../alerting/" >}}).
 
 {{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" >}}
 
@@ -57,7 +57,7 @@ These options allow you to limit alerts shown to only those that match the query
 
 ## State filter
 
-Choose which alert states to display in this panel.
+Choose which alert states to display in this visualization.
 
 - Alerting / Firing
 - Pending

--- a/docs/sources/panels-visualizations/visualizations/annotations/index.md
+++ b/docs/sources/panels-visualizations/visualizations/annotations/index.md
@@ -14,13 +14,13 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Annotations
+title: Annotations list
 weight: 100
 ---
 
-# Annotations
+# Annotations list
 
-The Annotations panel shows a list of available annotations you can use to view annotated data. Various options are available to filter the list based on tags and on the current dashboard.
+The annotations list shows a list of available annotations you can use to view annotated data. Various options are available to filter the list based on tags and on the current dashboard.
 
 ## Annotation query
 
@@ -38,7 +38,7 @@ Use the query filter to create a list of annotations from all dashboards in your
 Use the time range option to specify whether the list should be limited to the current time range. It has the following options:
 
 - None - no time range limit for the annotations query.
-- This dashboard - Limit the list to the time range of the dashboard where the annotation list panel is available.
+- This dashboard - Limit the list to the time range of the dashboard where the annotations list is available.
 
 ### Tags
 
@@ -54,7 +54,7 @@ Use the limit option to limit the number of results returned.
 
 ## Display
 
-These options control additional meta-data included in the annotations panel display.
+These options control additional meta-data included in the annotations list display.
 
 ### Show user
 
@@ -66,7 +66,7 @@ Use this option to show or hide the time the annotation creation time.
 
 ### Show Tags
 
-Use this option to show or hide the tags associated with an annotation. _NB_: You can use the tags to live-filter the annotation list on the panel itself.
+Use this option to show or hide the tags associated with an annotation. _NB_: You can use the tags to live-filter the annotations list on the visualization itself.
 
 ## Link behavior
 

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -20,7 +20,7 @@ weight: 100
 
 # Bar chart
 
-This panel visualization allows you to graph categorical data.
+Bar charts allow you to graph categorical data.
 
 {{< figure src="/static/img/docs/bar-chart-panel/barchart_small_example.png" max-width="1000px" caption="Bar chart" >}}
 
@@ -35,7 +35,7 @@ Example:
 | Chrome  | 50           |
 | IE      | 17.5         |
 
-If you have more than one numerical field the panel will show grouped bars.
+If you have more than one numerical field the visualization will show grouped bars.
 
 ### Visualizing time series or multiple result sets
 

--- a/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
@@ -19,7 +19,7 @@ weight: 100
 
 # Bar gauge
 
-The bar gauge simplifies your data by reducing every field to a single value. You choose how Grafana calculates the reduction.
+Bar gauges simplify your data by reducing every field to a single value. You choose how Grafana calculates the reduction.
 
 This panel can show one or more bar gauges depending on how many series, rows, or columns your query returns.
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -19,17 +19,17 @@ weight: 100
 
 # Canvas
 
-Canvas is a new panel that combines the power of Grafana with the flexibility of custom elements. Canvas visualizations are extensible form-built panels that allow you to explicitly place elements within static and dynamic layouts. This empowers you to design custom visualizations and overlay data in ways that aren't possible with standard Grafana panels, all within Grafana's UI. If you've used popular UI and web design tools, then designing Canvas panels will feel very familiar.
+Canvases combine the power of Grafana with the flexibility of custom elements. Canvases are extensible form-built visualizations that allow you to explicitly place elements within static and dynamic layouts. This empowers you to design custom visualizations and overlay data in ways that aren't possible with standard Grafana panels, all within Grafana's UI. If you've used popular UI and web design tools, then designing canvases will feel very familiar.
 
 > We would love your feedback on Canvas. Please check out the [Github discussion](https://github.com/grafana/grafana/discussions/56835) and join the conversation.
 
-{{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" caption="Canvas panel beta overview" >}}
+{{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" caption="Canvas beta overview" >}}
 
 ## Elements
 
 ### Metric value
 
-The metric value element enables you to easily select the data you want to display on canvas. This element has a unique “edit” mode that can be triggered either through the context menu “Edit” option or by double clicking. When in edit mode you can select which field data that you want to display.
+The metric value element enables you to easily select the data you want to display on a canvas. This element has a unique “edit” mode that can be triggered either through the context menu “Edit” option or by double clicking. When in edit mode you can select which field data that you want to display.
 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-metric-value-9-2-0.mp4" max-width="750px" caption="Metric value element demo" >}}
 
@@ -55,7 +55,7 @@ The server element enables you to easily represent a single server, a stack of s
 
 ## Connections
 
-When building a canvas panel, you can connect elements together to create more complex visualizations. Connections are created by dragging from the connection anchor of one element to the connection anchor of another element. You can also create connections to the background of the canvas panel. Connection anchors are displayed when you hover over an element and inline editing is turned on. To remove a connection, simply click on the connection directly and then press the "Delete" or "Backspace" key.
+When building a canvas, you can connect elements together to create more complex visualizations. Connections are created by dragging from the connection anchor of one element to the connection anchor of another element. You can also create connections to the background of the canvas. Connection anchors are displayed when you hover over an element and inline editing is turned on. To remove a connection, simply click on the connection directly and then press the "Delete" or "Backspace" key.
 
 {{< video-embed src="/media/docs/grafana/canvas-connections-9-4-0.mp4" max-width="750px" caption="Canvas connections demo" >}}
 
@@ -67,13 +67,13 @@ You can set both the size and color of connections based on fixed or field value
 
 ### Inline editor
 
-Canvas introduces a new editing experience. You can now edit your canvas panel inline while in the context of dashboard mode.
+You can edit your canvas inline while in the context of dashboard mode.
 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-inline-editor-9-2-0.mp4" max-width="750px" caption="Inline editor demo" >}}
 
 ### Context menu
 
-Related to a fresh look at panel editing, the context menu enables you to perform common tasks quickly and efficiently. Supported functionality includes opening / closing the inline editor, duplicating an element, deleting an element, and more.
+The context menu enables you to perform common tasks quickly and efficiently. Supported functionality includes opening / closing the inline editor, duplicating an element, deleting an element, and more.
 
 The context menu is triggered by a right click action over the panel / over a given canvas element. When right clicking the panel, you are able to set a background image and easily add elements to the canvas.
 
@@ -87,13 +87,13 @@ When right clicking an element, you are able to edit, delete, duplicate, and mod
 
 ### Inline editing
 
-The inline editing toggle enables you to lock or unlock the canvas panel. When turned off the canvas panel becomes “locked”, freezing elements in place and preventing unintended modifications.
+The inline editing toggle enables you to lock or unlock the canvas. When turned off the canvas becomes “locked”, freezing elements in place and preventing unintended modifications.
 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-inline-editing-toggle-9-2-0.mp4" max-width="750px" caption="Inline editing toggle demo" >}}
 
 ### Data links
 
-Canvas supports [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/). You can create a data link for a metric-value element and display it for all elements that use the field name by following these steps:
+Canvases support [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/). You can create a data link for a metric-value element and display it for all elements that use the field name by following these steps:
 
 1. Set an element to be tied to a field value.
 1. Turn off the inline editing toggle.
@@ -106,7 +106,7 @@ Canvas supports [data links](https://grafana.com/docs/grafana/latest/panels-visu
 
 If multiple elements use the same field name, and you want to control which elements display the data link, you can create a unique field name using the [add field from calculation transform](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#add-field-from-calculation). The alias you create in the transformation will appear as a field you can use with an element.
 
-1. In the panel editor for the canvas panel, click the **Transform** tab.
+1. In the panel editor for the canvas, click the **Transform** tab.
 1. Select **Add field from calculation** from the list of transformations, or click **+ Add transformation** to display the list first.
 1. Choose **Reduce row** from the dropdown and click the field name that you want to use for the element.
 1. Select **All Values** from the **Calculation** dropdown.

--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -21,7 +21,7 @@ weight: 100
 
 # Dashboard list
 
-The dashboard list visualization allows you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, recently viewed dashboards, a search query, and dashboard tags.
+Dashboard lists allow you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, recently viewed dashboards, a search query, and dashboard tags.
 
 {{< figure src="/static/img/docs/v45/dashboard-list-panels.png" max-width="850px">}}
 

--- a/docs/sources/panels-visualizations/visualizations/datagrid/index.md
+++ b/docs/sources/panels-visualizations/visualizations/datagrid/index.md
@@ -25,11 +25,11 @@ weight: 100
 
 {{% admonition type="note" %}}
 
-The Grafana Datagrid panel is experimental. This feature is supported by the engineering team on a best-effort basis, and breaking changes may occur without notice prior to general availability.
+The Grafana datagrid is experimental. This feature is supported by the engineering team on a best-effort basis, and breaking changes may occur without notice prior to general availability.
 
 {{% /admonition %}}
 
-The Datagrid panel offers you the ability to create, edit, and fine-tune data within Grafana. As such, this panel can act as a data source for other panels
+Datagrids offer you the ability to create, edit, and fine-tune data within Grafana. As such, this panel can act as a data source for other panels
 inside a dashboard.
 
 ![Datagrid panel](/media/docs/datagrid/screenshot-grafana-datagrid-panel.png)
@@ -45,7 +45,7 @@ Learn more about the inbuilt `-- Grafana --` and `-- Dashboard --` data sources 
 
 ## Context menu
 
-To provide a more streamlined experience, the Datagrid panel has a context menu that can be accessed by right-clicking on a cell, column header, or row selector. Depending on the state of your datagrid, the context menu offers different options including:
+To provide a more streamlined experience, the datagrid has a context menu that can be accessed by right-clicking on a cell, column header, or row selector. Depending on the state of your datagrid, the context menu offers different options including:
 
 - Delete or clear rows and columns.
 - Remove all existing data (rendering your datagrid blank).
@@ -63,11 +63,11 @@ You can also access a header menu by clicking the dropdown icon next to the head
 
 ## Selecting series
 
-If there are multiple series, you can set the Datagrid panel to display the preferred dataset using the **Select series** dropdown in the panel options.
+If there are multiple series, you can set the datagrid to display the preferred dataset using the **Select series** dropdown in the panel options.
 
-## Using Datagrid
+## Using datagrids
 
-Datagrid offers various ways of interacting with your data. You can add, edit, move, clear, and remove rows and columns; use the inbuilt search functionality to find specific data; and convert field types or freeze horizontal scroll on a specific column.
+Datagrids offer various ways of interacting with your data. You can add, edit, move, clear, and remove rows and columns; use the inbuilt search functionality to find specific data; and convert field types or freeze horizontal scroll on a specific column.
 
 ### Add data
 

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -19,7 +19,7 @@ weight: 100
 
 # Gauge
 
-Gauge is a single-value visualization that can repeat a gauge for every series, column or row.
+Gauges are single-value visualizations that can repeat a gauge for every series, column or row.
 
 {{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="1025px" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -38,9 +38,9 @@ weight: 100
 
 # Geomap
 
-The Geomap panel visualization allows you to view and customize the world map using geospatial data. You can configure various overlay styles and map view settings to easily focus on the important location-based characteristics of the data.
+Geomaps allow you to view and customize the world map using geospatial data. You can configure various overlay styles and map view settings to easily focus on the important location-based characteristics of the data.
 
-> We would love your feedback on Geomap. Please check out the [Github discussion](https://github.com/grafana/grafana/discussions/62159) and join the conversation.
+> We would love your feedback on geomaps. Please check out the [Github discussion](https://github.com/grafana/grafana/discussions/62159) and join the conversation.
 
 {{< figure src="/static/img/docs/geomap-panel/geomap-example-8-1-0.png" max-width="1200px" caption="Geomap panel" >}}
 
@@ -50,7 +50,7 @@ The map view controls the initial view of the map when the dashboard loads.
 
 ### Initial View
 
-The initial view configures how the GeoMap panel renders when the panel is first loaded.
+The initial view configures how the geomap renders when the panel is first loaded.
 
 - **View** sets the center for the map when the panel first loads.
   - **Fit to data** fits the map view based on the data extents of Map layers and updates when data changes.
@@ -77,11 +77,11 @@ The initial view configures how the GeoMap panel renders when the panel is first
 
 ## Map layers
 
-The Geomap visualization supports showing multiple layers. Each layer determines how you visualize geospatial data on top of the base map.
+Geomaps support showing multiple layers. Each layer determines how you visualize geospatial data on top of the base map.
 
 ### Types
 
-There are three map layer types to choose from in the Geomap visualization.
+There are three map layer types to choose from in a geomap.
 
 - [Markers]({{< relref "#markers-layer" >}}) renders a marker at each data point.
 - [Heatmap]({{< relref "#heatmap-layer" >}}) visualizes a heatmap of the data.
@@ -103,17 +103,17 @@ There are also five alpha layer types.
 
 The layer controls allow you to create layers, change their name, reorder and delete layers.
 
-- **Add layer** creates an additional, configurable data layer for the Geomap visualization. When you add a layer, you are prompted to select a layer type. You can change the layer type at any point during panel configuration. See the **Layer Types** section above for details on each layer type.
-- The layer controls allow you to rename, delete, and reorder the layers of the panel.
+- **Add layer** creates an additional, configurable data layer for the geomap. When you add a layer, you are prompted to select a layer type. You can change the layer type at any point during panel configuration. See the **Layer Types** section above for details on each layer type.
+- The layer controls allow you to rename, delete, and reorder the layers of the visualization.
   - **Edit layer name (pencil icon)** renames the layer.
   - **Trash Bin** deletes the layer.
-  - **Reorder (six dots/grab handle)** allows you to change the layer order. Data on higher layers will appear above data on lower layers. The panel will update the layer order as you drag and drop to help simplify choosing a layer order.
+  - **Reorder (six dots/grab handle)** allows you to change the layer order. Data on higher layers will appear above data on lower layers. The visualization will update the layer order as you drag and drop to help simplify choosing a layer order.
 
-You can add multiple layers of data to a single Geomap panel in order to create rich, detailed visualizations.
+You can add multiple layers of data to a single geomap in order to create rich, detailed visualizations.
 
 ### Location
 
-The Geomap panel needs a source of geographical data. This data comes from a database query, and there are four mapping options for your data.
+Geomaps need a source of geographical data. This data comes from a database query, and there are four mapping options for your data.
 
 - **Auto** automatically searches for location data. Use this option when your query is based on one of the following names for data fields.
   - geohash: “geohash”
@@ -131,7 +131,7 @@ are available each with specific configuration options to style the base map.
 
 ### Types
 
-There are four basemap layer types to choose from in the Geomap visualization.
+There are four basemap layer types to choose from in a geomap.
 
 - [Open Street Map]({{< relref "#open-street-map-layer" >}}) adds a map from a collaborative free geographic world database.
 - [CARTO]({{< relref "#carto-layer" >}}) adds a layer from CARTO Raster basemaps.

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -19,7 +19,7 @@ weight: 100
 
 # Heatmap
 
-The Heatmap panel visualization allows you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../../fundamentals/intro-histograms/" >}}).
+Heatmaps allow you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../../fundamentals/intro-histograms/" >}}).
 
 ![](/static/img/docs/v43/heatmap_panel_cover.jpg)
 

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -21,13 +21,13 @@ weight: 100
 
 # Histogram
 
-The histogram visualization calculates the distribution of values and presents them as a bar chart. The Y-axis and the height of each bar represent the count of values that fall into each bracket while the X-axis represents the value range.
+Histograms calculate the distribution of values and present them as a bar chart. The Y-axis and the height of each bar represent the count of values that fall into each bracket while the X-axis represents the value range.
 
 {{< figure src="/static/img/docs/histogram-panel/histogram-example-v8-0.png" max-width="625px" caption="Bar chart example" >}}
 
 ## Supported data formats
 
-Histogram visualization supports time series and any table results with one or more numerical fields.
+Histograms support time series and any table results with one or more numerical fields.
 
 ## Display options
 

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -15,17 +15,17 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Logs panel
+title: Logs
 weight: 100
 ---
 
-# Logs panel
+# Logs
 
-The logs panel visualization shows log lines from data sources that support logs, such as Elastic, Influx, and Loki. Typically you would use this panel next to a graph panel to display the log output of a related process.
+The logs visualization shows log lines from data sources that support logs, such as Elastic, Influx, and Loki. Typically you would use this visualization next to a graph visualization to display the log output of a related process.
 
 <img class="screenshot" src="/static/img/docs/v64/logs-panel.png">
 
-The logs panel shows the result of queries that were entered in the Query tab. The results of multiple queries are merged and sorted by time. You can scroll inside the panel if the data source returns more lines than can be displayed at any one time.
+The logs visualization shows the result of queries that were entered in the Query tab. The results of multiple queries are merged and sorted by time. You can scroll inside the panel if the data source returns more lines than can be displayed at any one time.
 
 To limit the number of lines rendered, you can use the **Max data points** setting in the **Query options**. If it is not set, then the data source will usually enforce a default limit.
 

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -19,12 +19,12 @@ weight: 100
 
 ## News
 
-This panel visualization displays an RSS feed. By default, it displays articles from the Grafana Labs blog, and users can change this by entering a different RSS feed URL.
+Th news visualization displays an RSS feed. By default, it displays articles from the Grafana Labs blog, and users can change this by entering a different RSS feed URL.
 
-Enter the URL of an RSS in the URL field in the Display section. This panel type does not accept any other queries, and users should not expect to be able to filter or query the RSS feed data in any way using this panel.
+Enter the URL of an RSS in the URL field in the Display section. This visualization type does not accept any other queries, and users should not expect to be able to filter or query the RSS feed data in any way using this visualization.
 
-In version 8.5, we discontinued the "Use Proxy" option for Grafana news panels. As a result, RSS feeds that are not configured for request by Grafana's frontend (with the appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)) may not load.
+In version 8.5, we discontinued the "Use Proxy" option for Grafana news visualizations. As a result, RSS feeds that are not configured for request by Grafana's frontend (with the appropriate [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)) may not load.
 
 If you're having trouble loading an RSS feed, you can try rehosting the feed on a different server or using a CORS proxy. A CORS proxy is a tool that allows you to bypass CORS restrictions by making requests to the RSS feed on your behalf. You can find more information about using CORS proxies online.
 
-If you're unable to display an RSS feed using the News panel, you can try using the community RSS/Atom data source plugin [RSS/Atom data source](https://grafana.com/grafana/plugins/volkovlabs-rss-datasource/) in combination with the Dynamic text community panel [Dynamic text](https://grafana.com/grafana/plugins/marcusolsson-dynamictext-panel/). This will allow you to display the RSS feed in a different way.
+If you're unable to display an RSS feed using the news visualization, you can try using the community RSS/Atom data source plugin [RSS/Atom data source](https://grafana.com/grafana/plugins/volkovlabs-rss-datasource/) in combination with the Dynamic text community panel [Dynamic text](https://grafana.com/grafana/plugins/marcusolsson-dynamictext-panel/). This will allow you to display the RSS feed in a different way.

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -19,7 +19,7 @@ weight: 100
 
 ## News
 
-Th news visualization displays an RSS feed. By default, it displays articles from the Grafana Labs blog, and users can change this by entering a different RSS feed URL.
+The news visualization displays an RSS feed. By default, it displays articles from the Grafana Labs blog, and users can change this by entering a different RSS feed URL.
 
 Enter the URL of an RSS in the URL field in the Display section. This visualization type does not accept any other queries, and users should not expect to be able to filter or query the RSS feed data in any way using this visualization.
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -18,17 +18,17 @@ title: Node graph
 weight: 100
 ---
 
-# Node graph panel
+# Node graph
 
-The _Node graph_ can visualize directed graphs or networks. It uses a directed force layout to effectively position the nodes, so it can display complex infrastructure maps, hierarchies, or execution diagrams.
+Node graphs can visualize directed graphs or networks. They use a directed force layout to effectively position the nodes, so they can display complex infrastructure maps, hierarchies, or execution diagrams.
 
-![Node graph panel](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
+![Node graph visualization](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
 
 ## Data requirements
 
-The Node graph panel requires specific shape of the data to be able to display its nodes and edges. This means not every data source or query can be visualized in this panel. If you want to use this as a data source developer see the section about data API.
+A node graph requires a specific shape of the data to be able to display its nodes and edges. This means not every data source or query can be visualized with this graph. If you want to use this as a data source developer see the section about data API.
 
-The Node graph visualization consists of _nodes_ and _edges_.
+A node graph consists of _nodes_ and _edges_.
 
 - A _node_ is displayed as a circle. A node might represent an application, a service, or anything else that is relevant from an application perspective.
 - An _edge_ is displayed as a line that connects two nodes. The connection might be a request, an execution, or some other relationship between the two nodes.
@@ -38,7 +38,7 @@ Both nodes and edges can have associated metadata or statistics. The data source
 ### Nodes
 
 {{% admonition type="note" %}}
-Node graph can show only 1,500 nodes. If this limit is crossed a warning will be visible in upper right corner, and some nodes will be hidden. You can expand hidden parts of the graph by clicking on the "Hidden nodes" markers in the graph.
+Node graphs can show only 1,500 nodes. If this limit is crossed a warning will be visible in upper right corner, and some nodes will be hidden. You can expand hidden parts of the graph by clicking on the "Hidden nodes" markers in the graph.
 {{% /admonition %}}
 
 Usually, nodes show two statistical values inside the node and two identifiers just below the node, usually name and type. Nodes can also show another set of values as a color circle around the node, with sections of different color represents different values that should add up to 1.
@@ -55,7 +55,7 @@ The first data source supporting this visualization is X-Ray data source for its
 
 ## Navigating the node graph
 
-You can pan and zoom in or out the node graph.
+You can pan and zoom in or out a node graph.
 
 ### Pan
 
@@ -89,7 +89,7 @@ Click on the node and select "Show in Graph layout" option to switch back to gra
 
 This visualization needs a specific shape of the data to be returned from the data source in order to correctly display it.
 
-Node Graph at minimum requires a data frame describing the edges of the graph. By default, node graph will compute the nodes and any stats based on this data frame. Optionally a second data frame describing the nodes can be sent in case there is need to show more node specific metadata. You have to set `frame.meta.preferredVisualisationType = 'nodeGraph'` on both data frames or name them `nodes` and `edges` respectively for the node graph to render.
+Node graphs, at minimum, require a data frame describing the edges of the graph. By default, node graphs will compute the nodes and any stats based on this data frame. Optionally a second data frame describing the nodes can be sent in case there is need to show more node specific metadata. You have to set `frame.meta.preferredVisualisationType = 'nodeGraph'` on both data frames or name them `nodes` and `edges` respectively for the node graph to render.
 
 ### Edges data frame structure
 

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -16,9 +16,9 @@ weight: 100
 
 # Pie chart
 
-{{< figure src="/static/img/docs/pie-chart-panel/pie-chart-example.png" max-width="1200px" lightbox="true" caption="Pie chart visualization" >}}
+{{< figure src="/static/img/docs/pie-chart-panel/pie-chart-example.png" max-width="1200px" lightbox="true" caption="Pie charts" >}}
 
-The pie chart displays reduced series, or values in a series, from one or more queries, as they relate to each other, in the form of slices of a pie. The arc length, area and central angle of a slice are all proportional to the slices value, as it relates to the sum of all values. This type of chart is best used when you want a quick comparison of a small set of values in an aesthetically pleasing form.
+Pie charts display reduced series, or values in a series, from one or more queries, as they relate to each other, in the form of slices of a pie. The arc length, area and central angle of a slice are all proportional to the slices value, as it relates to the sum of all values. This type of chart is best used when you want a quick comparison of a small set of values in an aesthetically pleasing form.
 
 ## Value options
 

--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -21,15 +21,15 @@ weight: 100
 
 # Stat
 
-The Stat panel visualization shows a one large stat value with an optional graph sparkline. You can control the background or value color using thresholds or overrides.
+Stats show one large stat value with an optional graph sparkline. You can control the background or value color using thresholds or overrides.
 
-{{< figure src="/static/img/docs/v66/stat_panel_dark3.png" max-width="1025px" caption="Stat panel" >}}
+{{< figure src="/static/img/docs/v66/stat_panel_dark3.png" max-width="1025px" caption="Stat visualization" >}}
 
 {{% admonition type="note" %}}
-This panel replaces the Singlestat panel, which was deprecated in Grafana 7.0 and removed in Grafana 8.0.
+This visualization replaces the Singlestat visualization, which was deprecated in Grafana 7.0 and removed in Grafana 8.0.
 {{% /admonition %}}
 
-By default, the Stat panel displays one of the following:
+By default, a stat displays one of the following:
 
 - Just the value for a single series or field.
 - Both the value and name for multiple series or fields.
@@ -38,7 +38,7 @@ You can use the **Text mode** to control how the text is displayed.
 
 Example screenshot:
 
-{{< figure src="/static/img/docs/v71/stat-panel-text-modes.png" max-width="1025px" caption="Stat panel" >}}
+{{< figure src="/static/img/docs/v71/stat-panel-text-modes.png" max-width="1025px" caption="Stat visualization" >}}
 
 ## Automatic layout adjustment
 
@@ -57,14 +57,14 @@ Display a single value per column or series, or show values for each row.
 Display a calculated value based on all rows.
 
 - **Calculation -** Select a reducer function that Grafana will use to reduce many fields to a single value. For a list of available calculations, refer to [Calculation types]({{< relref "../../calculation-types/" >}}).
-- **Fields -** Select the fields display in the panel.
+- **Fields -** Select the fields display in the visualization.
 
 #### All values
 
 Show a separate stat for every row. If you select this option, then you can also limit the number of rows to display.
 
 - **Limit -** The maximum number of rows to display. Default is 5,000.
-- **Fields -** Select the fields display in the panel.
+- **Fields -** Select the fields display in the visualization.
 
 ## Stat styles
 
@@ -80,7 +80,7 @@ Choose a stacking direction.
 
 ### Text mode
 
-You can use the Text mode option to control what text the panel renders. If the value is not important, only the name and color is, then change the **Text mode** to **Name**. The value will still be used to determine color and is displayed in a tooltip.
+You can use the Text mode option to control what text the visualization renders. If the value is not important, only the name and color is, then change the **Text mode** to **Name**. The value will still be used to determine color and is displayed in a tooltip.
 
 - **Auto -** If the data contains multiple series or fields, show both name and value.
 - **Value -** Show only value, never name. Name is displayed in the hover tooltip instead.
@@ -99,7 +99,7 @@ Select a color mode.
 
 ### Graph mode
 
-Select a graph and splarkline mode.
+Select a graph and sparkline mode.
 
 - **None -** Hides the graph and only shows the value.
 - **Area -** Shows the area graph below the value. This requires that your query returns a time column.

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -19,7 +19,7 @@ weight: 100
 
 # State timeline
 
-The state timeline panel visualization shows discrete state changes over time. Each field or series is rendered as its unique horizontal band. State regions can either be rendered with or without values. This panel works well with string or boolean states but can also be used with time series. When used with time series, the thresholds are used to turn the numerical values into discrete state regions.
+State timelines show discrete state changes over time. Each field or series is rendered as its unique horizontal band. State regions can either be rendered with or without values. This visualization works well with string or boolean states but can also be used with time series. When used with time series, the thresholds are used to turn the numerical values into discrete state regions.
 
 {{< figure src="/static/img/docs/v8/state_timeline_strings.png" max-width="1025px" caption="state timeline with string states" >}}
 
@@ -59,7 +59,7 @@ To assign colors to boolean or string values, you can use [Value mappings]({{< r
 
 ## Time series data with thresholds
 
-The panel can be used with time series data as well. In this case, the thresholds are used to turn the time series into discrete colored state regions.
+The visualization can be used with time series data as well. In this case, the thresholds are used to turn the time series into discrete colored state regions.
 
 {{< figure src="/static/img/docs/v8/state_timeline_time_series.png" max-width="1025px" caption="state timeline with time series" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -19,13 +19,13 @@ weight: 100
 
 # Status history
 
-The Status history visualization shows periodic states over time. Each field or series is rendered as a horizontal row. Boxes are rendered and centered around each value.
+Status histories show periodic states over time. Each field or series is rendered as a horizontal row. Boxes are rendered and centered around each value.
 
 {{< figure src="/static/img/docs/status-history-panel/status-history-example-v8-0.png" max-width="1025px" caption="Status history example" >}}
 
 ## Supported data
 
-Status history visualization works with string, boolean and numerical fields or time series. A time field is required. You can use value mappings to color strings or assign text values to numerical ranges.
+A status history works with string, boolean and numerical fields or time series. A time field is required. You can use value mappings to color strings or assign text values to numerical ranges.
 
 ## Display options
 
@@ -55,7 +55,7 @@ To assign colors to boolean or string values, use the [Value mappings]({{< relre
 
 ## Time series data with thresholds
 
-The panel can be used with time series data as well. In this case, the thresholds are used to color the boxes. You can also
+The visualization can be used with time series data as well. In this case, the thresholds are used to color the boxes. You can also
 use gradient color schemes to color values.
 
 {{< figure src="/static/img/docs/v8/state_timeline_time_series.png" max-width="1025px" caption="state timeline with time series" >}}

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -21,20 +21,19 @@ labels:
     - cloud
     - enterprise
     - oss
-menuTitle: Table
 title: Table
 weight: 100
 ---
 
 # Table
 
-The table panel visualization is very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This panel also provides date formatting, value formatting, and coloring options.
+Tables are very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This visualization also provides date formatting, value formatting, and coloring options.
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
 ## Annotation and alert support
 
-Annotations and alerts are not currently supported in the new table panel.
+Annotations and alerts are not currently supported in tables.
 
 ## Sort column
 
@@ -45,7 +44,7 @@ Click a column title to change the sort order from default to descending to asce
 ## Table options
 
 {{% admonition type="note" %}}
-If you are using a table visualization created before Grafana 7.0, then you need to migrate to the new table version in order to see these options. To migrate, on the Panel tab, click **Table** visualization. Grafana updates the table version and you can then access all table options.
+If you are using a table created before Grafana 7.0, then you need to migrate to the new table version in order to see these options. To migrate, on the Panel tab, click **Table** visualization. Grafana updates the table version and you can then access all table options.
 {{% /admonition %}}
 
 ### Show header
@@ -60,11 +59,11 @@ For example, if you enter `100` in the field, then when you click outside the fi
 
 ## Minimum column width
 
-By default, the minimum width of the table column is 150 pixels. This field option can override that default and will define the new minimum column width for the table panel in pixels.
+By default, the minimum width of the table column is 150 pixels. This field option can override that default and will define the new minimum column width for the table in pixels.
 
 For example, if you enter `75` in the field, then when you click outside the field, all the columns will scale to no smaller than 75 pixels wide.
 
-For small-screen devices, such as smartphones or tablets, reduce the default `150` pixel value to`50` to allow table based panels to render correctly in dashboards.
+For small-screen devices, such as smartphones or tablets, reduce the default `150` pixel value to`50` to allow table-based panels to render correctly in dashboards.
 
 ## Column alignment
 

--- a/docs/sources/panels-visualizations/visualizations/text/index.md
+++ b/docs/sources/panels-visualizations/visualizations/text/index.md
@@ -20,7 +20,7 @@ weight: 100
 
 # Text
 
-The text panel enables you to directly include text or HTML in your dashboards. This can be used to add contextual information and descriptions or embed complex HTML.
+Text visualizations enable you to directly include text or HTML in your dashboards. This can be used to add contextual information and descriptions or embed complex HTML.
 
 ## Mode
 

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -37,10 +37,10 @@ weight: 10
 
 {{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" caption="Time series" >}}
 
-The time series visualization type is the default and primary way to visualize time series data as a graph. It can render series as lines, points, or bars. It is versatile enough to display almost any time-series data. [This public demo dashboard](https://play.grafana.org/d/000000016/1-time-series-graphs?orgId=1) contains many different examples of how it can be configured and styled.
+Time series visualizations are the default and primary way to visualize time series data as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data. [This public demo dashboard](https://play.grafana.org/d/000000016/1-time-series-graphs?orgId=1) contains many different examples of how a time series visualization can be configured and styled.
 
 {{% admonition type="note" %}}
-You can migrate from the old Graph visualization to the new Time series visualization. To migrate, open the panel and click the **Migrate** button in the side pane.
+You can migrate from the old Graph visualization to the new time series visualization. To migrate, open the panel and click the **Migrate** button in the side pane.
 {{% /admonition %}}
 
 ## Tooltip options

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -16,10 +16,10 @@ title: Traces
 weight: 100
 ---
 
-# Traces panel
+# Traces
 
-Traces let you follow a request as it traverses the services in your infrastructure.
-The Traces panel visualizes traces data into a diagram that allows you to easily interpret it.
+Traces visualizations let you follow a request as it traverses the services in your infrastructure.
+The traces visualization displays traces data in a diagram that allows you to easily interpret it.
 
 For more information about traces and how to use them, refer to the following documentation:
 
@@ -43,15 +43,15 @@ To use this procedure, you need:
 - A Grafana instance
 - A Tempo data source connected to your Grafana instance (refer to [documentation]({{< relref "../../../datasources/tempo" >}}))
 
-### Add the Traces panel query
+### Add the traces visualization query {#add-the-traces-panel-query}
 
-To view and analyze traces data in a dashboard, you need to add the tracing panel to your dashboard and define a query using the panel editor.
-The query determines the data that is displayed in the panel.
+To view and analyze traces data in a dashboard, you need to add the traces visualization to your dashboard and define a query using the panel editor.
+The query determines the data that is displayed in the visualization.
 For more information on the panel editor, refer to the [Panel editor documentation]({{< relref "../../panel-editor-overview" >}}).
 
 This procedure uses dashboard variables and templates to allow you to enter trace IDs which can then be visualized. You'll use a variable called `traceId` and add it as a template query.
 
-1. From your Grafana stack, create a new dashboard or go to an existing dashboard where you'd like to add tracing panels.
+1. From your Grafana stack, create a new dashboard or go to an existing dashboard where you'd like to add traces visualizations.
 1. Select **Add visualization** from a new dashboard or select **Add Panel** on an existing dashboard.
 1. Search for and select the appropriate tracing data source.
 1. In the top-right of the panel editor, select the **Visualizations** tab, search for, and select **Traces**.
@@ -68,11 +68,11 @@ This procedure uses dashboard variables and templates to allow you to enter trac
 
 1. Verify that the panel works by using a valid trace ID for the data source used for the trace panel and editing the ID in the dashboard variable.
 
-   {{< figure src="/static/img/docs/panels/traces/screenshot-traces-traceid-panel.png" caption="Results of query in Trace panel" >}}
+   {{< figure src="/static/img/docs/panels/traces/screenshot-traces-traceid-panel.png" caption="Results of query in trace panel" >}}
 
 ## Add TraceQL with table visualizations
 
-While you can add a trace panel visualization to a dashboard, having to manually add trace IDs as a dashboard variable is cumbersome.
+While you can add a trace visualization to a dashboard, having to manually add trace IDs as a dashboard variable is cumbersome.
 It’s more useful to instead be able to use TraceQL queries to search for specific types of traces and then select appropriate traces from matching results.
 
 1. In the same dashboard where you added the trace visualization, select **Add panel** to add a new visualization panel.
@@ -90,7 +90,7 @@ When results are returned from a query, the results are rendered in the panel’
 
 ### Use a variable to add other links to traces
 
-The results in the Traces panel include links to the **Explore** page that renders the trace. You can add other links to traces in the table that fill in the `traceId` dashboard variable when selected, so that the trace is visualized in the same dashboard.
+The results in the traces visualization include links to the **Explore** page that renders the trace. You can add other links to traces in the table that fill in the `traceId` dashboard variable when selected, so that the trace is visualized in the same dashboard.
 
 To create a set of data links in the panel, use the following steps:
 
@@ -109,7 +109,7 @@ To create a set of data links in the panel, use the following steps:
 1. Select **Apply** from the panel editor to apply the panel to the dashboard.
 1. Save the dashboard.
 
-You should now see a list of matching traces in the Table visualization. While selecting the **TraceID** or **SpanID** fields will give you the option to either open the **Explore** page to visualize the trace or following the data link, selecting any other field (such as **Start time**, **Name** or **Duration**) automatically follows the data link, filling in the `traceId` dashboard variable, and then shows the relevant trace in the trace panel.
+You should now see a list of matching traces in the table visualization. While selecting the **TraceID** or **SpanID** fields will give you the option to either open the **Explore** page to visualize the trace or following the data link, selecting any other field (such as **Start time**, **Name** or **Duration**) automatically follows the data link, filling in the `traceId` dashboard variable, and then shows the relevant trace in the trace panel.
 
 {{< figure src="/static/img/docs/panels/traces/screenshot-traces-trace-link.png" caption="Selecting the trace link" >}}
 


### PR DESCRIPTION
Backport 2192a34fc43d21b8b53f9995605303265fbdcc64 from #74770

---

Updating visualization docs with following changes:

- Make visualization names common nouns rather than proper nouns (lower case, add an article)
- Replace adjective form of visualization with noun form
- Replace the word "panel" with "visualization" where appropriate
- Fix titles to match with name of visualization in the UI

This is one of two PRs doing this work. This PR covers the visualizations for which the new naming convention isn't a question. A second PR will address trickier visualization names and references on the Visualizations index page.

**Note for reviewers**: I only need you to read the first sentence of each file and ensure that the new way we refer to the visualization doesn't sound confusing or just weird. If you want to do a closer review, feel free, but I'm just trying to ensure we don't make anything less clear.
