### PR TITLE
Properly manage trigger chars with open editor box

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -251,19 +251,14 @@ describe('CompletionProvider', () => {
   });
 
   it.each([
-    ['{ .foo }', 6],
     ['{ .foo }', 7],
-    ['{.foo   300}', 5],
     ['{.foo   300}', 6],
     ['{.foo   300}', 7],
     ['{.foo   300}', 8],
-    ['{.foo  300 && .bar = 200}', 5],
     ['{.foo  300 && .bar = 200}', 6],
     ['{.foo  300 && .bar = 200}', 7],
-    ['{.foo  300 && .bar  200}', 18],
     ['{.foo  300 && .bar  200}', 19],
     ['{.foo  300 && .bar  200}', 20],
-    ['{ .foo = 1 && .bar }', 18],
     ['{ .foo = 1 && .bar }', 19],
     ['{ .foo = 1 && .bar  }', 19],
   ])('suggests with incomplete spanset - %s, %i', async (input: string, offset: number) => {
@@ -274,6 +269,17 @@ describe('CompletionProvider', () => {
         (s) => expect.objectContaining({ label: s.label, insertText: s.insertText })
       )
     );
+  });
+
+  it.each([
+    ['{ .foo }', 6],
+    ['{.foo   300}', 5],
+    ['{.foo  300 && .bar = 200}', 5],
+    ['{ .foo = 1 && .bar }', 18],
+  ])('suggests with incomplete spanset with no space before cursor - %s, %i', async (input: string, offset: number) => {
+    const { provider, model } = setup(input, offset);
+    const result = await provider.provideCompletionItems(model, emptyPosition);
+    expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual([]);
   });
 
   it.each([

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -283,6 +283,17 @@ describe('CompletionProvider', () => {
   });
 
   it.each([
+    ['{ span.d }', 8],
+    ['{ span.db }', 9],
+  ])('suggests to complete attribute - %s, %i', async (input: string, offset: number) => {
+    const { provider, model } = setup(input, offset, undefined, v2Tags);
+    const result = await provider.provideCompletionItems(model, emptyPosition);
+    expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual([
+      expect.objectContaining({ label: 'db', insertText: 'db' }),
+    ]);
+  });
+
+  it.each([
     ['{.foo=1}  {.bar=2}', 8],
     ['{.foo=1}  {.bar=2}', 9],
     ['{.foo=1}  {.bar=2}', 10],

--- a/public/app/plugins/datasource/tempo/traceql/situation.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.test.ts
@@ -25,6 +25,11 @@ describe('situation', () => {
     {
       query: '{.foo}',
       cursorPos: 5,
+      expected: { type: 'SPANSET_IN_NAME_SCOPE', scope: '{' },
+    },
+    {
+      query: '{.foo }',
+      cursorPos: 6,
       expected: { type: 'SPANSET_EXPRESSION_OPERATORS' },
     },
     {
@@ -49,7 +54,7 @@ describe('situation', () => {
     },
     {
       query: '{span.foo = 200 }',
-      cursorPos: 15,
+      cursorPos: 16,
       expected: { type: 'SPANFIELD_COMBINING_OPERATORS' },
     },
     {

--- a/public/app/plugins/datasource/tempo/traceql/situation.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.test.ts
@@ -25,7 +25,7 @@ describe('situation', () => {
     {
       query: '{.foo}',
       cursorPos: 5,
-      expected: { type: 'SPANSET_IN_NAME_SCOPE', scope: '{' },
+      expected: { type: 'SPANSET_IN_NAME_SCOPE', scope: '' },
     },
     {
       query: '{.foo }',

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -250,7 +250,9 @@ const RESOLVERS: Resolver[] = [
 ];
 
 function resolveSpanset(node: SyntaxNode, text: string, _: number, originalPos: number): SituationType {
-  // The user is completing an expression
+  // The user is completing an expression. We can take advantage of the fact that the Monaco editor is smart
+  // enough to automatically detect that there are some characters before the cursor and to take them into
+  // account when providing suggestions.
   let endOfPathNode = walk(node, [['firstChild', [FieldExpression]]]);
   if (endOfPathNode && text[originalPos - 1] !== ' ') {
     const attributeFieldParent = walk(endOfPathNode, [['firstChild', [AttributeField]]]);

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -249,12 +249,15 @@ const RESOLVERS: Resolver[] = [
   },
 ];
 
-function resolveSpanset(node: SyntaxNode, text: string, pos: number, originalPos: number): SituationType {
+function resolveSpanset(node: SyntaxNode, text: string, _: number, originalPos: number): SituationType {
   // The user is completing an expression
   let endOfPathNode = walk(node, [['firstChild', [FieldExpression]]]);
   if (endOfPathNode && text[originalPos - 1] !== ' ') {
-    const indexOfDot = text.indexOf('.');
-    const attributeFieldUpToDot = text.slice(0, indexOfDot);
+    const attributeFieldParent = walk(endOfPathNode, [['firstChild', [AttributeField]]]);
+    const attributeFieldParentText = attributeFieldParent ? getNodeText(attributeFieldParent, text) : '';
+    const indexOfDot = attributeFieldParentText.indexOf('.');
+    const attributeFieldUpToDot = attributeFieldParentText.slice(0, indexOfDot);
+
     return {
       type: 'SPANSET_IN_NAME_SCOPE',
       scope: attributeFieldUpToDot,


### PR DESCRIPTION
Currently, when the user is typing a TraceQL and the suggestion box for autocompletions is already open, pressing a trigger character can confuse the completion system. Example of issue:
![bugged](https://github.com/grafana/grafana/assets/135109076/2c0c0900-2bcd-4b59-9e1d-8c4bc6d10955)

This PR fixes this, with the approach explained in the comments. Working example:
![working](https://github.com/grafana/grafana/assets/135109076/bee61bbf-a68f-4beb-8f94-9144456f0a56)

Fixes https://github.com/grafana/grafana/issues/74020

Some improvements could be done on how we manage spaces and more generally trigger characters, but we keep them out of this PR.