### PR TITLE
[v8.0.x] Remove plugins

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -2,7 +2,7 @@
 title = "Grafana documentation"
 description = "Guides, installation, and feature documentation"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/latest/guides/reference/admin"]
+aliases = ["/docs/grafana/v8.0/guides/reference/admin"]
 +++
 
 # Grafana documentation

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -2,21 +2,25 @@
 title = "Configuration"
 description = "Configuration documentation"
 keywords = ["grafana", "configuration", "documentation"]
-aliases = ["/docs/grafana/latest/installation/configuration/"]
+aliases = ["/docs/grafana/v8.0/installation/configuration/"]
 weight = 150
 +++
 
 # Configuration
 
-Grafana has default and custom configuration files. You can customize your Grafana instance by modifying the custom configuration file or by using environment variables. To see the list of settings for a Grafana instance, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
+Grafana has a number of configuration options that you can specify in a `.ini` configuration file or specified using environment variables.
 
-> **Note:** After you add custom options, [uncomment](#remove-comments-in-the-ini-files) the relevant sections of the configuration file. Restart Grafana for your changes to take effect.
+> **Note:** You must restart Grafana for any configuration changes to take effect.
 
-## Configuration file location
+To see all settings currently applied to the Grafana server, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
 
-The default settings for a Grafana instance are stored in the `$WORKING_DIR/conf/defaults.ini` file. _Do not_ change the location in this file. 
+## Config file locations
 
-Depending on your OS, your custom configuration file is either the `$WORKING_DIR/conf/defaults.ini` file or the `/usr/local/etc/grafana/grafana.ini` file. The custom configuration file path can be overridden using the `--config` parameter.
+_Do not_ change `defaults.ini`! Grafana defaults are stored in this file. Depending on your OS, make all configuration changes in either `custom.ini` or `grafana.ini`.
+
+- Default configuration from `$WORKING_DIR/conf/defaults.ini`
+- Custom configuration from `$WORKING_DIR/conf/custom.ini`
+- The custom configuration file path can be overridden using the `--config` parameter
 
 ### Linux
 
@@ -28,22 +32,24 @@ Refer to [Configure a Grafana Docker image]({{< relref "configure-docker.md" >}}
 
 ### Windows
 
-On Windows, the `sample.ini` file is located in the same directory as `defaults.ini` file. It contains all the settings commented out. Copy `sample.ini` and name it `custom.ini`.
+`sample.ini` is in the same directory as `defaults.ini` and contains all the settings commented out. Copy `sample.ini` and name it `custom.ini`.
 
 ### macOS
 
-By default, the configuration file is located at `/usr/local/etc/grafana/grafana.ini`. For a Grafana instance installed using Homebrew, edit the `grafana.ini` file directly. Otherwise, add a configuration file named `custom.ini` to the `conf` folder to override the settings defined in `conf/defaults.ini`.
+By default, the configuration file is located at `/usr/local/etc/grafana/grafana.ini`. For a Grafana instance installed using Homebrew, edit the `grafana.ini` file directly. Otherwise, add a configuration file named `custom.ini` to the `conf` folder to override any of the settings defined in `conf/defaults.ini`.
 
-## Remove comments in the .ini files
+## Comments in .ini Files
 
-Grafana uses semicolons (the `;` char) to comment out lines in a `.ini` file. You must uncomment each line in the `custom.ini` or the `grafana.ini` file that you are modify by removing `;` from the beginning of that line. Otherwise your changes will be ignored.
+Semicolons (the `;` char) are the standard way to comment out lines in a `.ini` file. If you want to change a setting, you must delete the semicolon (`;`) in front of the setting before it will work.
 
-For example:
+**Example**
 
 ```
 # The HTTP port  to use
 ;http_port = 3000
 ```
+
+A common problem is forgetting to uncomment a line in the `custom.ini` (or `grafana.ini`) file which causes the configuration option to be ignored.
 
 ## Configure with environment variables
 

--- a/docs/sources/administration/configure-docker.md
+++ b/docs/sources/administration/configure-docker.md
@@ -2,7 +2,7 @@
 title = "Configure Grafana Docker image"
 description = "Guide for configuring the Grafana Docker image"
 keywords = ["grafana", "configuration", "documentation", "docker"]
-aliases = ["/docs/grafana/latest/installation/configure-docker/"]
+aliases = ["/docs/grafana/v8.0/installation/configure-docker/"]
 weight = 200
 +++
 

--- a/docs/sources/administration/preferences/_index.md
+++ b/docs/sources/administration/preferences/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Preferences"
-aliases =["/docs/grafana/latest/administration/preferences.md"]
+aliases =["/docs/grafana/v8.0/administration/preferences.md"]
 weight = 50
 +++
 

--- a/docs/sources/administration/preferences/change-grafana-name.md
+++ b/docs/sources/administration/preferences/change-grafana-name.md
@@ -8,7 +8,7 @@ weight = 100
 
 In Grafana, you can change your names and emails associated with groups or accounts in the Settings or Preferences. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Change organization name
 
@@ -19,7 +19,7 @@ Grafana server administrators and organization administrators can change organiz
 Follow these instructions if you are a Grafana Server Admin.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the organization list, click the name of the organization that you want to change.
 1. In **Name**, enter the new organization name.
 1. Click **Update**.
@@ -30,7 +30,7 @@ Follow these instructions if you are a Grafana Server Admin.
 If you are an Organization Admin, follow these steps:
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In **Organization name**, enter the new name.
 1. Click **Update organization name**.
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-grafana-theme.md
+++ b/docs/sources/administration/preferences/change-grafana-theme.md
@@ -9,7 +9,7 @@ weight = 200
 
 In Grafana, you can modify the UI theme configured in the Settings or Preferences. Set the UI theme for the server, an organization, a team, or your personal user account using the instructions in this topic.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Theme options
 
@@ -42,8 +42,8 @@ To see what the current settings are, refer to [View server settings]({{< relref
 Organization administrators can change the UI theme for all users in an organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Change team UI theme
@@ -51,9 +51,9 @@ Organization administrators can change the UI theme for all users in an organiza
 Organization and team administrators can change the UI theme for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click on the team that you want to change the UI theme for and then navigate to the **Settings** tab.
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Change your personal UI theme
@@ -61,6 +61,6 @@ Organization and team administrators can change the UI theme for all users in a 
 You can change the UI theme for your user account. This setting overrides UI theme settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-grafana-timezone.md
+++ b/docs/sources/administration/preferences/change-grafana-timezone.md
@@ -9,7 +9,7 @@ weight = 400
 
 By default, Grafana uses the timezone in your web browser. However, you can override this setting at the server, organization, team, or individual user level. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Set server timezone
 
@@ -20,8 +20,8 @@ Grafana server administrators can choose a default timezone for all users on the
 Organization administrators can choose a default timezone for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set team timezone
@@ -29,9 +29,9 @@ Organization administrators can choose a default timezone for their organization
 Organization administrators and team administrators can choose a default timezone for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click on the team you that you want to change the timezone for and then navigate to the **Settings** tab.
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set your personal timezone
@@ -39,6 +39,6 @@ Organization administrators and team administrators can choose a default timezon
 You can change the timezone for your user account. This setting overrides timezone settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-home-dashboard.md
+++ b/docs/sources/administration/preferences/change-home-dashboard.md
@@ -2,7 +2,7 @@
 title = "Change home dashboard"
 description = "How to replace the default home dashboard"
 keywords = ["grafana", "configuration", "documentation", "home"]
-aliases = ["/docs/grafana/latest/administration/change-home-dashboard/"]
+aliases = ["/docs/grafana/v8.0/administration/change-home-dashboard/"]
 weight = 300
 +++
 
@@ -10,7 +10,7 @@ weight = 300
 
 The home dashboard you set is the one all users will see by default when they log in. You can set the home dashboard for the server, an organization, a team, or your personal user account. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Navigate to the home dashboard
 
@@ -47,9 +47,9 @@ default_home_dashboard_path = data/main-dashboard.json
 Organization administrators can choose a home dashboard for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set home dashboard for your team
@@ -57,10 +57,10 @@ Organization administrators can choose a home dashboard for their organization.
 Organization administrators and Team Admins can choose a home dashboard for a team.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click on the team that you want to change the home dashboard for and then navigate to the **Settings** tab.
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set your personal home dashboard
@@ -68,7 +68,7 @@ Organization administrators and Team Admins can choose a home dashboard for a te
 You can choose your own personal home dashboard. This setting overrides all home dashboards set at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -2,7 +2,7 @@
 title = "Provisioning"
 description = ""
 keywords = ["grafana", "provisioning"]
-aliases = ["/docs/grafana/latest/installation/provisioning"]
+aliases = ["/docs/grafana/v8.0/installation/provisioning"]
 weight = 800
 +++
 
@@ -439,11 +439,11 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `discord`
 
-| Name       | Secure setting |
-| ---------- | -------------- |
-| url        | yes            |
-| avatar_url |                |
-| content    |                |
+| Name           | Secure setting |
+| -------------- | -------------- |
+| url            | yes            |
+| avatar_url     |                |
+| message        |                |
 
 #### Alert notification `slack`
 

--- a/docs/sources/administration/security.md
+++ b/docs/sources/administration/security.md
@@ -2,7 +2,7 @@
 title = "Security"
 description = "Security Docs"
 keywords = ["grafana", "security", "documentation"]
-aliases = ["/docs/grafana/latest/installation/security/"]
+aliases = ["/docs/grafana/v8.0/installation/security/"]
 weight = 500
 +++
 

--- a/docs/sources/administration/set-up-for-high-availability.md
+++ b/docs/sources/administration/set-up-for-high-availability.md
@@ -1,7 +1,7 @@
 +++
 title = "Set up Grafana for high availability"
 keywords = ["grafana", "tutorials", "HA", "high availability"]
-aliases = ["/docs/grafana/latest/tutorials/ha_setup/"]
+aliases = ["/docs/grafana/v8.0/tutorials/ha_setup/"]
 weight = 1200
 +++
 
@@ -18,7 +18,7 @@ and other persistent data. So the default embedded SQLite database will not work
 
 First, you need to set up MySQL or Postgres on another server and configure Grafana to use that database.
 You can find the configuration for doing that in the [[database]]({{< relref "../administration/configuration.md#database" >}}) section in the Grafana config.
-Grafana will now persist all long term data in the database. How to configure the database for high availability is out of scope for this guide. We recommend finding an expert on the database you're using.
+Grafana will now persist all long term data in the database. How to configure the database for high availability is out of scope for this guide. We recommend finding an expert on for the database you're using.
 
 ## Alerting
 

--- a/docs/sources/administration/view-server/internal-metrics.md
+++ b/docs/sources/administration/view-server/internal-metrics.md
@@ -2,7 +2,7 @@
 title = "Internal Grafana metrics"
 description = "Internal metrics exposed by Grafana"
 keywords = ["grafana", "metrics", "internal metrics"]
-aliases = ["/docs/grafana/latest/admin/metrics/"]
+aliases = ["/docs/grafana/v8.0/admin/metrics/"]
 weight = 200
 +++
 

--- a/docs/sources/administration/view-server/view-server-settings.md
+++ b/docs/sources/administration/view-server/view-server-settings.md
@@ -2,7 +2,7 @@
 title = "View server settings"
 description = "How to view server settings in the Grafana UI"
 keywords = ["grafana", "configuration", "server", "settings"]
-aliases = ["/docs/grafana/latest/admin/view-server-settings/"]
+aliases = ["/docs/grafana/v8.0/admin/view-server-settings/"]
 weight = 300
 +++
 

--- a/docs/sources/administration/view-server/view-server-stats.md
+++ b/docs/sources/administration/view-server/view-server-stats.md
@@ -1,7 +1,7 @@
 +++
 title = "View server stats"
 keywords = ["grafana", "server", "statistics"]
-aliases = ["/docs/grafana/latest/admin/view-server-stats/"]
+aliases = ["/docs/grafana/v8.0/admin/view-server-stats/"]
 weight = 400
 +++
 

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Alerts"
-aliases = ["/docs/grafana/latest/alerting/rules/", "/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.0/alerting/rules/", "/docs/grafana/v8.0/alerting/metrics/"]
 weight = 110
 +++
 

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy Grafana Alerts"
-aliases = ["/docs/grafana/latest/alerting/rules/", "/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.0/alerting/rules/", "/docs/grafana/v8.0/alerting/metrics/"]
 weight = 114
 +++
 

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -40,7 +40,7 @@ Grafana managed alerts are evaluated by the Grafana backend. Rule evaluations ar
 Alert rules can only query backend data sources with alerting enabled:
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
 `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
 
 ## Metrics from the alert engine
 

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -40,7 +40,7 @@ Grafana managed alerts are evaluated by the Grafana backend. Rule evaluations ar
 Alert rules can only query backend data sources with alerting enabled:
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
 `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
 
 ## Metrics from the alert engine
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Grafana 8 Alerts"
-aliases = ["/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.0/alerting/metrics/"]
 weight = 113
 +++
 
@@ -24,7 +24,6 @@ You can perform the following tasks for alerts:
 - [Create a Grafana managed alert rule]({{< relref "alerting-rules/create-grafana-managed-rule.md" >}})
 - [Create a Cortex or Loki managed alert rule]({{< relref "alerting-rules/create-cortex-loki-managed-rule.md" >}})
 - [View existing alert rules and their current state]({{< relref "alerting-rules/rule-list.md" >}})
-- [Test alert rules and troubleshoot]({{< relref "./troubleshoot-alerts.md" >}})
 - [Add or edit an alert contact point]({{< relref "./contact-points.md" >}})
 - [Add or edit notification policies]({{< relref "./notification-policies.md" >}})
 - [Create and edit silences]({{< relref "./silences.md" >}})

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -39,7 +39,7 @@ Grafana managed alerts are evaluated by the Grafana backend. Rule evaluations ar
 Alerting rules can only query backend data sources with alerting enabled:
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
 
 ## Metrics from the alerting engine
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -39,7 +39,7 @@ Grafana managed alerts are evaluated by the Grafana backend. Rule evaluations ar
 Alerting rules can only query backend data sources with alerting enabled:
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
 
 ## Metrics from the alerting engine
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Create and manage rules"
-aliases = ["/docs/grafana/latest/alerting/rules/"]
+aliases = ["/docs/grafana/v8.0/alerting/rules/"]
 weight = 130
 +++
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -32,19 +32,19 @@ This section describes the fields you fill out to create an alert.
   - **Namespace -** Select an existing rule namespace or click **Add new** to create a new one.
   - **Group -** Select an existing group within the selected namespace or click **Add new** to create a new one. Newly created rules will be added to the end of the rule group.
 
-![Alert type section screenshot](/static/img/docs/alerting/unified/rule-edit-cortex-alert-type-8-0.png 'Alert type section screenshot')
+![Alert type section screenshot](/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png 'Alert type section screenshot')
 
 ### Query
 
 Enter a PromQL or LogQL expression. Rule will fire if evaluation result has at least one series with value > 0. An alert will be created per each such series.
 
-![Query section](/static/img/docs/alerting/unified/rule-edit-cortex-query-8-0.png 'Query section screenshot')
+![Query section](/static/img/docs/alerting/unified/rule-edit-mimir-query-8-0.png 'Query section screenshot')
 
 ### Conditions
 
   - **For -** For how long the selected condition should violated before an alert enters `Firing` state. When condition threshold is violated for the first time, an alert becomes `Pending`. If the **for** time elapses and the condition is still violated, it becomes `Firing`. Else it reverts back to `Normal`. 
 
-![Conditions section](/static/img/docs/alerting/unified/rule-edit-cortex-conditions-8-0.png 'Conditions section screenshot')
+![Conditions section](/static/img/docs/alerting/unified/rule-edit-mimir-conditions-8-0.png 'Conditions section screenshot')
 
 ### Details
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Message templating"
 description = "Message templating"
-aliases = ["/docs/grafana/latest/alerting/message-templating/"]
+aliases = ["/docs/grafana/v8.0/alerting/message-templating/"]
 keywords = ["grafana", "alerting", "guide", "contact point", "templating"]
 weight = 400
 +++

--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -2,7 +2,7 @@
 title = "Auth Proxy"
 description = "Grafana Auth Proxy Guide "
 keywords = ["grafana", "configuration", "documentation", "proxy"]
-aliases = ["/docs/grafana/latest/tutorials/authproxy/"]
+aliases = ["/docs/grafana/v8.0/tutorials/authproxy/"]
 weight = 200
 +++
 

--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -2,7 +2,7 @@
 title = "LDAP Authentication"
 description = "Grafana LDAP Authentication Guide "
 keywords = ["grafana", "configuration", "documentation", "ldap", "active directory"]
-aliases = ["/docs/grafana/latest/installation/ldap/"]
+aliases = ["/docs/grafana/v8.0/installation/ldap/"]
 weight = 300
 +++
 

--- a/docs/sources/auth/overview.md
+++ b/docs/sources/auth/overview.md
@@ -121,11 +121,6 @@ Defaults to `false`.
 oauth_auto_login = true
 ```
 
-### Avoid automatic OAuth login
-
-To sign in with a username and password and avoid automatic OAuth login, add the `disableAutoLogin` parameter to your login URL.
-For example: `grafana.example.com/login?disableAutoLogin` or `grafana.example.com/login?disableAutoLogin=true`
-
 ### Hide sign-out menu
 
 Set the option detailed below to true to hide sign-out menu link. Useful if you use an auth proxy or JWT authentication.

--- a/docs/sources/auth/saml.md
+++ b/docs/sources/auth/saml.md
@@ -2,7 +2,7 @@
 title = "SAML Authentication"
 description = "Grafana SAML Authentication"
 keywords = ["grafana", "saml", "documentation", "saml-auth"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.0/auth/saml/"]
 weight = 1100
 +++
 

--- a/docs/sources/auth/team-sync.md
+++ b/docs/sources/auth/team-sync.md
@@ -2,7 +2,7 @@
 title = "Team Sync"
 description = "Grafana Team Sync"
 keywords = ["grafana", "auth", "documentation"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.0/auth/saml/"]
 weight = 1200
 +++
 

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -7,8 +7,8 @@ weight = 15
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/basics/exemplars/_index.md
+++ b/docs/sources/basics/exemplars/_index.md
@@ -9,7 +9,7 @@ weight = 400
 
 An exemplar is a specific trace representative of a repeated pattern of data in a given time interval. It helps you identify higher cardinality metadata from specific events within time series data.
 
-Suppose your company website is experiencing a surge in traffic volumes. While more than eighty percent of the users are able to access the website in under two seconds, some users are experiencing a higher than normal response time resulting in bad user experience.
+Suppose your company website is experiencing a surge in traffic volumes. While more than eighty percent of the users are able to access the website in under two seconds, some users are experiencing a higher than normal response time resulting in bad user experience
 
 To identify the factors that are contributing to the latency, you must compare a trace for a fast response against a trace for a slow response. Given the vast amount of data in a typical production environment, it will be extremely laborious and time-consuming effort.
 

--- a/docs/sources/basics/glossary.md
+++ b/docs/sources/basics/glossary.md
@@ -2,7 +2,7 @@
 title = "Glossary"
 description = "Grafana glossary"
 keywords = ["grafana", "intro", "glossary", "dictionary"]
-aliases = ["/docs/grafana/latest/guides/glossary", "/docs/grafana/latest/getting-started/glossary"]
+aliases = ["/docs/grafana/v8.0/guides/glossary", "/docs/grafana/v8.0/getting-started/glossary"]
 weight = 800
 +++
 
@@ -32,7 +32,7 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
   <tr>
     <td style="vertical-align: top">Explore</td>
     <td>
-      Explore allows a user to focus on building a query. Users can refine the query to return the expected metrics before building a dashboard. For more information, refer to the <a href="https://grafana.com/docs/grafana/latest/explore">Explore</a> topic.
+      Explore allows a user to focus on building a query. Users can refine the query to return the expected metrics before building a dashboard. For more information, refer to the <a href="https://grafana.com/docs/grafana/v8.0/explore">Explore</a> topic.
     </td>
   </tr>
   <tr>
@@ -109,7 +109,7 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
   <tr>
     <td style="vertical-align: top">Transformation</td>
     <td>
-      Transformations process the result set of a query before it’s passed on for visualization. For more information, refer to the <a href="https://grafana.com/docs/grafana/latest/panels/transformations">Transformations overview</a> topic.
+      Transformations process the result set of a query before it’s passed on for visualization. For more information, refer to the <a href="https://grafana.com/docs/grafana/v8.0/panels/transformations">Transformations overview</a> topic.
     </td>
   </tr>
   <tr>

--- a/docs/sources/basics/intro-histograms.md
+++ b/docs/sources/basics/intro-histograms.md
@@ -2,7 +2,7 @@
 title = "Histograms and heatmaps"
 description = "An introduction to histograms and heatmaps"
 keywords = ["grafana", "heatmap", "panel", "documentation", "histogram"]
-aliases = ["/docs/grafana/latest/getting-started/intro-histograms"]
+aliases = ["/docs/grafana/v8.0/getting-started/intro-histograms"]
 weight = 700
 +++
 

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -2,7 +2,7 @@
 title = "Time series dimensions"
 description = "time series dimensions"
 keywords = ["grafana", "intro", "guide", "concepts", "timeseries", "labels"]
-aliases = ["/docs/grafana/latest/guides/timeseries-dimensions", "/docs/grafana/latest/getting-started/timeseries-dimensions"]
+aliases = ["/docs/grafana/v8.0/guides/timeseries-dimensions", "/docs/grafana/v8.0/getting-started/timeseries-dimensions"]
 weight = 600
 +++
 

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -82,4 +82,4 @@ In this case the labels that represent the dimensions will have two keys based o
 
 In the case SQL-like data sources, more than one numeric column can be selected, with or without additional string columns to be used as dimensions. For example, `AVG(Temperature) AS AvgTemp, MAX(Temperature) AS MaxTemp`. This, if combined with multiple dimensions can result in a lot of series. Selecting multiple values is currently only designed to be used with visualization.
 
-Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series]({{< relref "../developers/plugins/data-frames.md#data-frames-as-time-series" >}}).
+Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](https://grafana.com/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -82,4 +82,4 @@ In this case the labels that represent the dimensions will have two keys based o
 
 In the case SQL-like data sources, more than one numeric column can be selected, with or without additional string columns to be used as dimensions. For example, `AVG(Temperature) AS AvgTemp, MAX(Temperature) AS MaxTemp`. This, if combined with multiple dimensions can result in a lot of series. Selecting multiple values is currently only designed to be used with visualization.
 
-Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](https://grafana.com/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).
+Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series]({{< relref "../developers/plugins/data-frames.md#data-frames-as-time-series" >}}).

--- a/docs/sources/best-practices/common-observability-strategies.md
+++ b/docs/sources/best-practices/common-observability-strategies.md
@@ -2,7 +2,7 @@
 title = "Common observability strategies"
 description = "Common observability strategies"
 keywords = ["grafana", "intro", "guide", "concepts", "methods"]
-aliases = ["/docs/grafana/latest/getting-started/strategies/"]
+aliases = ["/docs/grafana/v8.0/getting-started/strategies/"]
 weight = 300
 +++
 

--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Dashboards"
-aliases = ["/docs/grafana/latest/features/dashboard/dashboards/"]
+aliases = ["/docs/grafana/v8.0/features/dashboard/dashboards/"]
 weight = 80
 +++
 

--- a/docs/sources/dashboards/annotations.md
+++ b/docs/sources/dashboards/annotations.md
@@ -1,7 +1,7 @@
 +++
 title = "Annotations"
 keywords = ["grafana", "annotations", "documentation", "guide"]
-aliases = ["/docs/grafana/latest/reference/annotations/"]
+aliases = ["/docs/grafana/v8.0/reference/annotations/"]
 weight = 2
 +++
 

--- a/docs/sources/dashboards/dashboard_folders.md
+++ b/docs/sources/dashboards/dashboard_folders.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard Folders"
 keywords = ["grafana", "dashboard", "dashboard folders", "folder", "folders", "documentation", "guide"]
-aliases = ["/docs/grafana/latest/reference/dashboard_folders/"]
+aliases = ["/docs/grafana/v8.0/reference/dashboard_folders/"]
 weight = 3
 +++
 

--- a/docs/sources/dashboards/dashboard_history.md
+++ b/docs/sources/dashboards/dashboard_history.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard Version History"
 keywords = ["grafana", "dashboard", "documentation", "version", "history"]
-aliases = ["/docs/grafana/latest/reference/dashboard_history/"]
+aliases = ["/docs/grafana/v8.0/reference/dashboard_history/"]
 weight = 100
 +++
 

--- a/docs/sources/dashboards/export-import.md
+++ b/docs/sources/dashboards/export-import.md
@@ -1,7 +1,7 @@
 +++
 title = "Export and import"
 keywords = ["grafana", "dashboard", "documentation", "export", "import"]
-aliases = ["/docs/grafana/latest/reference/export_import/"]
+aliases = ["/docs/grafana/v8.0/reference/export_import/"]
 weight = 800
 +++
 

--- a/docs/sources/dashboards/json-model.md
+++ b/docs/sources/dashboards/json-model.md
@@ -1,7 +1,7 @@
 +++
 title = "JSON model"
 keywords = ["grafana", "dashboard", "documentation", "json", "model"]
-aliases = ["/docs/grafana/latest/reference/dashboard/"]
+aliases = ["/docs/grafana/v8.0/reference/dashboard/"]
 weight = 1200
 +++
 

--- a/docs/sources/dashboards/playlist.md
+++ b/docs/sources/dashboards/playlist.md
@@ -1,7 +1,7 @@
 +++
 title = "Playlist"
 keywords = ["grafana", "dashboard", "documentation", "playlist"]
-aliases = ["/docs/grafana/latest/reference/playlist/"]
+aliases = ["/docs/grafana/v8.0/reference/playlist/"]
 weight = 4
 +++
 

--- a/docs/sources/dashboards/reporting.md
+++ b/docs/sources/dashboards/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting"
 description = ""
 keywords = ["grafana", "reporting"]
-aliases = ["/docs/grafana/latest/administration/reports"]
+aliases = ["/docs/grafana/v8.0/administration/reports"]
 weight = 8
 +++
 

--- a/docs/sources/dashboards/scripted-dashboards.md
+++ b/docs/sources/dashboards/scripted-dashboards.md
@@ -1,7 +1,7 @@
 +++
 title = "Scripted dashboards"
 keywords = ["grafana", "dashboard", "documentation", "scripted"]
-aliases = ["/docs/grafana/latest/reference/scripting/"]
+aliases = ["/docs/grafana/v8.0/reference/scripting/"]
 weight = 1500
 +++
 

--- a/docs/sources/dashboards/search.md
+++ b/docs/sources/dashboards/search.md
@@ -1,7 +1,7 @@
 +++
 title = "Search"
 keywords = ["grafana", "dashboard", "documentation", "search"]
-aliases =["/docs/grafana/latest/reference/search/"]
+aliases =["/docs/grafana/v8.0/reference/search/"]
 weight = 5
 +++
 

--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -1,7 +1,7 @@
 +++
 title = "Time range controls"
 keywords = ["grafana", "dashboard", "documentation", "time range"]
-aliases = ["/docs/grafana/latest/reference/timerange/"]
+aliases = ["/docs/grafana/v8.0/reference/timerange/"]
 weight = 7
 +++
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Data sources"
-aliases = ["/docs/grafana/latest/datasources/overview/"]
+aliases = ["/docs/grafana/v8.0/datasources/overview/"]
 weight = 60
 +++
 

--- a/docs/sources/datasources/add-a-data-source.md
+++ b/docs/sources/datasources/add-a-data-source.md
@@ -1,6 +1,6 @@
 +++
 title = "Add data source"
-aliases = ["/docs/grafana/latest/features/datasources/add-a-data-source/"]
+aliases = ["/docs/grafana/v8.0/features/datasources/add-a-data-source/"]
 weight = 100
 +++
 

--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -2,13 +2,13 @@
 title = "Alertmanager"
 description = "Guide for using Alertmanager in Grafana"
 keywords = ["grafana", "prometheus", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/alertmanager"]
+aliases = ["/docs/grafana/v8.0/features/datasources/alertmanager"]
 weight = 1300
 +++
 
 # Alertmanager data source
 
-Grafana includes built-in support for Prometheus Alertmanager. It is presently in alpha and not accessible unless [alpha plugins are enabled in Grafana settings](https://grafana.com/docs/grafana/latest/administration/configuration/#enable_alpha). Once you add it as a data source, you can use the [Grafana alerting UI](https://grafana.com/docs/grafana/latest/alerting/) to manage silences, contact points as well as notification policies. A drop down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources .
+Grafana includes built-in support for Prometheus Alertmanager. It is presently in alpha and not accessible unless [alpha plugins are enabled in Grafana settings](https://grafana.com/docs/grafana/v8.0/administration/configuration/#enable_alpha). Once you add it as a data source, you can use the [Grafana alerting UI](https://grafana.com/docs/grafana/v8.0/alerting/) to manage silences, contact points as well as notification policies. A drop down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources .
 
 >**Note:** New in Grafana 8.0.
 

--- a/docs/sources/datasources/azuremonitor/_index.md
+++ b/docs/sources/datasources/azuremonitor/_index.md
@@ -2,7 +2,7 @@
 title = "Azure Monitor"
 description = "Guide for using Azure Monitor in Grafana"
 keywords = ["grafana", "microsoft", "azure", "monitor", "application", "insights", "log", "analytics", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/azuremonitor"]
+aliases = ["/docs/grafana/v8.0/features/datasources/azuremonitor"]
 weight = 300
 +++
 
@@ -243,7 +243,7 @@ See the following topics to learn more about the Azure Monitor data source:
 
 Customers who host Grafana in Azure (e.g. App Service, Azure Virtual Machines) and have managed identity enabled on their VM, will now be able to use the managed identity to configure Azure Monitor in Grafana. This will simplify the data source configuration, requiring the data source to be securely authenticated without having to manually configure credentials via Azure AD App Registrations for each data source. For more details on Azure managed identities, refer to the [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).
 
-To enable managed identity for Grafana, set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server config](https://grafana.com/docs/grafana/latest/administration/configuration/#azure).
+To enable managed identity for Grafana, set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server config](https://grafana.com/docs/grafana/v8.0/administration/configuration/#azure).
 
 ```ini
 [azure]

--- a/docs/sources/datasources/cloudwatch.md
+++ b/docs/sources/datasources/cloudwatch.md
@@ -2,7 +2,7 @@
 title = "AWS CloudWatch"
 description = "Guide for using CloudWatch in Grafana"
 keywords = ["grafana", "cloudwatch", "guide"]
-aliases = ["/docs/grafana/latest/datasources/cloudwatch"]
+aliases = ["/docs/grafana/v8.0/datasources/cloudwatch"]
 weight = 200
 +++
 
@@ -41,7 +41,7 @@ There are three different authentication methods available. `AWS SDK Default` pe
 
 ### IAM roles
 
-Currently all access to CloudWatch is done server side by the Grafana backend using the official AWS SDK. Providing you have chosen the _AWS SDK Default_ authentication method, and your Grafana server is running on AWS, you can use IAM Roles to handle authentication automatically.
+Currently all access to CloudWatch is done server side by the Grafana backend using the official AWS SDK. Providing you have chosen the _AWS SDK Default_ authentication method, and your Grafana server is running on AWS, you can use IAM Roles to handle authentication automically.
 
 See the AWS documentation on [IAM Roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
@@ -383,7 +383,7 @@ Allows you to disable `assume role (ARN)` in the CloudWatch data source. By defa
 
 ### list_metrics_page_limit
 
-When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) is used to populate the _Metrics_ field and the _Dimension_ fields. The API is paginated and returns up to 500 results per page. The CloudWatch data source also limits the number of pages to 500. However, you can change this limit using the `list_metrics_page_limit` variable in the [grafana configuration file](https://grafana.com/docs/grafana/latest/administration/configuration/#aws).
+When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) is used to populate the _Metrics_ field and the _Dimension_ fields. The API is paginated and returns up to 500 results per page. The CloudWatch data source also limits the number of pages to 500. However, you can change this limit using the `list_metrics_page_limit` variable in the [grafana configuration file](https://grafana.com/docs/grafana/v8.0/administration/configuration/#aws).
 
 ## Configure the data source with provisioning
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -2,7 +2,7 @@
 title = "Elasticsearch"
 description = "Guide for using Elasticsearch in Grafana"
 keywords = ["grafana", "elasticsearch", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/elasticsearch"]
+aliases = ["/docs/grafana/v8.0/features/datasources/elasticsearch"]
 weight = 400
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -2,7 +2,7 @@
 title = "Google Cloud Monitoring"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/next/datasources/cloudmonitoring/", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/v8.0/features/datasources/stackdriver", "/docs/grafana/next/datasources/cloudmonitoring/", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
 weight = 200
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -2,7 +2,7 @@
 title = "Preconfigured dashboards"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/v8.0/features/datasources/stackdriver", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
 weight = 10
 +++
 

--- a/docs/sources/datasources/graphite.md
+++ b/docs/sources/datasources/graphite.md
@@ -2,7 +2,7 @@
 title = "Graphite"
 description = "Guide for using graphite in Grafana"
 keywords = ["grafana", "graphite", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/graphite"]
+aliases = ["/docs/grafana/v8.0/features/datasources/graphite"]
 weight = 600
 +++
 

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -2,13 +2,13 @@
 title = "InfluxDB data source"
 description = "Guide for using InfluxDB in Grafana"
 keywords = ["grafana", "influxdb", "guide", "flux"]
-aliases = ["/docs/grafana/latest/features/datasources/influxdb", "/docs/grafana/latest/datasources/influxdb"]
+aliases = ["/docs/grafana/v8.0/features/datasources/influxdb", "/docs/grafana/v8.0/datasources/influxdb"]
 weight = 700
 +++
 
 # InfluxDB data source
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic explains options, variables, querying, and other options specific to this data source. Refer to [Add a data source]({{< relref "../add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 

--- a/docs/sources/datasources/jaeger.md
+++ b/docs/sources/datasources/jaeger.md
@@ -2,7 +2,7 @@
 title = "Jaeger"
 description = "Guide for using Jaeger in Grafana"
 keywords = ["grafana", "jaeger", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/features/datasources/jaeger"]
+aliases = ["/docs/grafana/v8.0/features/datasources/jaeger"]
 weight = 800
 +++
 

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -2,7 +2,7 @@
 title = "Loki"
 description = "Guide for using Loki in Grafana"
 keywords = ["grafana", "loki", "logging", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/loki"]
+aliases = ["/docs/grafana/v8.0/features/datasources/loki"]
 weight = 800
 +++
 

--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -2,7 +2,7 @@
 title = "Microsoft SQL Server"
 description = "Guide for using Microsoft SQL Server in Grafana"
 keywords = ["grafana", "MSSQL", "Microsoft", "SQL", "guide", "Azure SQL Database"]
-aliases = ["/docs/grafana/latest/features/datasources/mssql/"]
+aliases = ["/docs/grafana/v8.0/features/datasources/mssql/"]
 weight = 900
 +++
 
@@ -168,96 +168,122 @@ The resulting table panel:
 
 ## Time series queries
 
-If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
+If you set `Format as` to `Time series`, for use in Graph panel for example, then the query must have a column named `time` that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. You may return a column named `metric` that is used as metric name for the value column. Any column except `time` and `metric` is treated as a value column. If you omit the `metric` column, the name of the value column will be the metric name. You may select multiple value columns, each will have its name as metric.
+If you return multiple value columns and a column named `metric` then this column is used as prefix for the series name (only available in Grafana 5.3+).
 
-A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+Result sets of time series queries need to be sorted by time.
 
-> For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
+**Example database table:**
 
-You can optionally customize the default series name formatting using instructions in [Standard field options/Display name]({{< relref "../panels/standard-options.md#display-name" >}}).
+```sql
+CREATE TABLE [event] (
+  time_sec bigint,
+  description nvarchar(100),
+  tags nvarchar(100),
+)
+```
 
-**Example with `metric` column:**
+```sql
+CREATE TABLE metric_values (
+  time datetime,
+  measurement nvarchar(100),
+  valueOne int,
+  valueTwo int,
+)
+
+INSERT metric_values (time, measurement, valueOne, valueTwo) VALUES('2018-03-15 12:30:00', 'Metric A', 62, 6)
+INSERT metric_values (time, measurement, valueOne, valueTwo) VALUES('2018-03-15 12:30:00', 'Metric B', 49, 11)
+...
+INSERT metric_values (time, measurement, valueOne, valueTwo) VALUES('2018-03-15 13:55:00', 'Metric A', 14, 25)
+INSERT metric_values (time, measurement, valueOne, valueTwo) VALUES('2018-03-15 13:55:00', 'Metric B', 48, 10)
+
+```
+
+{{< figure src="/static/img/docs/v51/mssql_time_series_one.png" class="docs-image--no-shadow docs-image--right" >}}
+
+**Example with one `value` and one `metric` column.**
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time, '5m') as time,
-  min("value_double"),
-  'min' as metric
-FROM test_data
-WHERE $__timeFilter(time_date_time)
-GROUP BY $__timeGroup(time_date_time, '5m')
-ORDER BY 1
-```
-
-Data frame result:
-
-```text
-+---------------------+-----------------+
-| Name: time          | Name: min       |
-| Labels:             | Labels:         |
-| Type: []time.Time   | Type: []float64 |
-+---------------------+-----------------+
-| 2020-01-02 03:05:00 | 3               |
-| 2020-01-02 03:10:00 | 6               |
-+---------------------+-----------------+
-```
-
-**Example using the fill parameter in the $\_\_timeGroup macro to convert null values to be zero instead:**
-
-```sql
-SELECT
-  $__timeGroup(createdAt, '5m', 0) as time,
-  sum(value) as value,
-  hostname
-FROM test_data
+  time,
+  valueOne,
+  measurement as metric
+FROM
+  metric_values
 WHERE
-  $__timeFilter(createdAt)
-GROUP BY
-  $__timeGroup(createdAt, '5m', 0),
-  hostname
+  $__timeFilter(time)
 ORDER BY 1
 ```
 
-Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard field options/Display name]({{< relref "../panels/standard-options.md#display-name" >}}) value of `${__field.labels.hostname}`.
+When the above query is used in a graph panel, it will produce two series named `Metric A` and `Metric B` with the values `valueOne` and `valueTwo` plotted over `time`.
 
-Data frame result:
+<div class="clearfix"></div>
 
-```text
-+---------------------+---------------------------+---------------------------+
-| Name: time          | Name: value               | Name: value               |
-| Labels:             | Labels: hostname=10.0.1.1 | Labels: hostname=10.0.1.2 |
-| Type: []time.Time   | Type: []float64           | Type: []float64           |
-+---------------------+---------------------------+---------------------------+
-| 2020-01-02 03:05:00 | 3                         | 4                         |
-| 2020-01-02 03:10:00 | 6                         | 7                         |
-+---------------------+---------------------------+---------------------------+
-```
+{{< figure src="/static/img/docs/v51/mssql_time_series_two.png" class="docs-image--no-shadow docs-image--right" >}}
 
-**Example with multiple columns:**
+**Example with multiple `value` columns:**
 
 ```sql
 SELECT
-  $__timeGroup(time_date_time, '5m'),
-  min(value_double) as min_value,
-  max(value_double) as max_value
-FROM test_data
-WHERE $__timeFilter(time_date_time)
-GROUP BY $__timeGroup(time_date_time, '5m')
+  time,
+  valueOne,
+  valueTwo
+FROM
+  metric_values
+WHERE
+  $__timeFilter(time)
 ORDER BY 1
 ```
 
-Data frame result:
+When the above query is used in a graph panel, it will produce two series named `Metric A` and `Metric B` with the values `valueOne` and `valueTwo` plotted over `time`.
 
-```text
-+---------------------+-----------------+-----------------+
-| Name: time          | Name: min_value | Name: max_value |
-| Labels:             | Labels:         | Labels:         |
-| Type: []time.Time   | Type: []float64 | Type: []float64 |
-+---------------------+-----------------+-----------------+
-| 2020-01-02 03:04:00 | 3               | 4               |
-| 2020-01-02 03:05:00 | 6               | 7               |
-+---------------------+-----------------+-----------------+
+<div class="clearfix"></div>
+
+{{< figure src="/static/img/docs/v51/mssql_time_series_three.png" class="docs-image--no-shadow docs-image--right" >}}
+
+**Example using the \$\_\_timeGroup macro:**
+
+```sql
+SELECT
+  $__timeGroup(time, '3m') as time,
+  measurement as metric,
+  avg(valueOne)
+FROM
+  metric_values
+WHERE
+  $__timeFilter(time)
+GROUP BY
+  $__timeGroup(time, '3m'),
+  measurement
+ORDER BY 1
 ```
+
+When the above query is used in a graph panel, it will produce two series named `Metric A` and `Metric B` with the values `valueOne` and `valueTwo` plotted over `time`.
+Any two series lacking a value in a three-minute window will render a line between those two lines. You'll notice that the graph to the right never goes down to zero.
+
+<div class="clearfix"></div>
+
+{{< figure src="/static/img/docs/v51/mssql_time_series_four.png" class="docs-image--no-shadow docs-image--right" >}}
+
+**Example using the \$\_\_timeGroup macro with fill parameter set to zero:**
+
+```sql
+SELECT
+  $__timeGroup(time, '3m', 0) as time,
+  measurement as metric,
+  sum(valueTwo)
+FROM
+  metric_values
+WHERE
+  $__timeFilter(time)
+GROUP BY
+  $__timeGroup(time, '3m'),
+  measurement
+ORDER BY 1
+```
+
+When the above query is used in a graph panel, the result is two series named `Metric A` and `Metric B` with a sum of `valueTwo` plotted over `time`.
+Any series lacking a value in a 3 minute window will have a value of zero which you'll see rendered in the graph to the right.
 
 ## Templating
 

--- a/docs/sources/datasources/mysql.md
+++ b/docs/sources/datasources/mysql.md
@@ -2,7 +2,7 @@
 title = "MySQL"
 description = "Guide for using MySQL in Grafana"
 keywords = ["grafana", "mysql", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/mysql/"]
+aliases = ["/docs/grafana/v8.0/features/datasources/mysql/"]
 weight = 1000
 +++
 
@@ -177,13 +177,12 @@ The resulting table panel:
 
 ## Time series queries
 
-If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
+If you set `Format as` to `Time series`, for use in Graph panel for example, then the query must return a column named `time` that returns either a SQL datetime or any numeric datatype representing Unix epoch.
+Any column except `time` and `metric` is treated as a value column.
+You may return a column named `metric` that is used as metric name for the value column.
+If you return multiple value columns and a column named `metric` then this column is used as prefix for the series name (only available in Grafana 5.3+).
 
-A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
-
-> For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
-
-You can optionally customize the default series name formatting using instructions in [Standard field options/Display name]({{< relref "../panels/standard-options.md#display-name" >}}).
+Resultsets of time series queries need to be sorted by time.
 
 **Example with `metric` column:**
 
@@ -198,46 +197,18 @@ GROUP BY time
 ORDER BY time
 ```
 
-Data frame result:
-
-```text
-+---------------------+-----------------+
-| Name: time          | Name: min       |
-| Labels:             | Labels:         |
-| Type: []time.Time   | Type: []float64 |
-+---------------------+-----------------+
-| 2020-01-02 03:05:00 | 3               |
-| 2020-01-02 03:10:00 | 6               |
-+---------------------+-----------------+
-```
-
-**Example using the fill parameter in the $\_\_timeGroup macro to convert null values to be zero instead:**
+**Example using the fill parameter in the $__timeGroup macro to convert null values to be zero instead:**
 
 ```sql
 SELECT
   $__timeGroup(createdAt,'5m',0),
   sum(value_double) as value,
-  hostname
+  measurement
 FROM test_data
 WHERE
   $__timeFilter(createdAt)
-GROUP BY time, hostname
+GROUP BY time, measurement
 ORDER BY time
-```
-
-Given the data frame result in the following example and using the graph panel, you will get two series named _value 10.0.1.1_ and _value 10.0.1.2_. To render the series with a name of _10.0.1.1_ and _10.0.1.2_ , use a [Standard field options/Display name]({{< relref "../panels/standard-options.md#display-name" >}}) value of `${__field.labels.hostname}`.
-
-Data frame result:
-
-```text
-+---------------------+---------------------------+---------------------------+
-| Name: time          | Name: value               | Name: value               |
-| Labels:             | Labels: hostname=10.0.1.1 | Labels: hostname=10.0.1.2 |
-| Type: []time.Time   | Type: []float64           | Type: []float64           |
-+---------------------+---------------------------+---------------------------+
-| 2020-01-02 03:05:00 | 3                         | 4                         |
-| 2020-01-02 03:10:00 | 6                         | 7                         |
-+---------------------+---------------------------+---------------------------+
 ```
 
 **Example with multiple columns:**
@@ -251,19 +222,6 @@ FROM test_data
 WHERE $__timeFilter(time_date_time)
 GROUP BY time
 ORDER BY time
-```
-
-Data frame result:
-
-```text
-+---------------------+-----------------+-----------------+
-| Name: time          | Name: min_value | Name: max_value |
-| Labels:             | Labels:         | Labels:         |
-| Type: []time.Time   | Type: []float64 | Type: []float64 |
-+---------------------+-----------------+-----------------+
-| 2020-01-02 03:04:00 | 3               | 4               |
-| 2020-01-02 03:05:00 | 6               | 7               |
-+---------------------+-----------------+-----------------+
 ```
 
 Currently, there is no support for a dynamic group by time based on time range and panel width.

--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -2,7 +2,7 @@
 title = "OpenTSDB"
 description = "Guide for using OpenTSDB in Grafana"
 keywords = ["grafana", "opentsdb", "guide"]
-aliases = ["/docs/grafana/latest/features/opentsdb", "/docs/grafana/latest/features/datasources/opentsdb/"]
+aliases = ["/docs/grafana/v8.0/features/opentsdb", "/docs/grafana/v8.0/features/datasources/opentsdb/"]
 weight = 1100
 +++
 

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -2,7 +2,7 @@
 title = "Prometheus"
 description = "Guide for using Prometheus in Grafana"
 keywords = ["grafana", "prometheus", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/prometheus"]
+aliases = ["/docs/grafana/v8.0/features/datasources/prometheus"]
 weight = 1300
 +++
 

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -2,7 +2,7 @@
 title = "Tempo"
 description = "High volume, minimal dependency trace storage. OSS tracing solution from Grafana Labs."
 keywords = ["grafana", "tempo", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/features/datasources/tempo"]
+aliases = ["/docs/grafana/v8.0/features/datasources/tempo"]
 weight = 1400
 +++
 

--- a/docs/sources/datasources/testdata.md
+++ b/docs/sources/datasources/testdata.md
@@ -1,7 +1,7 @@
 +++
 title = "TestData"
 keywords = ["grafana", "dashboard", "documentation", "panels", "testdata"]
-aliases = ["/docs/grafana/latest/features/datasources/testdata"]
+aliases = ["/docs/grafana/v8.0/features/datasources/testdata"]
 weight = 1500
 +++
 

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -2,7 +2,7 @@
 title = "Zipkin"
 description = "Guide for using Zipkin in Grafana"
 keywords = ["grafana", "zipkin", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/datasources/zipkin"]
+aliases = ["/docs/grafana/v8.0/datasources/zipkin"]
 weight = 1600
 +++
 

--- a/docs/sources/developers/_index.md
+++ b/docs/sources/developers/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Developers"
-aliases = ["/docs/grafana/latest/plugins/developing/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/"]
 weight = 190
 +++
 

--- a/docs/sources/developers/cla.md
+++ b/docs/sources/developers/cla.md
@@ -1,7 +1,7 @@
 +++
 title = "Contributor License Agreement (CLA)"
 description = "Contributor License Agreement (CLA)"
-aliases = ["/docs/grafana/latest/project/cla", "docs/contributing/cla.html"]
+aliases = ["/docs/grafana/v8.0/project/cla", "docs/contributing/cla.html"]
 +++
 
 # Grafana Labs Software Grant and Contributor License Agreement ("Agreement")

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Build a plugin"
-aliases = ["/docs/grafana/latest/plugins/developing/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/"]
 +++
 
 # Build a plugin
@@ -19,8 +19,8 @@ npx @grafana/toolkit plugin:create my-grafana-plugin
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
+- [Build a panel plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin/)
+- [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -30,13 +30,13 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
-- [Build a data source backend plugin]({{< relref "/tutorials/build-a-data-source-backend-plugin.md" >}})
+- [Build a panel plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin/)
+- [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
+- [Build a data source backend plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js]({{< relref "/tutorials/build-a-panel-plugin-with-d3.md" >}})
+- [Build a panel plugin with D3.js](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin-with-d3/)
 
 ### Guides
 

--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -1,6 +1,6 @@
 +++
 title = "Add authentication for data source plugins"
-aliases = ["/docs/grafana/latest/plugins/developing/auth-for-datasources/", "/docs/grafana/next/developers/plugins/authentication/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/auth-for-datasources/", "/docs/grafana/next/developers/plugins/authentication/"]
 +++
 
  # Add authentication for data source plugins
@@ -23,7 +23,7 @@ Users with the _Viewer_ role can access data source configuration—such as the 
 
 > **Note:** You can see the settings that the current user has access to by entering `window.grafanaBootData` in the developer console of your browser.
 
-> **Note:** Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/latest/enterprise/datasource_permissions).
+> **Note:** Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/v8.0/enterprise/datasource_permissions).
 
 If you need to store sensitive information, such as passwords, tokens and API keys, use `secureJsonData` instead. Whenever the user saves the data source configuration, the secrets in `secureJsonData` are sent to the Grafana server and encrypted before they're stored.
 
@@ -108,7 +108,7 @@ The Grafana server comes with a proxy that lets you define templates for your re
 
 ### Add a proxy route to your plugin
 
-To forward requests through the Grafana proxy, you need to configure one or more proxy routes. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file.
+To forward requests through the Grafana proxy, you need to configure one or more proxy routes. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](https://grafana.com/docs/grafana/v8.0/developers/plugins/metadata/) file.
 
 1. Add the route to plugin.json. Note that you need to restart the Grafana server every time you make a change to your plugin.json file.
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -6,7 +6,7 @@ title = "Add support for annotations"
 
 This guide explains how to add support for [annotations]({{< relref "../../dashboards/annotations.md" >}}) to an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 > **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to the [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -6,7 +6,7 @@ title = "Add support for Explore queries"
 
 This guide explains how to improve support for [Explore]({{< relref "../../explore/_index.md" >}}) in an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 
@@ -101,4 +101,4 @@ const firstResult = new MutableDataFrame({
 });
 ```
 
-For possible options, refer to [PreferredVisualisationType](https://grafana.com/docs/grafana/latest/packages_api/data/preferredvisualisationtype/).
+For possible options, refer to [PreferredVisualisationType](https://grafana.com/docs/grafana/v8.0/packages_api/data/preferredvisualisationtype/).

--- a/docs/sources/developers/plugins/backend/_index.md
+++ b/docs/sources/developers/plugins/backend/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Backend plugins"
 keywords = ["grafana", "plugins", "backend", "plugin", "backend-plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/backend-plugins-guide/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/backend-plugins-guide/"]
 +++
 
 # Backend plugins

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -6,7 +6,7 @@ title = "Build a logs data source plugin"
 
 This guide explains how to build a logs data source plugin.
 
-Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}) for metrics.
+Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/) for metrics.
 
 ## Add logs support to your data source
 

--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -6,7 +6,7 @@ title = "Build a streaming data source plugin"
 
 This guide explains how to build a streaming data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 When monitoring critical applications, you want your dashboard to refresh as soon as your data does. In Grafana, you can set your dashboards to automatically refresh at a certain interval, no matter what data source you use. Unfortunately, this means that your queries are requesting all the data to be sent again, regardless of whether the data has actually changed.
 

--- a/docs/sources/developers/plugins/legacy/_index.md
+++ b/docs/sources/developers/plugins/legacy/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy plugins"
-aliases = ["/docs/grafana/latest/plugins/development/", "/docs/grafana/next/plugins/datasources/", "/docs/grafana/next/plugins/apps/", "/docs/grafana/next/plugins/panels/", "/docs/grafana/next/plugins/developing/development/"]
+aliases = ["/docs/grafana/v8.0/plugins/development/", "/docs/grafana/next/plugins/datasources/", "/docs/grafana/next/plugins/apps/", "/docs/grafana/next/plugins/panels/", "/docs/grafana/next/plugins/developing/development/"]
 +++
 
 # Legacy plugins

--- a/docs/sources/developers/plugins/legacy/apps.md
+++ b/docs/sources/developers/plugins/legacy/apps.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy app plugins"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/apps/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/apps/"]
 +++
 
 # Legacy app plugins

--- a/docs/sources/developers/plugins/legacy/data-sources.md
+++ b/docs/sources/developers/plugins/legacy/data-sources.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy data source plugins"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/datasources/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/datasources/"]
 +++
 
 # Legacy data source plugins

--- a/docs/sources/developers/plugins/legacy/defaults-and-editor-mode.md
+++ b/docs/sources/developers/plugins/legacy/defaults-and-editor-mode.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy defaults and editor mode"
-aliases = ["/docs/grafana/latest/plugins/developing/defaults-and-editor-mode/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/defaults-and-editor-mode/"]
 +++
 
 # Legacy defaults and editor mode

--- a/docs/sources/developers/plugins/legacy/panels.md
+++ b/docs/sources/developers/plugins/legacy/panels.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy panel plugins"
 keywords = ["grafana", "plugins", "panel", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/panels/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/panels/"]
 +++
 
 # Legacy panel plugins

--- a/docs/sources/developers/plugins/legacy/review-guidelines.md
+++ b/docs/sources/developers/plugins/legacy/review-guidelines.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy review guidelines"
-aliases = ["/docs/grafana/latest/plugins/developing/plugin-review-guidelines/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/plugin-review-guidelines/"]
 +++
 
 # Legacy review guidelines

--- a/docs/sources/developers/plugins/legacy/snapshot-mode.md
+++ b/docs/sources/developers/plugins/legacy/snapshot-mode.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy snapshot mode"
-aliases = ["/docs/grafana/latest/plugins/developing/snapshot-mode/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/snapshot-mode/"]
 +++
 
 # Legacy snapshot mode

--- a/docs/sources/developers/plugins/legacy/style-guide.md
+++ b/docs/sources/developers/plugins/legacy/style-guide.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy code style guide"
-aliases = ["/docs/grafana/latest/plugins/developing/code-styleguide/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/code-styleguide/"]
 +++
 
 # Legacy code style guide

--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------
 title = "plugin.json"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/plugin.json/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/plugin.json/"]
 +++
 
 # plugin.json

--- a/docs/sources/developers/plugins/metadata.md.tpl
+++ b/docs/sources/developers/plugins/metadata.md.tpl
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------
 title = "plugin.json"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/plugin.json/"]
+aliases = ["/docs/grafana/v8.0/plugins/developing/plugin.json/"]
 +++
 
 {{ .Markdown 1 }}

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -4,410 +4,44 @@ title = "Plugin migration guide"
 
 # Plugin migration guide
 
-## Introduction
+This guide explains how to migrate pre-Grafana 7.0 plugins from Angular to the new React-based plugin platform introduced in Grafana 7.0.
 
-This guide helps you identify the steps you need to take based on the Grafana version your plugin supports and explains how to migrate the plugin to the 8.2.x or a later version.
+It's written for:
 
-> **Note:** If you've successfully migrated your plugin using this guide, then share your experiences with us! If you find missing information, then we encourage you to [submit an issue on GitHub](https://github.com/grafana/grafana/issues/new?title=Docs%20feedback:%20/developers/plugins/migration-guide.md) so that we can improve this guide!
+- Plugin authors who want to migrate their plugins to Grafana 7.0+.
+- Plugin users who are using custom plugins and want to know whether they can upgrade to Grafana 7.0 without losing functionality.
 
-## Table of contents
+> If you've successfully migrated your plugin from Angular to React, please [submit an issue on GitHub](https://github.com/grafana/grafana/issues/new?title=Docs%20feedback:%20/developers/plugins/migration-guide.md) and share your experiences with us so that we can improve this guide!
 
-- [From version 7.x.x to 8.0.0](#from-version-7xx-to-800)
-  - [Backend plugin v1 support has been dropped](#backend-plugin-v1-support-has-been-dropped)
-    - [1. Add dependency on grafana-plugin-sdk-go](#1-add-dependency-on-grafana-plugin-sdk-go)
-    - [2. Update the way you bootstrap your plugin](#2-update-the-way-you-bootstrap-your-plugin)
-    - [3. Update the plugin package](#3-update-the-plugin-package)
-  - [Unsigned backend plugins will not be loaded](#unsigned-backend-plugins-will-not-be-loaded)
-  - [Update react-hook-form from v6 to v7](#update-react-hook-form-from-v6-to-v7)
-  - [Update the plugin.json](#update-the-pluginjson)
-  - [Update imports to match emotion 11](#update-imports-to-match-emotion-11)
-  - [8.0 Deprecations](#80-deprecations)
-    - [Grafana theme v1](#grafana-theme-v1)
-- [From version 6.2.x to 7.4.0](#from-version-62x-to-740)
-  - [Legend components](#legend-components)
-- [From version 6.x.x to 7.0.0](#from-version-6xx-to-700)
-  - [What's new in Grafana 7.0?](#whats-new-in-grafana-70)
-  - [Migrate a plugin from Angular to React](#migrate-a-plugin-from-angular-to-react)
-    - [Migrate a panel plugin](#migrate-a-panel-plugin)
-    - [Migrate a data source plugin](#migrate-a-data-source-plugin)
-    - [Migrate to data frames](#migrate-to-data-frames)
-  - [Troubleshoot plugin migration](#troubleshoot-plugin-migration)
-
-## From version 7.x.x to 8.x.x
-
-This section explains how to migrate Grafana v7.x.x plugins to the updated plugin system available in Grafana v8.x.x. Depending on your plugin, you need to perform one or more of the following steps. We have documented the breaking changes in Grafana v8.x.x and the steps you need to take to upgrade your plugin.
-
-### Backend plugin v1 support has been dropped
-
-Use the new [plugin sdk](https://github.com/grafana/grafana-plugin-sdk-go) to run your backend plugin running in Grafana 8.
-
-#### 1. Add dependency on grafana-plugin-sdk-go
-
-Add a dependency on the `https://github.com/grafana/grafana-plugin-sdk-go`. We recommend using [go modules](https://go.dev/blog/using-go-modules) to manage your dependencies.
-
-#### 2. Update the way you bootstrap your plugin
-
-Update your `main` package to bootstrap via the new plugin sdk.
-
-```go
-// before
-package main
-
-import (
-  "github.com/grafana/grafana_plugin_model/go/datasource"
-  hclog "github.com/hashicorp/go-hclog"
-  plugin "github.com/hashicorp/go-plugin"
-
-  "github.com/myorgid/datasource/pkg/plugin"
-)
-
-func main() {
-  pluginLogger.Debug("Running GRPC server")
-
-  ds, err := NewSampleDatasource(pluginLogger);
-  if err != nil {
-    pluginLogger.Error("Unable to create plugin");
-  }
-
-  plugin.Serve(&plugin.ServeConfig{
-    HandshakeConfig: plugin.HandshakeConfig{
-			ProtocolVersion:  1,
-			MagicCookieKey:   "grafana_plugin_type",
-			MagicCookieValue: "datasource",
-		},
-    Plugins: map[string]plugin.Plugin{
-			"myorgid-datasource": &datasource.DatasourcePluginImpl{Plugin: ds},
-    },
-    GRPCServer: plugin.DefaultGRPCServer,
-  })
-}
-
-// after
-package main
-
-import (
-  "os"
-
-  "github.com/grafana/grafana-plugin-sdk-go/backend/log"
-  "github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
-
-  "github.com/myorgid/datasource/pkg/plugin"
-)
-
-func main() {
-  log.DefaultLogger.Debug("Running GRPC server")
-
-  if err := datasource.Manage("myorgid-datasource", NewSampleDatasource, datasource.ManageOpts{}); err != nil {
-				log.DefaultLogger.Error(err.Error())
-				os.Exit(1)
-		}
-}
-```
-
-#### 3. Update the plugin package
-
-Update your `plugin` package to use the new plugin sdk.
-
-```go
-// before
-package plugin
-
-import (
-  "context"
-
-  "github.com/grafana/grafana_plugin_model/go/datasource"
-  "github.com/hashicorp/go-hclog"
-)
-
-func NewSampleDatasource(pluginLogger hclog.Logger) (*SampleDatasource, error) {
-	return &SampleDatasource{
-		logger: pluginLogger,
-	}, nil
-}
-
-type SampleDatasource struct{
-  logger hclog.Logger
-}
-
-func (d *SampleDatasource) Query(ctx context.Context, tsdbReq *datasource.DatasourceRequest) (*datasource.DatasourceResponse, error) {
-  d.logger.Info("QueryData called", "request", req)
-  // logic for querying your datasource.
-}
-
-// after
-package plugin
-
-import (
-  "context"
-
-  "github.com/grafana/grafana-plugin-sdk-go/backend"
-  "github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-  "github.com/grafana/grafana-plugin-sdk-go/backend/log"
-  "github.com/grafana/grafana-plugin-sdk-go/data"
-)
-
-func NewSampleDatasource(_ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	return &SampleDatasource{}, nil
-}
-
-type SampleDatasource struct{}
-
-
-func (d *SampleDatasource) Dispose() {
-	// Clean up datasource instance resources.
-}
-
-func (d *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-  log.DefaultLogger.Info("QueryData called", "request", req)
-  // logic for querying your datasource.
-}
-
-func (d *SampleDatasource) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-  log.DefaultLogger.Info("CheckHealth called", "request", req)
-  // The main use case for these health checks is the test button on the
-  // datasource configuration page which allows users to verify that
-  // a datasource is working as expected.
-}
-```
-
-### Sign and load backend plugins
-
-We strongly recommend that you not allow unsigned plugins in your Grafana installation. By allowing unsigned plugins, we cannot guarantee the authenticity of the plugin, which could compromise the security of your Grafana installation.
-
-To sign your plugin, see [Sign a plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#sign-a-plugin).
-
-You can still run and develop an unsigned plugin by running your Grafana instance in [development mode](https://grafana.com/docs/grafana/latest/administration/configuration/#app_mode). Alternatively, you can use the [allow_loading_unsigned_plugins configuration setting.]({{< relref "../administration/#allow_loading_unsigned_plugins" >}})
-
-### Update react-hook-form from v6 to v7
-
-We have upgraded react-hook-form from version 6 to version 7. To make your forms compatible with version 7, refer to the [react-hook-form-migration-guide](https://react-hook-form.com/migrate-v6-to-v7/).
-
-### Update the plugin.json
-
-The property that defines which Grafana version your plugin supports has been renamed and now it is a range instead of a specific version.
-
-```json
-// before
-{
-"dependencies": {
-    "grafanaVersion": "7.5.x",
-    "plugins": []
-  }
-}
-
-// after
-{
-  "dependencies": {
-    "grafanaDependency": ">=8.0.0",
-    "plugins": []
-  }
-}
-```
-
-### Update imports to match emotion 11
-
-Grafana uses Emotion library to manage frontend styling. We have updated the Emotion package and this can affect your frontend plugin if you have custom styling. You only need to update the import statements to get it working in Grafana 8.
-
-```ts
-// before
-import { cx, css } from 'emotion';
-
-// after
-import { cx, css } from '@emotion/css';
-```
-
-### 8.0 deprecations
-
-#### Grafana theme v1
-
-In Grafana 8 we have introduced a new improved version of our theming system. The previous version of the theming system is still available but is deprecated and will be removed in the next major version of Grafana.
-
-You can find more detailed information on how to apply the v2 theme [here](https://github.com/grafana/grafana/blob/main/contribute/style-guides/themes.md#theming-grafana).
-
-**How to style a functional component**
-
-The `useStyles` hook is the preferred way to access the theme when styling. It provides basic memoization and access to the theme object.
-
-```ts
-// before
-import React, { ReactElement } from 'react';
-import css from 'emotion';
-import { GrafanaTheme } from '@grafana/data';
-import { useStyles } from '@grafana/ui';
-
-function Component(): ReactElement | null {
-  const styles = useStyles(getStyles);
-}
-
-const getStyles = (theme: GrafanaTheme) => ({
-  myStyle: css`
-    background: ${theme.colors.bodyBg};
-    display: flex;
-  `,
-});
-
-// after
-import React, { ReactElement } from 'react';
-import { css } from '@emotion/css';
-import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
-
-function Component(): ReactElement | null {
-  const theme = useStyles2(getStyles);
-}
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  myStyle: css`
-    background: ${theme.colors.background.canvas};
-    display: flex;
-  `,
-});
-```
-
-**How to use the theme in a functional component**
-
-```ts
-// before
-import React, { ReactElement } from 'react';
-import { useTheme } from '@grafana/ui';
-
-function Component(): ReactElement | null {
-  const theme = useTheme();
-}
-
-// after
-import React, { ReactElement } from 'react';
-import { useTheme2 } from '@grafana/ui';
-
-function Component(): ReactElement | null {
-  const theme = useTheme2();
-  // Your component has access to the theme variables now
-}
-```
-
-**How to use the theme in a class component**
-
-```ts
-// before
-import React from 'react';
-import { Themeable, withTheme } from '@grafana/ui';
-
-type Props = {} & Themeable;
-
-class Component extends React.Component<Props> {
-  render() {
-    const { theme } = this.props;
-    // Your component has access to the theme variables now
-  }
-}
-
-export default withTheme(Component);
-
-// after
-import React from 'react';
-import { Themeable2, withTheme2 } from '@grafana/ui';
-
-type Props = {} & Themeable2;
-
-class Component extends React.Component<Props> {
-  render() {
-    const { theme } = this.props;
-    // Your component has access to the theme variables now
-  }
-}
-
-export default withTheme2(Component);
-```
-
-**Gradually migrating components**
-
-If you need to use both the v1 and v2 themes due to using migrated and non-migrated components in the same context, use the `v1` property on the `v2` theme as described in the following example.
-
-```ts
-function Component(): ReactElement | null {
-  const theme = useTheme2();
-  return (
-    <NonMigrated theme={theme.v1}>
-      <Migrated theme={theme] />
-    </NonMigrate>
-  );
-};
-```
-
-## From version 6.2.x to 7.4.0
-
-### Legend components
-
-The Legend components have been refactored and introduced the following changes within the `@grafana/ui` package.
-
-```ts
-// before
-import { LegendItem, LegendOptions, GraphLegend } from '@grafana/ui';
-
-// after
-import { VizLegendItem, VizLegendOptions, VizLegend } from '@grafana/ui';
-```
-
-- `LegendPlacement` has been updated from `'under' | 'right' | 'over'` to `'bottom' | 'right'` so you can not place the legend above the visualization anymore.
-- The `isVisible` in the `LegendItem` has been renamed to `disabled` in `VizLegendItem`.
-
-## From version 6.5.x to 7.3.0
-
-### getColorForTheme changes
-
-The `getColorForTheme` function arguments have changed from `(color: ColorDefinition, theme?: GrafanaThemeType)` to `(color: string, theme: GrafanaTheme)`.
-
-```ts
-// before
-const color: ColorDefinition = {
-  hue: 'green';
-  name: 'dark-green';
-  variants: {
-    light: '#19730E'
-    dark: '#37872D'
-  };
-}
-const themeType: GrafanaThemeType = 'dark';
-const themeColor = getColorForTheme(color, themeType);
-
-// after
-const color = 'green';
-const theme: GrafanaTheme = useTheme();
-const themeColor = getColorForTheme(color, theme);
-
-```
-
-## From version 6.x.x to 7.x.x
-
-### What's new in Grafana 7.0?
+## What's new in Grafana 7.0?
 
 Grafana 7.0 introduced a whole new plugin platform based on React. The new platform supersedes the previous Angular-based plugin platform.
 
 Plugins built using Angular still work for the foreseeable future, but we encourage new plugin authors to develop with the new platform.
 
-#### New data format
+### New data format
 
 Along with the move to React, the new plugin platform introduced a new internal data format called [data frames]({{< relref "data-frames.md" >}}).
 
 Previously, data source plugins could send data either as time series or tables. With data frames, data sources can send any data in a table-like structure. This gives you more flexibility to visualize your data in Grafana.
 
-#### Improved TypeScript support
+### Improved TypeScript support
 
 While the previous Angular-based plugin SDK did support TypeScript, for the React platform, we’ve greatly improved the support. All our APIs are now TypeScript, which might require existing code to update to the new stricter type definitions. Grafana 7.0 also introduced several new APIs for plugin developers that take advantage of many of the new features in Grafana 7.0.
 
-#### Grafana Toolkit
+### Grafana Toolkit
 
 With Grafana 7.0, we released a new tool for making it easier to develop plugins. Before, you’d use Gulp, Grunt, or similar tools to generate the minified assets. Grafana Toolkit takes care of building and testing your plugin without complicated configuration files.
 
 For more information, refer to [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit).
 
-#### Field options
+### Field options
 
 Grafana 7.0 introduced the concept of _field options_, a new way of configuring your data before it gets visualized. Since this was not available in previous versions, any plugin that enables field-based configuration will not work in previous versions of Grafana.
 
 For plugins prior to Grafana 7.0, all options are considered _Display options_. The tab for field configuration isn't available.
 
-#### Backend plugins
+### Backend plugins
 
 While backend plugins were available as an experimental feature in previous versions of Grafana, the support has been greatly improved for Grafana 7. Backend plugins for Grafana 7.0 are backwards-compatible and will continue to work. However, the old backend plugin system has been deprecated, and we recommend that you use the new SDK for backend plugins.
 
@@ -415,7 +49,32 @@ Since Grafana 7.0 introduced [signing of backend plugins]({{< relref "../../plug
 
 To learn more, refer to [Backend plugins]({{< relref "backend" >}}).
 
-### Migrate a plugin from Angular to React
+## Why should I migrate my plugin?
+
+There are several benefits in using the new plugin platform.
+
+- **Better performance:** Components written in React are more responsive.
+- **Support for field options:** By migrating to the new data frame format, you can leverage the new field options to let users customize their data and display options.
+
+## Compatibility between Grafana versions
+
+A plugin developed for Grafana 6 will work for Grafana 7.0. However, plugins developed using the new plugin platform in Grafana 7.0 will only work for Grafana 7.0 and up.
+
+### Interoperability between data formats
+
+Grafana detects the data format sent by the data source and transforms it for the panel, if needed.
+
+For example:
+
+- A legacy panel with data source that returns data frames: Grafana converts the response to the legacy format.
+- A legacy data source with a panel using data frames: Grafana converts the response to the data frame format.
+- If both panel and data source use the same format, no transformations are made. Data is passed as is.
+
+### target and jsonData are unchanged
+
+The query model, `target`, and the configuration model, jsonData, are still the same. This means that if you use the same query model and configuration for your plugin, then the migrated plugin will use existing queries and configuration. You don’t have to worry about breaking existing dashboards.
+
+## Migrate a plugin from Angular to React
 
 If you’re looking to migrate a plugin to the new plugin platform, then we recommend that you release it under a new major version. Consider keeping a release branch for the previous version to be able to roll out patch releases for versions prior to Grafana 7.
 
@@ -425,7 +84,7 @@ While there's no 1-to-1 migration path from an Angular plugin to the new React p
 1. Start from scratch with one of the templates provided by Grafana Toolkit.
 1. Move the existing code into the new plugin incrementally, one component at a time.
 
-#### Migrate a panel plugin
+### Migrate a panel plugin
 
 Prior to Grafana 7.0, you would export a MetricsPanelCtrl from module.ts.
 
@@ -463,7 +122,7 @@ export const MyPanel: React.FC<Props> = ({ options, data, width, height }) => {
 };
 ```
 
-#### Migrate a data source plugin
+### Migrate a data source plugin
 
 While all plugins are different, we'd like to share a migration process that has worked for some of our users.
 
@@ -476,15 +135,15 @@ By now, you should be able to release your new version.
 
 To fully migrate to the new plugin platform, convert the time series response to a data frame response.
 
-#### Migrate to data frames
+### Migrate to data frames
 
 Before 7.0, data source and panel plugins exchanged data using either time series or tables. Starting with 7.0, plugins use the new data frame format to pass data from data sources to panels.
 
 Grafana 7.0 is backward compatible with the old data format used in previous versions. Panels and data sources using the old format will still work with plugins using the new data frame format.
 
-The `DataQueryResponse` returned by the `query` method can be either a [LegacyResponseData](https://grafana.com/docs/grafana/latest/packages_api/data/legacyresponsedata/) or a [DataFrame](https://grafana.com/docs/grafana/latest/packages_api/data/dataframe/).
+The `DataQueryResponse` returned by the `query` method can be either a [LegacyResponseData](https://grafana.com/docs/grafana/v8.0/packages_api/data/legacyresponsedata/) or a [DataFrame](https://grafana.com/docs/grafana/v8.0/packages_api/data/dataframe/).
 
-The [toDataFrame()](https://grafana.com/docs/grafana/latest/packages_api/data/todataframe/) function converts a legacy response, such as `TimeSeries` or `Table`, to a `DataFrame`. Use it to gradually move your code to the new format.
+The [toDataFrame()](https://grafana.com/docs/grafana/v8.0/packages_api/data/todataframe/) function converts a legacy response, such as `TimeSeries` or `Table`, to a `DataFrame`. Use it to gradually move your code to the new format.
 
 ```ts
 import { toDataFrame } from '@grafana/data';
@@ -503,6 +162,6 @@ async query(options: DataQueryRequest<MyQuery>): Promise<DataQueryResponse> {
 
 For more information, refer to [Data frames]({{< relref "data-frames.md">}}).
 
-### Troubleshoot plugin migration
+## Troubleshoot plugin migration
 
 As of Grafana 7.0, backend plugins can now be cryptographically signed to verify their origin. By default, Grafana ignores unsigned plugins. For more information, refer to [Allow unsigned plugins]({{< relref "../../plugins/plugin-signatures.md#allow-unsigned-plugins" >}}).

--- a/docs/sources/developers/plugins/package-a-plugin.md
+++ b/docs/sources/developers/plugins/package-a-plugin.md
@@ -1,7 +1,7 @@
 +++
 title = "Package a plugin"
 type = "docs"
-aliases = ["/docs/grafana/latest/developers/plugins/share-a-plugin/"]
+aliases = ["/docs/grafana/v8.0/developers/plugins/share-a-plugin/"]
 +++
 
 # Package a plugin

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -322,10 +322,10 @@
     },
     "routes": {
       "type": "array",
-      "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).",
+      "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.0/developers/plugins/authentication/).",
       "items": {
         "type": "object",
-        "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).",
+        "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.0/developers/plugins/authentication/).",
         "additionalProperties": false,
         "properties": {
           "path": {

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -26,7 +26,7 @@ To verify ownership of your plugin, you need to generate an API key that you'll 
 
    You can find the plugin ID in the `plugin.json` file inside your plugin directory. For example, if your account slug is `acmecorp`, you need to prefix the plugin ID with `acmecorp-`.
 
-1. [Create a Grafana Cloud API key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/) with the **PluginPublisher** role.
+1. [Create a Grafana Cloud API key](https://grafana.com/docs/grafana-cloud/cloud-portal/create-api-key/) with the **PluginPublisher** role.
 
 ## Sign a public plugin
 

--- a/docs/sources/enterprise/auditing.md
+++ b/docs/sources/enterprise/auditing.md
@@ -15,7 +15,7 @@ Auditing allows you to track important changes to your Grafana instance. By defa
 
 Audit logs are JSON objects representing user actions like:
 
-- Modifications to resources such as dashboards and data sources.
+- Modifications ro resources such as dashboards and data sources.
 - A user failing to log in.
 
 ### Format

--- a/docs/sources/enterprise/license/activate-license.md
+++ b/docs/sources/enterprise/license/activate-license.md
@@ -2,7 +2,7 @@
 title = "Activate an Enterprise license"
 description = "Activate an Enterprise license"
 keywords = ["grafana", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/activate-license"]
+aliases = ["/docs/grafana/v8.0/enterprise/activate-license"]
 weight = 100
 +++
 
@@ -68,13 +68,13 @@ In your configuration file:
 
 ```
 [server]
-root_url = https://grafana.example.com/
+root_url = https://grafana.blah.com/
 ```
 
 Or with an environment variable:
 
 ```
-GF_SERVER_ROOT_URL=https://grafana.example.com/
+GF_SERVER_ROOT_URL=https://grafana.blah.com/
 ```
 
 ## Step 4. Restart Grafana

--- a/docs/sources/enterprise/license/license-expiration.md
+++ b/docs/sources/enterprise/license/license-expiration.md
@@ -2,7 +2,7 @@
 title = "License expiration"
 description = ""
 keywords = ["grafana", "licensing"]
-aliases = ["/docs/grafana/latest/enterprise/license-expiration"]
+aliases = ["/docs/grafana/v8.0/enterprise/license-expiration"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/license/license-restrictions.md
+++ b/docs/sources/enterprise/license/license-restrictions.md
@@ -2,7 +2,7 @@
 title = "License restrictions"
 description = "Grafana Enterprise license restrictions"
 keywords = ["grafana", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/license-restrictions"]
+aliases = ["/docs/grafana/v8.0/enterprise/license-restrictions"]
 weight = 300
 +++
 

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting"
 description = ""
 keywords = ["grafana", "reporting"]
-aliases = ["/docs/grafana/latest/administration/reports"]
+aliases = ["/docs/grafana/v8.0/administration/reports"]
 weight = 800
 +++
 

--- a/docs/sources/enterprise/saml.md
+++ b/docs/sources/enterprise/saml.md
@@ -2,7 +2,7 @@
 title = "SAML Authentication"
 description = "Grafana SAML Authentication"
 keywords = ["grafana", "saml", "documentation", "saml-auth"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.0/auth/saml/"]
 weight = 900
 +++
 

--- a/docs/sources/enterprise/settings-updates.md
+++ b/docs/sources/enterprise/settings-updates.md
@@ -12,7 +12,7 @@ weight = 500
 Settings updates at runtime allows you to update Grafana settings with no need to restart the Grafana server.
 
 Updates that happen at runtime are stored in the database and override
-[settings from the other sources](https://grafana.com/docs/grafana/latest/administration/configuration/)
+[settings from the other sources](https://grafana.com/docs/grafana/v8.0/administration/configuration/)
 (arguments, environment variables, settings file, etc). Therefore, every time a specific setting key is removed at runtime,
 the value used for that key is the inherited one from the other sources in the reverse order of precedence 
 (`arguments > environment variables > settings file`), being the application default the value used when no one provided

--- a/docs/sources/enterprise/team-sync.md
+++ b/docs/sources/enterprise/team-sync.md
@@ -2,7 +2,7 @@
 title = "Team sync"
 description = "Grafana Team Sync"
 keywords = ["grafana", "auth", "documentation"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.0/auth/saml/"]
 weight = 1000
 +++
 

--- a/docs/sources/enterprise/usage-insights/_index.md
+++ b/docs/sources/enterprise/usage-insights/_index.md
@@ -2,7 +2,7 @@
 title = "Usage insights"
 description = "Understand how your Grafana instance is used"
 keywords = ["grafana", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/"]
+aliases = ["/docs/grafana/v8.0/enterprise/usage-insights/"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/usage-insights/dashboard-datasource-insights.md
+++ b/docs/sources/enterprise/usage-insights/dashboard-datasource-insights.md
@@ -2,7 +2,7 @@
 title = "Dashboard and data source insights"
 description = "Understand how your dashboards and data sources are used"
 keywords = ["grafana", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/dashboard-datasource-insights.md"]
+aliases = ["/docs/grafana/v8.0/enterprise/usage-insights/dashboard-datasource-insights.md"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/usage-insights/export-logs.md
+++ b/docs/sources/enterprise/usage-insights/export-logs.md
@@ -2,7 +2,7 @@
 title = "Export logs of usage insights"
 description = "Export logs of usage insights"
 keywords = ["grafana", "export", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/export-logs.md"]
+aliases = ["/docs/grafana/v8.0/enterprise/usage-insights/export-logs.md"]
 weight = 500
 +++
 

--- a/docs/sources/enterprise/usage-insights/improved-search.md
+++ b/docs/sources/enterprise/usage-insights/improved-search.md
@@ -2,7 +2,7 @@
 title = "Sort dashboards by using insights data"
 description = "Sort dashboards by using insights data"
 keywords = ["grafana", "search", "sort", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/improved-search.md"]
+aliases = ["/docs/grafana/v8.0/enterprise/usage-insights/improved-search.md"]
 weight = 400
 +++
 

--- a/docs/sources/enterprise/usage-insights/presence-indicator.md
+++ b/docs/sources/enterprise/usage-insights/presence-indicator.md
@@ -2,7 +2,7 @@
 title = "Presence indicator"
 description = "Know who is looking at the same dashboard as you are"
 keywords = ["grafana", "presence-indicator", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/presence-indicator.md"]
+aliases = ["/docs/grafana/v8.0/enterprise/usage-insights/presence-indicator.md"]
 weight = 300
 +++
 

--- a/docs/sources/enterprise/white-labeling.md
+++ b/docs/sources/enterprise/white-labeling.md
@@ -2,7 +2,7 @@
 title = "White labeling"
 description = "Change the look of Grafana to match your corporate brand"
 keywords = ["grafana", "white-labeling", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/white-labeling/"]
+aliases = ["/docs/grafana/v8.0/enterprise/white-labeling/"]
 weight = 1300
 +++
 

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Explore"
 keywords = ["explore", "loki", "logs"]
-aliases = ["/docs/grafana/latest/features/explore/"]
+aliases = ["/docs/grafana/v8.0/features/explore/"]
 weight = 90
 +++
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -103,4 +103,4 @@ Optional fields:
 | stackTraces    | string[]            | List of stack traces associated with the current span.             |
 | errorIconColor | string              | Color of the error icon in case span is tagged with `error: true`. |
 
-For details about the types see [TraceSpanRow](https://grafana.com/docs/grafana/latest/packages_api/data/tracespanrow/), [TraceKeyValuePair](https://grafana.com/docs/grafana/latest/packages_api/data/tracekeyvaluepair/) and [TraceLog](https://grafana.com/docs/grafana/latest/packages_api/data/tracelog/)
+For details about the types see [TraceSpanRow](https://grafana.com/docs/grafana/v8.0/packages_api/data/tracespanrow/), [TraceKeyValuePair](https://grafana.com/docs/grafana/v8.0/packages_api/data/tracekeyvaluepair/) and [TraceLog](https://grafana.com/docs/grafana/v8.0/packages_api/data/tracelog/)

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -1,14 +1,14 @@
 +++
 title = "Getting started"
 weight = 10
-aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
+aliases = ["/docs/grafana/v8.0/guides/what-is-grafana"]
 +++
 
 # Getting started
 
 This section provides a high-level look at Grafana, the Grafana process, and Grafana features. It's a good place to learn how to use the Grafana software.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 After creating a dashboard like you do in [Getting started]({{< relref "getting-started.md" >}}), there are many possible things you might do next. It all depends on your needs and your use case.
 
@@ -72,6 +72,6 @@ Refer to [Provisioning]({{< relref "../administration/provisioning.md" >}}) for 
 
 When organizations have one Grafana and multiple teams, they often want the ability to both keep things separate and share dashboards. You can create a team of users and then set [permissions]({{< relref "../permissions/_index.md" >}}) on folders, dashboards, and down to the [data source level]({{< relref "../enterprise/datasource_permissions.md" >}}) if you're using [Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}).
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/getting-started/getting-started-influxdb.md
+++ b/docs/sources/getting-started/getting-started-influxdb.md
@@ -7,9 +7,9 @@ weight = 250
 
 # Getting started with Grafana and InfluxDB
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Get InfluxDB
 
@@ -106,5 +106,5 @@ In your Grafana instance, go to the [Explore]({{< relref "../explore/_index.md" 
 There you go! Use Explore and Data Explorer to experiment with your data, and add the queries that you like to your dashboard as panels. Have fun!
 
 Here are some resources to learn more:
-- Grafana documentation: [InfluxDB data source]({{< relref "../datasources/influxdb/_index.md" >}})
+- Grafana documentation: [InfluxDB data source](../datasources/influxdb/_index.md)
 - InfluxDB documentation: [Comparison of Flux vs InfluxQL](https://docs.influxdata.com/influxdb/v1.8/flux/flux-vs-influxql/)

--- a/docs/sources/getting-started/getting-started-prometheus.md
+++ b/docs/sources/getting-started/getting-started-prometheus.md
@@ -2,7 +2,7 @@
 title = "With Grafana and Prometheus"
 description = "Guide for getting started with Grafana and Prometheus"
 keywords = ["grafana", "intro", "guide", "started"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.0/guides/gettingstarted","/docs/grafana/v8.0/guides/getting_started"]
 weight = 300
 +++
 
@@ -12,7 +12,7 @@ Prometheus is an open source systems monitoring system for which Grafana provide
 
 You can also configure a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance to display system metrics without having to host Grafana yourself.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Download Prometheus and node_exporter
 

--- a/docs/sources/getting-started/getting-started-sql.md
+++ b/docs/sources/getting-started/getting-started-sql.md
@@ -2,7 +2,7 @@
 title = "With Grafana and MS SQL Server"
 description = "Guide for getting started with Grafana and MS SQL Server"
 keywords = ["grafana", "intro", "guide", "started", "SQL", "MSSQL"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.0/guides/gettingstarted","/docs/grafana/v8.0/guides/getting_started"]
 weight = 400
 +++
 
@@ -10,7 +10,7 @@ weight = 400
 
 Microsoft SQL Server is a popular relational database management system that is widely used in development and production environments. This topic walks you through the steps to create a series of dashboards in Grafana to display metrics from a MS SQL Server database. You can also configure the MS SQL Server data source on a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance without having to host Grafana yourself.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 > **Note:** You must install Grafana 5.1+ in order to use the integrated MS SQL data source.
 

--- a/docs/sources/getting-started/getting-started.md
+++ b/docs/sources/getting-started/getting-started.md
@@ -2,7 +2,7 @@
 title = "With Grafana"
 description = "Guide for getting started with Grafana"
 keywords = ["grafana", "intro", "guide", "started"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.0/guides/gettingstarted","/docs/grafana/v8.0/guides/getting_started"]
 weight = 200
 +++
 

--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -2,7 +2,7 @@
 title = "HTTP API"
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "overview"]
-aliases = ["/docs/grafana/latest/overview"]
+aliases = ["/docs/grafana/v8.0/overview"]
 weight = 170
 +++
 

--- a/docs/sources/http_api/access_control.md
+++ b/docs/sources/http_api/access_control.md
@@ -2,7 +2,7 @@
 title = "Fine-grained access control HTTP API "
 description = "Fine-grained access control API"
 keywords = ["grafana", "http", "documentation", "api", "fine-grained-access-control", "acl", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/accesscontrol/"]
+aliases = ["/docs/grafana/v8.0/http_api/accesscontrol/"]
 +++
 
 # Fine-grained access control API

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -2,7 +2,7 @@
 title = "Admin HTTP API "
 description = "Grafana Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "admin"]
-aliases = ["/docs/grafana/latest/http_api/admin/"]
+aliases = ["/docs/grafana/v8.0/http_api/admin/"]
 +++
 
 # Admin API

--- a/docs/sources/http_api/alerting.md
+++ b/docs/sources/http_api/alerting.md
@@ -2,7 +2,7 @@
 title = "Alerting HTTP API "
 description = "Grafana Alerts HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "alerting", "alerts"]
-aliases = ["/docs/grafana/latest/http_api/alerting/"]
+aliases = ["/docs/grafana/v8.0/http_api/alerting/"]
 +++
 
 # Alerting API

--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -2,7 +2,7 @@
 title = "Annotations HTTP API "
 description = "Grafana Annotations HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "annotation", "annotations", "comment"]
-aliases = ["/docs/grafana/latest/http_api/annotations/"]
+aliases = ["/docs/grafana/v8.0/http_api/annotations/"]
 +++
 
 # Annotations resources / actions

--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -2,7 +2,7 @@
 title = "Authentication HTTP API "
 description = "Grafana Authentication HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "authentication"]
-aliases = ["/docs/grafana/latest/http_api/authentication/"]
+aliases = ["/docs/grafana/v8.0/http_api/authentication/"]
 +++
 
 # Authentication API
@@ -39,7 +39,7 @@ standard basic auth. Basic auth will also authenticate LDAP users.
 
 curl example:
 ```bash
-curl http://admin:admin@localhost:3000/api/org
+?curl http://admin:admin@localhost:3000/api/org
 {"id":1,"name":"Main Org."}
 ```
 
@@ -65,7 +65,7 @@ The API Token can also be passed as a Basic authorization password with the spec
 
 curl example:
 ```bash
-curl http://api_key:eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk@localhost:3000/api/org
+?curl http://api_key:eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk@localhost:3000/api/org
 {"id":1,"name":"Main Org."}
 ```
 

--- a/docs/sources/http_api/create-api-tokens-for-org.md
+++ b/docs/sources/http_api/create-api-tokens-for-org.md
@@ -1,7 +1,7 @@
 +++
 title = "API Tutorial: Create API tokens and dashboards for an organization"
 keywords = ["grafana", "tutorials", "API", "Token", "Org", "Organization"]
-aliases =["/docs/grafana/latest/tutorials/api_org_token_howto/"]
+aliases =["/docs/grafana/v8.0/tutorials/api_org_token_howto/"]
 weight = 150
 +++
 

--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -2,7 +2,7 @@
 title = "Dashboard HTTP API "
 description = "Grafana Dashboard HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard"]
-aliases = ["/docs/grafana/latest/http_api/dashboard/"]
+aliases = ["/docs/grafana/v8.0/http_api/dashboard/"]
 +++
 
 # Dashboard API
@@ -22,7 +22,7 @@ The uid can have a maximum length of 40 characters.
 
 `POST /api/dashboards/db`
 
-Creates a new dashboard or updates an existing dashboard. When updating existing dashboards, if you do not define the `folderId` and `folderUid` properties, then the dashboard(s) are moved to the `General` folder.
+Creates a new dashboard or updates an existing dashboard.
 
 **Example Request for new dashboard**:
 

--- a/docs/sources/http_api/dashboard_permissions.md
+++ b/docs/sources/http_api/dashboard_permissions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Permissions HTTP API "
 description = "Grafana Dashboard Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "permission", "permissions", "acl"]
-aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/v8.0/http_api/dashboardpermissions/"]
 +++
 
 # Dashboard Permissions API

--- a/docs/sources/http_api/dashboard_versions.md
+++ b/docs/sources/http_api/dashboard_versions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Versions HTTP API "
 description = "Grafana Dashboard Versions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "versions"]
-aliases = ["/docs/grafana/latest/http_api/dashboardversions/"]
+aliases = ["/docs/grafana/v8.0/http_api/dashboardversions/"]
 +++
 
 # Dashboard Versions

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -2,7 +2,7 @@
 title = "Data source HTTP API "
 description = "Grafana Data source HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "data source"]
-aliases = ["/docs/grafana/latest/http_api/datasource/"]
+aliases = ["/docs/grafana/v8.0/http_api/datasource/"]
 +++
 
 

--- a/docs/sources/http_api/datasource_permissions.md
+++ b/docs/sources/http_api/datasource_permissions.md
@@ -2,7 +2,7 @@
 title = "Datasource Permissions HTTP API "
 description = "Data Source Permissions API"
 keywords = ["grafana", "http", "documentation", "api", "datasource", "permission", "permissions", "acl", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/datasourcepermissions/"]
+aliases = ["/docs/grafana/v8.0/http_api/datasourcepermissions/"]
 +++
 
 # Data Source Permissions API

--- a/docs/sources/http_api/external_group_sync.md
+++ b/docs/sources/http_api/external_group_sync.md
@@ -2,7 +2,7 @@
 title = "External Group Sync HTTP API "
 description = "Grafana External Group Sync HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group", "member", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/external_group_sync/"]
+aliases = ["/docs/grafana/v8.0/http_api/external_group_sync/"]
 +++
 
 # External Group Synchronization API

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -2,7 +2,7 @@
 title = "Folder HTTP API "
 description = "Grafana Folder HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder"]
-aliases = ["/docs/grafana/latest/http_api/folder/"]
+aliases = ["/docs/grafana/v8.0/http_api/folder/"]
 +++
 
 # Folder API

--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -2,7 +2,7 @@
 title = "Folder/Dashboard Search HTTP API "
 description = "Grafana Folder/Dashboard Search HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "search", "folder", "dashboard"]
-aliases = ["/docs/grafana/latest/http_api/folder_dashboard_search/"]
+aliases = ["/docs/grafana/v8.0/http_api/folder_dashboard_search/"]
 +++
 
 # Folder/Dashboard Search API

--- a/docs/sources/http_api/folder_permissions.md
+++ b/docs/sources/http_api/folder_permissions.md
@@ -2,7 +2,7 @@
 title = "Folder Permissions HTTP API "
 description = "Grafana Folder Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder", "permission", "permissions", "acl"]
-aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/v8.0/http_api/dashboardpermissions/"]
 +++
 
 # Folder Permissions API

--- a/docs/sources/http_api/licensing.md
+++ b/docs/sources/http_api/licensing.md
@@ -2,7 +2,7 @@
 title = "Licensing HTTP API "
 description = "Enterprise Licensing HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/licensing/"]
+aliases = ["/docs/grafana/v8.0/http_api/licensing/"]
 +++
 
 # Enterprise License API

--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -2,7 +2,7 @@
 title = "Organization HTTP API "
 description = "Grafana Organization HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "organization"]
-aliases = ["/docs/grafana/latest/http_api/organization/"]
+aliases = ["/docs/grafana/v8.0/http_api/organization/"]
 +++
 
 # Organization API

--- a/docs/sources/http_api/other.md
+++ b/docs/sources/http_api/other.md
@@ -2,7 +2,7 @@
 title = "Other HTTP API "
 description = "Grafana Other HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "other"]
-aliases = ["/docs/grafana/latest/http_api/other/"]
+aliases = ["/docs/grafana/v8.0/http_api/other/"]
 +++
 
 

--- a/docs/sources/http_api/playlist.md
+++ b/docs/sources/http_api/playlist.md
@@ -2,7 +2,7 @@
 title = "Playlist HTTP API "
 description = "Playlist Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "playlist"]
-aliases = ["/docs/grafana/latest/http_api/playlist/"]
+aliases = ["/docs/grafana/v8.0/http_api/playlist/"]
 +++
 
 # Playlist API

--- a/docs/sources/http_api/preferences.md
+++ b/docs/sources/http_api/preferences.md
@@ -2,7 +2,7 @@
 title = "HTTP Preferences API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "preferences"]
-aliases = ["/docs/grafana/latest/http_api/preferences/"]
+aliases = ["/docs/grafana/v8.0/http_api/preferences/"]
 +++
 
 # User and Org Preferences API

--- a/docs/sources/http_api/reporting.md
+++ b/docs/sources/http_api/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting API"
 description = "Grafana Enterprise APIs"
 keywords = ["grafana", "enterprise", "api", "reporting"]
-aliases = ["/docs/grafana/latest/http_api/reporting/"]
+aliases = ["/docs/grafana/v8.0/http_api/reporting/"]
 +++
 
 # Reporting API

--- a/docs/sources/http_api/short_url.md
+++ b/docs/sources/http_api/short_url.md
@@ -2,7 +2,7 @@
 title = "Short URL HTTP API "
 description = "Grafana Short URL HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "shortUrl"]
-aliases = ["/docs/grafana/latest/http_api/short_url/"]
+aliases = ["/docs/grafana/v8.0/http_api/short_url/"]
 +++
 
 # Short URL API

--- a/docs/sources/http_api/snapshot.md
+++ b/docs/sources/http_api/snapshot.md
@@ -2,7 +2,7 @@
 title = "HTTP Snapshot API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "snapshot"]
-aliases = ["/docs/grafana/latest/http_api/snapshot/"]
+aliases = ["/docs/grafana/v8.0/http_api/snapshot/"]
 +++
 
 # Snapshot API

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -2,7 +2,7 @@
 title = "Team HTTP API "
 description = "Grafana Team HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group"]
-aliases = ["/docs/grafana/latest/http_api/team/"]
+aliases = ["/docs/grafana/v8.0/http_api/team/"]
 +++
 
 # Team API

--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -2,7 +2,7 @@
 title = "User HTTP API "
 description = "Grafana User HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "user"]
-aliases = ["/docs/grafana/latest/http_api/user/"]
+aliases = ["/docs/grafana/v8.0/http_api/user/"]
 +++
 
 # User API

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -2,7 +2,7 @@
 title = "Installation"
 description = "Installation guide for Grafana"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/latest/installation/installation/", "/docs/grafana/v2.1/installation/install/", "/docs/grafana/latest/install"]
+aliases = ["/docs/grafana/v8.0/installation/installation/", "/docs/grafana/v2.1/installation/install/", "/docs/grafana/v8.0/install"]
 weight = 30
 +++
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -2,7 +2,7 @@
 title = "Install on Debian/Ubuntu"
 description = "Install guide for Grafana on Debian or Ubuntu"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/latest/installation/installation/debian"]
+aliases = ["/docs/grafana/v8.0/installation/installation/debian"]
 weight = 200
 +++
 

--- a/docs/sources/installation/requirements.md
+++ b/docs/sources/installation/requirements.md
@@ -59,6 +59,6 @@ Grafana is supported in the current version of the following browsers. Older ver
 - Firefox
 - Safari
 - Microsoft Edge
-- Internet Explorer 11 is only fully supported in Grafana versions prior v6.0.
+- Internet Explorer 11 is only fully supported in Grafana versions prior to v6.0.
 
 > **Note:** Always enable JavaScript in your browser. Running Grafana without JavaScript enabled in the browser is not supported.

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -2,7 +2,7 @@
 title = "Install on RPM-based Linux"
 description = "Grafana Installation guide for RPM-based Linux, such as Centos, Fedora, OpenSuse, and Red Hat."
 keywords = ["grafana", "installation", "documentation", "centos", "fedora", "opensuse", "redhat"]
-aliases = ["/docs/grafana/latest/installation/installation/rpm"]
+aliases = ["/docs/grafana/v8.0/installation/installation/rpm"]
 weight = 300
 +++
 

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -342,27 +342,5 @@ Refer to [Grafana Live configuration]({{< relref "../live/configure-grafana-live
 Grafana v8.0 changes the underlying data structure to [data frames]({{< relref "../developers/plugins/data-frames.md" >}}) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). To make the visualizations work as they did before, you might have to do some manual migrations.
 
 For any existing panels/visualizations using a _Time series_ query, where the time column is only needed for filtering the time range, for example, using the bar gauge or pie chart panel, we recommend that you use a _Table query_ instead and exclude the time column as a field in the response.
-
+		
 Refer to this [issue comment](https://github.com/grafana/grafana/issues/35534#issuecomment-861519658) for detailed instructions and workarounds.
-
-#### Prefix added to series names
-
-When you have a query where there's a time value and a numeric value selected together with a string value that's not named _metric_, the graph panel renders series names as `value <hostname>` rather than just `<hostname>` which was the case before Grafana 8.
-
-```sql
-SELECT
-  $__timeGroup("createdAt",'10m'),
-  avg(value) as "value",
-  hostname
-FROM grafana_metric
-WHERE $__timeFilter("createdAt")
-GROUP BY time, hostname
-ORDER BY time
-```
-
-There are two possible workarounds to resolve this problem:
-
-1. In Grafana v8.0.3, use an alias of the string column selected as `metric`. for example, `hostname as metric`.
-2. Use the [Standard field options/Display name]({{< relref "../panels/standard-options.md#display-name" >}}) to format the alias. For the preceding example query, you would use `${__field.labels.hostname}` option.
-
-For more information, refer to the our relational databases documentation of [Postgres]({{< relref "../datasources/postgres.md#time-series-queries" >}}), [MySQL]({{< relref "../datasources/mysql.md#time-series-queries" >}}), [Microsoft SQL Server]({{< relref "../datasources/mssql.md#time-series-queries" >}}).

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -339,7 +339,7 @@ Refer to [Grafana Live configuration]({{< relref "../live/configure-grafana-live
 
 ### Postgres, MySQL, Microsoft SQL Server data sources
 
-Grafana v8.0 changes the underlying data structure to [data frames](https://grafana.com/developers/plugin-tools/introduction/data-frames) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). To make the visualizations work as they did before, you might have to do some manual migrations.
+Grafana v8.0 changes the underlying data structure to [data frames]({{< relref "../developers/plugins/data-frames.md" >}}) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). To make the visualizations work as they did before, you might have to do some manual migrations.
 
 For any existing panels/visualizations using a _Time series_ query, where the time column is only needed for filtering the time range, for example, using the bar gauge or pie chart panel, we recommend that you use a _Table query_ instead and exclude the time column as a field in the response.
 		

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -339,7 +339,7 @@ Refer to [Grafana Live configuration]({{< relref "../live/configure-grafana-live
 
 ### Postgres, MySQL, Microsoft SQL Server data sources
 
-Grafana v8.0 changes the underlying data structure to [data frames]({{< relref "../developers/plugins/data-frames.md" >}}) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). To make the visualizations work as they did before, you might have to do some manual migrations.
+Grafana v8.0 changes the underlying data structure to [data frames](https://grafana.com/developers/plugin-tools/introduction/data-frames) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). To make the visualizations work as they did before, you might have to do some manual migrations.
 
 For any existing panels/visualizations using a _Time series_ query, where the time column is only needed for filtering the time range, for example, using the bar gauge or pie chart panel, we recommend that you use a _Table query_ instead and exclude the time column as a field in the response.
 		

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "URL variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "data link"]
-aliases = ["/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
+aliases = ["/docs/grafana/v8.0/variables/url-variables.md","/docs/grafana/v8.0/variables/variable-types/url-variables.md"]
 weight = 400
 +++
 

--- a/docs/sources/linking/data-links.md
+++ b/docs/sources/linking/data-links.md
@@ -1,7 +1,7 @@
 +++
 title = "Data links"
 keywords = ["grafana", "data links", "documentation", "playlist"]
-aliases = ["/docs/grafana/latest/reference/datalinks/"]
+aliases = ["/docs/grafana/v8.0/reference/datalinks/"]
 +++
 
 # Data links

--- a/docs/sources/linking/linking-overview.md
+++ b/docs/sources/linking/linking-overview.md
@@ -1,7 +1,7 @@
 +++
 title = "Linking overview"
 keywords = ["grafana", "linking", "create links", "link panels", "link dashboards", "navigate"]
-aliases = ["/docs/grafana/latest/features/navigation-links/"]
+aliases = ["/docs/grafana/v8.0/features/navigation-links/"]
 weight = 100
 +++
 

--- a/docs/sources/linking/panel-links.md
+++ b/docs/sources/linking/panel-links.md
@@ -2,13 +2,13 @@
 title = "Panel links"
 description = ""
 keywords = ["grafana", "linking", "create links", "link panels", "link dashboards", "navigate"]
-aliases = ["/docs/grafana/latest/features/navigation-links/"]
+aliases = ["/docs/grafana/v8.0/features/navigation-links/"]
 weight = 300
 +++
 
 # Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
+Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
 
 Click the icon on the top left corner of a panel to see available panel links.
 

--- a/docs/sources/live/_index.md
+++ b/docs/sources/live/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Grafana Live"
-aliases = ["/docs/grafana/latest/live/live-feature-overview/"]
+aliases = ["/docs/grafana/v8.0/live/live-feature-overview/"]
 weight = 115
 +++
 

--- a/docs/sources/manage-users/manage-teams/index.md
+++ b/docs/sources/manage-users/manage-teams/index.md
@@ -1,6 +1,6 @@
 +++
 title = "Manage teams"
-aliases =["/docs/grafana/latest/manage-users/add-or-remove-user-from-team/","/docs/grafana/latest/manage-users/create-or-remove-team/"]
+aliases =["/docs/grafana/v8.0/manage-users/add-or-remove-user-from-team/","/docs/grafana/v8.0/manage-users/create-or-remove-team/"]
 weight = 300
 +++
 
@@ -18,7 +18,7 @@ Teams members are assigned one of two permissions:
 
 See the complete list of teams in your Grafana organization.
 
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Org Admin view
 
@@ -33,7 +33,7 @@ See the complete list of teams in your Grafana organization.
 Add a team to your Grafana organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click **New Team**.
 1. Enter team information:
    - **Name -** Enter the name of the new team.
@@ -46,7 +46,7 @@ Add a team to your Grafana organization.
 Add an existing user account to a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the name of the team that you want to add users to.
 1. Click **Add member**.
 1. In the **Add team member** list, click the user account that you want to add to the team. You can also type in the field to filter the list.
@@ -61,7 +61,7 @@ Add an existing user account to a team.
 Remove a user account from the team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the name of the team that you want to remove users from.
 1. Click the red **X** next to the name of the user that you want to remove from the team and then click **Delete**.
 {{< /docs/list >}}
@@ -71,7 +71,7 @@ Remove a user account from the team.
 Change team member permission levels.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the name of the team in which you want to change user permissions.
 1. In the team member list, find and click the user account that you want to change. You can use the search field to filter the list if necessary.
 1. Click the **Permission** list, and then click the new user permission level.
@@ -84,6 +84,6 @@ Change team member permission levels.
 Permanently delete the team and all special permissions assigned to it.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the red **X** next to the team that you want to delete and then click **Delete**.
 {{< /docs/list >}}

--- a/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
@@ -15,7 +15,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of organizations set up on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all organizations set up on the server, listed in alphabetical order by organization name. The following information is displayed:
 - **Id -** The ID number of the organization.
@@ -28,7 +28,7 @@ Grafana displays all organizations set up on the server, listed in alphabetical 
 Add an organization to your Grafana server.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click **+ New org**.
 1. Enter the name of the new organization and then click **Create**.
 {{< /docs/list >}}
@@ -46,7 +46,7 @@ Permanently remove an organization from your Grafana server.
 **Warning:** Deleting the organization also deletes all teams and dashboards for this organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the red **X** next to the organization that you want to remove.
 1. Click **Delete**.
 {{< /docs/list >}}
@@ -62,7 +62,7 @@ Grafana Server Admins can perform some organization management tasks that are al
 See which user accounts are assigned to the organization and their assigned roles.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click the name of the organization for which you want to view members.
 1. Scroll down to the Organization Users section. User accounts are displayed in alphabetical order.
 {{< /docs/list >}}
@@ -70,7 +70,7 @@ See which user accounts are assigned to the organization and their assigned role
 ### Change organization name
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the **Name** field, type the new organization name.
 1. Click **Update**.
 {{< /docs/list >}}
@@ -80,7 +80,7 @@ See which user accounts are assigned to the organization and their assigned role
 Change the organization role assigned to a user account that is assigned to the organization you are editing.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. In the **Role** field, select the new role that you want to assign.
 {{< /docs/list >}}
@@ -88,7 +88,7 @@ Change the organization role assigned to a user account that is assigned to the 
 ## Remove a user from an organization
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. Click the red **X** next to the user account listing and then click **Delete**.
 {{< /docs/list >}}

--- a/docs/sources/manage-users/server-admin/server-admin-manage-users.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-users.md
@@ -1,7 +1,7 @@
 +++
 title = "Manage users"
 weight = 100
-aliases =["/docs/grafana/latest/manage-users/add-or-remove-user/","/docs/grafana/latest/manage-users/enable-or-disable-user/"]
+aliases =["/docs/grafana/v8.0/manage-users/add-or-remove-user/","/docs/grafana/v8.0/manage-users/enable-or-disable-user/"]
 +++
 
 # Manage users as a Server Admin
@@ -16,7 +16,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of users with accounts on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all user accounts on the server, listed in alphabetical order by user name. The following information is displayed:
 
@@ -34,7 +34,7 @@ Grafana displays all user accounts on the server, listed in alphabetical order b
 See all details associated with a specific user account.
 
 {{< docs/list >}}
-  {{< docs/shared "manage-users/view-server-user-list.md" >}}
+  {{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account you wish to view. If necessary, use the search field at the top of the tab to search for the specific user account that you need.
 {{< /docs/list >}}
 
@@ -74,7 +74,7 @@ See recent sessions that the user was logged on, including when they logged on a
 Create a new user account at the server level.
 
 {{< docs/list >}}
-  {{< docs/shared "manage-users/view-server-user-list.md" >}}
+  {{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click **New user**.
   1. Enter the following information:
     - **Name -** Required.
@@ -95,7 +95,7 @@ Change information or settings in an individual user account.
 Edit information on an existing user account, including the user name, email, username, and password.
 
 {{< docs/list >}}
-  {{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+  {{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. In the User information section, click **Edit** next to the field that you want to change.
   1. Enter the new value and then click **Save**.
 {{< /docs/list >}}
@@ -105,7 +105,7 @@ Edit information on an existing user account, including the user name, email, us
 Users can change their own passwords, but Server Admins can change user passwords as well.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the User information section, click **Edit** next to the **Password** field.
 1. Enter the new value and then click **Save**. Grafana requires a value at least four characters long in this field.
 {{< /docs/list >}}
@@ -115,7 +115,7 @@ Users can change their own passwords, but Server Admins can change user password
 Permanently remove a user account from the server.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click **Delete User**.
 1. Click **Delete user** to confirm the action.
 {{< /docs/list >}}
@@ -129,7 +129,7 @@ Temporarily turn on or off account access, but do not remove the account from th
 Prevent a user from logging in with this account, but do not delete the account. You might disable an account if a colleague goes on sabbatical.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click **Disable User**.
 1. Click **Disable user** to confirm the action.
 {{< /docs/list >}}
@@ -139,7 +139,7 @@ Prevent a user from logging in with this account, but do not delete the account.
 Reactivate a disabled user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Click **Enable User**.
 {{< /docs/list >}}
 
@@ -148,7 +148,7 @@ Reactivate a disabled user account.
 Give or remove the Grafana Server Admin role from a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Permissions section, click **Change**.
 1. Click **Yes** or **No**, depending on whether or not you want this user account to have the Grafana Server Admin role.
 1. Click **Change**.
@@ -161,7 +161,7 @@ The next time this user logs in, their permissions will be updated.
 Add a user account to an existing organization. User accounts can belong to multiple organizations, but each user account must belong to at least one organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Organisations section, click **Add user to organisation**.
 1. In the **Add to an organization** window, select the **Organisation** that you are adding the user to.
 1. Select the **Role** that the user should have in the organization.
@@ -173,7 +173,7 @@ Add a user account to an existing organization. User accounts can belong to mult
 Remove a user account from an organization that it is currently assigned to.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Organisations section, click **Remove from organisation** next to the organization that you want to remove the user from.
 1. Click **Confirm removal**.
 {{< /docs/list >}}
@@ -183,7 +183,7 @@ Remove a user account from an organization that it is currently assigned to.
 Change the organization role assigned to a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. In the Organisations section, click **Change role** next to the organization that you want to change the user role for.
 1. Select the new role and then click **Save**.
 {{< /docs/list >}}
@@ -193,7 +193,7 @@ Change the organization role assigned to a user account.
 See when a user last logged in and information about how they logged in. You can also force the account to log out of Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Scroll down to the Sessions section to view sessions associated with this user account.
 {{< /docs/list >}}
 
@@ -206,7 +206,7 @@ If you suspect a user account is compromised or is no longer authorized to acces
 Log the user account out of one specific device that is logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Scroll down to the Sessions section.
 1. Click **Force logout** next to the session entry that you want logged out of Grafana.
 1. Click **Confirm logout**.
@@ -217,7 +217,7 @@ Log the user account out of one specific device that is logged in to Grafana.
 Log the user account out of all devices that are logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 1. Scroll down to the Sessions section.
 1. Click **Force logout from all devices**.
 1. Click **Force logout**.

--- a/docs/sources/manage-users/user-admin/change-your-password.md
+++ b/docs/sources/manage-users/user-admin/change-your-password.md
@@ -2,7 +2,7 @@
 title = "Change your password"
 description = "How to change your Grafana password"
 keywords = ["grafana", "password", "change", "preferences"]
-aliases = ["/docs/grafana/latest/administration/change-your-password/"]
+aliases = ["/docs/grafana/v8.0/administration/change-your-password/"]
 weight = 200
 +++
 

--- a/docs/sources/panels/_index.md
+++ b/docs/sources/panels/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Panels"
-aliases = ["/docs/grafana/latest/features/panels/panels/"]
+aliases = ["/docs/grafana/v8.0/features/panels/panels/"]
 weight = 70
 +++
 

--- a/docs/sources/panels/field-overrides.md
+++ b/docs/sources/panels/field-overrides.md
@@ -1,7 +1,7 @@
 +++
 title = "Field overrides"
 keywords = ["grafana", "field options", "documentation", "format fields", "overrides", "override fields"]
-aliases = ["/docs/grafana/latest/panels/field-options/", "/docs/grafana/latest/panels/field-options/configure-specific-fields/"]
+aliases = ["/docs/grafana/v8.0/panels/field-options/", "/docs/grafana/v8.0/panels/field-options/configure-specific-fields/"]
 weight = 700
 +++
 

--- a/docs/sources/panels/legend-options.md
+++ b/docs/sources/panels/legend-options.md
@@ -1,6 +1,6 @@
 +++
 title = "Legend options"
-aliases = ["/docs/grafana/latest/panels/visualizations/panel-legend/"]
+aliases = ["/docs/grafana/v8.0/panels/visualizations/panel-legend/"]
 weight = 950
 +++
 

--- a/docs/sources/panels/panel-editor.md
+++ b/docs/sources/panels/panel-editor.md
@@ -62,7 +62,7 @@ The section contains tabs where you enter queries, transform your data, and crea
 
 The section contains tabs where you configure almost every aspect of your data Visualization. Not all options are available for each visualization.
 
-The data model used in Grafana, namely the [data frame](https://grafana.com/developers/plugin-tools/introduction/data-frames), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
+The data model used in Grafana, namely the [data frame]({{< relref "../developers/plugins/data-frames.md" >}}), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
 
 Field options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, however they change how Grafana displays the data.
 

--- a/docs/sources/panels/panel-editor.md
+++ b/docs/sources/panels/panel-editor.md
@@ -62,7 +62,7 @@ The section contains tabs where you enter queries, transform your data, and crea
 
 The section contains tabs where you configure almost every aspect of your data Visualization. Not all options are available for each visualization.
 
-The data model used in Grafana, namely the [data frame]({{< relref "../developers/plugins/data-frames.md" >}}), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
+The data model used in Grafana, namely the [data frame](https://grafana.com/developers/plugin-tools/introduction/data-frames), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
 
 Field options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, however they change how Grafana displays the data.
 

--- a/docs/sources/panels/panel-options.md
+++ b/docs/sources/panels/panel-options.md
@@ -27,12 +27,8 @@ Toggle the transparent background option on your panel display.
 
 ## Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
-
 For more information, refer to [Panel links]({{< relref "../linking/panel-links.md" >}}).
 
 ## Repeat options
-
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
 
 For more information, refer to [Repeat panels or rows]({{< relref "./repeat-panels-or-rows.md" >}}).

--- a/docs/sources/panels/repeat-panels-or-rows.md
+++ b/docs/sources/panels/repeat-panels-or-rows.md
@@ -1,13 +1,13 @@
 +++
 title = "Repeat panels or rows"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable", "repeat"]
-aliases = ["/docs/grafana/latest/variables/repeat-panels-or-rows/"]
+aliases = ["/docs/grafana/v8.0/variables/repeat-panels-or-rows/"]
 weight = 800
 +++
 
 # Repeat panels or rows
 
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
+Grafana lets you create dynamic dashboards using _template variables_. All variables in your queries expand to the current value of the variable before the query is sent to the database. Variables let you reuse a single dashboard for all your services.
 
 Template variables can be very useful to dynamically change your queries across a whole dashboard. If you want
 Grafana to dynamically create new panels or rows based on what values you have selected, you can use the _Repeat_ feature.

--- a/docs/sources/panels/standard-options.md
+++ b/docs/sources/panels/standard-options.md
@@ -1,7 +1,7 @@
 +++
 title = "Standard field options"
 keywords = ["grafana", "table options", "documentation", "format tables"]
-aliases = ["/docs/grafana/latest/panels/field-options/standard-field-options/"]
+aliases = ["/docs/grafana/v8.0/panels/field-options/standard-field-options/"]
 weight = 430
 +++
 

--- a/docs/sources/panels/transformations/types-options.md
+++ b/docs/sources/panels/transformations/types-options.md
@@ -453,7 +453,7 @@ With the transformation applied, you can see we are left with just the remainder
 
 > **Note:** This transformation is available in Grafana 7.5.10+ and Grafana 8.0.6+.
 
-Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here]({{< relref "../../developers/plugins/data-frames.md" >}}).
+Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here](https://grafana.com/developers/plugin-tools/introduction/data-frames).
 
 This transformation helps you resolve this issue by converting the time series data from either the wide format to the long format or the other way around.
 

--- a/docs/sources/panels/transformations/types-options.md
+++ b/docs/sources/panels/transformations/types-options.md
@@ -453,7 +453,7 @@ With the transformation applied, you can see we are left with just the remainder
 
 > **Note:** This transformation is available in Grafana 7.5.10+ and Grafana 8.0.6+.
 
-Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here](https://grafana.com/developers/plugin-tools/introduction/data-frames).
+Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here]({{< relref "../../developers/plugins/data-frames.md" >}}).
 
 This transformation helps you resolve this issue by converting the time series data from either the wide format to the long format or the other way around.
 

--- a/docs/sources/panels/visualizations/alert-list-panel.md
+++ b/docs/sources/panels/visualizations/alert-list-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Alert list"
 keywords = ["grafana", "alert list", "documentation", "panel", "alertlist"]
-aliases = ["/docs/grafana/latest/reference/alertlist/", "/docs/grafana/latest/features/panels/alertlist/"]
+aliases = ["/docs/grafana/v8.0/reference/alertlist/", "/docs/grafana/v8.0/features/panels/alertlist/"]
 weight = 100
 +++
 

--- a/docs/sources/panels/visualizations/bar-chart.md
+++ b/docs/sources/panels/visualizations/bar-chart.md
@@ -83,9 +83,9 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels/visualizations/bar-gauge-panel.md
+++ b/docs/sources/panels/visualizations/bar-gauge-panel.md
@@ -2,7 +2,7 @@
 title = "Bar gauge"
 description = "Bar gauge panel options"
 keywords = ["grafana", "bar", "bar gauge"]
-aliases =["/docs/grafana/latest/features/panels/bar_gauge/"]
+aliases =["/docs/grafana/v8.0/features/panels/bar_gauge/"]
 weight = 200
 +++
 

--- a/docs/sources/panels/visualizations/dashboard-list-panel.md
+++ b/docs/sources/panels/visualizations/dashboard-list-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard list"
 keywords = ["grafana", "dashboard list", "documentation", "panel", "dashlist"]
-aliases = ["/docs/grafana/latest/reference/dashlist/", "/docs/grafana/latest/features/panels/dashlist/"]
+aliases = ["/docs/grafana/v8.0/reference/dashlist/", "/docs/grafana/v8.0/features/panels/dashlist/"]
 weight = 300
 +++
 

--- a/docs/sources/panels/visualizations/gauge-panel.md
+++ b/docs/sources/panels/visualizations/gauge-panel.md
@@ -2,7 +2,7 @@
 title = "Gauge"
 description = "Gauge panel docs"
 keywords = ["grafana", "gauge", "gauge panel"]
-aliases = ["/docs/grafana/latest/features/panels/gauge/"]
+aliases = ["/docs/grafana/v8.0/features/panels/gauge/"]
 weight = 400
 +++
 

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -1,13 +1,13 @@
 +++
 title = "Graph panel (old)"
 keywords = ["grafana", "graph panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/reference/graph/", "/docs/grafana/latest/features/panels/graph/"]
+aliases = ["/docs/grafana/v8.0/reference/graph/", "/docs/grafana/v8.0/features/panels/graph/"]
 weight = 500
 +++
 
 # Graph panel (old)
 
-> **Note:** [Time series panel](time-series/) visualization is going to replace the Graph panel visualization in a future release.
+> **Note:** [Time series panel]({{< relref "./time-series" >}}) visualization is going to replace the Graph panel visualization in a future release.
 
 The graph panel can render metrics as a line, a path of dots, or a series of bars. This type of graph is versatile enough to display almost any time-series data.
 
@@ -41,7 +41,7 @@ Use these settings to refine your visualization.
 - **Null value -** How null values are displayed. _This is a very important setting._ See note below.
   - **connected -** If there is a gap in the series, meaning a null value or values, then the line will skip the gap and connect to the next non-null value.
   - **null -** (default) If there is a gap in the series, meaning a null value, then the line in the graph will be broken and show the gap.
-  - **null as zero -** If there is a gap in the series, meaning  a null value, then it will be displayed as a zero value in the graph panel.
+  - **null as zero -** If there is a gap in the series, meaning a null value, then it will be displayed as a zero value in the graph panel.
 
 > **Note:** If you are monitoring a server's CPU load and the load reaches 100%, then the server will lock up and the agent sending statistics will not be able to collect the load statistic. This leads to a gap in the metrics and having the default as _null_ means Grafana will show the gaps and indicate that something is wrong. If this is set to _connected_, then it would be easy to miss this signal.
 
@@ -68,30 +68,31 @@ You can add multiple series overrides.
 1. Click **Add series override**.
 1. In **Alias or regex** Type or select a series. Click in the field to see a list of available series.
 
-   **Example:**  `/Network.*/` would match two series named `Network out` and `Network in`.
+   **Example:** `/Network.*/` would match two series named `Network out` and `Network in`.
 
 1. Click **+** and then select a style to apply to the series. You can add multiple styles to each entry.
-  - **Bars -** Show series as a bar graph.
-  - **Lines -** Show series as line graph.
-  - **Line fill -** Show line graph with area fill.
-  - **Fill gradient -** Area fill gradient amount.
-  - **Line width -** Set line width.
-  - **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
-  - **Fill below to -** Fill area between two series.
-  - **Staircase line -** Show series as a staircase line.
-  - **Dashes -** Show line with dashes.
-  - **Hidden Series -** Hide the series.
-  - **Dash Length -** Dashed line length.
-  - **Dash Space -** Dashed line spacing.
-  - **Points -** Show series as separate points.
-  - **Point Radius -** Radius for point rendering.
-  - **Stack -** Set stack group for series.
-  - **Color -** Set series color.
-  - **Y-axis -** Set series y-axis.
-  - **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
-  - **Transform -** Transform value to negative to render below the y-axis.
-  - **Legend -** Control if a series is shown in legend.
-  - **Hide in tooltip -** Control if a series is shown in graph tooltip.
+
+- **Bars -** Show series as a bar graph.
+- **Lines -** Show series as line graph.
+- **Line fill -** Show line graph with area fill.
+- **Fill gradient -** Area fill gradient amount.
+- **Line width -** Set line width.
+- **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
+- **Fill below to -** Fill area between two series.
+- **Staircase line -** Show series as a staircase line.
+- **Dashes -** Show line with dashes.
+- **Hidden Series -** Hide the series.
+- **Dash Length -** Dashed line length.
+- **Dash Space -** Dashed line spacing.
+- **Points -** Show series as separate points.
+- **Point Radius -** Radius for point rendering.
+- **Stack -** Set stack group for series.
+- **Color -** Set series color.
+- **Y-axis -** Set series y-axis.
+- **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
+- **Transform -** Transform value to negative to render below the y-axis.
+- **Legend -** Control if a series is shown in legend.
+- **Hide in tooltip -** Control if a series is shown in graph tooltip.
 
 ## Axes
 
@@ -110,6 +111,7 @@ Options are identical for both Y-axes.
 - **Label -** The Y axis label. (default “")
 
 ### Y-Axes
+
 - **Align -** Select to align left and right Y-axes by value. (default unchecked/false)
 - **Level -** Available when **Align** is selected. Value to use for alignment of left and right Y-axes, starting from Y=0. (default 0)
 
@@ -117,12 +119,14 @@ Options are identical for both Y-axes.
 
 - **Show -** Click to show or hide the axis.
 - **Mode -** The display mode completely changes the visualization of the graph panel. It's like three panels in one. The main mode is the time series mode with time on the X-axis. The other two modes are a basic bar chart mode with series on the X-axis instead of time and a histogram mode.
+
   - **Time -** (default) The X-axis represents time and that the data is grouped by time (for example, by hour, or by minute).
   - **Series -** The data is grouped by series and not by time. The Y-axis still represents the value.
-    - **Value -**  The aggregation type to use for the values. The default is total (summing the values together).
+    - **Value -** The aggregation type to use for the values. The default is total (summing the values together).
   - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range.
 
     For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../basics/intro-histograms.md" >}}).
+
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.

--- a/docs/sources/panels/visualizations/heatmap.md
+++ b/docs/sources/panels/visualizations/heatmap.md
@@ -2,7 +2,7 @@
 title = "Heatmap"
 description = "Heatmap visualization documentation"
 keywords = ["grafana", "heatmap", "panel", "documentation"]
-aliases =["/docs/grafana/latest/features/panels/heatmap/"]
+aliases =["/docs/grafana/v8.0/features/panels/heatmap/"]
 weight = 600
 +++
 

--- a/docs/sources/panels/visualizations/histogram.md
+++ b/docs/sources/panels/visualizations/histogram.md
@@ -57,9 +57,9 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels/visualizations/logs-panel.md
+++ b/docs/sources/panels/visualizations/logs-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Logs panel"
 keywords = ["grafana", "dashboard", "documentation", "panels", "logs panel"]
-aliases = ["/docs/grafana/latest/reference/logs/", "/docs/grafana/latest/features/panels/logs/",]
+aliases = ["/docs/grafana/v8.0/reference/logs/", "/docs/grafana/v8.0/features/panels/logs/",]
 weight = 700
 +++
 

--- a/docs/sources/panels/visualizations/pie-chart-panel.md
+++ b/docs/sources/panels/visualizations/pie-chart-panel.md
@@ -67,9 +67,9 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend values
 

--- a/docs/sources/panels/visualizations/stat-panel.md
+++ b/docs/sources/panels/visualizations/stat-panel.md
@@ -2,7 +2,7 @@
 title = "Stat"
 description = "Stat panel documentation"
 keywords = ["grafana", "docs", "stat panel"]
-aliases = ["/docs/grafana/latest/features/panels/stat/", "/docs/grafana/latest/features/panels/singlestat/", "/docs/grafana/latest/reference/singlestat/"]
+aliases = ["/docs/grafana/v8.0/features/panels/stat/", "/docs/grafana/v8.0/features/panels/singlestat/", "/docs/grafana/v8.0/reference/singlestat/"]
 weight = 900
 +++
 

--- a/docs/sources/panels/visualizations/state-timeline.md
+++ b/docs/sources/panels/visualizations/state-timeline.md
@@ -55,4 +55,4 @@ The panel can be used with time series data as well. In this case, the threshold
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` option under [Standard options]({{< relref "../standard-options.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels/visualizations/status-history.md
+++ b/docs/sources/panels/visualizations/status-history.md
@@ -7,13 +7,13 @@ weight = 900
 
 # Status history
 
-The Status history visualization shows periodic states over time. Each field or series is rendered as a horizontal row. Boxes are rendered and centered around each value. 
+The Status history visualization shows periodic states over time. Each field or series is rendered as a horizontal row. Boxes are rendered and centered around each value.
 
 {{< figure src="/static/img/docs/status-history-panel/status-history-example-v8-0.png" max-width="1025px" caption="Status history example" >}}
 
-## Supported data 
+## Supported data
 
-Status history visualization works with string, boolean and numerical fields or time series. A time field is required. You can use value mappings to color strings or assign text values to numerical ranges.  
+Status history visualization works with string, boolean and numerical fields or time series. A time field is required. You can use value mappings to color strings or assign text values to numerical ranges.
 
 ## Display options
 
@@ -37,7 +37,7 @@ Controls the opacity of state regions.
 
 ## Value mappings
 
-To assign colors to boolean or string values, use the [Value mappings](< {{ refref "../value-mappings.md"}} >).
+To assign colors to boolean or string values, use the [Value mappings]({{< relref "../value-mappings" >}}).
 
 {{< figure src="/static/img/docs/v8/value_mappings_side_editor.png" max-width="300px" caption="Value mappings side editor" >}}
 
@@ -52,4 +52,4 @@ use gradient color schemes to color values.
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` option under [Standard options]({{< relref "../standard-options.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/panels/visualizations/table/_index.md
+++ b/docs/sources/panels/visualizations/table/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Table"
 keywords = ["grafana", "dashboard", "documentation", "panels", "table panel"]
-aliases = ["/docs/grafana/latest/reference/table/", "/docs/grafana/latest/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
+aliases = ["/docs/grafana/v8.0/reference/table/", "/docs/grafana/v8.0/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
 weight = 1000
 +++
 

--- a/docs/sources/panels/visualizations/table/filter-table-columns.md
+++ b/docs/sources/panels/visualizations/table/filter-table-columns.md
@@ -1,7 +1,7 @@
 +++
 title = "Filter table columns"
 keywords = ["grafana", "table options", "documentation", "format tables", "table filter", "filter columns"]
-aliases = ["/docs/grafana/latest/reference/table/", "/docs/grafana/latest/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
+aliases = ["/docs/grafana/v8.0/reference/table/", "/docs/grafana/v8.0/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
 weight = 600
 +++
 

--- a/docs/sources/panels/visualizations/table/table-field-options.md
+++ b/docs/sources/panels/visualizations/table/table-field-options.md
@@ -10,11 +10,6 @@ This section explains all available table field options. They are listed in the 
 
 Most field options will not affect the visualization until you click outside of the field option box you are editing or press Enter.
 
-For more information about applying these options, refer to:
-
-- [Configure all fields]({{< relref "../../field-options/configure-all-fields.md" >}})
-- [Configure specific fields]({{< relref "../../field-options/configure-specific-fields.md" >}})
-
 ## Column alignment
 
 Choose how Grafana should align cell contents:

--- a/docs/sources/panels/visualizations/text-panel.md
+++ b/docs/sources/panels/visualizations/text-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Text"
 keywords = ["grafana", "text", "documentation", "panel"]
-aliases = ["/docs/grafana/latest/reference/alertlist/", "/docs/grafana/latest/features/panels/text/"]
+aliases = ["/docs/grafana/v8.0/reference/alertlist/", "/docs/grafana/v8.0/features/panels/text/"]
 weight = 1100
 +++
 

--- a/docs/sources/panels/visualizations/time-series/_index.md
+++ b/docs/sources/panels/visualizations/time-series/_index.md
@@ -18,9 +18,9 @@ For Time series panel examples, refer to the Grafana Play dashboard [New Feature
 
 These options are available whether you are graphing your time series as lines, bars, or points.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/panels/visualizations/time-series/graph-time-series-as-bars.md
+++ b/docs/sources/panels/visualizations/time-series/graph-time-series-as-bars.md
@@ -128,9 +128,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/bar-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Bar graph examples
 

--- a/docs/sources/panels/visualizations/time-series/graph-time-series-as-lines.md
+++ b/docs/sources/panels/visualizations/time-series/graph-time-series-as-lines.md
@@ -196,9 +196,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/line-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Fill below to
 

--- a/docs/sources/panels/visualizations/time-series/graph-time-series-as-points.md
+++ b/docs/sources/panels/visualizations/time-series/graph-time-series-as-points.md
@@ -38,6 +38,6 @@ Point size set to 35:
 
 ![Show points point size 35 example](/static/img/docs/time-series-panel/points-graph-show-points-35-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/permissions/_index.md
+++ b/docs/sources/permissions/_index.md
@@ -2,7 +2,7 @@
 title = "Permissions"
 description = "Permissions"
 keywords = ["grafana", "configuration", "documentation", "admin", "users", "datasources", "permissions"]
-aliases = ["/docs/grafana/latest/permissions/overview/"]
+aliases = ["/docs/grafana/v8.0/permissions/overview/"]
 weight = 50
 +++
 

--- a/docs/sources/permissions/dashboard-folder-permissions.md
+++ b/docs/sources/permissions/dashboard-folder-permissions.md
@@ -2,7 +2,7 @@
 title = "Dashboard and folder permissions"
 description = "Grafana Dashboard and Folder Permissions Guide "
 keywords = ["grafana", "configuration", "documentation", "dashboard", "folder", "permissions", "teams"]
-aliases = ["/docs/grafana/latest/permissions/dashboard_folder_permissions/"]
+aliases = ["/docs/grafana/v8.0/permissions/dashboard_folder_permissions/"]
 weight = 200
 +++
 

--- a/docs/sources/plugins/_index.md
+++ b/docs/sources/plugins/_index.md
@@ -7,7 +7,7 @@ weight = 160
 
 Besides the wide range of visualizations and data sources that are available immediately after you install Grafana, you can extend your Grafana experience with _plugins_.
 
-You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself](https://grafana.com/developers/plugin-tools).
+You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../developers/plugins/_index.md" >}}).
 
 Grafana supports three types of plugins: [panels](https://grafana.com/grafana/plugins?type=panel), [data sources](https://grafana.com/grafana/plugins?type=datasource), and [apps](https://grafana.com/grafana/plugins?type=app).
 

--- a/docs/sources/plugins/_index.md
+++ b/docs/sources/plugins/_index.md
@@ -7,7 +7,7 @@ weight = 160
 
 Besides the wide range of visualizations and data sources that are available immediately after you install Grafana, you can extend your Grafana experience with _plugins_.
 
-You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../developers/plugins/_index.md" >}}).
+You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself](https://grafana.com/developers/plugin-tools).
 
 Grafana supports three types of plugins: [panels](https://grafana.com/grafana/plugins?type=panel), [data sources](https://grafana.com/grafana/plugins?type=datasource), and [apps](https://grafana.com/grafana/plugins?type=app).
 

--- a/docs/sources/plugins/catalog.md
+++ b/docs/sources/plugins/catalog.md
@@ -1,6 +1,6 @@
 +++
 title = "Plugin catalog"
-aliases = ["/docs/grafana/latest/plugins/catalog/"]
+aliases = ["/docs/grafana/v8.0/plugins/catalog/"]
 weight = 1
 +++
 

--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -1,6 +1,6 @@
 +++
 title = "Install plugins"
-aliases = ["/docs/grafana/latest/plugins/installation/"]
+aliases = ["/docs/grafana/v8.0/plugins/installation/"]
 weight = 1
 +++
 

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -1,7 +1,7 @@
 +++
 title = "Plugin signatures"
 type = "docs"
-aliases = ["/docs/grafana/latest/plugins/plugin-signature-verification"]
+aliases = ["/docs/grafana/v8.0/plugins/plugin-signature-verification"]
 +++
 
 # Plugin signatures

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -16,7 +16,7 @@ Grafana also writes an error message to the server log:
 WARN[05-26|12:00:00] Some plugin scanning errors were found   errors="plugin '<plugin id>' is unsigned, plugin '<plugin id>' has an invalid signature"
 ```
 
-If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).
+If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin]({{< relref "../developers/plugins/sign-a-plugin.md" >}}).
 
 | Signature status | Description |
 | ---------------- | ----------- |

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -16,7 +16,7 @@ Grafana also writes an error message to the server log:
 WARN[05-26|12:00:00] Some plugin scanning errors were found   errors="plugin '<plugin id>' is unsigned, plugin '<plugin id>' has an invalid signature"
 ```
 
-If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin]({{< relref "../developers/plugins/sign-a-plugin.md" >}}).
+If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).
 
 | Signature status | Description |
 | ---------------- | ----------- |

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,7 +8,6 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
-- [Release notes for 8.0.7]({{< relref "release-notes-8-0-7" >}})
 - [Release notes for 8.0.6]({{< relref "release-notes-8-0-6" >}})
 - [Release notes for 8.0.5]({{< relref "release-notes-8-0-5" >}})
 - [Release notes for 8.0.4]({{< relref "release-notes-8-0-4" >}})
@@ -19,7 +18,6 @@ about deprecations, breaking changes as well as changes that relate to plugin de
 - [Release notes for 8.0.0-beta3]({{< relref "release-notes-8-0-0-beta3" >}})
 - [Release notes for 8.0.0-beta2]({{< relref "release-notes-8-0-0-beta2" >}})
 - [Release notes for 8.0.0-beta1]({{< relref "release-notes-8-0-0-beta1" >}})
-- [Release notes for 7.5.11]({{< relref "release-notes-7-5-11" >}})
 - [Release notes for 7.5.10]({{< relref "release-notes-7-5-10" >}})
 - [Release notes for 7.5.9]({{< relref "release-notes-7-5-9" >}})
 - [Release notes for 7.5.8]({{< relref "release-notes-7-5-8" >}})

--- a/docs/sources/shared/example.md
+++ b/docs/sources/shared/example.md
@@ -11,7 +11,7 @@ When you have a chunk of text or steps that stand alone, not part of an ordered 
 The syntax to invoke this file would be the following, minus the backslash:
 
 ```
-\{{< docs/shared "example.md" >}}
+\{{< docs/shared lookup="example.md" source="grafana" version="<GRAFANA VERSION>" >}}
 ```
 
 ## Part of a list
@@ -24,7 +24,7 @@ Below is an example from the docs, with backslashes added. The initial spaces ar
 
 ```
 \{{< docs/list >}}
-  \{{< docs/shared "manage-users/view-server-user-list.md" >}}
+  \{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 \{{< /docs/list >}}
 ```
@@ -36,6 +36,6 @@ You cannot use short codes in an ordered list with sublists. The shortcode break
 All unordered list steps included as part of a list will appear as second-level lists (with the hollow circle bullet) rather than first-level lists (solid circle bullet), even if the list is not indented in the shared file or the document file.
 
 {{< docs/list >}}
-  {{< docs/shared "test.md" >}}
+  {{< docs/shared lookup="test.md" source="grafana" version="<GRAFANA VERSION>" >}}
   - Bullet text
 {{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -3,6 +3,9 @@ title: View org list as server admin
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="v8.0" >}}
+
 1. Click the name of the organization that you want to edit.
+
 {{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -3,6 +3,9 @@ title: View user list and search - list format
 ---
 
 {{< docs/list >}}
-  {{< docs/shared "manage-users/view-server-user-list.md" >}}
-  1. Click the user account that you want to edit. If necessary, use the search field to find the account.
+
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="v8.0" >}}
+
+1. Click the user account that you want to edit. If necessary, use the search field to find the account.
+
 {{< /docs/list >}}

--- a/docs/sources/sharing/share-dashboard.md
+++ b/docs/sources/sharing/share-dashboard.md
@@ -1,7 +1,7 @@
 +++
 title = "Share a dashboard"
 keywords = ["grafana", "dashboard", "documentation", "sharing"]
-aliases = ["/docs/grafana/latest/dashboards/share-dashboard/","/docs/grafana/latest/reference/share_dashboard/"]
+aliases = ["/docs/grafana/v8.0/dashboards/share-dashboard/","/docs/grafana/v8.0/reference/share_dashboard/"]
 weight = 6
 +++
 

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Share a panel"
 keywords = ["grafana", "dashboard", "documentation", "sharing", "library panel"]
-aliases = ["/docs/grafana/latest/dashboards/share-dashboard/","/docs/grafana/latest/reference/share_panel/"]
+aliases = ["/docs/grafana/v8.0/dashboards/share-dashboard/","/docs/grafana/v8.0/reference/share_panel/"]
 weight = 6
 +++
 
@@ -61,7 +61,7 @@ If you created a snapshot by mistake, click **delete snapshot** to remove the sn
 
 You can embed a panel using an iframe on another web site. A viewer must be signed into Grafana to view the graph. 
 
-**> Note:** As of Grafana 8.0, anonymous access permission is no longer available for Grafana Cloud.
+**> Note:** As of Grafana 8.0, anonymous access permission is no available for Grafana Cloud.
 
 ![Panel share embed](/static/img/docs/sharing/share-panel-embedded-link-8-0.png)
 

--- a/docs/sources/variables/inspect-variable.md
+++ b/docs/sources/variables/inspect-variable.md
@@ -1,7 +1,7 @@
 +++
 title = "Inspect variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.0/reference/templating"]
 weight = 125
 +++
 

--- a/docs/sources/variables/manage-variable.md
+++ b/docs/sources/variables/manage-variable.md
@@ -1,7 +1,7 @@
 +++
 title = "Manage variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.0/reference/templating"]
 weight = 120
 +++
 

--- a/docs/sources/variables/syntax.md
+++ b/docs/sources/variables/syntax.md
@@ -1,7 +1,7 @@
 +++
 title = "Variable syntax"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.0/reference/templating"]
 weight = 100
 +++
 

--- a/docs/sources/variables/variable-types/add-ad-hoc-filters.md
+++ b/docs/sources/variables/variable-types/add-ad-hoc-filters.md
@@ -1,6 +1,6 @@
 +++
 title = "Add ad hoc filters"
-aliases = ["/docs/grafana/latest/variables/add-ad-hoc-filters.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-ad-hoc-filters.md"]
 weight = 700
 +++
 

--- a/docs/sources/variables/variable-types/add-constant-variable.md
+++ b/docs/sources/variables/variable-types/add-constant-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a constant variable"
-aliases = ["/docs/grafana/latest/variables/add-constant-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-constant-variable.md"]
 weight = 400
 +++
 

--- a/docs/sources/variables/variable-types/add-custom-variable.md
+++ b/docs/sources/variables/variable-types/add-custom-variable.md
@@ -1,12 +1,12 @@
 +++
 title = "Add a custom variable"
-aliases = ["/docs/grafana/latest/variables/add-custom-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-custom-variable.md"]
 weight = 200
 +++
 
 # Add a custom variable
 
-Use a _custom_ variable for a value that does not change, such as a number or a string.
+Use a _custom_ variable for values that do not change. This might be numbers, strings, or even other variables.
 
 For example, if you have server names or region names that never change, then you might want to create them as custom variables rather than query variables. Because they do not change, you might use them in [chained variables]({{< relref "chained-variables.md" >}}) rather than other query variables. That would reduce the number of queries Grafana must send when chained variables are updated.
 
@@ -24,7 +24,7 @@ For example, if you have server names or region names that never change, then yo
 
 ## Enter Custom Options
 
-1. In the **Values separated by comma** list, enter the values for this variable in a comma-separated list. You can include numbers, strings, or key/value pairs separated by a space and a colon. For example, `key1 : value1,key2 : value2`.
+1. In the **Values separated by comma** list, enter the values for this variable in a comma-separated list. You can include numbers, strings, other variables or key/value pairs separated by a space and a colon, i.e. `key1 : value1,key2 : value2`.
 1. (optional) Enter [Selection Options]({{< relref "../variable-selection-options.md" >}}).
 1. In **Preview of values**, Grafana displays a list of the current variable values. Review them to ensure they match what you expect.
 1. Click **Add** to add the variable to the dashboard.

--- a/docs/sources/variables/variable-types/add-data-source-variable.md
+++ b/docs/sources/variables/variable-types/add-data-source-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a data source variable"
-aliases = ["/docs/grafana/latest/variables/add-data-source-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-data-source-variable.md"]
 weight = 500
 +++
 

--- a/docs/sources/variables/variable-types/add-interval-variable.md
+++ b/docs/sources/variables/variable-types/add-interval-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add an interval variable"
-aliases = ["/docs/grafana/latest/variables/add-interval-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-interval-variable.md"]
 weight = 600
 +++
 

--- a/docs/sources/variables/variable-types/add-query-variable.md
+++ b/docs/sources/variables/variable-types/add-query-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a query variable"
-aliases = ["/docs/grafana/latest/variables/add-query-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-query-variable.md"]
 weight = 100
 +++
 

--- a/docs/sources/variables/variable-types/add-text-box-variable.md
+++ b/docs/sources/variables/variable-types/add-text-box-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a text box variable"
-aliases = ["/docs/grafana/latest/variables/add-text-box-variable.md"]
+aliases = ["/docs/grafana/v8.0/variables/add-text-box-variable.md"]
 weight = 300
 +++
 

--- a/docs/sources/variables/variable-types/chained-variables.md
+++ b/docs/sources/variables/variable-types/chained-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "Chained variables"
 keywords = ["grafana", "templating", "variable", "nested", "chained", "linked"]
-aliases = ["/docs/grafana/latest/variables/chained-variables.md"]
+aliases = ["/docs/grafana/v8.0/variables/chained-variables.md"]
 weight = 800
 +++
 

--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "Global variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable", "global", "standard"]
-aliases = ["/docs/grafana/latest/variables/global-variables.md"]
+aliases = ["/docs/grafana/v8.0/variables/global-variables.md"]
 weight = 900
 +++
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "What's new"
-aliases = ["/docs/grafana/latest/guides/"]
+aliases = ["/docs/grafana/v8.0/guides/"]
 weight = 1
 +++
 

--- a/docs/sources/whatsnew/whats-new-in-v2-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.0"
 description = "Feature and improvement highlights for Grafana v2.0"
 keywords = ["grafana", "new", "documentation", "2.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v2/"]
 weight = -1
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.1"
 description = "Feature and improvement highlights for Grafana v2.1"
 keywords = ["grafana", "new", "documentation", "2.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v2-1/"]
 weight = -2
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.5"
 description = "Feature and improvement highlights for Grafana v2.5"
 keywords = ["grafana", "new", "documentation", "2.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-5/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v2-5/"]
 weight = -3
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.6"
 description = "Feature and improvement highlights for Grafana v2.6"
 keywords = ["grafana", "new", "documentation", "2.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-6/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v2-6/"]
 weight = -4
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v3-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v3-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v3.0"
 description = "Feature and improvement highlights for Grafana v3.0"
 keywords = ["grafana", "new", "documentation", "3.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v3/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v3/"]
 weight = -5
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v3-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v3-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v3.1"
 description = "Feature and improvement highlights for Grafana v3.1"
 keywords = ["grafana", "new", "documentation", "3.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v3-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v3-1/"]
 weight = -6
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.0"
 description = "Feature and improvement highlights for Grafana v4.0"
 keywords = ["grafana", "new", "documentation", "4.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4/"]
 weight = -7
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.1"
 description = "Feature and improvement highlights for Grafana v4.1"
 keywords = ["grafana", "new", "documentation", "4.1.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-1/"]
 weight = -8
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.2"
 description = "Feature and improvement highlights for Grafana v4.2"
 keywords = ["grafana", "new", "documentation", "4.2.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-2/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-2/"]
 weight = -9
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.3"
 description = "Feature and improvement highlights for Grafana v4.3"
 keywords = ["grafana", "new", "documentation", "4.3.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-3/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-3/"]
 weight = -10
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.4"
 description = "Feature and improvement highlights for Grafana v4.4"
 keywords = ["grafana", "new", "documentation", "4.4.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-4/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-4/"]
 weight = -11
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.5"
 description = "Feature and improvement highlights for Grafana v4.5"
 keywords = ["grafana", "new", "documentation", "4.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-5/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-5/"]
 weight = -12
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.6"
 description = "Feature and improvement highlights for Grafana v4.6"
 keywords = ["grafana", "new", "documentation", "4.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-6/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v4-6/"]
 weight = -13
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.0"
 description = "Feature and improvement highlights for Grafana v5.0"
 keywords = ["grafana", "new", "documentation", "5.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v5/"]
 weight = -14
 [_build]
 list = false
@@ -115,7 +115,6 @@ in sync with dashboards in Grafana's database. The dashboard provisioner has mul
 which makes it possible to star them, use one as the home dashboard, set permissions and other features in Grafana that
 expects the dashboards to exist in the database. More info in the [dashboard provisioning docs]({{< relref "../administration/provisioning#dashboards" >}})
 
-
 ## Graphite Tags and Integrated Function Docs
 
 {{< figure src="/static/img/docs/v50/graphite_tags.png" max-width="1000px" class="docs-image--right" >}}
@@ -144,5 +143,6 @@ This might seem like a small change, but we are incredibly excited about it sinc
 much easier to manage, collaborate and navigate between dashboards.
 
 ### API changes
+
 New uid-based routes in the dashboard API have been introduced to retrieve and delete dashboards.
 The corresponding slug-based routes have been deprecated and will be removed in a future release.

--- a/docs/sources/whatsnew/whats-new-in-v5-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.1"
 description = "Feature and improvement highlights for Grafana v5.1"
 keywords = ["grafana", "new", "documentation", "5.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v5-1/"]
 weight = -15
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.2"
 description = "Feature and improvement highlights for Grafana v5.2"
 keywords = ["grafana", "new", "documentation", "5.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-2/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v5-2/"]
 weight = -16
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.3"
 description = "Feature and improvement highlights for Grafana v5.3"
 keywords = ["grafana", "new", "documentation", "5.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-3/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v5-3/"]
 weight = -17
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.4"
 description = "Feature and improvement highlights for Grafana v5.4"
 keywords = ["grafana", "new", "documentation", "5.4", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-4/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v5-4/"]
 weight = -18
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.0"
 description = "Feature and improvement highlights for Grafana v6.0"
 keywords = ["grafana", "new", "documentation", "6.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-0/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-0/"]
 weight = -19
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.1"
 description = "Feature and improvement highlights for Grafana v6.1"
 keywords = ["grafana", "new", "documentation", "6.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-1/"]
 weight = -20
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.2"
 description = "Feature and improvement highlights for Grafana v6.2"
 keywords = ["grafana", "new", "documentation", "6.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-2/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-2/"]
 weight = -21
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.3"
 description = "Feature and improvement highlights for Grafana v6.3"
 keywords = ["grafana", "new", "documentation", "6.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-3/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-3/"]
 weight = -22
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.4"
 description = "Feature and improvement highlights for Grafana v6.4"
 keywords = ["grafana", "new", "documentation", "6.4", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-4/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-4/"]
 weight = -23
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.5"
 description = "Feature and improvement highlights for Grafana v6.5"
 keywords = ["grafana", "new", "documentation", "6.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-5/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-5/"]
 weight = -24
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.6"
 description = "Feature and improvement highlights for Grafana v6.6"
 keywords = ["grafana", "new", "documentation", "6.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-6/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-6/"]
 weight = -25
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-7.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-7.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v6.7"
 description = "Feature and improvement highlights for Grafana v6.7"
 keywords = ["grafana", "new", "documentation", "6.7", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-7/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v6-7/"]
 weight = -26
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.0"
 description = "Feature and improvement highlights for Grafana v7"
 keywords = ["grafana", "new", "documentation", "7.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-0/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-0/"]
 weight = -27
 [_build]
 list = false
@@ -130,7 +130,7 @@ In Grafana 7.0 we are maturing our panel and front-end datasource plugins platfo
 
 Plugins can use the same React components that the Grafana team uses to build Grafana. Using these components means the Grafana team will support and improve them continually and make your plugin as polished as the rest of Grafana’s UI. The new [`@grafana/ui` components library](https://developers.grafana.com/ui) is documented with Storybook (visual documentation) and is available on NPM.
 
-The `@grafana/data`, `@grafana/runtime`, `@grafana/e2e packages` (also available via NPM) aim to simplify the way plugins are developed. We want to deliver a set of [reliable APIs](https://grafana.com/docs/grafana/latest/packages_api/) for plugin developers.
+The `@grafana/data`, `@grafana/runtime`, `@grafana/e2e packages` (also available via NPM) aim to simplify the way plugins are developed. We want to deliver a set of [reliable APIs](https://grafana.com/docs/grafana/v8.0/packages_api/) for plugin developers.
 
 With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are delivering a simple CLI that helps plugin authors quickly scaffold, develop and test their plugins without worrying about configuration details. A plugin author no longer needs to be a grunt or webpack expert to build their plugin.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
+Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
 
 ### Front end plugins platform
 
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -136,7 +136,7 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
+Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
 
 ### Front end plugins platform
 
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
+Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
 
 ### Front end plugins platform
 

--- a/docs/sources/whatsnew/whats-new-in-v7-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-1.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.1"
 description = "Feature and improvement highlights for Grafana v7.1"
 keywords = ["grafana", "new", "documentation", "7.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-1/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-1/"]
 weight = -28
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-2.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.2"
 description = "Feature and improvement highlights for Grafana v7.2"
 keywords = ["grafana", "new", "documentation", "7.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-2/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-2/"]
 weight = -29
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-3.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.3"
 description = "Feature and improvement highlights for Grafana v7.3"
 keywords = ["grafana", "new", "documentation", "7.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-3/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-3/"]
 weight = -30
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -3,7 +3,7 @@ title = "What's New in Grafana v7.4"
 description = "Feature and improvement highlights for Grafana v7.4"
 keywords = ["grafana", "new", "documentation", "7.4", "release notes"]
 weight = -31
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-4/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-4/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -172,7 +172,7 @@ The feature previously referred to as DataSource Start Pages or Cheat Sheets has
 
 [Queries]({{< relref "../panels/queries.md" >}}) was updated as a result of this feature.
 
-For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-query-editor-help).
+For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component]({{< relref "../developers/plugins/add-query-editor-help.md" >}}).
 
 ### Variable inspector
 

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -172,7 +172,7 @@ The feature previously referred to as DataSource Start Pages or Cheat Sheets has
 
 [Queries]({{< relref "../panels/queries.md" >}}) was updated as a result of this feature.
 
-For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component]({{< relref "../developers/plugins/add-query-editor-help.md" >}}).
+For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-query-editor-help).
 
 ### Variable inspector
 

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v7.5"
 description = "Feature and improvement highlights for Grafana v7.5"
 keywords = ["grafana", "new", "documentation", "7.5", "release notes"]
 weight = -32
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-5/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v7-5/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v8.0"
 description = "Feature and improvement highlights for Grafana v8.0"
 keywords = ["grafana", "new", "documentation", "8.0", "release notes"]
 weight = -33
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v8-0/"]
+aliases = ["/docs/grafana/v8.0/guides/whats-new-in-v8-0/"]
 [_build]
 list = false
 +++
@@ -180,7 +180,7 @@ The Azure Monitor data source now supports Managed Identity for users hosting Gr
 
 Also, in addition to querying Log Analytics Workspaces, you can now query the logs for any individual [supported resource](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported), or for all resources in a subscription or resource group.
 
-> **Note:** In Grafana 7.5 we started the deprecation for separate Application Insights queries, in favor of querying Application Insights resources through Metrics and Logs. In Grafana 8.0 new Application Insights and Insights Analytics queries cannot be made, and existing queries have been made read-only. For more details, refer to the [Deprecating Application Insights]({{< relref "../datasources/azuremonitor/_index.md#deprecating-application-insights" >}}).
+> **Note:** In Grafana 7.5 we started the deprecation for separate Application Insights queries, in favor of querying Application Insights resources through Metrics and Logs. In Grafana 8.0 new Application Insights and Insights Analytics queries cannot be made, and existing queries have been made read-only. For more details, refer to the [Deprecating Application Insights]({{< relref "../datasources/azuremonitor/_index.md#deprecating-application-insights" >}}.
 
 [Azure Monitor data source]({{< relref "../datasources/azuremonitor/_index.md" >}}) was updated as a result of these changes.
 


### PR DESCRIPTION
We can choose not to merge this if we like as it is clear from the bigger than expected diff that this version of docs is now maintained in the website repository rather than here.

Links have been checked in https://github.com/grafana/website/pull/15588.

