### PR TITLE
Instrumentation: Handle context.Canceled

### DIFF
--- a/contribute/backend/errors.md
+++ b/contribute/backend/errors.md
@@ -31,6 +31,7 @@ functions, e.g.
 - `errutil.Forbidden(messageID, opts...)`
 - `errutil.TooManyRequests(messageID, opts...)`
 - `errutil.NotImplemented(messageID, opts...)`
+- `errutil.ClientClosedRequest(messageID, opts...)`
 
 Above functions uses `errutil.NewBase(status, messageID, opts...)` under the covers, and that function should in general only be used outside the `errutil` package for `errutil.StatusUnknown`, e.g. when there are no accurate status code available/provided.
 

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -74,8 +74,14 @@ datasources:
     type: prometheus
     access: proxy
     url: http://localhost:3011
+    basicAuth: true #username: admin, password: admin
+    basicAuthUser: admin
     jsonData:
       manageAlerts: false
+      prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
+      prometheusVersion: 2.40.0
+    secureJsonData:
+      basicAuthPassword: admin #https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables
 
   - name: gdev-testdata
     isDefault: true

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -290,6 +290,8 @@ func Err(err error) *NormalResponse {
 // The signature is equivalent to that of Error which allows us to
 // rename this to Error when we're confident that that would be safe to
 // do.
+// If the error provided is not an errutil.Error and is/wraps context.Canceled
+// the function returns an Err(errRequestCanceledBase).
 func ErrOrFallback(status int, message string, err error) *NormalResponse {
 	grafanaErr := errutil.Error{}
 	if errors.As(err, &grafanaErr) {

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -29,4 +29,10 @@ var (
 	ErrPluginDownstreamErrorBase = errutil.Internal("plugin.downstreamError",
 		errutil.WithPublicMessage("An error occurred within the plugin"),
 		errutil.WithDownstream())
+
+	// ErrPluginRequestCanceledErrorBase error returned when a plugin request
+	// is cancelled by the client (context is cancelled).
+	// Exposed as a base error to wrap it with plugin cancelled errors.
+	ErrPluginRequestCanceledErrorBase = errutil.ClientClosedRequest("plugin.requestCanceled",
+		errutil.WithPublicMessage("Plugin request canceled"))
 )

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -72,6 +72,10 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			return nil, err
 		}
 
+		if errors.Is(err, context.Canceled) {
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: query data request cancelled: %w", err)
+		}
+
 		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to query data: %w", err)
 	}
 
@@ -131,6 +135,10 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	})
 
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request cancelled: %w", err)
+		}
+
 		return plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to call resources: %w", err)
 	}
 
@@ -155,6 +163,10 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 		return
 	})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: collect metrics request cancelled: %w", err)
+		}
+
 		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to collect metrics: %w", err)
 	}
 
@@ -186,6 +198,10 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 
 		if errors.Is(err, plugins.ErrPluginUnavailable) {
 			return nil, err
+		}
+
+		if errors.Is(err, context.Canceled) {
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: check health request cancelled: %w", err)
 		}
 
 		return nil, plugins.ErrPluginHealthCheck.Errorf("client: failed to check health: %w", err)

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -73,7 +73,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 
 		if errors.Is(err, context.Canceled) {
-			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: query data request cancelled: %w", err)
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: query data request canceled: %w", err)
 		}
 
 		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to query data: %w", err)
@@ -136,7 +136,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request cancelled: %w", err)
+			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request canceled: %w", err)
 		}
 
 		return plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to call resources: %w", err)
@@ -164,7 +164,7 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: collect metrics request cancelled: %w", err)
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: collect metrics request canceled: %w", err)
 		}
 
 		return nil, plugins.ErrPluginDownstreamErrorBase.Errorf("client: failed to collect metrics: %w", err)
@@ -201,7 +201,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		}
 
 		if errors.Is(err, context.Canceled) {
-			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: check health request cancelled: %w", err)
+			return nil, plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: check health request canceled: %w", err)
 		}
 
 		return nil, plugins.ErrPluginHealthCheck.Errorf("client: failed to check health: %w", err)

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -41,6 +41,10 @@ func TestQueryData(t *testing.T) {
 				err:           errors.New("surprise surprise"),
 				expectedError: plugins.ErrPluginDownstreamErrorBase,
 			},
