### PR TITLE
Alert: Restore the v10 Alert/Inline banner design

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { AriaRole, HTMLAttributes, ReactNode } from 'react';
+import tinycolor2 from 'tinycolor2';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -8,8 +9,6 @@ import { useTheme2 } from '../../themes';
 import { IconName } from '../../types/icon';
 import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
-import { Box } from '../Layout/Box/Box';
-import { Text } from '../Text/Text';
 
 export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
 
@@ -56,55 +55,42 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
     return (
       <div
         ref={ref}
-        className={cx(styles.wrapper, className)}
+        className={cx(styles.alert, className)}
         data-testid={selectors.components.Alert.alertV2(severity)}
         role={role}
         aria-label={ariaLabel}
         {...restProps}
       >
-        <Box
-          display="flex"
-          backgroundColor={severity}
-          borderRadius="default"
-          paddingY={1}
-          paddingX={2}
-          borderStyle="solid"
-          borderColor={severity}
-          alignItems="stretch"
-          boxShadow={elevated ? 'z3' : undefined}
-        >
-          <Box paddingTop={1} paddingRight={2}>
-            <div className={styles.icon}>
-              <Icon size="xl" name={getIconFromSeverity(severity)} />
-            </div>
-          </Box>
+        <div className={styles.icon}>
+          <Icon size="xl" name={getIconFromSeverity(severity)} />
+        </div>
 
-          <Box paddingY={1} grow={1}>
-            <Text weight="medium">{title}</Text>
-            {children && <div className={styles.content}>{children}</div>}
-          </Box>
-          {/* If onRemove is specified, giving preference to onRemove */}
-          {onRemove && !buttonContent && (
-            <div className={styles.close}>
-              <Button
-                aria-label="Close alert"
-                icon="times"
-                onClick={onRemove}
-                type="button"
-                fill="text"
-                variant="secondary"
-              />
-            </div>
-          )}
+        <div className={styles.body}>
+          <div className={styles.title}>{title}</div>
+          {children && <div className={styles.content}>{children}</div>}
+        </div>
 
-          {onRemove && buttonContent && (
-            <Box marginLeft={1} display="flex" alignItems="center">
-              <Button aria-label="Close alert" variant="secondary" onClick={onRemove} type="button">
-                {buttonContent}
-              </Button>
-            </Box>
-          )}
-        </Box>
+        {/* If onRemove is specified, giving preference to onRemove */}
+        {onRemove && !buttonContent && (
+          <div className={styles.close}>
+            <Button
+              aria-label="Close alert"
+              icon="times"
+              onClick={onRemove}
+              type="button"
+              fill="text"
+              variant="secondary"
+            />
+          </div>
+        )}
+
+        {onRemove && buttonContent && (
+          <div className={styles.buttonWrapper}>
+            <Button aria-label="Close alert" variant="secondary" onClick={onRemove} type="button">
+              {buttonContent}
+            </Button>
+          </div>
+        )}
       </div>
     );
   }
@@ -134,13 +120,24 @@ const getStyles = (
   topSpacing?: number
 ) => {
   const color = theme.colors[severity];
+  const borderRadius = theme.shape.radius.default;
+  const borderColor = tinycolor2(color.border).setAlpha(0.2).toString();
 
   return {
-    wrapper: css({
+    alert: css({
+      label: 'alert',
       flexGrow: 1,
+      position: 'relative',
+      borderRadius,
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'stretch',
+      background: color.transparent,
+      boxShadow: elevated ? theme.shadows.z3 : 'none',
+      padding: theme.spacing(1, 2),
+      border: `1px solid ${borderColor}`,
       marginBottom: theme.spacing(bottomSpacing ?? 2),
       marginTop: theme.spacing(topSpacing ?? 0),
-      position: 'relative',
 
       '&:before': {
         content: '""',
@@ -154,12 +151,32 @@ const getStyles = (
       },
     }),
     icon: css({
+      padding: theme.spacing(1, 2, 0, 0),
       color: color.text,
+      display: 'flex',
+    }),
+    title: css({
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    body: css({
+      padding: theme.spacing(1, 0),
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      overflowWrap: 'break-word',
+      wordBreak: 'break-word',
     }),
     content: css({
       paddingTop: hasTitle ? theme.spacing(0.5) : 0,
       maxHeight: '50vh',
       overflowY: 'auto',
+    }),
+    buttonWrapper: css({
+      marginLeft: theme.spacing(1),
+      display: 'flex',
+      alignItems: 'center',
+      alignSelf: 'center',
     }),
     close: css({
       position: 'relative',


### PR DESCRIPTION
The alert design / aesthetic look was radically changed in the [recent Box PR](https://github.com/grafana/grafana/pull/73637/), not sure if it was intentional or not (I did comment that Alert could not use Box without the support of its border color). The design of it was very finely tweaked and agreed on by me, Erik & Staton. Not sure why we are changing it now to this much uglier harsher design. 

I know the border is not an official theme border. If we want to use it in other places we can add it, for example via theme.colors and the ThemeRichColor type (something like weakBorder)

But in the meantime, I would like to restore the design. 

Current incorrect (main) design: 
![Screenshot from 2023-09-25 07-10-30](https://github.com/grafana/grafana/assets/10999/fa18bfc5-5248-4388-a05c-657f0b55c5b9)
![Screenshot from 2023-09-25 07-10-36](https://github.com/grafana/grafana/assets/10999/da6c358a-230f-4479-8058-d6f3f687a78f)

The correct new v10 design: 
![Screenshot from 2023-09-25 07-10-46](https://github.com/grafana/grafana/assets/10999/3ec46953-5dc5-4de9-98cd-11b05b4076b9)
![Screenshot from 2023-09-25 07-10-52](https://github.com/grafana/grafana/assets/10999/709a7034-7912-4941-8be2-b7e95817facc)

We do use similar weak-colored (transparent) borders in the Badge component, so maybe some opportunity to unify. 
