### PR TITLE
Alerting: Show panels within collapsed rows in dashboard picker

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -1,4 +1,4 @@
-import { findByRole, findByText, findByTitle, getByTestId, render } from '@testing-library/react';
+import { findByRole, findByText, findByTitle, getByTestId, queryByText, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
@@ -161,6 +161,71 @@ describe('AnnotationsField', function () {
       expect(annotationValueElements).toHaveLength(2);
       expect(annotationValueElements[0]).toHaveTextContent('dash-test-uid');
       expect(annotationValueElements[1]).toHaveTextContent('2');
+    });
+
+    it('should not show rows as panels', async function () {
+      mockSearchApiResponse(server, [
+        mockDashboardSearchItem({ title: 'My dashboard', uid: 'dash-test-uid', type: DashboardSearchItemType.DashDB }),
+      ]);
+
+      mockGetDashboardResponse(
+        mockDashboardDto({
+          title: 'My dashboard',
+          uid: 'dash-test-uid',
+          panels: [
+            { id: 1, title: 'Row panel', type: 'row' },
+            { id: 2, title: 'First panel', type: 'timeseries' },
+          ],
+        })
+      );
+
+      const user = userEvent.setup();
+
+      render(<FormWrapper />);
+
+      await user.click(ui.setDashboardButton.get());
+      expect(ui.dashboardPicker.confirmButton.get()).toBeDisabled();
+
+      await user.click(await findByTitle(ui.dashboardPicker.dialog.get(), 'My dashboard'));
+
+      expect(await findByText(ui.dashboardPicker.dialog.get(), 'First panel')).toBeInTheDocument();
+      expect(await queryByText(ui.dashboardPicker.dialog.get(), 'Row panel')).not.toBeInTheDocument();
+    });
+
+    it('should show panels within collapsed rows', async function () {
+      mockSearchApiResponse(server, [
+        mockDashboardSearchItem({ title: 'My dashboard', uid: 'dash-test-uid', type: DashboardSearchItemType.DashDB }),
+      ]);
+
+      mockGetDashboardResponse(
+        mockDashboardDto({
+          title: 'My dashboard',
+          uid: 'dash-test-uid',
+          panels: [
+            { id: 1, title: 'First panel', type: 'timeseries' },
+            {
+              id: 2,
+              title: 'Row panel',
+              collapsed: true,
+              type: 'row',
+              panels: [{ id: 3, title: 'Panel within collapsed row', type: 'timeseries' }],
+            },
+          ],
+        })
+      );
+
+      const user = userEvent.setup();
+
+      render(<FormWrapper />);
+
+      await user.click(ui.setDashboardButton.get());
+      expect(ui.dashboardPicker.confirmButton.get()).toBeDisabled();
+
+      await user.click(await findByTitle(ui.dashboardPicker.dialog.get(), 'My dashboard'));
+
+      expect(await findByText(ui.dashboardPicker.dialog.get(), 'First panel')).toBeInTheDocument();
+      expect(await queryByText(ui.dashboardPicker.dialog.get(), 'Row panel')).not.toBeInTheDocument();
+      expect(await findByText(ui.dashboardPicker.dialog.get(), 'Panel within collapsed row')).toBeInTheDocument();
     });
 
     // this test _should_ work in theory but something is stopping the 'onClick' function on the dashboard item

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -15,7 +15,7 @@ import { Annotation, annotationLabels } from '../../utils/constants';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
 import DashboardAnnotationField from './DashboardAnnotationField';
-import { DashboardPicker, PanelDTO } from './DashboardPicker';
+import { DashboardPicker, findSelectedPanel, mergePanels, PanelDTO } from './DashboardPicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
 
@@ -53,7 +53,9 @@ const AnnotationsStep = () => {
     }
 
     setSelectedDashboard(dashboardResult?.dashboard);
-    const currentPanel = dashboardResult?.dashboard?.panels?.find((panel) => panel.id.toString() === selectedPanelId);
+
+    const allPanels = mergePanels(dashboardResult);
+    const currentPanel = allPanels.find((panel) => panel.id.toString() === selectedPanelId);
     setSelectedPanel(currentPanel);
   }, [selectedPanelId, dashboardResult, isDashboardFetching]);
 

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -15,7 +15,7 @@ import { Annotation, annotationLabels } from '../../utils/constants';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
 import DashboardAnnotationField from './DashboardAnnotationField';
-import { DashboardPicker, findSelectedPanel, mergePanels, PanelDTO } from './DashboardPicker';
+import { DashboardPicker, mergePanels, PanelDTO } from './DashboardPicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
 

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -19,6 +19,7 @@ import {
 } from '@grafana/ui';
 
 import { dashboardApi } from '../../api/dashboardApi';
+import { DashboardDTO } from 'app/types';
 
 export interface PanelDTO {
   id?: number;
@@ -47,6 +48,18 @@ interface DashboardPickerProps {
   onDismiss: () => void;
 }
 
+export function mergePanels(dashboardResult: DashboardDTO | undefined) {
+  const panels = dashboardResult?.dashboard?.panels?.filter((panel) => panel.type !== 'row') || [];
+  const nestedPanels =
+    dashboardResult?.dashboard?.panels
+      ?.filter((row: { collapsed: boolean }) => row.collapsed)
+      .map((collapsedRow: { panels: PanelDTO[] }) => collapsedRow.panels) || [];
+
+  const allDashboardPanels = [...panels, ...nestedPanels.flat()];
+
+  return allDashboardPanels;
+}
+
 export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDismiss }: DashboardPickerProps) => {
   const styles = useStyles2(getPickerStyles);
 
@@ -72,12 +85,15 @@ export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDis
     setSelectedPanelId(undefined);
   }, []);
 
+
+  const allDashboardPanels = mergePanels(dashboardResult);
+
   const filteredPanels =
-    dashboardResult?.dashboard?.panels
+    allDashboardPanels
       ?.filter((panel) => panel.title?.toLowerCase().includes(panelFilter.toLowerCase()))
       .sort(panelSort) ?? [];
 
-  const currentPanel: PanelDTO | undefined = dashboardResult?.dashboard?.panels?.find(
+  const currentPanel: PanelDTO | undefined = allDashboardPanels.find(
     (panel: PanelDTO) => isValidPanelIdentifier(panel) && panel.id?.toString() === selectedPanelId
   );
 

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -85,7 +85,6 @@ export const DashboardPicker = ({ dashboardUid, panelId, isOpen, onChange, onDis
     setSelectedPanelId(undefined);
   }, []);
 
-
   const allDashboardPanels = mergePanels(dashboardResult);
 
   const filteredPanels =

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -17,9 +17,9 @@ import {
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
+import { DashboardDTO } from 'app/types';
 
 import { dashboardApi } from '../../api/dashboardApi';
-import { DashboardDTO } from 'app/types';
 
 export interface PanelDTO {
   id?: number;


### PR DESCRIPTION
**What is this feature?**

Currently, when creating an alert rule and linking it to a dashboard and panel, the picker is not showing panels within collapsed rows. Additionally, it's listing rows as panels. This PR fixes that by allowing to choose from panels that are within collapsed rows and also filters out rows from the modal.

**Why do we need this feature?**

To be able to select panels within collapsed rows.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/75093

![2023-09-26 15 06 31](https://github.com/grafana/grafana/assets/6271380/f3eaa23f-20f2-40bb-96eb-6fcf7008fea0)

