### PR TITLE
Transformations: Add naming mode to partition by value.

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -766,8 +766,8 @@ With the _Partition by values_ transformer, you can now issue a single query and
 
 There are two naming modes:
 
-- **As labels -** The value that is partitioned by will be set as a label.
-- **As frame name-** The value will be used to set the frame name, this is useful if the data will be visualized in a table.
+- **As labels** - The value that results are partitioned by is set as a label.
+- **As frame name**  - The value is used to set the frame name. This is useful if the data will be visualized in a table.
 
 ### Reduce
 

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -767,7 +767,7 @@ With the _Partition by values_ transformer, you can now issue a single query and
 There are two naming modes:
 
 - **As labels** - The value that results are partitioned by is set as a label.
-- **As frame name**  - The value is used to set the frame name. This is useful if the data will be visualized in a table.
+- **As frame name** - The value is used to set the frame name. This is useful if the data will be visualized in a table.
 
 ### Reduce
 

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -764,6 +764,11 @@ With the _Partition by values_ transformer, you can now issue a single query and
 | 2022-10-20 12:00:00 | EU     | 2936  |
 | 2022-10-20 01:00:00 | EU     | 912   |
 
+There are two naming modes:
+
+- **As labels -** The value that is partitioned by will be set as a label.
+- **As frame name-** The value will be used to set the frame name, this is useful if the data will be visualized in a table.
+
 ### Reduce
 
 The _Reduce_ transformation applies a calculation to each field in the frame and return a single value. Time fields are removed when applying this transformation.

--- a/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
+++ b/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
@@ -8,7 +8,15 @@ import {
   SelectableValue,
   TransformerCategory,
 } from '@grafana/data';
-import { InlineField, InlineFieldRow, ValuePicker, Button, HorizontalGroup, FieldValidationMessage } from '@grafana/ui';
+import {
+  InlineField,
+  InlineFieldRow,
+  ValuePicker,
+  Button,
+  HorizontalGroup,
+  FieldValidationMessage,
+  RadioButtonGroup,
+} from '@grafana/ui';
 import { useFieldDisplayNames, useSelectOptions } from '@grafana/ui/src/components/MatchersUI/utils';
 
 import { partitionByValuesTransformer, PartitionByValuesTransformerOptions } from './partitionByValues';
@@ -46,6 +54,16 @@ export function PartitionByValuesEditor({
     },
     [onChange, options]
   );
+
+  enum nameingModes {
+    asLabels,
+    frameName,
+  }
+
+  const namingModesOptions = [
+    { label: 'As label', value: nameingModes.asLabels },
+    { label: 'As frame name', value: nameingModes.frameName },
+  ];
 
   const removeField = useCallback(
     (v: string) => {
@@ -92,6 +110,27 @@ export function PartitionByValuesEditor({
               />
             )}
           </HorizontalGroup>
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          tooltip={
+            'Sets how the names of the selected fields will be displayed. As frame name is usually better for tabular data'
+          }
+          label={'Naming'}
+          labelWidth={10}
+        >
+          <RadioButtonGroup
+            options={namingModesOptions}
+            value={
+              options.naming?.asLabels === undefined || options.naming.asLabels
+                ? nameingModes.asLabels
+                : nameingModes.frameName
+            }
+            onChange={(v) =>
+              onChange({ ...options, naming: { ...options.naming, asLabels: v === nameingModes.asLabels } })
+            }
+          />
         </InlineField>
       </InlineFieldRow>
     </div>

--- a/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
+++ b/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
@@ -55,14 +55,14 @@ export function PartitionByValuesEditor({
     [onChange, options]
   );
 
-  enum nameingModes {
+  enum namingModes {
     asLabels,
     frameName,
   }
 
   const namingModesOptions = [
-    { label: 'As label', value: nameingModes.asLabels },
-    { label: 'As frame name', value: nameingModes.frameName },
+    { label: 'As label', value: namingModes.asLabels },
+    { label: 'As frame name', value: namingModes.frameName },
   ];
 
   const removeField = useCallback(
@@ -124,11 +124,11 @@ export function PartitionByValuesEditor({
             options={namingModesOptions}
             value={
               options.naming?.asLabels === undefined || options.naming.asLabels
-                ? nameingModes.asLabels
-                : nameingModes.frameName
+                ? namingModes.asLabels
+                : namingModes.frameName
             }
             onChange={(v) =>
-              onChange({ ...options, naming: { ...options.naming, asLabels: v === nameingModes.asLabels } })
+              onChange({ ...options, naming: { ...options.naming, asLabels: v === namingModes.asLabels } })
             }
           />
         </InlineField>

--- a/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
+++ b/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
@@ -115,7 +115,7 @@ export function PartitionByValuesEditor({
       <InlineFieldRow>
         <InlineField
           tooltip={
-            'Sets how the names of the selected fields will be displayed. As frame name is usually better for tabular data'
+            'Sets how the names of the selected fields are displayed. As frame name is usually better for tabular data'
           }
           label={'Naming'}
           labelWidth={10}


### PR DESCRIPTION
**What is this feature?**

Adds a UI element to partition by value to let the user set the asLabel option.

**Why do we need this feature?**

When using partition by value with a table, the drop down below the table all gets the same name. 
![image](https://github.com/grafana/grafana/assets/468940/d308707e-e54b-40f9-9e36-04bf9f10bad2)

With this feature the user can decide if the name should instead be applied to the frame:
![image](https://github.com/grafana/grafana/assets/468940/598124a9-18f2-4746-a630-52420c7e2928)


**Which issue(s) does this PR fix?**:

Fixes #73608

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
