### PR TITLE
Toggletip: Add ability to set maxWidth

### DIFF
--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
@@ -30,6 +30,8 @@ export interface ToggletipProps {
   children: JSX.Element;
   /** Determine whether the toggletip should fit its content or not */
   fitContent?: boolean;
+  /** The maximum width of the toggletip */
+  maxWidth?: number;
 }
 
 export const Toggletip = React.memo(
@@ -43,8 +45,9 @@ export const Toggletip = React.memo(
     onClose,
     footer,
     fitContent = false,
+    maxWidth = 400,
   }: ToggletipProps) => {
-    const styles = useStyles2(getStyles);
+    const styles = useStyles2(getStyles, maxWidth);
     const style = styles[theme];
     const contentRef = useRef(null);
     const [controlledVisible, setControlledVisible] = React.useState(false);
@@ -135,20 +138,22 @@ export const Toggletip = React.memo(
 
 Toggletip.displayName = 'Toggletip';
 
-export const getStyles = (theme: GrafanaTheme2) => {
+export const getStyles = (theme: GrafanaTheme2, maxWidth: number) => {
   const info = buildTooltipTheme(
     theme,
     theme.components.tooltip.background,
     theme.components.tooltip.background,
     theme.components.tooltip.text,
-    { topBottom: 2, rightLeft: 2 }
+    { topBottom: 2, rightLeft: 2 },
+    maxWidth
   );
   const error = buildTooltipTheme(
     theme,
     theme.colors.error.main,
     theme.colors.error.main,
     theme.colors.error.contrastText,
-    { topBottom: 2, rightLeft: 2 }
+    { topBottom: 2, rightLeft: 2 },
+    maxWidth
   );
 
   return {

--- a/packages/grafana-ui/src/utils/tooltipUtils.ts
+++ b/packages/grafana-ui/src/utils/tooltipUtils.ts
@@ -45,7 +45,7 @@ export function buildTooltipTheme(
       padding: theme.spacing(tooltipPadding.topBottom, tooltipPadding.rightLeft),
       transition: 'opacity 0.3s',
       zIndex: theme.zIndex.tooltip,
-      maxWidth: '400px',
+      maxWidth: '550px',
       overflowWrap: 'break-word',
 
       "&[data-popper-interactive='false']": {

--- a/packages/grafana-ui/src/utils/tooltipUtils.ts
+++ b/packages/grafana-ui/src/utils/tooltipUtils.ts
@@ -7,7 +7,8 @@ export function buildTooltipTheme(
   tooltipBg: string,
   toggletipBorder: string,
   tooltipText: string,
-  tooltipPadding: { topBottom: number; rightLeft: number }
+  tooltipPadding: { topBottom: number; rightLeft: number },
+  maxWidth?: number
 ) {
   return {
     arrow: css({
@@ -45,7 +46,7 @@ export function buildTooltipTheme(
       padding: theme.spacing(tooltipPadding.topBottom, tooltipPadding.rightLeft),
       transition: 'opacity 0.3s',
       zIndex: theme.zIndex.tooltip,
-      maxWidth: '550px',
+      maxWidth: maxWidth ? `${maxWidth}px` : '400px',
       overflowWrap: 'break-word',
 
       "&[data-popper-interactive='false']": {


### PR DESCRIPTION
As part of the WIP DashGPT project, we needed a wider toggletip to acomodate the current design.
PR for visibility of changes.

![Screenshot 2023-10-02 at 3 43 28 PM](https://github.com/grafana/grafana/assets/88068998/6668d6df-6078-4b43-ad8e-ac2cb09d520c)


Extracted from https://github.com/grafana/grafana/pull/75204


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
