### PR TITLE
Elasticsearch: Added support for calendar_interval in ES date histogram queries

### DIFF
--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -212,14 +212,20 @@ type HistogramAgg struct {
 
 // DateHistogramAgg represents a date histogram aggregation
 type DateHistogramAgg struct {
-	Field          string          `json:"field"`
-	FixedInterval  string          `json:"fixed_interval,omitempty"`
-	MinDocCount    int             `json:"min_doc_count"`
-	Missing        *string         `json:"missing,omitempty"`
-	ExtendedBounds *ExtendedBounds `json:"extended_bounds"`
-	Format         string          `json:"format"`
-	Offset         string          `json:"offset,omitempty"`
-	TimeZone       string          `json:"time_zone,omitempty"`
+	Field            string          `json:"field"`
+	FixedInterval    string          `json:"fixed_interval,omitempty"`
+	CalendarInterval string          `json:"calendar_interval,omitempty"`
+	MinDocCount      int             `json:"min_doc_count"`
+	Missing          *string         `json:"missing,omitempty"`
+	ExtendedBounds   *ExtendedBounds `json:"extended_bounds"`
+	Format           string          `json:"format"`
+	Offset           string          `json:"offset,omitempty"`
+	TimeZone         string          `json:"time_zone,omitempty"`
+}
+
+// GetCalendarIntervals provides the list of intervals used for building calendar bucketAgg
+func GetCalendarIntervals() []string {
+	return []string{"1w", "1M", "1q", "1y"}
 }
 
 // FiltersAggregation represents a filters aggregation

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+    "golang.org/x/exp/slices"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -53,6 +54,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 	from := e.dataQueries[0].TimeRange.From.UnixNano() / int64(time.Millisecond)
 	to := e.dataQueries[0].TimeRange.To.UnixNano() / int64(time.Millisecond)
 	for _, q := range queries {
+		fmt.Printf("Query = %v", q)
 		if err := e.processQuery(q, ms, from, to); err != nil {
 			mq, _ := json.Marshal(q)
 			e.logger.Error("Failed to process query to multisearch request builder", "error", err, "query", string(mq), "queriesLength", len(queries), "duration", time.Since(start), "stage", es.StagePrepareRequest)
@@ -160,21 +162,26 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 		field = timeField
 	}
 	aggBuilder.DateHistogram(bucketAgg.ID, field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
-		a.FixedInterval = bucketAgg.Settings.Get("interval").MustString("auto")
+		var interval string = bucketAgg.Settings.Get("interval").MustString("auto")
+		if slices.Contains(es.GetCalendarIntervals(), interval) {
+			a.CalendarInterval = interval
+		} else {
+			if interval == "auto" {
+				// note this is not really a valid grafana-variable-handling,
+				// because normally this would not match `$__interval_ms`,
+				// but because how we apply these in the go-code, this will work
+				// correctly, and becomes something like `500ms`.
+				// a nicer way would be to use `${__interval_ms}ms`, but
+				// that format is not recognized where we apply these variables
+				// in the elasticsearch datasource
+				a.FixedInterval = "$__interval_msms"
+			} else {
+				a.FixedInterval = interval
+			}
+		}
 		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
 		a.ExtendedBounds = &es.ExtendedBounds{Min: timeFrom, Max: timeTo}
 		a.Format = bucketAgg.Settings.Get("format").MustString(es.DateFormatEpochMS)
-
-		if a.FixedInterval == "auto" {
-			// note this is not really a valid grafana-variable-handling,
-			// because normally this would not match `$__interval_ms`,
-			// but because how we apply these in the go-code, this will work
-			// correctly, and becomes something like `500ms`.
-			// a nicer way would be to use `${__interval_ms}ms`, but
-			// that format is not recognized where we apply these variables
-			// in the elasticsearch datasource
-			a.FixedInterval = "$__interval_msms"
-		}
 
 		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {
 			a.Offset = offset

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-    "golang.org/x/exp/slices"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -162,7 +162,7 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 		field = timeField
 	}
 	aggBuilder.DateHistogram(bucketAgg.ID, field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
-		var interval string = bucketAgg.Settings.Get("interval").MustString("auto")
+		var interval = bucketAgg.Settings.Get("interval").MustString("auto")
 		if slices.Contains(es.GetCalendarIntervals(), interval) {
 			a.CalendarInterval = interval
 		} else {

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1781,7 +1781,7 @@ func TestSettingsCasting(t *testing.T) {
 			assert.Equal(t, dateHistogramAgg.FixedInterval, "1d")
 		})
 
-		t.Run("Should use fixed_interval", func(t *testing.T) {
+		t.Run("Should use calendar_interval", func(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "count", "id": "1" }],

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1459,7 +1459,7 @@ func TestSettingsCasting(t *testing.T) {
 								"gamma": "3",
 								"period": "4"
 							}
-						} 
+						}
 					}
 				],
 				"bucketAggs": [{"type": "date_histogram", "field": "@timestamp", "id": "1"}]
@@ -1669,6 +1669,31 @@ func TestSettingsCasting(t *testing.T) {
 
 				assert.NotZero(t, dateHistogramAgg.FixedInterval)
 			})
+
+			t.Run("Uses calendar_interval", func(t *testing.T) {
+				c := newFakeClient()
+				_, err := executeElasticsearchDataQuery(c, `{
+					"bucketAggs": [
+						{
+							"type": "date_histogram",
+							"field": "@timestamp",
+							"id": "2",
+							"settings": {
+								"interval": "1M"
+							}
+						}
+					],
+					"metrics": [
+						{ "id": "1", "type": "average", "field": "@value" }
+					]
+				}`, from, to)
+				assert.Nil(t, err)
+				sr := c.multisearchRequests[0].Requests[0]
+
+				dateHistogramAgg := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
+
+				assert.NotZero(t, dateHistogramAgg.CalendarInterval)
+			})
 		})
 	})
 
