### PR TITLE
Alerting: Update alert rule export models to omit default values

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -592,8 +592,7 @@ func TestProvisioningApi(t *testing.T) {
     condition = "A"
 
     data {
-      ref_id     = "A"
-      query_type = ""
+      ref_id = "A"
 
       relative_time_range {
         from = 0
@@ -620,8 +619,7 @@ func TestProvisioningApi(t *testing.T) {
     condition = "A"
 
     data {
-      ref_id     = "A"
-      query_type = ""
+      ref_id = "A"
 
       relative_time_range {
         from = 0
@@ -635,8 +633,6 @@ func TestProvisioningApi(t *testing.T) {
     no_data_state  = "OK"
     exec_err_state = "OK"
     for            = 0
-    annotations    = null
-    labels         = null
     is_paused      = false
   }
 }

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -9,8 +9,7 @@ resource "grafana_rule_group" "rule_group_0000" {
     condition = "condition"
 
     data {
-      ref_id     = "query"
-      query_type = ""
+      ref_id = "query"
 
       relative_time_range {
         from = 18000
@@ -21,8 +20,7 @@ resource "grafana_rule_group" "rule_group_0000" {
       model          = "{\n              \"expr\": \"http_request_duration_microseconds_count\",\n              \"hide\": false,\n              \"interval\": \"\",\n              \"intervalMs\": 1000,\n              \"legendFormat\": \"\",\n              \"maxDataPoints\": 100,\n              \"refId\": \"query\"\n            }"
     }
     data {
-      ref_id     = "reduced"
-      query_type = ""
+      ref_id = "reduced"
 
       relative_time_range {
         from = 18000
@@ -33,8 +31,7 @@ resource "grafana_rule_group" "rule_group_0000" {
       model          = "{\n              \"expression\": \"query\",\n              \"hide\": false,\n              \"intervalMs\": 1000,\n              \"maxDataPoints\": 100,\n              \"reducer\": \"mean\",\n              \"refId\": \"reduced\",\n              \"type\": \"reduce\"\n            }"
     }
     data {
-      ref_id     = "condition"
-      query_type = ""
+      ref_id = "condition"
 
       relative_time_range {
         from = 18000
@@ -47,9 +44,6 @@ resource "grafana_rule_group" "rule_group_0000" {
 
     no_data_state  = "NoData"
     exec_err_state = "Alerting"
-    for            = 0
-    annotations    = null
-    labels         = null
     is_paused      = false
   }
   rule {
@@ -57,8 +51,7 @@ resource "grafana_rule_group" "rule_group_0000" {
     condition = "B"
 
     data {
-      ref_id     = "A"
-      query_type = ""
+      ref_id = "A"
 
       relative_time_range {
         from = 18000
@@ -69,8 +62,7 @@ resource "grafana_rule_group" "rule_group_0000" {
       model          = "{\n              \"alias\": \"just-testing\",\n              \"intervalMs\": 1000,\n              \"maxDataPoints\": 100,\n              \"orgId\": 0,\n              \"refId\": \"A\",\n              \"scenarioId\": \"csv_metric_values\",\n              \"stringInput\": \"1,20,90,30,5,0\"\n            }"
     }
     data {
-      ref_id     = "B"
-      query_type = ""
+      ref_id = "B"
 
       relative_time_range {
         from = 18000
@@ -83,9 +75,6 @@ resource "grafana_rule_group" "rule_group_0000" {
 
     no_data_state  = "NoData"
     exec_err_state = "Alerting"
-    for            = 0
-    annotations    = null
-    labels         = null
     is_paused      = false
   }
 }

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
@@ -8,7 +8,6 @@
       "interval": "10s",
       "rules": [
         {
-          "uid": "",
           "title": "prom query with SSE - 2",
           "condition": "condition",
           "data": [
@@ -69,7 +68,6 @@
           "isPaused": false
         },
         {
-          "uid": "",
           "title": "reduced testdata query - 2",
           "condition": "B",
           "data": [

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
@@ -5,8 +5,7 @@ groups:
       folder: foo bar
       interval: 10s
       rules:
-        - uid: ""
-          title: prom query with SSE - 2
+        - title: prom query with SSE - 2
           condition: condition
           data:
             - refId: query
@@ -51,8 +50,7 @@ groups:
           execErrState: Alerting
           for: 0s
           isPaused: false
-        - uid: ""
-          title: reduced testdata query - 2
+        - title: reduced testdata query - 2
           condition: B
           data:
             - refId: A

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -234,7 +234,7 @@ type AlertRuleGroupExport struct {
 
 // AlertRuleExport is the provisioned file export of models.AlertRule.
 type AlertRuleExport struct {
-	UID          string              `json:"uid" yaml:"uid"`
+	UID          string              `json:"uid,omitempty" yaml:"uid,omitempty"`
 	Title        string              `json:"title" yaml:"title" hcl:"name"`
 	Condition    string              `json:"condition" yaml:"condition" hcl:"condition"`
 	Data         []AlertQueryExport  `json:"data" yaml:"data" hcl:"data,block"`

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -238,21 +238,21 @@ type AlertRuleExport struct {
 	Title        string              `json:"title" yaml:"title" hcl:"name"`
 	Condition    string              `json:"condition" yaml:"condition" hcl:"condition"`
 	Data         []AlertQueryExport  `json:"data" yaml:"data" hcl:"data,block"`
-	DashboardUID string              `json:"dasboardUid,omitempty" yaml:"dashboardUid,omitempty"`
-	PanelID      int64               `json:"panelId,omitempty" yaml:"panelId,omitempty"`
+	DashboardUID *string             `json:"dasboardUid,omitempty" yaml:"dashboardUid,omitempty"`
+	PanelID      *int64              `json:"panelId,omitempty" yaml:"panelId,omitempty"`
 	NoDataState  NoDataState         `json:"noDataState" yaml:"noDataState" hcl:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"execErrState" yaml:"execErrState" hcl:"exec_err_state"`
 	For          model.Duration      `json:"for" yaml:"for"`
-	ForSeconds   int64               `json:"-" yaml:"-" hcl:"for"`
-	Annotations  map[string]string   `json:"annotations,omitempty" yaml:"annotations,omitempty" hcl:"annotations"`
-	Labels       map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty" hcl:"labels"`
+	ForSeconds   *int64              `json:"-" yaml:"-" hcl:"for"`
+	Annotations  *map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty" hcl:"annotations"`
+	Labels       *map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty" hcl:"labels"`
 	IsPaused     bool                `json:"isPaused" yaml:"isPaused" hcl:"is_paused"`
 }
 
 // AlertQueryExport is the provisioned export of models.AlertQuery.
 type AlertQueryExport struct {
 	RefID             string                  `json:"refId" yaml:"refId" hcl:"ref_id"`
-	QueryType         string                  `json:"queryType,omitempty" yaml:"queryType,omitempty" hcl:"query_type"`
+	QueryType         *string                 `json:"queryType,omitempty" yaml:"queryType,omitempty" hcl:"query_type"`
 	RelativeTimeRange RelativeTimeRangeExport `json:"relativeTimeRange,omitempty" yaml:"relativeTimeRange,omitempty" hcl:"relative_time_range,block"`
 	DatasourceUID     string                  `json:"datasourceUid" yaml:"datasourceUid" hcl:"datasource_uid"`
 	Model             map[string]any          `json:"model" yaml:"model"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR updates structs `definitions.AlertRuleExport` and `definitions.AlertQueryExport`. Some optional fields such as `labels`, `annotations`, `for`, and `query_type` are made to be optional so export to HCL drops the empty fields.

Also, it updates tags of field `definitions.AlertRuleExport.UID` to be optional because in the case of the "Modify Export" flow with a new rule, the field can be empty.

**Why do we need this feature?**
This allows us to reduce the size of the export payload and declutter the resulting file.

**Who is this feature for?**
Users who use export to HCL

**Special notes for your reviewer:**
HCL export library does not have tags like JSON's `omitempty` and the only way to drop the default value is to use pointers, even for maps.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
