### PR TITLE
IDForwarding: Add basic metrics

### DIFF
--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -1,0 +1,37 @@
+package idimpl
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	metricsSubSystem = "authn"
+	metricsNamespace = "grafana"
+)
+
+func newMetircus(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		singedTokens: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "idforwarding_signed_tokens_total",
+			Help:      "Number of signed tokens",
+		}),
+		signedTokensFromCache: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "idforwarding_signed_tokens_from_cache_total",
+			Help:      "Number of signed tokens retrieved from cahce",
+		}),
+	}
+
+	if reg != nil {
+		reg.MustRegister(m.singedTokens)
+		reg.MustRegister(m.signedTokensFromCache)
+	}
+
+	return m
+}
+
+type metrics struct {
+	singedTokens          prometheus.Counter
+	signedTokensFromCache prometheus.Counter
+}

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -1,37 +1,57 @@
 package idimpl
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 const (
-	metricsSubSystem = "authn"
 	metricsNamespace = "grafana"
+	metricsSubSystem = "idforwarding"
 )
 
 func newMetircus(reg prometheus.Registerer) *metrics {
 	m := &metrics{
-		singedTokens: prometheus.NewCounter(prometheus.CounterOpts{
+		tokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
-			Name:      "idforwarding_signed_tokens_total",
-			Help:      "Number of signed tokens",
+			Name:      "idforwarding_token_sining_total",
+			Help:      "Number of token signings",
 		}),
-		signedTokensFromCache: prometheus.NewCounter(prometheus.CounterOpts{
+		tokenSigningFromCacheCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
-			Name:      "idforwarding_signed_tokens_from_cache_total",
+			Name:      "idforwarding_token_signing_from_cache_total",
 			Help:      "Number of signed tokens retrieved from cahce",
+		}),
+		failedTokenSingingCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "idforwarding_failed_token_sining_total",
+			Help:      "Number of failed token singings",
+		}),
+
+		tokenSigningDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "idfowrading_token_signing_duration_seconds",
+			Help:      "Histrogram of token signing duration",
+			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
 		}),
 	}
 
 	if reg != nil {
-		reg.MustRegister(m.singedTokens)
-		reg.MustRegister(m.signedTokensFromCache)
+		reg.MustRegister(m.tokenSigningCounter)
+		reg.MustRegister(m.tokenSigningFromCacheCounter)
+		reg.MustRegister(m.failedTokenSingingCounter)
+		reg.MustRegister(m.tokenSigningDurationHistogram)
 	}
 
 	return m
 }
 
 type metrics struct {
-	singedTokens          prometheus.Counter
-	signedTokensFromCache prometheus.Counter
+	tokenSigningCounter           prometheus.Counter
+	tokenSigningFromCacheCounter  prometheus.Counter
+	failedTokenSingingCounter     prometheus.Counter
+	tokenSigningDurationHistogram prometheus.Histogram
 }

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -33,7 +33,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
 			Name:      "idforwarding_token_signing_duration_seconds",
-			Help:      "Histrogram of token signing duration",
+			Help:      "Histogram of token signing duration",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
 		}),
 	}

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -9,7 +9,7 @@ const (
 	metricsSubSystem = "idforwarding"
 )
 
-func newMetircus(reg prometheus.Registerer) *metrics {
+func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
 		tokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -23,7 +23,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 			Name:      "idforwarding_token_signing_from_cache_total",
 			Help:      "Number of signed tokens retrieved from cahce",
 		}),
-		failedTokenSingingCounter: prometheus.NewCounter(prometheus.CounterOpts{
+		failedTokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
 			Name:      "idforwarding_failed_token_sining_total",

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -32,7 +32,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 		tokenSigningDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
-			Name:      "idfowrading_token_signing_duration_seconds",
+			Name:      "idforwarding_token_signing_duration_seconds",
 			Help:      "Histrogram of token signing duration",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
 		}),

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -21,13 +21,13 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
 			Name:      "idforwarding_token_signing_from_cache_total",