+			{
+				err:           context.Canceled,
+				expectedError: plugins.ErrPluginRequestCanceledErrorBase,
+			},
 		}
 
 		for _, tc := range tcs {
@@ -98,6 +102,10 @@ func TestCheckHealth(t *testing.T) {
 			{
 				err:           errors.New("surprise surprise"),
 				expectedError: plugins.ErrPluginHealthCheck,
+			},
+			{
+				err:           context.Canceled,
+				expectedError: plugins.ErrPluginRequestCanceledErrorBase,
 			},
 		}
 

--- a/pkg/util/errutil/errors.go
+++ b/pkg/util/errutil/errors.go
@@ -133,6 +133,17 @@ func TooManyRequests(msgID string, opts ...BaseOpt) Base {
 	return NewBase(StatusTooManyRequests, msgID, opts...)
 }
 
+// ClientClosedRequest initializes a new [Base] error with reason StatusClientClosedRequest
+// that is used to construct [Error]. The msgID is passed to the caller
+// to serve as the base for user facing error messages.
+//
+// msgID should be structured as component.errorBrief, for example
+//
+//	plugin.requestCanceled
+func ClientClosedRequest(msgID string, opts ...BaseOpt) Base {
+	return NewBase(StatusClientClosedRequest, msgID, opts...)
+}
+
 // NotImplemented initializes a new [Base] error with reason StatusNotImplemented
 // that is used to construct [Error]. The msgID is passed to the caller
 // to serve as the base for user facing error messages.

--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -28,6 +28,13 @@ const (
 	// parameters or payload for the request.
 	// HTTP status code 400.
 	StatusBadRequest CoreStatus = "Bad request"
+	// StatusClientClosedRequest means that a client closes the connection
+	// while the server is processing the request.
+	//
+	// This is a non-standard HTTP status code introduced by nginx, see
+	// https://httpstatus.in/499/ for more information.
+	// HTTP status code 499.
+	StatusClientClosedRequest CoreStatus = "Client closed request"
 	// StatusValidationFailed means that the server was able to parse
 	// the payload for the request but it failed one or more validation
 	// checks.
@@ -57,6 +64,11 @@ const (
 	StatusGatewayTimeout CoreStatus = "Gateway timeout"
 )
 
+// HTTPStatusClientClosedRequest A non-standard status code introduced by nginx
+// for the case when a client closes the connection while nginx is processing
+// the request. See https://httpstatus.in/499/ for more information.
+const HTTPStatusClientClosedRequest = 499
+
 // StatusReason allows for wrapping of CoreStatus.
 type StatusReason interface {
 	Status() CoreStatus
@@ -84,6 +96,8 @@ func (s CoreStatus) HTTPStatus() int {
 		return http.StatusTooManyRequests
 	case StatusBadRequest, StatusValidationFailed:
 		return http.StatusBadRequest
+	case StatusClientClosedRequest:
+		return HTTPStatusClientClosedRequest
 	case StatusNotImplemented:
 		return http.StatusNotImplemented
 	case StatusBadGateway:


### PR DESCRIPTION
**What is this feature?**

If a `context.Canceled` error is being returned to the API layer we wrap that in a `errutil.ClientClosedRequest()` error to make the API return a 499 status code. Since the request is cancelled it will never reach the client, but our metrics and logs will without this capture a 500 internal server error which is bad from an SLO standpoint.

Original logs captured looked something like this:
```
logger=context t=2023-10-02T18:40:54.234740554Z level=error msg="Request Completed" method=POST path=/api/ds/query status=500 time_ms=517 duration=517.976293ms size=75  db_call_count=2 handler=/api/ds/query status_source=server
logger=context t=2023-10-02T18:40:54.234155206Z level=error msg="Query data error" error="context canceled" 
logger=secrets.kvstore t=2023-10-02T18:40:54.23356009Z level=error msg="error getting secret value" orgId=1 type=datasource err="context canceled"
```

At first I tried to reproduce this using Prometheus and the slow proxy docker block, but couldn't. Seems like Prometheus ds handle all errors and puts it in the query data response(s). Then I realized above error happens before the plugin client is called and hardcoded a `time.Sleep(time.Second)` at 
https://github.com/grafana/grafana/blob/353df0477996efdde39af489b569af19fdbf27ab/pkg/services/secrets/kvstore/sql.go#L56

This allowed me to reproduce the behavior by refreshing a dashboard really fast, see logs:
```
ERROR[10-03|11:00:00] error getting secret value               logger=secrets.kvstore orgId=1 type=datasource namespace=gdev-sl
ow-prometheus err="context canceled"                                                                                           
ERROR[10-03|11:00:00] Client closed request                    logger=context traceID=a1a252dd23b5f85a31029fbff0209ff7 userId=1
 orgId=1 uname=admin error="[api.requestCancelled] response: request cancelled: context canceled" remote_addr=[::1] traceID=a1a
252dd23b5f85a31029fbff0209ff7                                                                                                  
INFO [10-03|11:00:00] Request Completed                        logger=context traceID=a1a252dd23b5f85a31029fbff0209ff7 userId=1
 orgId=1 uname=admin method=POST path=/api/ds/query status=499 remote_addr=[::1] time_ms=1003 duration=1.003016423s size=128 re
ferer="http://localhost:3000/d/hMkk45wWk/slow-prometheus?orgId=1" db_call_count=1 handler=/api/ds/query status_source=server 
```

**Why do we need this feature?**

For Grafana operators to properly be able to define and track HTTP request metrics SLO's.

**Who is this feature for?**

Grafana operators.

**Which issue(s) does this PR fix?**:

Ref #68480 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
