### PR TITLE
Table: Add data frame to cell link context

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -327,8 +327,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "packages/grafana-data/src/types/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -319,15 +319,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "packages/grafana-data/src/types/dataLink.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "packages/grafana-data/src/types/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -3595,21 +3595,23 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Do not use any type assertions.", "12"],
+      [0, 0, 0, "Do not use any type assertions.", "11"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
       [0, 0, 0, "Do not use any type assertions.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
+      [0, 0, 0, "Do not use any type assertions.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Do not use any type assertions.", "18"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "19"],
       [0, 0, 0, "Do not use any type assertions.", "20"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "21"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "23"]
+      [0, 0, 0, "Do not use any type assertions.", "22"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "23"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "24"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "25"]
     ],
     "public/app/features/dashboard/state/TimeModel.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4348,6 +4350,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
+    "public/app/features/explore/utils/links.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/features/explore/utils/links.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
     "public/app/features/expressions/ExpressionDatasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -4714,14 +4723,27 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/panel/panellinks/linkSuppliers.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/panel/panellinks/link_srv.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Do not use any type assertions.", "7"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
+    ],
+    "public/app/features/panel/panellinks/specs/link_srv.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/panel/state/actions.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -446,7 +446,7 @@ export const getLinksSupplier =
           href: link.url,
           title: replaceVariables(link.title || '', dataLinkScopedVars),
           target: link.targetBlank ? '_blank' : undefined,