@@ -1754,6 +1779,21 @@ func TestSettingsCasting(t *testing.T) {
 			sr := c.multisearchRequests[0].Requests[0]
 			dateHistogramAgg := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
 			assert.Equal(t, dateHistogramAgg.FixedInterval, "1d")
+		})
+
+		t.Run("Should use fixed_interval", func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeElasticsearchDataQuery(c, `{
+				"metrics": [{ "type": "count", "id": "1" }],
+				"bucketAggs": [
+					{ "type": "date_histogram", "id": "2", "field": "@time", "settings": { "min_doc_count": "1", "interval": "1w" } }
+				]
+			}`, from, to)
+
+			assert.Nil(t, err)
+			sr := c.multisearchRequests[0].Requests[0]
+			dateHistogramAgg := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
+			assert.Equal(t, dateHistogramAgg.CalendarInterval, "1w")
 		})
 	})
 }

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
@@ -899,6 +899,25 @@ describe('ElasticQueryBuilder', () => {
           expect(query.aggs['2'].date_histogram.interval).toBeUndefined();
           expect(query.aggs['2'].date_histogram.fixed_interval).toBe('1d');
         });
+
+        it('should use calendar_interval', () => {
+          const query = builder.build({
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            timeField: '@timestamp',
+            bucketAggs: [
+              {
+                type: 'date_histogram',
+                id: '2',
+                field: '@time',
+                settings: { min_doc_count: '1', interval: '1w' },
+              },
+            ],
+          });
+
+          expect(query.aggs['2'].date_histogram.interval).toBeUndefined();
+          expect(query.aggs['2'].date_histogram.calendar_interval).toBe('1w');
+        });
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
@@ -100,6 +100,7 @@ export class ElasticQueryBuilder {
   getDateHistogramAgg(aggDef: DateHistogram) {
     const esAgg: any = {};
     const settings = aggDef.settings || {};
+    const calendarIntervals: string[] = ['1w', '1M', '1q', '1y'];
 
     esAgg.field = aggDef.field || this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;
@@ -115,7 +116,11 @@ export class ElasticQueryBuilder {
 
     const interval = settings.interval === 'auto' ? '${__interval_ms}ms' : settings.interval;
 
-    esAgg.fixed_interval = interval;
+    if (calendarIntervals.includes(interval)) {
+      esAgg.calendar_interval = interval;
+    } else {
+      esAgg.fixed_interval = interval;
+    }
 
     return esAgg;
   }

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
@@ -116,7 +116,7 @@ export class ElasticQueryBuilder {
 
     const interval = settings.interval === 'auto' ? '${__interval_ms}ms' : settings.interval;
 
-    if (calendarIntervals.includes(interval)) {
+    if (interval !== undefined && calendarIntervals.includes(interval)) {
       esAgg.calendar_interval = interval;
     } else {
       esAgg.fixed_interval = interval;


### PR DESCRIPTION
**What is this feature?**

Elasticsearch: Add support for calendar interval in date histogram queries

**Why do we need this feature?**

Since introducing the fixed_interval as the only option replacing the "interval" in the ES date histogram queries, Grafana has lost the functionality of serving plots with long aggregation intervals (1 week, 1 month, 1 year) accurately, and that was a breaking change for many users (some still forced to use Grafana v9). This missing functionality was mentioned in several issues and it has been discussed in https://github.com/grafana/grafana/discussions/55034

Currently only workaround is possible using 30d/365d but this is not accurate and the resulting bins are not matching the calendar intervals precisely.

**Who is this feature for?**

Users of Elasticsearch datasource queries aiming to do aggregation over longer intervals (1w, 1M, 1q, 1y) that are not supported within the ES fixed_interval range.
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#search-aggregations-bucket-datehistogram-aggregation

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Provides accurate aggregation intervals and remove the need of using 30d/365d workaround that creates wrong results.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
