### PR TITLE
Theme: Add borderTransparent to ThemeRichColor use in Box borders

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -294,6 +294,9 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
     if (!color.contrastText) {
       color.contrastText = getContrastText(color.main);
     }
+    if (!color.borderTranparent) {
+      color.borderTranparent = alpha(color.border, 0.3);
+    }
     return color as ThemeRichColor;
   };
 

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -294,8 +294,8 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
     if (!color.contrastText) {
       color.contrastText = getContrastText(color.main);
     }
-    if (!color.borderTranparent) {
-      color.borderTranparent = alpha(color.border, 0.3);
+    if (!color.borderTransparent) {
+      color.borderTransparent = alpha(color.border, 0.3);
     }
     return color as ThemeRichColor;
   };

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -295,7 +295,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
       color.contrastText = getContrastText(color.main);
     }
     if (!color.borderTransparent) {
-      color.borderTransparent = alpha(color.border, 0.3);
+      color.borderTransparent = alpha(color.border, 0.25);
     }
     return color as ThemeRichColor;
   };

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -49,6 +49,8 @@ export interface ThemeRichColor {
   border: string;
   /** Used subtly colored backgrounds */
   transparent: string;
+  /** Used for weak borders like larger alert/banner boxes */
+  borderTranparent: string;
   /** Text color for text ontop of main */
   contrastText: string;
 }

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -49,7 +49,7 @@ export interface ThemeRichColor {
   border: string;
   /** Used subtly colored backgrounds */
   transparent: string;
-  /** Used for weak borders like larger alert/banner boxes */
+  /** Used for weak colored borders like larger alert/banner boxes and smaller badges and tags */
   borderTransparent: string;
   /** Text color for text ontop of main */
   contrastText: string;

--- a/packages/grafana-data/src/themes/types.ts
+++ b/packages/grafana-data/src/themes/types.ts
@@ -50,7 +50,7 @@ export interface ThemeRichColor {
   /** Used subtly colored backgrounds */
   transparent: string;
   /** Used for weak borders like larger alert/banner boxes */
-  borderTranparent: string;
+  borderTransparent: string;
   /** Text color for text ontop of main */
   contrastText: string;
 }

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -46,11 +46,11 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
 
   if (theme.isDark) {
     bgColor = tinycolor(sourceColor).setAlpha(0.15).toString();
-    borderColor = tinycolor(sourceColor).darken(30).toString();
+    borderColor = tinycolor(sourceColor).setAlpha(0.3).toString();
     textColor = tinycolor(sourceColor).lighten(15).toString();
   } else {
     bgColor = tinycolor(sourceColor).setAlpha(0.15).toString();
-    borderColor = tinycolor(sourceColor).lighten(20).toString();
+    borderColor = tinycolor(sourceColor).setAlpha(0.3).toString();
     textColor = tinycolor(sourceColor).darken(20).toString();
   }
 

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -46,11 +46,11 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
 
   if (theme.isDark) {
     bgColor = tinycolor(sourceColor).setAlpha(0.15).toString();
-    borderColor = tinycolor(sourceColor).setAlpha(0.3).toString();
+    borderColor = tinycolor(sourceColor).setAlpha(0.25).toString();
     textColor = tinycolor(sourceColor).lighten(15).toString();
   } else {
     bgColor = tinycolor(sourceColor).setAlpha(0.15).toString();
-    borderColor = tinycolor(sourceColor).setAlpha(0.3).toString();
+    borderColor = tinycolor(sourceColor).setAlpha(0.25).toString();
     textColor = tinycolor(sourceColor).darken(20).toString();
   }
 

--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -136,7 +136,7 @@ const customBorderColor = (color: BorderColor, theme: GrafanaTheme2) => {
     case 'success':
     case 'info':
     case 'warning':
-      return theme.colors[color].border;
+      return theme.colors[color].borderTranparent;
     default:
       return color ? theme.colors.border[color] : undefined;
   }

--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -136,7 +136,7 @@ const customBorderColor = (color: BorderColor, theme: GrafanaTheme2) => {
     case 'success':
     case 'info':
     case 'warning':
-      return theme.colors[color].borderTranparent;
+      return theme.colors[color].borderTransparent;
     default:
       return color ? theme.colors.border[color] : undefined;
   }

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -27,7 +27,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
     <Flex alignItems="center" justifyContent="center">
       <div className={styles.wrapper}>
         <Flex alignItems="stretch" justifyContent="center" gap={4} direction="column">
-          <Box borderStyle="dashed" borderColor="info" padding={4}>
+          <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={4}>
             <Flex direction="column" alignItems="center" gap={2}>
               <Text element="h1" textAlignment="center" weight="medium">
                 <Trans i18nKey="dashboard.empty.add-visualization-header">
@@ -60,7 +60,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
           </Box>
           <Flex direction={{ xs: 'column', md: 'row' }} wrap="wrap" gap={4}>
             {config.featureToggles.vizAndWidgetSplit && (
-              <Box borderStyle="dashed" borderColor="info" padding={3} grow={1}>
+              <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
                 <Flex direction="column" alignItems="center" gap={1}>
                   <Text element="h3" textAlignment="center" weight="medium">
                     <Trans i18nKey="dashboard.empty.add-widget-header">Add a widget</Trans>
@@ -85,7 +85,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Flex>
               </Box>
             )}
-            <Box borderStyle="dashed" borderColor="info" padding={3} grow={1}>
+            <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
               <Flex direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.add-library-panel-header">Import panel</Trans>
@@ -111,7 +111,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Button>
               </Flex>
             </Box>
-            <Box borderStyle="dashed" borderColor="info" padding={3} grow={1}>
+            <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
               <Flex direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.import-a-dashboard-header">Import a dashboard</Trans>

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -27,7 +27,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
     <Flex alignItems="center" justifyContent="center">
       <div className={styles.wrapper}>
         <Flex alignItems="stretch" justifyContent="center" gap={4} direction="column">
-          <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={4}>
+          <Box borderColor="strong" borderStyle="dashed" padding={4}>
             <Flex direction="column" alignItems="center" gap={2}>
               <Text element="h1" textAlignment="center" weight="medium">
                 <Trans i18nKey="dashboard.empty.add-visualization-header">
@@ -60,7 +60,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
           </Box>
           <Flex direction={{ xs: 'column', md: 'row' }} wrap="wrap" gap={4}>
             {config.featureToggles.vizAndWidgetSplit && (
-              <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
+              <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
                 <Flex direction="column" alignItems="center" gap={1}>
                   <Text element="h3" textAlignment="center" weight="medium">
                     <Trans i18nKey="dashboard.empty.add-widget-header">Add a widget</Trans>
@@ -85,7 +85,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Flex>
               </Box>
             )}
-            <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
+            <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
               <Flex direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.add-library-panel-header">Import panel</Trans>
@@ -111,7 +111,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Button>
               </Flex>
             </Box>
-            <Box backgroundColor="primary" borderColor="weak" borderStyle="solid" padding={3} grow={1}>
+            <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
               <Flex direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.import-a-dashboard-header">Import a dashboard</Trans>


### PR DESCRIPTION
Restores the v10 Alert design by adding a new theme color to ThemeRichColor 

* Make Box use this new color for border (makes sense as it uses the .transparent color for the background always) 
* Update the DashboardEmpty to use panel containers (using Box still), as the dashed border is not working great with the weaker border (and no box background). And it's not a design we use anywhere else. (not sure Box should have borderStyle). It would be nice if just setting Box borderColor set border style to solid automatically, now you have to set so many props to get a border. 
* Tweak Badge border to use same alpha value (We can look at unifying Badge later, esp the red color would be nice to unify, Badge takes it's red from the visualization palette which is a different red from our theme.colors.error.* reds) 

![Screenshot from 2023-09-26 07-42-59](https://github.com/grafana/grafana/assets/10999/6f0bf7a3-32b8-4e27-9273-acf78ce63c6d)
![Screenshot from 2023-09-26 07-42-53](https://github.com/grafana/grafana/assets/10999/dbb0e19c-8402-480f-8b1e-a30a2c5ab2d8)
 
DashboardEmpty: 
![image](https://github.com/grafana/grafana/assets/10999/f0f5e329-4604-47c3-91a9-c0d4de28a52d)

