### PR TITLE
Postgres: Make securejson password optional

### DIFF
--- a/public/app/plugins/datasource/postgres/types.ts
+++ b/public/app/plugins/datasource/postgres/types.ts
@@ -23,5 +23,5 @@ export interface PostgresOptions extends SQLOptions {
 }
 
 export interface SecureJsonData {
-  password: string;
+  password?: string;
 }


### PR DESCRIPTION
**What is this feature?**
makes the password optional

**Why do we need this feature?**
consistency with other datasources.. mysql, mssql.
it also unblocks this [PR](https://github.com/grafana/grafana/pull/75525) which needed a type assertion to bypass this being required.

**Which issue(s) does this PR fix?**:
Fixes #
