### PR TITLE
instrumentation: rename team to grafana_team to improve alert routing.

### DIFF
--- a/pkg/middleware/request_metadata_test.go
+++ b/pkg/middleware/request_metadata_test.go
@@ -16,7 +16,7 @@ func TestRequestMetaDefault(t *testing.T) {
 
 	m.Get("/", func(rw http.ResponseWriter, req *http.Request) {
 		v := requestmeta.GetRequestMetaData(req.Context())
-		assert.Equal(t, requestmeta.TeamCore, v.Team)
+		assert.Equal(t, requestmeta.TeamBackend, v.Team)
 	})
 
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -42,7 +42,7 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 	}
 
 	if cfg.MetricsIncludeTeamLabel {
-		histogramLabels = append(histogramLabels, "team")
+		histogramLabels = append(histogramLabels, "grafana_team")
 	}
 
 	if features.IsEnabled(featuremgmt.FlagHttpSLOLevels) {

--- a/pkg/middleware/requestmeta/request_metadata.go
+++ b/pkg/middleware/requestmeta/request_metadata.go
@@ -10,7 +10,7 @@ import (
 const (
 	TeamAlerting = "alerting"
 	TeamAuth     = "auth"
-	TeamCore     = "core"
+	TeamBackend  = "grafana_backend"
 )
 
 type StatusSource string
@@ -119,7 +119,7 @@ func WithStatusSource(ctx context.Context, statusCode int) {
 
 func defaultRequestMetadata() RequestMetaData {
 	return RequestMetaData{
-		Team:         TeamCore,
+		Team:         TeamBackend,
 		StatusSource: StatusSourceServer,
 		SLOGroup:     SLOGroupHighFast,
 	}

--- a/pkg/middleware/requestmeta/request_metadata.go
+++ b/pkg/middleware/requestmeta/request_metadata.go
@@ -10,7 +10,7 @@ import (
 const (
 	TeamAlerting = "alerting"
 	TeamAuth     = "auth"
-	TeamBackend  = "grafana_backend"
+	TeamBackend  = "backend"
 )
 
 type StatusSource string


### PR DESCRIPTION
This PR changes the label name from `team` to `grafana_team` since `team` is used for alert routing in our infra. While we want to use `team` eventually using `grafana_` makes the difference more explicit and easier to understand. 


renamning `core` to `backend` to be more explicit about ownership. 