### PR TITLE
BrowseDashboards: Enable new Browse Dashboards UI by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -49,6 +49,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `toggleLabelsInLogsUI`                           | Enable toggleable filters in log details view                                                                                                                                                       | Yes                |
 | `azureMonitorDataplane`                          | Adds dataplane compliant frame metadata in the Azure Monitor datasource                                                                                                                             | Yes                |
 | `prometheusConfigOverhaulAuth`                   | Update the Prometheus configuration page with the new auth component                                                                                                                                | Yes                |
+| `newBrowseDashboards`                            | New browse/manage dashboards UI                                                                                                                                                                     | Yes                |
 | `cloudWatchWildCardDimensionValues`              | Fetches dimension values from CloudWatch to correctly label wildcard dimensions                                                                                                                     | Yes                |
 
 ## Preview feature toggles
@@ -78,7 +79,6 @@ Some features are enabled by default. You can disable these feature by setting t
 | `awsAsyncQueryCaching`           | Enable caching for async queries for Redshift and Athena. Requires that the `useCachingService` feature toggle is enabled and the datasource has caching and async query support enabled     |
 | `splitScopes`                    | Support faster dashboard and folder search by splitting permission scopes into parts                                                                                                         |
 | `reportingRetries`               | Enables rendering retries for the reporting feature                                                                                                                                          |
-| `newBrowseDashboards`            | New browse/manage dashboards UI                                                                                                                                                              |
 
 ## Experimental feature toggles
 

--- a/e2e/dashboards-suite/dashboard-browse.spec.ts
+++ b/e2e/dashboards-suite/dashboard-browse.spec.ts
@@ -6,22 +6,7 @@ describe('Dashboard browse', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
-  it('Basic folder view test', () => {
-    e2e.flows.importDashboard(testDashboard, 1000, true);
-
-    e2e.pages.Dashboards.visit();
-
-    // folder view is collapsed - verify its content does not exist
-    e2e.components.Search.folderContent('General').should('not.exist');
-    e2e.components.Search.dashboardItem('E2E Test - Dashboard Search').should('not.exist');
-
-    e2e.components.Search.folderHeader('General').click({ force: true });
-
-    e2e.components.Search.folderContent('General').should('be.visible');
-    e2e.components.Search.dashboardItem('E2E Test - Import Dashboard').should('be.visible');
-  });
-
-  it.skip('Manage Dashboards tests', () => {
+  it('Manage Dashboards tests', () => {
     e2e.flows.importDashboard(testDashboard, 1000, true);
 
     e2e.pages.Dashboards.visit();

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -729,9 +729,10 @@ var (
 		{
 			Name:         "newBrowseDashboards",
 			Description:  "New browse/manage dashboards UI",
-			Stage:        FeatureStagePublicPreview,
+			Stage:        FeatureStageGeneralAvailability,
 			Owner:        grafanaFrontendPlatformSquad,
 			FrontendOnly: true,
+			Expression:   "true", // on by default
 		},
 		{
 			Name:        "sseGroupByDatasource",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -103,7 +103,7 @@ alertingNoDataErrorExecution,privatePreview,@grafana/alerting-squad,false,false,
 angularDeprecationUI,experimental,@grafana/plugins-platform-backend,false,false,false,true
 dashgpt,experimental,@grafana/dashboards-squad,false,false,false,true
 reportingRetries,preview,@grafana/sharing-squad,false,false,true,false
-newBrowseDashboards,preview,@grafana/grafana-frontend-platform,false,false,false,true
+newBrowseDashboards,GA,@grafana/grafana-frontend-platform,false,false,false,true
 sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,false,false
 requestInstrumentationStatusSource,experimental,@grafana/plugins-platform-backend,false,false,false,false
 lokiRunQueriesInParallel,privatePreview,@grafana/observability-logs,false,false,false,false


### PR DESCRIPTION
**What is this feature?**

Enables the new Browse Dashboards UI by default. See [What’s new in Grafana Cloud](https://grafana.com/docs/grafana-cloud/whatsnew/#new-browse-dashboards-view) for more details 

Apart from the easier to use and more performant UI, this change removes the 'General' folder from the frontend, and instead lists dashboards at the root level of the view, after folders. This is because the General folder was never a "real" folder, and so there were lots of inconsistencies with it - it couldn't be renamed or deleted. Permissions could not be managed on it, and alerts could not be stored within the General folder.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64210
Fixes https://github.com/grafana/grafana/issues/51825
Fixes https://github.com/grafana/grafana/issues/59543
