### PR TITLE
Stat: Disable wide layout

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -74,6 +74,11 @@ export interface Props extends Themeable2 {
    * Used by BigValueTextMode.Auto text mode.
    */
   count?: number;
+
+  /**
+   * Disable the wide layout for the BigValue
+   */
+  disableWideLayout?: boolean;
 }
 
 export class BigValue extends PureComponent<Props> {

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -445,7 +445,7 @@ export class StackedWithNoChartLayout extends BigValueLayout {
 
 export function buildLayout(props: Props): BigValueLayout {
   const { width, height, sparkline } = props;
-  const useWideLayout = width / height > 2.5;
+  const useWideLayout = width / height > 2.5 && !props.disableWideLayout;
 
   if (useWideLayout) {
     if (height > 50 && !!sparkline && sparkline.y.values.length > 1) {

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -48,6 +48,7 @@ export class StatPanel extends PureComponent<PanelProps<Options>> {
         theme={config.theme2}
         onClick={openMenu}
         className={targetClassName}
+        disableWideLayout={true}
       />
     );
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the wide layout functionality in the stat panel. This primarily applies when displaying both the value and the label.

Before


https://github.com/grafana/grafana/assets/22381771/0a81ace0-0447-4eb7-97cd-e833997faf89



After


https://github.com/grafana/grafana/assets/22381771/5231d2d0-0d87-4729-a3d1-ae9239b858ac

Stat panel test dashboard
[Stat!-1695827506475.json.txt](https://github.com/grafana/grafana/files/12740282/Stat.-1695827506475.json.txt)

**Why do we need this feature?**

We received feedback that the current experience was not consistent with user expectations. This is relatively subjective though so we may want to consider making this an option in `BigValue` based panels vs strictly enforcing it / disabling it.

**Who is this feature for?**

Users with feedback that stat layout was inconsistent

**Which issue(s) does this PR fix?**: 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/7513

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
