### PR TITLE
Sandbox: use same trusted types default policy than grafana main realm

### DIFF
--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -3,27 +3,29 @@ import { config } from '@grafana/runtime';
 
 const CSP_REPORT_ONLY_ENABLED = config.bootData.settings.cspReportOnlyEnabled;
 
+export const defaultTrustedTypesPolicy = {
+  createHTML: (string: string, source: string, sink: string) => {
+    if (!CSP_REPORT_ONLY_ENABLED) {
+      return string.replace(/<script/gi, '&lt;script');
+    }
+    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    return string;
+  },
+  createScript: (string: string) => string,
+  createScriptURL: (string: string, source: string, sink: string) => {
+    if (!CSP_REPORT_ONLY_ENABLED) {
+      return textUtil.sanitizeUrl(string);
+    }
+    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    return string;
+  },
+};
+
 if (
   config.bootData.settings.trustedTypesDefaultPolicyEnabled &&
   window.trustedTypes &&
   window.trustedTypes.createPolicy
 ) {
   // check if browser supports Trusted Types
-  window.trustedTypes.createPolicy('default', {
-    createHTML: (string, source, sink) => {
-      if (!CSP_REPORT_ONLY_ENABLED) {
-        return string.replace(/<script/gi, '&lt;script');
-      }
-      console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
-      return string;
-    },
-    createScript: (string) => string,
-    createScriptURL: (string, source, sink) => {
-      if (!CSP_REPORT_ONLY_ENABLED) {
-        return textUtil.sanitizeUrl(string);
-      }
-      console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
-      return string;
-    },
-  });
+  window.trustedTypes.createPolicy('default', defaultTrustedTypesPolicy);
 }

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -2,6 +2,7 @@ import createVirtualEnvironment from '@locker/near-membrane-dom';
 import { ProxyTarget } from '@locker/near-membrane-shared';
 
 import { PluginMeta } from '@grafana/data';
+import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
 import { getPluginSettings } from '../pluginSettings';
 
@@ -72,11 +73,7 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
       // distortions are interceptors to modify the behavior of objects when
       // the code inside the sandbox tries to access them
       distortionCallback,
-      defaultPolicy: {
-        createHTML: (string: string) => string,
-        createScript: (string: string) => string,
-        createScriptURL: (string: string) => string,
-      },
+      defaultPolicy: defaultTrustedTypesPolicy,
       liveTargetCallback: isLiveTarget,
       // endowments are custom variables we make available to plugins in their window object
       endowments: Object.getOwnPropertyDescriptors({


### PR DESCRIPTION
**What is this feature?**

It makes plugins running inside the sandbox adhere to the same default trusted types policy that is used by Grafana itself.

**Why do we need this feature?**

Plugins inside sandbox use their own trusted types policy since they run in a separate document than grafana but that is part of the same origin (they share the CSP header)

With this change that separate document shares the same trusted type policy than grafana and we ensure a consistent behaviour with
plugins not running inside the sandbox.

**Who is this feature for?**

All plugins running inside the sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/75290

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
