### PR TITLE
Loki: Improve getLogQueryFromMetricsQuery

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -30,7 +30,7 @@ import {
   LabelExtractionExpressionList,
 } from '@grafana/lezer-logql';
 
-import { getLogQueryFromMetricsQuery, getNodesFromQuery } from '../../../queryUtils';
+import { getLogQueryFromMetricsQueryAtPosition, getNodesFromQuery } from '../../../queryUtils';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling';
 type NodeType = number;
@@ -303,7 +303,7 @@ function getLabels(selectorNode: SyntaxNode, text: string): Label[] {
 function resolveAfterUnwrap(node: SyntaxNode, text: string, pos: number): Situation | null {
   return {
     type: 'AFTER_UNWRAP',
-    logQuery: getLogQueryFromMetricsQuery(text).trim(),
+    logQuery: getLogQueryFromMetricsQueryAtPosition(text, pos).trim(),
   };
 }
 
@@ -353,7 +353,7 @@ function resolveLabelsForGrouping(node: SyntaxNode, text: string, pos: number): 
 
   return {
     type: 'IN_GROUPING',
-    logQuery: getLogQueryFromMetricsQuery(text).trim(),
+    logQuery: getLogQueryFromMetricsQueryAtPosition(text, pos).trim(),
   };
 }
 
@@ -465,7 +465,7 @@ function resolveLogfmtParser(_: SyntaxNode, text: string, cursorPosition: number
     type: 'IN_LOGFMT',
     otherLabels,
     flags,
-    logQuery: getLogQueryFromMetricsQuery(text).trim(),
+    logQuery: getLogQueryFromMetricsQueryAtPosition(text, position).trim(),
   };
 }
 
@@ -539,7 +539,7 @@ function resolveLogOrLogRange(node: SyntaxNode, text: string, pos: number, after
     type: 'AFTER_SELECTOR',
     afterPipe,
     hasSpace: text.charAt(pos - 1) === ' ',
-    logQuery: getLogQueryFromMetricsQuery(text).trim(),
+    logQuery: getLogQueryFromMetricsQueryAtPosition(text, pos).trim(),
   };
 }
 
