### PR TITLE
Alerting: Make shareable alert rule link work if rule name contains forward slashes

### DIFF
--- a/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
@@ -12,6 +12,7 @@ import { RuleViewerLayout } from './components/rule-viewer/RuleViewerLayout';
 import { useCloudCombinedRulesMatching } from './hooks/useCombinedRule';
 import { getRulesSourceByName } from './utils/datasource';
 import { createViewLink } from './utils/misc';
+import { unescapePathSeparators } from './utils/rule-id';
 
 const pageTitle = 'Find rule';
 const subUrl = config.appSubUrl;
@@ -27,8 +28,7 @@ function useRuleFindParams() {
 
   return useMemo(() => {
     const segments = location.pathname?.replace(subUrl, '').split('/') ?? []; // ["", "alerting", "{sourceName}", "{name}]
-
-    const name = decodeURIComponent(segments[3]);
+    const name = unescapePathSeparators(decodeURIComponent(unescapePathSeparators(segments[3])));
     const sourceName = decodeURIComponent(segments[2]);
 
     const searchParams = new URLSearchParams(location.search);

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -2,6 +2,7 @@ import { sortBy } from 'lodash';
 
 import { UrlQueryMap, Labels, DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { DataSourceRef } from '@grafana/schema';
+import { escapePathSeparators } from 'app/features/alerting/unified/utils/rule-id';
 import { alertInstanceKey } from 'app/features/alerting/unified/utils/rules';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
 import { Alert, CombinedRule, FilterState, RulesSource, SilenceFilterState } from 'app/types/unified-alerting';
@@ -55,7 +56,9 @@ export function createMuteTimingLink(muteTimingName: string, alertManagerSourceN
 
 export function createShareLink(ruleSource: RulesSource, rule: CombinedRule): string {
   if (isCloudRulesSource(ruleSource)) {
-    return createAbsoluteUrl(`/alerting/${encodeURIComponent(ruleSource.name)}/${encodeURIComponent(rule.name)}/find`);
+    return createAbsoluteUrl(
+      `/alerting/${encodeURIComponent(ruleSource.name)}/${encodeURIComponent(escapePathSeparators(rule.name))}/find`
+    );
   }
 
   return window.location.href.split('?')[0];

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -106,11 +106,11 @@ function unescapeDollars(value: string): string {
  * we'll use some non-printable characters from the ASCII table that will get encoded properly but very unlikely
  * to ever be used in a rule name or namespace
  */
-function escapePathSeparators(value: string): string {
+export function escapePathSeparators(value: string): string {
   return value.replace(/\//g, '\x1f').replace(/\\/g, '\x1e');
 }
 
-function unescapePathSeparators(value: string): string {
+export function unescapePathSeparators(value: string): string {
   return value.replace(/\x1f/g, '/').replace(/\x1e/g, '\\');
 }
 


### PR DESCRIPTION
URL produced by "Copy link to rule" button would not open the rule page on Grafana Cloud instances if alert name contains forward slashes. This is because proxy in front of grafana auto unescapes slashes thereby mangling the URL. 

This is solved by using `unescapePathSeparators` and `escapePathSeparators` which are intended to solve this exact problem and are used for rule id, but were not being used for the short link.

Fixes https://github.com/grafana/grafana/issues/74807

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
