### PR TITLE
Transformations: Make "Go Back to Transformations" button sticky when adding more than one transformation

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -390,10 +390,9 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
           </Container>
         )}
         {showPicker ? (
-          <>
-            {config.featureToggles.transformationsRedesign && (
-              <>
-                {!noTransforms && (
+          <div className={styles.transformPickerContainer}>
+            {config.featureToggles.transformationsRedesign && !noTransforms && (
+              <div className={styles.goBackHeader}>
                   <Button
                     variant="secondary"
                     fill="text"
@@ -404,20 +403,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
                   >
                     Go back to&nbsp;<i>Transformations in use</i>
                   </Button>
-                )}
-                <div className={styles.pickerInformationLine}>
-                  <a
-                    href={getDocsLink(DocsId.Transformations)}
-                    className="external-link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <span className={styles.pickerInformationLineHighlight}>Transformations</span>{' '}
-                    <Icon name="external-link-alt" />
-                  </a>
-                  &nbsp;allow you to manipulate your data before a visualization is applied.
-                </div>
-              </>
+              </div>
             )}
             <VerticalGroup>
               {!config.featureToggles.transformationsRedesign && (
@@ -492,7 +478,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
                 />
               )}
             </VerticalGroup>
-          </>
+          </div>
         ) : (
           <Button
             icon="plus"
@@ -673,7 +659,20 @@ const getStyles = (theme: GrafanaTheme2) => {
     pluginStateInfoWrapper: css`
       margin-left: 5px;
     `,
-  };
+    transformPickerContainer: css`
+      position: relative;
+    `,
+    goBackHeader: css`
+      padding: ${theme.spacing(1)};
+      position: sticky;
+      top: 0;
+      margin-left: -${theme.spacing(1.5)};
+      margin-bottom: ${theme.spacing(1)};
+      z-index: 10;
+      background-color: ${theme.colors.background.primary};
+      width: calc(100% + ${theme.spacing(3)});
+    `
+  }; 
 };
 
 interface TransformationsGridProps {


### PR DESCRIPTION

**What is this feature?**

This makes the header for going back to the list of currently applied transformations sticky so that it can still be seen even when scrolling the transformations list. It additionally removes the inline help message taking up space.

**Why do we need this feature?**

Usage of transformations is often experimental, so making navigation faster is critical to improved transformation usage.

**Who is this feature for?**

Users adding more than one transform to a visualization.

**Which issue(s) does this PR fix?**:

Fixes #74203

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
