### PR TITLE
Loki Query Builder: Browser resource cache PoC

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6444,8 +6444,7 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/loki/LanguageProvider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/loki/LiveStreams.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -150,6 +150,10 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 	respHeaders := map[string][]string{
 		"content-type": {"application/json"},
 	}
+	if len(req.GetHTTPHeaders().Get("X-Grafana-Cache")) > 0 {
+		respHeaders["X-Grafana-Cache"] = []string{"y"}
+		respHeaders["Cache-Control"] = []string{req.GetHTTPHeaders().Get("X-Grafana-Cache")}
+	}
 	if rawLokiResponse.Encoding != "" {
 		respHeaders["content-encoding"] = []string{rawLokiResponse.Encoding}
 	}


### PR DESCRIPTION
**What is this feature?**
PoC of adding browser cache to resource calls. 
Works by snapping ranges to closest minute, but this is configurable to include longer durations

**Why do we need this feature?**
The react LRU cache is very limited and not maintained, browsers can do a better job of managing cache resources then we can control in the client application.

Also makes debugging easier as the LRU cache doesn't log cache hits/misses, browser cache shows all requests in network inspector.


**Who is this feature for?**
Loki users

**Which issue(s) does this PR fix?**:
Relates to https://github.com/grafana/grafana/issues/75512
Needs issue

**Special notes for your reviewer:**
Very quick/dirty PoC, want to spend a bit more time investigating https://github.com/grafana/grafana/issues/75512, as it looks like the most redundant API call is the query itself, and not the resource calls.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
