### PR TITLE
Remove duplicate "Legend values" heading

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -79,7 +79,14 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+### Legend values
+
+Select values to display in the legend. You can select more than one.
+
+- **Percent:** The percentage of the whole.
+- **Value:** The raw numerical value.
+
+For more information about the legend, refer to [Configure a legend]{{< relref "../../configure-legend" >}}).
 
 {{% docs/reference %}}
 [Calculation types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -81,15 +81,6 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-### Legend values
-
-Select values to display in the legend. You can select more than one.
-
-- **Percent:** The percentage of the whole.
-- **Value:** The raw numerical value.
-
-For more information about the legend, refer to [Configure a legend](../configure-legend/).
-
 {{% docs/reference %}}
 [Calculation types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"
 [Calculation types]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"


### PR DESCRIPTION
As discussed in the PR conversation, the shared include is not required, and the alternative heading is preferred.

Once backported, this should fix 11 instances of the build error: The "toc" partial detected duplicate heading IDs (legend-values)`

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
