### PR TITLE
Angular: Fix issue where panels in collapsed rows were not auto-migrated

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -184,13 +184,13 @@ export class DashboardModel implements TimeModel {
 
     // Auto-migrate old angular panels
     if (options?.autoMigrateOldPanels || !config.angularSupportEnabled || config.featureToggles.autoMigrateOldPanels) {
-      this.panels.forEach((p) => {
+      for (const p of this.panelIterator()) {
         const newType = autoMigrateAngular[p.type];
         if (!p.autoMigrateFrom && newType) {
           p.autoMigrateFrom = p.type;
           p.type = newType;
         }
-      });
+      }
     }
 
     this.addBuiltInAnnotationQuery();


### PR DESCRIPTION
Fixes an issue where angular panels that were in collapsed rows were not auto-migrated as they should have been.