### PR TITLE
DashboardScene serialization: Handle transformations and queries

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3019,7 +3019,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/dashboard-scene/utils/test-utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModel.test.ts.snap
+++ b/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModel.test.ts.snap
@@ -123,6 +123,11 @@ exports[`transformSceneToSaveModel Given a scene with rows Should transform back
 </div>",
         "mode": "markdown",
       },
+      "targets": [
+        {
+          "refId": "A",
+        },
+      ],
       "title": "",
       "transformations": [],
       "transparent": false,
@@ -265,6 +270,10 @@ exports[`transformSceneToSaveModel Given a simple scene Should transform back to
   "links": [],
   "panels": [
     {
+      "datasource": {
+        "type": "testdata",
+        "uid": "PD8C576611E62080A",
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -297,6 +306,18 @@ exports[`transformSceneToSaveModel Given a simple scene Should transform back to
           "sort": "none",
         },
       },
+      "targets": [
+        {
+          "alias": "series",
+          "datasource": {
+            "type": "testdata",
+            "uid": "PD8C576611E62080A",
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1,
+        },
+      ],
       "title": "Simple time series graph ",
       "transformations": [],
       "transparent": false,
@@ -316,6 +337,10 @@ exports[`transformSceneToSaveModel Given a simple scene Should transform back to
       "type": "row",
     },
     {
+      "datasource": {
+        "type": "testdata",
+        "uid": "PD8C576611E62080A",
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": [],
@@ -328,6 +353,18 @@ exports[`transformSceneToSaveModel Given a simple scene Should transform back to
       },
       "id": 29,
       "options": {},
+      "targets": [
+        {
+          "alias": "series",
+          "datasource": {
+            "type": "testdata",
+            "uid": "PD8C576611E62080A",
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1,
+        },
+      ],
       "title": "panel inside row",
       "transformations": [],
       "transparent": false,
@@ -354,6 +391,11 @@ exports[`transformSceneToSaveModel Given a simple scene Should transform back to
         "content": "content",
         "mode": "markdown",
       },
+      "targets": [
+        {
+          "refId": "A",
+        },
+      ],
       "title": "Transparent text panel",
       "transformations": [],
       "transparent": true,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -7,14 +7,26 @@ import {
   VizPanel,
   dataLayers,
   SceneDataLayerProvider,
+  SceneQueryRunner,
+  SceneDataTransformer,
 } from '@grafana/scenes';
-import { AnnotationQuery, Dashboard, defaultDashboard, FieldConfigSource, Panel, RowPanel } from '@grafana/schema';
+import {
+  AnnotationQuery,
+  Dashboard,
+  DataTransformerConfig,
+  defaultDashboard,
+  FieldConfigSource,
+  Panel,
+  RowPanel,
+} from '@grafana/schema';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
+import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { PanelRepeaterGridItem } from '../scene/PanelRepeaterGridItem';
 import { PanelTimeRange } from '../scene/PanelTimeRange';
 import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
+import { ShareQueryDataProvider } from '../scene/ShareQueryDataProvider';
 import { getPanelIdForVizPanel } from '../utils/utils';
 
 export function transformSceneToSaveModel(scene: DashboardScene): Dashboard {
@@ -113,6 +125,58 @@ export function gridItemToPanel(gridItem: SceneGridItemLike): Panel {
     panel.timeFrom = panelTime.state.timeFrom;
     panel.timeShift = panelTime.state.timeShift;
     panel.hideTimeOverride = panelTime.state.hideTimeOverride;
+  }
+
+  const dataProvider = vizPanel.state.$data;
+
+  // Dashboard datasource handling
+  if (dataProvider instanceof ShareQueryDataProvider) {
+    panel.datasource = {
+      type: 'datasource',
+      uid: SHARED_DASHBOARD_QUERY,
+    };
+    panel.targets = [
+      {
+        datasource: { ...panel.datasource },
+        refId: 'A',
+        panelId: dataProvider.state.query.panelId,
+        topic: dataProvider.state.query.topic,
+      },
+    ];
+  }
+
+  // Regular queries handling
+  if (dataProvider instanceof SceneQueryRunner) {
+    panel.targets = dataProvider.state.queries;
+    panel.maxDataPoints = dataProvider.state.maxDataPoints;
+    panel.datasource = dataProvider.state.datasource;
+  }
+
+  // Transformations handling
+  if (dataProvider instanceof SceneDataTransformer) {
+    const panelData = dataProvider.state.$data;
+    if (panelData instanceof ShareQueryDataProvider) {
+      panel.datasource = {
+        type: 'datasource',
+        uid: SHARED_DASHBOARD_QUERY,
+      };
+      panel.targets = [
+        {
+          datasource: { ...panel.datasource },
+          refId: 'A',
+          panelId: panelData.state.query.panelId,
+          topic: panelData.state.query.topic,
+        },
+      ];
+    }
+
+    if (panelData instanceof SceneQueryRunner) {
+      panel.targets = panelData.state.queries;
+      panel.maxDataPoints = panelData.state.maxDataPoints;
+      panel.datasource = panelData.state.datasource;
+    }
+
+    panel.transformations = dataProvider.state.transformations as DataTransformerConfig[];
   }
 
   if (vizPanel.state.displayMode === 'transparent') {

--- a/public/app/features/dashboard-scene/utils/createPanelDataProvider.ts
+++ b/public/app/features/dashboard-scene/utils/createPanelDataProvider.ts
@@ -22,6 +22,7 @@ export function createPanelDataProvider(panel: PanelModel): SceneDataProvider | 
     dataProvider = new ShareQueryDataProvider({ query: panel.targets[0] });
   } else {
     dataProvider = new SceneQueryRunner({
+      datasource: panel.datasource ?? undefined,
       queries: panel.targets,
       maxDataPoints: panel.maxDataPoints ?? undefined,
       dataLayerFilter: {


### PR DESCRIPTION
Given a `DashboardScene` instance, will transform queries and transformations back to dashboard JSON.

Prep work for snapshot tab migration, also needed for i.e. export tab.

