### PR TITLE
[v8.2.x] Remove plugins

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -2,7 +2,7 @@
 title = "Grafana documentation"
 description = "Guides, Installation and Feature Documentation"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", "/docs/grafana/v3.1"]
+aliases = ["/docs/grafana/v1.1", "/docs/grafana/v8.2/guides/reference/admin", "/docs/grafana/v3.1"]
 +++
 
 # Grafana documentation

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -2,7 +2,7 @@
 title = "Configuration"
 description = "Configuration documentation"
 keywords = ["grafana", "configuration", "documentation"]
-aliases = ["/docs/grafana/latest/installation/configuration/"]
+aliases = ["/docs/grafana/v8.2/installation/configuration/"]
 weight = 150
 +++
 

--- a/docs/sources/administration/configure-docker.md
+++ b/docs/sources/administration/configure-docker.md
@@ -2,7 +2,7 @@
 title = "Configure Grafana Docker image"
 description = "Guide for configuring the Grafana Docker image"
 keywords = ["grafana", "configuration", "documentation", "docker"]
-aliases = ["/docs/grafana/latest/installation/configure-docker/"]
+aliases = ["/docs/grafana/v8.2/installation/configure-docker/"]
 weight = 200
 +++
 

--- a/docs/sources/administration/preferences/_index.md
+++ b/docs/sources/administration/preferences/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Preferences"
-aliases =["/docs/grafana/latest/administration/preferences.md"]
+aliases =["/docs/grafana/v8.2/administration/preferences.md"]
 weight = 50
 +++
 

--- a/docs/sources/administration/preferences/change-grafana-name.md
+++ b/docs/sources/administration/preferences/change-grafana-name.md
@@ -8,7 +8,7 @@ weight = 100
 
 In Grafana, you can change your names and emails associated with groups or accounts in the Settings or Preferences. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Change organization name
 
@@ -19,7 +19,7 @@ Grafana server administrators and organization administrators can change organiz
 Follow these instructions if you are a Grafana Server Admin.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the organization list, click the name of the organization that you want to change.
 1. In **Name**, enter the new organization name.
@@ -31,7 +31,7 @@ Follow these instructions if you are a Grafana Server Admin.
 If you are an Organization Admin, follow these steps:
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In **Organization name**, enter the new name.
 1. Click **Update organization name**.

--- a/docs/sources/administration/preferences/change-grafana-theme.md
+++ b/docs/sources/administration/preferences/change-grafana-theme.md
@@ -9,7 +9,7 @@ weight = 200
 
 In Grafana, you can modify the UI theme configured in the Settings or Preferences. Set the UI theme for the server, an organization, a team, or your personal user account using the instructions in this topic.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Theme options
 
