### PR TITLE
Loki Query Autocomplete: better suggestions and insertions for Logfmt

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -814,6 +814,37 @@ describe('IN_LOGFMT completions', () => {
     `);
   });
 
+  it('autocompleting logfmt labels should correctly handle trailing commas', async () => {
+    const situation: Situation = {
+      type: 'IN_LOGFMT',
+      logQuery: `{job="grafana"} | logfmt lab`,
+      flags: true,
+      otherLabels: ['lab'],
+    };
+
+    const completions = await getCompletions(situation, completionProvider);
+    const labelCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
+
+    expect(labelCompletions).toHaveLength(2);
+    expect(labelCompletions[0].insertText.startsWith(' ,')).toBe(false);
+    expect(labelCompletions[1].insertText.startsWith(' ,')).toBe(false);
+  });
+
+  it('autocompleting logfmt labels should correctly add trailing commas', async () => {
+    const situation: Situation = {
+      type: 'IN_LOGFMT',
+      logQuery: `{job="grafana"} | logfmt label1,`,
+      flags: true,
+      otherLabels: ['label1'],
+    };
+
+    const completions = await getCompletions(situation, completionProvider);
+    const labelCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
+
+    expect(labelCompletions).toHaveLength(1);
+    expect(labelCompletions[0].insertText.startsWith(' ,')).toBe(false);
+  });
+
   it('autocompleting logfmt without flags should only offer labels when the user has a trailing comma', async () => {
     const situation: Situation = {
       type: 'IN_LOGFMT',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -538,6 +538,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt `,
       flags: false,
       trailingSpace: true,
+      trailingComma: false,
       otherLabels: [],
     };
 
@@ -615,6 +616,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt`,
       flags: true,
       trailingSpace: true,
+      trailingComma: false,
       otherLabels: [],
     };
 
@@ -680,6 +682,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt`,
       flags: false,
       trailingComma: true,
+      trailingSpace: false,
       otherLabels: [],
     };
 
@@ -707,6 +710,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt label1, label2`,
       flags: true,
       trailingSpace: true,
+      trailingComma: false,
       otherLabels: ['label1', 'label2'],
     };
     const completions = await getCompletions(situation, completionProvider);
@@ -721,6 +725,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt label1,`,
       flags: true,
       trailingComma: true,
+      trailingSpace: false,
       otherLabels: ['label1'],
     };
 
@@ -737,6 +742,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: false,
       trailingComma: true,
+      trailingSpace: false,
       otherLabels: ['label1'],
     };
 
