### PR TITLE
Azure: Add support for Workload Identity authentication

### DIFF
--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -161,7 +161,7 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
    {{< figure src="/media/docs/grafana/data-sources/screenshot-managed-identity-2.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
 
-3. The `managed_identity_client_id` field can be set in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be  used instead of the default system-assigned identity.
+3. The `managed_identity_client_id` field can be set in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be used instead of the default system-assigned identity.
 
   ```ini
   [azure]

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -163,12 +163,12 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
 3. You can set the `managed_identity_client_id` field in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be used instead of the default system-assigned identity.
 
-  ```ini
-  [azure]
-  managed_identity_enabled = true
-  managed_identity_client_id = USER_ASSIGNED_IDENTITY_CLIENT_ID
-  ```
-   
+```ini
+[azure]
+managed_identity_enabled = true
+managed_identity_client_id = USER_ASSIGNED_IDENTITY_CLIENT_ID
+```
+
 ### Configure Workload Identity
 
 You can use workload identity to configure Azure Monitor in Grafana if you host Grafana in a Kubernetes environment, such as AKS, in conjunction with managed identities.

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -63,7 +63,7 @@ For more information, refer to [Azure documentation for role assignments](https:
 If you host Grafana in Azure, such as in App Service or Azure Virtual Machines, you can configure the Azure Monitor data source to use Managed Identity for secure authentication without entering credentials into Grafana.
 For details, refer to [Configuring using Managed Identity](#configuring-using-managed-identity).
 
-If you host Grafana in a Kubernetes environment, such as AKS, and require access to Azure resources you can configure the Azure Monitor data source to use Workload Identity for secure authentication without entering credentials into Grafana.
+You can configure the Azure Monitor data source to use Workload Identity for secure authentication without entering credentials into Grafana if you host Grafana in a Kubernetes environment, such as AKS, and require access to Azure resources.
 For details, refer to [Configuring using Workload Identity](#configuring-using-workload-identity).
 
 | Name                        | Description                                                                                                                                                                                                                                                                                           |

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -159,9 +159,9 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
    This hides the directory ID, application ID, and client secret fields, and the data source uses managed identity to authenticate to Azure Monitor Metrics and Logs, and Azure Resource Graph.
 
-   {{< figure src="/media/docs/grafana/data-sources/screenshot-managed-identity-2.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
+   {{< figure src="/media/docs/grafana/data-sources/screenshot-managed-identity-2.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor screenshot showing Managed Identity authentication" >}}
 
-3. The `managed_identity_client_id` field can be set in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be used instead of the default system-assigned identity.
+3. You can set the `managed_identity_client_id` field in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be used instead of the default system-assigned identity.
 
   ```ini
   [azure]
@@ -173,7 +173,7 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
 You can use workload identity to configure Azure Monitor in Grafana if you host Grafana in a Kubernetes environment, such as AKS, in conjunction with managed identities.
 This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
-For details on workload identity, refer to the [documentation](https://azure.github.io/azure-workload-identity/docs/).
+For details on workload identity, refer to the [Azure workload identity documentation](https://azure.github.io/azure-workload-identity/docs/).
 
 **To enable workload identity for Grafana:**
 
@@ -186,9 +186,9 @@ For details on workload identity, refer to the [documentation](https://azure.git
 
 2. In the Azure Monitor data source configuration, set **Authentication** to **Workload Identity**.
 
-   This hides the directory ID, application ID, and client secret fields, and the data source uses managed identity to authenticate to Azure Monitor Metrics and Logs, and Azure Resource Graph.
+   This hides the directory ID, application ID, and client secret fields, and the data source uses workload identity to authenticate to Azure Monitor Metrics and Logs, and Azure Resource Graph.
 
-   {{< figure src="/media/docs/grafana/data-sources/screenshot-workload-identity.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
+   {{< figure src="/media/docs/grafana/data-sources/screenshot-workload-identity.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor screenshot showing Workload Identity authentication" >}}
 
 3. There are additional configuration variables that can control the authentication method.`workload_identity_tenant_id` represents the Azure AD tenant that contains the managed identity, `workload_identity_client_id` represents the client ID of the managed identity if it differs from the default client ID, `workload_identity_token_file` represents the path to the token file. Refer to the [documentation](https://azure.github.io/azure-workload-identity/docs/) for more information on what values these variables should use, if any.
 

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -171,7 +171,7 @@ For details on Azure managed identities, refer to the [Azure documentation](http
    
 ### Configure Workload Identity
 
-If you host Grafana in a Kubernetes environment, such as AKS, in conjunction with managed identities you can use workload identity to configure Azure Monitor in Grafana.
+You can use workload identity to configure Azure Monitor in Grafana if you host Grafana in a Kubernetes environment, such as AKS, in conjunction with managed identities.
 This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
 For details on workload identity, refer to the [documentation](https://azure.github.io/azure-workload-identity/docs/).
 

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -63,6 +63,9 @@ For more information, refer to [Azure documentation for role assignments](https:
 If you host Grafana in Azure, such as in App Service or Azure Virtual Machines, you can configure the Azure Monitor data source to use Managed Identity for secure authentication without entering credentials into Grafana.
 For details, refer to [Configuring using Managed Identity](#configuring-using-managed-identity).
 
+If you host Grafana in a Kubernetes environment, such as AKS, and require access to Azure resources you can configure the Azure Monitor data source to use Workload Identity for secure authentication without entering credentials into Grafana.
+For details, refer to [Configuring using Workload Identity](#configuring-using-workload-identity).
+
 | Name                        | Description                                                                                                                                                                                                                                                                                           |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Authentication**          | Enables Managed Identity. Selecting Managed Identity hides many of the other fields. For details, see [Configuring using Managed Identity](#configuring-using-managed-identity).                                                                                                                      |
@@ -114,6 +117,21 @@ datasources:
     version: 1
 ```
 
+**Workload Identity:**
+
+```yaml
+apiVersion: 1 # config file version
+
+datasources:
+  - name: Azure Monitor
+    type: grafana-azure-monitor-datasource
+    access: proxy
+    jsonData:
+      azureAuthType: workloadidentity
+      subscriptionId: <subscription-id> # Optional, default subscription
+    version: 1
+```
+
 #### Supported cloud names
 
 | Azure Cloud                          | `cloudName` Value          |
@@ -125,7 +143,7 @@ datasources:
 ### Configure Managed Identity
 
 If you host Grafana in Azure, such as an App Service or with Azure Virtual Machines, and have managed identity enabled on your VM, you can use managed identity to configure Azure Monitor in Grafana.
-This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations for each.
+This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
 For details on Azure managed identities, refer to the [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).
 
 **To enable managed identity for Grafana:**
@@ -141,7 +159,46 @@ For details on Azure managed identities, refer to the [Azure documentation](http
 
    This hides the directory ID, application ID, and client secret fields, and the data source uses managed identity to authenticate to Azure Monitor Metrics and Logs, and Azure Resource Graph.
 
-   {{< figure src="/media/docs/grafana/data-sources/screenshot-managed-identity.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
+   {{< figure src="/media/docs/grafana/data-sources/screenshot-managed-identity-2.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
+
+3. The `managed_identity_client_id` field can be set in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure] to allow a user-assigned managed identity to be  used instead of the default system-assigned identity.
+
+  ```ini
+  [azure]
+  managed_identity_enabled = true
+  managed_identity_client_id = USER_ASSIGNED_IDENTITY_CLIENT_ID
+  ```
+   
+### Configure Workload Identity
+
+If you host Grafana in a Kubernetes environment, such as AKS, in conjunction with managed identities you can use workload identity to configure Azure Monitor in Grafana.
+This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
+For details on workload identity, refer to the [documentation](https://azure.github.io/azure-workload-identity/docs/).
+
+**To enable workload identity for Grafana:**
+
+1. Set the `workload_identity_enabled` flag in the `[azure]` section of the [Grafana server configuration][configure-grafana-azure].
+
+   ```ini
+   [azure]
+   workload_identity_enabled = true
+   ```
+
+2. In the Azure Monitor data source configuration, set **Authentication** to **Workload Identity**.
+
+   This hides the directory ID, application ID, and client secret fields, and the data source uses managed identity to authenticate to Azure Monitor Metrics and Logs, and Azure Resource Graph.
+
+   {{< figure src="/media/docs/grafana/data-sources/screenshot-workload-identity.png" max-width="800px" class="docs-image--no-shadow" caption="Azure Monitor Metrics screenshot showing Dimensions" >}}
+
+3. There are additional configuration variables that can control the authentication method.`workload_identity_tenant_id` represents the Azure AD tenant that contains the managed identity, `workload_identity_client_id` represents the client ID of the managed identity if it differs from the default client ID, `workload_identity_token_file` represents the path to the token file. Refer to the [documentation](https://azure.github.io/azure-workload-identity/docs/) for more information on what values these variables should use, if any.
+
+   ```ini
+   [azure]
+   workload_identity_enabled = true
+   workload_identity_tenant_id = IDENTITY_TENANT_ID
+   workload_identity_client_id = IDENTITY_CLIENT_ID
+   workload_identity_token_file = TOKEN_FILE_PATH
+   ```
 
 ## Query the data source
 

--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -142,7 +142,7 @@ datasources:
 
 ### Configure Managed Identity
 
-If you host Grafana in Azure, such as an App Service or with Azure Virtual Machines, and have managed identity enabled on your VM, you can use managed identity to configure Azure Monitor in Grafana.
+You can use managed identity to configure Azure Monitor in Grafana if you host Grafana in Azure (such as an App Service or with Azure Virtual Machines) and have managed identity enabled on your VM.
 This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
 For details on Azure managed identities, refer to the [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).
 

--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -77,6 +77,66 @@ func TestCredentials_getAuthType(t *testing.T) {
 			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
 		})
 	})
+
+	t.Run("when workload identities enabled", func(t *testing.T) {
+		cfg.Azure.WorkloadIdentityEnabled = true
+
+		t.Run("should be client secret if auth type is set to client secret", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: azcredentials.AzureAuthClientSecret,
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+
+		t.Run("should be workload identity if datasource not configured and managed identity is disabled", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthWorkloadIdentity, authType)
+		})
+
+		t.Run("should be client secret if auth type not specified but credentials configured", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+				TenantId:      "9b9d90ee-a5cc-49c2-b97e-0d1b0f086b5c",
+				ClientId:      "849ccbb0-92eb-4226-b228-ef391abd8fe6",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
+
+	t.Run("when workload identities disabled", func(t *testing.T) {
+		cfg.Azure.WorkloadIdentityEnabled = false
+
+		t.Run("should be workload identity if auth type is set to workload identity", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: azcredentials.AzureAuthWorkloadIdentity,
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthWorkloadIdentity, authType)
+		})
+
+		t.Run("should be client secret if datasource not configured", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
 }
 
 func TestCredentials_getAzureCloud(t *testing.T) {

--- a/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.test.tsx
@@ -6,6 +6,7 @@ import AzureCredentialsForm, { Props } from './AzureCredentialsForm';
 const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: false,
+    workloadIdentityEnabled: false,
     credentials: {
       authType: 'clientsecret',
       azureCloud: 'azuremonitor',

--- a/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.tsx
@@ -9,39 +9,59 @@ import { AzureAuthType, AzureCredentials } from '../types';
 
 export interface Props {
   managedIdentityEnabled: boolean;
+  workloadIdentityEnabled: boolean;
   credentials: AzureCredentials;
   azureCloudOptions?: SelectableValue[];
-  onCredentialsChange?: (updatedCredentials: AzureCredentials) => void;
+  onCredentialsChange: (updatedCredentials: AzureCredentials) => void;
   disabled?: boolean;
   children?: JSX.Element;
 }
 
-const authTypeOptions: Array<SelectableValue<AzureAuthType>> = [
-  {
-    value: 'msi',
-    label: 'Managed Identity',
-  },
-  {
-    value: 'clientsecret',
-    label: 'App Registration',
-  },
-];
-
 export const AzureCredentialsForm = (props: Props) => {
-  const { credentials, azureCloudOptions, onCredentialsChange, disabled, managedIdentityEnabled } = props;
+  const {
+    credentials,
+    azureCloudOptions,
+    onCredentialsChange,
+    disabled,
+    managedIdentityEnabled,
+    workloadIdentityEnabled,
+  } = props;
+  const authTypeOptions: Array<SelectableValue<AzureAuthType>> = [
+    {
+      value: 'clientsecret',
+      label: 'App Registration',
+    },
+  ];
+
+  if (managedIdentityEnabled) {
+    authTypeOptions.push({
+      value: 'msi',
+      label: 'Managed Identity',
+    });
+  }
+
+  if (workloadIdentityEnabled) {
+    authTypeOptions.push({
+      value: 'workloadidentity',
+      label: 'Workload Identity',
+    });
+  }
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
-    if (onCredentialsChange) {
-      const updated: AzureCredentials = {
-        ...credentials,
-        authType: selected.value || 'msi',
-      };
-      onCredentialsChange(updated);
-    }
+    const defaultAuthType = managedIdentityEnabled
+      ? 'msi'
+      : workloadIdentityEnabled
+      ? 'workloadidentity'
+      : 'clientsecret';
+    const updated: AzureCredentials = {
+      ...credentials,
+      authType: selected.value || defaultAuthType,
+    };
+    onCredentialsChange(updated);
   };
 
   const onAzureCloudChange = (selected: SelectableValue<string>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       const updated: AzureCredentials = {
         ...credentials,
         azureCloud: selected.value,
@@ -51,7 +71,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onTenantIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       const updated: AzureCredentials = {
         ...credentials,
         tenantId: event.target.value,
@@ -61,7 +81,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       const updated: AzureCredentials = {
         ...credentials,
         clientId: event.target.value,
@@ -71,7 +91,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientSecretChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       const updated: AzureCredentials = {
         ...credentials,
         clientSecret: event.target.value,
@@ -81,7 +101,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientSecretReset = () => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       const updated: AzureCredentials = {
         ...credentials,
         clientSecret: '',
@@ -92,7 +112,7 @@ export const AzureCredentialsForm = (props: Props) => {
 
   return (
     <ConfigSection title="Authentication">
-      {managedIdentityEnabled && (
+      {(managedIdentityEnabled || workloadIdentityEnabled) && (
         <Field
           label="Authentication"
           description="Choose the type of authentication to Azure services"

--- a/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { ConfigSection } from '@grafana/experimental';
@@ -26,26 +26,31 @@ export const AzureCredentialsForm = (props: Props) => {
     managedIdentityEnabled,
     workloadIdentityEnabled,
   } = props;
-  const authTypeOptions: Array<SelectableValue<AzureAuthType>> = [
-    {
-      value: 'clientsecret',
-      label: 'App Registration',
-    },
-  ];
 
-  if (managedIdentityEnabled) {
-    authTypeOptions.push({
-      value: 'msi',
-      label: 'Managed Identity',
-    });
-  }
+  const authTypeOptions = useMemo(() => {
+    let opts: Array<SelectableValue<AzureAuthType>> = [
+      {
+        value: 'clientsecret',
+        label: 'App Registration',
+      },
+    ];
 
-  if (workloadIdentityEnabled) {
-    authTypeOptions.push({
-      value: 'workloadidentity',
-      label: 'Workload Identity',
-    });
-  }
+    if (managedIdentityEnabled) {
+      opts.push({
+        value: 'msi',
+        label: 'Managed Identity',
+      });
+    }
+
+    if (workloadIdentityEnabled) {
+      opts.push({
+        value: 'workloadidentity',
+        label: 'Workload Identity',
+      });
+    }
+
+    return opts;
+  }, [managedIdentityEnabled, workloadIdentityEnabled]);
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
     const defaultAuthType = managedIdentityEnabled
@@ -112,7 +117,7 @@ export const AzureCredentialsForm = (props: Props) => {
 
   return (
     <ConfigSection title="Authentication">
-      {(managedIdentityEnabled || workloadIdentityEnabled) && (
+      {authTypeOptions.length > 1 && (
         <Field
           label="Authentication"
           description="Choose the type of authentication to Azure services"

--- a/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
@@ -45,6 +45,7 @@ export const MonitorConfig = (props: Props) => {
     <>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
+        workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
         credentials={credentials}
         azureCloudOptions={azureClouds}
         onCredentialsChange={onCredentialsChange}

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -32,7 +32,7 @@ export enum AzureCloud {
   None = '',
 }
 
-export type AzureAuthType = 'msi' | 'clientsecret';
+export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
 
 export type ConcealedSecret = symbol;
 
@@ -44,6 +44,10 @@ export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
   authType: 'msi';
 }
 
+export interface AzureWorkloadIdentityCredentials extends AzureCredentialsBase {
+  authType: 'workloadidentity';
+}
+
 export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   authType: 'clientsecret';
   azureCloud?: string;
@@ -52,7 +56,10 @@ export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
-export type AzureCredentials = AzureManagedIdentityCredentials | AzureClientSecretCredentials;
+export type AzureCredentials =
+  | AzureManagedIdentityCredentials
+  | AzureClientSecretCredentials
+  | AzureWorkloadIdentityCredentials;
 
 export interface AzureDataSourceJsonData extends DataSourceJsonData {
   cloudName: string;

--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -50,6 +50,7 @@ export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
       <h6>Azure authentication</h6>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
+        workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
         credentials={credentials}
         azureCloudOptions={KnownAzureClouds}
         onCredentialsChange={onCredentialsChange}

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
@@ -13,7 +13,7 @@ export const KnownAzureClouds: Array<SelectableValue<AzureCloud>> = [
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ];
 
-export type AzureAuthType = 'msi' | 'clientsecret';
+export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
 
 export type ConcealedSecret = symbol;
 
@@ -26,6 +26,10 @@ export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
   authType: 'msi';
 }
 
+export interface AzureWorkloadIdentityCredentials extends AzureCredentialsBase {
+  authType: 'workloadidentity';
+}
+
 export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   authType: 'clientsecret';
   azureCloud?: string;
@@ -34,11 +38,15 @@ export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
-export type AzureCredentials = AzureManagedIdentityCredentials | AzureClientSecretCredentials;
+export type AzureCredentials =
+  | AzureManagedIdentityCredentials
+  | AzureClientSecretCredentials
+  | AzureWorkloadIdentityCredentials;
 
 export function isCredentialsComplete(credentials: AzureCredentials): boolean {
   switch (credentials.authType) {
     case 'msi':
+    case 'workloadidentity':
       return true;
     case 'clientsecret':
       return !!(credentials.azureCloud && credentials.tenantId && credentials.clientId && credentials.clientSecret);

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
@@ -42,12 +42,16 @@ export function getCredentials(options: DataSourceSettings<any, any>): AzureCred
 
   switch (credentials.authType) {
     case 'msi':
-      if (config.azure.managedIdentityEnabled) {
+    case 'workloadidentity':
+      if (
+        (credentials.authType === 'msi' && config.azure.managedIdentityEnabled) ||
+        (credentials.authType === 'workloadidentity' && config.azure.workloadIdentityEnabled)
+      ) {
         return {
-          authType: 'msi',
+          authType: credentials.authType,
         };
       } else {
-        // If authentication type is managed identity but managed identities were disabled in Grafana config,
+        // If authentication type is managed identity or workload identity but either method is disabled in Grafana config,
         // then we should fallback to an empty app registration (client secret) configuration
         return {
           authType: 'clientsecret',
@@ -71,16 +75,21 @@ export function updateCredentials(
 ): DataSourceSettings<any, any> {
   switch (credentials.authType) {
     case 'msi':
-      if (!config.azure.managedIdentityEnabled) {
+    case 'workloadidentity':
+      if (credentials.authType === 'msi' && !config.azure.managedIdentityEnabled) {
         throw new Error('Managed Identity authentication is not enabled in Grafana config.');
+      }
+      if (credentials.authType === 'workloadidentity' && !config.azure.workloadIdentityEnabled) {
+        throw new Error('Workload Identity authentication is not enabled in Grafana config.');
       }
 
       options = {
         ...options,
         jsonData: {
           ...options.jsonData,
+          azureAuthType: credentials.authType,
           azureCredentials: {
-            authType: 'msi',
+            authType: credentials.authType,
           },
         },
       };

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
@@ -6,6 +6,7 @@ import AzureCredentialsForm, { Props } from './AzureCredentialsForm';
 const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: false,
+    workloadIdentityEnabled: false,
     credentials: {
       authType: 'clientsecret',
       azureCloud: 'azuremonitor',

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import React, { ChangeEvent, useEffect, useReducer, useState } from 'react';
+import React, { ChangeEvent, useEffect, useMemo, useReducer, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -34,26 +34,29 @@ export const AzureCredentialsForm = (props: Props) => {
   const [subscriptions, setSubscriptions] = useState<Array<SelectableValue<string>>>([]);
   const [loadSubscriptionsClicked, onLoadSubscriptions] = useReducer((val) => val + 1, 0);
 
-  const authTypeOptions: Array<SelectableValue<AzureAuthType>> = [
-    {
-      value: 'clientsecret',
-      label: 'App Registration',
-    },
-  ];
+  const authTypeOptions = useMemo(() => {
+    let opts: Array<SelectableValue<AzureAuthType>> = [
+      {
+        value: 'clientsecret',
+        label: 'App Registration',
+      },
+    ];
 
-  if (managedIdentityEnabled) {
-    authTypeOptions.push({
-      value: 'msi',
-      label: 'Managed Identity',
-    });
-  }
+    if (managedIdentityEnabled) {
+      opts.push({
+        value: 'msi',
+        label: 'Managed Identity',
+      });
+    }
 
-  if (workloadIdentityEnabled) {
-    authTypeOptions.push({
-      value: 'workloadidentity',
-      label: 'Workload Identity',
-    });
-  }
+    if (workloadIdentityEnabled) {
+      opts.push({
+        value: 'workloadidentity',
+        label: 'Workload Identity',
+      });
+    }
+    return opts;
+  }, [managedIdentityEnabled, workloadIdentityEnabled]);
 
   useEffect(() => {
     if (!getSubscriptions || !hasRequiredFields) {
@@ -175,7 +178,7 @@ export const AzureCredentialsForm = (props: Props) => {
 
   return (
     <div className="gf-form-group">
-      {(managedIdentityEnabled || workloadIdentityEnabled) && (
+      {authTypeOptions.length > 1 && (
         <div className="gf-form-inline">
           <div className="gf-form">
             <InlineFormLabel className="width-12" tooltip="Choose the type of authentication to Azure services">


### PR DESCRIPTION
As #75283 has been merged we can now add support for the Workload Identity authentication method to the core Azure datasources (Azure Monitor and Prometheus).

Docs have also been updated and code has been cleaned up in general.

Related #75404

cc. @kostrse 