### PR TITLE
[v10.1.x] Azure: Add support for Workload Identity authentication

### DIFF
--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -77,6 +77,66 @@ func TestCredentials_getAuthType(t *testing.T) {
 			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
 		})
 	})
+
+	t.Run("when workload identities enabled", func(t *testing.T) {
+		cfg.Azure.WorkloadIdentityEnabled = true
+
+		t.Run("should be client secret if auth type is set to client secret", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: azcredentials.AzureAuthClientSecret,
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+
+		t.Run("should be workload identity if datasource not configured and managed identity is disabled", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthWorkloadIdentity, authType)
+		})
+
+		t.Run("should be client secret if auth type not specified but credentials configured", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+				TenantId:      "9b9d90ee-a5cc-49c2-b97e-0d1b0f086b5c",
+				ClientId:      "849ccbb0-92eb-4226-b228-ef391abd8fe6",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
+
+	t.Run("when workload identities disabled", func(t *testing.T) {
+		cfg.Azure.WorkloadIdentityEnabled = false
+
+		t.Run("should be workload identity if auth type is set to workload identity", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: azcredentials.AzureAuthWorkloadIdentity,
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthWorkloadIdentity, authType)
+		})
+
+		t.Run("should be client secret if datasource not configured", func(t *testing.T) {
+			jsonData := &types.AzureClientSettings{
+				AzureAuthType: "",
+			}
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
 }
 
 func TestCredentials_getAzureCloud(t *testing.T) {

--- a/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/AzureCredentialsForm.test.tsx
@@ -6,6 +6,7 @@ import AzureCredentialsForm, { Props } from './AzureCredentialsForm';
 const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: false,
+    workloadIdentityEnabled: false,
     credentials: {
       authType: 'clientsecret',
       azureCloud: 'azuremonitor',

--- a/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
@@ -46,6 +46,7 @@ export const MonitorConfig = (props: Props) => {
       <h3 className="page-heading">Authentication</h3>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
+        workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
         credentials={credentials}
         azureCloudOptions={azureClouds}
         onCredentialsChange={onCredentialsChange}

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -29,7 +29,7 @@ export enum AzureCloud {
   None = '',
 }
 
-export type AzureAuthType = 'msi' | 'clientsecret';
+export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
 
 export type ConcealedSecret = symbol;
 
@@ -41,6 +41,10 @@ export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
   authType: 'msi';
 }
 
+export interface AzureWorkloadIdentityCredentials extends AzureCredentialsBase {
+  authType: 'workloadidentity';
+}
+
 export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   authType: 'clientsecret';
   azureCloud?: string;
@@ -49,7 +53,10 @@ export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
-export type AzureCredentials = AzureManagedIdentityCredentials | AzureClientSecretCredentials;
+export type AzureCredentials =
+  | AzureManagedIdentityCredentials
+  | AzureClientSecretCredentials
+  | AzureWorkloadIdentityCredentials;
 
 export interface AzureDataSourceJsonData extends DataSourceJsonData {
   cloudName: string;

--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -50,6 +50,7 @@ export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
       <h6>Azure authentication</h6>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
+        workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
         credentials={credentials}
         azureCloudOptions={KnownAzureClouds}
         onCredentialsChange={onCredentialsChange}

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
@@ -13,7 +13,7 @@ export const KnownAzureClouds: Array<SelectableValue<AzureCloud>> = [
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ];
 
-export type AzureAuthType = 'msi' | 'clientsecret';
+export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
 
 export type ConcealedSecret = symbol;
 
@@ -26,6 +26,10 @@ export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
   authType: 'msi';
 }
 
+export interface AzureWorkloadIdentityCredentials extends AzureCredentialsBase {
+  authType: 'workloadidentity';
+}
+
 export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   authType: 'clientsecret';
   azureCloud?: string;
@@ -34,11 +38,15 @@ export interface AzureClientSecretCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
-export type AzureCredentials = AzureManagedIdentityCredentials | AzureClientSecretCredentials;
+export type AzureCredentials =
+  | AzureManagedIdentityCredentials
+  | AzureClientSecretCredentials
+  | AzureWorkloadIdentityCredentials;
 
 export function isCredentialsComplete(credentials: AzureCredentials): boolean {
   switch (credentials.authType) {
     case 'msi':
+    case 'workloadidentity':
       return true;
     case 'clientsecret':
       return !!(credentials.azureCloud && credentials.tenantId && credentials.clientId && credentials.clientSecret);

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
@@ -42,12 +42,16 @@ export function getCredentials(options: DataSourceSettings<any, any>): AzureCred
 
   switch (credentials.authType) {
     case 'msi':
-      if (config.azure.managedIdentityEnabled) {
+    case 'workloadidentity':
+      if (
+        (credentials.authType === 'msi' && config.azure.managedIdentityEnabled) ||
+        (credentials.authType === 'workloadidentity' && config.azure.workloadIdentityEnabled)
+      ) {
         return {
-          authType: 'msi',
+          authType: credentials.authType,
         };
       } else {
-        // If authentication type is managed identity but managed identities were disabled in Grafana config,
+        // If authentication type is managed identity or workload identity but either method is disabled in Grafana config,
         // then we should fallback to an empty app registration (client secret) configuration
         return {
           authType: 'clientsecret',
@@ -71,16 +75,21 @@ export function updateCredentials(
 ): DataSourceSettings<any, any> {
   switch (credentials.authType) {
     case 'msi':
-      if (!config.azure.managedIdentityEnabled) {
+    case 'workloadidentity':
+      if (credentials.authType === 'msi' && !config.azure.managedIdentityEnabled) {
         throw new Error('Managed Identity authentication is not enabled in Grafana config.');
+      }
+      if (credentials.authType === 'workloadidentity' && !config.azure.workloadIdentityEnabled) {
+        throw new Error('Workload Identity authentication is not enabled in Grafana config.');
       }
 
       options = {
         ...options,
         jsonData: {
           ...options.jsonData,
+          azureAuthType: credentials.authType,
           azureCredentials: {
-            authType: 'msi',
+            authType: credentials.authType,
           },
         },
       };

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
@@ -6,6 +6,7 @@ import AzureCredentialsForm, { Props } from './AzureCredentialsForm';
 const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: false,
+    workloadIdentityEnabled: false,
     credentials: {
       authType: 'clientsecret',
       azureCloud: 'azuremonitor',

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import React, { ChangeEvent, useEffect, useReducer, useState } from 'react';
+import React, { ChangeEvent, useEffect, useMemo, useReducer, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -11,6 +11,7 @@ import { AzureAuthType, AzureCredentials, isCredentialsComplete } from './AzureC
 
 export interface Props {
   managedIdentityEnabled: boolean;
+  workloadIdentityEnabled: boolean;
   credentials: AzureCredentials;
   azureCloudOptions?: SelectableValue[];
   onCredentialsChange: (updatedCredentials: AzureCredentials) => void;
@@ -18,23 +19,45 @@ export interface Props {
   disabled?: boolean;
 }
 
-const authTypeOptions: Array<SelectableValue<AzureAuthType>> = [
-  {
-    value: 'msi',
-    label: 'Managed Identity',
-  },
-  {
-    value: 'clientsecret',
-    label: 'App Registration',
-  },
-];
-
 export const AzureCredentialsForm = (props: Props) => {
-  const { credentials, azureCloudOptions, onCredentialsChange, getSubscriptions, disabled } = props;
+  const {
+    credentials,
+    azureCloudOptions,
+    onCredentialsChange,
+    getSubscriptions,
+    disabled,
+    managedIdentityEnabled,
+    workloadIdentityEnabled,
+  } = props;
   const hasRequiredFields = isCredentialsComplete(credentials);
 
   const [subscriptions, setSubscriptions] = useState<Array<SelectableValue<string>>>([]);
   const [loadSubscriptionsClicked, onLoadSubscriptions] = useReducer((val) => val + 1, 0);
+
+  const authTypeOptions = useMemo(() => {
+    let opts: Array<SelectableValue<AzureAuthType>> = [
+      {
+        value: 'clientsecret',
+        label: 'App Registration',
+      },
+    ];
+
+    if (managedIdentityEnabled) {
+      opts.push({
+        value: 'msi',
+        label: 'Managed Identity',
+      });
+    }
+
+    if (workloadIdentityEnabled) {
+      opts.push({
+        value: 'workloadidentity',
+        label: 'Workload Identity',
+      });
+    }
+    return opts;
+  }, [managedIdentityEnabled, workloadIdentityEnabled]);
+
   useEffect(() => {
     if (!getSubscriptions || !hasRequiredFields) {
       updateSubscriptions([]);
@@ -70,19 +93,22 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
-    if (onCredentialsChange) {
-      setSubscriptions([]);
-      const updated: AzureCredentials = {
-        ...credentials,
-        authType: selected.value || 'msi',
-        defaultSubscriptionId: undefined,
-      };
-      onCredentialsChange(updated);
-    }
+    setSubscriptions([]);
+    const defaultAuthType = managedIdentityEnabled
+      ? 'msi'
+      : workloadIdentityEnabled
+      ? 'workloadidentity'
+      : 'clientsecret';
+    const updated: AzureCredentials = {
+      ...credentials,
+      authType: selected.value || defaultAuthType,
+      defaultSubscriptionId: undefined,
+    };
+    onCredentialsChange(updated);
   };
 
   const onAzureCloudChange = (selected: SelectableValue<string>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
@@ -94,7 +120,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onTenantIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
@@ -106,7 +132,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
@@ -118,7 +144,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientSecretChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
@@ -130,7 +156,7 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onClientSecretReset = () => {
-    if (onCredentialsChange && credentials.authType === 'clientsecret') {
+    if (credentials.authType === 'clientsecret') {
       setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
@@ -142,19 +168,17 @@ export const AzureCredentialsForm = (props: Props) => {
   };
 
   const onSubscriptionChange = (selected: SelectableValue<string> | undefined) => {
-    if (onCredentialsChange) {
-      const updated: AzureCredentials = {
-        ...credentials,
-        defaultSubscriptionId: selected?.value,
-      };
-      onCredentialsChange(updated);
-    }
+    const updated: AzureCredentials = {
+      ...credentials,
+      defaultSubscriptionId: selected?.value,
+    };
+    onCredentialsChange(updated);
   };
   const prometheusConfigOverhaulAuth = config.featureToggles.prometheusConfigOverhaulAuth;
 
   return (
     <div className="gf-form-group">
-      {props.managedIdentityEnabled && (
+      {authTypeOptions.length > 1 && (
         <div className="gf-form-inline">
           <div className="gf-form">
             <InlineFormLabel className="width-12" tooltip="Choose the type of authentication to Azure services">


### PR DESCRIPTION
Backport 5796836662198ef09375c87f83ebf298f1c595b8 from #75681

---

As #75283 has been merged we can now add support for the Workload Identity authentication method to the core Azure datasources (Azure Monitor and Prometheus).

Docs have also been updated and code has been cleaned up in general.

Related #75404

cc. @kostrse 
