### PR TITLE
Sandbox: Patch array vector prototype methods inside the sandbox

### DIFF
--- a/packages/grafana-data/src/types/vector.ts
+++ b/packages/grafana-data/src/types/vector.ts
@@ -13,42 +13,46 @@ declare global {
 
 // JS original sin
 // this if condition is because Jest will re-exec this block multiple times (in a browser this only runs once)
-if (!Object.getOwnPropertyDescriptor(Array.prototype, 'toArray')) {
-  Object.defineProperties(Array.prototype, {
-    get: {
-      value: function (idx: number) {
-        return this[idx];
+export function patchArrayVectorProrotypeMethods() {
+  if (!Object.getOwnPropertyDescriptor(Array.prototype, 'toArray')) {
+    Object.defineProperties(Array.prototype, {
+      get: {
+        value: function (idx: number) {
+          return this[idx];
+        },
+        writable: true,
+        enumerable: false,
+        configurable: true,
       },
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-    set: {
-      value: function (idx: number, value: unknown) {
-        this[idx] = value;
+      set: {
+        value: function (idx: number, value: unknown) {
+          this[idx] = value;
+        },
+        writable: true,
+        enumerable: false,
+        configurable: true,
       },
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-    add: {
-      value: function (value: unknown) {
-        this.push(value);
+      add: {
+        value: function (value: unknown) {
+          this.push(value);
+        },
+        writable: true,
+        enumerable: false,
+        configurable: true,
       },
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-    toArray: {
-      value: function () {
-        return this;
+      toArray: {
+        value: function () {
+          return this;
+        },
+        writable: true,
+        enumerable: false,
+        configurable: true,
       },
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-  });
+    });
+  }
 }
+//this function call is intentional
+patchArrayVectorProrotypeMethods();
 
 /** @deprecated use a simple Array<T> */
 export interface Vector<T = any> extends Array<T> {

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -1,4 +1,4 @@
-import { PluginMeta } from '@grafana/data';
+import { PluginMeta, patchArrayVectorProrotypeMethods } from '@grafana/data';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
 import { resolveWithCache } from '../loader/cache';
@@ -90,4 +90,12 @@ function patchPluginSourceMap(meta: PluginMeta, pluginCode: string): string {
     return pluginCode.replace('//# sourceMappingURL=module.js.map', replaceWith);
   }
   return pluginCode;
+}
+
+export function patchSandboxEnvironmentPrototype(sandboxEnvironment: SandboxEnvironment) {
+  // same as https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/vector.ts#L16
+  // Array is a "reflective" type in Near-membrane and doesn't get an identify continuity
+  sandboxEnvironment.evaluate(
+    `${patchArrayVectorProrotypeMethods.toString()};${patchArrayVectorProrotypeMethods.name}()`
+  );
 }

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -7,7 +7,7 @@ import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
 import { getPluginSettings } from '../pluginSettings';
 
-import { getPluginCode } from './code_loader';
+import { getPluginCode, patchSandboxEnvironmentPrototype } from './code_loader';
 import { getGeneralSandboxDistortionMap, distortLiveApis } from './distortion_map';
 import {
   getSafeSandboxDomElement,
@@ -178,6 +178,8 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
         error: () => {},
       },
     });
+
+    patchSandboxEnvironmentPrototype(sandboxEnvironment);
 
     // fetch plugin's code
     let pluginCode = '';


### PR DESCRIPTION
**What is this feature?**

Ensures the arrays inside the sandbox also contain the same [vector methods](https://github.com/grafana/grafana/blob/ed7d29f2b98e0e1221327a55a4096499ef78d3a2/packages/grafana-data/src/types/vector.ts#L16) than the main realm

**Why do we need this feature?**

Some plugins were built with the old vectors and they will fail to work if these methods are not existent in newer versions of grafana

Normally near-membrane takes care of using the main realm prototypes (as it does with most objects) but Array is a special type and the prototype does not get transfered

**Who is this feature for?**

All plugins running inside the frontend sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
