### PR TITLE
Table: Make sparkline cell respect no value option.

### DIFF
--- a/packages/grafana-ui/src/components/Table/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/SparklineCell.tsx
@@ -35,7 +35,7 @@ export const SparklineCell = (props: TableCellProps) => {
   if (!sparkline) {
     return (
       <div {...cellProps} className={tableStyles.cellContainer}>
-        no data
+        {field.config.noValue || 'no data'}
       </div>
     );
   }


### PR DESCRIPTION
**What is this feature?**

Let's the user set the no value field config option to display when a sparkline cannot be created from the data.

**Why do we need this feature?**

If there is no data or the data can't be used for a sparkline we currently get a static "no data". This makes the sparkline respect the no value option.

Fixes #75352

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
