### PR TITLE
Chore: Remove reference to storybook 6

### DIFF
--- a/packages/grafana-ui/README.md
+++ b/packages/grafana-ui/README.md
@@ -19,7 +19,3 @@ See [package source](https://github.com/grafana/grafana/tree/main/packages/grafa
 ## Development
 
 For development purposes we suggest using `yarn link` that will create symlink to @grafana/ui lib. To do so navigate to `packages/grafana-ui` and run `yarn link`. Then, navigate to your project and run `yarn link @grafana/ui` to use the linked version of the lib. To unlink follow the same procedure, but use `yarn unlink` instead.
-
-### Storybook 6.x migration
-
-We've upgraded Storybook to version 6 and with that we will convert to using [controls](https://storybook.js.org/docs/react/essentials/controls) instead of knobs for manipulating components. Controls will not require as much coding as knobs do. Please refer to the [storybook style-guide](https://github.com/grafana/grafana/blob/main/contribute/style-guides/storybook.md#contrls) for further information.


### PR DESCRIPTION
**What is this feature?**

Removes grafana/ui guidelines for upgrading to Storybook 6. 

**Why do we need this feature?**

We recently [migrated](https://github.com/grafana/grafana/pull/65943) from Storybook v6 to v7, so this guideline feels irrelevant. 

**Who is this feature for?**

Grafana contributors 

Fixes #75810

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
