### PR TITLE
Drawer: remove wrapping `div` preventing `Drawer` from scrolling properly

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -1193,9 +1193,6 @@ exports[`better eslint`] = {
     ],
     "public/app/core/components/AppChrome/News/NewsContainer.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
-    ],
-    "public/app/core/components/AppChrome/News/NewsWrapper.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"],

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -133,9 +133,7 @@ export function Drawer({
             </div>
           )}
           {typeof title !== 'string' && title}
-          <div className={styles.contentScroll}>
-            {!scrollableContent ? content : <CustomScrollbar autoHeightMin="100%">{content}</CustomScrollbar>}
-          </div>
+          {!scrollableContent ? content : <CustomScrollbar>{content}</CustomScrollbar>}
         </div>
       </FocusScope>
     </RcDrawer>
@@ -300,10 +298,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: theme.spacing(2),
       height: '100%',
       flexGrow: 1,
-    }),
-    contentScroll: css({
-      label: 'drawer-content',
-      flex: 1,
     }),
     tabsWrapper: css({
       label: 'drawer-tabs',

--- a/public/app/core/components/AppChrome/News/NewsWrapper.tsx
+++ b/public/app/core/components/AppChrome/News/NewsWrapper.tsx
@@ -49,13 +49,13 @@ export function NewsWrapper({ feedUrl }: NewsWrapperProps) {
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    innerWrapper: css`
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    `,
+    innerWrapper: css({
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    }),
     grot: css({
       display: `flex`,
       alignItems: `center`,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes wrapping `div` which prevents drawer from scrolling properly
- follow up to https://github.com/grafana/grafana/pull/75287

**Why do we need this feature?**

- so save/news drawer scrolls correctly

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
