### PR TITLE
Explore: Improve timeseries limit disclaimer

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3825,10 +3825,9 @@ exports[`better eslint`] = {
     "public/app/features/explore/FlameGraph/FlameGraphExploreContainer.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
-    "public/app/features/explore/Graph/ExploreGraph.tsx:5381": [
+    "public/app/features/explore/Graph/GraphContainer.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"]
+      [0, 0, 0, "Styles should be written using objects.", "1"]
     ],
     "public/app/features/explore/LiveTailButton.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -3825,10 +3825,6 @@ exports[`better eslint`] = {
     "public/app/features/explore/FlameGraph/FlameGraphExploreContainer.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
-    "public/app/features/explore/Graph/GraphContainer.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"]
-    ],
     "public/app/features/explore/LiveTailButton.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import { identity } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -11,7 +10,6 @@ import {
   FieldColorModeId,
   FieldConfigSource,
   getFrameDisplayName,
-  GrafanaTheme2,
   LoadingState,
   SplitOpen,
   TimeZone,
@@ -27,15 +25,7 @@ import {
   SortOrder,
   GraphThresholdsStyleConfig,
 } from '@grafana/schema';
-import {
-  Button,
-  Icon,
-  PanelContext,
-  PanelContextProvider,
-  SeriesVisibilityChangeMode,
-  useStyles2,
-  useTheme2,
-} from '@grafana/ui';
+import { PanelContext, PanelContextProvider, SeriesVisibilityChangeMode, useTheme2 } from '@grafana/ui';
 import { GraphFieldConfig } from 'app/plugins/panel/graph/types';
 import { defaultGraphConfig, getGraphFieldConfig } from 'app/plugins/panel/timeseries/config';
 import { Options as TimeSeriesOptions } from 'app/plugins/panel/timeseries/panelcfg.gen';
@@ -47,7 +37,7 @@ import { useExploreDataLinkPostProcessor } from '../hooks/useExploreDataLinkPost
 import { applyGraphStyle, applyThresholdsConfig } from './exploreGraphStyleUtils';
 import { useStructureRev } from './useStructureRev';
 
-const MAX_NUMBER_OF_TIME_SERIES = 20;
+export const MAX_NUMBER_OF_TIME_SERIES = 20;
 
 interface Props {
   data: DataFrame[];
@@ -67,6 +57,7 @@ interface Props {
   thresholdsConfig?: ThresholdsConfig;
   thresholdsStyle?: GraphThresholdsStyleConfig;
   eventBus: EventBus;
+  showAllTimeSeries: boolean;
 }
 
 export function ExploreGraph({
@@ -87,10 +78,9 @@ export function ExploreGraph({
   thresholdsConfig,
   thresholdsStyle,
   eventBus,
+  showAllTimeSeries,
 }: Props) {
   const theme = useTheme2();
-  const style = useStyles2(getStyles);
-  const [showAllTimeSeries, setShowAllTimeSeries] = useState(false);
 
   const timeRange = useMemo(
     () => ({
@@ -198,20 +188,6 @@ export function ExploreGraph({
 
   return (
     <PanelContextProvider value={panelContext}>
-      {data.length > MAX_NUMBER_OF_TIME_SERIES && !showAllTimeSeries && (
-        <div className={style.timeSeriesDisclaimer}>
-          <Icon className={style.disclaimerIcon} name="exclamation-triangle" />
-          Showing only {MAX_NUMBER_OF_TIME_SERIES} time series.
-          <Button
-            variant="primary"
-            fill="text"
-            onClick={() => setShowAllTimeSeries(true)}
-            className={style.showAllButton}
-          >
-            Show all {data.length}
-          </Button>
-        </div>
-      )}
       <PanelRenderer
         data={{
           series: dataWithConfig,
@@ -231,20 +207,3 @@ export function ExploreGraph({
     </PanelContextProvider>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  timeSeriesDisclaimer: css`
-    label: time-series-disclaimer;
-    margin: ${theme.spacing(1)} auto;
-    padding: 10px 0;
-    text-align: center;
-  `,
-  disclaimerIcon: css`
-    label: disclaimer-icon;
-    color: ${theme.colors.warning.main};
-    margin-right: ${theme.spacing(0.5)};
-  `,
-  showAllButton: css`
-    margin-left: ${theme.spacing(0.5)};
-  `,
-});

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -111,16 +111,16 @@ export const GraphContainer = ({
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  timeSeriesDisclaimer: css`
-    label: time-series-disclaimer;
-    text-align: center;
-    font-size: ${theme.typography.bodySmall.fontSize};
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(0.5)};
-  `,
-  disclaimerIcon: css`
-    label: disclaimer-icon;
-    color: ${theme.colors.warning.main};
-  `,
+  timeSeriesDisclaimer: css({
+    label: 'time-series-disclaimer',
+    textSlign: 'center',
+    fontSize: theme.typography.bodySmall.fontSize,
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  }),
+  disclaimerIcon: css({
+    label: 'disclaimer-icon',
+    color: theme.colors.warning.main,
+  }),
 });

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -73,7 +73,7 @@ export const GraphContainer = ({
       titleItems={[
         MAX_NUMBER_OF_TIME_SERIES < data.length && !showAllTimeSeries && (
           <div key="disclaimer" className={styles.timeSeriesDisclaimer}>
-            <Tooltip content="Showing only 20 time series">
+            <Tooltip content={`Showing only ${MAX_NUMBER_OF_TIME_SERIES} time series`}>
               <Icon className={styles.disclaimerIcon} name="exclamation-triangle" />
             </Tooltip>
             <Button variant="secondary" size="sm" onClick={() => setShowAllTimeSeries(true)}>

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import React, { useCallback, useState } from 'react';
 
 import {
@@ -8,13 +9,22 @@ import {
   SplitOpen,
   LoadingState,
   ThresholdsConfig,
+  GrafanaTheme2,
 } from '@grafana/data';
-import { GraphThresholdsStyleConfig, PanelChrome, PanelChromeProps } from '@grafana/ui';
+import {
+  GraphThresholdsStyleConfig,
+  PanelChrome,
+  PanelChromeProps,
+  Icon,
+  Button,
+  useStyles2,
+  Tooltip,
+} from '@grafana/ui';
 import { ExploreGraphStyle } from 'app/types';
 
 import { storeGraphStyle } from '../state/utils';
 
-import { ExploreGraph } from './ExploreGraph';
+import { ExploreGraph, MAX_NUMBER_OF_TIME_SERIES } from './ExploreGraph';
 import { ExploreGraphLabel } from './ExploreGraphLabel';
 import { loadGraphStyle } from './utils';
 
@@ -48,7 +58,9 @@ export const GraphContainer = ({
   loadingState,
   statusMessage,
 }: Props) => {
+  const [showAllTimeSeries, setShowAllTimeSeries] = useState(false);
   const [graphStyle, setGraphStyle] = useState(loadGraphStyle);
+  const styles = useStyles2(getStyles);
 
   const onGraphStyleChange = useCallback((graphStyle: ExploreGraphStyle) => {
     storeGraphStyle(graphStyle);
@@ -58,6 +70,18 @@ export const GraphContainer = ({
   return (
     <PanelChrome
       title="Graph"
+      titleItems={[
+        MAX_NUMBER_OF_TIME_SERIES < data.length && !showAllTimeSeries && (
+          <div key="disclaimer" className={styles.timeSeriesDisclaimer}>
+            <Tooltip content="Showing only 20 time series">
+              <Icon className={styles.disclaimerIcon} name="exclamation-triangle" />
+            </Tooltip>
+            <Button variant="secondary" size="sm" onClick={() => setShowAllTimeSeries(true)}>
+              Show all {data.length} series
+            </Button>
+          </div>
+        ),
+      ].filter(Boolean)}
       width={width}
       height={height}
       loadingState={loadingState}
@@ -79,8 +103,24 @@ export const GraphContainer = ({
           thresholdsConfig={thresholdsConfig}
           thresholdsStyle={thresholdsStyle}
           eventBus={eventBus}
+          showAllTimeSeries={showAllTimeSeries}
         />
       )}
     </PanelChrome>
   );
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  timeSeriesDisclaimer: css`
+    label: time-series-disclaimer;
+    text-align: center;
+    font-size: ${theme.typography.bodySmall.fontSize};
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacing(0.5)};
+  `,
+  disclaimerIcon: css`
+    label: disclaimer-icon;
+    color: ${theme.colors.warning.main};
+  `,
+});

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -117,7 +117,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(1),
   }),
   disclaimerIcon: css({
     label: 'disclaimer-icon',

--- a/public/app/features/explore/Logs/LogsVolumePanel.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanel.tsx
@@ -80,6 +80,7 @@ export function LogsVolumePanel(props: Props) {
         anchorToZero
         yAxisMaximum={allLogsVolumeMaximum}
         eventBus={props.eventBus}
+        showAllTimeSeries
       />
       {extraInfoComponent && <div className={styles.extraInfoContainer}>{extraInfoComponent}</div>}
     </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Revamps the "Showing only 20 series" disclaimer in Explore:

![Screenshot 2023-09-27 at 18 09 19](https://github.com/grafana/grafana/assets/1170767/1f153051-49a0-44d7-b58d-692e9a08b024)




**Special notes for your reviewer:**

The code is uglier then my hair right now, and the Graph is coupled with the container, but this should unblock https://github.com/grafana/grafana/pull/75499. Will create a follow up issue to do a tiny bit of refactoring as discussed with @gelicia to introduce a `limit` prop the the ExploreGraph (instead of the current solution) so it'll be a bit cleaner

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
