### PR TITLE
DockedMegaMenu: Show correct breadcrumbs on dashboard settings

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -1,4 +1,5 @@
 import { NavModelItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { Breadcrumb } from './types';
 
@@ -15,6 +16,13 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     // construct the URL to match
     const urlParts = node.url?.split('?') ?? ['', ''];
     let urlToMatch = urlParts[0];
+
+    if (config.featureToggles.dockedMegaMenu) {
+      const urlSearchParams = new URLSearchParams(urlParts[1]);
+      if (urlSearchParams.has('editview')) {
+        urlToMatch += `?editview=${urlSearchParams.get('editview')}`;
+      }
+    }
 
     // Check if we found home/root if if so return early
     if (homeNav && urlToMatch === homeNav.url) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- reintroduces the logic removed by https://github.com/grafana/grafana/pull/75263 behind the `dockedMegaMenu` feature toggle

**Why do we need this feature?**

- so breadcrumbs are displayed correctly when in dashboard settings

**Who is this feature for?**

- anyone using `dockedMegaMenu`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
