### PR TITLE
Tempo: Use timezone of selected range for timestamps

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -117,8 +117,8 @@ describe('createTableFrameFromSearch()', () => {
     expect(frame.fields[2].values[0]).toBe('app');
 
     expect(frame.fields[3].name).toBe('startTime');
-    expect(frame.fields[3].values[0]).toBe('2022-01-28 03:00:28');
-    expect(frame.fields[3].values[1]).toBe('2022-01-27 22:56:06');
+    expect(frame.fields[3].values[0]).toBe(1643356828724);
+    expect(frame.fields[3].values[1]).toBe(1643342166678.0002);
 
     expect(frame.fields[4].name).toBe('traceDuration');
     expect(frame.fields[4].values[0]).toBe(65);
@@ -135,8 +135,8 @@ describe('createTableFrameFromTraceQlQuery()', () => {
     expect(frame.fields[0].config.unit).toBe('string');
     // Start time field
     expect(frame.fields[1].name).toBe('startTime');
-    expect(frame.fields[1].type).toBe('string');
-    expect(frame.fields[1].values[1]).toBe('2022-01-27 22:56:06');
+    expect(frame.fields[1].type).toBe('time');
+    expect(frame.fields[1].values[1]).toBe(1643342166678.0002);
     // Trace service field
     expect(frame.fields[2].name).toBe('traceService');
     expect(frame.fields[2].type).toBe('string');
@@ -158,7 +158,7 @@ describe('createTableFrameFromTraceQlQuery()', () => {
     expect(frame.fields[5].values[0][0].fields[1].name).toBe('spanID');
     expect(frame.fields[5].values[0][0].fields[1].values[0]).toBe('162a4adae63b61f1');
     expect(frame.fields[5].values[0][0].fields[2].name).toBe('spanStartTime');
-    expect(frame.fields[5].values[0][0].fields[2].values[0]).toBe('2022-10-19 09:03:34');
+    expect(frame.fields[5].values[0][0].fields[2].values[0]).toBe(1666188214303.201);
     expect(frame.fields[5].values[0][0].fields[4].name).toBe('http.method');
     expect(frame.fields[5].values[0][0].fields[4].values[0]).toBe('GET');
     expect(frame.fields[5].values[0][0].fields[5].name).toBe('service.name');
@@ -171,7 +171,7 @@ describe('createTableFrameFromTraceQlQuery()', () => {
     expect(frame.fields[5].values[1][0].fields[1].name).toBe('spanID');
     expect(frame.fields[5].values[1][0].fields[1].values[0]).toBe('3b9a5c222d3ddd8f');
     expect(frame.fields[5].values[1][0].fields[2].name).toBe('spanStartTime');
-    expect(frame.fields[5].values[1][0].fields[2].values[0]).toBe('2022-10-19 08:57:55');
+    expect(frame.fields[5].values[1][0].fields[2].values[0]).toBe(1666187875397.7212);
     expect(frame.fields[5].values[1][0].fields[4].name).toBe('by(resource.service.name)');
     expect(frame.fields[5].values[1][0].fields[4].values[0]).toBe('db');
     expect(frame.fields[5].values[1][0].fields[5].name).toBe('http.method');
@@ -186,7 +186,7 @@ describe('createTableFrameFromTraceQlQuery()', () => {
     expect(frame.fields[5].values[1][1].fields[1].name).toBe('spanID');
     expect(frame.fields[5].values[1][1].fields[1].values[0]).toBe('894d90db6b5807f');
     expect(frame.fields[5].values[1][1].fields[2].name).toBe('spanStartTime');
-    expect(frame.fields[5].values[1][1].fields[2].values[0]).toBe('2022-10-19 08:57:55');
+    expect(frame.fields[5].values[1][1].fields[2].values[0]).toBe(1666187875393.293);
     expect(frame.fields[5].values[1][1].fields[4].name).toBe('by(resource.service.name)');
     expect(frame.fields[5].values[1][1].fields[4].values[0]).toBe('app');
     expect(frame.fields[5].values[1][1].fields[5].name).toBe('http.method');

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -12,7 +12,6 @@ import {
   TraceLog,
   TraceSpanReference,
   TraceSpanRow,
-  dateTimeFormat,
   FieldDTO,
   createDataFrame,
   getDisplayProcessor,
@@ -533,7 +532,7 @@ export function createTableFrameFromSearch(data: TraceSearchMetadata[], instance
       },
       { name: 'traceService', type: FieldType.string, config: { displayNameFromDS: 'Trace service' } },
       { name: 'traceName', type: FieldType.string, config: { displayNameFromDS: 'Trace name' } },
-      { name: 'startTime', type: FieldType.string, config: { displayNameFromDS: 'Start time' } },
+      { name: 'startTime', type: FieldType.time, config: { displayNameFromDS: 'Start time' } },
       { name: 'traceDuration', type: FieldType.number, config: { displayNameFromDS: 'Duration', unit: 'ms' } },
     ],
     meta: {
@@ -556,12 +555,9 @@ export function createTableFrameFromSearch(data: TraceSearchMetadata[], instance
 }
 
 function transformToTraceData(data: TraceSearchMetadata) {
-  const traceStartTime = parseInt(data.startTimeUnixNano!, 10) / 1000000;
-  const startTime = !isNaN(traceStartTime) ? dateTimeFormat(traceStartTime) : '';
-
   return {
     traceID: data.traceID,
-    startTime,
+    startTime: parseInt(data.startTimeUnixNano!, 10) / 1000000,
     traceDuration: data.durationMs,
     traceService: data.rootServiceName || '',
     traceName: data.rootTraceName || '',
@@ -603,7 +599,7 @@ export function createTableFrameFromTraceQlQuery(
       },
       {
         name: 'startTime',
-        type: FieldType.string,
+        type: FieldType.time,
         config: {
           displayNameFromDS: 'Start time',
           custom: {
@@ -733,7 +729,7 @@ const traceSubFrame = (
       },
       {
         name: 'spanStartTime',
-        type: FieldType.string,
+        type: FieldType.time,
         config: {
           displayNameFromDS: 'Start time',
           custom: {
@@ -780,19 +776,16 @@ interface TraceTableData {
   [key: string]: string | number | boolean | undefined; // dynamic attribute name
   traceID?: string;
   spanID?: string;
-  startTime?: string;
+  startTime?: number;
   name?: string;
   traceDuration?: number;
 }
 
 function transformSpanToTraceData(span: Span, spanSet: Spanset, traceID: string): TraceTableData {
-  const spanStartTimeUnixMs = parseInt(span.startTimeUnixNano, 10) / 1000000;
-  let spanStartTime = dateTimeFormat(spanStartTimeUnixMs);
-
   const data: TraceTableData = {
     traceIdHidden: traceID,
     spanID: span.spanID,
-    spanStartTime,
+    spanStartTime: parseInt(span.startTimeUnixNano, 10) / 1000000,
     duration: parseInt(span.durationNanos, 10),
     name: span.name,
   };


### PR DESCRIPTION
In the Search or TraceQL tabs, users can select traces and filter them using a time range—traces outside of the specified time range are discarded. For this time range, Grafana uses by default the browser timezone, but the user can override it. However, when the user overrides the timezone, the timestamps of the returned traces are not formatted using the chosen timezone. This has been reported by at least one customer to be misleading.

This PR fixes the issue by resorting on the default formatting of the `Table` component. Example of outcome when selecting traces for the last 6 hours at around 11:45 AM UTC:
- With default (browser) timezone (UTC+2, and thus 1:45 PM UTC):
<img width="1440" alt="Screenshot 2023-09-26 at 13 49 56" src="https://github.com/grafana/grafana/assets/135109076/1dfabcf2-6968-4876-a5b9-e886ce3afcce">

- Using UTC as timezone:
<img width="1440" alt="Screenshot 2023-09-26 at 13 50 06" src="https://github.com/grafana/grafana/assets/135109076/f9689881-2152-4c7b-a2af-a3dcc6d3a776">
