### PR TITLE
CI: Run publish-kinds workflows only on the main repository

### DIFF
--- a/.github/workflows/publish-kinds-next.yml
+++ b/.github/workflows/publish-kinds-next.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   config:
     runs-on: "ubuntu-latest"
+    if: github.repository == 'grafana/grafana'
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -24,7 +25,7 @@ jobs:
 
   main:
     needs: config
-    if: needs.config.outputs.has-secrets
+    if: github.repository == 'grafana/grafana' && needs.config.outputs.has-secrets
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-kinds-release.yml
+++ b/.github/workflows/publish-kinds-release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   config:
     runs-on: "ubuntu-latest"
+    if: github.repository == 'grafana/grafana'
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -26,7 +27,7 @@ jobs:
 
   main:
     needs: config
-    if: needs.config.outputs.has-secrets
+    if: github.repository == 'grafana/grafana' && needs.config.outputs.has-secrets
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"


### PR DESCRIPTION
These workflows should only be run on grafana/grafana to prevent false alerts.