### PR TITLE
Use the full commit sha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ build-docker-full: ## Build Docker image for development.
 	--build-arg BINGO=false \
 	--build-arg GO_BUILD_TAGS=$(GO_BUILD_TAGS) \
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
-	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
+	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--tag grafana/grafana$(TAG_SUFFIX):dev \
 	$(DOCKER_BUILD_ARGS)
@@ -235,7 +235,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg BINGO=false \
 	--build-arg GO_BUILD_TAGS=$(GO_BUILD_TAGS) \
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
-	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
+	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
 	--build-arg GO_IMAGE=golang:1.20.8 \


### PR DESCRIPTION
**What is this feature?**

In `/api/health` we show the commit sha displaying what commit this instance was built from. We had an anomaly where one of our commits was not visible from the short version via `github.com/grafana/grafana/commit/<id>`. This change just removes the --short which will make the SHA the full version, not the first 8 characters.

**Who is this feature for?**

Mostly admin usage on monitoring which versions are where.
