### PR TITLE
Alerting: Show Insights only for cloud users

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -23,7 +23,7 @@ import { getRulesSourceName, isCloudRulesSource, isGrafanaRulesSource } from '..
 import {
   createExploreLink,
   createShareLink,
-  isDevelopment,
+  isLocalDevEnv,
   isOpenSourceEdition,
   makeRuleBasedSilenceLink,
 } from '../../utils/misc';
@@ -272,7 +272,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
  * We should show it in development mode
  */
 function shouldShowDeclareIncidentButton() {
-  return !isOpenSourceEdition() || isDevelopment();
+  return !isOpenSourceEdition() || isLocalDevEnv();
 }
 
 /**

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -3,7 +3,6 @@ import React, { Fragment, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, textUtil, urlUtil } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/src/types/config';
 import { config } from '@grafana/runtime';
 import { Button, ClipboardButton, ConfirmModal, HorizontalGroup, LinkButton, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
@@ -21,7 +20,13 @@ import { getRulesPermissions } from '../../utils/access-control';
 import { getAlertmanagerByUid } from '../../utils/alertmanager';
 import { Annotation } from '../../utils/constants';
 import { getRulesSourceName, isCloudRulesSource, isGrafanaRulesSource } from '../../utils/datasource';
-import { createExploreLink, createShareLink, makeRuleBasedSilenceLink } from '../../utils/misc';
+import {
+  createExploreLink,
+  createShareLink,
+  isDevelopment,
+  isOpenSourceEdition,
+  makeRuleBasedSilenceLink,
+} from '../../utils/misc';
 import * as ruleId from '../../utils/rule-id';
 import { isAlertingRule, isFederatedRuleGroup, isGrafanaRulerRule } from '../../utils/rules';
 import { DeclareIncident } from '../bridges/DeclareIncidentButton';
@@ -267,11 +272,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
  * We should show it in development mode
  */
 function shouldShowDeclareIncidentButton() {
-  const buildInfo = config.buildInfo;
-  const isOpenSourceEdition = buildInfo.edition === GrafanaEdition.OpenSource;
-  const isDevelopment = buildInfo.env === 'development';
-
-  return !isOpenSourceEdition || isDevelopment;
+  return !isOpenSourceEdition() || isDevelopment();
 }
 
 /**

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -5,6 +5,8 @@ import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { usePageNav } from 'app/core/components/Page/usePageNav';
 import { PluginPageContext, PluginPageContextType } from 'app/features/plugins/components/PluginPageContext';
 
+import { isDevelopment, isOpenSourceEdition } from '../utils/misc';
+
 import { getOverviewScene, WelcomeHeader } from './GettingStarted';
 import { getGrafanaScenes } from './Insights';
 
@@ -56,7 +58,7 @@ export function getHomeApp(insightsEnabled: boolean) {
 }
 
 export default function Home() {
-  const insightsEnabled = !!config.featureToggles.alertingInsights;
+  const insightsEnabled = (!isOpenSourceEdition() || isDevelopment()) && !!config.featureToggles.alertingInsights;
 
   const appScene = getHomeApp(insightsEnabled);
 

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -5,7 +5,7 @@ import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { usePageNav } from 'app/core/components/Page/usePageNav';
 import { PluginPageContext, PluginPageContextType } from 'app/features/plugins/components/PluginPageContext';
 
-import { isDevelopment, isOpenSourceEdition } from '../utils/misc';
+import { isLocalDevEnv, isOpenSourceEdition } from '../utils/misc';
 
 import { getOverviewScene, WelcomeHeader } from './GettingStarted';
 import { getGrafanaScenes } from './Insights';
@@ -58,7 +58,8 @@ export function getHomeApp(insightsEnabled: boolean) {
 }
 
 export default function Home() {
-  const insightsEnabled = (!isOpenSourceEdition() || isDevelopment()) && !!config.featureToggles.alertingInsights;
+  const insightsEnabled =
+    (!isOpenSourceEdition() || isLocalDevEnv()) && Boolean(config.featureToggles.alertingInsights);
 
   const appScene = getHomeApp(insightsEnabled);
 

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -214,7 +214,7 @@ export function isOpenSourceEdition() {
   return buildInfo.edition === GrafanaEdition.OpenSource;
 }
 
-export function isDevelopment() {
+export function isLocalDevEnv() {
   const buildInfo = config.buildInfo;
   return buildInfo.env === 'development';
 }

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -1,6 +1,8 @@
 import { sortBy } from 'lodash';
 
 import { UrlQueryMap, Labels, DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
+import { GrafanaEdition } from '@grafana/data/src/types/config';
+import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { alertInstanceKey } from 'app/features/alerting/unified/utils/rules';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
@@ -205,4 +207,14 @@ export function sortAlerts(sortOrder: SortOrder, alerts: Alert[]): Alert[] {
   }
 
   return result;
+}
+
+export function isOpenSourceEdition() {
+  const buildInfo = config.buildInfo;
+  return buildInfo.edition === GrafanaEdition.OpenSource;
+}
+
+export function isDevelopment() {
+  const buildInfo = config.buildInfo;
+  return buildInfo.env === 'development';
 }


### PR DESCRIPTION
**What is this feature?**

- Creates common functions to detect whether the build version is OSS, and also if it's a development version. 
- Uses these functions to prevent showing the Insights landing page for OSS users 
- Uses these functions for the Declare Incident button 

**Why do we need this feature?**

Insights landing page uses datasources and metrics that are only available for cloud users, hence we need to restrict its access for that scenario only.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/617
