### PR TITLE
Azure Monitor: change variable definitions in OOB dashboards to avoid dependency on sub level permission

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/dashboards/adx.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/adx.json
@@ -8214,7 +8214,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceGroups($sub)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -8223,7 +8223,16 @@
         "multi": false,
         "name": "rg",
         "options": [],
-        "query": "ResourceGroups($sub)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Kusto/clusters\" \r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -8235,29 +8244,33 @@
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "Microsoft.Kusto/clusters",
-          "value": "Microsoft.Kusto/clusters"
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
         },
-        "description": null,
-        "error": null,
+        "definition": "",
         "hide": 0,
         "includeAll": false,
-        "label": "Name Space",
+        "label": "Namespace",
         "multi": false,
         "name": "ns",
-        "options": [
-          {
-            "selected": true,
-            "text": "Microsoft.Kusto/clusters",
-            "value": "Microsoft.Kusto/clusters"
-          }
-        ],
-        "query": "Microsoft.Kusto/clusters",
+        "options": [],
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Kusto/clusters\" and resourceGroup =~ \"$rg\"\r\n| distinct [\"type\"]"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 5,
+        "type": "query"
       },
       {
         "allValue": null,
@@ -8272,7 +8285,13 @@
         "multi": false,
         "name": "resource",
         "options": [],
-        "query": "ResourceNames($sub, $rg, $ns)",
+        "query": {
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
+          "refId": "A",
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/public/app/plugins/datasource/azuremonitor/dashboards/appInsights.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/appInsights.json
@@ -2472,7 +2472,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${ds}",
-        "definition": "ResourceGroups($sub)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2481,7 +2481,16 @@
         "multi": false,
         "name": "rg",
         "options": [],
-        "query": "ResourceGroups($sub)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Insights/components\"\r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2492,7 +2501,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${ds}",
-        "definition": "Namespaces($sub, $rg)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 2,
@@ -2501,9 +2510,18 @@
         "multi": false,
         "name": "ns",
         "options": [],
-        "query": "Namespaces($sub, $rg)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Insights/components\" and resourceGroup =~ \"$rg\"\r\n| distinct [\"type\"]"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 1,
-        "regex": "([mM](icrosoft)\\.[iI](nsights)/(components))",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "type": "query"
@@ -2512,7 +2530,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${ds}",
-        "definition": "ResourceNames($sub, $rg, $ns)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2521,7 +2539,13 @@
         "multi": false,
         "name": "res",
         "options": [],
-        "query": "ResourceNames($sub, $rg, $ns)",
+        "query": {
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
+          "refId": "A",
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsGeoMap.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsGeoMap.json
@@ -791,14 +791,14 @@
         "name": "rg",
         "options": [],
         "query": {
-          "grafanaTemplateVariableFn": {
-            "kind": "ResourceGroupsQuery",
-            "rawQuery": "ResourceGroups($sub)",
-            "subscription": "$sub"
+          "azureResourceGraph": {
+            "query": "resources\r\n|  where [\"type\"] =~ \"Microsoft.Insights/components\"\r\n| distinct resourceGroup"
           },
-          "queryType": "Grafana Template Variable Function",
+          "queryType": "Azure Resource Graph",
           "refId": "A",
-          "subscription": ""
+          "subscriptions": [
+            "$sub"
+          ]
         },
         "refresh": 1,
         "regex": "",
@@ -820,18 +820,17 @@
         "name": "ns",
         "options": [],
         "query": {
-          "grafanaTemplateVariableFn": {
-            "kind": "MetricNamespaceQuery",
-            "rawQuery": "Namespaces($sub, $rg)",
-            "resourceGroup": "$rg",
-            "subscription": "$sub"
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Insights/components\" and resourceGroup =~ \"$rg\"\r\n| distinct [\"type\"]"
           },
-          "queryType": "Grafana Template Variable Function",
+          "queryType": "Azure Resource Graph",
           "refId": "A",
-          "subscription": ""
+          "subscriptions": [
+            "$sub"
+          ]
         },
         "refresh": 1,
-        "regex": "([mM](icrosoft)\\.[iI](nsights)/(components))",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "type": "query"
@@ -850,16 +849,11 @@
         "name": "res",
         "options": [],
         "query": {
-          "grafanaTemplateVariableFn": {
-            "kind": "ResourceNamesQuery",
-            "metricDefinition": "$ns",
-            "rawQuery": "ResourceNames($sub, $rg, $ns)",
-            "resourceGroup": "$rg",
-            "subscription": "$sub"
-          },
-          "queryType": "Grafana Template Variable Function",
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
           "refId": "A",
-          "subscription": ""
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
         },
         "refresh": 1,
         "regex": "",

--- a/public/app/plugins/datasource/azuremonitor/dashboards/cosmosdb.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/cosmosdb.json
@@ -4921,7 +4921,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceGroups($sub)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -4930,7 +4930,16 @@
         "multi": false,
         "name": "rg",
         "options": [],
-        "query": "ResourceGroups($sub)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n|  where [\"type\"] =~ \"Microsoft.DocumentDb/databaseAccounts\"\r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4942,35 +4951,39 @@
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "Microsoft.DocumentDb/databaseAccounts",
-          "value": "Microsoft.DocumentDb/databaseAccounts"
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
         },
-        "description": null,
-        "error": null,
+        "definition": "",
         "hide": 0,
         "includeAll": false,
-        "label": "Name Space",
+        "label": "Namespace",
         "multi": false,
         "name": "ns",
-        "options": [
-          {
-            "selected": true,
-            "text": "Microsoft.DocumentDb/databaseAccounts",
-            "value": "Microsoft.DocumentDb/databaseAccounts"
-          }
-        ],
-        "query": "Microsoft.DocumentDb/databaseAccounts",
+        "options": [],
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.DocumentDb/databaseAccounts\"\r\n| distinct [\"type\"]"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 5,
+        "type": "query"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceNames($sub, $rg, $ns)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -4979,7 +4992,13 @@
         "multi": false,
         "name": "resource",
         "options": [],
-        "query": "ResourceNames($sub, $rg, $ns)",
+        "query": {
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
+          "refId": "A",
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/public/app/plugins/datasource/azuremonitor/dashboards/keyvault.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/keyvault.json
@@ -2589,7 +2589,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceGroups($sub)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2598,7 +2598,16 @@
         "multi": false,
         "name": "rg",
         "options": [],
-        "query": "ResourceGroups($sub)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.KeyVault/vaults\"\r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2610,20 +2619,39 @@
         "useTags": false
       },
       {
-        "description": null,
-        "error": null,
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "definition": "",
         "hide": 2,
+        "includeAll": false,
         "label": "Namespace",
+        "multi": false,
         "name": "ns",
-        "query": "Microsoft.KeyVault/vaults",
+        "options": [],
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.KeyVault/vaults\"\r\n| distinct [\"type\"]"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "constant"
+        "sort": 5,
+        "type": "query"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceNames($sub, $rg, $ns)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2632,7 +2660,13 @@
         "multi": false,
         "name": "resource",
         "options": [],
-        "query": "ResourceNames($sub, $rg, $ns)",
+        "query": {
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
+          "refId": "A",
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/public/app/plugins/datasource/azuremonitor/dashboards/storage.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/storage.json
@@ -6358,20 +6358,39 @@
         "useTags": false
       },
       {
-        "description": null,
-        "error": null,
+        "current": {},
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "definition": "",
         "hide": 2,
+        "includeAll": false,
         "label": "Namespace",
+        "multi": false,
         "name": "ns",
-        "query": "Microsoft.Storage/storageAccounts",
+        "options": [],
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Storage/storageAccounts\"\r\n| distinct [\"type\"]"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "constant"
+        "sort": 5,
+        "type": "query"
       },
       {
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceGroups($sub)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -6380,7 +6399,16 @@
         "multi": false,
         "name": "rg",
         "options": [],
-        "query": "ResourceGroups($sub)",
+        "query": {
+          "azureResourceGraph": {
+            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Storage/storageAccounts\"\r\n| distinct resourceGroup"
+          },
+          "queryType": "Azure Resource Graph",
+          "refId": "A",
+          "subscriptions": [
+            "$sub"
+          ]
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -6395,7 +6423,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$ds",
-        "definition": "ResourceNames($sub, $rg, $ns)",
+        "definition": "",
         "description": null,
         "error": null,
         "hide": 0,
@@ -6404,7 +6432,13 @@
         "multi": false,
         "name": "resource",
         "options": [],
-        "query": "ResourceNames($sub, $rg, $ns)",
+        "query": {
+          "namespace": "$ns",
+          "queryType": "Azure Resource Names",
+          "refId": "A",
+          "resourceGroup": "$rg",
+          "subscription": "$sub"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Copy of #75765 for build reasons

**What is this feature?**

Modifies existing OOB Azure Monitor dashboards variable definitions so that they don't depend on sub level permission access to work.

Change namespace and RG variables from function variable definition to ARG so that even if access is granted on resource level, and not sub level, dashboard is still usable.

**Why do we need this feature?**

Previously, since a lot of our dahsboards were using function variable definitions for Resource group and namespace variables, the dashboard would not properly work for users who granted access on a resource level. Using ARG variables instead gets rid of this permission requiremenet

**Who is this feature for?**

anyone using AzMon provisioned dashboards.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
