### PR TITLE
Bug Fix: Restore health check error

### DIFF
--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -18,6 +18,12 @@ var (
 	// ErrMethodNotImplemented error returned when a plugin method is not implemented.
 	ErrMethodNotImplemented = errMethodNotImplementedBase.Errorf("method not implemented")
 
+	// ErrPluginHealthCheck error returned when a plugin fails its health check.
+	// Exposed as a base error to wrap it with plugin error.
+	ErrPluginHealthCheck = errutil.Internal("plugin.healthCheck",
+		errutil.WithPublicMessage("Plugin health check failed"),
+		errutil.WithDownstream())
+
 	// ErrPluginDownstreamError error returned when a plugin request fails.
 	// Exposed as a base error to wrap it with plugin downstream errors.
 	ErrPluginDownstreamErrorBase = errutil.Internal("plugin.downstreamError",

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -188,7 +188,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 			return nil, err
 		}
 
-		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to check health: %w", err)
+		return nil, plugins.ErrPluginHealthCheck.Errorf("client: failed to check health: %w", err)
 	}
 
 	return resp, nil

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -97,7 +97,7 @@ func TestCheckHealth(t *testing.T) {
 			},
 			{
 				err:           errors.New("surprise surprise"),
-				expectedError: plugins.ErrPluginDownstreamErrorBase,
+				expectedError: plugins.ErrPluginHealthCheck,
 			},
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Failed health checks were returning "An error ocurred within the plugin" rather than the previous "Plugin health check failed".

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
