### PR TITLE
I18n: Run psuedo when extracting phrases

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "watch": "yarn start -d watch,start core:start --watchTheme",
     "ci:test-frontend": "yarn run test:ci",
     "i18n:clean": "rimraf public/locales/en-US/grafana.json",
-    "i18n:extract": "yarn run i18next -c public/locales/i18next-parser.config.js 'public/**/*.{tsx,ts}' 'packages/grafana-ui/**/*.{tsx,ts}'",
+    "i18n:extract": "yarn run i18next -c public/locales/i18next-parser.config.js 'public/**/*.{tsx,ts}' 'packages/grafana-ui/**/*.{tsx,ts}' && yarn i18n:pseudo",
     "i18n:compile": "echo 'no i18n compile yet, all good'",
     "i18n:pseudo": "node ./public/locales/pseudo.js",
     "betterer": "betterer",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -820,7 +820,7 @@
       "time-range-description": "Ŧřäŉşƒőřmş ŧĥę čūřřęŉŧ řęľäŧįvę ŧįmę řäŉģę ŧő äŉ äþşőľūŧę ŧįmę řäŉģę"
     },
     "export": {
-      "back-button": "",
+      "back-button": "ßäčĸ ŧő ęχpőřŧ čőŉƒįģ",
       "cancel-button": "Cäŉčęľ",
       "info-text": "Ēχpőřŧ ŧĥįş đäşĥþőäřđ.",
       "save-button": "Ŝävę ŧő ƒįľę",


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/75729

Runs `yarn i18n:psuedo` when extracting i18n phrases from source to prevent them from getting out of sync in the future.

This will also implicitly let the verify-i18n CI step test that the psuedo locale is correctly up to date.