### PR TITLE
Loki: Cache extracted labels

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -18,7 +18,7 @@ import {
   extractUnwrapLabelKeysFromDataFrame,
 } from './responseUtils';
 import syntax, { FUNCTIONS, PIPE_PARSERS, PIPE_OPERATORS } from './syntax';
-import { LokiQuery, LokiQueryType } from './types';
+import { ExtractedLabelKeys, LokiQuery, LokiQueryType } from './types';
 
 const DEFAULT_KEYS = ['job', 'namespace'];
 const EMPTY_SELECTOR = '{}';
@@ -459,13 +459,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     return labelValues ?? [];
   }
 
-  async getParserAndLabelKeys(selector: string): Promise<{
-    extractedLabelKeys: string[];
-    hasJSON: boolean;
-    hasLogfmt: boolean;
-    hasPack: boolean;
-    unwrapLabelKeys: string[];
-  }> {
+  async getParserAndLabelKeys(selector: string): Promise<ExtractedLabelKeys> {
     const series = await this.datasource.getDataSamples({ expr: selector, refId: 'data-samples' });
 
     if (!series.length) {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -110,6 +110,57 @@ describe('CompletionDataProvider', () => {
 
   test('Returns the expected parser and label keys', async () => {
     expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(1);
+  });
+
+  test('Returns the expected parser and label keys, cache duplicate query', async () => {
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(1);
+  });
+
+  test('Returns the expected parser and label keys, unique query is not cached', async () => {
+    //1
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+
+    //2
+    expect(await completionProvider.getParserAndLabelKeys('unique')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('unique')).toEqual(parserAndLabelKeys);
+
+    // 3
+    expect(await completionProvider.getParserAndLabelKeys('uffdah')).toEqual(parserAndLabelKeys);
+
+    // 4
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(4);
+  });
+
+  test('Returns the expected parser and label keys, cache size is 2', async () => {
+    //1
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+
+    //2
+    expect(await completionProvider.getParserAndLabelKeys('unique')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('unique')).toEqual(parserAndLabelKeys);
+
+    // 2
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(2);
+
+    // 3
+    expect(await completionProvider.getParserAndLabelKeys('new')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('unique')).toEqual(parserAndLabelKeys);
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(3);
+
+    // 4
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
+    expect(languageProvider.getParserAndLabelKeys).toHaveBeenCalledTimes(4);
   });
 
   test('Returns the expected series labels', async () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -62,9 +62,8 @@ export class CompletionDataProvider {
    * Runs a Loki query to extract label keys from the result.
    * The result is cached for the query string.
    *
-   * Since each stop char in the editor triggers this function, it is prone to being called multiple times for the same query
-   * Here is a very simple map (cache) to avoid calling the backend multiple times for the same query.
-   * It only stores the previous two results
+   * Since various "situations" in the monaco code editor trigger this function, it is prone to being called multiple times for the same query
+   * Here is a lightweight and simple cache to avoid calling the backend multiple times for the same query.
    *
    * @param logQuery
    */
@@ -77,7 +76,7 @@ export class CompletionDataProvider {
     } else {
       // Save last two results in the cache
       if (this.queryToLabelKeysCache.size > EXTRACTED_LABEL_KEYS_MAX_CACHE_SIZE) {
-        // Make room in the cache for the fresh result
+        // Make room in the cache for the fresh result by deleting the "first" index
         const keys = this.queryToLabelKeysCache.keys();
         const firstKey = keys.next().value;
         this.queryToLabelKeysCache.delete(firstKey);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -75,7 +75,7 @@ export class CompletionDataProvider {
       return this.queryToLabelKeysCache.get(logQuery) as ExtractedLabelKeys;
     } else {
       // Save last two results in the cache
-      if (this.queryToLabelKeysCache.size > EXTRACTED_LABEL_KEYS_MAX_CACHE_SIZE) {
+      if (this.queryToLabelKeysCache.size >= EXTRACTED_LABEL_KEYS_MAX_CACHE_SIZE) {
         // Make room in the cache for the fresh result by deleting the "first" index
         const keys = this.queryToLabelKeysCache.keys();
         const firstKey = keys.next().value;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -84,4 +84,12 @@ export interface ContextFilter {
   description?: string;
 }
 
+export interface ExtractedLabelKeys {
+  extractedLabelKeys: string[];
+  hasJSON: boolean;
+  hasLogfmt: boolean;
+  hasPack: boolean;
+  unwrapLabelKeys: string[];
+}
+
 export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[] };


### PR DESCRIPTION
**What is this feature?**
Adds simple Map to cache the previous results of Loki data samples in the Loki language provider.

**Why do we need this feature?**
loki-data-samples queries are currently triggered directly from the Monaco completion callbacks, and not part of the react/UI application layer, so certain keystrokes in certain contexts will trigger another query. When this query takes a long time to complete, the editor UX is very sluggish and difficult to work with. Since the values returned by this query are extracted label values, which are not expected to change second-to-second, the solution proposed here is to cache requests and serve "stale" labels to prevent needing to wait for an api request whenever the user presses spacebar or comma inside a stream selector.

TL;DR;
To prevent duplicate API calls getting labels in autocomplete, we cache 2 unique query strings and their associated labels.

**Who is this feature for?**
Users of Loki code editor.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/75512

**Special notes for your reviewer:**
This is the lightest implementation I could imagine in terms of CPU/memory consumption, worried about cases where this list of labels is quite long.

We could use LRU for the added feature of smarter cache purging (instead of purging the first inserted, we'd be purging the least recently used), but that's a lot of additional overhead, and the API between map and LRU are very similar, so swapping it out would be very easy. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
