### PR TITLE
Alerting: improve insights UX 

### DIFF
--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -27,12 +27,12 @@ export function getHomeApp(insightsEnabled: boolean) {
           hideFromBreadcrumbs: true,
           tabs: [
             new SceneAppPage({
-              title: 'Grafana',
+              title: 'Insights',
               url: '/alerting/home/insights',
               getScene: getGrafanaScenes,
             }),
             new SceneAppPage({
-              title: 'Overview',
+              title: 'Get started',
               url: '/alerting/home/overview',
               getScene: getOverviewScene,
             }),

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -8,7 +8,7 @@ import { PluginPageContext, PluginPageContextType } from 'app/features/plugins/c
 import { isLocalDevEnv, isOpenSourceEdition } from '../utils/misc';
 
 import { getOverviewScene, WelcomeHeader } from './GettingStarted';
-import { getGrafanaScenes } from './Insights';
+import { getInsightsScenes } from './Insights';
 
 let homeApp: SceneApp | undefined;
 
@@ -29,7 +29,7 @@ export function getHomeApp(insightsEnabled: boolean) {
             new SceneAppPage({
               title: 'Insights',
               url: '/alerting/home/insights',
-              getScene: getGrafanaScenes,
+              getScene: getInsightsScenes,
             }),
             new SceneAppPage({
               title: 'Get started',

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -36,7 +36,7 @@ import { getFiringCloudAlertsScene } from '../insights/mimir/rules/Firing';
 import { getInstancesByStateScene } from '../insights/mimir/rules/InstancesByState';
 import { getInstancesPercentageByStateScene } from '../insights/mimir/rules/InstancesPercentageByState';
 import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIterationsScene';
-import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
+import { getMostFiredRulesScene } from '../insights/mimir/rules/MostFiredRules';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
 
 const ashDs = {
@@ -149,10 +149,10 @@ function getGrafanaAlertmanagerScenes() {
           }),
         }),
         new SceneFlexLayout({
-          children: [getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications')],
-        }),
-        new SceneFlexLayout({
-          children: [getGrafanaAlertmanagerSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences')],
+          children: [
+            getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
+            getGrafanaAlertmanagerSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences'),
+          ],
         }),
       ],
     }),
@@ -206,7 +206,7 @@ function getMimirManagedRulesScenes() {
         }),
         new SceneFlexLayout({
           children: [
-            getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
+            getMostFiredRulesScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing rules this week'),
             getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Firing instances'),
             getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending instances'),
           ],

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -37,6 +37,7 @@ import { getInstancesPercentageByStateScene } from '../insights/mimir/rules/Inst
 import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIterationsScene';
 import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
+import { getRuleGroupEvaluationDurationIntervalRatioScene } from '../insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene';
 
 const ashDs = {
   type: 'loki',
@@ -218,6 +219,11 @@ function getMimirManagedRulesPerGroupScenes() {
           children: [
             getRuleGroupEvaluationDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule group evaluation duration'),
             getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per group'),
+            getRuleGroupEvaluationDurationIntervalRatioScene(
+              THIS_WEEK_TIME_RANGE,
+              cloudUsageDs,
+              'Evaluation duration / interval ratio'
+            ),
           ],
         }),
       ],

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,9 +1,12 @@
+import React from 'react';
+
 import {
   EmbeddedScene,
   NestedScene,
   QueryVariable,
   SceneFlexItem,
   SceneFlexLayout,
+  SceneReactObject,
   SceneTimeRange,
   SceneVariableSet,
   VariableValueSelectors,
@@ -57,52 +60,75 @@ export const PANEL_STYLES = { minHeight: 300 };
 const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
 const LAST_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-2w', to: 'now-1w' });
 
+export function SectionSubheader({ children }: React.PropsWithChildren) {
+  return <div>{children}</div>;
+}
+
 export function getGrafanaScenes() {
   return new EmbeddedScene({
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: SectionSubheader,
+            props: { children: <div>Grafana</div> },
+          }),
+        }),
         new SceneFlexLayout({
+          direction: 'column',
           children: [
-            getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
-            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing instances'),
-            getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused instances'),
+            new SceneFlexLayout({
+              children: [
+                getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
+                getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing instances'),
+                getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused instances'),
+              ],
+            }),
+            new SceneFlexLayout({
+              children: [
+                getGrafanaInstancesByStateScene(
+                  THIS_WEEK_TIME_RANGE,
+                  cloudUsageDs,
+                  'Count of alert instances by state'
+                ),
+                getGrafanaInstancesPercentageByStateScene(
+                  THIS_WEEK_TIME_RANGE,
+                  cloudUsageDs,
+                  '% of Alert Instances by State'
+                ),
+              ],
+            }),
+            new SceneFlexLayout({
+              children: [
+                getGrafanaEvalSuccessVsFailuresScene(
+                  THIS_WEEK_TIME_RANGE,
+                  cloudUsageDs,
+                  'Evaluation success vs failures'
+                ),
+                getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations missed'),
+              ],
+            }),
+            new SceneFlexLayout({
+              children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation duration')],
+            }),
+            new SceneFlexItem({
+              ySizing: 'content',
+              body: getGrafanaAlertmanagerScenes(),
+            }),
+            new SceneFlexItem({
+              ySizing: 'content',
+              body: getCloudScenes(),
+            }),
+            new SceneFlexItem({
+              ySizing: 'content',
+              body: getMimirManagedRulesScenes(),
+            }),
+            new SceneFlexItem({
+              ySizing: 'content',
+              body: getMimirManagedRulesPerGroupScenes(),
+            }),
           ],
-        }),
-        new SceneFlexLayout({
-          children: [
-            getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Count of alert instances by state'),
-            getGrafanaInstancesPercentageByStateScene(
-              THIS_WEEK_TIME_RANGE,
-              cloudUsageDs,
-              '% of Alert Instances by State'
-            ),
-          ],
-        }),
-        new SceneFlexLayout({
-          children: [
-            getGrafanaEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation success vs failures'),
-            getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations missed'),
-          ],
-        }),
-        new SceneFlexLayout({
-          children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation duration')],
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: getGrafanaAlertmanagerScenes(),
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: getCloudScenes(),
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: getMimirManagedRulesScenes(),
-        }),
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: getMimirManagedRulesPerGroupScenes(),
         }),
       ],
     }),
