### PR TITLE
Remove duplicate "Legend values" heading (#75614)

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -79,8 +79,6 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
-
 ### Legend values
 
 Select values to display in the legend. You can select more than one.
@@ -88,4 +86,4 @@ Select values to display in the legend. You can select more than one.
 - **Percent:** The percentage of the whole.
 - **Value:** The raw numerical value.
 
-For more information about the legend, refer to [Configure a legend](../configure-legend/).
+For more information about the legend, refer to [Configure a legend]{{< relref "../../configure-legend" >}}).


### PR DESCRIPTION
* Remove second "Legend values" heading

I'm not honestly sure if this is the correct choice but there are two "Legend values" in the current document because the shared page "visualizations/legend-mode.md" has that heading.

I'm assuming because of the use of the shared page, that the information there is preferred.



* Prefer alternative text



---------



(cherry picked from commit 030e891b3f3948ad520b0a292ed14ab1a8e093d6)