### PR TITLE
[v10.1.x] Geomap: Fix tooltip field name regression

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -15,6 +15,11 @@ function checkScenario(scenario: TitleScenario): string {
   return getFieldDisplayName(field, frame, scenario.frames);
 }
 
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  isEqual: jest.fn().mockImplementation((obj1, obj2) => obj1 === obj2),
+}));
+
 describe('getFrameDisplayName', () => {
   it('Should return frame name if set', () => {
     const frame = toDataFrame({

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'lodash';
+
 import { DataFrame, Field, TIME_SERIES_VALUE_FIELD_NAME, FieldType, TIME_SERIES_TIME_FIELD_NAME } from '../types';
 import { formatLabels } from '../utils/labels';
 
@@ -162,7 +164,7 @@ function getUniqueFieldName(field: Field, frame?: DataFrame) {
     for (let i = 0; i < frame.fields.length; i++) {
       const otherField = frame.fields[i];
 
-      if (field === otherField) {
+      if (isEqual(field, otherField)) {
         foundSelf = true;
 
         if (dupeCount > 0) {

--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -72,8 +72,11 @@ export const DataHoverView = ({ data, rowIndex, columnIndex, sortOrder, mode, he
       });
     }
 
+    // Sanitize field by removing hovered property to fix unique display name issue
+    const { hovered, ...sanitizedField } = field;
+
     displayValues.push({
-      name: getFieldDisplayName(field, data),
+      name: getFieldDisplayName(sanitizedField, data),
       value,
       valueString: formattedValueToString(fieldDisplay),
       highlight: field.hovered,


### PR DESCRIPTION
Backport 7875dbc6eb2b728715c88412b4ef04ca3455a4ee from #75511

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Address regression introduced by https://github.com/grafana/grafana/pull/67872 that caused tooltip field name to have "1" appended to them

Before


https://github.com/grafana/grafana/assets/22381771/fe4834fa-475f-48ac-97d8-b29d497116c2




After



https://github.com/grafana/grafana/assets/22381771/5b96d2a9-a632-4651-8ab0-4c5d1262ff78


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/73976

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
