### PR TITLE
Docs: Remove duplicate "Legend values" heading

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -108,7 +108,6 @@ Select values to display in the legend. You can select more than one.
 - **Percent:** The percentage of the whole.
 - **Value:** The raw numerical value.
 
-For more information about the legend, refer to [Configure a legend]({{< relref "../../configure-legend" >}}).
 
 {{% docs/reference %}}
 [Calculation types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -108,7 +108,6 @@ Select values to display in the legend. You can select more than one.
 - **Percent:** The percentage of the whole.
 - **Value:** The raw numerical value.
 
-
 {{% docs/reference %}}
 [Calculation types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"
 [Calculation types]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -79,13 +79,20 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
+## Legend options
+
+Use these settings to define how the legend appears in your visualization. For more information about the legend, refer to [Configure a legend]({{< relref "../../configure-legend" >}}).
+
+### Legend visibility
+
+Use the **Visibility** switch to show or hide the legend.
+
 ### Legend mode
 
-Use these settings to define how the legend appears in your visualization. For more information about the legend, refer to [Configure a legend](../configure-legend/).
+Set the display mode of the legend:
 
 - **List -** Displays the legend as a list. This is a default display mode of the legend.
 - **Table -** Displays the legend as a table.
-- **Hidden -** Hides the legend.
 
 ### Legend placement
 
@@ -101,7 +108,7 @@ Select values to display in the legend. You can select more than one.
 - **Percent:** The percentage of the whole.
 - **Value:** The raw numerical value.
 
-For more information about the legend, refer to [Configure a legend](../configure-legend/).
+For more information about the legend, refer to [Configure a legend]({{< relref "../../configure-legend" >}}).
 
 {{% docs/reference %}}
 [Calculation types]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/calculation-types"

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -79,7 +79,20 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+### Legend mode
+
+Use these settings to define how the legend appears in your visualization. For more information about the legend, refer to [Configure a legend](../configure-legend/).
+
+- **List -** Displays the legend as a list. This is a default display mode of the legend.
+- **Table -** Displays the legend as a table.
+- **Hidden -** Hides the legend.
+
+### Legend placement
+
+Choose where to display the legend.
+
+- **Bottom -** Below the graph.
+- **Right -** To the right of the graph.
 
 ### Legend values
 


### PR DESCRIPTION
Once backported, this should fix 11 instances of the build error: The "toc" partial detected duplicate heading IDs (legend-values)`

Most of these backports will fail and need to be created manually but this PR acts as a record of the intended backports.