### PR TITLE
Revert "Dashboard: Reduce scope of `contain: strict` to TextPanel

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -403,6 +403,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     content: css({
       label: 'panel-content',
       flexGrow: 1,
+      contain: 'strict',
     }),
     headerContainer: css({
       label: 'panel-header',

--- a/public/app/plugins/panel/text/TextPanel.tsx
+++ b/public/app/plugins/panel/text/TextPanel.tsx
@@ -51,7 +51,7 @@ export function TextPanel(props: Props) {
   }
 
   return (
-    <CustomScrollbar autoHeightMin="100%" className={styles.containStrict}>
+    <CustomScrollbar autoHeightMin="100%">
       <DangerouslySetHtmlContent
         html={processed.content}
         className={styles.markdown}
@@ -103,7 +103,4 @@ const getStyles = (theme: GrafanaTheme2) => ({
       height: 100%;
     `
   ),
-  containStrict: css({
-    contain: 'strict',
-  }),
 });

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -46,6 +46,7 @@
   padding: $panel-padding;
   width: 100%;
   flex-grow: 1;
+  contain: strict;
   height: calc(100% - #{$panel-header-height});
 
   &--no-padding {


### PR DESCRIPTION
This reverts commit ade0de5ae9277f17bf4977bf2e350f9a4e4da224 that caused issues with panels content overlapping the panel container.


I.e. dashboards list:

<img width="1499" alt="image" src="https://github.com/grafana/grafana/assets/2376619/6f109efd-cbe7-495e-8c00-9e5daef7e5ae">
