### PR TITLE
Sandbox: Use resolveCache to resolve plugin's code file as systemjs does

### DIFF
--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -41,7 +41,7 @@ export async function loadScriptIntoSandbox(url: string, meta: PluginMeta, sandb
 
 export async function getPluginCode(meta: PluginMeta): Promise<string> {
   if (isHostedOnCDN(meta.module)) {
-    // should load plugin from a CDN
+    // Load plugin from CDN, no need for "resolveWithCache" as CDN URLs already include the version
     const url = meta.module;
     const response = await fetch(url);
     let pluginCode = await response.text();
@@ -52,9 +52,9 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     });
     return pluginCode;
   } else {
+    // local plugin. resolveWithCache will append a query parameter with its version
+    // to ensure correct cached version is served
     const pluginCodeUrl = resolveWithCache(meta.module);
-
-    //local plugin loading
     const response = await fetch(pluginCodeUrl);
     let pluginCode = await response.text();
     pluginCode = patchPluginSourceMap(meta, pluginCode);

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -1,6 +1,7 @@
 import { PluginMeta } from '@grafana/data';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
+import { resolveWithCache } from '../loader/cache';
 import { isHostedOnCDN } from '../loader/utils';
 
 import { SandboxEnvironment } from './types';
@@ -51,8 +52,10 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     });
     return pluginCode;
   } else {
+    const pluginCodeUrl = resolveWithCache(meta.module);
+
     //local plugin loading
-    const response = await fetch(meta.module);
+    const response = await fetch(pluginCodeUrl);
     let pluginCode = await response.text();
     pluginCode = patchPluginSourceMap(meta, pluginCode);
     pluginCode = patchPluginAPIs(pluginCode);


### PR DESCRIPTION
**What is this feature?**

It makes sure the sandbox uses the same cache query parameter than systemjs does to make sure plugin modulejs files are not cached in between versions

**Why do we need this feature?**

Browsers tend to cache assets for a long period of time. With the cache query parameter we make sure that when a plugin updates in grafana we force the
browser to fetch the plugin code new version and, if the version is the same, we use the cached version (this is up to the browser)

This makes the sandbox plugin loading system the same as the non-sandbox one (systemjs)

**Who is this feature for?**

All plugins running inside the sandbox

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/74552

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
