### PR TITLE
DataLinkButton: Remove icon for target _self

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx
@@ -29,7 +29,12 @@ export function DataLinkButton({ link, buttonProps }: DataLinkButtonProps) {
           : undefined
       }
     >
-      <Button icon="external-link-alt" variant="primary" size="sm" {...buttonProps}>
+      <Button
+        icon={link.target === '_blank' ? 'external-link-alt' : undefined}
+        variant="primary"
+        size="sm"
+        {...buttonProps}
+      >
         {link.title}
       </Button>
     </a>


### PR DESCRIPTION
As discussed with @lukasztyrala, there should be a difference between the data links that open in the same tab vs new tab. `DataLinkButton` component seems to be only used in exemplar markers and I'm reusing it in tooltips.  

![datalinkbutton](https://github.com/grafana/grafana/assets/88068998/1fcea9bf-376e-4e72-b06a-5883a13fd532)


Fixes #71790 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
