### PR TITLE
AzureMonitor: Use `Field` instead of `InlineField`

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { SelectableValue } from '@grafana/data';
-import { Alert, InlineField, Select } from '@grafana/ui';
+import { Alert, Field, Select } from '@grafana/ui';
 
 import DataSource from '../../datasource';
 import { selectors } from '../../e2e/selectors';
@@ -228,9 +228,8 @@ const VariableEditor = (props: Props) => {
 
   return (
     <>
-      <InlineField
-        label="Select query type"
-        labelWidth={20}
+      <Field
+        label="Query Type"
         data-testid={selectors.components.variableEditor.queryType.input}
       >
         <Select
@@ -240,7 +239,7 @@ const VariableEditor = (props: Props) => {
           width={25}
           value={queryType}
         />
-      </InlineField>
+      </Field>
       {query.queryType === AzureQueryType.LogAnalytics && (
         <>
           <LogsQueryEditor
@@ -266,9 +265,8 @@ const VariableEditor = (props: Props) => {
         <GrafanaTemplateVariableFnInput query={query} updateQuery={props.onChange} datasource={datasource} />
       )}
       {requireSubscription && (
-        <InlineField
-          label="Select subscription"
-          labelWidth={20}
+        <Field
+          label="Subscription"
           data-testid={selectors.components.variableEditor.subscription.input}
         >
           <Select
@@ -278,12 +276,11 @@ const VariableEditor = (props: Props) => {
             width={25}
             value={query.subscription || null}
           />
-        </InlineField>
+        </Field>
       )}
       {(requireResourceGroup || hasResourceGroup) && (
-        <InlineField
-          label="Select resource group"
-          labelWidth={20}
+        <Field
+          label="Resource Group"
           data-testid={selectors.components.variableEditor.resourceGroup.input}
         >
           <Select
@@ -298,12 +295,11 @@ const VariableEditor = (props: Props) => {
             value={query.resourceGroup || null}
             placeholder={requireResourceGroup ? undefined : 'Optional'}
           />
-        </InlineField>
+        </Field>
       )}
       {(requireNamespace || hasNamespace) && (
-        <InlineField
-          label="Select namespace"
-          labelWidth={20}
+        <Field
+          label="Namespace"
           data-testid={selectors.components.variableEditor.namespace.input}
         >
           <Select
@@ -318,12 +314,11 @@ const VariableEditor = (props: Props) => {
             value={query.namespace || null}
             placeholder={requireNamespace ? undefined : 'Optional'}
           />
-        </InlineField>
+        </Field>
       )}
       {hasRegion && (
-        <InlineField
-          label="Select region"
-          labelWidth={20}
+        <Field
+          label="Region"
           data-testid={selectors.components.variableEditor.region.input}
         >
           <Select
@@ -334,12 +329,11 @@ const VariableEditor = (props: Props) => {
             value={query.region || null}
             placeholder="Optional"
           />
-        </InlineField>
+        </Field>
       )}
       {requireResource && (
-        <InlineField
-          label="Select resource"
-          labelWidth={20}
+        <Field
+          label="Resource"
           data-testid={selectors.components.variableEditor.resource.input}
         >
           <Select
@@ -349,7 +343,7 @@ const VariableEditor = (props: Props) => {
             width={25}
             value={query.resource || null}
           />
-        </InlineField>
+        </Field>
       )}
       {query.queryType === AzureQueryType.AzureResourceGraph && (
         <>

--- a/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx
@@ -228,10 +228,7 @@ const VariableEditor = (props: Props) => {
 
   return (
     <>
-      <Field
-        label="Query Type"
-        data-testid={selectors.components.variableEditor.queryType.input}
-      >
+      <Field label="Query Type" data-testid={selectors.components.variableEditor.queryType.input}>
         <Select
           aria-label="select query type"
           onChange={onQueryTypeChange}
@@ -265,10 +262,7 @@ const VariableEditor = (props: Props) => {
         <GrafanaTemplateVariableFnInput query={query} updateQuery={props.onChange} datasource={datasource} />
       )}
       {requireSubscription && (
-        <Field
-          label="Subscription"
-          data-testid={selectors.components.variableEditor.subscription.input}
-        >
+        <Field label="Subscription" data-testid={selectors.components.variableEditor.subscription.input}>
           <Select
             aria-label="select subscription"
             onChange={onChangeSubscription}
@@ -279,10 +273,7 @@ const VariableEditor = (props: Props) => {
         </Field>
       )}
       {(requireResourceGroup || hasResourceGroup) && (
-        <Field
-          label="Resource Group"
-          data-testid={selectors.components.variableEditor.resourceGroup.input}
-        >
+        <Field label="Resource Group" data-testid={selectors.components.variableEditor.resourceGroup.input}>
           <Select
             aria-label="select resource group"
             onChange={onChangeResourceGroup}
@@ -298,10 +289,7 @@ const VariableEditor = (props: Props) => {
         </Field>
       )}
       {(requireNamespace || hasNamespace) && (
-        <Field
-          label="Namespace"
-          data-testid={selectors.components.variableEditor.namespace.input}
-        >
+        <Field label="Namespace" data-testid={selectors.components.variableEditor.namespace.input}>
           <Select
             aria-label="select namespace"
             onChange={onChangeNamespace}
@@ -317,10 +305,7 @@ const VariableEditor = (props: Props) => {
         </Field>
       )}
       {hasRegion && (
-        <Field
-          label="Region"
-          data-testid={selectors.components.variableEditor.region.input}
-        >
+        <Field label="Region" data-testid={selectors.components.variableEditor.region.input}>
           <Select
             aria-label="select region"
             onChange={onChangeRegion}
@@ -332,10 +317,7 @@ const VariableEditor = (props: Props) => {
         </Field>
       )}
       {requireResource && (
-        <Field
-          label="Resource"
-          data-testid={selectors.components.variableEditor.resource.input}
-        >
+        <Field label="Resource" data-testid={selectors.components.variableEditor.resource.input}>
           <Select
             aria-label="select resource"
             onChange={onChangeResource}


### PR DESCRIPTION
Final part of #66479 for Azure Monitor. Uses newer form components and updates labels.

![image](https://github.com/grafana/grafana/assets/15019026/dd7d2cec-02ce-40e0-99d9-f681eb5f3993)
