### PR TITLE
Prometheus: adding simple error in parse response

### DIFF
--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -88,7 +88,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -33,7 +33,7 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 
 	// Throw client/server error
 	if res.StatusCode/100 == 4 || res.StatusCode/100 == 5 {
-		r.Error = fmt.Errorf("%s", backend.ErrDataResponse(backend.Status(res.StatusCode), res.Status))
+		r.Error = fmt.Errorf("%v", backend.ErrDataResponse(backend.Status(res.StatusCode), res.Status))
 	}
 
 	// Add frame to attach metadata

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -31,6 +31,11 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		Dataplane:        s.enableDataplane,
 	})
 
+	// Throw client/server error
+	if res.StatusCode/100 == 4 || res.StatusCode/100 == 5 {
+		r.Error = fmt.Errorf("%s", backend.ErrDataResponse(backend.Status(res.StatusCode), res.Status))
+	}
+
 	// Add frame to attach metadata
 	if len(r.Frames) == 0 && !q.ExemplarQuery {
 		r.Frames = append(r.Frames, data.NewFrame(""))


### PR DESCRIPTION
Backport into 9.5.x fix for 4xx/5xx responses not being parsed by backend

PoC fix for https://github.com/grafana/grafana/issues/75697