### PR TITLE
Chore: Remove unreachable return in parseDataplaneLogsFrame

### DIFF
--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -80,7 +80,6 @@ function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
     getAttributesAsLabels: () => (attributes !== null ? attributes.map(attributesToLabels) : null),
     extraFields,
   };
-  return null;
 }
 
 export function parseLogsFrame(frame: DataFrame): LogsFrame | null {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/70318 introduced an unreachable return statement, which is logged to the console as a warning in some browsers. Annoying. This fixes that.