### PR TITLE
Dashboard: DashboardGrid - don't animate if reduced-motion set

### DIFF
--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -109,8 +109,10 @@
   transition-property: none;
 }
 
-.react-grid-layout--enable-move-animations {
-  .react-grid-item.cssTransforms {
-    transition-property: transform;
+@media (prefers-reduced-motion: no-preference) {
+  .react-grid-layout--enable-move-animations {
+    .react-grid-item.cssTransforms {
+      transition-property: transform;
+    }
   }
 }


### PR DESCRIPTION
**What is this feature?**

Obey the [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
) CSS media feature and only enable the react-grid movement animations if the user hasn't set any preference for reduced motion

**Why do we need this feature?**

Accessibility support to avoid vestibular motion triggers as well as better support for headless browser image capture.

**Which issue(s) does this PR fix?**:

Contributes-to: grafana/grafana#74603 (provides a workaround to disable the animation)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.