### PR TITLE
DataSourcePicker: Disable autocomplete for the search input 

### DIFF
--- a/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceDropdown.tsx
@@ -199,6 +199,7 @@ export function DataSourceDropdown(props: DataSourceDropdownProps) {
           className={inputHasFocus ? undefined : styles.input}
           data-testid={selectors.components.DataSourcePicker.inputV2}
           aria-label="Select a data source"
+          autoComplete="off"
           prefix={currentValue ? prefixIcon : undefined}
           suffix={<Icon name={isOpen ? 'search' : 'angle-down'} />}
           placeholder={hideTextValue ? '' : dataSourceLabel(currentValue) || placeholder}


### PR DESCRIPTION
**Problem**
The data source picker is based on input, so the input, by default, has autocomplete enabled. This PR removes auto-complete for the input field, avoiding the annoying experience of getting the autocomplete dropdown.

![image (4)](https://github.com/grafana/grafana/assets/5699976/3dc67e5a-d7ba-4fff-9c7f-af4e05a6f9ac)

**Solution**
Use `autocomplete` HTML attribute to indicate the browser to not store and suggest anything for that form field. More info [here](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion).