### PR TITLE
chore: Add slack notification to dataviz channel when OSS issues are created

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -9,3 +9,112 @@ test:
 area/alerting:
   channel-label: C028MCV4R7C
   exclude-github-team: alerting-squad
+
+# DataViz squad
+area/dataviz:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/legend:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/barchart:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/bargauge:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/candlestick:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/canvas:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/common:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/common:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/gauge:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/geomap:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/graph:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/heatmap:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/histogram:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/icon:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/icon:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/piechart:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/stat:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/state-timeline:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/status-history:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/timeseries:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/trend:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/xychart:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/panel/xychart:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/tooltip:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/transformations:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/value-mapping:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad
+
+area/units:
+  channel-label: C04J73AAQ87 # grafana-dataviz
+  exclude-github-team: dataviz-squad

--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -39,10 +39,6 @@ area/panel/common:
   channel-label: C04J73AAQ87 # grafana-dataviz
   exclude-github-team: dataviz-squad
 
-area/panel/common:
-  channel-label: C04J73AAQ87 # grafana-dataviz
-  exclude-github-team: dataviz-squad
-
 area/panel/gauge:
   channel-label: C04J73AAQ87 # grafana-dataviz
   exclude-github-team: dataviz-squad
@@ -60,14 +56,6 @@ area/panel/heatmap:
   exclude-github-team: dataviz-squad
 
 area/panel/histogram:
-  channel-label: C04J73AAQ87 # grafana-dataviz
-  exclude-github-team: dataviz-squad
-
-area/panel/icon:
-  channel-label: C04J73AAQ87 # grafana-dataviz
-  exclude-github-team: dataviz-squad
-
-area/panel/icon:
   channel-label: C04J73AAQ87 # grafana-dataviz
   exclude-github-team: dataviz-squad
 
@@ -92,10 +80,6 @@ area/panel/timeseries:
   exclude-github-team: dataviz-squad
 
 area/panel/trend:
-  channel-label: C04J73AAQ87 # grafana-dataviz
-  exclude-github-team: dataviz-squad
-
-area/panel/xychart:
   channel-label: C04J73AAQ87 # grafana-dataviz
   exclude-github-team: dataviz-squad
 


### PR DESCRIPTION
In our daily this morning @leeoniya had a great idea to try and incorporate our slack notification system that we have in place for customer escalations for OSS issues. 

I combed through [Grafana repos 410 labels](https://github.com/grafana/grafana/labels?page=1&sort=name-asc) (not sure why we have so many haha) and added webhooks for all of the labels that our team owns (please let me know if I missed some / put some in incorrectly)

This functionality hasn't been tested so we may risk some spam - I was thinking to first try this in squad channel first and then move it over to our main dataviz channel but yolo 😬 