### PR TITLE
GrafanaUI: Adds overflow wrapper to loading bar

### DIFF
--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -1,5 +1,7 @@
-import { css, cx, keyframes } from '@emotion/css';
-import React from 'react';
+import { css, keyframes } from '@emotion/css';
+import React, { CSSProperties } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 
@@ -17,41 +19,43 @@ const DEFAULT_ANIMATION_DELAY = 300;
 const MAX_TRANSLATE_X = (100 / BAR_WIDTH) * 100;
 
 export function LoadingBar({ width, delay = DEFAULT_ANIMATION_DELAY, ariaLabel = 'Loading bar' }: LoadingBarProps) {
-  const styles = useStyles2(getStyles);
   const durationMs = Math.min(Math.max(Math.round(width * MILLISECONDS_PER_PIXEL), MIN_DURATION_MS), MAX_DURATION_MS);
-  const animationStyles = {
-    animationName: styles.animation,
-    // an initial delay to prevent the loader from showing if the response is faster than the delay
-    animationDelay: `${delay}ms`,
-    animationDuration: `${durationMs}ms`,
-    animationTimingFunction: 'linear',
-    animationIterationCount: 'infinite',
-    willChange: 'transform',
+  const styles = useStyles2((theme) => getStyles(theme, delay, durationMs));
+  const containerStyles: CSSProperties = {
+    overflow: 'hidden',
   };
 
   return (
-    <div style={{ overflow: 'hidden' }}>
-      <div aria-label={ariaLabel} className={cx(styles.bar, css(animationStyles))} />
+    <div style={containerStyles}>
+      <div aria-label={ariaLabel} className={styles.bar} />
     </div>
   );
 }
 
-const getStyles = () => {
+const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
+  const animation = keyframes({
+    '0%': {
+      transform: 'translateX(-100%)',
+    },
+    // this gives us a delay between iterations
+    '85%, 100%': {
+      transform: `translateX(${MAX_TRANSLATE_X}%)`,
+    },
+  });
+
   return {
-    animation: keyframes({
-      '0%': {
-        transform: 'translateX(-100%)',
-      },
-      // this gives us a delay between iterations
-      '85%, 100%': {
-        transform: `translateX(${MAX_TRANSLATE_X}%)`,
-      },
-    }),
     bar: css({
       width: BAR_WIDTH + '%',
       height: 1,
       background: 'linear-gradient(90deg, rgba(110, 159, 255, 0) 0%, #6E9FFF 80.75%, rgba(110, 159, 255, 0) 100%)',
       transform: 'translateX(-100%)',
+      animationName: animation,
+      // an initial delay to prevent the loader from showing if the response is faster than the delay
+      animationDelay: `${delay}ms`,
+      animationDuration: `${duration}ms`,
+      animationTimingFunction: 'linear',
+      animationIterationCount: 'infinite',
+      willChange: 'transform',
     }),
   };
 };

--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -1,29 +1,37 @@
-import { css, keyframes } from '@emotion/css';
-import React, { CSSProperties } from 'react';
+import { css, cx, keyframes } from '@emotion/css';
+import React from 'react';
 
 import { useStyles2 } from '../../themes';
 
 export interface LoadingBarProps {
   width: number;
+  delay?: number;
   ariaLabel?: string;
 }
 
+const BAR_WIDTH = 28;
 const MILLISECONDS_PER_PIXEL = 2.4;
 const MIN_DURATION_MS = 500;
 const MAX_DURATION_MS = 4000;
+const DEFAULT_ANIMATION_DELAY = 300;
+const MAX_TRANSLATE_X = (100 / BAR_WIDTH) * 100;
 
-export function LoadingBar({ width, ariaLabel = 'Loading bar' }: LoadingBarProps) {
+export function LoadingBar({ width, delay = DEFAULT_ANIMATION_DELAY, ariaLabel = 'Loading bar' }: LoadingBarProps) {
   const styles = useStyles2(getStyles);
   const durationMs = Math.min(Math.max(Math.round(width * MILLISECONDS_PER_PIXEL), MIN_DURATION_MS), MAX_DURATION_MS);
-  const containerStyles: CSSProperties = {
-    width: '100%',
-    animation: `${styles.animation} ${durationMs}ms infinite linear`,
+  const animationStyles = {
+    animationName: styles.animation,
+    // an initial delay to prevent the loader from showing if the response is faster than the delay
+    animationDelay: `${delay}ms`,
+    animationDuration: `${durationMs}ms`,
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
     willChange: 'transform',
   };
 
   return (
-    <div style={containerStyles}>
-      <div aria-label={ariaLabel} className={styles.bar} />
+    <div style={{ overflow: 'hidden' }}>
+      <div aria-label={ariaLabel} className={cx(styles.bar, css(animationStyles))} />
     </div>
   );
 }
@@ -32,16 +40,18 @@ const getStyles = () => {
   return {
     animation: keyframes({
       '0%': {
-        transform: 'translateX(-50%)',
+        transform: 'translateX(-100%)',
       },
-      '100%': {
-        transform: `translateX(100%)`,
+      // this gives us a delay between iterations
+      '85%, 100%': {
+        transform: `translateX(${MAX_TRANSLATE_X}%)`,
       },
     }),
     bar: css({
-      width: '28%',
+      width: BAR_WIDTH + '%',
       height: 1,
       background: 'linear-gradient(90deg, rgba(110, 159, 255, 0) 0%, #6E9FFF 80.75%, rgba(110, 159, 255, 0) 100%)',
+      transform: 'translateX(-100%)',
     }),
   };
 };

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -395,7 +395,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'absolute',
       top: 0,
       width: '100%',
-      overflow: 'hidden',
     }),
     containNone: css({
       contain: 'none',


### PR DESCRIPTION
**What is this feature?**

This PR removes the necessity to wrap the loading bar with a `<div style={{ overflow: 'hidden' }} >` container.

Additionally, allows a `delay` to be manually specified.

**Why do we need this feature?**

In Alerting we've a few places where we'd love to use the `<LoadingBar />` for some new designs and wrapping it seems unnecessary since it will always require a container with overflow styling.