@@ -582,7 +582,7 @@ function resolveSelector(node: SyntaxNode, text: string, pos: number): Situation
 }
 
 function resolveAfterKeepAndDrop(node: SyntaxNode, text: string, pos: number): Situation | null {
-  let logQuery = getLogQueryFromMetricsQuery(text).trim();
+  let logQuery = getLogQueryFromMetricsQueryAtPosition(text, pos).trim();
   let keepAndDropParent: SyntaxNode | null = null;
   let parent = node.parent;
   while (parent !== null) {

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -18,6 +18,7 @@ import {
   getNormalizedLokiQuery,
   getNodePositionsFromQuery,
   formatLogqlQuery,
+  getLogQueryFromMetricsQueryAtPosition,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -430,6 +431,27 @@ describe('getLogQueryFromMetricsQuery', () => {
   it('does not return a query when there is no log query', () => {
     expect(getLogQueryFromMetricsQuery('1+1')).toBe('');
     expect(getLogQueryFromMetricsQuery('count_over_time([1s])')).toBe('');
+  });
+});
+
+describe('getLogQueryFromMetricsQueryAtPosition', () => {
+  it('works like getLogQueryFromMetricsQuery for simple querles', () => {
+    expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} | logfmt | label="value" [1m])', 57)).toBe(
+      '{job="grafana"} | logfmt | label="value"'
+    );
+    expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} [1m])', 37)).toBe('{job="grafana"}');
+    expect(
+      getLogQueryFromMetricsQueryAtPosition(
+        'sum(quantile_over_time(0.5, {label="$var"} | logfmt | __error__=`` | unwrap latency | __error__=`` [$__interval]))',
+        45
+      )
+    ).toBe('{label="$var"} | logfmt | __error__=``');
+  });
+  it.each([
+    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="moon"} | json test="test"', 49],
+    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="luna"} | logfmt test="test"', 107]
+  ])('gets the right query for complex queries', (metric: string, log: string, position: number) => {
+    expect(getLogQueryFromMetricsQueryAtPosition(metric, position)).toBe(log);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -435,7 +435,7 @@ describe('getLogQueryFromMetricsQuery', () => {
 });
 
 describe('getLogQueryFromMetricsQueryAtPosition', () => {
-  it('works like getLogQueryFromMetricsQuery for simple querles', () => {
+  it('works like getLogQueryFromMetricsQuery for simple queries', () => {
     expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} | logfmt | label="value" [1m])', 57)).toBe(
       '{job="grafana"} | logfmt | label="value"'
     );

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -427,6 +427,10 @@ describe('getLogQueryFromMetricsQuery', () => {
       )
     ).toBe('{label="$var"} | logfmt | __error__=``');
   });
+  it('does not return a query when there is no log query', () => {
+    expect(getLogQueryFromMetricsQuery('1+1')).toBe('');
+    expect(getLogQueryFromMetricsQuery('count_over_time([1s])')).toBe('');
+  });
 });
 
 describe('getNodePositionsFromQuery', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -436,9 +436,9 @@ describe('getLogQueryFromMetricsQuery', () => {
 
 describe('getLogQueryFromMetricsQueryAtPosition', () => {
   it('works like getLogQueryFromMetricsQuery for simple queries', () => {
-    expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} | logfmt | label="value" [1m])', 57)).toBe(
-      '{job="grafana"} | logfmt | label="value"'
-    );
+    expect(
+      getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} | logfmt | label="value" [1m])', 57)
+    ).toBe('{job="grafana"} | logfmt | label="value"');
     expect(getLogQueryFromMetricsQueryAtPosition('count_over_time({job="grafana"} [1m])', 37)).toBe('{job="grafana"}');
     expect(
       getLogQueryFromMetricsQueryAtPosition(
@@ -448,8 +448,16 @@ describe('getLogQueryFromMetricsQueryAtPosition', () => {
     ).toBe('{label="$var"} | logfmt | __error__=``');
   });
   it.each([
-    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="moon"} | json test="test"', 49],
-    ['count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])', '{place="luna"} | logfmt test="test"', 107]
+    [
+      'count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])',
+      '{place="moon"} | json test="test"',
+      49,
+    ],
+    [
+      'count_over_time({place="moon"} | json test="test" [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])',
+      '{place="luna"} | logfmt test="test"',
+      107,
+    ],
   ])('gets the right query for complex queries', (metric: string, log: string, position: number) => {
     expect(getLogQueryFromMetricsQueryAtPosition(metric, position)).toBe(log);
   });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -241,6 +241,20 @@ export function getLogQueryFromMetricsQuery(query: string): string {
   return `${selector} ${pipelineExpr}`.trim();
 }
 
+export function getLogQueryFromMetricsQueryAtPosition(query: string, position: number): string {
+  if (isLogsQuery(query)) {
+    return query;
+  }
+
+  const metricQuery = getNodesFromQuery(query, [MetricExpr])
+    .reverse() // So we don't get the root metric node
+    .filter((node) => node.from <= position && node.to >= position);
+  if (metricQuery.length === 0) {
+    return '';
+  }
+  return getLogQueryFromMetricsQuery(query.substring(metricQuery[0].from, metricQuery[0].to));
+}
+
 export function isQueryWithLabelFilter(query: string): boolean {
   return isQueryWithNode(query, LabelFilter);
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -231,7 +231,7 @@ export function getLogQueryFromMetricsQuery(query: string): string {
   // Log query in metrics query composes of Selector & PipelineExpr
   const selectorNode = getNodeFromQuery(query, Selector);
   if (!selectorNode) {
-    return query;
+    return '';
   }
   const selector = query.substring(selectorNode.from, selectorNode.to);
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -248,11 +248,11 @@ export function getLogQueryFromMetricsQueryAtPosition(query: string, position: n
 
   const metricQuery = getNodesFromQuery(query, [MetricExpr])
     .reverse() // So we don't get the root metric node
-    .filter((node) => node.from <= position && node.to >= position);
-  if (metricQuery.length === 0) {
+    .find((node) => node.from <= position && node.to >= position);
+  if (!metricQuery) {
     return '';
   }
-  return getLogQueryFromMetricsQuery(query.substring(metricQuery[0].from, metricQuery[0].to));
+  return getLogQueryFromMetricsQuery(query.substring(metricQuery.from, metricQuery.to));
 }
 
 export function isQueryWithLabelFilter(query: string): boolean {


### PR DESCRIPTION
In this PR:

- A bug has been fixed in `getLogQueryFromMetricsQuery()` where it would return the same query if it didn't have a `Selector` node. For example, calling `getLogQueryFromMetricsQuery("count_over_time()")` would return `"count_over_time()"`. Now it returns an empty string.
- ` getLogQueryFromMetricsQueryAtPosition()` has been created to be used for the autocomplete. This new function returns the log query where the current user cursor is placed at. For example:
  If the current query is `count_over_time({level="info"} | logfmt [1m]) + avg_over_time({place="luna"} | logfmt test="test" [1m])` and the user cursor is placed in `avg_over_time`, it will return `{place="luna"} | logfmt test="test"` as the log query.

**Why do we need this feature?**

Better autocompletion experience when writing complex queries. With these changes we send a query request for samples using the query the user is currently writing, not the first one.

**Special notes for your reviewer:**

Nothing should change from a functionality perspective, other than now being able to get samples for the actual log query the user is writing, not the first one.

Before:

https://github.com/grafana/grafana/assets/1069378/e6e6ea22-7e92-4939-b4a2-fbf77492f54a

After:

https://github.com/grafana/grafana/assets/1069378/912b9421-a8eb-4677-932f-e1aad88ea26d