-			Help:      "Number of signed tokens retrieved from cahce",
+			Help:      "Number of signed tokens retrieved from cache",
 		}),
 		failedTokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
 			Name:      "idforwarding_failed_token_signing_total",
-			Help:      "Number of failed token singings",
+			Help:      "Number of failed token signings",
 		}),
 		tokenSigningDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
@@ -41,7 +41,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 	if reg != nil {
 		reg.MustRegister(m.tokenSigningCounter)
 		reg.MustRegister(m.tokenSigningFromCacheCounter)
-		reg.MustRegister(m.failedTokenSingingCounter)
+		reg.MustRegister(m.failedTokenSigningCounter)
 		reg.MustRegister(m.tokenSigningDurationHistogram)
 	}
 
@@ -51,6 +51,6 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 type metrics struct {
 	tokenSigningCounter           prometheus.Counter
 	tokenSigningFromCacheCounter  prometheus.Counter
-	failedTokenSingingCounter     prometheus.Counter
+	failedTokenSigningCounter     prometheus.Counter
 	tokenSigningDurationHistogram prometheus.Histogram
 }

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -14,7 +14,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 		tokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
-			Name:      "idforwarding_token_sining_total",
+			Name:      "idforwarding_token_signing_total",
 			Help:      "Number of token signings",
 		}),
 		tokenSigningFromCacheCounter: prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -29,7 +29,6 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 			Name:      "idforwarding_failed_token_sining_total",
 			Help:      "Number of failed token singings",
 		}),
-
 		tokenSigningDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,

--- a/pkg/services/auth/idimpl/metrics.go
+++ b/pkg/services/auth/idimpl/metrics.go
@@ -26,7 +26,7 @@ func newMetircus(reg prometheus.Registerer) *metrics {
 		failedTokenSigningCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,
-			Name:      "idforwarding_failed_token_sining_total",
+			Name:      "idforwarding_failed_token_signing_total",
 			Help:      "Number of failed token singings",
 		}),
 		tokenSigningDurationHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -29,7 +29,7 @@ func ProvideService(
 	cfg *setting.Cfg, signer auth.IDSigner, cache remotecache.CacheStorage,
 	features featuremgmt.FeatureToggles, authnService authn.Service, reg prometheus.Registerer,
 ) *Service {
-	s := &Service{cfg, log.New("id-service"), signer, cache, newMetircus(reg)}
+	s := &Service{cfg, log.New("id-service"), signer, cache, newMetrics(reg)}
 
 	if features.IsEnabled(featuremgmt.FlagIdForwarding) {
 		authnService.RegisterPostAuthHook(s.hook, 140)

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -77,7 +77,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 	})
 
 	if err != nil {
-		s.metrics.failedTokenSingingCounter.Inc()
+		s.metrics.failedTokenSigningCounter.Inc()
 		return "", err
 	}
 

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -3,11 +3,12 @@ package idimpl
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ProvideService(t *testing.T) {

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -21,7 +21,7 @@ func Test_ProvideService(t *testing.T) {
 			},
 		}
 
-		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService)
+		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil)
 		assert.True(t, hookRegistered)
 	})
 
@@ -35,7 +35,7 @@ func Test_ProvideService(t *testing.T) {
 			},
 		}
 
-		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService)
+		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil)
 		assert.False(t, hookRegistered)
 	})
 }


### PR DESCRIPTION
**What is this feature?**
Add metrics to id token signing.
* tokenSigningCounter - Counter newly signed tokens
* tokenSigningFromCacheCounter - Counter of tokens resolved from cache
* failedTokenSingingCounter - Counter of failed token signings
* tokenSigningDurationHistogram - Histogram of time taken for token signing


**Which issue(s) does this PR fix?**:
Part of: https://github.com/grafana/identity-access-team/issues/310

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