@@ -117,6 +143,12 @@ function getGrafanaAlertmanagerScenes() {
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: SectionSubheader,
+            props: { children: <div>Grafana Alertmanager</div> },
+          }),
+        }),
         new SceneFlexLayout({
           children: [
             getGrafanaAlertmanagerInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state'),
@@ -139,6 +171,12 @@ function getCloudScenes() {
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: SectionSubheader,
+            props: { children: <div>Mimir Alertmanager</div> },
+          }),
+        }),
         new SceneFlexLayout({
           children: [
             getAlertsByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state'),
@@ -164,6 +202,12 @@ function getMimirManagedRulesScenes() {
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: SectionSubheader,
+            props: { children: <div>Mimir-managed rules</div> },
+          }),
+        }),
         new SceneFlexLayout({
           children: [
             getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
@@ -207,6 +251,12 @@ function getMimirManagedRulesPerGroupScenes() {
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: SectionSubheader,
+            props: { children: <div>Mimir-managed Rules - Per Rule Group</div> },
+          }),
+        }),
         new SceneFlexLayout({
           children: [
             getRuleGroupEvaluationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule group evaluation'),

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {
   EmbeddedScene,
@@ -26,6 +25,7 @@ import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';
 import { getInvalidConfigScene } from '../insights/mimir/InvalidConfig';
 import { getNotificationsScene } from '../insights/mimir/Notifications';
 import { getSilencesScene } from '../insights/mimir/Silences';
+import { getRuleGroupEvaluationDurationIntervalRatioScene } from '../insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene';
 import { getRuleGroupEvaluationDurationScene } from '../insights/mimir/perGroup/RuleGroupEvaluationDurationScene';
 import { getRuleGroupEvaluationsScene } from '../insights/mimir/perGroup/RuleGroupEvaluationsScene';
 import { getRuleGroupIntervalScene } from '../insights/mimir/perGroup/RuleGroupIntervalScene';
@@ -37,7 +37,6 @@ import { getInstancesPercentageByStateScene } from '../insights/mimir/rules/Inst
 import { getMissedIterationsScene } from '../insights/mimir/rules/MissedIterationsScene';
 import { getMostFiredInstancesScene as getMostFiredCloudInstances } from '../insights/mimir/rules/MostFiredInstances';
 import { getPendingCloudAlertsScene } from '../insights/mimir/rules/Pending';
-import { getRuleGroupEvaluationDurationIntervalRatioScene } from '../insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene';
 
 const ashDs = {
   type: 'loki',

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -80,12 +80,12 @@ export function getGrafanaScenes() {
         }),
         new SceneFlexLayout({
           children: [
-            getGrafanaEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Success vs Failures'),
-            getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations Missed'),
+            getGrafanaEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation success vs failures'),
+            getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations missed'),
           ],
         }),
         new SceneFlexLayout({
-          children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Duration')],
+          children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation duration')],
         }),
         new SceneFlexItem({
           ySizing: 'content',
@@ -118,7 +118,7 @@ function getGrafanaAlertmanagerScenes() {
       children: [
         new SceneFlexLayout({
           children: [
-            getGrafanaAlertmanagerInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by State'),
+            getGrafanaAlertmanagerInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state'),
             getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
           ],
         }),
@@ -140,7 +140,7 @@ function getCloudScenes() {
       children: [
         new SceneFlexLayout({
           children: [
-            getAlertsByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by State'),
+            getAlertsByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state'),
             getNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
           ],
         }),
@@ -182,8 +182,8 @@ function getMimirManagedRulesScenes() {
         }),
         new SceneFlexLayout({
           children: [
-            getEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation Success vs Failures'),
-            getMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations Missed'),
+            getEvalSuccessVsFailuresScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation success vs failures'),
+            getMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations missed'),
           ],
         }),
       ],
@@ -208,14 +208,14 @@ function getMimirManagedRulesPerGroupScenes() {
       children: [
         new SceneFlexLayout({
           children: [
-            getRuleGroupEvaluationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation'),
-            getRuleGroupIntervalScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Interval'),
+            getRuleGroupEvaluationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule group evaluation'),
+            getRuleGroupIntervalScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule group interval'),
           ],
         }),
         new SceneFlexLayout({
           children: [
-            getRuleGroupEvaluationDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule Group Evaluation Duration'),
-            getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per Group'),
+            getRuleGroupEvaluationDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rule group evaluation duration'),
+            getRulesPerGroupScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Rules per group'),
           ],
         }),
       ],

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,4 +1,3 @@
-
 import {
   EmbeddedScene,
   NestedScene,

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   EmbeddedScene,
   NestedScene,
@@ -64,7 +66,7 @@ export function getGrafanaScenes() {
         new SceneFlexLayout({
           children: [
             getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
-            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing'),
+            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Active'),
             getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused'),
           ],
         }),
@@ -166,7 +168,7 @@ function getMimirManagedRulesScenes() {
         new SceneFlexLayout({
           children: [
             getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
-            getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Firing'),
+            getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Active'),
             getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending'),
           ],
         }),
@@ -176,7 +178,7 @@ function getMimirManagedRulesScenes() {
             getInstancesPercentageByStateScene(
               THIS_WEEK_TIME_RANGE,
               grafanaCloudPromDs,
-              '% of Alert Instances by State'
+              '% of alert instances by State'
             ),
           ],
         }),

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -66,8 +66,8 @@ export function getGrafanaScenes() {
         new SceneFlexLayout({
           children: [
             getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
-            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Active'),
-            getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused'),
+            getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing instances'),
+            getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused instances'),
           ],
         }),
         new SceneFlexLayout({
@@ -168,8 +168,8 @@ function getMimirManagedRulesScenes() {
         new SceneFlexLayout({
           children: [
             getMostFiredCloudInstances(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Top 10 firing instance this week'),
-            getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Active'),
-            getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending'),
+            getFiringCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Firing instances'),
+            getPendingCloudAlertsScene(THIS_WEEK_TIME_RANGE, grafanaCloudPromDs, 'Pending instances'),
           ],
         }),
         new SceneFlexLayout({

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -12,15 +12,14 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 
-import { getGrafanaEvalDurationScene } from '../insights/grafana/EvalDurationScene';
+import { getGrafanaInstancesByStateScene } from '../insights/grafana/AlertsByStateScene';
 import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
-import { getGrafanaInstancesByStateScene } from '../insights/grafana/InstancesByState';
-import { getGrafanaInstancesPercentageByStateScene } from '../insights/grafana/InstancesPercentageByState';
 import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
 import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
-import { getGrafanaAlertmanagerInstancesByStateScene } from '../insights/grafana/alertmanager/AlertsByStateScene';
+import { getGrafanaRulesByEvaluationScene } from '../insights/grafana/RulesByEvaluation';
+import { getGrafanaRulesByEvaluationPercentageScene } from '../insights/grafana/RulesByEvaluationPercentage';
 import { getGrafanaAlertmanagerNotificationsScene } from '../insights/grafana/alertmanager/NotificationsScene';
 import { getGrafanaAlertmanagerSilencesScene } from '../insights/grafana/alertmanager/SilencesByStateScene';
 import { getAlertsByStateScene } from '../insights/mimir/AlertsByState';
@@ -81,21 +80,17 @@ export function getGrafanaScenes() {
             new SceneFlexLayout({
               children: [
                 getMostFiredInstancesScene(THIS_WEEK_TIME_RANGE, ashDs, 'Top 10 firing instances this week'),
-                getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing instances'),
-                getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused instances'),
+                getFiringGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Firing rules'),
+                getPausedGrafanaAlertsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Paused rules'),
               ],
             }),
             new SceneFlexLayout({
               children: [
-                getGrafanaInstancesByStateScene(
+                getGrafanaRulesByEvaluationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alert rule evaluation'),
+                getGrafanaRulesByEvaluationPercentageScene(
                   THIS_WEEK_TIME_RANGE,
                   cloudUsageDs,
-                  'Count of alert instances by state'
-                ),
-                getGrafanaInstancesPercentageByStateScene(
-                  THIS_WEEK_TIME_RANGE,
-                  cloudUsageDs,
-                  '% of Alert Instances by State'
+                  '% of alert rule evaluation'
                 ),
               ],
             }),
@@ -106,11 +101,15 @@ export function getGrafanaScenes() {
                   cloudUsageDs,
                   'Evaluation success vs failures'
                 ),
-                getGrafanaMissedIterationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Iterations missed'),
+                getGrafanaMissedIterationsScene(
+                  THIS_WEEK_TIME_RANGE,
+                  cloudUsageDs,
+                  'Iterations missed per evaluation group'
+                ),
               ],
             }),
             new SceneFlexLayout({
-              children: [getGrafanaEvalDurationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Evaluation duration')],
+              children: [getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state')],
             }),
             new SceneFlexItem({
               ySizing: 'content',
@@ -150,10 +149,7 @@ function getGrafanaAlertmanagerScenes() {
           }),
         }),
         new SceneFlexLayout({
-          children: [
-            getGrafanaAlertmanagerInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state'),
-            getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications'),
-          ],
+          children: [getGrafanaAlertmanagerNotificationsScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Notifications')],
         }),
         new SceneFlexLayout({
           children: [getGrafanaAlertmanagerSilencesScene(LAST_WEEK_TIME_RANGE, cloudUsageDs, 'Silences')],

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -63,8 +63,41 @@ export function SectionSubheader({ children }: React.PropsWithChildren) {
   return <div>{children}</div>;
 }
 
-export function getGrafanaScenes() {
+export function getInsightsScenes() {
   return new EmbeddedScene({
+    body: new SceneFlexLayout({
+      direction: 'column',
+      children: [
+        new SceneFlexItem({
+          ySizing: 'content',
+          body: getGrafanaManagedScenes(),
+        }),
+        new SceneFlexItem({
+          ySizing: 'content',
+          body: getGrafanaAlertmanagerScenes(),
+        }),
+        new SceneFlexItem({
+          ySizing: 'content',
+          body: getCloudScenes(),
+        }),
+        new SceneFlexItem({
+          ySizing: 'content',
+          body: getMimirManagedRulesScenes(),
+        }),
+        new SceneFlexItem({
+          ySizing: 'content',
+          body: getMimirManagedRulesPerGroupScenes(),
+        }),
+      ],
+    }),
+  });
+}
+
+function getGrafanaManagedScenes() {
+  return new NestedScene({
+    title: 'Grafana-managed rules',
+    canCollapse: true,
+    isCollapsed: false,
     body: new SceneFlexLayout({
       direction: 'column',
       children: [
@@ -110,22 +143,6 @@ export function getGrafanaScenes() {
             }),
             new SceneFlexLayout({
               children: [getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state')],
-            }),
-            new SceneFlexItem({
-              ySizing: 'content',
-              body: getGrafanaAlertmanagerScenes(),
-            }),
-            new SceneFlexItem({
-              ySizing: 'content',
-              body: getCloudScenes(),
-            }),
-            new SceneFlexItem({
-              ySizing: 'content',
-              body: getMimirManagedRulesScenes(),
-            }),
-            new SceneFlexItem({
-              ySizing: 'content',
-              body: getMimirManagedRulesPerGroupScenes(),
             }),
           ],
         }),

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -15,6 +15,7 @@ import {
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/AlertsByStateScene';
 import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
+import { getInstanceStatByStatusScene } from '../insights/grafana/InstanceStatusScene';
 import { getGrafanaMissedIterationsScene } from '../insights/grafana/MissedIterationsScene';
 import { getMostFiredInstancesScene } from '../insights/grafana/MostFiredInstancesTable';
 import { getPausedGrafanaAlertsScene } from '../insights/grafana/Paused';
@@ -104,7 +105,7 @@ function getGrafanaManagedScenes() {
         new SceneFlexItem({
           body: new SceneReactObject({
             component: SectionSubheader,
-            props: { children: <div>Grafana</div> },
+            props: { children: <div>Grafana-managed rules</div> },
           }),
         }),
         new SceneFlexLayout({
@@ -143,6 +144,14 @@ function getGrafanaManagedScenes() {
             }),
             new SceneFlexLayout({
               children: [getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state')],
+            }),
+            new SceneFlexLayout({
+              children: [
+                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerting instances', 'alerting'),
+                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Pending instances', 'pending'),
+                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Nodata instances', 'nodata'),
+                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Error instances', 'error'),
+              ],
             }),
           ],
         }),

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -120,6 +120,40 @@ function getGrafanaManagedScenes() {
             }),
             new SceneFlexLayout({
               children: [
+                getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alert instances by state'),
+                new SceneFlexLayout({
+                  height: '400px',
+                  direction: 'column',
+                  children: [
+                    new SceneFlexLayout({
+                      height: '400px',
+                      children: [
+                        getInstanceStatByStatusScene(
+                          THIS_WEEK_TIME_RANGE,
+                          cloudUsageDs,
+                          'Alerting instances',
+                          'alerting'
+                        ),
+                        getInstanceStatByStatusScene(
+                          THIS_WEEK_TIME_RANGE,
+                          cloudUsageDs,
+                          'Pending instances',
+                          'pending'
+                        ),
+                      ],
+                    }),
+                    new SceneFlexLayout({
+                      children: [
+                        getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'No data instances', 'nodata'),
+                        getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Error instances', 'error'),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+            new SceneFlexLayout({
+              children: [
                 getGrafanaRulesByEvaluationScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alert rule evaluation'),
                 getGrafanaRulesByEvaluationPercentageScene(
                   THIS_WEEK_TIME_RANGE,
@@ -140,17 +174,6 @@ function getGrafanaManagedScenes() {
                   cloudUsageDs,
                   'Iterations missed per evaluation group'
                 ),
-              ],
-            }),
-            new SceneFlexLayout({
-              children: [getGrafanaInstancesByStateScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerts by state')],
-            }),
-            new SceneFlexLayout({
-              children: [
-                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Alerting instances', 'alerting'),
-                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Pending instances', 'pending'),
-                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Nodata instances', 'nodata'),
-                getInstanceStatByStatusScene(THIS_WEEK_TIME_RANGE, cloudUsageDs, 'Error instances', 'error'),
               ],
             }),
           ],

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -55,6 +55,27 @@ const grafanaCloudPromDs = {
   uid: 'grafanacloud-prom',
 };
 
+const SERIES_COLORS = {
+  alerting: 'red',
+  firing: 'red',
+  active: 'red',
+  missed: 'red',
+  failed: 'red',
+  pending: 'yellow',
+  nodata: 'blue',
+  'active evaluation': 'blue',
+  normal: 'green',
+  success: 'green',
+  error: 'orange',
+};
+
+export function overrideToFixedColor(key: keyof typeof SERIES_COLORS) {
+  return {
+    mode: 'fixed',
+    fixedColor: SERIES_COLORS[key],
+  };
+}
+
 export const PANEL_STYLES = { minHeight: 300 };
 
 const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -1,9 +1,9 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
 
-export function getGrafanaAlertmanagerInstancesByStateScene(
+export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
   panelTitle: string

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -23,6 +23,7 @@ export function getGrafanaInstancesByStateScene(
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
+    height: '400px',
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
       .setDescription(panelTitle)

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
@@ -33,30 +33,15 @@ export function getGrafanaInstancesByStateScene(
       .setOverrides((b) =>
         b
           .matchFieldsWithName('alerting')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('alerting'))
           .matchFieldsWithName('normal')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('normal'))
           .matchFieldsWithName('pending')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'yellow',
-          })
+          .overrideColor(overrideToFixedColor('pending'))
           .matchFieldsWithName('error')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'orange',
-          })
+          .overrideColor(overrideToFixedColor('error'))
           .matchFieldsWithName('nodata')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'blue',
-          })
+          .overrideColor(overrideToFixedColor('nodata'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -29,7 +29,21 @@ export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasourc
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOverrides((b) =>
+        b
+          .matchFieldsWithName('success')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('failed')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -27,6 +27,7 @@ export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasourc
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -34,15 +34,9 @@ export function getGrafanaEvalDurationScene(timeRange: SceneTimeRange, datasourc
       .setOverrides((b) =>
         b
           .matchFieldsWithName('success')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('success'))
           .matchFieldsWithName('failed')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('failed'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -33,7 +33,21 @@ export function getGrafanaEvalSuccessVsFailuresScene(
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOverrides((b) =>
+        b
+          .matchFieldsWithName('success')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('failed')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -31,6 +31,7 @@ export function getGrafanaEvalSuccessVsFailuresScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -38,15 +38,9 @@ export function getGrafanaEvalSuccessVsFailuresScene(
       .setOverrides((b) =>
         b
           .matchFieldsWithName('success')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('success'))
           .matchFieldsWithName('failed')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('failed'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -21,6 +21,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
     ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setThresholds({
         mode: ThresholdsMode.Absolute,

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -36,6 +36,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
           },
         ],
       })
+      .setNoValue('0')
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsPercentage.tsx
@@ -61,6 +61,11 @@ export function getFiringAlertsScene(timeRange: SceneTimeRange, datasource: Data
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.stat().setTitle(panelTitle).setData(transformation).setUnit('percent').build(),
+    body: PanelBuilders.stat()
+      .setTitle(panelTitle)
+      .setDescription(panelTitle)
+      .setData(transformation)
+      .setUnit('percent')
+      .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/FiringAlertsRate.tsx
@@ -21,6 +21,7 @@ export function getFiringAlertsRateScene(timeRange: SceneTimeRange, datasource: 
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setCustomFieldConfig('fillOpacity', 10)

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -1,8 +1,6 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
-
 const STATUS_COLORS = {
   alerting: 'red',
   pending: 'yellow',
@@ -41,6 +39,7 @@ export function getInstanceStatByStatusScene(
           fixedColor: STATUS_COLORS[status],
         })
       )
+      .setNoValue('0')
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -1,0 +1,46 @@
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema';
+
+import { PANEL_STYLES } from '../../home/Insights';
+
+const STATUS_COLORS = {
+  alerting: 'red',
+  pending: 'yellow',
+  nodata: 'blue',
+  normal: 'green',
+  error: 'orange',
+};
+
+export function getInstanceStatByStatusScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string,
+  status: 'alerting' | 'pending' | 'nodata' | 'normal' | 'error'
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        instant: true,
+        expr: `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}"})`,
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  return new SceneFlexItem({
+    ...PANEL_STYLES,
+    body: PanelBuilders.stat()
+      .setTitle(panelTitle)
+      .setDescription(panelTitle)
+      .setData(query)
+      .setOverrides((b) =>
+        b.matchFieldsWithName(status).overrideColor({
+          mode: 'fixed',
+          fixedColor: STATUS_COLORS[status],
+        })
+      )
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -30,7 +30,7 @@ export function getInstanceStatByStatusScene(
   });
 
   return new SceneFlexItem({
-    ...PANEL_STYLES,
+    height: '100%',
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setDescription(panelTitle)

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -1,13 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-const STATUS_COLORS = {
-  alerting: 'red',
-  pending: 'yellow',
-  nodata: 'blue',
-  normal: 'green',
-  error: 'orange',
-};
+import { overrideToFixedColor } from '../../home/Insights';
 
 export function getInstanceStatByStatusScene(
   timeRange: SceneTimeRange,
@@ -33,12 +27,7 @@ export function getInstanceStatByStatusScene(
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
-      .setOverrides((b) =>
-        b.matchFieldsWithName(status).overrideColor({
-          mode: 'fixed',
-          fixedColor: STATUS_COLORS[status],
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName(status).overrideColor(overrideToFixedColor(status)))
       .setNoValue('0')
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -16,6 +16,7 @@ export function getInstanceStatByStatusScene(
         refId: 'A',
         instant: true,
         expr: `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}"})`,
+        legendFormat: '{{state}}',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -29,6 +29,12 @@ export function getGrafanaInstancesByStateScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('active').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -27,6 +27,7 @@ export function getGrafanaInstancesByStateScene(
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesByState.tsx
@@ -25,6 +25,7 @@ export function getGrafanaInstancesByStateScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -26,6 +26,7 @@ export function getGrafanaInstancesPercentageByStateScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setCustomFieldConfig('fillOpacity', 45)

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -45,6 +45,12 @@ export function getGrafanaInstancesPercentageByStateScene(
           },
         ],
       })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('active').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstancesPercentageByState.tsx
@@ -1,6 +1,6 @@
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -31,6 +31,7 @@ export function getGrafanaInstancesPercentageByStateScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setCustomFieldConfig('fillOpacity', 45)
       .setUnit('percentunit')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setMax(1)
       .setThresholds({
         mode: ThresholdsMode.Absolute,

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -15,7 +15,7 @@ export function getGrafanaMissedIterationsScene(
         refId: 'A',
         expr: 'sum by (rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m)',
         range: true,
-        legendFormat: 'missed',
+        legendFormat: '{{rule_group}}',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -25,6 +25,7 @@ export function getGrafanaMissedIterationsScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -27,6 +27,7 @@ export function getGrafanaMissedIterationsScene(
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/css';
 import React from 'react';
 import { Observable, map } from 'rxjs';
 
-import { DataFrame, Field } from '@grafana/data';
+import { DataFrame, Field, GrafanaTheme2 } from '@grafana/data';
 import {
   CustomTransformOperator,
   PanelBuilders,
@@ -11,7 +12,7 @@ import {
   SceneTimeRange,
 } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
-import { Icon, Link } from '@grafana/ui';
+import { Link, useStyles2 } from '@grafana/ui';
 
 import { PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
@@ -36,11 +37,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
       values: field.values.map((value, index) => {
         const ruleUIDs = frame.fields.find((field) => field.name === 'ruleUID');
         const ruleUID = ruleUIDs?.values[index];
-        return (
-          <Link key={value} target="_blank" href={createUrl(`/alerting/grafana/${ruleUID}/view`)}>
-            {value} <Icon name="external-link-alt" />
-          </Link>
-        );
+        return <RuleLink key={value} value={value} ruleUID={ruleUID} />;
       }),
     };
   };
@@ -109,4 +106,24 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
       .setNoValue('No new alerts fired last week')
       .build(),
   });
+}
+
+export function RuleLink({ value, ruleUID }: { value: string; ruleUID: string }) {
+  const getStyles = (theme: GrafanaTheme2) => ({
+    link: css`
+      & > a {
+        color: ${theme.colors.text.link};
+      }
+    `,
+  });
+
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.link}>
+      <Link target="_blank" href={createUrl(`/alerting/grafana/${ruleUID}/view`)}>
+        {value}
+      </Link>
+    </div>
+  );
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -102,6 +102,11 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(transformation).build(),
+    body: PanelBuilders.table()
+      .setTitle(panelTitle)
+      .setDescription(panelTitle)
+      .setData(transformation)
+      .setNoValue('No new alerts fired last week')
+      .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -89,7 +89,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
             'Value #A': 1,
           },
           renameByName: {
-            labels_alertname: 'Alert Name',
+            labels_alertname: 'Alert rule name',
             'Value #A': 'Fires this week',
           },
         },

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -102,6 +102,6 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
+    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -110,11 +110,11 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
 
 export function RuleLink({ value, ruleUID }: { value: string; ruleUID: string }) {
   const getStyles = (theme: GrafanaTheme2) => ({
-    link: css`
-      & > a {
-        color: ${theme.colors.text.link};
-      }
-    `,
+    link: css({
+      '& > a': {
+        color: theme.colors.text.link,
+      },
+    }),
   });
 
   const styles = useStyles2(getStyles);

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredRulesTable.tsx
@@ -54,6 +54,6 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
+    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
@@ -52,6 +52,6 @@ export function getMostFiredLabelsScene(timeRange: SceneTimeRange, datasource: D
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setData(query).build(),
+    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(query).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -21,6 +21,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
     ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setThresholds({
         mode: ThresholdsMode.Absolute,

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -36,6 +36,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
           },
         ],
       })
+      .setNoValue('0')
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -3,7 +3,7 @@ import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/sche
 
 import { PANEL_STYLES } from '../../home/Insights';
 
-export function getGrafanaInstancesByStateScene(
+export function getGrafanaRulesByEvaluationScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
   panelTitle: string
@@ -15,7 +15,7 @@ export function getGrafanaInstancesByStateScene(
         refId: 'A',
         expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)',
         range: true,
-        legendFormat: '{{state}}',
+        legendFormat: '{{state}} evaluation',
       },
     ],
     $timeRange: timeRange,
@@ -32,7 +32,7 @@ export function getGrafanaInstancesByStateScene(
       .setOverrides((b) =>
         b.matchFieldsWithName('active').overrideColor({
           mode: 'fixed',
-          fixedColor: 'red',
+          fixedColor: 'blue',
         })
       )
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -30,7 +30,7 @@ export function getGrafanaRulesByEvaluationScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) =>
-        b.matchFieldsWithName('active').overrideColor({
+        b.matchFieldsWithName('active evaluation').overrideColor({
           mode: 'fixed',
           fixedColor: 'blue',
         })

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaRulesByEvaluationScene(
   timeRange: SceneTimeRange,
@@ -30,10 +30,7 @@ export function getGrafanaRulesByEvaluationScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) =>
-        b.matchFieldsWithName('active evaluation').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'blue',
-        })
+        b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -15,7 +15,7 @@ export function getGrafanaRulesByEvaluationPercentageScene(
         refId: 'A',
         expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)',
         range: true,
-        legendFormat: '{{alertstate}} evaluation',
+        legendFormat: '{{state}} evaluation',
       },
     ],
     $timeRange: timeRange,
@@ -33,7 +33,7 @@ export function getGrafanaRulesByEvaluationPercentageScene(
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setMax(1)
       .setOverrides((b) =>
-        b.matchFieldsWithName('active').overrideColor({
+        b.matchFieldsWithName('active evaluation').overrideColor({
           mode: 'fixed',
           fixedColor: 'blue',
         })

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -1,10 +1,9 @@
-import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
-export function getGrafanaInstancesPercentageByStateScene(
+export function getGrafanaRulesByEvaluationPercentageScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
   panelTitle: string
@@ -16,7 +15,7 @@ export function getGrafanaInstancesPercentageByStateScene(
         refId: 'A',
         expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)',
         range: true,
-        legendFormat: '{{alertstate}}',
+        legendFormat: '{{alertstate}} evaluation',
       },
     ],
     $timeRange: timeRange,
@@ -33,23 +32,10 @@ export function getGrafanaInstancesPercentageByStateScene(
       .setUnit('percentunit')
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setMax(1)
-      .setThresholds({
-        mode: ThresholdsMode.Absolute,
-        steps: [
-          {
-            color: 'green',
-            value: 0,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      })
       .setOverrides((b) =>
         b.matchFieldsWithName('active').overrideColor({
           mode: 'fixed',
-          fixedColor: 'red',
+          fixedColor: 'blue',
         })
       )
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaRulesByEvaluationPercentageScene(
   timeRange: SceneTimeRange,
@@ -33,10 +33,7 @@ export function getGrafanaRulesByEvaluationPercentageScene(
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setMax(1)
       .setOverrides((b) =>
-        b.matchFieldsWithName('active evaluation').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'blue',
-        })
+        b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -27,6 +27,7 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -25,6 +25,7 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -30,10 +30,32 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) =>
-        b.matchFieldsWithName('alerting').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
+        b
+          .matchFieldsWithName('alerting')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+          .matchFieldsWithName('normal')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('pending')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'yellow',
+          })
+          .matchFieldsWithName('error')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'orange',
+          })
+          .matchFieldsWithName('nodata')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'blue',
+          })
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByStateScene.tsx
@@ -29,6 +29,12 @@ export function getGrafanaAlertmanagerInstancesByStateScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('alerting').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -35,10 +35,32 @@ export function getGrafanaAlertmanagerNotificationsScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOverrides((b) =>
-        b.matchFieldsWithName('failed').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
+        b
+          .matchFieldsWithName('alerting')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+          .matchFieldsWithName('normal')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('pending')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'yellow',
+          })
+          .matchFieldsWithName('error')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'orange',
+          })
+          .matchFieldsWithName('nodata')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'blue',
+          })
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -31,6 +31,7 @@ export function getGrafanaAlertmanagerNotificationsScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -34,6 +34,12 @@ export function getGrafanaAlertmanagerNotificationsScene(
       .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOverrides((b) =>
+        b.matchFieldsWithName('failed').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -36,16 +36,10 @@ export function getGrafanaAlertmanagerNotificationsScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOverrides((b) =>
         b
-          .matchFieldsWithName('alerting')
-          .overrideColor(overrideToFixedColor('alerting'))
-          .matchFieldsWithName('normal')
-          .overrideColor(overrideToFixedColor('normal'))
-          .matchFieldsWithName('pending')
-          .overrideColor(overrideToFixedColor('pending'))
-          .matchFieldsWithName('error')
-          .overrideColor(overrideToFixedColor('error'))
-          .matchFieldsWithName('nodata')
-          .overrideColor(overrideToFixedColor('nodata'))
+          .matchFieldsWithName('success')
+          .overrideColor(overrideToFixedColor('success'))
+          .matchFieldsWithName('failed')
+          .overrideColor(overrideToFixedColor('failed'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getGrafanaAlertmanagerNotificationsScene(
   timeRange: SceneTimeRange,
@@ -37,30 +37,15 @@ export function getGrafanaAlertmanagerNotificationsScene(
       .setOverrides((b) =>
         b
           .matchFieldsWithName('alerting')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('alerting'))
           .matchFieldsWithName('normal')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('normal'))
           .matchFieldsWithName('pending')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'yellow',
-          })
+          .overrideColor(overrideToFixedColor('pending'))
           .matchFieldsWithName('error')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'orange',
-          })
+          .overrideColor(overrideToFixedColor('error'))
           .matchFieldsWithName('nodata')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'blue',
-          })
+          .overrideColor(overrideToFixedColor('nodata'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -25,6 +25,7 @@ export function getGrafanaAlertmanagerSilencesScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .build(),

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -21,6 +21,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -25,6 +25,12 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('active').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -23,6 +23,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,12 +25,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setOverrides((b) =>
-        b.matchFieldsWithName('active').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName('active').overrideColor(overrideToFixedColor('active')))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -24,6 +24,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('bool_yes_no')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef } from '@grafana/schema';
+import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -24,6 +24,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
       .setDescription(panelTitle)
       .setData(query)
       .setUnit('bool_yes_no')
+      .setOption('graphMode', BigValueGraphMode.None)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -21,6 +21,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('bool_yes_no')

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
+import { DataSourceRef } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -19,13 +19,11 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.timeseries()
+    body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
-      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('bool_yes_no')
-      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -11,13 +11,13 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
         refId: 'A',
         expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
         range: true,
-        legendFormat: '{{cluster}} - success',
+        legendFormat: 'success',
       },
       {
         refId: 'B',
         expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
         range: true,
-        legendFormat: '{{cluster}} - failed',
+        legendFormat: 'failed',
       },
     ],
     $timeRange: timeRange,
@@ -31,6 +31,19 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b
+          .matchFieldsWithName('success')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('failed')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -27,6 +27,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -29,6 +29,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getNotificationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -34,15 +34,9 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
       .setOverrides((b) =>
         b
           .matchFieldsWithName('success')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('success'))
           .matchFieldsWithName('failed')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('failed'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../home/Insights';
 
@@ -23,6 +23,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -21,6 +21,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -1,0 +1,62 @@
+import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
+
+import { PANEL_STYLES } from '../../../home/Insights';
+
+export function getRuleGroupEvaluationDurationIntervalRatioScene(
+  timeRange: SceneTimeRange,
+  datasource: DataSourceRef,
+  panelTitle: string
+) {
+  const query = new SceneQueryRunner({
+    datasource,
+    queries: [
+      {
+        refId: 'A',
+        expr: `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`,
+        range: true,
+        legendFormat: 'duration',
+      },
+      {
+        refId: 'B',
+        expr: `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`,
+        range: true,
+        legendFormat: 'duration',
+      },
+    ],
+    $timeRange: timeRange,
+  });
+
+  const transformation = new SceneDataTransformer({
+    $data: query,
+    transformations: [
+      {
+        id: 'calculateField',
+        options: {
+          mode: 'binary',
+
+          binary: {
+            left: 'duration',
+            reducer: 'sum',
+            operator: '/',
+            right: 'interval',
+          },
+          replaceFields: true,
+        },
+      },
+    ],
+  });
+
+  return new SceneFlexItem({
+    ...PANEL_STYLES,
+    body: PanelBuilders.timeseries()
+      .setTitle(panelTitle)
+      .setDescription(panelTitle)
+      .setData(transformation)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setUnit('s')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOption('legend', { showLegend: false })
+      .build(),
+  });
+}

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -21,7 +21,7 @@ export function getRuleGroupEvaluationDurationIntervalRatioScene(
         refId: 'B',
         expr: `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`,
         range: true,
-        legendFormat: 'duration',
+        legendFormat: 'interval',
       },
     ],
     $timeRange: timeRange,

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -28,6 +28,7 @@ export function getRuleGroupEvaluationDurationScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -30,6 +30,12 @@ export function getRuleGroupEvaluationDurationScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsByQuery('A').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'blue',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -25,6 +25,7 @@ export function getRuleGroupEvaluationDurationScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -30,6 +30,7 @@ export function getRuleGroupEvaluationDurationScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOption('legend', { showLegend: false })
       .setOverrides((b) =>
         b.matchFieldsByQuery('A').overrideColor({
           mode: 'fixed',

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -29,6 +29,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -27,6 +27,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -31,6 +31,19 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b
+          .matchFieldsWithName('success')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'green',
+          })
+          .matchFieldsWithName('failed')
+          .overrideColor({
+            mode: 'fixed',
+            fixedColor: 'red',
+          })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -34,15 +34,9 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
       .setOverrides((b) =>
         b
           .matchFieldsWithName('success')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'green',
-          })
+          .overrideColor(overrideToFixedColor('success'))
           .matchFieldsWithName('failed')
-          .overrideColor({
-            mode: 'fixed',
-            fixedColor: 'red',
-          })
+          .overrideColor(overrideToFixedColor('failed'))
       )
       .build(),
   });

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -24,6 +24,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -21,6 +21,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
+import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -19,13 +19,12 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.timeseries()
+    body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
-      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('s')
-      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOption('graphMode', BigValueGraphMode.None)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -24,7 +24,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
       .setDescription(panelTitle)
       .setData(query)
       .setUnit('s')
-      .setOption('graphMode', BigValueGraphMode.None)
+      .setOption('graphMode', BigValueGraphMode.Area)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -21,6 +21,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('none')

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -26,6 +26,12 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('none')
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsByQuery('A').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'blue',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -24,6 +24,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('none')
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -25,6 +25,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('none')
+      .setOption('legend', { showLegend: false })
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) =>
         b.matchFieldsByQuery('A').overrideColor({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -31,6 +31,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
           fixedColor: 'blue',
         })
       )
+      .setNoValue('0')
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
+import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -19,14 +19,12 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.timeseries()
+    body: PanelBuilders.stat()
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(query)
-      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setUnit('none')
-      .setOption('legend', { showLegend: false })
-      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOption('graphMode', BigValueGraphMode.Area)
       .setOverrides((b) =>
         b.matchFieldsByQuery('A').overrideColor({
           mode: 'fixed',

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -33,6 +33,7 @@ export function getEvalSuccessVsFailuresScene(
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -35,6 +35,12 @@ export function getEvalSuccessVsFailuresScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('failed').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -31,6 +31,7 @@ export function getEvalSuccessVsFailuresScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -35,12 +35,7 @@ export function getEvalSuccessVsFailuresScene(
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setOverrides((b) =>
-        b.matchFieldsWithName('failed').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName('failed').overrideColor(overrideToFixedColor('failed')))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -21,6 +21,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
     ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setThresholds({
         mode: ThresholdsMode.Absolute,

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -36,6 +36,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
           },
         ],
       })
+      .setNoValue('0')
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -23,6 +23,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -21,6 +21,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -25,6 +25,12 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('firing').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,12 +25,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setOverrides((b) =>
-        b.matchFieldsWithName('firing').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -26,6 +26,7 @@ export function getInstancesPercentageByStateScene(
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setCustomFieldConfig('fillOpacity', 45)

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,4 +1,3 @@
-import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -33,19 +33,12 @@ export function getInstancesPercentageByStateScene(
       .setUnit('percentunit')
       .setMax(1)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setThresholds({
-        mode: ThresholdsMode.Absolute,
-        steps: [
-          {
-            color: 'green',
-            value: 0,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('firing').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,6 +1,6 @@
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -31,6 +31,7 @@ export function getInstancesPercentageByStateScene(
       .setCustomFieldConfig('fillOpacity', 45)
       .setUnit('percentunit')
       .setMax(1)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setThresholds({
         mode: ThresholdsMode.Absolute,
         steps: [

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
@@ -32,12 +32,7 @@ export function getInstancesPercentageByStateScene(
       .setUnit('percentunit')
       .setMax(1)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setOverrides((b) =>
-        b.matchFieldsWithName('firing').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -25,6 +25,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOption('legend', { showLegend: false })
       .setOverrides((b) =>
         b.matchFieldsWithName('missed').overrideColor({
           mode: 'fixed',

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,5 +1,5 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
@@ -23,6 +23,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setTitle(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -25,6 +25,12 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setOverrides((b) =>
+        b.matchFieldsWithName('missed').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'red',
+        })
+      )
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -21,6 +21,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -26,12 +26,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOption('legend', { showLegend: false })
-      .setOverrides((b) =>
-        b.matchFieldsWithName('missed').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'red',
-        })
-      )
+      .setOverrides((b) => b.matchFieldsWithName('missed').overrideColor(overrideToFixedColor('missed')))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredInstances.tsx
@@ -40,6 +40,6 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setData(transformation).build(),
+    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(transformation).build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
@@ -9,8 +9,8 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
     queries: [
       {
         refId: 'A',
-        expr: 'topk(10, sum by (alertname) (ALERTS))',
-        range: true,
+        expr: 'topk(10, sum by(alertname) (ALERTS{alertstate="firing"}))',
+        instant: true,
       },
     ],
 
@@ -21,16 +21,14 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
     $data: query,
     transformations: [
       {
-        id: 'timeSeriesTable',
-        options: {},
-      },
-      {
         id: 'organize',
         options: {
-          excludeByName: {},
+          excludeByName: {
+            Time: true,
+          },
           indexByName: {},
           renameByName: {
-            Trend: '',
+            Value: '',
             alertname: 'Alert Rule Name',
           },
         },

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
@@ -11,6 +11,8 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
         refId: 'A',
         expr: 'topk(10, sum by(alertname) (ALERTS{alertstate="firing"}))',
         instant: true,
+        range: false,
+        format: 'table',
       },
     ],
 
@@ -28,7 +30,7 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
           },
           indexByName: {},
           renameByName: {
-            Value: '',
+            Value: 'Fires this week',
             alertname: 'Alert Rule Name',
           },
         },

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
@@ -3,7 +3,7 @@ import { DataSourceRef } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 
-export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
+export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
     datasource,
     queries: [

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -21,6 +21,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
     ...PANEL_STYLES,
     body: PanelBuilders.stat()
       .setTitle(panelTitle)
+      .setDescription(panelTitle)
       .setData(query)
       .setThresholds({
         mode: ThresholdsMode.Absolute,

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -36,6 +36,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
           },
         ],
       })
+      .setNoValue('0')
       .build(),
   });
 }


### PR DESCRIPTION
**What is this feature?**

Address comments from https://docs.google.com/document/d/1bXj-hKiMc0rSAOaAGeSdn25s9Irj2s9WdGZW1OYrVYc/edit

## General

- [x] Panel Tooltip mode: Change from Single to All
- [x] Panel titles: Use sentence capitalization
- [x] Add placeholder for section subtitles
- [x] Add tooltip next to panel titles (Placeholder for tooltip text)

### Top 10 firing instances this week

- [x]  Alert names and link icon should all be in Blue to denote they are links
- [x]  Alert name and link icon seem misaligned
- [x] ~~Table should not be sortable~~ (can't be disabled https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1695451772966089?thread_ts=1695413781.319629&cid=C04FRQ2S0AV)

#### Pending and Firing

- [x] Rename instances panels to "Firing/Paused instances"

### Mimir Alertmanager

#### Alerts by State

- ⚠️ Shouldn’t we rename “Active” to “Firing”? If yes, then we should also do this rename in other parts of the UI. (_Currently being discussed_)
- [x] Make Active be red instead of green
- ⚠️ Find a better way to indicate that Normal alerts are not part of the chart.  (_Currently being discussed_)

#### Invalid configuration

- [x] Explore other options for visualizations - probably Stat?

### Mimir-managed Rules / Mimir-managed Rules - Per Rule Group

#### Pending and Firing

- [x] Rename instances panels to "Firing/Pending instances"

#### Top 10 firing instance this week

- ⚠️ Can we navigate to the alerts? _(Not currently possible with the data returned by the query of that scene)_
- [x] ~~Table should not be sortable~~ (can't be disabled https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1695451772966089?thread_ts=1695413781.319629&cid=C04FRQ2S0AV)
- ⚠️ Why are we showing a trend instead of a number, like we do for GMA? Can we also show the trend for GMA? _Josh will look into that_

#### Count of alert instances by state

- [x] Make firing be red instead of green
- ⚠️ We should find a better way to indicate that Normal alerts are not part of the chart.  (_Currently being discussed_)

#### % of Alert Instances by State

- [x] Make firing be red instead of green
- ⚠️ We should find a better way to indicate that Normal alerts are not part of the chart. (_Currently being discussed_)

#### Evaluation Success vs Failures

- [x] Success is in Green here. Failure is in yellow - can it be red?
- ⚠️ Do we care about successes at all? Don’t we only care about failures? (_Currently being discussed_)

#### Iterations Missed

- [x] This is a single metric. Do we need the legend?
- [x] Can we use either red or a neutral color for the chart? Green sounds like a good thing, but we’re measuring issues.

#### Rule Group Interval

- [x] What does this chart denote? The evaluation interval? This is something that typically is the same all the time. If it is an important piece of information, then let’s use the “Stat” visualization.

#### Rule Group Evaluation Duration

- [x] There’s only one metric, so maybe we don’t need the legend?
- [x] Use a neutral color instead of green?
- [x]  Wouldn’t it be interesting or valuable to add one more chart which presents the ratio between evaluation duration and evaluation interval?

#### Rules per Group

- [x] There’s only one metric, so maybe we don’t need the legend?
- [x] Use a neutral color instead of gree



Closes https://github.com/grafana/alerting-squad/issues/611

![2023-10-02 14 10 39](https://github.com/grafana/grafana/assets/6271380/4a00aec4-ae5f-4d4f-9ff4-bbdbafe07294)


