### PR TITLE
Canvas: Add border options to button

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2890,6 +2890,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
+    "public/app/features/canvas/elements/button.tsx:5381": [
+      [0, 0, 0, "Styles should be written using objects.", "0"]
+    ],
     "public/app/features/canvas/elements/droneFront.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],

--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -20,7 +20,7 @@ interface ButtonData {
   api?: APIEditorConfig;
   style?: ButtonStyleConfig;
   borderColor?: string;
-  width?: number;
+  borderWidth?: number;
 }
 
 interface ButtonConfig {
@@ -28,7 +28,7 @@ interface ButtonConfig {
   api?: APIEditorConfig;
   style?: ButtonStyleConfig;
   borderColor?: ColorDimensionConfig;
-  width?: number;
+  borderWidth?: number;
 }
 
 export const defaultApiConfig: APIEditorConfig = {
@@ -43,6 +43,8 @@ export const defaultApiConfig: APIEditorConfig = {
 export const defaultStyleConfig: ButtonStyleConfig = {
   variant: 'primary',
 };
+
+export const defaultBorderWidth = 0;
 
 class ButtonDisplay extends PureComponent<CanvasElementProps<ButtonConfig, ButtonData>> {
   render() {
@@ -89,7 +91,7 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
       borderColor: {
         fixed: 'transparent',
       },
-      width: 1,
+      borderWidth: defaultBorderWidth,
       background: {
         color: {
           fixed: 'transparent',
@@ -123,7 +125,7 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
       text: cfg?.text ? ctx.getText(cfg.text).value() : '',
       api: getCfgApi(),
       style: cfg?.style ?? defaultStyleConfig,
-      width: cfg.width,
+      borderWidth: cfg.borderWidth,
     };
 
     if (cfg.borderColor) {
@@ -162,10 +164,10 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
       })
       .addNumberInput({
         category,
-        path: 'config.width',
+        path: 'config.borderWidth',
         name: 'Button border width',
         settings: {
-          placeholder: 'Auto',
+          placeholder: '0',
         },
       })
       .addCustomEditor({
@@ -181,6 +183,6 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
 const getStyles = stylesFactory((theme: GrafanaTheme2, data) => ({
   container: css`
     background-color: ${data?.backgroundColor};
-    border: ${data?.width}px solid ${data?.borderColor};
+    border: ${data?.borderWidth}px solid ${data?.borderColor};
   `,
 }));

--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -87,11 +87,11 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
         },
         api: defaultApiConfig,
         style: defaultStyleConfig,
+        borderColor: {
+          fixed: 'text',
+        },
+        borderWidth: defaultBorderWidth,
       },
-      borderColor: {
-        fixed: 'transparent',
-      },
-      borderWidth: defaultBorderWidth,
       background: {
         color: {
           fixed: 'transparent',
@@ -135,8 +135,8 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
     return data;
   },
 
-  // Heatmap overlay options
-  registerOptionsUI: (builder) => {
+  // Button options
+  registerOptionsUI: (builder, ctx) => {
     const category = ['Button'];
     builder
       .addCustomEditor({
@@ -153,15 +153,6 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
         name: 'Style',
         editor: ButtonStyleEditor,
       })
-      .addCustomEditor({
-        category,
-        id: 'config.borderColor',
-        path: 'config.borderColor',
-        name: 'Button border color',
-        editor: ColorDimensionEditor,
-        settings: {},
-        defaultValue: {},
-      })
       .addNumberInput({
         category,
         path: 'config.borderWidth',
@@ -169,14 +160,25 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
         settings: {
           placeholder: '0',
         },
-      })
-      .addCustomEditor({
-        category,
-        id: 'apiSelector',
-        path: 'config.api',
-        name: 'API',
-        editor: APIEditor,
       });
+    if (ctx.options?.config?.borderWidth) {
+      builder.addCustomEditor({
+        category,
+        id: 'config.borderColor',
+        path: 'config.borderColor',
+        name: 'Button border color',
+        editor: ColorDimensionEditor,
+        settings: {},
+        defaultValue: {},
+      });
+    }
+    builder.addCustomEditor({
+      category,
+      id: 'apiSelector',
+      path: 'config.api',
+      name: 'API',
+      editor: APIEditor,
+    });
   },
 };
 


### PR DESCRIPTION
Add options for button border color and width.
After:
![image](https://github.com/grafana/grafana/assets/60050885/265e0785-fae9-47bd-9cfb-d28f1d505f14)

- [ ] Need to agree on path forward here: https://github.com/grafana/grafana/issues/74903

Fixes #74501