@@ -758,6 +764,7 @@ describe('IN_LOGFMT completions', () => {
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: true,
       trailingComma: true,
+      trailingSpace: false,
       otherLabels: ['label1'],
     };
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -679,7 +679,7 @@ describe('IN_LOGFMT completions', () => {
   it('autocompleting logfmt with labels and trailing comma should only return labels', async () => {
     const situation: Situation = {
       type: 'IN_LOGFMT',
-      logQuery: `{job="grafana"} | logfmt`,
+      logQuery: `{job="grafana"} | logfmt,`,
       flags: false,
       trailingComma: true,
       trailingSpace: false,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -556,36 +556,6 @@ describe('IN_LOGFMT completions', () => {
         },
         {
           "documentation": "Operator docs",
-          "insertText": "| json",
-          "label": "json",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| logfmt",
-          "label": "logfmt",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| pattern",
-          "label": "pattern",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| regexp",
-          "label": "regexp",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| unpack",
-          "label": "unpack",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
           "insertText": "| line_format "{{.$0}}"",
           "isSnippet": true,
           "label": "line_format",
@@ -648,36 +618,6 @@ describe('IN_LOGFMT completions', () => {
 
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
-        {
-          "documentation": "Operator docs",
-          "insertText": "| json",
-          "label": "json",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| logfmt",
-          "label": "logfmt",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| pattern",
-          "label": "pattern",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| regexp",
-          "label": "regexp",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| unpack",
-          "label": "unpack",
-          "type": "PARSER",
-        },
         {
           "documentation": "Operator docs",
           "insertText": "| line_format "{{.$0}}"",
@@ -744,36 +684,6 @@ describe('IN_LOGFMT completions', () => {
       [
         {
           "documentation": "Operator docs",
-          "insertText": "| json",
-          "label": "json",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| logfmt",
-          "label": "logfmt",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| pattern",
-          "label": "pattern",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| regexp",
-          "label": "regexp",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| unpack",
-          "label": "unpack",
-          "type": "PARSER",
-        },
-        {
-          "documentation": "Operator docs",
           "insertText": "| line_format "{{.$0}}"",
           "isSnippet": true,
           "label": "line_format",
@@ -812,22 +722,6 @@ describe('IN_LOGFMT completions', () => {
         },
       ]
     `);
-  });
-
-  it('autocompleting logfmt labels should correctly handle trailing commas', async () => {
-    const situation: Situation = {
-      type: 'IN_LOGFMT',
-      logQuery: `{job="grafana"} | logfmt lab`,
-      flags: true,
-      otherLabels: ['lab'],
-    };
-
-    const completions = await getCompletions(situation, completionProvider);
-    const labelCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
-
-    expect(labelCompletions).toHaveLength(2);
-    expect(labelCompletions[0].insertText.startsWith(' ,')).toBe(false);
-    expect(labelCompletions[1].insertText.startsWith(' ,')).toBe(false);
   });
 
   it('autocompleting logfmt labels should correctly add trailing commas', async () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -720,11 +720,20 @@ describe('IN_LOGFMT completions', () => {
   });
 
   it.each([
+    // {label="value"} | logfmt ^
     [true, false, [], false],
-    [true, false, ['otherLabel'], false],
+    // {label="value"} | logfmt otherLabel ^
+    [true, false, ['otherLabel'], true],
+    // {label="value"} | logfmt otherLabel^
+    [false, false, ['otherLabel'], false],
+    // {label="value"} | logfmt lab^
     [false, false, ['lab'], false],
-    [false, true, ['lab'], false],
-    [true, true, ['lab'], false],
+    // {label="value"} | logfmt otherLabel,^
+    [false, true, ['otherLabel'], false],
+    // {label="value"} | logfmt lab, ^
+    [true, true, ['otherLabel'], false],
+    // {label="value"} | logfmt otherLabel ^
+    [true, false, ['otherLabel'], true],
   ])(
     'when space is %p, comma %p, and other labels %o => inserting a comma should be %p',
     async (trailingSpace: boolean, trailingComma: boolean, otherLabels: string[], shouldHaveComma: boolean) => {
@@ -740,8 +749,8 @@ describe('IN_LOGFMT completions', () => {
       const labelCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
 
       expect(labelCompletions).toHaveLength(2);
-      expect(labelCompletions[0].insertText.startsWith(' ,')).toBe(shouldHaveComma);
-      expect(labelCompletions[1].insertText.startsWith(' ,')).toBe(shouldHaveComma);
+      expect(labelCompletions[0].insertText.startsWith(',')).toBe(shouldHaveComma);
+      expect(labelCompletions[1].insertText.startsWith(',')).toBe(shouldHaveComma);
     }
   );
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -532,11 +532,12 @@ describe('IN_LOGFMT completions', () => {
       hasPack: false,
     });
   });
-  it('autocompleting logfmt should return flags, parsers, pipe operations, and labels', async () => {
+  it('autocompleting logfmt should return flags, pipe operations, and labels', async () => {
     const situation: Situation = {
       type: 'IN_LOGFMT',
-      logQuery: `{job="grafana"} | logfmt`,
+      logQuery: `{job="grafana"} | logfmt `,
       flags: false,
+      trailingSpace: true,
       otherLabels: [],
     };
 
@@ -608,11 +609,12 @@ describe('IN_LOGFMT completions', () => {
     `);
   });
 
-  it('autocompleting logfmt with flags should return parser, pipe operations, and labels', async () => {
+  it('autocompleting logfmt with flags and trailing space should return pipe operations, and labels', async () => {
     const situation: Situation = {
       type: 'IN_LOGFMT',
       logQuery: `{job="grafana"} | logfmt`,
       flags: true,
+      trailingSpace: true,
       otherLabels: [],
     };
 
@@ -672,56 +674,45 @@ describe('IN_LOGFMT completions', () => {
     `);
   });
 
-  it('autocompleting logfmt should exclude already used labels from the suggestions', async () => {
+  it('autocompleting logfmt with labels and trailing comma should only return labels', async () => {
     const situation: Situation = {
       type: 'IN_LOGFMT',
       logQuery: `{job="grafana"} | logfmt`,
-      flags: true,
-      otherLabels: ['label1', 'label2'],
+      flags: false,
+      trailingComma: true,
+      otherLabels: [],
     };
 
     expect(await getCompletions(situation, completionProvider)).toMatchInlineSnapshot(`
       [
         {
-          "documentation": "Operator docs",
-          "insertText": "| line_format "{{.$0}}"",
-          "isSnippet": true,
-          "label": "line_format",
-          "type": "PIPE_OPERATION",
+          "insertText": "label1",
+          "label": "label1",
+          "triggerOnInsert": false,
+          "type": "LABEL_NAME",
         },
         {
-          "documentation": "Operator docs",
-          "insertText": "| label_format",
-          "isSnippet": true,
-          "label": "label_format",
-          "type": "PIPE_OPERATION",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| unwrap",
-          "label": "unwrap",
-          "type": "PIPE_OPERATION",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| decolorize",
-          "label": "decolorize",
-          "type": "PIPE_OPERATION",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| drop",
-          "label": "drop",
-          "type": "PIPE_OPERATION",
-        },
-        {
-          "documentation": "Operator docs",
-          "insertText": "| keep",
-          "label": "keep",
-          "type": "PIPE_OPERATION",
+          "insertText": "label2",
+          "label": "label2",
+          "triggerOnInsert": false,
+          "type": "LABEL_NAME",
         },
       ]
     `);
+  });
+
+  it('autocompleting logfmt should exclude already used labels from the suggestions', async () => {
+    const situation: Situation = {
+      type: 'IN_LOGFMT',
+      logQuery: `{job="grafana"} | logfmt label1, label2`,
+      flags: true,
+      trailingSpace: true,
+      otherLabels: ['label1', 'label2'],
+    };
+    const completions = await getCompletions(situation, completionProvider);
+    const labelCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
+
+    expect(labelCompletions).toHaveLength(0);
   });
 
   it('autocompleting logfmt labels should correctly add trailing commas', async () => {
@@ -729,6 +720,7 @@ describe('IN_LOGFMT completions', () => {
       type: 'IN_LOGFMT',
       logQuery: `{job="grafana"} | logfmt label1,`,
       flags: true,
+      trailingComma: true,
       otherLabels: ['label1'],
     };
 
@@ -744,6 +736,7 @@ describe('IN_LOGFMT completions', () => {
       type: 'IN_LOGFMT',
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: false,
+      trailingComma: true,
       otherLabels: ['label1'],
     };
 
@@ -764,6 +757,7 @@ describe('IN_LOGFMT completions', () => {
       type: 'IN_LOGFMT',
       logQuery: `{job="grafana"} | logfmt --strict label3,`,
       flags: true,
+      trailingComma: true,
       otherLabels: ['label1'],
     };
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -380,14 +380,26 @@ export async function getLogfmtCompletions(
     completions = [...completions, ...parserCompletions, ...pipeOperations];
   }
 
-  const labelPrefix = otherLabels.length === 0 || trailingComma ? '' : ', ';
   const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
+
+  // No other labels or trailing comma, so we don't need to add a prefix
+  let labelPrefix = otherLabels.length === 0 || trailingComma ? '' : ', ';
+
+  // But the user can be in the process of writing a label and, for example, backspaced one character.
+  if (otherLabels.length === 1 && !trailingComma) {
+    const matchingLabel = labels.find(label => {
+      return label.startsWith(otherLabels[0]) && label !== otherLabels[0];
+    });
+    labelPrefix = matchingLabel ? '' : labelPrefix;
+  }
+  
   const labelCompletions: Completion[] = labels.map((label) => ({
     type: 'LABEL_NAME',
     label,
     insertText: labelPrefix + label,
     triggerOnInsert: false,
   }));
+
   completions = [...completions, ...labelCompletions];
 
   return completions;

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -383,28 +383,32 @@ export async function getLogfmtCompletions(
         : [];
     completions = [...completions, ...parserCompletions, ...pipeOperations];
   }
+
+  const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
+
   /**
-   * We want to offer labels if there are no other labels or if there is a trailing comma.
-   * Otherwise, there are situations where the label suggestion will be inserted with an extra comma.
    * {label="value"} | logfmt ^
+   * - trailingSpace: true, trailingComma: false, otherLabels: []
+   * {label="value"} | logfmt lab^
+   * trailingSpace: false, trailignComma: false, otherLabels: [lab]
    * {label="value"} | logfmt label,^
+   * trailingSpace: false, trailingComma: true, otherLabels: [label]
    * {label="value"} | logfmt label, ^
+   * trailingSpace: true, trailingComma: true, otherLabels: [label]
    */
-  if (otherLabels.length === 0 || trailingSpace || trailingComma) {
-    const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
-
-    // No other labels or trailing comma, so we don't need to add a prefix
-    let labelPrefix = otherLabels.length === 0 || trailingComma ? '' : ', ';
-
-    const labelCompletions: Completion[] = labels.map((label) => ({
-      type: 'LABEL_NAME',
-      label,
-      insertText: labelPrefix + label,
-      triggerOnInsert: false,
-    }));
-
-    completions = [...completions, ...labelCompletions];
+  let labelPrefix = '';
+  if (otherLabels.length > 0 && trailingSpace) {
+    labelPrefix = trailingComma ? '' : ', ';
   }
+
+  const labelCompletions: Completion[] = labels.map((label) => ({
+    type: 'LABEL_NAME',
+    label,
+    insertText: labelPrefix + label,
+    triggerOnInsert: false,
+  }));
+
+  completions = [...completions, ...labelCompletions];
 
   return completions;
 }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -360,7 +360,7 @@ export async function getLogfmtCompletions(
     // The user is typing a new label, so we remove the last comma
     logQuery = trimEnd(logQuery, ', ');
   }
-  
+
   let completions: Completion[] = [];
 
   const { extractedLabelKeys, hasJSON, hasLogfmt, hasPack } = await dataProvider.getParserAndLabelKeys(logQuery);
@@ -377,14 +377,10 @@ export async function getLogfmtCompletions(
      * Don't offer parsers: {label="value"} | logfmt ^
      * Offer parsers: {label="value"} | logfmt label ^
      */
-    const parserCompletions = otherLabels.length > 0 ? await getParserCompletions(
-      '| ',
-      hasJSON,
-      hasLogfmt,
-      hasPack,
-      extractedLabelKeys,
-      true
-    ) : [];
+    const parserCompletions =
+      otherLabels.length > 0
+        ? await getParserCompletions('| ', hasJSON, hasLogfmt, hasPack, extractedLabelKeys, true)
+        : [];
     completions = [...completions, ...parserCompletions, ...pipeOperations];
   }
   /**
@@ -393,13 +389,13 @@ export async function getLogfmtCompletions(
    * {label="value"} | logfmt ^
    * {label="value"} | logfmt label,^
    * {label="value"} | logfmt label, ^
-   */ 
+   */
   if (otherLabels.length === 0 || trailingSpace || trailingComma) {
     const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
 
     // No other labels or trailing comma, so we don't need to add a prefix
     let labelPrefix = otherLabels.length === 0 || trailingComma ? '' : ', ';
-    
+
     const labelCompletions: Completion[] = labels.map((label) => ({
       type: 'LABEL_NAME',
       label,
@@ -492,7 +488,14 @@ export async function getCompletions(
     case 'AFTER_KEEP_AND_DROP':
       return getAfterKeepAndDropCompletions(situation.logQuery, dataProvider);
     case 'IN_LOGFMT':
-      return getLogfmtCompletions(situation.logQuery, situation.flags, situation.trailingComma, situation.trailingSpace, situation.otherLabels, dataProvider);
+      return getLogfmtCompletions(
+        situation.logQuery,
+        situation.flags,
+        situation.trailingComma,
+        situation.trailingSpace,
+        situation.otherLabels,
+        dataProvider
+      );
     default:
       throw new NeverCaseError(situation);
   }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -97,85 +97,124 @@ describe('situation', () => {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('{level="info"} | logfmt --strict ^', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt --strict',
     });
     assertSituation('{level="info"} | logfmt --strict --keep-empty^', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: true,
+      trailingComma: false,
+      trailingSpace: false,
       logQuery: '{level="info"} | logfmt --strict --keep-empty',
     });
     assertSituation('{level="info"} | logfmt --strict label, label1="expression"^', {
       type: 'IN_LOGFMT',
       otherLabels: ['label', 'label1'],
       flags: false,
+      trailingSpace: false,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt --strict label, label1="expression"',
     });
     assertSituation('{level="info"} | logfmt --strict label, label1="expression",^', {
       type: 'IN_LOGFMT',
       otherLabels: ['label', 'label1'],
       flags: false,
+      trailingComma: true,
+      trailingSpace: false,
       logQuery: '{level="info"} | logfmt --strict label, label1="expression",',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^)', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt ^ [$__auto])', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('count_over_time({level="info"} | logfmt --keep-empty^)', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: false,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt --keep-empty',
     });
     assertSituation('count_over_time({level="info"} | logfmt --keep-empty label1, label2^)', {
       type: 'IN_LOGFMT',
       otherLabels: ['label1', 'label2'],
       flags: false,
+      trailingSpace: false,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt --keep-empty label1, label2',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt ^))', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt label ^))', {
       type: 'IN_LOGFMT',
       otherLabels: ['label'],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt label',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt label,^))', {
       type: 'IN_LOGFMT',
       otherLabels: ['label'],
       flags: false,
+      trailingComma: true,
+      trailingSpace: false,
       logQuery: '{level="info"} | logfmt label,',
     });
     assertSituation('sum by (test) (count_over_time({level="info"} | logfmt --strict ^))', {
       type: 'IN_LOGFMT',
       otherLabels: [],
       flags: false,
+      trailingSpace: true,
+      trailingComma: false,
       logQuery: '{level="info"} | logfmt --strict',
+    });
+  });
+
+  it('identifies AFTER_LOGFMT autocomplete situations when the cursor is not at the end', () => {
+    assertSituation('{level="info"} | logfmt ^ label1, label2', {
+      type: 'IN_LOGFMT',
+      otherLabels: ['label1', 'label2'],
+      flags: false,
+      trailingSpace: true,
+      trailingComma: false,
+      logQuery: '{level="info"} | logfmt  label1, label2',
     });
   });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -161,10 +161,7 @@ const ERROR_NODE_ID = 0;
 
 const RESOLVERS: Resolver[] = [
   {
-    paths: [
-      [Selector],
-      [ERROR_NODE_ID, Matchers, Selector]
-    ],
+    paths: [[Selector], [ERROR_NODE_ID, Matchers, Selector]],
     fun: resolveSelector,
   },
   {
@@ -176,15 +173,12 @@ const RESOLVERS: Resolver[] = [
       [LogRangeExpr],
       [ERROR_NODE_ID, LabelExtractionExpressionList],
       [LabelExtractionExpressionList],
-      [LogfmtExpressionParser]
+      [LogfmtExpressionParser],
     ],
     fun: resolveLogfmtParser,
   },
   {
-    paths: [
-      [LogQL],
-      [ERROR_NODE_ID, Selector],
-    ],
+    paths: [[LogQL], [ERROR_NODE_ID, Selector]],
     fun: resolveTopLevel,
   },
   {
@@ -436,10 +430,10 @@ function resolveLogfmtParser(_: SyntaxNode, text: string, cursorPosition: number
   // We want to know if the cursor if after a log query with logfmt parser.
   // E.g. `{x="y"} | logfmt ^`
   /**
-   * Wait until the user adds a space to be sure of what the last identifier is. Otherwise 
+   * Wait until the user adds a space to be sure of what the last identifier is. Otherwise
    * it creates suggestion bugs with queries like {label="value"} | parser^ suggest "parser"
    * and it can be inserted with extra pipes or commas.
-   */ 
+   */
   const tree = parser.parse(text);
 
   // Adjust the cursor position if there are spaces at the end of the text.
@@ -492,7 +486,7 @@ function resolveTopLevel(node: SyntaxNode, text: string, pos: number): Situation
    * Top level examples:
    * - Empty query
    * - {label="value"}
-   * - {label="value"} | parser 
+   * - {label="value"} | parser
    */
   const logExprNode = walk(node, [
     ['lastChild', Expr],
@@ -500,10 +494,10 @@ function resolveTopLevel(node: SyntaxNode, text: string, pos: number): Situation
   ]);
 
   /**
-   * Wait until the user adds a space to be sure of what the last identifier is. Otherwise 
+   * Wait until the user adds a space to be sure of what the last identifier is. Otherwise
    * it creates suggestion bugs with queries like {label="value"} | parser^ suggest "parser"
    * and it can be inserted with extra pipes.
-   */ 
+   */
   if (logExprNode != null && text.endsWith(' ')) {
     return resolveLogOrLogRange(logExprNode, text, pos, false);
   }
@@ -631,7 +625,7 @@ function resolveAfterKeepAndDrop(node: SyntaxNode, text: string, pos: number): S
 
 // If there is an error in the current cursor position, it's likely that the user is
 // in the middle of writing a query. If we can't find an error node, we use the node
-// at the cursor position to identify the situation. 
+// at the cursor position to identify the situation.
 function resolveCursor(text: string, cursorPos: number): TreeCursor {
   // Sometimes the cursor is a couple spaces after the end of the expression.
   // To account for this situation, we "move" the cursor position back to the real end


### PR DESCRIPTION
After the recent changes in Logfmt, there were scenarios where we were making suggestions for things that were already in the query, and there were also situations were the user had written a label or was in the process of writing one, and we were interfiring with it without knowing if we can insert a trailing comma or not.

For example:

- `{label="value"} | logfmt `, deleting the last space would trigger a `logfmt` suggestion that would also come with an extra pipe.
- `{label="value"} | logfmt someString` we couldn't tell if `someString` is the label the user wants, or was in the process of writing it.

For the tricky scenarios, we now wait for a trailing space or a trailing comma to make suggestions that we know are the right ones.

Other changes:
- Simplified `getSituation()`.
- Removed `getErrorNode()` in favor of `resolveCursor()`.
- Updated old comments.
- No longer suggest parsers when you're in IN_LOGFMT.
- Supports autocompleting logfmt in the middle of the expression.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/75493
Related with https://github.com/grafana/grafana/issues/71121

**Special notes for your reviewer:**

- The autocomplete experience should not have odd behaviors where extra symbols are being inserted. 
- It should also wait for spaces, commas, or pipes to have a better understanding of user intentions.
- Building log queries inside metric queries should be as good as outside of metric queries.

Demo:

https://github.com/grafana/grafana/assets/1069378/3e432099-f268-4629-a230-2d1eaf9f3f56

