### PR TITLE
feat: integrate pyroscope query editor with app

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
@@ -3,13 +3,20 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { CoreApp, PluginType } from '@grafana/data';
+import { setPluginExtensionGetter } from '@grafana/runtime';
 
 import { PyroscopeDataSource } from '../datasource';
+import { mockFetchPyroscopeDatasourceSettings } from '../datasource.test';
 import { ProfileTypeMessage } from '../types';
 
 import { Props, QueryEditor } from './QueryEditor';
 
 describe('QueryEditor', () => {
+  beforeEach(() => {
+    setPluginExtensionGetter(() => ({ extensions: [] })); // No extensions
+    mockFetchPyroscopeDatasourceSettings();
+  });
+
   it('should render without error', async () => {
     setup();
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
@@ -12,6 +12,7 @@ import { EditorRow } from './EditorRow';
 import { EditorRows } from './EditorRows';
 import { LabelsEditor } from './LabelsEditor';
 import { ProfileTypesCascader, useProfileTypes } from './ProfileTypesCascader';
+import { PyroscopeQueryLinkExtensions } from './QueryLinkExtension';
 import { QueryOptions } from './QueryOptions';
 
 export type Props = QueryEditorProps<PyroscopeDataSource, Query, PyroscopeDataSourceOptions>;
@@ -57,6 +58,7 @@ export function QueryEditor(props: Props) {
           labels={labels}
           getLabelValues={getLabelValues}
         />
+        <PyroscopeQueryLinkExtensions {...props} />
       </EditorRow>
       <EditorRow>
         <QueryOptions query={query} onQueryChange={props.onChange} app={props.app} labels={labels} />

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.test.tsx
@@ -12,7 +12,6 @@ import { Props, PyroscopeQueryLinkExtensions, resetPyroscopeQueryLinkExtensionsF
 
 // Constants copied from `QueryLinkExtension.tsx`
 const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
-const DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY = 'configuration-not-ready-yet';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -68,22 +67,6 @@ describe('PyroscopeQueryLinkExtensions', () => {
   it('Should not render if no extension present', async () => {
     await act(setup);
     expect(screen.queryByText(EXPECTED_BUTTON_LABEL)).toBeNull();
-  });
-
-  it('Should not immediately render if extension description signals `configuration-not-ready-yet`', async () => {
-    getPluginLinkExtensionsMock.mockReturnValue({
-      extensions: [createExtension({ description: DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY })],
-    }); // Extension config busy
-    await act(setup);
-    expect(screen.queryByText(EXPECTED_BUTTON_LABEL)).toBeNull();
-
-    // But if in the near future, the extension becomes available, it should then be rendered.
-    getPluginLinkExtensionsMock.mockReturnValue({ extensions: [createExtension()] }); // No longer busy
-
-    await act(() => {
-      return new Promise((accept) => setTimeout(accept, 1000));
-    });
-    expect(await screen.findAllByText(EXPECTED_BUTTON_LABEL)).toBeDefined();
   });
 });
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { PluginType, rangeUtil, PluginExtensionLink, PluginExtensionTypes } from '@grafana/data';
+import { getPluginLinkExtensions } from '@grafana/runtime';
+
+import { PyroscopeDataSource } from '../datasource';
+import { mockFetchPyroscopeDatasourceSettings } from '../datasource.test';
+
+import { Props, PyroscopeQueryLinkExtensions, resetPyroscopeQueryLinkExtensionsFetches } from './QueryLinkExtension';
+
+// Constants copied from `QueryLinkExtension.tsx`
+const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
+const DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY = 'configuration-not-ready-yet';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  setPluginExtensionGetter: jest.fn(),
+  getPluginLinkExtensions: jest.fn(),
+}));
+
+const getPluginLinkExtensionsMock = jest.mocked(getPluginLinkExtensions);
+
+const defaultPyroscopeDataSourceSettings = {
+  uid: 'default-pyroscope',
+  url: 'http://pyroscope',
+  basicAuthUser: 'pyroscope_user',
+};
+
+describe('PyroscopeQueryLinkExtensions', () => {
+  const EXPECTED_BUTTON_LABEL = 'Profiles App';
+  const DEFAULT_EXTENSION_PATH = 'a/mock-path-app/fake-path';
+
+  function createExtension(overrides?: Partial<PluginExtensionLink>) {
+    return {
+      ...{
+        description: 'unremarkable-description',
+        extensionPointId: EXTENSION_POINT_ID,
+        title: EXPECTED_BUTTON_LABEL,
+        path: DEFAULT_EXTENSION_PATH,
+        type: PluginExtensionTypes.link,
+        category: 'unremarkable-category',
+        icon: 'heart',
+        onClick() {},
+        pluginId: 'mock-path-app',
+        id: `${Date.now()}}`,
+      },
+      ...overrides,
+    } as PluginExtensionLink;
+  }
+
+  beforeEach(() => {
+    resetPyroscopeQueryLinkExtensionsFetches();
+    mockFetchPyroscopeDatasourceSettings(defaultPyroscopeDataSourceSettings);
+
+    getPluginLinkExtensionsMock.mockRestore();
+    getPluginLinkExtensionsMock.mockReturnValue({ extensions: [] }); // Unless stated otherwise, no extensions
+  });
+
+  it('should render if extension present', async () => {
+    getPluginLinkExtensionsMock.mockReturnValue({ extensions: [createExtension()] }); // Default extension
+
+    await act(setup);
+    expect(await screen.findAllByText(EXPECTED_BUTTON_LABEL)).toBeDefined();
+  });
+
+  it('Should not render if no extension present', async () => {
+    await act(setup);
+    expect(screen.queryByText(EXPECTED_BUTTON_LABEL)).toBeNull();
+  });
+
+  it('Should not immediately render if extension description signals `configuration-not-ready-yet`', async () => {
+    getPluginLinkExtensionsMock.mockReturnValue({
+      extensions: [createExtension({ description: DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY })],
+    }); // Extension config busy
+    await act(setup);
+    expect(screen.queryByText(EXPECTED_BUTTON_LABEL)).toBeNull();
+
+    // But if in the near future, the extension becomes available, it should then be rendered.
+    getPluginLinkExtensionsMock.mockReturnValue({ extensions: [createExtension()] }); // No longer busy
+
+    await act(() => {
+      return new Promise((accept) => setTimeout(accept, 1000));
+    });
+    expect(await screen.findAllByText(EXPECTED_BUTTON_LABEL)).toBeDefined();
+  });
+});
+
+function setupDs() {
+  const ds = new PyroscopeDataSource({
+    ...defaultPyroscopeDataSourceSettings,
+    name: 'test',
+    type: PluginType.datasource,
+    access: 'proxy',
+    id: 1,
+    jsonData: {},
+    meta: {
+      name: '',
+      id: '',
+      type: PluginType.datasource,
+      baseUrl: '',
+      info: {
+        author: {
+          name: '',
+        },
+        description: '',
+        links: [],
+        logos: {
+          large: '',
+          small: '',
+        },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+      module: '',
+    },
+    readOnly: false,
+  });
+
+  return ds;
+}
+
+async function setup(options: { props: Partial<Props> } = { props: {} }) {
+  const utils = render(
+    <PyroscopeQueryLinkExtensions
+      query={{
+        queryType: 'both',
+        labelSelector: '',
+        profileTypeId: 'process_cpu:cpu',
+        refId: 'A',
+        maxNodes: 1000,
+        groupBy: [],
+      }}
+      datasource={setupDs()}
+      range={rangeUtil.convertRawToRange({ from: 'now-1h', to: 'now' })}
+      {...options.props}
+    />
+  );
+  return { ...utils };
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import React, { useEffect } from 'react';
+import React from 'react';
+import { useAsync } from 'react-use';
 
 import { GrafanaTheme2, QueryEditorProps, TimeRange } from '@grafana/data';
 import { getBackendSrv, getPluginLinkExtensions } from '@grafana/runtime';
@@ -7,7 +8,6 @@ import { LinkButton, useStyles2 } from '@grafana/ui';
 
 import { PyroscopeDataSource } from '../datasource';
 import { PyroscopeDataSourceOptions, Query } from '../types';
-import { useAsync } from 'react-use';
 
 const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
 
@@ -48,7 +48,7 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
     range,
   } = props;
 
-  const { value:datasourceSettings } = useAsync(async () => {
+  const { value: datasourceSettings } = useAsync(async () => {
     if (pyroscopeDatasourceSettingsByUid[datasourceUid]) {
       return pyroscopeDatasourceSettingsByUid[datasourceUid];
     }

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { GrafanaTheme2, QueryEditorProps, TimeRange } from '@grafana/data';
 import { getBackendSrv, getPluginLinkExtensions } from '@grafana/runtime';
@@ -7,6 +7,7 @@ import { LinkButton, useStyles2 } from '@grafana/ui';
 
 import { PyroscopeDataSource } from '../datasource';
 import { PyroscopeDataSourceOptions, Query } from '../types';
+import { useAsync } from 'react-use';
 
 const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
 
@@ -69,18 +70,6 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
   });
 
   const styles = useStyles2(getStyles);
-
-  useEffect(() => {
-    let datasourceSettings = pyroscopeDatasourceSettingsByUid[datasourceUid];
-
-    if (datasourceSettings == null) {
-      // This explicit fetch of the datasource by its id ensures that we obtain its authentication settings
-      datasourceSettings = getBackendSrv().get<PyroscopeDatasourceSettings>(`/api/datasources/uid/${datasourceUid}`);
-      pyroscopeDatasourceSettingsByUid[datasourceUid] = datasourceSettings;
-    }
-
-    datasourceSettings.then(setDatasourceSettings, () => setDatasourceSettings(undefined));
-  }, [datasourceUid]);
 
   if (extensions.length === 0) {
     return null;

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
@@ -1,0 +1,128 @@
+import { css } from '@emotion/css';
+import React, { useEffect, useState } from 'react';
+
+import { GrafanaTheme2, QueryEditorProps, TimeRange } from '@grafana/data';
+import { getBackendSrv, getPluginLinkExtensions } from '@grafana/runtime';
+import { LinkButton, useStyles2 } from '@grafana/ui';
+
+import { PyroscopeDataSource } from '../datasource';
+import { PyroscopeDataSourceOptions, Query } from '../types';
+
+const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
+const DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY = 'configuration-not-ready-yet';
+
+/** A subset of the datasource settings that are relevant for this integration */
+type PyroscopeDatasourceSettings = {
+  uid: string;
+  url: string;
+  basicAuthUser: string;
+};
+
+/** The context object that will be shared with the link extension's configure function */
+type ExtensionQueryLinksContext = {
+  datasourceUid: string;
+  query: Query;
+  range?: TimeRange | undefined;
+  datasourceSettings?: PyroscopeDatasourceSettings;
+};
+
+/* Global promises to fetch pyroscope datasource settings by uid as encountered */
+const pyroscopeDatasourceSettingsByUid: Record<string, Promise<PyroscopeDatasourceSettings>> = {};
+
+/* Reset promises for testing purposes */
+export function resetPyroscopeQueryLinkExtensionsFetches() {
+  Object.keys(pyroscopeDatasourceSettingsByUid).forEach((key) => delete pyroscopeDatasourceSettingsByUid[key]);
+}
+
+/** A subset of the `PyroscopeDataSource` `QueryEditorProps` */
+export type Props = Pick<
+  QueryEditorProps<PyroscopeDataSource, Query, PyroscopeDataSourceOptions>,
+  'datasource' | 'query' | 'range'
+>;
+
+export function PyroscopeQueryLinkExtensions(props: Props) {
+  const {
+    datasource: { uid: datasourceUid },
+    query,
+    range,
+  } = props;
+
+  const [datasourceSettings, setDatasourceSettings] = useState<PyroscopeDatasourceSettings>();
+  const [waitingOnExtensionConfigure, setWaitingOnExtensionConfigure] = useState(false);
+
+  const context: ExtensionQueryLinksContext = {
+    datasourceUid,
+    query,
+    range,
+    datasourceSettings,
+  };
+
+  const { extensions } = getPluginLinkExtensions({
+    extensionPointId: EXTENSION_POINT_ID,
+    context,
+  });
+
+  if (!waitingOnExtensionConfigure) {
+    const delayedExtension = extensions.find(
+      (extension) => extension.description === DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY
+    );
+
+    if (delayedExtension) {
+      // Declare that we are waiting on the extension configuration
+      setWaitingOnExtensionConfigure(true);
+
+      // Wait a second, and then declare that we are no longer waiting.
+      // This trigger another `configure` call to each extension.
+      setTimeout(() => setWaitingOnExtensionConfigure(false), 1000);
+    }
+  }
+
+  const styles = useStyles2(getStyles);
+
+  useEffect(() => {
+    let datasourceSettings = pyroscopeDatasourceSettingsByUid[datasourceUid];
+
+    if (datasourceSettings == null) {
+      // This explicit fetch of the datasource by its id ensures that we obtain its authentication settings
+      datasourceSettings = getBackendSrv().get<PyroscopeDatasourceSettings>(`/api/datasources/uid/${datasourceUid}`);
+      pyroscopeDatasourceSettingsByUid[datasourceUid] = datasourceSettings;
+    }
+
+    datasourceSettings.then(setDatasourceSettings, () => setDatasourceSettings(undefined));
+  }, [datasourceUid]);
+
+  if (extensions.length === 0) {
+    return null;
+  }
+
+  const configuredExtensions = extensions.filter(
+    (extension) => extension.description !== DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY
+  );
+
+  return (
+    <>
+      {configuredExtensions.map((extension) => (
+        <LinkButton
+          className={styles.linkButton}
+          key={`${extension.id}`}
+          variant="secondary"
+          icon={extension.icon || 'external-link-alt'}
+          tooltip={extension.description}
+          target="_blank"
+          href={extension.path}
+          onClick={extension.onClick}
+        >
+          {extension.title}
+        </LinkButton>
+      ))}
+    </>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    linkButton: css({
+      marginLeft: theme.spacing(1),
+    }),
+  };
+}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
@@ -27,7 +27,7 @@ type ExtensionQueryLinksContext = {
 };
 
 /* Global promises to fetch pyroscope datasource settings by uid as encountered */
-const pyroscopeDatasourceSettingsByUid: Record<string, Promise<PyroscopeDatasourceSettings>> = {};
+const pyroscopeDatasourceSettingsByUid: Record<string, PyroscopeDatasourceSettings> = {};
 
 /* Reset promises for testing purposes */
 export function resetPyroscopeQueryLinkExtensionsFetches() {
@@ -47,7 +47,14 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
     range,
   } = props;
 
-  const [datasourceSettings, setDatasourceSettings] = useState<PyroscopeDatasourceSettings>();
+  const { value:datasourceSettings } = useAsync(async () => {
+    if (pyroscopeDatasourceSettingsByUid[datasourceUid]) {
+      return pyroscopeDatasourceSettingsByUid[datasourceUid];
+    }
+    const settings = await getBackendSrv().get<PyroscopeDatasourceSettings>(`/api/datasources/uid/${datasourceUid}`);
+    pyroscopeDatasourceSettingsByUid[datasourceUid] = settings;
+    return settings;
+  }, [datasourceUid]);
 
   const context: ExtensionQueryLinksContext = {
     datasourceUid,

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryLinkExtension.tsx
@@ -9,12 +9,12 @@ import { PyroscopeDataSource } from '../datasource';
 import { PyroscopeDataSourceOptions, Query } from '../types';
 
 const EXTENSION_POINT_ID = 'plugins/grafana-pyroscope-datasource/query-links';
-const DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY = 'configuration-not-ready-yet';
 
 /** A subset of the datasource settings that are relevant for this integration */
 type PyroscopeDatasourceSettings = {
   uid: string;
   url: string;
+  type: string;
   basicAuthUser: string;
 };
 
@@ -48,7 +48,6 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
   } = props;
 
   const [datasourceSettings, setDatasourceSettings] = useState<PyroscopeDatasourceSettings>();
-  const [waitingOnExtensionConfigure, setWaitingOnExtensionConfigure] = useState(false);
 
   const context: ExtensionQueryLinksContext = {
     datasourceUid,
@@ -61,21 +60,6 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
     extensionPointId: EXTENSION_POINT_ID,
     context,
   });
-
-  if (!waitingOnExtensionConfigure) {
-    const delayedExtension = extensions.find(
-      (extension) => extension.description === DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY
-    );
-
-    if (delayedExtension) {
-      // Declare that we are waiting on the extension configuration
-      setWaitingOnExtensionConfigure(true);
-
-      // Wait a second, and then declare that we are no longer waiting.
-      // This trigger another `configure` call to each extension.
-      setTimeout(() => setWaitingOnExtensionConfigure(false), 1000);
-    }
-  }
 
   const styles = useStyles2(getStyles);
 
@@ -95,13 +79,9 @@ export function PyroscopeQueryLinkExtensions(props: Props) {
     return null;
   }
 
-  const configuredExtensions = extensions.filter(
-    (extension) => extension.description !== DESCRIPTION_INDICATING_CONFIGURATION_NOT_READY
-  );
-
   return (
     <>
-      {configuredExtensions.map((extension) => (
+      {extensions.map((extension) => (
         <LinkButton
           className={styles.linkButton}
           key={`${extension.id}`}


### PR DESCRIPTION
**Apologies to people notified to review this PR**
This was an unintentional mass invitation due to a `git pull --rebase` automatically adding a large number of reviewer requests.

Please ignore this if you were mistakenly alerted to this PR.

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

If the Pyroscope app plugin is detected, and has the same configuration as the currently selected data source, create a link for the current query to the app plugin to explore further.

This image describes the goal:
![image](https://github.com/grafana/grafana/assets/38694490/5bfb93af-a021-48d4-b2e5-b2204532a65b)

**Why do we need this feature?**

To notify users that they can further explore their supported Pyroscope data source through the Pyroscope app plugin. This provides a way to access that app, so they can take advantage if its additional utility.

**Who is this feature for?**

Grafana cloud users of Pyroscope.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

DEMO video:
https://github.com/grafana/grafana/assets/38694490/4621a854-349e-451a-9cf7-f8df896f3746

If you would like to run this locally, see this branch:
- https://github.com/grafana/pyroscope-app-plugin/pull/112

Note that this obtains the `basicAuthUser` field from the currently selected datasource, using a URL like:
- `/api/datasources/uid/grafanacloud-profiles`

It seems that Reader and Editor roles can obtain these values, which is good for this feature. Are there any security concerns with highlighting that these values are accessible?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
  - It is not
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
  - N/A
- [ ] Evaluate if the Reader/Writer roles being able to access a datasource's basicAuthUser is a security concern
