### PR TITLE
Explore: Make Explore Toolbar sticky

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -44,7 +44,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   stickyToolbar: css({
     position: 'sticky',
     top: 0,
-    // reducing zIndex to 1 to make sure it doesn't overlap the top nav
+    // reducing zIndex to make sure it doesn't overlap the top nav
     zIndex: theme.zIndex.navbarFixed - 1,
   }),
 });

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -44,7 +44,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   stickyToolbar: css({
     position: 'sticky',
     top: 0,
-    // reducing zIndex to make sure it doesn't overlap the top nav
+    // reducing zIndex to prevent overlapping the top nav
     zIndex: theme.zIndex.navbarFixed - 1,
   }),
 });

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -3,9 +3,17 @@ import { pick } from 'lodash';
 import React, { RefObject, useMemo } from 'react';
 import { shallowEqual } from 'react-redux';
 
-import { DataSourceInstanceSettings, RawTimeRange } from '@grafana/data';
+import { DataSourceInstanceSettings, RawTimeRange, GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { defaultIntervals, PageToolbar, RefreshPicker, SetInterval, ToolbarButton, ButtonGroup } from '@grafana/ui';
+import {
+  defaultIntervals,
+  PageToolbar,
+  RefreshPicker,
+  SetInterval,
+  ToolbarButton,
+  ButtonGroup,
+  useStyles2,
+} from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { t, Trans } from 'app/core/internationalization';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
@@ -27,10 +35,17 @@ import { isSplit, selectPanesEntries } from './state/selectors';
 import { syncTimes, changeRefreshInterval } from './state/time';
 import { LiveTailControls } from './useLiveTailControls';
 
-const rotateIcon = css({
-  '> div > svg': {
-    transform: 'rotate(180deg)',
-  },
+const getStyles = (theme: GrafanaTheme2) => ({
+  rotateIcon: css({
+    '> div > svg': {
+      transform: 'rotate(180deg)',
+    },
+  }),
+  stickyToolbar: css({
+    position: 'sticky',
+    top: 0,
+    zIndex: theme.zIndex.navbarFixed,
+  }),
 });
 
 interface Props {
@@ -41,6 +56,7 @@ interface Props {
 
 export function ExploreToolbar({ exploreId, topOfViewRef, onChangeTime }: Props) {
   const dispatch = useDispatch();
+  const styles = useStyles2(getStyles);
 
   const splitted = useSelector(isSplit);
   const timeZone = useSelector((state: StoreState) => getTimeZone(state.user));
@@ -119,7 +135,7 @@ export function ExploreToolbar({ exploreId, topOfViewRef, onChangeTime }: Props)
   };
 
   return (
-    <div ref={topOfViewRef}>
+    <div ref={topOfViewRef} className={styles.stickyToolbar}>
       {refreshInterval && <SetInterval func={onRunQuery} interval={refreshInterval} loading={loading} />}
       <div ref={topOfViewRef}>
         <AppChromeUpdate
@@ -173,7 +189,7 @@ export function ExploreToolbar({ exploreId, topOfViewRef, onChangeTime }: Props)
                 onClick={onClickResize}
                 icon={isLargerPane ? 'gf-movepane-left' : 'gf-movepane-right'}
                 iconOnly={true}
-                className={cx(shouldRotateSplitIcon && rotateIcon)}
+                className={cx(shouldRotateSplitIcon && styles.rotateIcon)}
               />
               <ToolbarButton
                 tooltip={t('explore.toolbar.split-close-tooltip', 'Close split pane')}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -44,7 +44,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   stickyToolbar: css({
     position: 'sticky',
     top: 0,
-    zIndex: theme.zIndex.navbarFixed,
+    // reducing zIndex to 1 to make sure it doesn't overlap the top nav
+    zIndex: theme.zIndex.navbarFixed - 1,
   }),
 });
 


### PR DESCRIPTION
**Why this feature?**
Explore Toolbar contains buttons like `Add to dashboard` and `Run Query`. The problem is that when user is exploring data and loading visualization panels, they have to scroll to the top of the page to add that panel to a dashboard or run a query. 

Before:

https://github.com/grafana/grafana/assets/58232930/5557c455-a6d0-472e-988c-7decd603d788

After:

https://github.com/grafana/grafana/assets/58232930/92d95e15-202b-4926-9ef8-6fde7ec767e5

Fixes: https://github.com/grafana/grafana/issues/75494

Please check that:
- [ ] It works as expected from a user's perspective