### PR TITLE
mysql: config: fixed import and removed unused code

### DIFF
--- a/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
@@ -8,6 +8,7 @@ import {
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
 import { ConfigSection, DataSourceDescription, Stack } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
 import {
   Alert,
   Divider,
@@ -21,7 +22,6 @@ import {
   Switch,
   Tooltip,
 } from '@grafana/ui';
-import { config } from 'app/core/config';
 import { ConnectionLimits } from 'app/features/plugins/sql/components/configuration/ConnectionLimits';
 import { TLSSecretsConfig } from 'app/features/plugins/sql/components/configuration/TLSSecretsConfig';
 import { useMigrateDatabaseFields } from 'app/features/plugins/sql/components/configuration/useMigrateDatabaseFields';

--- a/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
@@ -139,9 +139,7 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<My
       {config.secureSocksDSProxyEnabled && (
         <>
           <Divider />
-          {config.secureSocksDSProxyEnabled && (
-            <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
-          )}
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
         </>
       )}
 


### PR DESCRIPTION
we adjust an import in the config-editor page to import from the correct place.

(also, somehow we were testing for `config.secureSocksDSProxyEnabled` two times, when 1 is enough too, so i removed the extra unneeded check)