### PR TITLE
Docs: Fixing Security Advisory URL

### DIFF
--- a/docs/sources/breaking-changes/breaking-changes-v10-0.md
+++ b/docs/sources/breaking-changes/breaking-changes-v10-0.md
@@ -192,7 +192,7 @@ We strongly recommend not doing this in case you are using Azure AD as an identi
 
 #### Learn more
 
-- [CVE-2023-3128 Advisory](https://grafana.com/security/security-advisories/CVE-2023-3128)
+- [CVE-2023-3128 Advisory](https://grafana.com/security/security-advisories/cve-2023-3128/)
 - [Enable email lookup]({{< relref "../setup-grafana/configure-security/configure-authentication/" >}})
 
 ### The "Alias" field in the CloudWatch data source is removed


### PR DESCRIPTION
Fixing broken URL to security CVE advisory

**What is this feature?**
Fixes Security Advisory URL on the G10 breaking changes page

**Why do we need this feature?**

Currently the URL is dead and does not route to a valid page.

**Who is this feature for?**

All customers

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
