### PR TITLE
EventBus: Fix error in ScopedEventBus

### DIFF
--- a/packages/grafana-data/src/events/EventBus.test.ts
+++ b/packages/grafana-data/src/events/EventBus.test.ts
@@ -47,7 +47,7 @@ describe('EventBus', () => {
     expect(events.length).toBe(1);
   });
 
-  describe('EventBusWithSource', () => {
+  describe('ScopedEventBus', () => {
     it('can add sources to the source path', () => {
       const bus = new EventBusSrv();
       const busWithSource = bus.newScopedBus('foo');
@@ -56,15 +56,34 @@ describe('EventBus', () => {
 
     it('adds the source to the event payload', () => {
       const bus = new EventBusSrv();
-      let events: BusEvent[] = [];
+      const events: BusEvent[] = [];
 
       bus.subscribe(DataHoverEvent, (event) => events.push(event));
 
-      const busWithSource = bus.newScopedBus('foo');
-      busWithSource.publish({ type: DataHoverEvent.type });
+      const scopedBus = bus.newScopedBus('foo');
+      scopedBus.publish({ type: DataHoverEvent.type });
 
       expect(events.length).toEqual(1);
-      expect(events[0].origin).toEqual(busWithSource);
+      expect(events[0].origin).toEqual(scopedBus);
+    });
+
+    it('Can subscribe to only local events', () => {
+      const bus = new EventBusSrv();
+      const allEvents: BusEvent[] = [];
+      const scopedEvents: BusEvent[] = [];
+
+      bus.subscribe(DataHoverEvent, (event) => allEvents.push(event));
+
+      const scopedBus1 = bus.newScopedBus('foo', { onlyLocal: true });
+      const scopedBus2 = bus.newScopedBus('foo', { onlyLocal: true });
+
+      scopedBus1.subscribe(DataHoverEvent, (event) => scopedEvents.push(event));
+
+      scopedBus1.publish({ type: DataHoverEvent.type });
+      scopedBus2.publish({ type: DataHoverEvent.type });
+
+      expect(allEvents.length).toEqual(2);
+      expect(scopedEvents.length).toEqual(1);
     });
   });
 

--- a/packages/grafana-data/src/events/EventBus.ts
+++ b/packages/grafana-data/src/events/EventBus.ts
@@ -136,7 +136,7 @@ class ScopedEventBus implements EventBus {
   }
 
   getStream<T extends BusEvent>(eventType: BusEventType<T>): Observable<T> {
-    return this.eventBus.getStream(eventType).pipe(filter(this.filter));
+    return this.eventBus.getStream(eventType).pipe(filter(this.filter.bind(this)));
   }
 
   // syntax sugar


### PR DESCRIPTION
Noticed this error in both Explore and in dashboards when hovering over graphs. Was caused by this PR https://github.com/grafana/grafana/pull/75271 merged 3 days ago. The unit tests where not complete enough to cover this issue. 

This bug should have block any non TimeSeries/uplot panel from getting the DataHoverEvent, could not find any bug report for it 


![Screenshot from 2023-09-25 08-45-54](https://github.com/grafana/grafana/assets/10999/85441e5a-f548-4679-a397-78f3006962e5)
