### PR TITLE
Expose enterprise-commit in server version output

### DIFF
--- a/pkg/cmd/grafana-cli/commands/cli.go
+++ b/pkg/cmd/grafana-cli/commands/cli.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
+const DefaultCommitValue = "NA"
+
 // CLICommand is the entrypoint for the grafana-cli command. It returns the exit code for the grafana-cli program.
 func CLICommand(version string) *cli.Command {
 	return &cli.Command{

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/grafana/grafana/pkg/api"
+	gcli "github.com/grafana/grafana/pkg/cmd/grafana-cli/commands"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/process"
 	"github.com/grafana/grafana/pkg/server"
@@ -52,7 +53,7 @@ func ServerCommand(version, commit, enterpriseCommit, buildBranch, buildstamp st
 
 func RunServer(opts ServerOptions) error {
 	if Version || VerboseVersion {
-		if opts.EnterpriseCommit != "NA" && opts.EnterpriseCommit != "" {
+		if opts.EnterpriseCommit != gcli.DefaultCommitValue && opts.EnterpriseCommit != "" {
 			fmt.Printf("Version %s (commit: %s, branch: %s, enterprise-commit: %s)\n", opts.Version, opts.Commit, opts.BuildBranch, opts.EnterpriseCommit)
 		} else {
 			fmt.Printf("Version %s (commit: %s, branch: %s)\n", opts.Version, opts.Commit, opts.BuildBranch)

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -52,7 +52,11 @@ func ServerCommand(version, commit, enterpriseCommit, buildBranch, buildstamp st
 
 func RunServer(opts ServerOptions) error {
 	if Version || VerboseVersion {
-		fmt.Printf("Version %s (commit: %s, branch: %s)\n", opts.Version, opts.Commit, opts.BuildBranch)
+		if opts.EnterpriseCommit != "NA" && opts.EnterpriseCommit != "" {
+			fmt.Printf("Version %s (commit: %s, branch: %s, enterprise-commit: %s)\n", opts.Version, opts.Commit, opts.BuildBranch, opts.EnterpriseCommit)
+		} else {
+			fmt.Printf("Version %s (commit: %s, branch: %s)\n", opts.Version, opts.Commit, opts.BuildBranch)
+		}
 		if VerboseVersion {
 			fmt.Println("Dependencies:")
 			if info, ok := debug.ReadBuildInfo(); ok {

--- a/pkg/cmd/grafana/main.go
+++ b/pkg/cmd/grafana/main.go
@@ -13,8 +13,8 @@ import (
 
 // The following variables cannot be constants, since they can be overridden through the -X link flag
 var version = "9.2.0"
-var commit = "NA"
-var enterpriseCommit = "NA"
+var commit = gcli.DefaultCommitValue
+var enterpriseCommit = gcli.DefaultCommitValue
 var buildBranch = "main"
 var buildstamp string
 


### PR DESCRIPTION
This is basically a follow-up to #75242 that also exposes the commit ID for enterprise builds through the `grafana server --version` command.

```
# Non-Enterprise
Version 10.2.0-pre (commit: abcdef, branch: abcdef)

# Enterprise
Version 10.2.0-pre (commit: abcdef, branch: abcdef, enterprise-commit: abcdef)
```