### PR TITLE
Transformations: Rename "Transform" tab to "Transform data"

### DIFF
--- a/e2e/panels-suite/geomap-spatial-operations-transform.spec.ts
+++ b/e2e/panels-suite/geomap-spatial-operations-transform.spec.ts
@@ -9,7 +9,7 @@ describe('Geomap spatial operations', () => {
 
   it('Tests location auto option', () => {
     e2e.flows.openDashboard({ uid: DASHBOARD_ID, queryParams: { editPanel: 1 } });
-    e2e.components.Tab.title('Transform').should('be.visible').click();
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
 
     e2e.components.TransformTab.newTransform('Spatial operations').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.SpatialOperations.actionLabel().type('Prepare spatial field{enter}');
@@ -26,7 +26,7 @@ describe('Geomap spatial operations', () => {
 
   it('Tests location coords option', () => {
     e2e.flows.openDashboard({ uid: DASHBOARD_ID, queryParams: { editPanel: 1 } });
-    e2e.components.Tab.title('Transform').should('be.visible').click();
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
 
     e2e.components.TransformTab.newTransform('Spatial operations').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.SpatialOperations.actionLabel().type('Prepare spatial field{enter}');
@@ -49,7 +49,7 @@ describe('Geomap spatial operations', () => {
 
   it('Tests geoshash field column appears in table view', () => {
     e2e.flows.openDashboard({ uid: DASHBOARD_ID, queryParams: { editPanel: 1 } });
-    e2e.components.Tab.title('Transform').should('be.visible').click();
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
 
     e2e.components.TransformTab.newTransform('Spatial operations').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.SpatialOperations.actionLabel().type('Prepare spatial field{enter}');
@@ -71,7 +71,7 @@ describe('Geomap spatial operations', () => {
 
   it('Tests location lookup option', () => {
     e2e.flows.openDashboard({ uid: DASHBOARD_ID, queryParams: { editPanel: 1 } });
-    e2e.components.Tab.title('Transform').should('be.visible').click();
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
 
     e2e.components.TransformTab.newTransform('Spatial operations').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.SpatialOperations.actionLabel().type('Prepare spatial field{enter}');

--- a/e2e/panels-suite/panelEdit_base.spec.ts
+++ b/e2e/panels-suite/panelEdit_base.spec.ts
@@ -37,7 +37,7 @@ describe('Panel edit tests', () => {
         //  Can change to Transform tab
         e2e.components.Tab.title('Transform data').should('be.visible').click();
         e2e.components.Tab.active().within((li: JQuery<HTMLLIElement>) => {
-          expect(li.text()).equals('Transform0'); // there's no transform so therefore Transform + 0
+          expect(li.text()).equals('Transform data0'); // there's no transform so therefore Transform + 0
         });
         e2e.components.Transforms.card('Merge').scrollIntoView().should('be.visible');
         e2e.components.QueryTab.content().should('not.exist');

--- a/e2e/panels-suite/panelEdit_base.spec.ts
+++ b/e2e/panels-suite/panelEdit_base.spec.ts
@@ -35,7 +35,7 @@ describe('Panel edit tests', () => {
 
         //  Bottom pane tabs
         //  Can change to Transform tab
-        e2e.components.Tab.title('Transform').should('be.visible').click();
+        e2e.components.Tab.title('Transform data').should('be.visible').click();
         e2e.components.Tab.active().within((li: JQuery<HTMLLIElement>) => {
           expect(li.text()).equals('Transform0'); // there's no transform so therefore Transform + 0
         });

--- a/e2e/panels-suite/panelEdit_transforms.spec.ts
+++ b/e2e/panels-suite/panelEdit_transforms.spec.ts
@@ -8,7 +8,7 @@ describe('Panel edit tests - transformations', () => {
   it('Tests transformations editor', () => {
     e2e.flows.openDashboard({ uid: '5SdHCadmz', queryParams: { editPanel: 3 } });
 
-    e2e.components.Tab.title('Transform').should('be.visible').click();
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
     e2e.components.TransformTab.newTransform('Reduce').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.Reduce.calculationsLabel().should('be.visible');
   });

--- a/public/app/features/dashboard/components/PanelEditor/state/selectors.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/selectors.test.ts
@@ -34,7 +34,7 @@ describe('getPanelEditorTabs selector', () => {
           "active": true,
           "icon": "process",
           "id": "transform",
-          "text": "Transform",
+          "text": "Transform data",
         },
       ]
     `);

--- a/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
@@ -33,7 +33,7 @@ export const getPanelEditorTabs = memoizeOne((tab?: string, plugin?: PanelPlugin
 
     tabs.push({
       id: PanelEditorTabId.Transform,
-      text: 'Transform Data',
+      text: 'Transform data',
       icon: 'process',
       active: false,
     });

--- a/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
@@ -33,7 +33,7 @@ export const getPanelEditorTabs = memoizeOne((tab?: string, plugin?: PanelPlugin
 
     tabs.push({
       id: PanelEditorTabId.Transform,
-      text: 'Transform',
+      text: 'Transform Data',
       icon: 'process',
       active: false,
     });


### PR DESCRIPTION
This PR changes the "Transform" tab in the panel editor to read "Transform Data" instead to help give it further clarity. Still need to take a look and see if there are any docs that need to be updated.

**Which issue(s) does this PR fix?**:

Fixes #74209

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