-          onClick: (evt: MouseEvent, origin: Field) => {
+          onClick: (evt: MouseEvent, origin?: Field) => {
             link.onClick!({
               origin: origin ?? field,
               e: evt,

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -1,6 +1,6 @@
 import { ScopedVars } from './ScopedVars';
 import { QueryResultBase, Labels, NullValueMode } from './data';
-import { DataLink, LinkModel } from './dataLink';
+import { DataLink, DataLinkContext, LinkModel } from './dataLink';
 import { DecimalCount, DisplayProcessor, DisplayValue, DisplayValueAlignmentFactors } from './displayValue';
 import { FieldColor } from './fieldColor';
 import { ThresholdsConfig } from './thresholds';
@@ -28,7 +28,7 @@ export enum FieldType {
  *
  * Plugins may extend this with additional properties. Something like series overrides
  */
-export interface FieldConfig<TOptions = any> {
+export interface FieldConfig<TOptions = any, DataLinkCtx = DataLinkContext> {
   /**
    * The display value for this field.  This supports template variables blank is auto.
    * If you are a datasource plugin, do not set this. Use `field.value` and if that
@@ -91,7 +91,7 @@ export interface FieldConfig<TOptions = any> {
   nullValueMode?: NullValueMode;
 
   // The behavior when clicking on a result
-  links?: DataLink[];
+  links?: Array<DataLink<any, DataLinkCtx>>;
 
   // Alternative to empty string
   noValue?: string;
@@ -169,7 +169,7 @@ export interface Field<T = any, V = Vector<T>> {
   /**
    * Get value data links with variables interpolated
    */
-  getLinks?: (config: ValueLinkConfig) => Array<LinkModel<Field>>;
+  getLinks?: (config: ValueLinkConfig) => Array<LinkModel<DataLinkContext>>;
 }
 
 /** @alpha */

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -93,7 +93,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: any, origin?: any) => void;
+  onClick?: (e: any, origin?: T) => void;
 }
 
 /**

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -1,12 +1,19 @@
+import { DataFrame, Field } from './dataFrame';
 import { ExplorePanelsState } from './explore';
 import { InterpolateFunction } from './panel';
 import { DataQuery } from './query';
 import { TimeRange } from './time';
 
+export interface DataLinkContext {
+  frame: DataFrame;
+  field: Field;
+  rowIndex?: number;
+}
+
 /**
  * Callback info for DataLink click events
  */
-export interface DataLinkClickEvent<T = any> {
+export interface DataLinkClickEvent<T = DataLinkContext> {
   origin: T;
   replaceVariables: InterpolateFunction | undefined;
   e?: any; // mouse|react event
@@ -28,7 +35,7 @@ export enum DataLinkConfigOrigin {
  * TODO: <T extends DataQuery> is not strictly true for internal links as we do not need refId for example but all
  *  data source defined queries extend this so this is more for documentation.
  */
-export interface DataLink<T extends DataQuery = any> {
+export interface DataLink<T extends DataQuery = any, Ctx = DataLinkContext> {
   title: string;
   targetBlank?: boolean;
 
@@ -37,11 +44,11 @@ export interface DataLink<T extends DataQuery = any> {
 
   // 2: If exists, use this to construct the URL
   // Not saved in JSON/DTO
-  onBuildUrl?: (event: DataLinkClickEvent) => string;
+  onBuildUrl?: (event: DataLinkClickEvent<Ctx>) => string;
 
   // 1: If exists, handle click directly
   // Not saved in JSON/DTO
-  onClick?: (event: DataLinkClickEvent) => void;
+  onClick?: (event: DataLinkClickEvent<Ctx>) => void;
 
   // If dataLink represents internal link this has to be filled. Internal link is defined as a query in a particular
   // data source that we want to show to the user. Usually this results in a link to explore but can also lead to
@@ -102,7 +109,7 @@ export interface LinkModel<T = any> {
  * TODO: ScopedVars in in GrafanaUI package!
  */
 export interface LinkModelSupplier<T extends object> {
-  getLinks(replaceVariables?: InterpolateFunction): Array<LinkModel<T>>;
+  getLinks(replaceVariables?: InterpolateFunction): LinkModel[];
 }
 
 export enum VariableOrigin {

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -133,7 +133,7 @@ export type DataLinkPostProcessorOptions = {
   linkModel: LinkModel;
 };
 
-export type DataLinkPostProcessor = (options: DataLinkPostProcessorOptions) => LinkModel<Field> | undefined;
+export type DataLinkPostProcessor = (options: DataLinkPostProcessorOptions) => LinkModel | undefined;
 
 export interface ApplyFieldOverrideOptions {
   data?: DataFrame[];

--- a/packages/grafana-data/src/utils/dataLinks.test.ts
+++ b/packages/grafana-data/src/utils/dataLinks.test.ts
@@ -28,16 +28,18 @@ describe('mapInternalLinkToExplore', () => {
       },
     };
 
+    const field = {
+      name: 'test',
+      type: FieldType.number,
+      config: {},
+      values: [2],
+    };
     const link = mapInternalLinkToExplore({
       link: dataLink,
       internalLink: dataLink.internal,
       scopedVars: {},
-      field: {
-        name: 'test',
-        type: FieldType.number,
-        config: {},
-        values: [2],
-      },
+      field,
+      frame: { fields: [field], length: 1 },
       replaceVariables: (val) => val,
     });
 
@@ -68,16 +70,19 @@ describe('mapInternalLinkToExplore', () => {
       },
     };
 
+    const field = {
+      name: 'test',
+      type: FieldType.number,
+      config: {},
+      values: [2],
+    };
+
     const link = mapInternalLinkToExplore({
       link: dataLink,
       internalLink: dataLink.internal!,
       scopedVars: {},
-      field: {
-        name: 'test',
-        type: FieldType.number,
-        config: {},
-        values: [2],
-      },
+      field,
+      frame: { fields: [field], length: 1 },
       replaceVariables: (val) => val,
     });
 
@@ -112,6 +117,13 @@ describe('mapInternalLinkToExplore', () => {
       },
     };
 
+    const field = {
+      name: 'test',
+      type: FieldType.number,
+      config: {},
+      values: [2],
+    };
+
     const link = mapInternalLinkToExplore({
       link: dataLink,
       internalLink: dataLink.internal,
@@ -119,12 +131,8 @@ describe('mapInternalLinkToExplore', () => {
         var1: { text: '', value: 'val1' },
       },
       range: TIME_RANGE,
-      field: {
-        name: 'test',
-        type: FieldType.number,
-        config: {},
-        values: [2],
-      },
+      field,
+      frame: { fields: [field], length: 1 },
       replaceVariables: (val, scopedVars) => val.replace(/\$var/g, scopedVars!['var1']!.value),
     });
 

--- a/packages/grafana-data/src/utils/dataLinks.ts
+++ b/packages/grafana-data/src/utils/dataLinks.ts
@@ -1,5 +1,7 @@
 import {
+  DataFrame,
   DataLink,
+  DataLinkContext,
   DataQuery,
   ExplorePanelsState,
   Field,
@@ -35,13 +37,14 @@ export type LinkToExploreOptions = {
   scopedVars: ScopedVars;
   range?: TimeRange;
   field: Field;
+  frame: DataFrame;
   internalLink: InternalDataLink;
   onClickFn?: SplitOpen;
   replaceVariables: InterpolateFunction;
 };
 
-export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkModel<Field> {
-  const { onClickFn, replaceVariables, link, scopedVars, range, field, internalLink } = options;
+export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkModel<DataLinkContext> {
+  const { onClickFn, replaceVariables, link, scopedVars, range, frame, field, internalLink } = options;
 
   const interpolatedQuery = interpolateObject(link.internal?.query, scopedVars, replaceVariables);
   const interpolatedPanelsState = interpolateObject(link.internal?.panelsState, scopedVars, replaceVariables);
@@ -67,7 +70,7 @@ export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkMod
         }
       : undefined,
     target: link?.targetBlank ? '_blank' : '_self',
-    origin: field,
+    origin: { field, frame },
   };
 }
 

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -144,7 +144,7 @@ function buildTableDataFrame(
           url: '',
           onClick: (e: DataLinkClickEvent) => {
             const field: Field = e.origin.field;
-            const value = field.values[e.origin.rowIndex];
+            const value = field.values[e.origin.rowIndex ?? 0];
             onSymbolClick(value);
           },
         },

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { Field, LinkModel } from '@grafana/data';
+import { LinkModel } from '@grafana/data';
 
 import { ButtonProps, Button } from '../Button';
 
 type DataLinkButtonProps = {
-  link: LinkModel<Field>;
+  link: LinkModel;
   buttonProps?: ButtonProps;
 };
 

--- a/packages/grafana-ui/src/components/DataLinks/FieldLinkList.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/FieldLinkList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { Field, GrafanaTheme2, LinkModel } from '@grafana/data';
+import { GrafanaTheme2, LinkModel } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 import { Icon } from '../Icon/Icon';
@@ -9,7 +9,7 @@ import { Icon } from '../Icon/Icon';
 import { DataLinkButton } from './DataLinkButton';
 
 type Props = {
-  links: Array<LinkModel<Field>>;
+  links: LinkModel[];
 };
 
 /**

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -25,7 +25,7 @@ export const DefaultCell = (props: TableCellProps) => {
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellOptions = getCellOptions(field);
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled);
-  const hasLinks = Boolean(getCellLinks(field, row)?.length);
+  const hasLinks = Boolean(getCellLinks(field, row, frame)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
   let value: string | ReactElement;
 
@@ -45,7 +45,7 @@ export const DefaultCell = (props: TableCellProps) => {
       {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
 
       {hasLinks && (
-        <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
+        <DataLinksContextMenu links={() => getCellLinks(field, row, frame) || []}>
           {(api) => {
             if (api.openMenu) {
               return (

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -9,18 +9,18 @@ import { DataLinksContextMenu } from '../DataLinks/DataLinksContextMenu';
 import { TableCellProps } from './types';
 
 export const ImageCell = (props: TableCellProps) => {
-  const { field, cell, tableStyles, row, cellProps } = props;
+  const { field, cell, tableStyles, row, cellProps, frame } = props;
 
   const displayValue = field.display!(cell.value);
 
-  const hasLinks = Boolean(getCellLinks(field, row)?.length);
+  const hasLinks = Boolean(getCellLinks(field, row, frame)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
       {!hasLinks && <img src={displayValue.text} className={tableStyles.imageCell} alt="" />}
       {hasLinks && (
-        <DataLinksContextMenu style={{ height: '100%' }} links={() => getCellLinks(field, row) || []}>
+        <DataLinksContextMenu style={{ height: '100%' }} links={() => getCellLinks(field, row, frame) || []}>
           {(api) => {
             const img = <img src={displayValue.text} className={tableStyles.imageCell} alt="" />;
             if (api.openMenu) {

--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -11,7 +11,7 @@ import { CellActions } from './CellActions';
 import { TableCellProps } from './types';
 
 export function JSONViewCell(props: TableCellProps): JSX.Element {
-  const { cell, tableStyles, cellProps, field, row } = props;
+  const { cell, tableStyles, cellProps, field, row, frame } = props;
   const inspectEnabled = Boolean(field.config.custom?.inspect);
   const txt = css({
     cursor: 'pointer',
@@ -29,7 +29,7 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
     displayValue = JSON.stringify(value, null, ' ');
   }
 
-  const hasLinks = Boolean(getCellLinks(field, row)?.length);
+  const hasLinks = Boolean(getCellLinks(field, row, frame)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
   return (
@@ -37,7 +37,7 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
       <div className={cx(tableStyles.cellText, txt)}>
         {!hasLinks && <div className={tableStyles.cellText}>{displayValue}</div>}
         {hasLinks && (
-          <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
+          <DataLinksContextMenu links={() => getCellLinks(field, row, frame) || []}>
             {(api) => {
               if (api.openMenu) {
                 return (

--- a/packages/grafana-ui/src/utils/table.ts
+++ b/packages/grafana-ui/src/utils/table.ts
@@ -1,12 +1,12 @@
 import { Row } from 'react-table';
 
-import { Field, LinkModel } from '@grafana/data';
+import { DataFrame, Field, LinkModel } from '@grafana/data';
 
 /**
  * @internal
  */
-export const getCellLinks = (field: Field, row: Row) => {
-  let links: Array<LinkModel<unknown>> | undefined;
+export const getCellLinks = (field: Field, row: Row, frame: DataFrame) => {
+  let links: LinkModel[] | undefined;
   if (field.getLinks) {
     links = field.getLinks({
       valueRowIndex: row.index,
@@ -28,6 +28,7 @@ export const getCellLinks = (field: Field, row: Row) => {
           origOnClick!(event, {
             field,
             rowIndex: row.index,
+            frame,
           });
         }
       };

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -174,7 +174,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   maxDataPoints?: number | null;
   interval?: string | null;
   description?: string;
-  links?: DataLink[];
+  links?: Array<DataLink<any, any>>;
   declare transparent: boolean;
 
   libraryPanel?: LibraryPanelRef | LibraryPanel;

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -30,6 +30,7 @@ import {
   serializeStateToUrlParam,
   urlUtil,
   TimeRange,
+  DataLinkContext,
 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -89,7 +90,7 @@ interface Props extends Themeable2 {
   getRowContext?: (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions) => Promise<any>;
   getRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions) => Promise<DataQuery | null>;
   getLogRowContextUi?: (row: LogRowModel, runContextQuery?: () => void) => React.ReactNode;
-  getFieldLinks: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
+  getFieldLinks: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>;
   addResultsToCache: () => void;
   clearCache: () => void;
   eventBus: EventBus;

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -6,6 +6,7 @@ import {
   CoreApp,
   DataFrame,
   DataLink,
+  DataLinkContext,
   DataSourceApi,
   DataSourceJsonData,
   Field,
@@ -216,7 +217,7 @@ function useFocusSpanLink(options: {
   splitOpenFn: SplitOpen;
   refId?: string;
   datasource?: DataSourceApi;
-}): [string | undefined, (traceId: string, spanId: string) => LinkModel<Field>] {
+}): [string | undefined, (traceId: string, spanId: string) => LinkModel<DataLinkContext>] {
   const panelState = useSelector((state) => state.explore.panes[options.exploreId]?.panelsState.trace);
   const focusedSpanId = panelState?.spanId;
 
@@ -263,6 +264,7 @@ function useFocusSpanLink(options: {
       scopedVars: {},
       range: {} as any,
       field: {} as Field,
+      frame: { fields: [], length: 0 },
       onClickFn: sameTrace
         ? () => setFocusedSpanId(focusedSpanId === spanId ? undefined : spanId)
         : options.splitOpenFn

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -1284,6 +1284,7 @@ function setupSpanLinkFactory(options: Partial<TraceToLogsOptionsV2> = {}, datas
     createFocusSpanLink: (traceId, spanId) => {
       return {
         href: `${traceId}-${spanId}`,
+        origin: {},
       } as unknown as LinkModel;
     },
     trace: dummyTraceData,

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   DataFrame,
   DataLink,
+  DataLinkContext,
   DataSourceInstanceSettings,
   DataSourceJsonData,
   dateTime,
@@ -45,7 +46,7 @@ export function createSpanLinkFactory({
   traceToLogsOptions?: TraceToLogsOptionsV2;
   traceToMetricsOptions?: TraceToMetricsOptions;
   dataFrame?: DataFrame;
-  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>;
+  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<DataLinkContext>;
   trace: Trace;
 }): SpanLinkFunc | undefined {
   if (!dataFrame) {
@@ -95,7 +96,7 @@ export function createSpanLinkFactory({
             href: link.href,
             onClick: link.onClick,
             content: <Icon name="link" title={link.title || 'Link'} />,
-            field: link.origin,
+            field: link.origin.field,
             type: SpanLinkType.Unknown,
           };
         });
@@ -133,7 +134,7 @@ function legacyCreateSpanLinkFactory(
   field: Field,
   traceToLogsOptions?: TraceToLogsOptionsV2,
   traceToMetricsOptions?: TraceToMetricsOptions,
-  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>,
+  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<DataLinkContext>,
   scopedVars?: ScopedVars
 ) {
   let logsDataSourceSettings: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
@@ -226,6 +227,7 @@ function legacyCreateSpanLinkFactory(
               isSplunkDS
             ),
             field: {} as Field,
+            frame: { fields: [], length: 0 },
             onClickFn: splitOpenFn,
             replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
           });
@@ -272,6 +274,7 @@ function legacyCreateSpanLinkFactory(
               : 120000,
           }),
           field: {} as Field,
+          frame: { fields: [], length: 0 },
           onClickFn: splitOpenFn,
           replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
         });
@@ -302,7 +305,7 @@ function legacyCreateSpanLinkFactory(
           title: reference.span ? reference.span.operationName : 'View linked span',
           content: <Icon name="link" title="View linked span" />,
           onClick: link.onClick,
-          field: link.origin,
+          field: link.origin.field,
           type: SpanLinkType.Traces,
         });
       }
@@ -317,7 +320,7 @@ function legacyCreateSpanLinkFactory(
           title: reference.span ? reference.span.operationName : 'View linked span',
           content: <Icon name="link" title="View linked span" />,
           onClick: link.onClick,
-          field: link.origin,
+          field: link.origin.field,
           type: SpanLinkType.Traces,
         });
       }

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -43,12 +43,13 @@ describe('explore links utils', () => {
     });
 
     it('returns correct link model for external link', () => {
-      const { field, range } = setup({
+      const { field, dataFrame, range } = setup({
         title: 'external',
         url: 'http://regionalhost',
       });
       const links = getFieldLinksForExplore({
         field,
+        dataFrame,
         rowIndex: ROW_WITH_TEXT_VALUE.index,
         splitOpenFn: jest.fn(),
         range,
@@ -60,12 +61,13 @@ describe('explore links utils', () => {
     });
 
     it('returns generates title for external link', () => {
-      const { field, range } = setup({
+      const { field, dataFrame, range } = setup({
         title: '',
         url: 'http://regionalhost',
       });
       const links = getFieldLinksForExplore({
         field,
+        dataFrame,
         rowIndex: ROW_WITH_TEXT_VALUE.index,
         splitOpenFn: jest.fn(),
         range,
@@ -76,7 +78,7 @@ describe('explore links utils', () => {
     });
 
     it('returns correct link model for internal link', () => {
-      const { field, range } = setup({
+      const { field, dataFrame, range } = setup({
         title: '',
         url: '',
         internal: {
@@ -93,6 +95,7 @@ describe('explore links utils', () => {
       const splitfn = jest.fn();
       const links = getFieldLinksForExplore({
         field,
+        dataFrame,
         rowIndex: ROW_WITH_TEXT_VALUE.index,
         splitOpenFn: splitfn,
         range,
@@ -134,21 +137,21 @@ describe('explore links utils', () => {
     });
 
     it('returns correct link model for external link when user does not have access to explore', () => {
-      const { field, range } = setup(
+      const { field, dataFrame, range } = setup(
         {
           title: 'external',
           url: 'http://regionalhost',
         },
         false
       );
-      const links = getFieldLinksForExplore({ field, rowIndex: ROW_WITH_TEXT_VALUE.index, range });
+      const links = getFieldLinksForExplore({ field, dataFrame, rowIndex: ROW_WITH_TEXT_VALUE.index, range });
 
       expect(links[0].href).toBe('http://regionalhost');
       expect(links[0].title).toBe('external');
     });
 
     it('returns no internal links if when user does not have access to explore', () => {
-      const { field, range } = setup(
+      const { field, dataFrame, range } = setup(
         {
           title: '',
           url: '',
@@ -160,7 +163,7 @@ describe('explore links utils', () => {
         },
         false
       );
-      const links = getFieldLinksForExplore({ field, rowIndex: ROW_WITH_TEXT_VALUE.index, range });
+      const links = getFieldLinksForExplore({ field, dataFrame, rowIndex: ROW_WITH_TEXT_VALUE.index, range });
       expect(links).toHaveLength(0);
     });
 
@@ -710,7 +713,7 @@ function setup(
   dataFrameOtherFieldOverride?: Field[]
 ) {
   setLinkSrv({
-    getDataLinkUIModel(link: DataLink, replaceVariables: InterpolateFunction | undefined, origin) {
+    getDataLinkUIModel<T>(link: DataLink<any, T>, replaceVariables: InterpolateFunction | undefined, origin: T) {
       return {
         href: link.url,
         title: link.title,

--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme, FieldType } from '@grafana/data';
+import { LogLevel, LogRowModel, MutableDataFrame, createTheme, FieldType } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { LogDetails, Props } from './LogDetails';
@@ -154,14 +154,14 @@ describe('LogDetails', () => {
     });
     setup(
       {
-        getFieldLinks: (field: Field, rowIndex: number) => {
+        getFieldLinks: (field, rowIndex, frame) => {
           if (field.config && field.config.links) {
             return field.config.links.map((link) => {
               return {
                 href: link.url.replace('${__value.text}', field.values[rowIndex]),
                 title: link.title,
                 target: '_blank',
-                origin: field,
+                origin: { field, frame, rowIndex },
               };
             });
           }

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { CoreApp, DataFrame, Field, LinkModel, LogRowModel } from '@grafana/data';
+import { CoreApp, DataFrame, DataLinkContext, Field, LinkModel, LogRowModel } from '@grafana/data';
 import { Themeable2, withTheme2 } from '@grafana/ui';
 
 import { calculateLogsLabelStats, calculateStats } from '../utils';
@@ -22,7 +22,7 @@ export interface Props extends Themeable2 {
 
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
-  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -3,7 +3,15 @@ import { isEqual } from 'lodash';
 import memoizeOne from 'memoize-one';
 import React, { PureComponent, useState } from 'react';
 
-import { CoreApp, Field, GrafanaTheme2, IconName, LinkModel, LogLabelStatsModel, LogRowModel } from '@grafana/data';
+import {
+  CoreApp,
+  DataLinkContext,
+  GrafanaTheme2,
+  IconName,
+  LinkModel,
+  LogLabelStatsModel,
+  LogRowModel,
+} from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { ClipboardButton, DataLinkButton, IconButton, Themeable2, withTheme2 } from '@grafana/ui';
 
@@ -18,7 +26,7 @@ export interface Props extends Themeable2 {
   isLabel?: boolean;
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
-  links?: Array<LinkModel<Field>>;
+  links?: Array<LinkModel<DataLinkContext>>;
   getStats: () => LogLabelStatsModel[] | null;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -2,7 +2,16 @@ import { cx } from '@emotion/css';
 import { debounce } from 'lodash';
 import React, { PureComponent } from 'react';
 
-import { Field, LinkModel, LogRowModel, LogsSortOrder, dateTimeFormat, CoreApp, DataFrame } from '@grafana/data';
+import {
+  Field,
+  LinkModel,
+  LogRowModel,
+  LogsSortOrder,
+  dateTimeFormat,
+  CoreApp,
+  DataFrame,
+  DataLinkContext,
+} from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
@@ -32,7 +41,7 @@ interface Props extends Themeable2 {
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   onContextClick?: () => void;
-  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { useMemo } from 'react';
 
-import { LogRowModel, Field, LinkModel, DataFrame } from '@grafana/data';
+import { LogRowModel, Field, LinkModel, DataFrame, DataLinkContext } from '@grafana/data';
 
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
@@ -11,7 +11,7 @@ export interface Props {
   row: LogRowModel;
   detectedFields: string[];
   wrapLogMessage: boolean;
-  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>;
   styles: LogRowStyles;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onOpenContext: (row: LogRowModel) => void;

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -11,6 +11,7 @@ import {
   LogsSortOrder,
   CoreApp,
   DataFrame,
+  DataLinkContext,
 } from '@grafana/data';
 import { withTheme2, Themeable2 } from '@grafana/ui';
 
@@ -41,7 +42,7 @@ export interface Props extends Themeable2 {
   showContextToggle?: (row?: LogRowModel) => boolean;
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
-  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
   onPinLine?: (row: LogRowModel) => void;

--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -408,14 +408,23 @@ describe('logParser', () => {
 
   describe('createLogLineLinks', () => {
     it('should change FieldDef to have keys of variable keys', () => {
+      const field = {
+        config: { links: [] },
+        name: 'Line',
+        type: FieldType.string,
+        values: ['a', 'b'],
+      };
       const variableLink: ExploreFieldLinkModel = {
         href: 'test',
         onClick: () => {},
         origin: {
-          config: { links: [] },
-          name: 'Line',
-          type: FieldType.string,
-          values: ['a', 'b'],
+          field: {
+            config: { links: [] },
+            name: 'Line',
+            type: FieldType.string,
+            values: ['a', 'b'],
+          },
+          frame: { fields: [field], length: 1 },
         },
         title: 'test',
         target: '_self',
@@ -442,14 +451,19 @@ describe('logParser', () => {
     });
 
     it('should return empty array if no variables', () => {
+      const field = {
+        config: { links: [] },
+        name: 'Line',
+        type: FieldType.string,
+        values: ['a', 'b'],
+      };
+
       const variableLink: ExploreFieldLinkModel = {
         href: 'test',
         onClick: () => {},
         origin: {
-          config: { links: [] },
-          name: 'Line',
-          type: FieldType.string,
-          values: ['a', 'b'],
+          field,
+          frame: { fields: [field], length: 1 },
         },
         title: 'test',
         target: '_self',

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -1,7 +1,7 @@
 import { partition } from 'lodash';
 import memoizeOne from 'memoize-one';
 
-import { DataFrame, Field, FieldWithIndex, LinkModel, LogRowModel } from '@grafana/data';
+import { DataFrame, DataLinkContext, Field, FieldWithIndex, LinkModel, LogRowModel } from '@grafana/data';
 import { safeStringifyValue } from 'app/core/utils/explore';
 import { ExploreFieldLinkModel } from 'app/features/explore/utils/links';
 
@@ -10,7 +10,7 @@ import { parseLogsFrame } from '../logsFrame';
 export type FieldDef = {
   keys: string[];
   values: string[];
-  links?: Array<LinkModel<Field>> | ExploreFieldLinkModel[];
+  links?: Array<LinkModel<DataLinkContext>> | ExploreFieldLinkModel[];
   fieldIndex: number;
 };
 
@@ -25,7 +25,7 @@ export const getAllFields = memoizeOne(
       field: Field,
       rowIndex: number,
       dataFrame: DataFrame
-    ) => Array<LinkModel<Field>> | ExploreFieldLinkModel[]
+    ) => Array<LinkModel<DataLinkContext>> | ExploreFieldLinkModel[]
   ) => {
     const dataframeFields = getDataframeFields(row, getFieldLinks);
 
@@ -66,7 +66,7 @@ export const createLogLineLinks = memoizeOne((hiddenFieldsWithLinks: FieldDef[])
 export const getDataframeFields = memoizeOne(
   (
     row: LogRowModel,
-    getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>
+    getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<DataLinkContext>>
   ): FieldDef[] => {
     const visibleFields = separateVisibleFields(row.dataFrame).visible;
     const nonEmptyVisibleFields = visibleFields.filter((f) => f.values[row.rowIndex] != null);

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -50,7 +50,7 @@ interface DataLinkScopedVars extends ScopedVars {
  * Link suppliers creates link models based on a link origin
  */
 export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<FieldDisplay> | undefined => {
-  const links = value.field.links;
+  const links = value.field.links as unknown as Array<DataLink<any, FieldDisplay>>;
   if (!links || links.length === 0) {
     return undefined;
   }
@@ -132,8 +132,8 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
         return replaceVariables(value, finalVars, fmt);
       };
 
-      return links.map((link: DataLink) => {
-        return getLinkSrv().getDataLinkUIModel(link, replace, value);
+      return links.map((link) => {
+        return getLinkSrv().getDataLinkUIModel<FieldDisplay>(link, replace, value);
       });
     },
   };
@@ -149,7 +149,7 @@ export const getPanelLinksSupplier = (panel: PanelModel): LinkModelSupplier<Pane
   return {
     getLinks: () => {
       return links.map((link) => {
-        return getLinkSrv().getDataLinkUIModel(link, panel.replaceVariables, panel);
+        return getLinkSrv().getDataLinkUIModel<PanelModel>(link, panel.replaceVariables, panel);
       });
     },
   };

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -244,7 +244,11 @@ export const getCalculationValueDataLinksVariableSuggestions = (dataFrames: Data
 };
 
 export interface LinkService {
-  getDataLinkUIModel: <T>(link: DataLink, replaceVariables: InterpolateFunction | undefined, origin: T) => LinkModel<T>;
+  getDataLinkUIModel: <T>(
+    link: DataLink<any, T>,
+    replaceVariables: InterpolateFunction | undefined,
+    origin: T
+  ) => LinkModel<T>;
   getAnchorInfo: (link: any) => {
     href: string;
     title: string;
@@ -288,7 +292,7 @@ export class LinkSrv implements LinkService {
    * Returns LinkModel which is basically a DataLink with all values interpolated through the templateSrv.
    */
   getDataLinkUIModel = <T>(
-    link: DataLink,
+    link: DataLink<any, T>,
     replaceVariables: InterpolateFunction | undefined,
     origin: T
   ): LinkModel<T> => {
@@ -338,7 +342,7 @@ export class LinkSrv implements LinkService {
     const replace: InterpolateFunction = (value, vars, fmt) =>
       getTemplateSrv().replace(value, { ...scopedVars, ...vars }, fmt);
 
-    return this.getDataLinkUIModel(link, replace, {});
+    return this.getDataLinkUIModel(link, replace, {} as any);
   }
 }
 

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -70,7 +70,7 @@ describe('linkSrv', () => {
               url: 'www.google.com?query=some query',
             },
             (v) => v,
-            {}
+            {} as any
           ).href
         ).toEqual('www.google.com?query=some query');
       });
@@ -83,7 +83,7 @@ describe('linkSrv', () => {
               url: 'www.google.com?query=some\nquery',
             },
             (v) => v,
-            {}
+            {} as any
           ).href
         ).toEqual('www.google.com?query=somequery');
       });
@@ -108,7 +108,7 @@ describe('linkSrv', () => {
               url,
             },
             (v) => v,
-            {}
+            {} as any
           ).href;
 
           expect(link).toBe(expected);
@@ -140,7 +140,7 @@ describe('linkSrv', () => {
               url,
             },
             (v) => v,
-            {}
+            {} as any
           ).href;
 
           expect(link).toBe(expected);

--- a/public/app/features/storage/StoragePage.tsx
+++ b/public/app/features/storage/StoragePage.tsx
@@ -68,14 +68,15 @@ export default function StoragePage(props: Props) {
           frame.fields[0] = {
             ...name,
             getLinks: (cfg: ValueLinkConfig) => {
-              const n = name.values[cfg.valueRowIndex ?? 0];
+              const rowIndex = cfg.valueRowIndex ?? 0;
+              const n = name.values[rowIndex];
               const p = path + '/' + n;
               return [
                 {
                   title: `Open ${n}`,
                   href: `/admin/storage/${p}`,
                   target: '_self',
-                  origin: name,
+                  origin: { field: name, frame, rowIndex },
                   onClick: () => {
                     setPath(p);
                   },

--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {
   arrayUtils,
   DataFrame,
-  Field,
+  DataLinkContext,
   formattedValueToString,
   getFieldDisplayName,
   GrafanaTheme2,
@@ -53,7 +53,7 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
   }
 
   const displayValues: DisplayValue[] = [];
-  const links: Array<LinkModel<Field>> = [];
+  const links: Array<LinkModel<DataLinkContext>> = [];
   const linkLookup = new Set<string>();
 
   for (const field of orderedVisibleFields) {

--- a/public/app/plugins/datasource/loki/configuration/DebugSection.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DebugSection.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 
-import { Field, FieldType, LinkModel } from '@grafana/data';
+import { DataLinkContext, FieldType, LinkModel } from '@grafana/data';
 import { InlineField, TextArea } from '@grafana/ui';
 
 import { getFieldLinksForExplore } from '../../../../features/explore/utils/links';
@@ -83,18 +83,21 @@ function makeDebugFields(derivedFields: DerivedFieldConfig[], debugText: string)
       try {
         const testMatch = debugText.match(field.matcherRegex);
         const value = testMatch && testMatch[1];
-        let link: LinkModel<Field> | null = null;
+        let link: LinkModel<DataLinkContext> | null = null;
 
         if (field.url && value) {
-          link = getFieldLinksForExplore({
-            field: {
-              name: '',
-              type: FieldType.string,
-              values: [value],
-              config: {
-                links: [{ title: '', url: field.url }],
-              },
+          const f = {
+            name: '',
+            type: FieldType.string,
+            values: [value],
+            config: {
+              links: [{ title: '', url: field.url }],
             },
+          };
+          const frame = { fields: [f], length: 1 };
+          link = getFieldLinksForExplore({
+            field: f,
+            dataFrame: frame,
             rowIndex: 0,
             range: {} as any,
           })[0];

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -1,6 +1,13 @@
 import { isNumber, isString } from 'lodash';
 
-import { AppEvents, Field, getFieldDisplayName, LinkModel, PluginState, SelectableValue } from '@grafana/data';
+import {
+  AppEvents,
+  DataLinkContext,
+  getFieldDisplayName,
+  LinkModel,
+  PluginState,
+  SelectableValue,
+} from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { hasAlphaPanels } from 'app/core/config';
 import {
@@ -110,7 +117,7 @@ export function getDataLinks(ctx: DimensionContext, cfg: TextConfig, textData: s
   const panelData = ctx.getPanelData();
   const frames = panelData?.series;
 
-  const links: Array<LinkModel<Field>> = [];
+  const links: Array<LinkModel<DataLinkContext>> = [];
   const linkLookup = new Set<string>();
 
   frames?.forEach((frame) => {

--- a/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import {
   DataFrameType,
-  Field,
   FieldType,
   formattedValueToString,
   getFieldDisplayName,
@@ -11,6 +10,7 @@ import {
   getLinksSupplier,
   InterpolateFunction,
   ScopedVars,
+  DataLinkContext,
 } from '@grafana/data';
 import { HeatmapCellLayout } from '@grafana/schema';
 import { LinkButton, VerticalGroup } from '@grafana/ui';
@@ -120,7 +120,7 @@ const HeatmapHoverCell = ({ data, hover, showHistogram, scopedVars, replaceVars 
   const count = countVals?.[index];
 
   const visibleFields = data.heatmap?.fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
-  const links: Array<LinkModel<Field>> = [];
+  const links: Array<LinkModel<DataLinkContext>> = [];
   const linkLookup = new Set<string>();
 
   for (const field of visibleFields ?? []) {

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -2,6 +2,7 @@ import {
   cacheFieldDisplayNames,
   DataFrame,
   DataFrameType,
+  DataLinkContext,
   Field,
   FieldType,
   formattedValueToString,
@@ -68,7 +69,7 @@ export function prepareHeatmapData(
   options: Options,
   palette: string[],
   theme: GrafanaTheme2,
-  getFieldLinks?: (exemplars: DataFrame, field: Field) => (config: ValueLinkConfig) => Array<LinkModel<Field>>
+  getFieldLinks?: (exemplars: DataFrame, field: Field) => (config: ValueLinkConfig) => Array<LinkModel<DataLinkContext>>
 ): HeatmapData {
   if (!frames?.length) {
     return {};

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -11,6 +11,7 @@ import {
   DataHoverClearEvent,
   DataHoverEvent,
   CoreApp,
+  DataFrame,
 } from '@grafana/data';
 import { CustomScrollbar, useStyles2, usePanelContext } from '@grafana/ui';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
@@ -84,8 +85,8 @@ export const LogsPanel = ({
   }, [isAscending, logRows]);
 
   const getFieldLinks = useCallback(
-    (field: Field, rowIndex: number) => {
-      return getFieldLinksForExplore({ field, rowIndex, range: data.timeRange });
+    (field: Field, rowIndex: number, dataFrame: DataFrame) => {
+      return getFieldLinksForExplore({ dataFrame, field, rowIndex, range: data.timeRange });
     },
     [data]
   );

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import {
   DataFrame,
   FALLBACK_COLOR,
-  Field,
   getDisplayProcessor,
   getFieldDisplayName,
   TimeZone,
   LinkModel,
+  DataLinkContext,
 } from '@grafana/data';
 import { MenuItem, SeriesTableRow, useTheme2 } from '@grafana/ui';
 import { findNextStateIndex, fmtDuration } from 'app/core/components/TimelineChart/utils';
@@ -37,7 +37,7 @@ export const StateTimelineTooltip = ({
 
   const field = alignedData.fields[seriesIdx!];
 
-  const links: Array<LinkModel<Field>> = [];
+  const links: Array<LinkModel<DataLinkContext>> = [];
   const linkLookup = new Set<string>();
 
   if (field.getLinks) {

--- a/public/app/plugins/panel/status-history/StatusHistoryTooltip.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryTooltip.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   DataFrame,
   FALLBACK_COLOR,
-  Field,
   getDisplayProcessor,
   getFieldDisplayName,
   TimeZone,
@@ -34,7 +33,7 @@ export const StatusHistoryTooltip = ({
 
   const field = alignedData.fields[seriesIdx!];
 
-  const links: Array<LinkModel<Field>> = [];
+  const links: LinkModel[] = [];
   const linkLookup = new Set<string>();
 
   if (field.getLinks) {


### PR DESCRIPTION
Adds the relevant data frame `frame` to the context passed to the click handler for table cell data links.

Closes https://github.com/grafana/scenes/issues/355