### PR TITLE
DataSourceWithBackend: Fix adhoc filters not passed to applyTemplateVariables 

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -176,7 +176,7 @@ class DataSourceWithBackend<
         dsUIDs.add(datasource.uid);
       }
       return {
-        ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars) : q),
+        ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
         datasource,
         datasourceId, // deprecated!
         intervalMs,


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/75552/ I must have missed this, and without it, it does not work when paired with a Prometheus data source that is configured to use the backend api (not proxy mode). 

