### PR TITLE
Flamegraph: Fix bug where package colors would be altered after focusin on a node

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/colors.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/colors.ts
@@ -57,9 +57,9 @@ export function getBarColorByPackage(label: string, theme: GrafanaTheme2) {
   // TODO: similar thing happens in trace view with selecting colors of the spans, so maybe this could be unified.
   const hash = murmurhash3_32_gc(packageName || '', 0);
   const colorIndex = hash % packageColors.length;
-  let packageColor = packageColors[colorIndex];
+  let packageColor = packageColors[colorIndex].clone();
   if (theme.isLight) {
-    packageColor = packageColor.clone().brighten(15);
+    packageColor = packageColor.brighten(15);
   }
   return packageColor;
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/75694

Forgot to clone the colors and any modification by the tinycolor2 lib is actually in place even though it returns the color instance 😞 .