### PR TITLE
[Proposal] Log Rows: Log details no longer toggled when text is selected

### DIFF
--- a/public/app/features/logs/components/LogRow.test.tsx
+++ b/public/app/features/logs/components/LogRow.test.tsx
@@ -167,4 +167,26 @@ describe('LogRow', () => {
     const row = container.querySelector('tr');
     expect(row).toHaveStyle(`background-color: ${tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString()}`);
   });
+
+  describe('Log details', () => {
+    it('should highlight the original log row when showing its context', async () => {
+      setup({ enableLogDetails: true });
+  
+      expect(screen.queryByText('No details available')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByText('test123'));
+      expect(await screen.findByText('No details available')).toBeInTheDocument();
+    });
+
+    it('should highlight the original log row when showing its context', async () => {
+      const selection = window.getSelection();
+      jest.spyOn(window, 'getSelection').mockReturnValue(selection);
+      jest.spyOn(selection!, 'toString').mockReturnValue('selection');
+
+      setup({ enableLogDetails: true });
+  
+      expect(screen.queryByText('No details available')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByText('test123'));
+      expect(screen.queryByText('No details available')).not.toBeInTheDocument();
+    });
+  })
 });

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -92,6 +92,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       return;
     }
 
+    // If the user selected some text, we don't want to toggle the details.
+    if (window.getSelection()?.toString()) {
+      return;
+    }
+
     reportInteraction('grafana_explore_logs_log_details_clicked', {
       datasourceType: this.props.row.datasourceType,
       type: this.state.showDetails ? 'close' : 'open',


### PR DESCRIPTION
While playing with https://github.com/grafana/grafana/pull/75306 I realized that having Log Details toggling when one is selecting text is very annoying.

With this PR I'm proposing to no longer toggle its state when text is selected.

**Special notes for your reviewer:**

Before behavior:

https://github.com/grafana/grafana/assets/1069378/d72575df-a8ab-4ed8-a389-ed70fa01a2ae

After behavior:

https://github.com/grafana/grafana/assets/1069378/5090ccaf-aa65-4cbd-9408-c61759293275
