### PR TITLE
Rendering: Fix panelsRendered counter on error

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -378,6 +378,15 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     if (this.state.errorMessage !== errorMessage) {
       this.setState({ errorMessage });
     }
+
+    // This is only done to increase a counter that is used by backend
+    // image rendering to know when to capture image
+    const { plugin } = this.props;
+    const { data } = this.state;
+    const { state: loadingState } = data;
+    if (this.shouldSignalRenderingCompleted(loadingState, plugin.meta)) {
+      profiler.renderingCompleted();
+    }
   };
 
   onPanelErrorRecover = () => {


### PR DESCRIPTION
**What is this feature?**
This increments the panelsRendered counter even on error to tell the image renderer that the panel was rendered.

**Why do we need this feature?**
Without this, when there is an error, we have no way to tell that the panel is rendered in the image renderer and wait for the timeout to be reached. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
