### PR TITLE
[v10.1.x] CI: Run publish-kinds workflows only on the main repository

### DIFF
--- a/.github/workflows/publish-kinds-next.yml
+++ b/.github/workflows/publish-kinds-next.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-kinds-release.yml
+++ b/.github/workflows/publish-kinds-release.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"


### PR DESCRIPTION
Backport 76c6bf88be741cb28f6ea5f60d064e0a2c2f457a from #75855

---

These workflows should only be run on grafana/grafana to prevent false alerts.
