### PR TITLE
Transformations: Correct description of rename by regex.

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -741,7 +741,8 @@ const getTransformationsRedesignDescriptions = (id: string): string => {
     [DataTransformerID.partitionByValues]: 'Splits a one-frame dataset into multiple series.',
     [DataTransformerID.prepareTimeSeries]: 'Will stretch data frames from the wide format into the long format.',
     [DataTransformerID.reduce]: 'Reduce all rows or data points to a single value (ex. max, mean).',
-    [DataTransformerID.renameByRegex]: 'Reduce all rows or data points to a single value (ex. max, mean).',
+    [DataTransformerID.renameByRegex]:
+      'Renames part of the query result by using regular expression with placeholders.',
     [DataTransformerID.seriesToRows]: 'Merge multiple series. Return time, metric and values as a row.',
   };
 

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -742,7 +742,7 @@ const getTransformationsRedesignDescriptions = (id: string): string => {
     [DataTransformerID.prepareTimeSeries]: 'Will stretch data frames from the wide format into the long format.',
     [DataTransformerID.reduce]: 'Reduce all rows or data points to a single value (ex. max, mean).',
     [DataTransformerID.renameByRegex]:
-      'Renames part of the query result by using regular expression with placeholders.',
+      'Rename parts of the query results using a regular expression and replacement pattern.',
     [DataTransformerID.seriesToRows]: 'Merge multiple series. Return time, metric and values as a row.',
   };
 


### PR DESCRIPTION
**What is this feature?**
The description for rename by regex was probably copied from reduce
Before:
![image](https://github.com/grafana/grafana/assets/468940/b1ca5682-e0f8-4357-b1df-5a8ea170d767)
After:
![image](https://github.com/grafana/grafana/assets/468940/d80fd91d-4f4a-4b53-9a0a-f03e5b1f6cb8)

This gives the rename by regex transformation it's own unique description.

Fixes: #74297