### PR TITLE
sql: added lint-rule againts wrong imports

### DIFF
--- a/public/app/features/plugins/sql/.eslintrc
+++ b/public/app/features/plugins/sql/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": ["app/*"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
to externalize the sql datasources, we have to make sure code does not import anything from core grafana. this PR adds an eslint rule to enforce this. (as best as it can... most of the problems in the past were because of importing from `app/...`)