### PR TITLE
sql: remove grafana-core import

### DIFF
--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -10,6 +10,7 @@ import { DatasetSelector } from './DatasetSelector';
 import { buildMockDatasetSelectorProps, buildMockTableSelectorProps } from './SqlComponents.testHelpers';
 import { TableSelector } from './TableSelector';
 import { removeQuotesForMultiVariables } from './visual-query-builder/SQLWhereRow';
+import { makeVariable } from '../utils/testHelpers';
 
 beforeEach(() => {
   config.featureToggles.sqlDatasourceDatabaseSelection = true;
@@ -69,34 +70,13 @@ describe('TableSelector', () => {
 });
 
 describe('SQLWhereRow', () => {
-  function makeVariable(id: string, name: string, multi: boolean): CustomVariableModel {
-    return {
-      id,
-      name,
-      multi,
-      type: 'custom',
-      includeAll: false,
-      current: {},
-      options: [],
-      query: '',
-      rootStateKey: null,
-      global: false,
-      hide: VariableHide.dontHide,
-      skipUrlSync: false,
-      index: -1,
-      state: LoadingState.NotStarted,
-      error: null,
-      description: null,
-    };
-  }
-
   it('should remove quotes in a where clause including multi-value variable', () => {
     const exp: SQLExpression = {
       whereString: "hostname IN ('${multiHost}')",
     };
 
-    const multiVar = makeVariable('multiVar', 'multiHost', true);
-    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
+    const multiVar = makeVariable('multiVar', 'multiHost', { multi: true });
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', { multi: false });
 
     const variables = [multiVar, nonMultiVar];
 
@@ -110,8 +90,8 @@ describe('SQLWhereRow', () => {
       whereString: "hostname IN ('${host}')",
     };
 
-    const multiVar = makeVariable('multiVar', 'multiHost', true);
-    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
+    const multiVar = makeVariable('multiVar', 'multiHost', { multi: true });
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', { multi: false });
 
     const variables = [multiVar, nonMultiVar];
 
@@ -125,8 +105,8 @@ describe('SQLWhereRow', () => {
       whereString: "hostname IN ('${nonMultiHost}')",
     };
 
-    const multiVar = makeVariable('multiVar', 'multiHost', true);
-    const nonMultiVar = makeVariable('nonMultiVar', 'host', false);
+    const multiVar = makeVariable('multiVar', 'multiHost', { multi: true });
+    const nonMultiVar = makeVariable('nonMultiVar', 'host', { multi: false });
 
     const variables = [multiVar, nonMultiVar];
 

--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -1,16 +1,15 @@
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { CustomVariableModel, LoadingState, VariableHide } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { SQLExpression } from '../types';
+import { makeVariable } from '../utils/testHelpers';
 
 import { DatasetSelector } from './DatasetSelector';
 import { buildMockDatasetSelectorProps, buildMockTableSelectorProps } from './SqlComponents.testHelpers';
 import { TableSelector } from './TableSelector';
 import { removeQuotesForMultiVariables } from './visual-query-builder/SQLWhereRow';
-import { makeVariable } from '../utils/testHelpers';
 
 beforeEach(() => {
   config.featureToggles.sqlDatasourceDatabaseSelection = true;

--- a/public/app/features/plugins/sql/utils/testHelpers.ts
+++ b/public/app/features/plugins/sql/utils/testHelpers.ts
@@ -1,0 +1,23 @@
+import { CustomVariableModel, LoadingState, VariableHide } from '@grafana/data';
+
+export function makeVariable(id: string, name: string, attributes?: Partial<CustomVariableModel>): CustomVariableModel {
+  return {
+    multi: false,
+    type: 'custom',
+    includeAll: false,
+    current: {},
+    options: [],
+    query: '',
+    rootStateKey: null,
+    global: false,
+    hide: VariableHide.dontHide,
+    skipUrlSync: false,
+    index: -1,
+    state: LoadingState.NotStarted,
+    error: null,
+    description: null,
+    ...attributes,
+    id,
+    name,
+  };
+}

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -12,8 +12,8 @@ import {
 import { FetchResponse, setBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { SQLQuery } from 'app/features/plugins/sql/types';
+import { makeVariable } from 'app/features/plugins/sql/utils/testHelpers';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { initialCustomVariableModelState } from 'app/features/variables/custom/reducer';
 
 import { MySqlDatasource } from '../MySqlDatasource';
 import { MySQLOptions } from '../types';
@@ -30,7 +30,7 @@ describe('MySQLDatasource', () => {
       },
     } as unknown as DataSourceInstanceSettings<MySQLOptions>;
     const templateSrv: TemplateSrv = new TemplateSrv();
-    const variable = { ...initialCustomVariableModelState };
+    const variable = makeVariable('id1', 'name1');
     fetchMock.mockImplementation((options) => of(createFetchResponse(response)));
 
     const ds = new MySqlDatasource(instanceSettings);

--- a/public/app/plugins/datasource/postgres/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/datasource.test.ts
@@ -15,9 +15,8 @@ import {
 import { FetchResponse } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { QueryFormat, SQLQuery } from 'app/features/plugins/sql/types';
+import { makeVariable } from 'app/features/plugins/sql/utils/testHelpers';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-
-import { initialCustomVariableModelState } from '../../../features/variables/custom/reducer';
 
 import { PostgresDatasource } from './datasource';
 import { PostgresOptions } from './types';
@@ -50,7 +49,7 @@ describe('PostgreSQLDatasource', () => {
       },
     } as unknown as DataSourceInstanceSettings<PostgresOptions>;
     const templateSrv: TemplateSrv = new TemplateSrv();
-    const variable = { ...initialCustomVariableModelState };
+    const variable = makeVariable('id1', 'name1');
     const ds = new PostgresDatasource(instanceSettings);
     Reflect.set(ds, 'templateSrv', templateSrv);
     return { ds, templateSrv, variable };


### PR DESCRIPTION
the sql datasource code does the following import:
```ts
import { initialCustomVariableModelState } from '../../../features/variables/custom/reducer';
```

this is a problem if we want to externalize the sql datasources.

we already handled something similar in `SqlComponents.test.tsx` in the past, so i took the helper function from there, and made it usable for this place too.

(long term we may want to extract such a helper to the grafana-sdk maybe, but we can do it later)