### PR TITLE
Subpath: Add check for url being same as subpath on stripBaseFromUrl

### DIFF
--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -54,6 +54,10 @@ describe('locationUtil', () => {
         const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl-backup/thisShouldRemain/');
         expect(urlWithoutMaster).toBe('/subUrl-backup/thisShouldRemain/');
       });
+      test('relative url with same url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl');
+        expect(urlWithoutMaster).toBe('');
+      });
       test('absolute url', () => {
         const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/thisShouldRemain/');
         expect(urlWithoutMaster).toBe('/thisShouldRemain/');
@@ -73,6 +77,10 @@ describe('locationUtil', () => {
           'http://www.domain.com:9877/subUrl-backup/thisShouldRemain/'
         );
         expect(urlWithoutMaster).toBe('http://www.domain.com:9877/subUrl-backup/thisShouldRemain/');
+      });
+      test('absolute url with same url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl');
+        expect(urlWithoutMaster).toBe('');
       });
     });
 

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -43,7 +43,8 @@ const stripBaseFromUrl = (urlOrPath: string): string => {
     segmentToStrip = `${window.location.origin}${appSubUrl}`;
   }
 
-  // Check if the segment is either exactly the same or followed by a '/' so it does not replace incorrect similarly named segments
+  // Check if the segment is either exactly the same as the url
+  // or followed by a '/' so it does not replace incorrect similarly named segments
   // i.e. /grafana should not replace /grafanadashboards
   return urlOrPath.length > 0 && (urlOrPath.indexOf(segmentToStrip + '/') === 0 || urlOrPath === segmentToStrip)
     ? urlOrPath.slice(segmentToStrip.length - stripExtraChars)

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -43,9 +43,9 @@ const stripBaseFromUrl = (urlOrPath: string): string => {
     segmentToStrip = `${window.location.origin}${appSubUrl}`;
   }
 
-  // Check if the segment is followed by a '/' so it does not replace incorrect similarly named segments
+  // Check if the segment is either exactly the same or followed by a '/' so it does not replace incorrect similarly named segments
   // i.e. /grafana should not replace /grafanadashboards
-  return urlOrPath.length > 0 && urlOrPath.indexOf(segmentToStrip + '/') === 0
+  return urlOrPath.length > 0 && (urlOrPath.indexOf(segmentToStrip + '/') === 0 || urlOrPath === segmentToStrip)
     ? urlOrPath.slice(segmentToStrip.length - stripExtraChars)
     : urlOrPath;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes an issue introduced in https://github.com/grafana/grafana/pull/75559 where if you passed to `stripBaseFromUrl` the base path it would return an incorrect url. For instance with a subPath of `/grafana` if you have a link that links to home, aka `/grafana`, it was returning `/grafana/grafana` because it didn't end in a `/`

**Why do we need this feature?**

So links to home from a subpath work

**Who is this feature for?**

Anyone with a subpath

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
