### PR TITLE
Loki Query Editor: Improved suggestions for JSON parser

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -512,7 +512,7 @@ describe('getAfterSelectorCompletions', () => {
   });
 });
 
-describe('IN_LOGFMT completions', () => {
+describe('Logfmt IN_EXPRESSION_PARSER completions', () => {
   let datasource: LokiDatasource;
   let languageProvider: LokiLanguageProvider;
   let completionProvider: CompletionDataProvider;
@@ -534,8 +534,9 @@ describe('IN_LOGFMT completions', () => {
   });
   it('autocompleting logfmt should return flags, parsers, pipe operations, and labels', async () => {
     const situation: Situation = {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       logQuery: `{job="grafana"} | logfmt`,
+      parser: 'logfmt',
       flags: false,
       otherLabels: [],
     };
@@ -640,8 +641,9 @@ describe('IN_LOGFMT completions', () => {
 
   it('autocompleting logfmt with flags should return parser, pipe operations, and labels', async () => {
     const situation: Situation = {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       logQuery: `{job="grafana"} | logfmt`,
+      parser: 'logfmt',
       flags: true,
       otherLabels: [],
     };
@@ -734,7 +736,8 @@ describe('IN_LOGFMT completions', () => {
 
   it('autocompleting logfmt should exclude already used labels from the suggestions', async () => {
     const situation: Situation = {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
+      parser: 'logfmt',
       logQuery: `{job="grafana"} | logfmt`,
       flags: true,
       otherLabels: ['label1', 'label2'],
@@ -816,7 +819,8 @@ describe('IN_LOGFMT completions', () => {
 
   it('autocompleting logfmt without flags should only offer labels when the user has a trailing comma', async () => {
     const situation: Situation = {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
+      parser: 'logfmt',
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: false,
       otherLabels: ['label1'],
@@ -836,7 +840,8 @@ describe('IN_LOGFMT completions', () => {
 
   it('autocompleting logfmt with flags should only offer labels when the user has a trailing comma', async () => {
     const situation: Situation = {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
+      parser: 'logfmt',
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: true,
       otherLabels: ['label1'],
@@ -846,6 +851,226 @@ describe('IN_LOGFMT completions', () => {
       [
         {
           "insertText": "label2",
+          "label": "label2",
+          "triggerOnInsert": false,
+          "type": "LABEL_NAME",
+        },
+      ]
+    `);
+  });
+});
+
+describe('json IN_EXPRESSION_PARSER completions', () => {
+  let datasource: LokiDatasource;
+  let languageProvider: LokiLanguageProvider;
+  let completionProvider: CompletionDataProvider;
+
+  beforeEach(() => {
+    datasource = createLokiDatasource();
+    languageProvider = new LokiLanguageProvider(datasource);
+    completionProvider = new CompletionDataProvider(languageProvider, {
+      current: history,
+    });
+
+    jest.spyOn(completionProvider, 'getParserAndLabelKeys').mockResolvedValue({
+      extractedLabelKeys: ['label1', 'label2'],
+      unwrapLabelKeys: [],
+      hasJSON: true,
+      hasjson: false,
+      hasPack: false,
+    });
+  });
+  it('autocompleting json should return parsers, pipe operations, and labels', async () => {
+    const situation: Situation = {
+      type: 'IN_EXPRESSION_PARSER',
+      logQuery: `{job="grafana"} | json`,
+      parser: 'json',
+      flags: false,
+      otherLabels: [],
+    };
+
+    expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
+      [
+        {
+          "documentation": "Operator docs",
+          "insertText": "| json",
+          "label": "json",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| json",
+          "label": "json",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| pattern",
+          "label": "pattern",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| regexp",
+          "label": "regexp",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| unpack",
+          "label": "unpack",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| line_format "{{.$0}}"",
+          "isSnippet": true,
+          "label": "line_format",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| label_format",
+          "isSnippet": true,
+          "label": "label_format",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| unwrap",
+          "label": "unwrap",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| decolorize",
+          "label": "decolorize",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| drop",
+          "label": "drop",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| keep",
+          "label": "keep",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "insertText": "label1=\\"\\""",
+          "label": "label1",
+          "triggerOnInsert": false,
+          "type": "LABEL_NAME",
+        },
+        {
+          "insertText": "label2=\\"\\"",
+          "label": "label2",
+          "triggerOnInsert": false,
+          "type": "LABEL_NAME",
+        },
+      ]
+    `);
+  });
+
+  it('autocompleting json should exclude already used labels from the suggestions', async () => {
+    const situation: Situation = {
+      type: 'IN_EXPRESSION_PARSER',
+      parser: 'json',
+      logQuery: `{job="grafana"} | json`,
+      flags: true,
+      otherLabels: ['label1', 'label2'],
+    };
+
+    expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
+      [
+        {
+          "documentation": "Operator docs",
+          "insertText": "| json",
+          "label": "json",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| json",
+          "label": "json",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| pattern",
+          "label": "pattern",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| regexp",
+          "label": "regexp",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| unpack",
+          "label": "unpack",
+          "type": "PARSER",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| line_format "{{.$0}}"",
+          "isSnippet": true,
+          "label": "line_format",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| label_format",
+          "isSnippet": true,
+          "label": "label_format",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| unwrap",
+          "label": "unwrap",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| decolorize",
+          "label": "decolorize",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| drop",
+          "label": "drop",
+          "type": "PIPE_OPERATION",
+        },
+        {
+          "documentation": "Operator docs",
+          "insertText": "| keep",
+          "label": "keep",
+          "type": "PIPE_OPERATION",
+        },
+      ]
+    `);
+  });
+
+  it('autocompleting json should only offer labels when the user has a trailing comma', async () => {
+    const situation: Situation = {
+      type: 'IN_EXPRESSION_PARSER',
+      parser: 'json',
+      logQuery: `{job="grafana"} | json label3,`,
+      flags: false,
+      otherLabels: ['label1'],
+    };
+
+    expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
+      [
+        {
+          "insertText": "label2=\\"\\""",
           "label": "label2",
           "triggerOnInsert": false,
           "type": "LABEL_NAME",

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -177,12 +177,26 @@ describe('situation', () => {
       flags: false,
       logQuery: '{level="info"} | logfmt label,',
     });
+    assertSituation('sum by (test) (count_over_time({level="info"} | logfmt label, ^))', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label'],
+      parser: 'logfmt',
+      flags: false,
+      logQuery: '{level="info"} | logfmt label,',
+    });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt --strict ^))', {
       type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
       parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --strict',
+    });
+    assertSituation('count_over_time({level="info"} | logfmt [1m]) + avg_over_time({place="luna"} | logfmt test="test"^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['test'],
+      parser: 'logfmt',
+      flags: false,
+      logQuery: '{place="luna"} | logfmt test="test"',
     });
   });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -199,6 +199,93 @@ describe('situation', () => {
       logQuery: '{place="luna"} | logfmt test="test"',
     });
   });
+  
+  it('identifies json IN_EXPRESSION_PARSER autocomplete situations', () => {
+    assertSituation('{level="info"} | json ^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: [],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json',
+    });
+    assertSituation('{level="info"} | json label="expression", label1="expression"^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label', 'label1'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label="expression", label1="expression"',
+    });
+    assertSituation('{level="info"} | json label="expression", label1="expression",^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label', 'label1'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label="expression", label1="expression",',
+    });
+    assertSituation('count_over_time({level="info"} | json ^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: [],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json',
+    });
+    assertSituation('count_over_time({level="info"} | json ^)', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: [],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json',
+    });
+    assertSituation('count_over_time({level="info"} | json ^ [$__auto])', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: [],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json',
+    });
+    assertSituation('count_over_time({level="info"} | json label1="expression"^)', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label1'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label1="expression"',
+    });
+    assertSituation('sum by (test) (count_over_time({level="info"} | json ^))', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: [],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json',
+    });
+    assertSituation('sum by (test) (count_over_time({level="info"} | json label=""^))', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label=""',
+    });
+    assertSituation('sum by (test) (count_over_time({level="info"} | json label="",^))', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label="",',
+    });
+    assertSituation('sum by (test) (count_over_time({level="info"} | json label="", ^))', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['label'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{level="info"} | json label="",',
+    });
+    assertSituation('count_over_time({level="info"} | json [1m]) + avg_over_time({place="luna"} | json test="test"^', {
+      type: 'IN_EXPRESSION_PARSER',
+      otherLabels: ['test'],
+      parser: 'json',
+      flags: false,
+      logQuery: '{place="luna"} | json test="test"',
+    });
+  });
 
   it('identifies IN_AGGREGATION autocomplete situations', () => {
     assertSituation('sum(^)', {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -52,13 +52,6 @@ describe('situation', () => {
     // check for an error we had during the implementation
     assertSituation('{level="info" ^', null);
 
-    assertSituation('{level="info"} | json ^', {
-      type: 'AFTER_SELECTOR',
-      afterPipe: false,
-      hasSpace: true,
-      logQuery: '{level="info"} | json',
-    });
-
     assertSituation('{level="info"} | json |^', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
@@ -92,88 +85,102 @@ describe('situation', () => {
     });
   });
 
-  it('identifies AFTER_LOGFMT autocomplete situations', () => {
+  it('identifies logfmt IN_EXPRESSION_PARSER autocomplete situations', () => {
     assertSituation('{level="info"} | logfmt ^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('{level="info"} | logfmt --strict ^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --strict',
     });
     assertSituation('{level="info"} | logfmt --strict --keep-empty^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: true,
       logQuery: '{level="info"} | logfmt --strict --keep-empty',
     });
     assertSituation('{level="info"} | logfmt --strict label, label1="expression"^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: ['label', 'label1'],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --strict label, label1="expression"',
     });
     assertSituation('{level="info"} | logfmt --strict label, label1="expression",^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: ['label', 'label1'],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --strict label, label1="expression",',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^)', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^ [$__auto])', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt --keep-empty^)', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --keep-empty',
     });
     assertSituation('count_over_time({level="info"} | logfmt --keep-empty label1, label2^)', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: ['label1', 'label2'],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --keep-empty label1, label2',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt ^))', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt label ^))', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: ['label'],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt label',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt label,^))', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: ['label'],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt label,',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt --strict ^))', {
-      type: 'IN_LOGFMT',
+      type: 'IN_EXPRESSION_PARSER',
       otherLabels: [],
+      parser: 'logfmt',
       flags: false,
       logQuery: '{level="info"} | logfmt --strict',
     });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -441,7 +441,7 @@ function resolveExpressionParser(_: SyntaxNode, text: string, cursorPosition: nu
   const cursor = tree.cursorAt(position);
 
   // Check if the user cursor is in any node that requires expression parser suggestions.
-  const logfmtNodes = [LogfmtExpressionParser, Logfmt, LogfmtParser];
+  const logfmtNodes = [LogfmtExpressionParser, Logfmt, LogfmtParser, LabelExtractionExpressionList];
   const jsonNodes = [Json, JsonExpressionParser];
   let logfmtParser = false;
   let jsonParser = false;
@@ -660,9 +660,7 @@ export function getSituation(text: string, pos: number): Situation | null {
   // might not be the best node.
   // so first we check if there is an error node at the cursor position
   const maybeErrorNode = getErrorNode(tree, text, pos);
-
   const cur = maybeErrorNode != null ? maybeErrorNode.cursor() : tree.cursorAt(pos);
-
   const currentNode = cur.node;
 
   const ids = [cur.type.id];

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -18,6 +18,7 @@ import {
   getNormalizedLokiQuery,
   getNodePositionsFromQuery,
   formatLogqlQuery,
+  getLogQueryFromMetricsQueryAtPosition,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -430,6 +431,27 @@ describe('getLogQueryFromMetricsQuery', () => {
   it('does not return a query when there is no log query', () => {
     expect(getLogQueryFromMetricsQuery('1+1')).toBe('');
     expect(getLogQueryFromMetricsQuery('count_over_time([1s])')).toBe('');
+  });
+});
+
+describe('getLogQueryFromMetricsQueryAtPosition', () => {
+  it('works like getLogQueryFromMetricsQuery for simple querles', () => {
+    expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} | logfmt | label="value" [1m])', 57)).toBe(
+      '{job="grafana"} | logfmt | label="value"'
+    );
+    expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} [1m])', 37)).toBe('{job="grafana"}');
+    expect(
+      getLogQueryFromMetricsQueryAtPosition(
+        'sum(quantile_over_time(0.5, {label="$var"} | logfmt | __error__=`` | unwrap latency | __error__=`` [$__interval]))',
+        45
+      )
+    ).toBe('{label="$var"} | logfmt | __error__=``');
+  });
+  it.each([
+    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="moon"} | json test="test"', 49],
+    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="luna"} | logfmt test="test"', 107]
+  ])('gets the right query for complex queries', (metric: string, log: string, position: number) => {
+    expect(getLogQueryFromMetricsQueryAtPosition(metric, position)).toBe(log);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -427,6 +427,10 @@ describe('getLogQueryFromMetricsQuery', () => {
       )
     ).toBe('{label="$var"} | logfmt | __error__=``');
   });
+  it('does not return a query when there is no log query', () => {
+    expect(getLogQueryFromMetricsQuery('1+1')).toBe('');
+    expect(getLogQueryFromMetricsQuery('count_over_time([1s])')).toBe('');
+  });
 });
 
 describe('getNodePositionsFromQuery', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -241,6 +241,20 @@ export function getLogQueryFromMetricsQuery(query: string): string {
   return `${selector} ${pipelineExpr}`.trim();
 }
 
+export function getLogQueryFromMetricsQueryAtPosition(query: string, position: number): string {
+  if (isLogsQuery(query)) {
+    return query;
+  }
+
+  const metricQuery = getNodesFromQuery(query, [MetricExpr])
+    .reverse() // So we don't get the root metric node
+    .filter((node) => node.from <= position && node.to >= position);
+  if (metricQuery.length === 0) {
+    return '';
+  }
+  return getLogQueryFromMetricsQuery(query.substring(metricQuery[0].from, metricQuery[0].to));
+}
+
 export function isQueryWithLabelFilter(query: string): boolean {
   return isQueryWithNode(query, LabelFilter);
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -231,7 +231,7 @@ export function getLogQueryFromMetricsQuery(query: string): string {
   // Log query in metrics query composes of Selector & PipelineExpr
   const selectorNode = getNodeFromQuery(query, Selector);
   if (!selectorNode) {
-    return query;
+    return '';
   }
   const selector = query.substring(selectorNode.from, selectorNode.to);
 


### PR DESCRIPTION
When we bumped Lezer to 0.2.0 in https://github.com/grafana/grafana/pull/74619, testing the JSON autocompletion suggestions seemed to be broken when trying to autocomplete JSON with label expressions arguments such as: `{label="value"} | json label="expression", otherLabel="expression", resulting instead in label filter suggestions `json | label`.

With the changes in this PR we're unifying Logfmt and JSON autocomplete situations and completions into a new category called expression parser, derived of the current tree structure:

![imagen](https://github.com/grafana/grafana/assets/1069378/d34f7765-a117-4961-9d1a-5971b52b7c2b)

![imagen](https://github.com/grafana/grafana/assets/1069378/0df3b5a8-2a89-4663-a9c3-baa97f034ad4)

Additionally, several improvements and bug have been made to improve the way we internally interpret user queries:

- A bug has been fixed in `getLogQueryFromMetricsQuery()` where it would return the same query if it didn't have a `Selector` node. For example, calling `getLogQueryFromMetricsQuery("count_over_time()")` would return `"count_over_time()"`. Now it returns an empty string.
- ` getLogQueryFromMetricsQueryAtPosition()` has been created to be used for the autocomplete. This new function returns the log query where the current user cursor is placed at. For example:
  If the current query is `count_over_time({level="info"} | logfmt [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])` and the user cursor is placed in `avg_over_time`, it will return `{place="luna"} | logfmt test="test"` as the log query.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/74685

**Special notes for your reviewer:**

Before the updates:

https://github.com/grafana/grafana/assets/1069378/95abbc2f-7a7a-4c57-9a67-d4725c7970b2

After the updates:

https://github.com/grafana/grafana/assets/1069378/9bfda515-353d-40ae-8e74-e26eff29aa6b


