### PR TITLE
Alerting: Fix calculation of the matching routes for notification policies when trying to match missing label

### DIFF
--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -107,36 +107,3 @@ export const normalizeMatchers = (route: Route): ObjectMatcher[] => {
 
   return matchers;
 };
-
-export type Label = [string, string];
-type OperatorPredicate = (labelValue: string, matcherValue: string) => boolean;
-const OperatorFunctions: Record<MatcherOperator, OperatorPredicate> = {
-  [MatcherOperator.equal]: (lv, mv) => lv === mv,
-  [MatcherOperator.notEqual]: (lv, mv) => lv !== mv,
-  [MatcherOperator.regex]: (lv, mv) => new RegExp(mv).test(lv),
-  [MatcherOperator.notRegex]: (lv, mv) => !new RegExp(mv).test(lv),
-};
-
-function isLabelMatch(matcher: ObjectMatcher, label: Label) {
-  const [labelKey, labelValue] = label;
-  const [matcherKey, operator, matcherValue] = matcher;
-
-  // not interested, keys don't match
-  if (labelKey !== matcherKey) {
-    return false;
-  }
-
-  const matchFunction = OperatorFunctions[operator];
-  if (!matchFunction) {
-    throw new Error(`no such operator: ${operator}`);
-  }
-
-  return matchFunction(labelValue, matcherValue);
-}
-
-// check if every matcher returns "true" for the set of labels
-export function labelsMatchObjectMatchers(matchers: ObjectMatcher[], labels: Label[]) {
-  return matchers.every((matcher) => {
-    return labels.some((label) => isLabelMatch(matcher, label));
-  });
-}

--- a/public/app/features/alerting/unified/utils/notification-policies.test.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.test.ts
@@ -1,10 +1,10 @@
 import { MatcherOperator, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
-import { Label } from './matchers';
 import {
   computeInheritedTree,
   findMatchingRoutes,
   getInheritedProperties,
+  Label,
   normalizeRoute,
 } from './notification-policies';
 

--- a/public/app/features/alerting/unified/utils/notification-policies.test.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.test.ts
@@ -1,10 +1,11 @@
 import { MatcherOperator, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
+import { Label } from './matchers';
 import {
-  findMatchingRoutes,
-  normalizeRoute,
-  getInheritedProperties,
   computeInheritedTree,
+  findMatchingRoutes,
+  getInheritedProperties,
+  normalizeRoute,
 } from './notification-policies';
 
 import 'core-js/stable/structured-clone';
@@ -38,15 +39,28 @@ describe('findMatchingRoutes', () => {
         receiver: 'C',
         object_matchers: [['foo', MatcherOperator.equal, 'bar']],
       },
+      {
+        receiver: 'D',
+        object_matchers: [['empty', MatcherOperator.equal, '']],
+      },
     ],
     group_wait: '10s',
     group_interval: '1m',
   };
 
+  const emptyLabel: Label = ['empty', ''];
+  const notEmptyLabel: Label = ['empty', 'something'];
+
   it('should match root route with no matching labels', () => {
-    const matches = findMatchingRoutes(policies, []);
+    const matches = findMatchingRoutes(policies, [notEmptyLabel]);
     expect(matches).toHaveLength(1);
     expect(matches[0].route).toHaveProperty('receiver', 'ROOT');
+  });
+
+  it('should not match root route when match policy with empty value', () => {
+    const matches = findMatchingRoutes(policies, [emptyLabel]);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].route).toHaveProperty('receiver', 'D');
   });
 
   it('should match parent route with no matching children', () => {

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -9,7 +9,9 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { Labels } from 'app/types/unified-alerting-dto';
 
-import { Label, normalizeMatchers } from './matchers';
+import { normalizeMatchers } from './matchers';
+
+export type Label = [string, string];
 
 type OperatorPredicate = (labelValue: string, matcherValue: string) => boolean;
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes the calculation of the matching routes when notification policy matches missing label.

This error is shown in:
- Notification policy view
- when previewing routes in alert form

as both cases use the same algorithm.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes (https://github.com/grafana/grafana/issues/75196)

**Special notes for your reviewer:**

https://github.com/grafana/grafana/assets/33540275/0bcbbbb3-3aab-4d55-9d50-c4a6ffbe76b0


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