@@ -42,8 +42,8 @@ To see what the current settings are, refer to [View server settings]({{< relref
 Organization administrators can change the UI theme for all users in an organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Change team UI theme
@@ -51,10 +51,10 @@ Organization administrators can change the UI theme for all users in an organiza
 Organization and team administrators can change the UI theme for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team that you want to change the UI theme for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-ui-theme-list.md" >}}
+   {{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Change your personal UI theme
@@ -62,6 +62,6 @@ Organization and team administrators can change the UI theme for all users in a 
 You can change the UI theme for your user account. This setting overrides UI theme settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-ui-theme-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-grafana-timezone.md
+++ b/docs/sources/administration/preferences/change-grafana-timezone.md
@@ -9,7 +9,7 @@ weight = 400
 
 By default, Grafana uses the timezone in your web browser. However, you can override this setting at the server, organization, team, or individual user level. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Set server timezone
 
@@ -20,8 +20,8 @@ Grafana server administrators can choose a default timezone for all users on the
 Organization administrators can choose a default timezone for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set team timezone
@@ -29,10 +29,10 @@ Organization administrators can choose a default timezone for their organization
 Organization administrators and team administrators can choose a default timezone for all users in a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team you that you want to change the timezone for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-timezone-list.md" >}}
+   {{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Set your personal timezone
@@ -40,6 +40,6 @@ Organization administrators and team administrators can choose a default timezon
 You can change the timezone for your user account. This setting overrides timezone settings at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-timezone-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/preferences/change-home-dashboard.md
+++ b/docs/sources/administration/preferences/change-home-dashboard.md
@@ -2,7 +2,7 @@
 title = "Change home dashboard"
 description = "How to replace the default home dashboard"
 keywords = ["grafana", "configuration", "documentation", "home"]
-aliases = ["/docs/grafana/latest/administration/change-home-dashboard/"]
+aliases = ["/docs/grafana/v8.2/administration/change-home-dashboard/"]
 weight = 300
 +++
 
@@ -10,7 +10,7 @@ weight = 300
 
 The home dashboard you set is the one all users will see by default when they log in. You can set the home dashboard for the server, an organization, a team, or your personal user account. This topic provides instructions for each task.
 
-{{< docs/shared "preferences/some-tasks-require-permissions.md" >}}
+{{< docs/shared lookup="preferences/some-tasks-require-permissions.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Navigate to the home dashboard
 
@@ -47,9 +47,9 @@ default_home_dashboard_path = data/main-dashboard.json
 Organization administrators can choose a home dashboard for their organization.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/org-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/org-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}
 
 ## Set home dashboard for your team
@@ -57,11 +57,11 @@ Organization administrators can choose a home dashboard for their organization.
 Organization administrators and Team Admins can choose a home dashboard for a team.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click on the team that you want to change the home dashboard for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+   {{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
    {{< /docs/list >}}
 
 ## Set your personal home dashboard
@@ -69,7 +69,7 @@ Organization administrators and Team Admins can choose a home dashboard for a te
 You can choose your own personal home dashboard. This setting overrides all home dashboards set at higher levels.
 
 {{< docs/list >}}
-{{< docs/shared "preferences/navigate-to-the-dashboard-list.md" >}}
-{{< docs/shared "preferences/navigate-user-preferences-list.md" >}}
-{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< docs/shared lookup="preferences/navigate-to-the-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/navigate-user-preferences-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="preferences/select-home-dashboard-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 {{< /docs/list >}}

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -2,7 +2,7 @@
 title = "Provisioning"
 description = ""
 keywords = ["grafana", "provisioning"]
-aliases = ["/docs/grafana/latest/installation/provisioning"]
+aliases = ["/docs/grafana/v8.2/installation/provisioning"]
 weight = 800
 +++
 

--- a/docs/sources/administration/security.md
+++ b/docs/sources/administration/security.md
@@ -2,7 +2,7 @@
 title = "Security"
 description = "Security Docs"
 keywords = ["grafana", "security", "documentation"]
-aliases = ["/docs/grafana/latest/installation/security/"]
+aliases = ["/docs/grafana/v8.2/installation/security/"]
 weight = 500
 +++
 

--- a/docs/sources/administration/set-up-for-high-availability.md
+++ b/docs/sources/administration/set-up-for-high-availability.md
@@ -1,7 +1,7 @@
 +++
 title = "Set up Grafana for high availability"
 keywords = ["grafana", "tutorials", "HA", "high availability"]
-aliases = ["/docs/grafana/latest/tutorials/ha_setup/"]
+aliases = ["/docs/grafana/v8.2/tutorials/ha_setup/"]
 weight = 1200
 +++
 

--- a/docs/sources/administration/view-server/internal-metrics.md
+++ b/docs/sources/administration/view-server/internal-metrics.md
@@ -2,7 +2,7 @@
 title = "Internal Grafana metrics"
 description = "Internal metrics exposed by Grafana"
 keywords = ["grafana", "metrics", "internal metrics"]
-aliases = ["/docs/grafana/latest/admin/metrics/"]
+aliases = ["/docs/grafana/v8.2/admin/metrics/"]
 weight = 200
 +++
 

--- a/docs/sources/administration/view-server/view-server-settings.md
+++ b/docs/sources/administration/view-server/view-server-settings.md
@@ -2,7 +2,7 @@
 title = "View server settings"
 description = "How to view server settings in the Grafana UI"
 keywords = ["grafana", "configuration", "server", "settings"]
-aliases = ["/docs/grafana/latest/admin/view-server-settings/"]
+aliases = ["/docs/grafana/v8.2/admin/view-server-settings/"]
 weight = 300
 +++
 

--- a/docs/sources/administration/view-server/view-server-stats.md
+++ b/docs/sources/administration/view-server/view-server-stats.md
@@ -1,7 +1,7 @@
 +++
 title = "View server stats"
 keywords = ["grafana", "server", "statistics"]
-aliases = ["/docs/grafana/latest/admin/view-server-stats/"]
+aliases = ["/docs/grafana/v8.2/admin/view-server-stats/"]
 weight = 400
 +++
 

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -21,4 +21,4 @@ You can perform the following tasks for alerts:
 - [Test alert rules and troubleshoot]({{< relref "troubleshoot-alerts.md" >}})
 - [Add or edit an alert contact point]({{< relref "notifications.md" >}})
 
-{{< docs/shared "alerts/grafana-managed-alerts.md" >}}
+{{< docs/shared lookup="alerts/grafana-managed-alerts.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/alerting/old-alerting/add-notification-template.md
+++ b/docs/sources/alerting/old-alerting/add-notification-template.md
@@ -2,7 +2,7 @@
 title = "Alert notification templating"
 keywords = ["grafana", "documentation", "alerting", "alerts", "notification", "templating"]
 weight = 110
-aliases = ["/docs/grafana/latest/alerting/add-notification-template/"]
+aliases = ["/docs/grafana/v8.2/alerting/add-notification-template/"]
 +++
 
 # Alert notification templating

--- a/docs/sources/alerting/old-alerting/create-alerts.md
+++ b/docs/sources/alerting/old-alerting/create-alerts.md
@@ -3,7 +3,7 @@ title = "Create alerts"
 description = "Configure alert rules"
 keywords = ["grafana", "alerting", "guide", "rules"]
 weight = 200
-aliases = ["/docs/grafana/latest/alerting/create-alerts/"]
+aliases = ["/docs/grafana/v8.2/alerting/create-alerts/"]
 +++
 
 # Create alerts

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -3,7 +3,7 @@ title = "Alert notifications"
 description = "Alerting notifications guide"
 keywords = ["Grafana", "alerting", "guide", "notifications"]
 weight = 100
-aliases = ["/docs/grafana/latest/alerting/notifications/"]
+aliases = ["/docs/grafana/v8.2/alerting/notifications/"]
 +++
 
 # Alert notifications

--- a/docs/sources/alerting/old-alerting/pause-an-alert-rule.md
+++ b/docs/sources/alerting/old-alerting/pause-an-alert-rule.md
@@ -3,7 +3,7 @@ title = "Pause alert rule"
 description = "Pause an existing alert rule"
 keywords = ["grafana", "alerting", "guide", "rules", "view"]
 weight = 400
-aliases = ["/docs/grafana/latest/alerting/pause-an-alert-rule/"]
+aliases = ["/docs/grafana/v8.2/alerting/pause-an-alert-rule/"]
 +++
 
 # Pause an alert rule

--- a/docs/sources/alerting/old-alerting/troubleshoot-alerts.md
+++ b/docs/sources/alerting/old-alerting/troubleshoot-alerts.md
@@ -3,7 +3,7 @@ title = "Troubleshoot alerts"
 description = "Troubleshoot alert rules"
 keywords = ["grafana", "alerting", "guide", "rules", "troubleshoot"]
 weight = 500
-aliases = ["/docs/grafana/latest/alerting/troubleshoot-alerts/"]
+aliases = ["/docs/grafana/v8.2/alerting/troubleshoot-alerts/"]
 +++
 
 # Troubleshoot alerts

--- a/docs/sources/alerting/old-alerting/view-alerts.md
+++ b/docs/sources/alerting/old-alerting/view-alerts.md
@@ -3,7 +3,7 @@ title = "View alerts"
 description = "View existing alert rules"
 keywords = ["grafana", "alerting", "guide", "rules", "view"]
 weight = 400
-aliases = ["/docs/grafana/latest/alerting/view-alerts/"]
+aliases = ["/docs/grafana/v8.2/alerting/view-alerts/"]
 +++
 
 # View existing alert rules

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Grafana 8 Alerts"
-aliases = ["/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.2/alerting/metrics/"]
 weight = 113
 +++
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Create and manage rules"
-aliases = ["/docs/grafana/latest/alerting/rules/"]
+aliases = ["/docs/grafana/v8.2/alerting/rules/"]
 weight = 130
 +++
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -29,10 +29,10 @@ For Cortex and Loki data sources to work with Grafana 8.0 alerting, enable the r
    - From the **Select data source** drop-down, select an external Prometheus, an external Loki, or a Grafana Cloud data source.
    - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose.
    - From the **Group** drop-down, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 2, add the query to evaluate.
    - Enter a PromQL or LogQL expression. The rule fires if the evaluation result has at least one series with a value that is greater than 0. An alert is created for each series.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-query-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-query-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 3, add additional metadata associated with the rule.
    - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting]({{< relref "./alert-annotation-label.md" >}}).
    - Add Runbook URL, panel, dashboard, and alert IDs.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -29,10 +29,10 @@ For Cortex and Loki data sources to work with Grafana 8.0 alerting, enable the r
    - From the **Select data source** drop-down, select an external Prometheus, an external Loki, or a Grafana Cloud data source.
    - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Cortex or Loki rule groups and namespaces]({{< relref "./edit-cortex-loki-namespace-group.md" >}}).
    - From the **Group** drop-down, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 2, add the query to evaluate.
    - Enter a PromQL or LogQL expression. The rule fires if the evaluation result has at least one series with a value that is greater than 0. An alert is created for each series.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-query-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-query-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 3, add conditions.
    - In the **For** text box, specify the duration for which the condition must be true before an alert fires. If you specify `5m`, the condition must be true for 5 minutes before the alert fires.
      > **Note:** Once a condition is met, the alert goes into the `Pending` state. If the condition remains active for the duration specified, the alert transitions to the `Firing` state, else it reverts to the `Normal` state.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -9,9 +9,9 @@ weight = 405
 
 A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Cortex or Loki rule namespaces and groups, and edit group evaluation intervals.
 
-![Group list](/static/img/docs/alerting/unified/rule-list-edit-cortex-loki-icon-8-2.png 'Rule group list screenshot')
+![Group list](/static/img/docs/alerting/unified/rule-list-edit-mimir-loki-icon-8-2.png 'Rule group list screenshot')
 
-{{< figure src="/static/img/docs/alerting/unified/rule-list-edit-cortex-loki-icon-8-2.png" max-width="550px" caption="Alert details" >}}
+{{< figure src="/static/img/docs/alerting/unified/rule-list-edit-mimir-loki-icon-8-2.png" max-width="550px" caption="Alert details" >}}
 
 ## Rename a namespace
 
@@ -36,4 +36,4 @@ The rules within a group are run sequentially at a regular interval, the default
 
 When you rename the group, a new group with all the rules from the old group is created. The old group is deleted.
 
-![Group edit modal](/static/img/docs/alerting/unified/rule-list-cortex-loki-edit-ns-group-8-2.png 'Rule group edit modal screenshot')
+![Group edit modal](/static/img/docs/alerting/unified/rule-list-mimir-loki-edit-ns-group-8-2.png 'Rule group edit modal screenshot')

--- a/docs/sources/alerting/unified-alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Alerting fundamentals"
-aliases = ["/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.2/alerting/metrics/"]
 weight = 120
 +++
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
@@ -1,6 +1,6 @@
 +++
 title = "Alertmanager"
-aliases = ["/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.2/alerting/metrics/"]
 weight = 116
 +++
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
@@ -1,6 +1,6 @@
 +++
 title = "Alerting on numeric data"
-aliases = ["/docs/grafana/latest/alerting/metrics/"]
+aliases = ["/docs/grafana/v8.2/alerting/metrics/"]
 weight = 116
 +++
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
@@ -17,7 +17,7 @@ Grafana managed alerts query the following backend data sources that have alerti
 
 - built-in data sources or those developed and maintained by Grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Monitor`
-- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
+- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../../developers/plugins/metadata.md" >}}))
 
 ### Metrics from the alerting engine
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/evaluate-grafana-alerts.md
@@ -17,7 +17,7 @@ Grafana managed alerts query the following backend data sources that have alerti
 
 - built-in data sources or those developed and maintained by Grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Monitor`
-- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../../developers/plugins/metadata.md" >}}))
+- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
 
 ### Metrics from the alerting engine
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Message templating"
 description = "Message templating"
-aliases = ["/docs/grafana/latest/alerting/message-templating/"]
+aliases = ["/docs/grafana/v8.2/alerting/message-templating/"]
 keywords = ["grafana", "alerting", "guide", "contact point", "templating"]
 weight = 440
 +++

--- a/docs/sources/alerting/unified-alerting/notification-policies.md
+++ b/docs/sources/alerting/unified-alerting/notification-policies.md
@@ -11,20 +11,6 @@ Notification policies determine how alerts are routed to contact points. Policie
 
 You can configure Grafana managed notification policies as well as notification policies for an [external Alertmanager data source]({{< relref "../../datasources/alertmanager.md" >}}). For more information, see [Alertmanager]({{< relref "./fundamentals/alertmanager.md" >}}).
 
-## Grouping
-
-{{< figure max-width="40%" src="/static/img/docs/alerting/unified/notification-policies-grouping.png" max-width="650px" caption="Notification policies grouping" >}}
-
-Grouping is a new and key concept of Grafana alerting that categorizes alert notifications of similar nature into a single funnel. This allows you to properly route alert notifications during larger outages when many parts of a system fail at once causing a high number of alerts to fire simultaneously.
-
-For example, suppose you have 100 services connected to a database in different environments. These services are differentiated by the label `env=environmentname`. An alert rule is in place to monitor whether your services can reach the database named `alertname=DatabaseUnreachable`.
-
-When a network partition occurs, half of your services can no longer reach the database. As a result, 50 different alerts (assuming half of your services) are fired. For this situation, you want to receive a single-page notification (as opposed to 50) with a list of the environments that are affected.
-
-You can configure grouping to be `group_by: [alertname]` (take note that the `env` label is omitted). With this configuration in place, Grafana sends a single compact notification that has all the affected environments for this alert rule.
-
-> **Note:** Grafana also has a special label named `...` that you can use to group all alerts by all labels (effectively disabling grouping), therefore each alert will go into its own group. It is different from the default of `group_by: null` where **all** alerts go into a single group.
-
 ## Edit root notification policy
 
 > **Note:** Before Grafana v8.2, the configuration of the embedded Alertmanager was shared across organisations. Users of Grafana 8.0 and 8.1 are advised to use the new Grafana 8 Alerts only if they have one organisation. Otherwise, silences for the Grafana managed alerts will be visible by all organizations.

--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -2,7 +2,7 @@
 title = "Auth Proxy"
 description = "Grafana Auth Proxy Guide "
 keywords = ["grafana", "configuration", "documentation", "proxy"]
-aliases = ["/docs/grafana/latest/tutorials/authproxy/"]
+aliases = ["/docs/grafana/v8.2/tutorials/authproxy/"]
 weight = 200
 +++
 

--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -2,7 +2,7 @@
 title = "LDAP Authentication"
 description = "Grafana LDAP Authentication Guide "
 keywords = ["grafana", "configuration", "documentation", "ldap", "active directory"]
-aliases = ["/docs/grafana/latest/installation/ldap/"]
+aliases = ["/docs/grafana/v8.2/installation/ldap/"]
 weight = 300
 +++
 

--- a/docs/sources/auth/saml.md
+++ b/docs/sources/auth/saml.md
@@ -2,7 +2,7 @@
 title = "SAML Authentication"
 description = "Grafana SAML Authentication"
 keywords = ["grafana", "saml", "documentation", "saml-auth"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.2/auth/saml/"]
 weight = 1100
 +++
 

--- a/docs/sources/auth/team-sync.md
+++ b/docs/sources/auth/team-sync.md
@@ -2,7 +2,7 @@
 title = "Team Sync"
 description = "Grafana Team Sync"
 keywords = ["grafana", "auth", "documentation"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.2/auth/saml/"]
 weight = 1200
 +++
 

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -7,8 +7,8 @@ weight = 15
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/basics/glossary.md
+++ b/docs/sources/basics/glossary.md
@@ -2,7 +2,7 @@
 title = "Glossary"
 description = "Grafana glossary"
 keywords = ["grafana", "intro", "glossary", "dictionary"]
-aliases = ["/docs/grafana/latest/guides/glossary", "/docs/grafana/latest/getting-started/glossary"]
+aliases = ["/docs/grafana/v8.2/guides/glossary", "/docs/grafana/v8.2/getting-started/glossary"]
 weight = 800
 +++
 
@@ -32,7 +32,7 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
   <tr>
     <td style="vertical-align: top">Explore</td>
     <td>
-      Explore allows a user to focus on building a query. Users can refine the query to return the expected metrics before building a dashboard. For more information, refer to the <a href="https://grafana.com/docs/grafana/latest/explore">Explore</a> topic.
+      Explore allows a user to focus on building a query. Users can refine the query to return the expected metrics before building a dashboard. For more information, refer to the <a href="https://grafana.com/docs/grafana/v8.2/explore">Explore</a> topic.
     </td>
   </tr>
   <tr>
@@ -109,7 +109,7 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
   <tr>
     <td style="vertical-align: top">Transformation</td>
     <td>
-      Transformations process the result set of a query before it’s passed on for visualization. For more information, refer to the <a href="https://grafana.com/docs/grafana/latest/panels/transformations">Transformations overview</a> topic.
+      Transformations process the result set of a query before it’s passed on for visualization. For more information, refer to the <a href="https://grafana.com/docs/grafana/v8.2/panels/transformations">Transformations overview</a> topic.
     </td>
   </tr>
   <tr>

--- a/docs/sources/basics/intro-histograms.md
+++ b/docs/sources/basics/intro-histograms.md
@@ -2,7 +2,7 @@
 title = "Histograms and heatmaps"
 description = "An introduction to histograms and heatmaps"
 keywords = ["grafana", "heatmap", "panel", "documentation", "histogram"]
-aliases = ["/docs/grafana/latest/getting-started/intro-histograms"]
+aliases = ["/docs/grafana/v8.2/getting-started/intro-histograms"]
 weight = 700
 +++
 

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -2,7 +2,7 @@
 title = "Time series dimensions"
 description = "time series dimensions"
 keywords = ["grafana", "intro", "guide", "concepts", "timeseries", "labels"]
-aliases = ["/docs/grafana/latest/guides/timeseries-dimensions", "/docs/grafana/latest/getting-started/timeseries-dimensions"]
+aliases = ["/docs/grafana/v8.2/guides/timeseries-dimensions", "/docs/grafana/v8.2/getting-started/timeseries-dimensions"]
 weight = 600
 +++
 

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -82,4 +82,4 @@ In this case the labels that represent the dimensions will have two keys based o
 
 In the case of SQL-like data sources, more than one numeric column can be selected, with or without additional string columns to be used as dimensions. For example, `AVG(Temperature) AS AvgTemp, MAX(Temperature) AS MaxTemp`. This, if combined with multiple dimensions, can result in a lot of series. Selecting multiple values is currently only designed to be used with visualization.
 
-Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](https://grafana.com/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).
+Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series]({{< relref "../developers/plugins/data-frames.md#data-frames-as-time-series" >}}).

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -82,4 +82,4 @@ In this case the labels that represent the dimensions will have two keys based o
 
 In the case of SQL-like data sources, more than one numeric column can be selected, with or without additional string columns to be used as dimensions. For example, `AVG(Temperature) AS AvgTemp, MAX(Temperature) AS MaxTemp`. This, if combined with multiple dimensions, can result in a lot of series. Selecting multiple values is currently only designed to be used with visualization.
 
-Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series]({{< relref "../developers/plugins/data-frames.md#data-frames-as-time-series" >}}).
+Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](https://grafana.com/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).

--- a/docs/sources/best-practices/common-observability-strategies.md
+++ b/docs/sources/best-practices/common-observability-strategies.md
@@ -2,7 +2,7 @@
 title = "Common observability strategies"
 description = "Common observability strategies"
 keywords = ["grafana", "intro", "guide", "concepts", "methods"]
-aliases = ["/docs/grafana/latest/getting-started/strategies/"]
+aliases = ["/docs/grafana/v8.2/getting-started/strategies/"]
 weight = 300
 +++
 

--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Dashboards"
-aliases = ["/docs/grafana/latest/features/dashboard/dashboards/"]
+aliases = ["/docs/grafana/v8.2/features/dashboard/dashboards/"]
 weight = 80
 +++
 

--- a/docs/sources/dashboards/annotations.md
+++ b/docs/sources/dashboards/annotations.md
@@ -1,7 +1,7 @@
 +++
 title = "Annotations"
 keywords = ["grafana", "annotations", "documentation", "guide"]
-aliases = ["/docs/grafana/latest/reference/annotations/"]
+aliases = ["/docs/grafana/v8.2/reference/annotations/"]
 weight = 2
 +++
 

--- a/docs/sources/dashboards/dashboard_folders.md
+++ b/docs/sources/dashboards/dashboard_folders.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard Folders"
 keywords = ["grafana", "dashboard", "dashboard folders", "folder", "folders", "documentation", "guide"]
-aliases = ["/docs/grafana/latest/reference/dashboard_folders/"]
+aliases = ["/docs/grafana/v8.2/reference/dashboard_folders/"]
 weight = 3
 +++
 

--- a/docs/sources/dashboards/dashboard_history.md
+++ b/docs/sources/dashboards/dashboard_history.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard Version History"
 keywords = ["grafana", "dashboard", "documentation", "version", "history"]
-aliases = ["/docs/grafana/latest/reference/dashboard_history/"]
+aliases = ["/docs/grafana/v8.2/reference/dashboard_history/"]
 weight = 100
 +++
 

--- a/docs/sources/dashboards/export-import.md
+++ b/docs/sources/dashboards/export-import.md
@@ -1,7 +1,7 @@
 +++
 title = "Export and import"
 keywords = ["grafana", "dashboard", "documentation", "export", "import"]
-aliases = ["/docs/grafana/latest/reference/export_import/"]
+aliases = ["/docs/grafana/v8.2/reference/export_import/"]
 weight = 800
 +++
 

--- a/docs/sources/dashboards/json-model.md
+++ b/docs/sources/dashboards/json-model.md
@@ -1,7 +1,7 @@
 +++
 title = "JSON model"
 keywords = ["grafana", "dashboard", "documentation", "json", "model"]
-aliases = ["/docs/grafana/latest/reference/dashboard/"]
+aliases = ["/docs/grafana/v8.2/reference/dashboard/"]
 weight = 1200
 +++
 

--- a/docs/sources/dashboards/playlist.md
+++ b/docs/sources/dashboards/playlist.md
@@ -1,7 +1,7 @@
 +++
 title = "Playlist"
 keywords = ["grafana", "dashboard", "documentation", "playlist"]
-aliases = ["/docs/grafana/latest/reference/playlist/"]
+aliases = ["/docs/grafana/v8.2/reference/playlist/"]
 weight = 4
 +++
 

--- a/docs/sources/dashboards/reporting.md
+++ b/docs/sources/dashboards/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting"
 description = ""
 keywords = ["grafana", "reporting"]
-aliases = ["/docs/grafana/latest/administration/reports"]
+aliases = ["/docs/grafana/v8.2/administration/reports"]
 weight = 8
 +++
 

--- a/docs/sources/dashboards/scripted-dashboards.md
+++ b/docs/sources/dashboards/scripted-dashboards.md
@@ -1,7 +1,7 @@
 +++
 title = "Scripted dashboards"
 keywords = ["grafana", "dashboard", "documentation", "scripted"]
-aliases = ["/docs/grafana/latest/reference/scripting/"]
+aliases = ["/docs/grafana/v8.2/reference/scripting/"]
 weight = 1500
 +++
 

--- a/docs/sources/dashboards/search.md
+++ b/docs/sources/dashboards/search.md
@@ -1,7 +1,7 @@
 +++
 title = "Search"
 keywords = ["grafana", "dashboard", "documentation", "search"]
-aliases =["/docs/grafana/latest/reference/search/"]
+aliases =["/docs/grafana/v8.2/reference/search/"]
 weight = 5
 +++
 

--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -1,7 +1,7 @@
 +++
 title = "Time range controls"
 keywords = ["grafana", "dashboard", "documentation", "time range"]
-aliases = ["/docs/grafana/latest/reference/timerange/"]
+aliases = ["/docs/grafana/v8.2/reference/timerange/"]
 weight = 7
 +++
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Data sources"
-aliases = ["/docs/grafana/latest/datasources/overview/"]
+aliases = ["/docs/grafana/v8.2/datasources/overview/"]
 weight = 60
 +++
 

--- a/docs/sources/datasources/add-a-data-source.md
+++ b/docs/sources/datasources/add-a-data-source.md
@@ -1,6 +1,6 @@
 +++
 title = "Add data source"
-aliases = ["/docs/grafana/latest/features/datasources/add-a-data-source/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/add-a-data-source/"]
 weight = 100
 +++
 

--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -2,13 +2,13 @@
 title = "Alertmanager"
 description = "Guide for using Alertmanager in Grafana"
 keywords = ["grafana", "prometheus", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/alertmanager"]
+aliases = ["/docs/grafana/v8.2/features/datasources/alertmanager"]
 weight = 150
 +++
 
 # Alertmanager data source
 
-Grafana includes built-in support for Prometheus Alertmanager. It is presently in alpha and not accessible unless [alpha plugins are enabled in Grafana settings](https://grafana.com/docs/grafana/latest/administration/configuration/#enable_alpha). Once you add it as a data source, you can use the [Grafana alerting UI](https://grafana.com/docs/grafana/latest/alerting/) to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources .
+Grafana includes built-in support for Prometheus Alertmanager. It is presently in alpha and not accessible unless [alpha plugins are enabled in Grafana settings](https://grafana.com/docs/grafana/v8.2/administration/configuration/#enable_alpha). Once you add it as a data source, you can use the [Grafana alerting UI](https://grafana.com/docs/grafana/v8.2/alerting/) to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources .
 
 > **Note:** Currently, the [Cortex implementation of Prometheus Alertmanager](https://cortexmetrics.io/docs/proposals/scalable-alertmanager/) is required to edit rules.
 

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -2,7 +2,7 @@
 title = "AWS CloudWatch"
 description = "Guide for using CloudWatch in Grafana"
 keywords = ["grafana", "cloudwatch", "guide"]
-aliases = ["/docs/grafana/latest/datasources/cloudwatch"]
+aliases = ["/docs/grafana/v8.2/datasources/cloudwatch"]
 weight = 200
 +++
 
@@ -343,7 +343,7 @@ Allows you to disable `assume role (ARN)` in the CloudWatch data source. By defa
 
 ### list_metrics_page_limit
 
-When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) is used to populate the _Metrics_ field and the _Dimension_ fields. The API is paginated and returns up to 500 results per page. The CloudWatch data source also limits the number of pages to 500. However, you can change this limit using the `list_metrics_page_limit` variable in the [grafana configuration file](https://grafana.com/docs/grafana/latest/administration/configuration/#aws).
+When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) is used to populate the _Metrics_ field and the _Dimension_ fields. The API is paginated and returns up to 500 results per page. The CloudWatch data source also limits the number of pages to 500. However, you can change this limit using the `list_metrics_page_limit` variable in the [grafana configuration file](https://grafana.com/docs/grafana/v8.2/administration/configuration/#aws).
 
 ## Configure the data source with provisioning
 

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication.md
@@ -2,7 +2,7 @@
 title = "Authentication"
 description = "AWS authentication"
 keywords = ["grafana", "aws", "authentication"]
-aliases = ["/docs/grafana/latest/datasources/cloudwatch"]
+aliases = ["/docs/grafana/v8.2/datasources/cloudwatch"]
 weight = 205
 +++
 

--- a/docs/sources/datasources/azuremonitor/_index.md
+++ b/docs/sources/datasources/azuremonitor/_index.md
@@ -2,7 +2,7 @@
 title = "Azure Monitor"
 description = "Guide for using Azure Monitor in Grafana"
 keywords = ["grafana", "microsoft", "azure", "monitor", "application", "insights", "log", "analytics", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/azuremonitor"]
+aliases = ["/docs/grafana/v8.2/features/datasources/azuremonitor"]
 weight = 300
 +++
 
@@ -265,7 +265,7 @@ See the following topics to learn more about the Azure Monitor data source:
 
 Customers who host Grafana in Azure (e.g. App Service, Azure Virtual Machines) and have managed identity enabled on their VM, will now be able to use the managed identity to configure Azure Monitor in Grafana. This will simplify the data source configuration, requiring the data source to be securely authenticated without having to manually configure credentials via Azure AD App Registrations for each data source. For more details on Azure managed identities, refer to the [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).
 
-To enable managed identity for Grafana, set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server config](https://grafana.com/docs/grafana/latest/administration/configuration/#azure).
+To enable managed identity for Grafana, set the `managed_identity_enabled` flag in the `[azure]` section of the [Grafana server config](https://grafana.com/docs/grafana/v8.2/administration/configuration/#azure).
 
 ```ini
 [azure]

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -2,7 +2,7 @@
 title = "Elasticsearch"
 description = "Guide for using Elasticsearch in Grafana"
 keywords = ["grafana", "elasticsearch", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/elasticsearch"]
+aliases = ["/docs/grafana/v8.2/features/datasources/elasticsearch"]
 weight = 325
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -2,7 +2,7 @@
 title = "Google Cloud Monitoring"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/next/datasources/cloudmonitoring/", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/stackdriver", "/docs/grafana/next/datasources/cloudmonitoring/", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
 weight = 350
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -2,7 +2,7 @@
 title = "Preconfigured dashboards"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/stackdriver", "/docs/grafana/next/features/datasources/cloudmonitoring/"]
 weight = 10
 +++
 

--- a/docs/sources/datasources/graphite.md
+++ b/docs/sources/datasources/graphite.md
@@ -2,7 +2,7 @@
 title = "Graphite"
 description = "Guide for using graphite in Grafana"
 keywords = ["grafana", "graphite", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/graphite"]
+aliases = ["/docs/grafana/v8.2/features/datasources/graphite"]
 weight = 600
 +++
 

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -2,13 +2,13 @@
 title = "InfluxDB data source"
 description = "Guide for using InfluxDB in Grafana"
 keywords = ["grafana", "influxdb", "guide", "flux"]
-aliases = ["/docs/grafana/latest/features/datasources/influxdb", "/docs/grafana/latest/datasources/influxdb"]
+aliases = ["/docs/grafana/v8.2/features/datasources/influxdb", "/docs/grafana/v8.2/datasources/influxdb"]
 weight = 700
 +++
 
 # InfluxDB data source
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 This topic explains options, variables, querying, and other options specific to this data source. Refer to [Add a data source]({{< relref "../add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 

--- a/docs/sources/datasources/jaeger.md
+++ b/docs/sources/datasources/jaeger.md
@@ -2,7 +2,7 @@
 title = "Jaeger"
 description = "Guide for using Jaeger in Grafana"
 keywords = ["grafana", "jaeger", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/features/datasources/jaeger"]
+aliases = ["/docs/grafana/v8.2/features/datasources/jaeger"]
 weight = 800
 +++
 

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -2,7 +2,7 @@
 title = "Loki"
 description = "Guide for using Loki in Grafana"
 keywords = ["grafana", "loki", "logging", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/loki"]
+aliases = ["/docs/grafana/v8.2/features/datasources/loki"]
 weight = 800
 +++
 

--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -2,7 +2,7 @@
 title = "Microsoft SQL Server"
 description = "Guide for using Microsoft SQL Server in Grafana"
 keywords = ["grafana", "MSSQL", "Microsoft", "SQL", "guide", "Azure SQL Database"]
-aliases = ["/docs/grafana/latest/features/datasources/mssql/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/mssql/"]
 weight = 900
 +++
 

--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -170,7 +170,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -170,7 +170,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/mysql.md
+++ b/docs/sources/datasources/mysql.md
@@ -2,7 +2,7 @@
 title = "MySQL"
 description = "Guide for using MySQL in Grafana"
 keywords = ["grafana", "mysql", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/mysql/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/mysql/"]
 weight = 1000
 +++
 

--- a/docs/sources/datasources/mysql.md
+++ b/docs/sources/datasources/mysql.md
@@ -182,7 +182,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/mysql.md
+++ b/docs/sources/datasources/mysql.md
@@ -182,7 +182,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -2,7 +2,7 @@
 title = "OpenTSDB"
 description = "Guide for using OpenTSDB in Grafana"
 keywords = ["grafana", "opentsdb", "guide"]
-aliases = ["/docs/grafana/latest/features/opentsdb", "/docs/grafana/latest/features/datasources/opentsdb/"]
+aliases = ["/docs/grafana/v8.2/features/opentsdb", "/docs/grafana/v8.2/features/datasources/opentsdb/"]
 weight = 1100
 +++
 

--- a/docs/sources/datasources/postgres.md
+++ b/docs/sources/datasources/postgres.md
@@ -2,7 +2,7 @@
 title = "PostgreSQL"
 description = "Guide for using PostgreSQL in Grafana"
 keywords = ["grafana", "postgresql", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/postgres/"]
+aliases = ["/docs/grafana/v8.2/features/datasources/postgres/"]
 weight = 1200
 +++
 

--- a/docs/sources/datasources/postgres.md
+++ b/docs/sources/datasources/postgres.md
@@ -187,7 +187,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/postgres.md
+++ b/docs/sources/datasources/postgres.md
@@ -187,7 +187,7 @@ The resulting table panel:
 
 If you set Format as to _Time series_, then the query must have a column named time that returns either a SQL datetime or any numeric datatype representing Unix epoch in seconds. In addition, result sets of time series queries must be sorted by time for panels to properly visualize the result.
 
-A time series query result is returned in a [wide data frame format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
+A time series query result is returned in a [wide data frame format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). Any column except time or of type string transforms into value fields in the data frame query result. Any string column transforms into field labels in the data frame query result.
 
 > For backward compatibility, there's an exception to the above rule for queries that return three columns including a string column named metric. Instead of transforming the metric column into field labels, it becomes the field name, and then the series name is formatted as the value of the metric column. See the example with the metric column below.
 

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -2,7 +2,7 @@
 title = "Prometheus"
 description = "Guide for using Prometheus in Grafana"
 keywords = ["grafana", "prometheus", "guide"]
-aliases = ["/docs/grafana/latest/features/datasources/prometheus"]
+aliases = ["/docs/grafana/v8.2/features/datasources/prometheus"]
 weight = 1300
 +++
 
@@ -10,7 +10,7 @@ weight = 1300
 
 Grafana includes built-in support for Prometheus. This topic explains options, variables, querying, and other options specific to the Prometheus data source. Refer to [Add a data source]({{< relref "add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## Prometheus settings
 

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -2,7 +2,7 @@
 title = "Tempo"
 description = "High volume, minimal dependency trace storage. OSS tracing solution from Grafana Labs."
 keywords = ["grafana", "tempo", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/features/datasources/tempo"]
+aliases = ["/docs/grafana/v8.2/features/datasources/tempo"]
 weight = 1400
 +++
 

--- a/docs/sources/datasources/testdata.md
+++ b/docs/sources/datasources/testdata.md
@@ -1,7 +1,7 @@
 +++
 title = "TestData"
 keywords = ["grafana", "dashboard", "documentation", "panels", "testdata"]
-aliases = ["/docs/grafana/latest/features/datasources/testdata"]
+aliases = ["/docs/grafana/v8.2/features/datasources/testdata"]
 weight = 1500
 +++
 

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -2,7 +2,7 @@
 title = "Zipkin"
 description = "Guide for using Zipkin in Grafana"
 keywords = ["grafana", "zipkin", "guide", "tracing"]
-aliases = ["/docs/grafana/latest/datasources/zipkin"]
+aliases = ["/docs/grafana/v8.2/datasources/zipkin"]
 weight = 1600
 +++
 

--- a/docs/sources/developers/_index.md
+++ b/docs/sources/developers/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Developers"
-aliases = ["/docs/grafana/latest/plugins/developing/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/"]
 weight = 190
 +++
 

--- a/docs/sources/developers/cla.md
+++ b/docs/sources/developers/cla.md
@@ -1,7 +1,7 @@
 +++
 title = "Contributor License Agreement (CLA)"
 description = "Contributor License Agreement (CLA)"
-aliases = ["/docs/grafana/latest/project/cla", "docs/contributing/cla.html"]
+aliases = ["/docs/grafana/v8.2/project/cla", "docs/contributing/cla.html"]
 +++
 
 # Grafana Labs Software Grant and Contributor License Agreement ("Agreement")

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Build a plugin"
-aliases = ["/docs/grafana/latest/plugins/developing/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/"]
 +++
 
 # Build a plugin
@@ -19,8 +19,8 @@ npx @grafana/toolkit plugin:create my-grafana-plugin
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
+- [Build a panel plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin/)
+- [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -30,13 +30,13 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}})
-- [Build a data source backend plugin]({{< relref "/tutorials/build-a-data-source-backend-plugin.md" >}})
+- [Build a panel plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin/)
+- [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
+- [Build a data source backend plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js]({{< relref "/tutorials/build-a-panel-plugin-with-d3.md" >}})
+- [Build a panel plugin with D3.js](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-panel-plugin-with-d3/)
 
 ### Guides
 

--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -1,6 +1,6 @@
 +++
 title = "Add authentication for data source plugins"
-aliases = ["/docs/grafana/latest/plugins/developing/auth-for-datasources/", "/docs/grafana/next/developers/plugins/authentication/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/auth-for-datasources/", "/docs/grafana/next/developers/plugins/authentication/"]
 +++
 
 # Add authentication for data source plugins
@@ -23,7 +23,7 @@ Users with the _Viewer_ role can access data source configuration—such as the 
 
 > **Note:** You can see the settings that the current user has access to by entering `window.grafanaBootData` in the developer console of your browser.
 
-> **Note:** Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/latest/enterprise/datasource_permissions).
+> **Note:** Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/v8.2/enterprise/datasource_permissions).
 
 If you need to store sensitive information, such as passwords, tokens and API keys, use `secureJsonData` instead. Whenever the user saves the data source configuration, the secrets in `secureJsonData` are sent to the Grafana server and encrypted before they're stored.
 
@@ -108,7 +108,7 @@ The Grafana server comes with a proxy that lets you define templates for your re
 
 ### Add a proxy route to your plugin
 
-To forward requests through the Grafana proxy, you need to configure one or more proxy routes. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file.
+To forward requests through the Grafana proxy, you need to configure one or more proxy routes. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](https://grafana.com/docs/grafana/v8.2/developers/plugins/metadata/) file.
 
 1. Add the route to plugin.json. Note that you need to restart the Grafana server every time you make a change to your plugin.json file.
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -6,7 +6,7 @@ title = "Add support for annotations"
 
 This guide explains how to add support for [annotations]({{< relref "../../dashboards/annotations.md" >}}) to an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 > **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to the [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -6,7 +6,7 @@ title = "Add support for Explore queries"
 
 This guide explains how to improve support for [Explore]({{< relref "../../explore/_index.md" >}}) in an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 
@@ -100,4 +100,4 @@ const firstResult = new MutableDataFrame({
 });
 ```
 
-For possible options, refer to [PreferredVisualisationType](https://grafana.com/docs/grafana/latest/packages_api/data/preferredvisualisationtype/).
+For possible options, refer to [PreferredVisualisationType](https://grafana.com/docs/grafana/v8.2/packages_api/data/preferredvisualisationtype/).

--- a/docs/sources/developers/plugins/backend/_index.md
+++ b/docs/sources/developers/plugins/backend/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Backend plugins"
 keywords = ["grafana", "plugins", "backend", "plugin", "backend-plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/backend-plugins-guide/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/backend-plugins-guide/"]
 +++
 
 # Backend plugins

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -6,7 +6,7 @@ title = "Build a logs data source plugin"
 
 This guide explains how to build a logs data source plugin.
 
-Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}) for metrics.
+Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/) for metrics.
 
 ## Add logs support to your data source
 

--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -6,7 +6,7 @@ title = "Build a streaming data source plugin"
 
 This guide explains how to build a streaming data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< relref "/tutorials/build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/docs/grafana/latest/developers/plugins/create-a-grafana-plugin/develop-a-plugin/build-a-data-source-plugin/).
 
 When monitoring critical applications, you want your dashboard to refresh as soon as your data does. In Grafana, you can set your dashboards to automatically refresh at a certain interval, no matter what data source you use. Unfortunately, this means that your queries are requesting all the data to be sent again, regardless of whether the data has actually changed.
 

--- a/docs/sources/developers/plugins/legacy/_index.md
+++ b/docs/sources/developers/plugins/legacy/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy plugins"
-aliases = ["/docs/grafana/latest/plugins/development/", "/docs/grafana/next/plugins/datasources/", "/docs/grafana/next/plugins/apps/", "/docs/grafana/next/plugins/panels/", "/docs/grafana/next/plugins/developing/development/"]
+aliases = ["/docs/grafana/v8.2/plugins/development/", "/docs/grafana/next/plugins/datasources/", "/docs/grafana/next/plugins/apps/", "/docs/grafana/next/plugins/panels/", "/docs/grafana/next/plugins/developing/development/"]
 +++
 
 # Legacy plugins

--- a/docs/sources/developers/plugins/legacy/apps.md
+++ b/docs/sources/developers/plugins/legacy/apps.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy app plugins"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/apps/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/apps/"]
 +++
 
 # Legacy app plugins

--- a/docs/sources/developers/plugins/legacy/data-sources.md
+++ b/docs/sources/developers/plugins/legacy/data-sources.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy data source plugins"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/datasources/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/datasources/"]
 +++
 
 # Legacy data source plugins

--- a/docs/sources/developers/plugins/legacy/defaults-and-editor-mode.md
+++ b/docs/sources/developers/plugins/legacy/defaults-and-editor-mode.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy defaults and editor mode"
-aliases = ["/docs/grafana/latest/plugins/developing/defaults-and-editor-mode/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/defaults-and-editor-mode/"]
 +++
 
 # Legacy defaults and editor mode

--- a/docs/sources/developers/plugins/legacy/panels.md
+++ b/docs/sources/developers/plugins/legacy/panels.md
@@ -1,7 +1,7 @@
 +++
 title = "Legacy panel plugins"
 keywords = ["grafana", "plugins", "panel", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/panels/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/panels/"]
 +++
 
 # Legacy panel plugins

--- a/docs/sources/developers/plugins/legacy/review-guidelines.md
+++ b/docs/sources/developers/plugins/legacy/review-guidelines.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy review guidelines"
-aliases = ["/docs/grafana/latest/plugins/developing/plugin-review-guidelines/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/plugin-review-guidelines/"]
 +++
 
 # Legacy review guidelines

--- a/docs/sources/developers/plugins/legacy/snapshot-mode.md
+++ b/docs/sources/developers/plugins/legacy/snapshot-mode.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy snapshot mode"
-aliases = ["/docs/grafana/latest/plugins/developing/snapshot-mode/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/snapshot-mode/"]
 +++
 
 # Legacy snapshot mode

--- a/docs/sources/developers/plugins/legacy/style-guide.md
+++ b/docs/sources/developers/plugins/legacy/style-guide.md
@@ -1,6 +1,6 @@
 +++
 title = "Legacy code style guide"
-aliases = ["/docs/grafana/latest/plugins/developing/code-styleguide/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/code-styleguide/"]
 +++
 
 # Legacy code style guide

--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------
 title = "plugin.json"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/plugin.json/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/plugin.json/"]
 +++
 
 # plugin.json
@@ -34,7 +34,7 @@ The plugin.json file is required for all plugins. When Grafana starts, it scans 
 | `metrics`            | boolean                       | No       | For data source plugins, if the plugin supports metric queries. Used in Explore.                                                                                                                                                                                                                                                                                                                        |
 | `preload`            | boolean                       | No       | Initialize plugin on startup. By default, the plugin initializes on first use.                                                                                                                                                                                                                                                                                                                          |
 | `queryOptions`       | [object](#queryoptions)       | No       | For data source plugins. There is a query options section in the plugin's query editor and these options can be turned on if needed.                                                                                                                                                                                                                                                                    |
-| `routes`             | [object](#routes)[]           | No       | For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).                                                                                                                       |
+| `routes`             | [object](#routes)[]           | No       | For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.2/developers/plugins/authentication/).                                                                                                                       |
 | `skipDataQuery`      | boolean                       | No       | For panel plugins. Hides the query editor.                                                                                                                                                                                                                                                                                                                                                              |
 | `state`              | string                        | No       | Marks a plugin as a pre-release. Possible values are: `alpha`, `beta`.                                                                                                                                                                                                                                                                                                                                  |
 | `streaming`          | boolean                       | No       | For data source plugins, if the plugin supports streaming.                                                                                                                                                                                                                                                                                                                                              |
@@ -180,7 +180,7 @@ For data source plugins. There is a query options section in the plugin's query 
 
 ## routes
 
-For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).
+For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.2/developers/plugins/authentication/).
 
 ### Properties
 

--- a/docs/sources/developers/plugins/metadata.md.tpl
+++ b/docs/sources/developers/plugins/metadata.md.tpl
@@ -4,7 +4,7 @@
 # -------------------------------------------------------------------------
 title = "plugin.json"
 keywords = ["grafana", "plugins", "documentation"]
-aliases = ["/docs/grafana/latest/plugins/developing/plugin.json/"]
+aliases = ["/docs/grafana/v8.2/plugins/developing/plugin.json/"]
 +++
 
 {{ .Markdown 1 }}

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -174,9 +174,9 @@ func (d *SampleDatasource) CheckHealth(_ context.Context, req *backend.CheckHeal
 
 We strongly recommend that you not allow unsigned plugins in your Grafana installation. By allowing unsigned plugins, we cannot guarantee the authenticity of the plugin, which could compromise the security of your Grafana installation.
 
-To sign your plugin, see [Sign a plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#sign-a-plugin).
+To sign your plugin, see [Sign a plugin](https://grafana.com/docs/grafana/v8.2/developers/plugins/sign-a-plugin/#sign-a-plugin).
 
-You can still run and develop an unsigned plugin by running your Grafana instance in [development mode](https://grafana.com/docs/grafana/latest/administration/configuration/#app_mode). Alternatively, you can use the [allow_loading_unsigned_plugins configuration setting.]({{< relref "../../administration/#allow_loading_unsigned_plugins" >}})
+You can still run and develop an unsigned plugin by running your Grafana instance in [development mode](https://grafana.com/docs/grafana/v8.2/administration/configuration/#app_mode). Alternatively, you can use the [allow_loading_unsigned_plugins configuration setting.]({{< relref "../../administration/#allow_loading_unsigned_plugins" >}})
 
 ### Update react-hook-form from v6 to v7
 
@@ -482,9 +482,9 @@ Before 7.0, data source and panel plugins exchanged data using either time serie
 
 Grafana 7.0 is backward compatible with the old data format used in previous versions. Panels and data sources using the old format will still work with plugins using the new data frame format.
 
-The `DataQueryResponse` returned by the `query` method can be either a [LegacyResponseData](https://grafana.com/docs/grafana/latest/packages_api/data/legacyresponsedata/) or a [DataFrame](https://grafana.com/docs/grafana/latest/packages_api/data/dataframe/).
+The `DataQueryResponse` returned by the `query` method can be either a [LegacyResponseData](https://grafana.com/docs/grafana/v8.2/packages_api/data/legacyresponsedata/) or a [DataFrame](https://grafana.com/docs/grafana/v8.2/packages_api/data/dataframe/).
 
-The [toDataFrame()](https://grafana.com/docs/grafana/latest/packages_api/data/todataframe/) function converts a legacy response, such as `TimeSeries` or `Table`, to a `DataFrame`. Use it to gradually move your code to the new format.
+The [toDataFrame()](https://grafana.com/docs/grafana/v8.2/packages_api/data/todataframe/) function converts a legacy response, such as `TimeSeries` or `Table`, to a `DataFrame`. Use it to gradually move your code to the new format.
 
 ```ts
 import { toDataFrame } from '@grafana/data';

--- a/docs/sources/developers/plugins/package-a-plugin.md
+++ b/docs/sources/developers/plugins/package-a-plugin.md
@@ -1,7 +1,7 @@
 +++
 title = "Package a plugin"
 type = "docs"
-aliases = ["/docs/grafana/latest/developers/plugins/share-a-plugin/"]
+aliases = ["/docs/grafana/v8.2/developers/plugins/share-a-plugin/"]
 +++
 
 # Package a plugin

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -328,10 +328,10 @@
     },
     "routes": {
       "type": "array",
-      "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).",
+      "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.2/developers/plugins/authentication/).",
       "items": {
         "type": "object",
-        "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/latest/developers/plugins/authentication/).",
+        "description": "For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](https://grafana.com/docs/grafana/v8.2/developers/plugins/authentication/).",
         "additionalProperties": false,
         "properties": {
           "path": {

--- a/docs/sources/enterprise/license/activate-license.md
+++ b/docs/sources/enterprise/license/activate-license.md
@@ -2,7 +2,7 @@
 title = "Activate an Enterprise license"
 description = "Activate an Enterprise license"
 keywords = ["grafana", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/activate-license"]
+aliases = ["/docs/grafana/v8.2/enterprise/activate-license"]
 weight = 100
 +++
 

--- a/docs/sources/enterprise/license/license-expiration.md
+++ b/docs/sources/enterprise/license/license-expiration.md
@@ -2,7 +2,7 @@
 title = "License expiration"
 description = ""
 keywords = ["grafana", "licensing"]
-aliases = ["/docs/grafana/latest/enterprise/license-expiration"]
+aliases = ["/docs/grafana/v8.2/enterprise/license-expiration"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/license/license-restrictions.md
+++ b/docs/sources/enterprise/license/license-restrictions.md
@@ -2,7 +2,7 @@
 title = "License restrictions"
 description = "Grafana Enterprise license restrictions"
 keywords = ["grafana", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/license-restrictions"]
+aliases = ["/docs/grafana/v8.2/enterprise/license-restrictions"]
 weight = 300
 +++
 

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting"
 description = ""
 keywords = ["grafana", "reporting"]
-aliases = ["/docs/grafana/latest/administration/reports"]
+aliases = ["/docs/grafana/v8.2/administration/reports"]
 weight = 800
 +++
 

--- a/docs/sources/enterprise/saml.md
+++ b/docs/sources/enterprise/saml.md
@@ -2,7 +2,7 @@
 title = "SAML Authentication"
 description = "Grafana SAML Authentication"
 keywords = ["grafana", "saml", "documentation", "saml-auth"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.2/auth/saml/"]
 weight = 900
 +++
 

--- a/docs/sources/enterprise/settings-updates.md
+++ b/docs/sources/enterprise/settings-updates.md
@@ -12,7 +12,7 @@ weight = 500
 Settings updates at runtime allows you to update Grafana settings with no need to restart the Grafana server.
 
 Updates that happen at runtime are stored in the database and override
-[settings from the other sources](https://grafana.com/docs/grafana/latest/administration/configuration/)
+[settings from the other sources](https://grafana.com/docs/grafana/v8.2/administration/configuration/)
 (arguments, environment variables, settings file, etc). Therefore, every time a specific setting key is removed at runtime,
 the value used for that key is the inherited one from the other sources in the reverse order of precedence
 (`arguments > environment variables > settings file`), being the application default the value used when no one provided

--- a/docs/sources/enterprise/team-sync.md
+++ b/docs/sources/enterprise/team-sync.md
@@ -2,7 +2,7 @@
 title = "Team sync"
 description = "Grafana Team Sync"
 keywords = ["grafana", "auth", "documentation"]
-aliases = ["/docs/grafana/latest/auth/saml/"]
+aliases = ["/docs/grafana/v8.2/auth/saml/"]
 weight = 1000
 +++
 

--- a/docs/sources/enterprise/usage-insights/_index.md
+++ b/docs/sources/enterprise/usage-insights/_index.md
@@ -2,7 +2,7 @@
 title = "Usage insights"
 description = "Understand how your Grafana instance is used"
 keywords = ["grafana", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/"]
+aliases = ["/docs/grafana/v8.2/enterprise/usage-insights/"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/usage-insights/dashboard-datasource-insights.md
+++ b/docs/sources/enterprise/usage-insights/dashboard-datasource-insights.md
@@ -2,7 +2,7 @@
 title = "Dashboard and data source insights"
 description = "Understand how your dashboards and data sources are used"
 keywords = ["grafana", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/dashboard-datasource-insights.md"]
+aliases = ["/docs/grafana/v8.2/enterprise/usage-insights/dashboard-datasource-insights.md"]
 weight = 200
 +++
 

--- a/docs/sources/enterprise/usage-insights/export-logs.md
+++ b/docs/sources/enterprise/usage-insights/export-logs.md
@@ -2,7 +2,7 @@
 title = "Export logs of usage insights"
 description = "Export logs of usage insights"
 keywords = ["grafana", "export", "usage-insights", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/export-logs.md"]
+aliases = ["/docs/grafana/v8.2/enterprise/usage-insights/export-logs.md"]
 weight = 500
 +++
 

--- a/docs/sources/enterprise/usage-insights/improved-search.md
+++ b/docs/sources/enterprise/usage-insights/improved-search.md
@@ -2,7 +2,7 @@
 title = "Sort dashboards by using insights data"
 description = "Sort dashboards by using insights data"
 keywords = ["grafana", "search", "sort", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/improved-search.md"]
+aliases = ["/docs/grafana/v8.2/enterprise/usage-insights/improved-search.md"]
 weight = 400
 +++
 

--- a/docs/sources/enterprise/usage-insights/presence-indicator.md
+++ b/docs/sources/enterprise/usage-insights/presence-indicator.md
@@ -2,7 +2,7 @@
 title = "Presence indicator"
 description = "Know who is looking at the same dashboard as you are"
 keywords = ["grafana", "presence-indicator", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/usage-insights/presence-indicator.md"]
+aliases = ["/docs/grafana/v8.2/enterprise/usage-insights/presence-indicator.md"]
 weight = 300
 +++
 

--- a/docs/sources/enterprise/white-labeling.md
+++ b/docs/sources/enterprise/white-labeling.md
@@ -2,7 +2,7 @@
 title = "White labeling"
 description = "Change the look of Grafana to match your corporate brand"
 keywords = ["grafana", "white-labeling", "enterprise"]
-aliases = ["/docs/grafana/latest/enterprise/white-labeling/"]
+aliases = ["/docs/grafana/v8.2/enterprise/white-labeling/"]
 weight = 1300
 +++
 

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Explore"
 keywords = ["explore", "loki", "logs"]
-aliases = ["/docs/grafana/latest/features/explore/"]
+aliases = ["/docs/grafana/v8.2/features/explore/"]
 weight = 90
 +++
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -103,4 +103,4 @@ Optional fields:
 | stackTraces    | string[]            | List of stack traces associated with the current span.             |
 | errorIconColor | string              | Color of the error icon in case span is tagged with `error: true`. |
 
-For details about the types see [TraceSpanRow](https://grafana.com/docs/grafana/latest/packages_api/data/tracespanrow/), [TraceKeyValuePair](https://grafana.com/docs/grafana/latest/packages_api/data/tracekeyvaluepair/) and [TraceLog](https://grafana.com/docs/grafana/latest/packages_api/data/tracelog/)
+For details about the types see [TraceSpanRow](https://grafana.com/docs/grafana/v8.2/packages_api/data/tracespanrow/), [TraceKeyValuePair](https://grafana.com/docs/grafana/v8.2/packages_api/data/tracekeyvaluepair/) and [TraceLog](https://grafana.com/docs/grafana/v8.2/packages_api/data/tracelog/)

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Getting started"
 weight = 10
-aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
+aliases = ["/docs/grafana/v8.2/guides/what-is-grafana"]
 +++
 
 # Getting started

--- a/docs/sources/getting-started/getting-started-influxdb.md
+++ b/docs/sources/getting-started/getting-started-influxdb.md
@@ -7,11 +7,11 @@ weight = 250
 
 # Getting started with Grafana and InfluxDB
 
-{{< docs/shared "influxdb/intro.md" >}}
+{{< docs/shared lookup="influxdb/intro.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 > **Note:** You can also configure a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance to display system metrics without having to host Grafana yourself. Grafana offers a [free account with Grafana Cloud](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) to help you get started.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Get InfluxDB
 

--- a/docs/sources/getting-started/getting-started-prometheus.md
+++ b/docs/sources/getting-started/getting-started-prometheus.md
@@ -2,7 +2,7 @@
 title = "With Grafana and Prometheus"
 description = "Guide for getting started with Grafana and Prometheus"
 keywords = ["grafana", "intro", "guide", "started"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.2/guides/gettingstarted","/docs/grafana/v8.2/guides/getting_started"]
 weight = 300
 +++
 
@@ -12,7 +12,7 @@ Prometheus is an open source monitoring system for which Grafana provides out-of
 
 > **Note:** You can configure a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance to display system metrics without having to host Grafana yourself. A [free forever plan](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) provides 10,000 active series for metrics.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Step 2. Download Prometheus and node_exporter
 

--- a/docs/sources/getting-started/getting-started-sql.md
+++ b/docs/sources/getting-started/getting-started-sql.md
@@ -1,7 +1,7 @@
 +++
 description = "Guide for getting started with Grafana and MS SQL Server"
 keywords = ["grafana", "intro", "guide", "started", "SQL", "MSSQL"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.2/guides/gettingstarted","/docs/grafana/v8.2/guides/getting_started"]
 draft = true
 weight = 400
 +++
@@ -10,7 +10,7 @@ weight = 400
 
 Microsoft SQL Server is a popular relational database management system that is widely used in development and production environments. This topic walks you through the steps to create a series of dashboards in Grafana to display metrics from a MS SQL Server database. You can also configure the MS SQL Server data source on a [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) instance without having to host Grafana yourself.
 
-{{< docs/shared "getting-started/first-step.md" >}}
+{{< docs/shared lookup="getting-started/first-step.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 > **Note:** You must install Grafana 5.1+ in order to use the integrated MS SQL data source.
 

--- a/docs/sources/getting-started/getting-started.md
+++ b/docs/sources/getting-started/getting-started.md
@@ -2,7 +2,7 @@
 title = "With Grafana"
 description = "Guide for getting started with Grafana"
 keywords = ["grafana", "intro", "guide", "started"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+aliases = ["/docs/grafana/v8.2/guides/gettingstarted","/docs/grafana/v8.2/guides/getting_started"]
 weight = 200
 +++
 

--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -2,7 +2,7 @@
 title = "HTTP API"
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "overview"]
-aliases = ["/docs/grafana/latest/overview"]
+aliases = ["/docs/grafana/v8.2/overview"]
 weight = 170
 +++
 

--- a/docs/sources/http_api/access_control.md
+++ b/docs/sources/http_api/access_control.md
@@ -2,7 +2,7 @@
 title = "Fine-grained access control HTTP API "
 description = "Fine-grained access control API"
 keywords = ["grafana", "http", "documentation", "api", "fine-grained-access-control", "acl", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/accesscontrol/"]
+aliases = ["/docs/grafana/v8.2/http_api/accesscontrol/"]
 +++
 
 # Fine-grained access control API

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -2,7 +2,7 @@
 title = "Admin HTTP API "
 description = "Grafana Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "admin"]
-aliases = ["/docs/grafana/latest/http_api/admin/"]
+aliases = ["/docs/grafana/v8.2/http_api/admin/"]
 +++
 
 # Admin API

--- a/docs/sources/http_api/alerting.md
+++ b/docs/sources/http_api/alerting.md
@@ -2,7 +2,7 @@
 title = "Alerting HTTP API "
 description = "Grafana Alerts HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "alerting", "alerts"]
-aliases = ["/docs/grafana/latest/http_api/alerting/"]
+aliases = ["/docs/grafana/v8.2/http_api/alerting/"]
 +++
 
 # Alerting API

--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -2,7 +2,7 @@
 title = "Annotations HTTP API "
 description = "Grafana Annotations HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "annotation", "annotations", "comment"]
-aliases = ["/docs/grafana/latest/http_api/annotations/"]
+aliases = ["/docs/grafana/v8.2/http_api/annotations/"]
 +++
 
 # Annotations resources / actions

--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -2,7 +2,7 @@
 title = "Authentication HTTP API "
 description = "Grafana Authentication HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "authentication"]
-aliases = ["/docs/grafana/latest/http_api/authentication/"]
+aliases = ["/docs/grafana/v8.2/http_api/authentication/"]
 +++
 
 # Authentication API

--- a/docs/sources/http_api/create-api-tokens-for-org.md
+++ b/docs/sources/http_api/create-api-tokens-for-org.md
@@ -1,7 +1,7 @@
 +++
 title = "API Tutorial: Create API tokens and dashboards for an organization"
 keywords = ["grafana", "tutorials", "API", "Token", "Org", "Organization"]
-aliases =["/docs/grafana/latest/tutorials/api_org_token_howto/"]
+aliases =["/docs/grafana/v8.2/tutorials/api_org_token_howto/"]
 weight = 150
 +++
 

--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -2,7 +2,7 @@
 title = "Dashboard HTTP API "
 description = "Grafana Dashboard HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard"]
-aliases = ["/docs/grafana/latest/http_api/dashboard/"]
+aliases = ["/docs/grafana/v8.2/http_api/dashboard/"]
 +++
 
 # Dashboard API

--- a/docs/sources/http_api/dashboard_permissions.md
+++ b/docs/sources/http_api/dashboard_permissions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Permissions HTTP API "
 description = "Grafana Dashboard Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "permission", "permissions", "acl"]
-aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/v8.2/http_api/dashboardpermissions/"]
 +++
 
 # Dashboard Permissions API

--- a/docs/sources/http_api/dashboard_versions.md
+++ b/docs/sources/http_api/dashboard_versions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Versions HTTP API "
 description = "Grafana Dashboard Versions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "versions"]
-aliases = ["/docs/grafana/latest/http_api/dashboardversions/"]
+aliases = ["/docs/grafana/v8.2/http_api/dashboardversions/"]
 +++
 
 # Dashboard Versions

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -2,7 +2,7 @@
 title = "Data source HTTP API "
 description = "Grafana Data source HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "data source"]
-aliases = ["/docs/grafana/latest/http_api/datasource/"]
+aliases = ["/docs/grafana/v8.2/http_api/datasource/"]
 +++
 
 # Data source API

--- a/docs/sources/http_api/datasource_permissions.md
+++ b/docs/sources/http_api/datasource_permissions.md
@@ -2,7 +2,7 @@
 title = "Datasource Permissions HTTP API "
 description = "Data Source Permissions API"
 keywords = ["grafana", "http", "documentation", "api", "datasource", "permission", "permissions", "acl", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/datasourcepermissions/"]
+aliases = ["/docs/grafana/v8.2/http_api/datasourcepermissions/"]
 +++
 
 # Data Source Permissions API

--- a/docs/sources/http_api/external_group_sync.md
+++ b/docs/sources/http_api/external_group_sync.md
@@ -2,7 +2,7 @@
 title = "External Group Sync HTTP API "
 description = "Grafana External Group Sync HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group", "member", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/external_group_sync/"]
+aliases = ["/docs/grafana/v8.2/http_api/external_group_sync/"]
 +++
 
 # External Group Synchronization API

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -2,7 +2,7 @@
 title = "Folder HTTP API "
 description = "Grafana Folder HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder"]
-aliases = ["/docs/grafana/latest/http_api/folder/"]
+aliases = ["/docs/grafana/v8.2/http_api/folder/"]
 +++
 
 # Folder API

--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -2,7 +2,7 @@
 title = "Folder/Dashboard Search HTTP API "
 description = "Grafana Folder/Dashboard Search HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "search", "folder", "dashboard"]
-aliases = ["/docs/grafana/latest/http_api/folder_dashboard_search/"]
+aliases = ["/docs/grafana/v8.2/http_api/folder_dashboard_search/"]
 +++
 
 # Folder/Dashboard Search API

--- a/docs/sources/http_api/folder_permissions.md
+++ b/docs/sources/http_api/folder_permissions.md
@@ -2,7 +2,7 @@
 title = "Folder Permissions HTTP API "
 description = "Grafana Folder Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder", "permission", "permissions", "acl"]
-aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/v8.2/http_api/dashboardpermissions/"]
 +++
 
 # Folder Permissions API

--- a/docs/sources/http_api/library_element.md
+++ b/docs/sources/http_api/library_element.md
@@ -2,7 +2,7 @@
 title = "Library Element HTTP API "
 description = "Grafana Library Element HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "library-element"]
-aliases = ["/docs/grafana/latest/http_api/library_element/"]
+aliases = ["/docs/grafana/v8.2/http_api/library_element/"]
 +++
 
 # Library Element API

--- a/docs/sources/http_api/licensing.md
+++ b/docs/sources/http_api/licensing.md
@@ -2,7 +2,7 @@
 title = "Licensing HTTP API "
 description = "Enterprise Licensing HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "licensing", "enterprise"]
-aliases = ["/docs/grafana/latest/http_api/licensing/"]
+aliases = ["/docs/grafana/v8.2/http_api/licensing/"]
 +++
 
 # Enterprise License API

--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -2,7 +2,7 @@
 title = "Organization HTTP API "
 description = "Grafana Organization HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "organization"]
-aliases = ["/docs/grafana/latest/http_api/organization/"]
+aliases = ["/docs/grafana/v8.2/http_api/organization/"]
 +++
 
 # Organization API

--- a/docs/sources/http_api/other.md
+++ b/docs/sources/http_api/other.md
@@ -2,7 +2,7 @@
 title = "Other HTTP API "
 description = "Grafana Other HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "other"]
-aliases = ["/docs/grafana/latest/http_api/other/"]
+aliases = ["/docs/grafana/v8.2/http_api/other/"]
 +++
 
 # Frontend Settings API

--- a/docs/sources/http_api/playlist.md
+++ b/docs/sources/http_api/playlist.md
@@ -2,7 +2,7 @@
 title = "Playlist HTTP API "
 description = "Playlist Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "playlist"]
-aliases = ["/docs/grafana/latest/http_api/playlist/"]
+aliases = ["/docs/grafana/v8.2/http_api/playlist/"]
 +++
 
 # Playlist API

--- a/docs/sources/http_api/preferences.md
+++ b/docs/sources/http_api/preferences.md
@@ -2,7 +2,7 @@
 title = "HTTP Preferences API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "preferences"]
-aliases = ["/docs/grafana/latest/http_api/preferences/"]
+aliases = ["/docs/grafana/v8.2/http_api/preferences/"]
 +++
 
 # User and Org Preferences API

--- a/docs/sources/http_api/reporting.md
+++ b/docs/sources/http_api/reporting.md
@@ -2,7 +2,7 @@
 title = "Reporting API"
 description = "Grafana Enterprise APIs"
 keywords = ["grafana", "enterprise", "api", "reporting"]
-aliases = ["/docs/grafana/latest/http_api/reporting/"]
+aliases = ["/docs/grafana/v8.2/http_api/reporting/"]
 +++
 
 # Reporting API

--- a/docs/sources/http_api/short_url.md
+++ b/docs/sources/http_api/short_url.md
@@ -2,7 +2,7 @@
 title = "Short URL HTTP API "
 description = "Grafana Short URL HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "shortUrl"]
-aliases = ["/docs/grafana/latest/http_api/short_url/"]
+aliases = ["/docs/grafana/v8.2/http_api/short_url/"]
 +++
 
 # Short URL API

--- a/docs/sources/http_api/snapshot.md
+++ b/docs/sources/http_api/snapshot.md
@@ -2,7 +2,7 @@
 title = "HTTP Snapshot API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "snapshot"]
-aliases = ["/docs/grafana/latest/http_api/snapshot/"]
+aliases = ["/docs/grafana/v8.2/http_api/snapshot/"]
 +++
 
 # Snapshot API

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -2,7 +2,7 @@
 title = "Team HTTP API "
 description = "Grafana Team HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group"]
-aliases = ["/docs/grafana/latest/http_api/team/"]
+aliases = ["/docs/grafana/v8.2/http_api/team/"]
 +++
 
 # Team API

--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -2,7 +2,7 @@
 title = "User HTTP API "
 description = "Grafana User HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "user"]
-aliases = ["/docs/grafana/latest/http_api/user/"]
+aliases = ["/docs/grafana/v8.2/http_api/user/"]
 +++
 
 # User API

--- a/docs/sources/image-rendering/_index.md
+++ b/docs/sources/image-rendering/_index.md
@@ -2,7 +2,7 @@
 title = "Image rendering"
 description = "Image rendering"
 keywords = ["grafana", "image", "rendering", "plugin"]
-aliases = ["/docs/grafana/latest/administration/image_rendering/"]
+aliases = ["/docs/grafana/v8.2/administration/image_rendering/"]
 weight = 55
 +++
 

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -2,7 +2,7 @@
 title = "Installation"
 description = "Installation guide for Grafana"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/latest/installation/installation/", "/docs/grafana/v2.1/installation/install/", "/docs/grafana/latest/install"]
+aliases = ["/docs/grafana/v8.2/installation/installation/", "/docs/grafana/v2.1/installation/install/", "/docs/grafana/v8.2/install"]
 weight = 30
 +++
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -2,7 +2,7 @@
 title = "Install on Debian/Ubuntu"
 description = "Install guide for Grafana on Debian or Ubuntu"
 keywords = ["grafana", "installation", "documentation"]
-aliases = ["/docs/grafana/latest/installation/installation/debian"]
+aliases = ["/docs/grafana/v8.2/installation/installation/debian"]
 weight = 200
 +++
 
@@ -14,7 +14,7 @@ This page explains how to install Grafana dependencies, download and install Gra
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "upgrading.md" >}}) for tips and guidance on updating an existing installation.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## 1. Download and install
 
@@ -139,7 +139,7 @@ sudo systemctl enable grafana-server.service
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Start the server with init.d
 

--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -11,7 +11,7 @@ You can install and run Grafana using the official Docker image. It comes in two
 
 This topic also contains important information about [migrating from earlier Docker image versions](#migrate-from-previous-docker-containers-versions).
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## Alpine image (recommended)
 

--- a/docs/sources/installation/requirements.md
+++ b/docs/sources/installation/requirements.md
@@ -59,6 +59,6 @@ Grafana is supported in the current version of the following browsers. Older ver
 - Firefox
 - Safari
 - Microsoft Edge
-- Internet Explorer 11 is only fully supported in Grafana versions prior v6.0.
+- Internet Explorer 11 is only fully supported in Grafana versions prior to v6.0.
 
 > **Note:** Always enable JavaScript in your browser. Running Grafana without JavaScript enabled in the browser is not supported.

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -2,7 +2,7 @@
 title = "Install on RPM-based Linux"
 description = "Grafana Installation guide for RPM-based Linux, such as Centos, Fedora, OpenSuse, and Red Hat."
 keywords = ["grafana", "installation", "documentation", "centos", "fedora", "opensuse", "redhat"]
-aliases = ["/docs/grafana/latest/installation/installation/rpm"]
+aliases = ["/docs/grafana/v8.2/installation/installation/rpm"]
 weight = 300
 +++
 
@@ -14,7 +14,7 @@ This topic explains how to install Grafana dependencies, download and install Gr
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "upgrading.md" >}}) for tips and guidance on updating an existing installation.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## 1. Download and install
 
@@ -170,7 +170,7 @@ sudo systemctl enable grafana-server
 
 #### Serving Grafana on a port < 1024
 
-{{< docs/shared "systemd/bind-net-capabilities.md" >}}
+{{< docs/shared lookup="systemd/bind-net-capabilities.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 #### Serving Grafana behind a proxy
 

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -342,7 +342,7 @@ Refer to [Grafana Live configuration]({{< relref "../live/configure-grafana-live
 
 ### Postgres, MySQL, Microsoft SQL Server data sources
 
-Grafana v8.0 changes the underlying data structure to [data frames]({{< relref "../developers/plugins/data-frames.md" >}}) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). To make the visualizations work as they did before, you might have to do some manual migrations.
+Grafana v8.0 changes the underlying data structure to [data frames](https://grafana.com/developers/plugin-tools/introduction/data-frames) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). To make the visualizations work as they did before, you might have to do some manual migrations.
 
 For any existing panels/visualizations using a _Time series_ query, where the time column is only needed for filtering the time range, for example, using the bar gauge or pie chart panel, we recommend that you use a _Table query_ instead and exclude the time column as a field in the response.
 Refer to this [issue comment](https://github.com/grafana/grafana/issues/35534#issuecomment-861519658) for detailed instructions and workarounds.

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -342,7 +342,7 @@ Refer to [Grafana Live configuration]({{< relref "../live/configure-grafana-live
 
 ### Postgres, MySQL, Microsoft SQL Server data sources
 
-Grafana v8.0 changes the underlying data structure to [data frames](https://grafana.com/developers/plugin-tools/introduction/data-frames) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format](https://grafana.com/developers/plugin-tools/introduction/data-frames#wide-format). To make the visualizations work as they did before, you might have to do some manual migrations.
+Grafana v8.0 changes the underlying data structure to [data frames]({{< relref "../developers/plugins/data-frames.md" >}}) for the Postgres, MySQL, Microsoft SQL Server data sources. As a result, a _Time series_ query result gets returned in a [wide format]({{< relref "../developers/plugins/data-frames.md#wide-format" >}}). To make the visualizations work as they did before, you might have to do some manual migrations.
 
 For any existing panels/visualizations using a _Time series_ query, where the time column is only needed for filtering the time range, for example, using the bar gauge or pie chart panel, we recommend that you use a _Table query_ instead and exclude the time column as a field in the response.
 Refer to this [issue comment](https://github.com/grafana/grafana/issues/35534#issuecomment-861519658) for detailed instructions and workarounds.

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -1,15 +1,15 @@
 +++
 title = "Introduction to Grafana"
 weight = 5
-aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
+aliases = ["/docs/grafana/v8.2/guides/what-is-grafana"]
 +++
 
 # Introduction to Grafana
 
 Grafana is a complete observability stack that allows you to monitor and analyze metrics, logs and traces. It allows you to query, visualize, alert on and understand your data no matter where it is stored. Create, explore, and share beautiful dashboards with your team and foster a data driven culture. For more information, refer to [Grafana overview](https://grafana.com/grafana/). Our observability stack has the following products and components.
 
-{{< docs/shared "basics/what-is-grafana.md" >}}
+{{< docs/shared lookup="basics/what-is-grafana.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-cloud.md" >}}
+{{< docs/shared lookup="basics/grafana-cloud.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "basics/grafana-enterprise.md" >}}
+{{< docs/shared lookup="basics/grafana-enterprise.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/introduction/oss-details.md
+++ b/docs/sources/introduction/oss-details.md
@@ -1,7 +1,7 @@
 +++
 title = "What is Grafana OSS"
 weight = 5
-aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
+aliases = ["/docs/grafana/v8.2/guides/what-is-grafana"]
 +++
 
 # What is Grafana OSS

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "URL variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "data link"]
-aliases = ["/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
+aliases = ["/docs/grafana/v8.2/variables/url-variables.md","/docs/grafana/v8.2/variables/variable-types/url-variables.md"]
 weight = 400
 +++
 

--- a/docs/sources/linking/data-links.md
+++ b/docs/sources/linking/data-links.md
@@ -1,7 +1,7 @@
 +++
 title = "Data links"
 keywords = ["grafana", "data links", "documentation", "playlist"]
-aliases = ["/docs/grafana/latest/reference/datalinks/"]
+aliases = ["/docs/grafana/v8.2/reference/datalinks/"]
 +++
 
 # Data links

--- a/docs/sources/linking/linking-overview.md
+++ b/docs/sources/linking/linking-overview.md
@@ -1,7 +1,7 @@
 +++
 title = "Linking overview"
 keywords = ["grafana", "linking", "create links", "link panels", "link dashboards", "navigate"]
-aliases = ["/docs/grafana/latest/features/navigation-links/"]
+aliases = ["/docs/grafana/v8.2/features/navigation-links/"]
 weight = 100
 +++
 

--- a/docs/sources/linking/panel-links.md
+++ b/docs/sources/linking/panel-links.md
@@ -2,13 +2,13 @@
 title = "Panel links"
 description = ""
 keywords = ["grafana", "linking", "create links", "link panels", "link dashboards", "navigate"]
-aliases = ["/docs/grafana/latest/features/navigation-links/"]
+aliases = ["/docs/grafana/v8.2/features/navigation-links/"]
 weight = 300
 +++
 
 # Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
+Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
 
 Click the icon on the top left corner of a panel to see available panel links.
 

--- a/docs/sources/live/_index.md
+++ b/docs/sources/live/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Grafana Live"
-aliases = ["/docs/grafana/latest/live/live-feature-overview/"]
+aliases = ["/docs/grafana/v8.2/live/live-feature-overview/"]
 weight = 115
 +++
 

--- a/docs/sources/manage-users/manage-teams/index.md
+++ b/docs/sources/manage-users/manage-teams/index.md
@@ -1,6 +1,6 @@
 +++
 title = "Manage teams"
-aliases =["/docs/grafana/latest/manage-users/add-or-remove-user-from-team/","/docs/grafana/latest/manage-users/create-or-remove-team/"]
+aliases =["/docs/grafana/v8.2/manage-users/add-or-remove-user-from-team/","/docs/grafana/v8.2/manage-users/create-or-remove-team/"]
 weight = 300
 +++
 
@@ -19,7 +19,7 @@ Teams members are assigned one of two permissions:
 
 See the complete list of teams in your Grafana organization.
 
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Org Admin view
 
@@ -34,7 +34,7 @@ See the complete list of teams in your Grafana organization.
 Add a team to your Grafana organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **New Team**.
 1. Enter team information:
@@ -48,7 +48,7 @@ Add a team to your Grafana organization.
 Add an existing user account to a team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team that you want to add users to.
 1. Click **Add member**.
@@ -64,7 +64,7 @@ Add an existing user account to a team.
 Remove a user account from the team.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team that you want to remove users from.
 1. Click the red **X** next to the name of the user that you want to remove from the team and then click **Delete**.
@@ -75,7 +75,7 @@ Remove a user account from the team.
 Change team member permission levels.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the team in which you want to change user permissions.
 1. In the team member list, find and click the user account that you want to change. You can use the search field to filter the list if necessary.
@@ -89,7 +89,7 @@ Change team member permission levels.
 Permanently delete the team and all special permissions assigned to it.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-team-list.md" >}}
+{{< docs/shared lookup="manage-users/view-team-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the red **X** next to the team that you want to delete and then click **Delete**.
    {{< /docs/list >}}

--- a/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-orgs.md
@@ -15,7 +15,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of organizations set up on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all organizations set up on the server, listed in alphabetical order by organization name. The following information is displayed:
 
@@ -29,7 +29,7 @@ Grafana displays all organizations set up on the server, listed in alphabetical 
 Add an organization to your Grafana server.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **+ New org**.
 1. Enter the name of the new organization and then click **Create**.
@@ -49,7 +49,7 @@ Permanently remove an organization from your Grafana server.
 **Warning:** Deleting the organization also deletes all teams and dashboards for this organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the red **X** next to the organization that you want to remove.
 1. Click **Delete**.
@@ -66,7 +66,7 @@ Grafana Server Admins can perform some organization management tasks that are al
 See which user accounts are assigned to the organization and their assigned roles.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the name of the organization for which you want to view members.
 1. Scroll down to the Organization Users section. User accounts are displayed in alphabetical order.
@@ -75,7 +75,7 @@ See which user accounts are assigned to the organization and their assigned role
 ### Change organization name
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the **Name** field, type the new organization name.
 1. Click **Update**.
@@ -86,7 +86,7 @@ See which user accounts are assigned to the organization and their assigned role
 Change the organization role assigned to a user account that is assigned to the organization you are editing.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. In the **Role** field, select the new role that you want to assign.
@@ -95,7 +95,7 @@ Change the organization role assigned to a user account that is assigned to the 
 ## Remove a user from an organization
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list-and-edit.md" >}}
+{{< docs/shared lookup="manage-users/view-server-org-list-and-edit.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organization Users section, locate the user account that you want to change the role of.
 1. Click the red **X** next to the user account listing and then click **Delete**.

--- a/docs/sources/manage-users/server-admin/server-admin-manage-users.md
+++ b/docs/sources/manage-users/server-admin/server-admin-manage-users.md
@@ -1,7 +1,7 @@
 +++
 title = "Manage users"
 weight = 100
-aliases =["/docs/grafana/latest/manage-users/add-or-remove-user/","/docs/grafana/latest/manage-users/enable-or-disable-user/"]
+aliases =["/docs/grafana/v8.2/manage-users/add-or-remove-user/","/docs/grafana/v8.2/manage-users/enable-or-disable-user/"]
 +++
 
 # Manage users as a Server Admin
@@ -16,7 +16,7 @@ In order to perform any of these tasks, you must be logged in to Grafana on an a
 
 See a complete list of users with accounts on your Grafana server.
 
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 Grafana displays all user accounts on the server, listed in alphabetical order by user name. The following information is displayed:
 
@@ -34,7 +34,7 @@ Grafana displays all user accounts on the server, listed in alphabetical order b
 See all details associated with a specific user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click the user account you wish to view. If necessary, use the search field at the top of the tab to search for the specific user account that you need.
    {{< /docs/list >}}
@@ -75,7 +75,7 @@ See recent sessions that the user was logged on, including when they logged on a
 Create a new user account at the server level.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **New user**.
 1. Enter the following information:
@@ -99,7 +99,7 @@ Change information or settings in an individual user account.
 Edit information on an existing user account, including the user name, email, username, and password.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the User information section, click **Edit** next to the field that you want to change.
 1. Enter the new value and then click **Save**.
@@ -110,7 +110,7 @@ Edit information on an existing user account, including the user name, email, us
 Users can change their own passwords, but Server Admins can change user passwords as well.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the User information section, click **Edit** next to the **Password** field.
 1. Enter the new value and then click **Save**. Grafana requires a value at least four characters long in this field.
@@ -121,7 +121,7 @@ Users can change their own passwords, but Server Admins can change user password
 Permanently remove a user account from the server.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Delete User**.
 1. Click **Delete user** to confirm the action.
@@ -136,7 +136,7 @@ Temporarily turn on or off account access, but do not remove the account from th
 Prevent a user from logging in with this account, but do not delete the account. You might disable an account if a colleague goes on sabbatical.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Disable User**.
 1. Click **Disable user** to confirm the action.
@@ -147,7 +147,7 @@ Prevent a user from logging in with this account, but do not delete the account.
 Reactivate a disabled user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Click **Enable User**.
    {{< /docs/list >}}
@@ -157,7 +157,7 @@ Reactivate a disabled user account.
 Give or remove the Grafana Server Admin role from a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Permissions section, click **Change**.
 1. Click **Yes** or **No**, depending on whether or not you want this user account to have the Grafana Server Admin role.
@@ -171,7 +171,7 @@ The next time this user logs in, their permissions will be updated.
 Add a user account to an existing organization. User accounts can belong to multiple organizations, but each user account must belong to at least one organization.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Add user to organisation**.
 1. In the **Add to an organization** window, select the **Organisation** that you are adding the user to.
@@ -184,7 +184,7 @@ Add a user account to an existing organization. User accounts can belong to mult
 Remove a user account from an organization that it is currently assigned to.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Remove from organisation** next to the organization that you want to remove the user from.
 1. Click **Confirm removal**.
@@ -195,7 +195,7 @@ Remove a user account from an organization that it is currently assigned to.
 Change the organization role assigned to a user account.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. In the Organisations section, click **Change role** next to the organization that you want to change the user role for.
 1. Select the new role and then click **Save**.
@@ -206,7 +206,7 @@ Change the organization role assigned to a user account.
 See when a user last logged in and information about how they logged in. You can also force the account to log out of Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section to view sessions associated with this user account.
    {{< /docs/list >}}
@@ -220,7 +220,7 @@ If you suspect a user account is compromised or is no longer authorized to acces
 Log the user account out of one specific device that is logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section.
 1. Click **Force logout** next to the session entry that you want logged out of Grafana.
@@ -232,7 +232,7 @@ Log the user account out of one specific device that is logged in to Grafana.
 Log the user account out of all devices that are logged in to Grafana.
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list-search.md" >}}
+{{< docs/shared lookup="manage-users/view-server-user-list-search.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 1. Scroll down to the Sessions section.
 1. Click **Force logout from all devices**.

--- a/docs/sources/manage-users/user-admin/change-your-password.md
+++ b/docs/sources/manage-users/user-admin/change-your-password.md
@@ -2,7 +2,7 @@
 title = "Change your password"
 description = "How to change your Grafana password"
 keywords = ["grafana", "password", "change", "preferences"]
-aliases = ["/docs/grafana/latest/administration/change-your-password/"]
+aliases = ["/docs/grafana/v8.2/administration/change-your-password/"]
 weight = 200
 +++
 

--- a/docs/sources/panels/_index.md
+++ b/docs/sources/panels/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Panels"
-aliases = ["/docs/grafana/latest/features/panels/panels/"]
+aliases = ["/docs/grafana/v8.2/features/panels/panels/"]
 weight = 70
 +++
 

--- a/docs/sources/panels/field-overrides.md
+++ b/docs/sources/panels/field-overrides.md
@@ -1,7 +1,7 @@
 +++
 title = "Field overrides"
 keywords = ["grafana", "field options", "documentation", "format fields", "overrides", "override fields"]
-aliases = ["/docs/grafana/latest/panels/field-options/", "/docs/grafana/latest/panels/field-options/configure-specific-fields/"]
+aliases = ["/docs/grafana/v8.2/panels/field-options/", "/docs/grafana/v8.2/panels/field-options/configure-specific-fields/"]
 weight = 700
 +++
 

--- a/docs/sources/panels/legend-options.md
+++ b/docs/sources/panels/legend-options.md
@@ -1,6 +1,6 @@
 +++
 title = "Legend options"
-aliases = ["/docs/grafana/latest/panels/visualizations/panel-legend/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/panel-legend/"]
 weight = 950
 +++
 

--- a/docs/sources/panels/panel-editor.md
+++ b/docs/sources/panels/panel-editor.md
@@ -62,7 +62,7 @@ The section contains tabs where you enter queries, transform your data, and crea
 
 The section contains tabs where you configure almost every aspect of your data Visualization. Not all options are available for each visualization.
 
-The data model used in Grafana, namely the [data frame](https://grafana.com/developers/plugin-tools/introduction/data-frames), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
+The data model used in Grafana, namely the [data frame]({{< relref "../developers/plugins/data-frames.md" >}}), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
 
 Field options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, however they change how Grafana displays the data.
 

--- a/docs/sources/panels/panel-editor.md
+++ b/docs/sources/panels/panel-editor.md
@@ -62,7 +62,7 @@ The section contains tabs where you enter queries, transform your data, and crea
 
 The section contains tabs where you configure almost every aspect of your data Visualization. Not all options are available for each visualization.
 
-The data model used in Grafana, namely the [data frame]({{< relref "../developers/plugins/data-frames.md" >}}), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
+The data model used in Grafana, namely the [data frame](https://grafana.com/developers/plugin-tools/introduction/data-frames), is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
 
 Field options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, however they change how Grafana displays the data.
 

--- a/docs/sources/panels/panel-options.md
+++ b/docs/sources/panels/panel-options.md
@@ -27,12 +27,8 @@ Toggle the transparent background option on your panel display.
 
 ## Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
-
 For more information, refer to [Panel links]({{< relref "../linking/panel-links.md" >}}).
 
 ## Repeat options
-
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
 
 For more information, refer to [Repeat panels or rows]({{< relref "./repeat-panels-or-rows.md" >}}).

--- a/docs/sources/panels/repeat-panels-or-rows.md
+++ b/docs/sources/panels/repeat-panels-or-rows.md
@@ -1,13 +1,13 @@
 +++
 title = "Repeat panels or rows"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable", "repeat"]
-aliases = ["/docs/grafana/latest/variables/repeat-panels-or-rows/"]
+aliases = ["/docs/grafana/v8.2/variables/repeat-panels-or-rows/"]
 weight = 800
 +++
 
 # Repeat panels or rows
 
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
+Grafana lets you create dynamic dashboards using _template variables_. All variables in your queries expand to the current value of the variable before the query is sent to the database. Variables let you reuse a single dashboard for all your services.
 
 Template variables can be very useful to dynamically change your queries across a whole dashboard. If you want
 Grafana to dynamically create new panels or rows based on what values you have selected, you can use the _Repeat_ feature.

--- a/docs/sources/panels/standard-options.md
+++ b/docs/sources/panels/standard-options.md
@@ -1,7 +1,7 @@
 +++
 title = "Standard field options"
 keywords = ["grafana", "table options", "documentation", "format tables"]
-aliases = ["/docs/grafana/latest/panels/field-options/standard-field-options/"]
+aliases = ["/docs/grafana/v8.2/panels/field-options/standard-field-options/"]
 weight = 430
 +++
 

--- a/docs/sources/panels/transformations/types-options.md
+++ b/docs/sources/panels/transformations/types-options.md
@@ -471,7 +471,7 @@ With the transformation applied, you can see we are left with just the remainder
 
 > **Note:** This transformation is available in Grafana 7.5.10+ and Grafana 8.0.6+.
 
-Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here](https://grafana.com/developers/plugin-tools/introduction/data-frames).
+Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here]({{< relref "../../developers/plugins/data-frames.md" >}}).
 
 This transformation helps you resolve this issue by converting the time series data from either the wide format to the long format or the other way around.
 

--- a/docs/sources/panels/transformations/types-options.md
+++ b/docs/sources/panels/transformations/types-options.md
@@ -471,7 +471,7 @@ With the transformation applied, you can see we are left with just the remainder
 
 > **Note:** This transformation is available in Grafana 7.5.10+ and Grafana 8.0.6+.
 
-Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here]({{< relref "../../developers/plugins/data-frames.md" >}}).
+Prepare time series transformation is useful when a data source returns time series data in a format that isn't supported by the panel you want to use. [Read more about the different data frame formats here](https://grafana.com/developers/plugin-tools/introduction/data-frames).
 
 This transformation helps you resolve this issue by converting the time series data from either the wide format to the long format or the other way around.
 

--- a/docs/sources/permissions/_index.md
+++ b/docs/sources/permissions/_index.md
@@ -2,7 +2,7 @@
 title = "Permissions"
 description = "Permissions"
 keywords = ["grafana", "configuration", "documentation", "admin", "users", "datasources", "permissions"]
-aliases = ["/docs/grafana/latest/permissions/overview/"]
+aliases = ["/docs/grafana/v8.2/permissions/overview/"]
 weight = 50
 +++
 

--- a/docs/sources/permissions/dashboard-folder-permissions.md
+++ b/docs/sources/permissions/dashboard-folder-permissions.md
@@ -2,7 +2,7 @@
 title = "Dashboard and folder permissions"
 description = "Grafana Dashboard and Folder Permissions Guide "
 keywords = ["grafana", "configuration", "documentation", "dashboard", "folder", "permissions", "teams"]
-aliases = ["/docs/grafana/latest/permissions/dashboard_folder_permissions/"]
+aliases = ["/docs/grafana/v8.2/permissions/dashboard_folder_permissions/"]
 weight = 200
 +++
 

--- a/docs/sources/plugins/_index.md
+++ b/docs/sources/plugins/_index.md
@@ -7,7 +7,7 @@ weight = 160
 
 Besides the wide range of visualizations and data sources that are available immediately after you install Grafana, you can extend your Grafana experience with _plugins_.
 
-You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself](https://grafana.com/developers/plugin-tools).
+You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../developers/plugins/_index.md" >}}).
 
 Grafana supports three types of plugins: [panels](https://grafana.com/grafana/plugins?type=panel), [data sources](https://grafana.com/grafana/plugins?type=datasource), and [apps](https://grafana.com/grafana/plugins?type=app).
 

--- a/docs/sources/plugins/_index.md
+++ b/docs/sources/plugins/_index.md
@@ -7,7 +7,7 @@ weight = 160
 
 Besides the wide range of visualizations and data sources that are available immediately after you install Grafana, you can extend your Grafana experience with _plugins_.
 
-You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../developers/plugins/_index.md" >}}).
+You can [install]({{< relref "installation.md" >}}) one of the plugins built by the Grafana community, or [build one yourself](https://grafana.com/developers/plugin-tools).
 
 Grafana supports three types of plugins: [panels](https://grafana.com/grafana/plugins?type=panel), [data sources](https://grafana.com/grafana/plugins?type=datasource), and [apps](https://grafana.com/grafana/plugins?type=app).
 

--- a/docs/sources/plugins/catalog.md
+++ b/docs/sources/plugins/catalog.md
@@ -1,6 +1,6 @@
 +++
 title = "Plugin catalog"
-aliases = ["/docs/grafana/latest/plugins/catalog/"]
+aliases = ["/docs/grafana/v8.2/plugins/catalog/"]
 weight = 1
 +++
 

--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -1,6 +1,6 @@
 +++
 title = "Install plugins"
-aliases = ["/docs/grafana/latest/plugins/installation/"]
+aliases = ["/docs/grafana/v8.2/plugins/installation/"]
 weight = 1
 +++
 

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -1,7 +1,7 @@
 +++
 title = "Plugin signatures"
 type = "docs"
-aliases = ["/docs/grafana/latest/plugins/plugin-signature-verification"]
+aliases = ["/docs/grafana/v8.2/plugins/plugin-signature-verification"]
 +++
 
 # Plugin signatures

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -16,7 +16,7 @@ Grafana also writes an error message to the server log:
 WARN[05-26|12:00:00] Some plugin scanning errors were found   errors="plugin '<plugin id>' is unsigned, plugin '<plugin id>' has an invalid signature"
 ```
 
-If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin]({{< relref "../developers/plugins/sign-a-plugin.md" >}}).
+If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).
 
 | Signature status   | Description                                                                     |
 | ------------------ | ------------------------------------------------------------------------------- |

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -16,7 +16,7 @@ Grafana also writes an error message to the server log:
 WARN[05-26|12:00:00] Some plugin scanning errors were found   errors="plugin '<plugin id>' is unsigned, plugin '<plugin id>' has an invalid signature"
 ```
 
-If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).
+If you are a plugin developer and want to know how to sign your plugin, refer to [Sign a plugin]({{< relref "../developers/plugins/sign-a-plugin.md" >}}).
 
 | Signature status   | Description                                                                     |
 | ------------------ | ------------------------------------------------------------------------------- |

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,9 +8,6 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
-- [Release notes for 8.2.7]({{< relref "release-notes-8-2-7" >}})
-- [Release notes for 8.2.6]({{< relref "release-notes-8-2-6" >}})
-- [Release notes for 8.2.5]({{< relref "release-notes-8-2-5" >}})
 - [Release notes for 8.2.4]({{< relref "release-notes-8-2-4" >}})
 - [Release notes for 8.2.3]({{< relref "release-notes-8-2-3" >}})
 - [Release notes for 8.2.2]({{< relref "release-notes-8-2-2" >}})

--- a/docs/sources/shared/alerts/grafana-managed-alerts.md
+++ b/docs/sources/shared/alerts/grafana-managed-alerts.md
@@ -14,7 +14,7 @@ Alerting rules can only query backend data sources with alerting enabled:
 
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
 
 ## Metrics from the alerting engine
 

--- a/docs/sources/shared/alerts/grafana-managed-alerts.md
+++ b/docs/sources/shared/alerts/grafana-managed-alerts.md
@@ -14,7 +14,7 @@ Alerting rules can only query backend data sources with alerting enabled:
 
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata.md" >}}))
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json))
 
 ## Metrics from the alerting engine
 

--- a/docs/sources/shared/example.md
+++ b/docs/sources/shared/example.md
@@ -11,7 +11,7 @@ When you have a chunk of text or steps that stand alone, not part of an ordered 
 The syntax to invoke this file would be the following, minus the backslash:
 
 ```
-\{{< docs/shared "example.md" >}}
+\{{< docs/shared lookup="example.md" source="grafana" version="<GRAFANA VERSION>" >}}
 ```
 
 ## Part of a list
@@ -24,7 +24,7 @@ Below is an example from the docs, with backslashes added. The initial spaces ar
 
 ```
 \{{< docs/list >}}
-  \{{< docs/shared "manage-users/view-server-user-list.md" >}}
+  \{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="<GRAFANA VERSION>" >}}
   1. Click the user account that you want to edit. If necessary, use the search field to find the account.
 \{{< /docs/list >}}
 ```
@@ -36,7 +36,7 @@ You cannot use short codes in an ordered list with sublists. The shortcode break
 All unordered list steps included as part of a list will appear as second-level lists (with the hollow circle bullet) rather than first-level lists (solid circle bullet), even if the list is not indented in the shared file or the document file.
 
 {{< docs/list >}}
-{{< docs/shared "test.md" >}}
+{{< docs/shared lookup="test.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 - Bullet text
   {{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -3,7 +3,9 @@ title: View org list as server admin
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="v8.2" >}}
 
 1. Click the name of the organization that you want to edit.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -3,7 +3,9 @@ title: View user list and search - list format
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="v8.2" >}}
 
 1. Click the user account that you want to edit. If necessary, use the search field to find the account.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}

--- a/docs/sources/sharing/share-dashboard.md
+++ b/docs/sources/sharing/share-dashboard.md
@@ -1,7 +1,7 @@
 +++
 title = "Share a dashboard"
 keywords = ["grafana", "dashboard", "documentation", "sharing"]
-aliases = ["/docs/grafana/latest/dashboards/share-dashboard/","/docs/grafana/latest/reference/share_dashboard/"]
+aliases = ["/docs/grafana/v8.2/dashboards/share-dashboard/","/docs/grafana/v8.2/reference/share_dashboard/"]
 weight = 6
 +++
 

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Share a panel"
 keywords = ["grafana", "dashboard", "documentation", "sharing", "library panel"]
-aliases = ["/docs/grafana/latest/dashboards/share-dashboard/","/docs/grafana/latest/reference/share_panel/"]
+aliases = ["/docs/grafana/v8.2/dashboards/share-dashboard/","/docs/grafana/v8.2/reference/share_panel/"]
 weight = 6
 +++
 

--- a/docs/sources/variables/inspect-variable.md
+++ b/docs/sources/variables/inspect-variable.md
@@ -1,7 +1,7 @@
 +++
 title = "Inspect variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.2/reference/templating"]
 weight = 125
 +++
 

--- a/docs/sources/variables/manage-variable.md
+++ b/docs/sources/variables/manage-variable.md
@@ -1,7 +1,7 @@
 +++
 title = "Manage variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.2/reference/templating"]
 weight = 120
 +++
 

--- a/docs/sources/variables/syntax.md
+++ b/docs/sources/variables/syntax.md
@@ -1,7 +1,7 @@
 +++
 title = "Variable syntax"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
-aliases = ["/docs/grafana/latest/reference/templating"]
+aliases = ["/docs/grafana/v8.2/reference/templating"]
 weight = 100
 +++
 

--- a/docs/sources/variables/variable-types/add-ad-hoc-filters.md
+++ b/docs/sources/variables/variable-types/add-ad-hoc-filters.md
@@ -1,6 +1,6 @@
 +++
 title = "Add ad hoc filters"
-aliases = ["/docs/grafana/latest/variables/add-ad-hoc-filters.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-ad-hoc-filters.md"]
 weight = 700
 +++
 

--- a/docs/sources/variables/variable-types/add-constant-variable.md
+++ b/docs/sources/variables/variable-types/add-constant-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a constant variable"
-aliases = ["/docs/grafana/latest/variables/add-constant-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-constant-variable.md"]
 weight = 400
 +++
 

--- a/docs/sources/variables/variable-types/add-custom-variable.md
+++ b/docs/sources/variables/variable-types/add-custom-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a custom variable"
-aliases = ["/docs/grafana/latest/variables/add-custom-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-custom-variable.md"]
 weight = 200
 +++
 

--- a/docs/sources/variables/variable-types/add-data-source-variable.md
+++ b/docs/sources/variables/variable-types/add-data-source-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a data source variable"
-aliases = ["/docs/grafana/latest/variables/add-data-source-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-data-source-variable.md"]
 weight = 500
 +++
 

--- a/docs/sources/variables/variable-types/add-interval-variable.md
+++ b/docs/sources/variables/variable-types/add-interval-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add an interval variable"
-aliases = ["/docs/grafana/latest/variables/add-interval-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-interval-variable.md"]
 weight = 600
 +++
 

--- a/docs/sources/variables/variable-types/add-query-variable.md
+++ b/docs/sources/variables/variable-types/add-query-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a query variable"
-aliases = ["/docs/grafana/latest/variables/add-query-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-query-variable.md"]
 weight = 100
 +++
 

--- a/docs/sources/variables/variable-types/add-text-box-variable.md
+++ b/docs/sources/variables/variable-types/add-text-box-variable.md
@@ -1,6 +1,6 @@
 +++
 title = "Add a text box variable"
-aliases = ["/docs/grafana/latest/variables/add-text-box-variable.md"]
+aliases = ["/docs/grafana/v8.2/variables/add-text-box-variable.md"]
 weight = 300
 +++
 

--- a/docs/sources/variables/variable-types/chained-variables.md
+++ b/docs/sources/variables/variable-types/chained-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "Chained variables"
 keywords = ["grafana", "templating", "variable", "nested", "chained", "linked"]
-aliases = ["/docs/grafana/latest/variables/chained-variables.md"]
+aliases = ["/docs/grafana/v8.2/variables/chained-variables.md"]
 weight = 800
 +++
 

--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "Global variables"
 keywords = ["grafana", "templating", "documentation", "guide", "template", "variable", "global", "standard"]
-aliases = ["/docs/grafana/latest/variables/global-variables.md"]
+aliases = ["/docs/grafana/v8.2/variables/global-variables.md"]
 weight = 900
 +++
 

--- a/docs/sources/visualizations/_index.md
+++ b/docs/sources/visualizations/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Visualizations"
 weight = 75
-aliases = ["/docs/grafana/latest/panels/visualizations/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/"]
 +++
 
 # Visualization panels

--- a/docs/sources/visualizations/alert-list-panel.md
+++ b/docs/sources/visualizations/alert-list-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Alert list"
 keywords = ["grafana", "alert list", "documentation", "panel", "alertlist"]
-aliases = ["/docs/grafana/latest/reference/alertlist/", "/docs/grafana/latest/features/panels/alertlist/", "/docs/grafana/latest/panels/visualizations/alert-list-panel/"]
+aliases = ["/docs/grafana/v8.2/reference/alertlist/", "/docs/grafana/v8.2/features/panels/alertlist/", "/docs/grafana/v8.2/panels/visualizations/alert-list-panel/"]
 weight = 100
 +++
 

--- a/docs/sources/visualizations/annotations.md
+++ b/docs/sources/visualizations/annotations.md
@@ -2,7 +2,7 @@
 title = "Annotations"
 description = "Annotations visualization documentation"
 keywords = ["grafana", "Annotations", "panel", "documentation"]
-aliases = ["/docs/grafana/latest/features/panels/anotations/", "/docs/grafana/latest/panels/visualizations/annotations/"]
+aliases = ["/docs/grafana/v8.2/features/panels/anotations/", "/docs/grafana/v8.2/panels/visualizations/annotations/"]
 weight = 105
 +++
 

--- a/docs/sources/visualizations/bar-chart.md
+++ b/docs/sources/visualizations/bar-chart.md
@@ -3,7 +3,7 @@ title = "Bar chart"
 description = "Bar chart visualization"
 keywords = ["grafana", "docs", "bar chart", "panel", "barchart"]
 weight = 170
-aliases = ["/docs/grafana/latest/panels/visualizations/bar-chart/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/bar-chart/"]
 +++
 
 # Bar chart
@@ -84,9 +84,9 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/bar-gauge-panel.md
+++ b/docs/sources/visualizations/bar-gauge-panel.md
@@ -2,7 +2,7 @@
 title = "Bar gauge"
 description = "Bar gauge panel options"
 keywords = ["grafana", "bar", "bar gauge"]
-aliases = ["/docs/grafana/latest/features/panels/bar_gauge/", "/docs/grafana/latest/panels/visualizations/bar-gauge-panel/"]
+aliases = ["/docs/grafana/v8.2/features/panels/bar_gauge/", "/docs/grafana/v8.2/panels/visualizations/bar-gauge-panel/"]
 weight = 200
 +++
 

--- a/docs/sources/visualizations/dashboard-list-panel.md
+++ b/docs/sources/visualizations/dashboard-list-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Dashboard list"
 keywords = ["grafana", "dashboard list", "documentation", "panel", "dashlist"]
-aliases = ["/docs/grafana/latest/reference/dashlist/", "/docs/grafana/latest/features/panels/dashlist/", "/docs/grafana/latest/panels/visualizations/dashboard-list-panel/"]
+aliases = ["/docs/grafana/v8.2/reference/dashlist/", "/docs/grafana/v8.2/features/panels/dashlist/", "/docs/grafana/v8.2/panels/visualizations/dashboard-list-panel/"]
 weight = 300
 +++
 

--- a/docs/sources/visualizations/gauge-panel.md
+++ b/docs/sources/visualizations/gauge-panel.md
@@ -2,7 +2,7 @@
 title = "Gauge"
 description = "Gauge panel docs"
 keywords = ["grafana", "gauge", "gauge panel"]
-aliases = ["/docs/grafana/latest/features/panels/gauge/", "/docs/grafana/latest/panels/visualizations/gauge-panel/"]
+aliases = ["/docs/grafana/v8.2/features/panels/gauge/", "/docs/grafana/v8.2/panels/visualizations/gauge-panel/"]
 weight = 400
 +++
 

--- a/docs/sources/visualizations/geomap.md
+++ b/docs/sources/visualizations/geomap.md
@@ -2,7 +2,7 @@
 title = "Geomap"
 description = "Geomap visualization documentation"
 keywords = ["grafana", "Geomap", "panel", "documentation"]
-aliases = ["/docs/grafana/latest/features/panels/geomap/", "/docs/grafana/latest/panels/visualizations/geomap/"]
+aliases = ["/docs/grafana/v8.2/features/panels/geomap/", "/docs/grafana/v8.2/panels/visualizations/geomap/"]
 weight = 600
 +++
 

--- a/docs/sources/visualizations/graph-panel.md
+++ b/docs/sources/visualizations/graph-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph (old)"
 keywords = ["grafana", "graph panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/reference/graph/", "/docs/grafana/latest/features/panels/graph/", "/docs/grafana/latest/panels/visualizations/graph-panel/"]
+aliases = ["/docs/grafana/v8.2/reference/graph/", "/docs/grafana/v8.2/features/panels/graph/", "/docs/grafana/v8.2/panels/visualizations/graph-panel/"]
 weight = 500
 +++
 

--- a/docs/sources/visualizations/heatmap.md
+++ b/docs/sources/visualizations/heatmap.md
@@ -2,7 +2,7 @@
 title = "Heatmap"
 description = "Heatmap visualization documentation"
 keywords = ["grafana", "heatmap", "panel", "documentation"]
-aliases =["/docs/grafana/latest/features/panels/heatmap/"]
+aliases =["/docs/grafana/v8.2/features/panels/heatmap/"]
 weight = 600
 +++
 

--- a/docs/sources/visualizations/histogram.md
+++ b/docs/sources/visualizations/histogram.md
@@ -2,7 +2,7 @@
 title = "Histogram"
 description = "Histogram visualization"
 keywords = ["grafana", "docs", "bar chart", "panel", "barchart"]
-aliases =["/docs/grafana/latest/features/panels/histogram/", "/docs/grafana/latest/panels/visualizations/histogram/"]
+aliases =["/docs/grafana/v8.2/features/panels/histogram/", "/docs/grafana/v8.2/panels/visualizations/histogram/"]
 weight = 605
 +++
 
@@ -58,9 +58,9 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/logs-panel.md
+++ b/docs/sources/visualizations/logs-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Logs panel"
 keywords = ["grafana", "dashboard", "documentation", "panels", "logs panel"]
-aliases = ["/docs/grafana/latest/reference/logs/", "/docs/grafana/latest/features/panels/logs/", "/docs/grafana/latest/panels/visualizations/logs-panel/"]
+aliases = ["/docs/grafana/v8.2/reference/logs/", "/docs/grafana/v8.2/features/panels/logs/", "/docs/grafana/v8.2/panels/visualizations/logs-panel/"]
 weight = 700
 +++
 

--- a/docs/sources/visualizations/news-panel.md
+++ b/docs/sources/visualizations/news-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "News"
 keywords = ["grafana", "news", "documentation", "panels", "news panel"]
-aliases = ["/docs/grafana/latest/panels/visualizations/news-graph/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/news-graph/"]
 weight = 800
 +++
 

--- a/docs/sources/visualizations/node-graph.md
+++ b/docs/sources/visualizations/node-graph.md
@@ -1,7 +1,7 @@
 +++
 title = "Node graph"
 keywords = ["grafana", "dashboard", "documentation", "panels", "node graph", "directed graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/node-graph/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/node-graph/"]
 weight = 850
 +++
 

--- a/docs/sources/visualizations/pie-chart-panel.md
+++ b/docs/sources/visualizations/pie-chart-panel.md
@@ -2,7 +2,7 @@
 title = "Pie chart"
 keywords = ["grafana", "pie chart"]
 weight = 850
-aliases = ["/docs/grafana/latest/panels/visualizations/pie-chart-pane/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/pie-chart-pane/"]
 +++
 
 # Pie chart
@@ -68,9 +68,9 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend values
 

--- a/docs/sources/visualizations/stat-panel.md
+++ b/docs/sources/visualizations/stat-panel.md
@@ -2,7 +2,7 @@
 title = "Stat"
 description = "Stat panel documentation"
 keywords = ["grafana", "docs", "stat panel"]
-aliases = ["/docs/grafana/latest/features/panels/stat/", "/docs/grafana/latest/features/panels/singlestat/", "/docs/grafana/latest/reference/singlestat/", "/docs/grafana/latest/panels/visualizations/stat-panel/"]
+aliases = ["/docs/grafana/v8.2/features/panels/stat/", "/docs/grafana/v8.2/features/panels/singlestat/", "/docs/grafana/v8.2/reference/singlestat/", "/docs/grafana/v8.2/panels/visualizations/stat-panel/"]
 weight = 900
 +++
 

--- a/docs/sources/visualizations/state-timeline.md
+++ b/docs/sources/visualizations/state-timeline.md
@@ -2,7 +2,7 @@
 title = "State timeline"
 description = "State timeline visualization"
 keywords = ["grafana", "docs", "state timeline", "panel"]
-aliases = ["/docs/grafana/latest/panels/visualizations/state-timeline/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/state-timeline/"]
 weight = 900
 +++
 
@@ -56,4 +56,4 @@ The panel can be used with time series data as well. In this case, the threshold
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` option under [Standard options]({{< relref "../panels/standard-options.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/visualizations/status-history.md
+++ b/docs/sources/visualizations/status-history.md
@@ -38,7 +38,7 @@ Controls the opacity of state regions.
 
 ## Value mappings
 
-To assign colors to boolean or string values, use the [Value mappings]({{< relref "../value-mappings" >}}).
+To assign colors to boolean or string values, use the [Value mappings]({{< relref "../panels/value-mappings" >}}).
 
 {{< figure src="/static/img/docs/v8/value_mappings_side_editor.png" max-width="300px" caption="Value mappings side editor" >}}
 

--- a/docs/sources/visualizations/status-history.md
+++ b/docs/sources/visualizations/status-history.md
@@ -38,7 +38,7 @@ Controls the opacity of state regions.
 
 ## Value mappings
 
-To assign colors to boolean or string values, use the [Value mappings]({{< relref "../panels/value-mappings" >}}).
+To assign colors to boolean or string values, use the [Value mappings]({{< relref "../value-mappings" >}}).
 
 {{< figure src="/static/img/docs/v8/value_mappings_side_editor.png" max-width="300px" caption="Value mappings side editor" >}}
 

--- a/docs/sources/visualizations/status-history.md
+++ b/docs/sources/visualizations/status-history.md
@@ -2,7 +2,7 @@
 title = "Status history"
 description = "Status history visualization"
 keywords = ["grafana", "docs", "status history", "panel"]
-aliases = ["/docs/grafana/latest/panels/visualizations/status-history/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/status-history/"]
 weight = 900
 +++
 
@@ -38,7 +38,7 @@ Controls the opacity of state regions.
 
 ## Value mappings
 
-To assign colors to boolean or string values, use the [Value mappings](< {{ refref "../value-mappings.md"}} >).
+To assign colors to boolean or string values, use the [Value mappings]({{< relref "../value-mappings" >}}).
 
 {{< figure src="/static/img/docs/v8/value_mappings_side_editor.png" max-width="300px" caption="Value mappings side editor" >}}
 
@@ -53,4 +53,4 @@ use gradient color schemes to color values.
 
 When the legend option is enabled it can show either the value mappings or the threshold brackets. To show the value mappings in the legend, it's important that the `Color scheme` option under [Standard options]({{< relref "../panels/standard-options.md" >}}) is set to `Single color` or `Classic palette`. To see the threshold brackets in the legend set the `Color scheme` to `From thresholds`.
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/visualizations/table/_index.md
+++ b/docs/sources/visualizations/table/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Table"
 keywords = ["grafana", "dashboard", "documentation", "panels", "table panel"]
-aliases = ["/docs/grafana/latest/reference/table/", "/docs/grafana/latest/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
+aliases = ["/docs/grafana/v8.2/reference/table/", "/docs/grafana/v8.2/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/"]
 weight = 1000
 +++
 

--- a/docs/sources/visualizations/table/filter-table-columns.md
+++ b/docs/sources/visualizations/table/filter-table-columns.md
@@ -1,7 +1,7 @@
 +++
 title = "Filter table columns"
 keywords = ["grafana", "table options", "documentation", "format tables", "table filter", "filter columns"]
-aliases = ["/docs/grafana/latest/reference/table/", "/docs/grafana/latest/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/", "/docs/grafana/latest/panels/visualizations/table/filter-table-columns/"]
+aliases = ["/docs/grafana/v8.2/reference/table/", "/docs/grafana/v8.2/features/panels/table_panel/", "/docs/grafana/next/panels/visualizations/table/table-field-options/", "/docs/grafana/v8.2/panels/visualizations/table/filter-table-columns/"]
 weight = 600
 +++
 

--- a/docs/sources/visualizations/text-panel.md
+++ b/docs/sources/visualizations/text-panel.md
@@ -1,7 +1,7 @@
 +++
 title = "Text"
 keywords = ["grafana", "text", "documentation", "panel"]
-aliases = ["/docs/grafana/latest/reference/alertlist/", "/docs/grafana/latest/features/panels/text/", "/docs/grafana/latest/panels/visualizations/text-panel/"]
+aliases = ["/docs/grafana/v8.2/reference/alertlist/", "/docs/grafana/v8.2/features/panels/text/", "/docs/grafana/v8.2/panels/visualizations/text-panel/"]
 weight = 1100
 +++
 

--- a/docs/sources/visualizations/time-series/_index.md
+++ b/docs/sources/visualizations/time-series/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Time series"
 keywords = ["grafana", "graph panel", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/"]
 weight = 1200
 +++
 
@@ -17,9 +17,9 @@ Time series visualization is the default and primary way to visualize time serie
 
 These options are available whether you are graphing your time series as lines, bars, or points.
 
-{{< docs/shared "visualizations/tooltip-mode.md" >}}
+{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/legend-mode.md" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Legend calculations
 

--- a/docs/sources/visualizations/time-series/annotate-time-series.md
+++ b/docs/sources/visualizations/time-series/annotate-time-series.md
@@ -1,7 +1,7 @@
 +++
 title = "Annotate time series"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph", "annotations"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/annotate-time-series/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/annotate-time-series/"]
 weight = 100
 +++
 

--- a/docs/sources/visualizations/time-series/change-axis-display.md
+++ b/docs/sources/visualizations/time-series/change-axis-display.md
@@ -1,7 +1,7 @@
 +++
 title = "Change axis display"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/change-axis-display/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/change-axis-display/"]
 weight = 400
 +++
 

--- a/docs/sources/visualizations/time-series/graph-color-scheme.md
+++ b/docs/sources/visualizations/time-series/graph-color-scheme.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph and color schemes "
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/graph-color-scheme/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/graph-color-scheme/"]
 weight = 400
 +++
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-bars.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-bars.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph time series as bars"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/graph-time-series-as-bars/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/graph-time-series-as-bars/"]
 weight = 200
 +++
 
@@ -133,9 +133,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/bar-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Bar graph examples
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-lines.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-lines.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph time series as lines"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/graph-time-series-as-lines/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/graph-time-series-as-lines/"]
 weight = 200
 +++
 
@@ -201,9 +201,9 @@ Never show the points.
 
 ![Show points point never example](/static/img/docs/time-series-panel/line-graph-show-points-never-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Fill below to
 

--- a/docs/sources/visualizations/time-series/graph-time-series-as-points.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-as-points.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph time series as points"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases = ["/docs/grafana/latest/panels/visualizations/time-series/graph-time-series-as-points/"]
+aliases = ["/docs/grafana/v8.2/panels/visualizations/time-series/graph-time-series-as-points/"]
 weight = 300
 +++
 
@@ -37,6 +37,6 @@ Point size set to 35:
 
 ![Show points point size 35 example](/static/img/docs/time-series-panel/points-graph-show-points-35-7-4.png)
 
-{{< docs/shared "visualizations/stack-series-link.md" >}}
+{{< docs/shared lookup="visualizations/stack-series-link.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared "visualizations/change-axis-link.md" >}}
+{{< docs/shared lookup="visualizations/change-axis-link.md" source="grafana" version="<GRAFANA VERSION>" >}}

--- a/docs/sources/visualizations/time-series/graph-time-series-stacking.md
+++ b/docs/sources/visualizations/time-series/graph-time-series-stacking.md
@@ -1,7 +1,7 @@
 +++
 title = "Graph stacked time series"
 keywords = ["grafana", "time series panel", "documentation", "guide", "graph"]
-aliases =["/docs/grafana/latest/features/panels/histogram/", "/docs/grafana/latest/panels/visualizations/time-series/graph-time-series-stacking/"]
+aliases =["/docs/grafana/v8.2/features/panels/histogram/", "/docs/grafana/v8.2/panels/visualizations/time-series/graph-time-series-stacking/"]
 weight = 400
 +++
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "What's new"
-aliases = ["/docs/grafana/latest/guides/"]
+aliases = ["/docs/grafana/v8.2/guides/"]
 weight = 1
 +++
 

--- a/docs/sources/whatsnew/whats-new-in-v2-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.0"
 description = "Feature and improvement highlights for Grafana v2.0"
 keywords = ["grafana", "new", "documentation", "2.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v2/"]
 weight = -1
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.1"
 description = "Feature and improvement highlights for Grafana v2.1"
 keywords = ["grafana", "new", "documentation", "2.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v2-1/"]
 weight = -2
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.5"
 description = "Feature and improvement highlights for Grafana v2.5"
 keywords = ["grafana", "new", "documentation", "2.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-5/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v2-5/"]
 weight = -3
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v2-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v2.6"
 description = "Feature and improvement highlights for Grafana v2.6"
 keywords = ["grafana", "new", "documentation", "2.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v2-6/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v2-6/"]
 weight = -4
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v3-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v3-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v3.0"
 description = "Feature and improvement highlights for Grafana v3.0"
 keywords = ["grafana", "new", "documentation", "3.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v3/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v3/"]
 weight = -5
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v3-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v3-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v3.1"
 description = "Feature and improvement highlights for Grafana v3.1"
 keywords = ["grafana", "new", "documentation", "3.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v3-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v3-1/"]
 weight = -6
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.0"
 description = "Feature and improvement highlights for Grafana v4.0"
 keywords = ["grafana", "new", "documentation", "4.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4/"]
 weight = -7
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.1"
 description = "Feature and improvement highlights for Grafana v4.1"
 keywords = ["grafana", "new", "documentation", "4.1.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-1/"]
 weight = -8
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.2"
 description = "Feature and improvement highlights for Grafana v4.2"
 keywords = ["grafana", "new", "documentation", "4.2.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-2/"]
 weight = -9
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.3"
 description = "Feature and improvement highlights for Grafana v4.3"
 keywords = ["grafana", "new", "documentation", "4.3.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-3/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-3/"]
 weight = -10
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.4"
 description = "Feature and improvement highlights for Grafana v4.4"
 keywords = ["grafana", "new", "documentation", "4.4.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-4/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-4/"]
 weight = -11
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.5"
 description = "Feature and improvement highlights for Grafana v4.5"
 keywords = ["grafana", "new", "documentation", "4.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-5/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-5/"]
 weight = -12
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v4-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v4-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v4.6"
 description = "Feature and improvement highlights for Grafana v4.6"
 keywords = ["grafana", "new", "documentation", "4.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v4-6/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v4-6/"]
 weight = -13
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.0"
 description = "Feature and improvement highlights for Grafana v5.0"
 keywords = ["grafana", "new", "documentation", "5.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v5/"]
 weight = -14
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.1"
 description = "Feature and improvement highlights for Grafana v5.1"
 keywords = ["grafana", "new", "documentation", "5.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v5-1/"]
 weight = -15
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.2"
 description = "Feature and improvement highlights for Grafana v5.2"
 keywords = ["grafana", "new", "documentation", "5.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v5-2/"]
 weight = -16
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.3"
 description = "Feature and improvement highlights for Grafana v5.3"
 keywords = ["grafana", "new", "documentation", "5.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-3/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v5-3/"]
 weight = -17
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v5-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v5.4"
 description = "Feature and improvement highlights for Grafana v5.4"
 keywords = ["grafana", "new", "documentation", "5.4", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v5-4/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v5-4/"]
 weight = -18
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-0.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.0"
 description = "Feature and improvement highlights for Grafana v6.0"
 keywords = ["grafana", "new", "documentation", "6.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-0/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-0/"]
 weight = -19
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-1.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.1"
 description = "Feature and improvement highlights for Grafana v6.1"
 keywords = ["grafana", "new", "documentation", "6.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-1/"]
 weight = -20
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-2.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.2"
 description = "Feature and improvement highlights for Grafana v6.2"
 keywords = ["grafana", "new", "documentation", "6.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-2/"]
 weight = -21
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-3.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.3"
 description = "Feature and improvement highlights for Grafana v6.3"
 keywords = ["grafana", "new", "documentation", "6.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-3/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-3/"]
 weight = -22
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-4.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.4"
 description = "Feature and improvement highlights for Grafana v6.4"
 keywords = ["grafana", "new", "documentation", "6.4", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-4/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-4/"]
 weight = -23
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-5.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.5"
 description = "Feature and improvement highlights for Grafana v6.5"
 keywords = ["grafana", "new", "documentation", "6.5", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-5/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-5/"]
 weight = -24
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-6.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-6.md
@@ -2,7 +2,7 @@
 title = "What's new in Grafana v6.6"
 description = "Feature and improvement highlights for Grafana v6.6"
 keywords = ["grafana", "new", "documentation", "6.6", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-6/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-6/"]
 weight = -25
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v6-7.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-7.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v6.7"
 description = "Feature and improvement highlights for Grafana v6.7"
 keywords = ["grafana", "new", "documentation", "6.7", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v6-7/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v6-7/"]
 weight = -26
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.0"
 description = "Feature and improvement highlights for Grafana v7"
 keywords = ["grafana", "new", "documentation", "7.0", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-0/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-0/"]
 weight = -27
 [_build]
 list = false
@@ -130,7 +130,7 @@ In Grafana 7.0 we are maturing our panel and front-end datasource plugins platfo
 
 Plugins can use the same React components that the Grafana team uses to build Grafana. Using these components means the Grafana team will support and improve them continually and make your plugin as polished as the rest of Grafana’s UI. The new [`@grafana/ui` components library](https://developers.grafana.com/ui) is documented with Storybook (visual documentation) and is available on NPM.
 
-The `@grafana/data`, `@grafana/runtime`, `@grafana/e2e packages` (also available via NPM) aim to simplify the way plugins are developed. We want to deliver a set of [reliable APIs](https://grafana.com/docs/grafana/latest/packages_api/) for plugin developers.
+The `@grafana/data`, `@grafana/runtime`, `@grafana/e2e packages` (also available via NPM) aim to simplify the way plugins are developed. We want to deliver a set of [reliable APIs](https://grafana.com/docs/grafana/v8.2/packages_api/) for plugin developers.
 
 With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are delivering a simple CLI that helps plugin authors quickly scaffold, develop and test their plugins without worrying about configuration details. A plugin author no longer needs to be a grunt or webpack expert to build their plugin.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
+Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
 
 ### Front end plugins platform
 
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -136,7 +136,7 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
+Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
 
 ### Front end plugins platform
 
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go]({{< relref "../developers/plugins/backend/grafana-plugin-sdk-for-go.md" >}}) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -66,7 +66,7 @@ For users with large dashboards or with heavy queries, being able to reuse the q
 
 The [Google Sheets data source](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource) that was published a few weeks ago works really well together with the transformations feature.
 
-We are also introducing a new shared data model for both time series and table data that we call [DataFrame]({{< relref "../developers/plugins/data-frames/#data-frames" >}}). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
+We are also introducing a new shared data model for both time series and table data that we call [DataFrame](https://grafana.com/developers/plugin-tools/introduction/data-frames). A DataFrame is like a table with columns but we refer to columns as fields. A time series is a DataFrame with two fields (time & value).
 
 **Transformations shipping in 7.0**
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -136,13 +136,13 @@ With [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) we are d
 
 ### Support for backend plugins
 
-Grafana now officially supports [backend plugins]({{< relref "../developers/plugins/backend/_index.md" >}}) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
+Grafana now officially supports [backend plugins](https://grafana.com/developers/plugin-tools/introduction/backend-plugins) and the first type of plugin to be introduced is a backend component for data source plugins. You can optionally add a backend component to your data source plugin and implement the query logic there to automatically enable alerting in Grafana for your plugin. In the 7.0 release, we introduce the [Grafana Plugin SDK for Go](https://grafana.com/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go) that enables and simplifies building a backend plugin in [Go](https://golang.org/).
 
 Plugins can be monitored with the new metrics and health check capabilities. The new Resources capability means backend components can return non-time series data like JSON or static resources like images and opens up Grafana for new use cases.
 
 With this release, we are deprecating the unofficial first version of backend plugins which will be removed in a future release.
 
-To learn more, start with the [overview]({{< relref "../developers/plugins/backend/_index.md" >}}). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
+To learn more, start with the [overview](https://grafana.com/developers/plugin-tools/introduction/backend-plugins). Next, in this [tutorial](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) you'll learn how to build a backend for a data source plugin and enable it for use with [Grafana Alerting]({{< relref "../alerting/_index.md" >}}). Make sure to keep an eye out for additional documentation and tutorials that will be published after the Grafana v7.0 release.
 
 ## New tutorials
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -120,9 +120,9 @@ Grafana 7.0 adds logging support to one of our most popular cloud provider data 
 
 ## Plugins platform
 
-The [platform for plugins]({{< relref "../developers/plugins/" >}}) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
+The [platform for plugins](https://grafana.com/developers/plugin-tools) has been completely re-imagined and provides ready-made components and tooling to help both inexperienced and experienced developers get up and running more quickly. The tooling, documentation, and new components will improve plugin quality and reduce long-term maintenance. We are already seeing that a high quality plugin with the Grafana look and feel can be written in much fewer lines of code than previously.
 
-Learn more about developing plugins in the new framework in [Build a plugin]({{< relref "../developers/plugins/_index.md" >}}).
+Learn more about developing plugins in the new framework in [Build a plugin](https://grafana.com/developers/plugin-tools).
 
 ### Front end plugins platform
 

--- a/docs/sources/whatsnew/whats-new-in-v7-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-1.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.1"
 description = "Feature and improvement highlights for Grafana v7.1"
 keywords = ["grafana", "new", "documentation", "7.1", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-1/"]
 weight = -28
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-2.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.2"
 description = "Feature and improvement highlights for Grafana v7.2"
 keywords = ["grafana", "new", "documentation", "7.2", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-2/"]
 weight = -29
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-3.md
@@ -2,7 +2,7 @@
 title = "What's New in Grafana v7.3"
 description = "Feature and improvement highlights for Grafana v7.3"
 keywords = ["grafana", "new", "documentation", "7.3", "release notes"]
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-3/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-3/"]
 weight = -30
 [_build]
 list = false

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -3,7 +3,7 @@ title = "What's New in Grafana v7.4"
 description = "Feature and improvement highlights for Grafana v7.4"
 keywords = ["grafana", "new", "documentation", "7.4", "release notes"]
 weight = -31
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-4/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-4/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -172,7 +172,7 @@ The feature previously referred to as DataSource Start Pages or Cheat Sheets has
 
 [Queries]({{< relref "../panels/queries.md" >}}) was updated as a result of this feature.
 
-For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-query-editor-help).
+For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component]({{< relref "../developers/plugins/add-query-editor-help.md" >}}).
 
 ### Variable inspector
 

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -172,7 +172,7 @@ The feature previously referred to as DataSource Start Pages or Cheat Sheets has
 
 [Queries]({{< relref "../panels/queries.md" >}}) was updated as a result of this feature.
 
-For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component]({{< relref "../developers/plugins/add-query-editor-help.md" >}}).
+For more information on adding a query editor help component to your plugin, refer to [Add a query editor help component](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/add-query-editor-help).
 
 ### Variable inspector
 

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v7.5"
 description = "Feature and improvement highlights for Grafana v7.5"
 keywords = ["grafana", "new", "documentation", "7.5", "release notes"]
 weight = -32
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-5/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v7-5/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v8.0"
 description = "Feature and improvement highlights for Grafana v8.0"
 keywords = ["grafana", "new", "documentation", "8.0", "release notes"]
 weight = -33
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v8-0/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v8-0/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v8-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-1.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v8.1"
 description = "Feature and improvement highlights for Grafana v8.1"
 keywords = ["grafana", "new", "documentation", "8.1", "release notes"]
 weight = -33
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v8-1/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v8-1/"]
 [_build]
 list = false
 +++

--- a/docs/sources/whatsnew/whats-new-in-v8-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-2.md
@@ -3,7 +3,7 @@ title = "What's new in Grafana v8.2"
 description = "Feature and improvement highlights for Grafana v8.2"
 keywords = ["grafana", "new", "documentation", "8.2", "release notes"]
 weight = -33
-aliases = ["/docs/grafana/latest/guides/whats-new-in-v8-2/"]
+aliases = ["/docs/grafana/v8.2/guides/whats-new-in-v8-2/"]
 [_build]
 list = false
 +++
@@ -22,7 +22,7 @@ We’ve summarized what’s new in the release here, but you might also be inter
 
 ## Community Contributions
 
-Grafana 8.2 includes a number of important community contributions including support for OAuth role mapping with GitLab accounts ([#30025](https://github.com/grafana/grafana/pull/30025)), a new wide-to-long function ([#38670](https://github.com/grafana/grafana/pull/38670)) included in the [prepare time series transformation](https://grafana.com/docs/grafana/latest/panels/transformations/types-options/#prepare-time-series). A number of additions to the Azure Monitor data source were submitted, including an overview dashboard([#38801](https://github.com/grafana/grafana/pull/38801)) and support for parsing numeric fields in the Azure Resource Graph([#38728](https://github.com/grafana/grafana/pull/38728)). Contributions also included [regular-expression based value mapping](https://grafana.com/docs/grafana/next/panels/value-mappings/#map-a-regular-expression) ([#38931](https://github.com/grafana/grafana/pull/38931)) and improvements to our systemd unit for Grafana installations ([#38109](https://github.com/grafana/grafana/pull/38109)). This list is by no means exhaustive or comprehensive. We greatly appreciate _all_ the contributions submitted for inclusion in Grafana.
+Grafana 8.2 includes a number of important community contributions including support for OAuth role mapping with GitLab accounts ([#30025](https://github.com/grafana/grafana/pull/30025)), a new wide-to-long function ([#38670](https://github.com/grafana/grafana/pull/38670)) included in the [prepare time series transformation](https://grafana.com/docs/grafana/v8.2/panels/transformations/types-options/#prepare-time-series). A number of additions to the Azure Monitor data source were submitted, including an overview dashboard([#38801](https://github.com/grafana/grafana/pull/38801)) and support for parsing numeric fields in the Azure Resource Graph([#38728](https://github.com/grafana/grafana/pull/38728)). Contributions also included [regular-expression based value mapping](https://grafana.com/docs/grafana/next/panels/value-mappings/#map-a-regular-expression) ([#38931](https://github.com/grafana/grafana/pull/38931)) and improvements to our systemd unit for Grafana installations ([#38109](https://github.com/grafana/grafana/pull/38109)). This list is by no means exhaustive or comprehensive. We greatly appreciate _all_ the contributions submitted for inclusion in Grafana.
 
 ## Accessibility
 
@@ -30,7 +30,7 @@ We’ve taken our first, measured but important step towards improving the acces
 
 ## Dashboards
 
-The biggest change to dashboards in Grafana 8.2 is the inclusion of a configurable fiscal year in the time picker. This option enables fiscal quarters as time ranges, which can be helpful for business-focused and executive dashboards in addition to many other common use cases. Please see the [time range controls documentation](https://grafana.com/docs/grafana/latest/dashboards/time-range-controls/) for more information.
+The biggest change to dashboards in Grafana 8.2 is the inclusion of a configurable fiscal year in the time picker. This option enables fiscal quarters as time ranges, which can be helpful for business-focused and executive dashboards in addition to many other common use cases. Please see the [time range controls documentation](https://grafana.com/docs/grafana/v8.2/dashboards/time-range-controls/) for more information.
 
 {{< figure src="/static/img/docs/time-range-controls/fiscal_year-8-2.png" max-width="1200px" caption="Fiscal Year Time Range Settings" >}}
 
@@ -42,7 +42,7 @@ We have continued to improve how you manage your plugins within Grafana. The new
 
 ## Grafana 8 Alerting
 
-We’ve continued to bolster the new, unified alerting system launched in Grafana 8. This update includes the addition of a UI to edit the Cortex/Loki namespace, edit the alert group name, and edit the alert group evaluation interval. We've also added a Test button to test an alert notification contact point. There's even more to explore here including custom grouping for alert manager notifications and several small but significant changes to improve creation editing and managing alert rules. Please see the [alerting documentation](https://grafana.com/docs/grafana/latest/alerting/unified-alerting/) for more details and information on how you can enable the unified alerting system in your instance of Grafana.
+We’ve continued to bolster the new, unified alerting system launched in Grafana 8. This update includes the addition of a UI to edit the Cortex/Loki namespace, edit the alert group name, and edit the alert group evaluation interval. We've also added a Test button to test an alert notification contact point. There's even more to explore here including custom grouping for alert manager notifications and several small but significant changes to improve creation editing and managing alert rules. Please see the [alerting documentation](https://grafana.com/docs/grafana/v8.2/alerting/unified-alerting/) for more details and information on how you can enable the unified alerting system in your instance of Grafana.
 
 ## Image Renderer performance improvements and measurement
 
@@ -52,24 +52,24 @@ You can use Grafana’s image renderer to generate images of panels and dashboar
 
 ## Brand-new license and stats screen
 
-We’ve revamped the Stats and License sections of Grafana for administrators. The new combined screen makes it easier to understand a license’s term and user counts, and find out early when you need to renew or expand a license. It’s also easier to parse Grafana statistics like the number of dashboards, data sources, and alerts in a given instance. This screen also includes an interactive list of dashboard and folder permissions, which can affect your users’ licensed roles in Grafana. Learn more about Grafana Enterprise on our [website](https://grafana.com/products/enterprise/grafana/), and more about licenses in particular in our [docs](https://grafana.com/docs/grafana/latest/enterprise/license/license-restrictions/).
+We’ve revamped the Stats and License sections of Grafana for administrators. The new combined screen makes it easier to understand a license’s term and user counts, and find out early when you need to renew or expand a license. It’s also easier to parse Grafana statistics like the number of dashboards, data sources, and alerts in a given instance. This screen also includes an interactive list of dashboard and folder permissions, which can affect your users’ licensed roles in Grafana. Learn more about Grafana Enterprise on our [website](https://grafana.com/products/enterprise/grafana/), and more about licenses in particular in our [docs](https://grafana.com/docs/grafana/v8.2/enterprise/license/license-restrictions/).
 
 {{< figure src="/static/img/docs/enterprise/8_2_stats_licensing_screen.png" max-width="1200px" caption="Stats and licensing" >}}
 
 ## New fine-grained access control permissions
 
-Fine-grained access control now covers data source and provisioning permissions. You can decide which roles (Viewers, Editors, and Admins) can manage data sources and data source permissions in Grafana, and which roles can reload provisioning configuration for dashboards, data sources, and other provisioned resources. We’ll continue adding fine-grained access control to more Grafana services, like dashboards and API Keys, in upcoming releases. Learn more about fine-grained access control in our [release post](https://grafana.com/blog/2021/06/23/new-in-grafana-enterprise-8.0-fine-grained-access-control-for-reporting-and-user-management/) and our [docs](https://grafana.com/docs/grafana/latest/enterprise/access-control/).
+Fine-grained access control now covers data source and provisioning permissions. You can decide which roles (Viewers, Editors, and Admins) can manage data sources and data source permissions in Grafana, and which roles can reload provisioning configuration for dashboards, data sources, and other provisioned resources. We’ll continue adding fine-grained access control to more Grafana services, like dashboards and API Keys, in upcoming releases. Learn more about fine-grained access control in our [release post](https://grafana.com/blog/2021/06/23/new-in-grafana-enterprise-8.0-fine-grained-access-control-for-reporting-and-user-management/) and our [docs](https://grafana.com/docs/grafana/v8.2/enterprise/access-control/).
 
 {{< figure src="/static/img/docs/enterprise/8_2_data_source_permissions.png" max-width="1200px" caption="Stats and licensing" >}}
 
 ## Export usage insights logs as server logs
 
-Usage Insights Logs contain valuable information about user dashboard visits, queries, and front-end errors that are otherwise impossible to track in Grafana. You can now export those logs alongside your regular server logs to identify problematic dashboards and data sources and improve users’ experience with Grafana. Previously, these metrics could only be exported directly to Loki. Learn more in the [documentation about exporting logs](https://grafana.com/docs/grafana/latest/enterprise/usage-insights/export-logs/)
+Usage Insights Logs contain valuable information about user dashboard visits, queries, and front-end errors that are otherwise impossible to track in Grafana. You can now export those logs alongside your regular server logs to identify problematic dashboards and data sources and improve users’ experience with Grafana. Previously, these metrics could only be exported directly to Loki. Learn more in the [documentation about exporting logs](https://grafana.com/docs/grafana/v8.2/enterprise/usage-insights/export-logs/)
 
 {{< figure src="/static/img/docs/enterprise/8_2_export_usage_insights.png" max-width="1200px" caption="Stats and licensing" >}}
 
 ## Create a report from the dashboard Share dialogue
 
-Reports offer a powerful way to deliver insights directly to your email inboxes. Now you can create a report directly from any dashboard, using the Share button. This is especially useful when combined with fine-grained access control, which you can use to grant Editors or Viewers the ability to create reports in Grafana. To learn more, see the [reporting documentation](https://grafana.com/docs/grafana/latest/enterprise/reporting/).
+Reports offer a powerful way to deliver insights directly to your email inboxes. Now you can create a report directly from any dashboard, using the Share button. This is especially useful when combined with fine-grained access control, which you can use to grant Editors or Viewers the ability to create reports in Grafana. To learn more, see the [reporting documentation](https://grafana.com/docs/grafana/v8.2/enterprise/reporting/).
 
 {{< figure src="/static/img/docs/enterprise/enterprise-report-from-share-8-2.png" max-width="1200px" caption="Create a report from the dashboard share dialogue" >}}


### PR DESCRIPTION
We can choose not to merge this if we like as it is clear from the bigger than expected diff that this version of docs is now maintained in the website repository rather than here.

Links have been checked in https://github.com/grafana/website/pull/15588.

