### PR TITLE
Alerting docs: remove alertmanager link (#75523)

### DIFF
--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -20,8 +20,6 @@ A mute timing is a recurring interval of time when no new notifications for a po
 
 Similar to silences, mute timings do not prevent alert rules from being evaluated, nor do they stop alert instances from being shown in the user interface. They only prevent notifications from being created.
 
-You can configure Grafana managed mute timings as well as mute timings for an [external Alertmanager data source]({{< relref "/docs/grafana/latest/datasources/alertmanager" >}}). For more information, refer to [Alertmanager documentation]({{< relref "/docs/grafana/latest/alerting/manage-notifications/alertmanager" >}}).
-
 ## Mute timings vs silences
 
 The following table highlights the key differences between mute timings and silences.


### PR DESCRIPTION
Partially reverts https://github.com/grafana/grafana/pull/75585

It included additional changes that reverted some Alerting fixes because I forgot to update the website source before reversing the changes into this repository.