### PR TITLE
Service accounts: Only create service accounts using the NoneRole by default

### DIFF
--- a/pkg/services/oauthserver/oasimpl/service.go
+++ b/pkg/services/oauthserver/oasimpl/service.go
@@ -455,7 +455,7 @@ func (s *OAuth2ServiceImpl) createServiceAccount(ctx context.Context, extSvcName
 	s.logger.Debug("Generate service account", "external service name", extSvcName, "orgID", oauthserver.TmpOrgID, "name", slug)
 	sa, err := s.saService.CreateServiceAccount(ctx, oauthserver.TmpOrgID, &serviceaccounts.CreateServiceAccountForm{
 		Name:       slug,
-		Role:       newRole(roletype.RoleViewer), // FIXME: Use empty role
+		Role:       newRole(roletype.RoleNone),
 		IsDisabled: newBool(false),
 	})
 	if err != nil {

--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -47,7 +47,8 @@ func (s *ServiceAccountsStoreImpl) CreateServiceAccount(ctx context.Context, org
 	generatedLogin := "sa-" + strings.ToLower(saForm.Name)
 	generatedLogin = strings.ReplaceAll(generatedLogin, " ", "-")
 	isDisabled := false
-	role := org.RoleViewer
+	// default to None role
+	role := org.RoleNone
 	if saForm.IsDisabled != nil {
 		isDisabled = *saForm.IsDisabled
 	}


### PR DESCRIPTION
**What is this feature?**

- Changes the default role for service account creation from `Viewer` to `None` by default.

```[tasklist]
- [x] https://github.com/grafana/grafana/pull/75949
- [ ] merge this PR with note on breaking changes
```

Confirmed that changing the oauth server to `None` from @gamab ✅ 

**Why do we need this feature?**
We want to minimize the permissions upon creation of a service account.

**Special notes for your reviewer:**

This is a breaking change as if you have been relying on service account endpoint creating a `Viewer` by default this will change to create a `None` role instead.

