### PR TITLE
Transformations: Fix bug with calculate field when using reduce and the all values calculation

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -254,7 +254,7 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
     name: 'All values',
     description: 'Returns an array with all values',
     standard: false,
-    reduce: (field: Field) => ({ allValues: field.values }),
+    reduce: (field: Field) => ({ allValues: [...field.values] }),
   },
   {
     id: ReducerID.uniqueValues,

--- a/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
@@ -222,6 +222,33 @@ describe('calculateField transformer w/ timeseries', () => {
     });
   });
 
+  it('reduces all field', async () => {
+    const cfg = {
+      id: DataTransformerID.calculateField,
+      options: {
+        mode: CalculateFieldMode.ReduceRow,
+        reduce: { include: ['B', 'C'], reducer: ReducerID.allValues },
+        replaceFields: true,
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [seriesBC])).toEmitValuesWith((received) => {
+      const data = received[0];
+      const filtered = data[0];
+      const rows = new DataFrameView(filtered).toArray();
+      expect(rows).toEqual([
+        {
+          'All values': [2, 3],
+          TheTime: 1000,
+        },
+        {
+          'All values': [200, 300],
+          TheTime: 2000,
+        },
+      ]);
+    });
+  });
+
   it('can add index field', async () => {
     const cfg = {
       id: DataTransformerID.calculateField,


### PR DESCRIPTION
**What is this feature?**
Fixes an issue where the values of the fields were assigned by reference. This would make all the values in the new column reference the last value.

Fixes #73676

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
