### PR TITLE
Auto-generate: Hide the button when LLM plugin is not enabled

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -33,13 +33,7 @@ export const GenAIButton = ({
 }: GenAIButtonProps) => {
   const styles = useStyles2(getStyles);
 
-  // TODO: Implement error handling (use error object from hook)
   const { setMessages, reply, isGenerating, value, error } = useOpenAIStream(OPEN_AI_MODEL, temperature);
-
-  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    onClickProp?.(e);
-    setMessages(messages);
-  };
 
   useEffect(() => {
     // Todo: Consider other options for `"` sanitation
@@ -47,6 +41,16 @@ export const GenAIButton = ({
       onGenerate(reply.replace(/^"|"$/g, ''));
     }
   }, [isGenerating, reply, onGenerate]);
+
+  // The button is disabled if the plugin is not installed or enabled
+  if (!value?.enabled) {
+    return null;
+  }
+
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClickProp?.(e);
+    setMessages(messages);
+  };
 
   const getIcon = () => {
     if (error || !value?.enabled) {
@@ -56,21 +60,6 @@ export const GenAIButton = ({
       return undefined;
     }
     return 'ai';
-  };
-
-  const getTooltipContent = () => {
-    if (error) {
-      return `Unexpected error: ${error.message}`;
-    }
-    if (!value?.enabled) {
-      return (
-        <span>
-          The LLM plugin is not correctly configured. See your <Link href={`/plugins/grafana-llm-app`}>settings</Link>{' '}
-          and enable your plugin.
-        </span>
-      );
-    }
-    return '';
   };
 
   const getText = () => {
@@ -84,7 +73,7 @@ export const GenAIButton = ({
   return (
     <div className={styles.wrapper}>
       {isGenerating && <Spinner size={14} />}
-      <Tooltip show={value?.enabled && !error ? false : undefined} interactive content={getTooltipContent()}>
+      <Tooltip show={error ? undefined : false} interactive content={`OpenAI error: ${error?.message}`}>
         <Button
           icon={getIcon()}
           onClick={onClick}

--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Spinner, useStyles2, Link, Tooltip } from '@grafana/ui';
+import { Button, Spinner, useStyles2, Tooltip } from '@grafana/ui';
 
 import { useOpenAIStream } from './hooks';
 import { OPEN_AI_MODEL, Message } from './utils';

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -40,14 +40,13 @@ export function useOpenAIStream(
   const [error, setError] = useState<Error>();
   const { error: notifyError } = useAppNotification();
 
+  const { error: enabledError, value: enabled } = useAsync(
+    async () => await isLLMPluginEnabled(),
+    [isLLMPluginEnabled]
+  );
+
   const { error: asyncError, value } = useAsync(async () => {
-    // Check if the LLM plugin is enabled and configured.
-    // If not, we won't be able to make requests, so return early.
-    const enabled = await isLLMPluginEnabled();
-    if (!enabled) {
-      return { enabled };
-    }
-    if (messages.length === 0) {
+    if (!enabled || !messages.length) {
       return { enabled };
     }
 
@@ -89,10 +88,10 @@ export function useOpenAIStream(
         },
       }),
     };
-  }, [messages]);
+  }, [messages, enabled]);
 
-  if (asyncError) {
-    setError(asyncError);
+  if (asyncError || enabledError) {
+    setError(asyncError || enabledError);
   }
 
   return {

--- a/public/app/features/dashboard/components/GenAI/llms/openai.ts
+++ b/public/app/features/dashboard/components/GenAI/llms/openai.ts
@@ -20,6 +20,7 @@ import {
 import { getBackendSrv, getGrafanaLiveSrv, logDebug } from '@grafana/runtime';
 
 import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE, setLLMPluginVersion } from './constants';
+import { LLMAppSettings } from './types';
 
 const OPENAI_CHAT_COMPLETIONS_PATH = 'openai/v1/chat/completions';
 
@@ -366,7 +367,7 @@ let loggedWarning = false;
 /** Check if the OpenAI API is enabled via the LLM plugin. */
 export const enabled = async () => {
   try {
-    const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
+    const settings: LLMAppSettings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
       showSuccessAlert: false,
       showErrorAlert: false,
     });

--- a/public/app/features/dashboard/components/GenAI/llms/openai.ts
+++ b/public/app/features/dashboard/components/GenAI/llms/openai.ts
@@ -366,13 +366,12 @@ let loggedWarning = false;
 
 /** Check if the OpenAI API is enabled via the LLM plugin. */
 export const enabled = async () => {
-  // Run a health check to see if the plugin is installed.
-  let response: LLMAppHealthCheck;
   try {
-    response = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/health`, undefined, undefined, {
+    const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
       showSuccessAlert: false,
       showErrorAlert: false,
     });
+    return settings.enabled ?? false;
   } catch (e) {
     if (!loggedWarning) {
       logDebug(String(e));
@@ -383,12 +382,4 @@ export const enabled = async () => {
     }
     return false;
   }
-
-  const { details } = response;
-  // Update the version if it's present on the response.
-  if (details.version !== undefined) {
-    setLLMPluginVersion(details.version);
-  }
-  // If the plugin is installed then check if it is configured.
-  return details?.openAI ?? false;
 };

--- a/public/app/features/dashboard/components/GenAI/llms/openai.ts
+++ b/public/app/features/dashboard/components/GenAI/llms/openai.ts
@@ -20,7 +20,6 @@ import {
 import { getBackendSrv, getGrafanaLiveSrv, logDebug } from '@grafana/runtime';
 
 import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE, setLLMPluginVersion } from './constants';
-import { LLMAppHealthCheck } from './types';
 
 const OPENAI_CHAT_COMPLETIONS_PATH = 'openai/v1/chat/completions';
 
@@ -371,6 +370,7 @@ export const enabled = async () => {
       showSuccessAlert: false,
       showErrorAlert: false,
     });
+    setLLMPluginVersion(settings.info.version);
     return settings.enabled ?? false;
   } catch (e) {
     if (!loggedWarning) {

--- a/public/app/features/dashboard/components/GenAI/llms/types.ts
+++ b/public/app/features/dashboard/components/GenAI/llms/types.ts
@@ -5,3 +5,10 @@ export type LLMAppHealthCheck = {
     version?: string;
   };
 };
+
+export type LLMAppSettings = {
+  enabled: boolean;
+  info: {
+    version: string;
+  };
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When the user is trying to use Auto-generate, it needs to meet some requirements to use the feature properly. This feature tries to differentiate between 2 states:
* The plugin is installed and enabled and the settings are provided (although the service could not work). This enables the button.
* The plugin is installed but disabled, or it is not installed. This removes the button and doesn't display anything about auto-generating.

The `health` endpoint was replaced by `settings` because the endpoint doesn't indicate if the button is enabled, it always returns info, no matter the plugin status.

It also improves the performance since we don't check if it is enabled before calling, only when the hook is rendered the first time.

https://github.com/grafana/grafana/assets/5699976/23ae1518-c6b3-4882-954f-c9217094f2b2

**Why do we need this feature?**

To not bother users who don't want or don't have the plugin, to display the button.

**Who is this feature for?**

Any Grafana user

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #75367

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
