### PR TITLE
Build: removing .linguirc to the copied files in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY plugins-bundled plugins-bundled
 
 RUN yarn install --immutable
 
-COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js babel.config.json .linguirc ./
+COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js babel.config.json ./
 COPY public public
 COPY scripts scripts
 COPY emails emails


### PR DESCRIPTION
Local Dockerfile fails with:

```
 => ERROR [js-builder  8/12] COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js babel.config.json .linguirc ./                                0.0s
 => [go-builder  3/20] WORKDIR /tmp/grafana                                                                                                                          0.0s
 => [go-builder  4/20] COPY go.* ./                                                                                                                                  0.3s
 => [go-builder  5/20] COPY .bingo .bingo                                                                                                                            0.0s
 => CANCELED [go-builder  6/20] RUN go mod download                                                                                                                  2.2s
------
 > [js-builder  8/12] COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js babel.config.json .linguirc ./:
------
Dockerfile:24
--------------------
  22 |     RUN yarn install --immutable
  23 |
  24 | >>> COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js babel.config.json .linguirc ./
  25 |     COPY public public
  26 |     COPY scripts scripts
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref cc72e2cc-395a-46c9-b6ce-98fa942823cd::dy0j4lc6k08aluey90uugfvr4: "/.linguirc": not found
make: *** [build-docker-full] Error 1
```

That file has not existed on `main` since PR #75658 got merged.
