### PR TITLE
Bug: Exclude 32-bit `arm` builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -587,7 +587,7 @@ steps:
     token:
       from_secret: drone_token
 - commands:
-  - /src/grafana-build package --distro=linux/amd64,linux/arm64,linux/arm/v7 --go-version=1.20.8
+  - /src/grafana-build package --distro=linux/amd64,linux/arm64 --go-version=1.20.8
     --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER --grafana-dir=$$PWD
     > packages.txt
   depends_on:
@@ -1744,7 +1744,7 @@ steps:
   image: node:18.12.0-alpine
   name: build-frontend-packages
 - commands:
-  - /src/grafana-build package --distro=linux/amd64,linux/arm64,linux/arm/v7 --go-version=1.20.8
+  - /src/grafana-build package --distro=linux/amd64,linux/arm64 --go-version=1.20.8
     --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER --grafana-dir=$$PWD
     > packages.txt
   depends_on:
@@ -4212,6 +4212,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 84da089797850e74589428fafc6485435b968df9183a7ee7203ae2cd03f420c1
+hmac: c14ca5e053041018df6b66df642accd7e7eee7e2b43ba8c8f7dee6c446a41bb0
 
 ...

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -1,7 +1,5 @@
 package config
 
-const PublicBucket = "grafana-downloads"
-
 var Versions = VersionMap{
 	PullRequestMode: {
 		Variants: []Variant{
@@ -9,8 +7,9 @@ var Versions = VersionMap{
 			VariantLinuxAmd64Musl,
 			VariantDarwinAmd64,
 			VariantWindowsAmd64,
-			VariantArm64,
-			VariantArm64Musl,
+			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+			// VariantArm64,
+			// VariantArm64Musl,
 		},
 		PluginSignature: PluginSignature{
 			Sign:      false,
@@ -29,9 +28,10 @@ var Versions = VersionMap{
 	},
 	MainMode: {
 		Variants: []Variant{
-			VariantArmV6,
-			VariantArmV7,
-			VariantArmV7Musl,
+			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+			// VariantArmV6,
+			// VariantArmV7,
+			// VariantArmV7Musl,
 			VariantArm64,
 			VariantArm64Musl,
 			VariantDarwinAmd64,
@@ -48,7 +48,8 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
+				// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+				// ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
 			},
 			Distribution: []Distribution{
 				Alpine,
@@ -65,9 +66,9 @@ var Versions = VersionMap{
 	DownstreamMode: {
 		Variants: []Variant{
 			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
-			//VariantArmV6,
+			// VariantArmV6,
 			//VariantArmV7,
-			//VariantArmV7Musl,
+			// VariantArmV7Musl,
 			VariantArm64,
 			VariantArm64Musl,
 			VariantDarwinAmd64,
@@ -173,9 +174,10 @@ var Versions = VersionMap{
 	},
 	Enterprise2Mode: {
 		Variants: []Variant{
-			VariantArmV6,
-			VariantArmV7,
-			VariantArmV7Musl,
+			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+			// VariantArmV6,
+			// VariantArmV7,
+			// VariantArmV7Musl,
 			VariantArm64,
 			VariantArm64Musl,
 			VariantDarwinAmd64,
@@ -192,7 +194,8 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARMv7,
+				// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+				// ArchARMv7,
 			},
 			Distribution: []Distribution{
 				Alpine,

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -82,7 +82,7 @@ def build_e2e(trigger, ver_mode):
 
     build_steps.extend(
         [
-            rgm_package_step(distros = "linux/amd64,linux/arm64,linux/arm/v7", file = "packages.txt"),
+            rgm_package_step(distros = "linux/amd64,linux/arm64", file = "packages.txt"),
             grafana_server_step(),
             e2e_tests_step("dashboards-suite"),
             e2e_tests_step("smoke-tests-suite"),


### PR DESCRIPTION
**What is this feature?**

Excludes `armv6` and `armv7` builds for PR, main and downstream pipelines.

**Why do we need this feature?**

Blocks all enterprise pipelines.

Part of https://github.com/grafana/grafana-delivery/issues/250

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
