### PR TITLE
AuthN: Implement requester interface for identity

### DIFF
--- a/pkg/services/anonymous/anonimpl/client_test.go
+++ b/pkg/services/anonymous/anonimpl/client_test.go
@@ -62,7 +62,7 @@ func TestAnonymous_Authenticate(t *testing.T) {
 				assert.Equal(t, true, identity.ID == "")
 				assert.Equal(t, tt.org.ID, identity.OrgID)
 				assert.Equal(t, tt.org.Name, identity.OrgName)
-				assert.Equal(t, tt.cfg.AnonymousOrgRole, string(identity.Role()))
+				assert.Equal(t, tt.cfg.AnonymousOrgRole, string(identity.GetOrgRole()))
 			}
 		})
 	}

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -80,9 +80,8 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 }
 
 func (s *Service) hook(ctx context.Context, identity *authn.Identity, _ *authn.Request) error {
-	// FIXME(kalleep): implement identity.Requester for authn.Identity
 	// FIXME(kalleep): we should probably lazy load this
-	token, err := s.SignIdentity(ctx, identity.SignedInUser())
+	token, err := s.SignIdentity(ctx, identity)
 	if err != nil {
 		namespace, id := identity.NamespacedID()
 		s.logger.Error("Failed to sign id token", "err", err, "namespace", namespace, "id", id)

--- a/pkg/services/authn/authnimpl/sync/permission_sync.go
+++ b/pkg/services/authn/authnimpl/sync/permission_sync.go
@@ -30,8 +30,7 @@ func (s *PermissionsSync) SyncPermissionsHook(ctx context.Context, identity *aut
 		return nil
 	}
 
-	permissions, err := s.ac.GetUserPermissions(ctx, identity.SignedInUser(),
-		accesscontrol.Options{ReloadCache: false})
+	permissions, err := s.ac.GetUserPermissions(ctx, identity, accesscontrol.Options{ReloadCache: false})
 	if err != nil {
 		s.log.FromContext(ctx).Error("Failed to fetch permissions from db", "error", err, "user_id", identity.ID)
 		return errSyncPermissionsForbidden

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -184,6 +184,7 @@ func (i *Identity) IsNil() bool {
 }
 
 // NamespacedID returns the namespace, e.g. "user" and the id for that namespace
+// FIXME(kalleep): Replace with GetNamespacedID
 func (i *Identity) NamespacedID() (string, int64) {
 	split := strings.Split(i.ID, ":")
 	if len(split) != 2 {
@@ -221,16 +222,16 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 
 	namespace, id := i.GetNamespacedID()
 	if namespace == NamespaceAPIKey {
-		u.ApiKeyID = IntIdentifier(id)
+		u.ApiKeyID = intIdentifier(id)
 	} else {
-		u.UserID = IntIdentifier(id)
+		u.UserID = intIdentifier(id)
 		u.IsServiceAccount = namespace == NamespaceServiceAccount
 	}
 
 	return u
 }
 
-func IntIdentifier(identifier string) int64 {
+func intIdentifier(identifier string) int64 {
 	id, err := strconv.ParseInt(identifier, 10, 64)
 	if err != nil {
 		// FIXME (kalleep): Improve error handling
@@ -246,7 +247,7 @@ func (i *Identity) ExternalUserInfo() login.ExternalUserInfo {
 		OAuthToken:     i.OAuthToken,
 		AuthModule:     i.AuthenticatedBy,
 		AuthId:         i.AuthID,
-		UserId:         IntIdentifier(id),
+		UserId:         intIdentifier(id),
 		Email:          i.Email,
 		Login:          i.Login,
 		Name:           i.Name,


### PR DESCRIPTION
**What is this feature?**
Implement `identity.Requester` for `authn.Idenitity` so we can pass that struct directly instead of first converting it to a `user.SignedInUser`

Left a fixme for replacing the usage of NamespacedID in favor of GetNamespacedID


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
