### PR TITLE
Transformations: Extended support for variables in filter by name

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5274,9 +5274,6 @@ exports[`better eslint`] = {
     "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"]
-    ],
     "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -283,7 +283,11 @@ You'll get the following output:
 
 Use this transformation to remove parts of the query results.
 
-You can filter field names in three different ways.
+You can filter field names in three different ways:
+
+- [Using a regular expression](#use-a-regular-expression)
+- [Manually selecting included fields](#manually-select-included-fields)
+- [Using a dashboard variable](#use-a-dashboard-variable)
 
 #### Using a regular expression
 

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -281,28 +281,37 @@ You'll get the following output:
 
 ### Filter by name
 
-Use this transformation to remove portions of the query results.
+Use this transformation to remove parts of the query results.
 
-Grafana displays the **Identifier** field, followed by the fields returned by your query.
+You can filter field names in three different ways.
 
-You can apply filters in one of two ways:
+#### Using a regular expression
 
-- Enter a regex expression.
-- Click a field to toggle filtering on that field. Filtered fields are displayed with dark gray text, unfiltered fields have white text.
+Field names that match the regular expression will be included.
 
-In the example below, I removed the Min field from the results.
+From the input data:
 
-Here is the original query table. (This is streaming data, so numbers change over time and between screenshots.)
+| Time                | dev-eu-west | dev-eu-north | prod-eu-west | prod-eu-north |
+| ------------------- | ----------- | ------------ | ------------ | ------------- |
+| 2023-03-04 23:56:23 | 23.5        | 24.5         | 22.2         | 20.2          |
+| 2023-03-04 23:56:23 | 23.6        | 24.4         | 22.1         | 20.1          |
 
-{{< figure src="/static/img/docs/transformations/filter-name-table-before-7-0.png" class="docs-image--no-shadow" max-width= "1100px" >}}
+The result from using the regular expression `prod.*` would be:
 
-Here is the table after I applied the transformation to remove the Min field.
+| Time                | prod-eu-west | prod-eu-north |
+| ------------------- | ------------ | ------------- |
+| 2023-03-04 23:56:23 | 22.2         | 20.2          |
+| 2023-03-04 23:56:23 | 22.1         | 20.1          |
 
-{{< figure src="/static/img/docs/transformations/filter-name-table-after-7-0.png" class="docs-image--no-shadow" max-width= "1100px" >}}
+The regular expression can include a dashboard variable interpolated by using the `${[variable name]}` syntax.
 
-Here is the same query using a Stat visualization.
+#### Manually selecting included fields
 
-{{< figure src="/static/img/docs/transformations/filter-name-stat-after-7-0.png" class="docs-image--no-shadow" max-width= "1100px" >}}
+By clicking and unchecking the field names they will not show up in the result. Fields that are matched by the regular expression will still be included, even if they are unchecked.
+
+#### Using a dashboard variable
+
+By enabling `From variable` you can select a dashboard variable that will be used to include fields. By settings up a [dashboard variable] with multiple choices, the same fields can be displayed across multiple visualizations.
 
 ### Filter data by query
 
@@ -1005,4 +1014,8 @@ Use this transformation to format the output of a time field. Output can be form
 
 [feature toggle]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
 [feature toggle]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
+
+[dashboard variable]: "/docs/grafana/ -> docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+[dashboard variable]: "/docs/grafana-cloud/ -> docs/grafana/<GRAFANA VERSION>/dashboards/variables"
+
 {{% /docs/reference %}}

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -289,9 +289,9 @@ You can filter field names in three different ways:
 - [Manually selecting included fields](#manually-select-included-fields)
 - [Using a dashboard variable](#use-a-dashboard-variable)
 
-#### Using a regular expression
+#### Use a regular expression
 
-Field names that match the regular expression will be included.
+When you filter using a regular expression, field names that match the regular expression are included.
 
 From the input data:
 
@@ -307,15 +307,15 @@ The result from using the regular expression `prod.*` would be:
 | 2023-03-04 23:56:23 | 22.2         | 20.2          |
 | 2023-03-04 23:56:23 | 22.1         | 20.1          |
 
-The regular expression can include a dashboard variable interpolated by using the `${[variable name]}` syntax.
+The regular expression can include an interpolated dashboard variable by using the `${[variable name]}` syntax.
 
-#### Manually selecting included fields
+#### Manually select included fields
 
-By clicking and unchecking the field names they will not show up in the result. Fields that are matched by the regular expression will still be included, even if they are unchecked.
+Click and uncheck the field names to remove them from the result. Fields that are matched by the regular expression are still included, even if they're unchecked.
 
-#### Using a dashboard variable
+#### Use a dashboard variable
 
-By enabling `From variable` you can select a dashboard variable that will be used to include fields. By settings up a [dashboard variable] with multiple choices, the same fields can be displayed across multiple visualizations.
+Enable `From variable` to let you select a dashboard variable that's used to include fields. By setting up a [dashboard variable][] with multiple choices, the same fields can be displayed across multiple visualizations.
 
 ### Filter data by query
 

--- a/packages/grafana-data/src/transformations/matchers/ids.ts
+++ b/packages/grafana-data/src/transformations/matchers/ids.ts
@@ -22,7 +22,6 @@ export enum FieldMatcherID {
   byTypes = 'byTypes',
   byName = 'byName',
   byNames = 'byNames',
-  byVariable = 'byVariable',
   byRegexp = 'byRegexp',
   byRegexpOrNames = 'byRegexpOrNames',
   byFrameRefID = 'byFrameRefID',

--- a/packages/grafana-data/src/transformations/matchers/ids.ts
+++ b/packages/grafana-data/src/transformations/matchers/ids.ts
@@ -22,6 +22,7 @@ export enum FieldMatcherID {
   byTypes = 'byTypes',
   byName = 'byName',
   byNames = 'byNames',
+  byVariable = 'byVariable',
   byRegexp = 'byRegexp',
   byRegexpOrNames = 'byRegexpOrNames',
   byFrameRefID = 'byFrameRefID',

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -8,6 +8,7 @@ import { FieldMatcherID, FrameMatcherID } from './ids';
 export interface RegexpOrNamesMatcherOptions {
   pattern?: string;
   names?: string[];
+  variable?: string;
 }
 
 /**

--- a/packages/grafana-data/src/transformations/transformers/filterByName.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByName.test.ts
@@ -196,8 +196,83 @@ describe('filterByName transformer', () => {
         expect(filtered.fields[0].name).toBe('B');
       });
     });
+    it('it can use a variable with multiple comma separated', async () => {
+      const cfg = {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            variable: '$var',
+          },
+          byVariable: true,
+        },
+      };
 
-    it('uses template variable substituion', async () => {
+      const ctx = {
+        interpolate: (target: string | undefined, scopedVars?: ScopedVars, format?: string | Function): string => {
+          if (!target) {
+            return '';
+          }
+          const variables: ScopedVars = {
+            var: {
+              value: 'B,D',
+              text: 'Test',
+            },
+          };
+          for (const key of Object.keys(variables)) {
+            return target.replace(`$${key}`, variables[key]!.value);
+          }
+          return target;
+        },
+      };
+
+      await expect(transformDataFrame([cfg], [seriesWithNamesToMatch], ctx)).toEmitValuesWith((received) => {
+        const data = received[0];
+        const filtered = data[0];
+        expect(filtered.fields.length).toBe(2);
+        expect(filtered.fields[0].name).toBe('B');
+        expect(filtered.fields[1].name).toBe('D');
+      });
+    });
+
+    it('it can use a variable with multiple comma separated values in {}', async () => {
+      const cfg = {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            variable: '$var',
+          },
+          byVariable: true,
+        },
+      };
+
+      const ctx = {
+        interpolate: (target: string | undefined, scopedVars?: ScopedVars, format?: string | Function): string => {
+          if (!target) {
+            return '';
+          }
+          const variables: ScopedVars = {
+            var: {
+              value: '{B,D}',
+              text: 'Test',
+            },
+          };
+          for (const key of Object.keys(variables)) {
+            return target.replace(`$${key}`, variables[key]!.value);
+          }
+          return target;
+        },
+      };
+
+      await expect(transformDataFrame([cfg], [seriesWithNamesToMatch], ctx)).toEmitValuesWith((received) => {
+        const data = received[0];
+        const filtered = data[0];
+        expect(filtered.fields.length).toBe(2);
+        expect(filtered.fields[0].name).toBe('B');
+        expect(filtered.fields[1].name).toBe('D');
+      });
+    });
+
+    it('uses template variable substitution', async () => {
       const cfg = {
         id: DataTransformerID.filterFieldsByName,
         options: {

--- a/packages/grafana-data/src/transformations/transformers/filterByName.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByName.ts
@@ -48,8 +48,8 @@ export const getMatcherConfig = (
   if (byVariable && variable) {
     const stringOfNames = ctx.interpolate(variable);
     if (/\{.*\}/.test(stringOfNames)) {
-      const n = stringOfNames.slice(1).slice(0, -1).split(',');
-      return { id: FieldMatcherID.byNames, options: { names: n } };
+      const namesFromString = stringOfNames.slice(1).slice(0, -1).split(',');
+      return { id: FieldMatcherID.byNames, options: { names: namesFromString } };
     }
     return { id: FieldMatcherID.byNames, options: { names: stringOfNames.split(',') } };
   }

--- a/packages/grafana-data/src/transformations/transformers/filterByName.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByName.ts
@@ -1,4 +1,4 @@
-import { DataTransformerInfo, MatcherConfig } from '../../types/transformations';
+import { DataTransformContext, DataTransformerInfo, MatcherConfig } from '../../types/transformations';
 import { FieldMatcherID } from '../matchers/ids';
 import { RegexpOrNamesMatcherOptions } from '../matchers/nameMatcher';
 
@@ -8,6 +8,7 @@ import { DataTransformerID } from './ids';
 export interface FilterFieldsByNameTransformerOptions {
   include?: RegexpOrNamesMatcherOptions;
   exclude?: RegexpOrNamesMatcherOptions;
+  byVariable?: boolean;
 }
 
 export const filterFieldsByNameTransformer: DataTransformerInfo<FilterFieldsByNameTransformerOptions> = {
@@ -20,25 +21,38 @@ export const filterFieldsByNameTransformer: DataTransformerInfo<FilterFieldsByNa
    * Return a modified copy of the series. If the transform is not or should not
    * be applied, just return the input series
    */
-  operator: (options, replace) => (source) =>
+  operator: (options, ctx) => (source) =>
     source.pipe(
       filterFieldsTransformer.operator(
         {
-          include: getMatcherConfig(options.include),
-          exclude: getMatcherConfig(options.exclude),
+          include: getMatcherConfig(ctx, options.include, options.byVariable),
+          exclude: getMatcherConfig(ctx, options.exclude, options.byVariable),
         },
-        replace
+        ctx
       )
     ),
 };
 
 // Exported to share with other implementations, but not exported to `@grafana/data`
-export const getMatcherConfig = (options?: RegexpOrNamesMatcherOptions): MatcherConfig | undefined => {
+export const getMatcherConfig = (
+  ctx: DataTransformContext,
+  options?: RegexpOrNamesMatcherOptions,
+  byVariable?: boolean
+): MatcherConfig | undefined => {
   if (!options) {
     return undefined;
   }
 
-  const { names, pattern } = options;
+  const { names, pattern, variable } = options;
+
+  if (byVariable && variable) {
+    const stringOfNames = ctx.interpolate(variable);
+    if (/\{(?:([^,]+),*)*\}/.test(stringOfNames)) {
+      const n = stringOfNames.slice(1).slice(0, -1).split(',');
+      return { id: FieldMatcherID.byNames, options: { names: n } };
+    }
+    return { id: FieldMatcherID.byNames, options: { names: stringOfNames.split(',') } };
+  }
 
   if ((!Array.isArray(names) || names.length === 0) && !pattern) {
     return undefined;

--- a/packages/grafana-data/src/transformations/transformers/filterByName.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByName.ts
@@ -47,7 +47,7 @@ export const getMatcherConfig = (
 
   if (byVariable && variable) {
     const stringOfNames = ctx.interpolate(variable);
-    if (/\{(?:([^,]+),*)*\}/.test(stringOfNames)) {
+    if (/\{.*\}/.test(stringOfNames)) {
       const n = stringOfNames.slice(1).slice(0, -1).split(',');
       return { id: FieldMatcherID.byNames, options: { names: n } };
     }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
 import {
@@ -10,9 +9,11 @@ import {
   getFieldDisplayName,
   stringToJsRegex,
   TransformerCategory,
+  SelectableValue,
 } from '@grafana/data';
 import { FilterFieldsByNameTransformerOptions } from '@grafana/data/src/transformations/transformers/filterByName';
-import { Field, Input, FilterPill, HorizontalGroup } from '@grafana/ui';
+import { getTemplateSrv } from '@grafana/runtime/src/services';
+import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
 
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
 
@@ -21,6 +22,9 @@ interface FilterByNameTransformerEditorState {
   options: FieldNameInfo[];
   selected: string[];
   regex?: string;
+  variable?: string;
+  variables: SelectableValue[];
+  byVariable?: boolean;
   isRegexValid?: boolean;
 }
 
@@ -37,7 +41,10 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     this.state = {
       include: props.options.include?.names || [],
       regex: props.options.include?.pattern,
+      variable: props.options.include?.variable,
+      byVariable: props.options.byVariable,
       options: [],
+      variables: [],
       selected: [],
       isRegexValid: true,
     };
@@ -57,6 +64,9 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     const { input, options } = this.props;
     const configuredOptions = Array.from(options.include?.names ?? []);
 
+    const variables = getTemplateSrv()
+      .getVariables()
+      .map((v) => ({ label: '$' + v.name, value: '$' + v.name }));
     const allNames: FieldNameInfo[] = [];
     const byName: KeyValue<FieldNameInfo> = {};
 
@@ -97,12 +107,18 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
       this.setState({
         options: allNames,
         selected: selected.map((s) => s.name),
+        variables: variables,
+        byVariable: options.byVariable,
+        variable: options.include?.variable,
         regex: options.include?.pattern,
       });
     } else {
       this.setState({
         options: allNames,
         selected: allNames.map((n) => n.name),
+        variables: variables,
+        byVariable: options.byVariable,
+        variable: options.include?.variable,
         regex: options.include?.pattern,
       });
     }
@@ -161,19 +177,46 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     this.setState({ isRegexValid });
   };
 
+  onVariableChange = (selected: SelectableValue) => {
+    this.props.onChange({
+      ...this.props.options,
+      include: { variable: selected.value },
+    });
+
+    this.setState({ variable: selected.value });
+  };
+
+  onFromVariableChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const val = e.currentTarget.checked;
+    this.props.onChange({ ...this.props.options, byVariable: val });
+    this.setState({ byVariable: val });
+  };
+
   render() {
     const { options, selected, isRegexValid } = this.state;
     return (
-      <div className="gf-form-inline">
-        <div className="gf-form gf-form--grow">
-          <div className="gf-form-label width-8">Identifier</div>
-          <HorizontalGroup spacing="xs" align="flex-start" wrap>
-            <Field
+      <div>
+        <InlineFieldRow label="Use variable">
+          <InlineField label="From variable">
+            <InlineSwitch value={this.state.byVariable} onChange={this.onFromVariableChange}></InlineSwitch>
+          </InlineField>
+        </InlineFieldRow>
+        {this.state.byVariable ? (
+          <InlineFieldRow>
+            <InlineField label="Variable">
+              <Select
+                value={this.state.variable}
+                onChange={this.onVariableChange}
+                options={this.state.variables || []}
+              ></Select>
+            </InlineField>
+          </InlineFieldRow>
+        ) : (
+          <InlineFieldRow label="Identifier">
+            <InlineField
+              label="Identifier"
               invalid={!isRegexValid}
               error={!isRegexValid ? 'Invalid pattern' : undefined}
-              className={css`
-                margin-bottom: 0;
-              `}
             >
               <Input
                 placeholder="Regular expression pattern"
@@ -182,7 +225,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
                 onBlur={this.onInputBlur}
                 width={25}
               />
-            </Field>
+            </InlineField>
             {options.map((o, i) => {
               const label = `${o.name}${o.count > 1 ? ' (' + o.count + ')' : ''}`;
               const isSelected = selected.indexOf(o.name) > -1;
@@ -197,8 +240,8 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
                 />
               );
             })}
-          </HorizontalGroup>
-        </div>
+          </InlineFieldRow>
+        )}
       </div>
     );
   }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -24,7 +24,7 @@ interface FilterByNameTransformerEditorState {
   regex?: string;
   variable?: string;
   variables: SelectableValue[];
-  byVariable?: boolean;
+  byVariable: boolean;
   isRegexValid?: boolean;
 }
 
@@ -42,7 +42,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
       include: props.options.include?.names || [],
       regex: props.options.include?.pattern,
       variable: props.options.include?.variable,
-      byVariable: props.options.byVariable,
+      byVariable: props.options.byVariable || false,
       options: [],
       variables: [],
       selected: [],
@@ -108,7 +108,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
         options: allNames,
         selected: selected.map((s) => s.name),
         variables: variables,
-        byVariable: options.byVariable,
+        byVariable: options.byVariable || false,
         variable: options.include?.variable,
         regex: options.include?.pattern,
       });
@@ -117,7 +117,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
         options: allNames,
         selected: allNames.map((n) => n.name),
         variables: variables,
-        byVariable: options.byVariable,
+        byVariable: options.byVariable || false,
         variable: options.include?.variable,
         regex: options.include?.pattern,
       });

--- a/public/app/features/transformers/partitionByValues/partitionByValues.ts
+++ b/public/app/features/transformers/partitionByValues/partitionByValues.ts
@@ -73,7 +73,7 @@ export const partitionByValuesTransformer: SynchronousDataTransformerInfo<Partit
     source.pipe(map((data) => partitionByValuesTransformer.transformer(options, ctx)(data))),
 
   transformer: (options: PartitionByValuesTransformerOptions, ctx: DataTransformContext) => {
-    const matcherConfig = getMatcherConfig({ names: options.fields });
+    const matcherConfig = getMatcherConfig(ctx, { names: options.fields });
 
     if (!matcherConfig) {
       return noopTransformer.transformer({}, ctx);


### PR DESCRIPTION
**What is this feature?**
This adds support for using variables with multiple values in the filter by name transformation.
![image](https://github.com/grafana/grafana/assets/468940/fa4a1cc5-8673-40d5-a558-4cffdbc37e08)

![Peek 2023-09-29 12-19](https://github.com/grafana/grafana/assets/468940/5b880240-5d5d-435f-bbd7-c9d82e575061)

Fixes #74488

The original feature request specified this behavior on organize fields. But the functionality fits a lot better in filter by name.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
