### PR TITLE
Fix the issue with cutoff CustomScrollbar

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -512,7 +512,6 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
         <ExploreToolbar exploreId={exploreId} onChangeTime={this.onChangeTime} topOfViewRef={this.topOfViewRef} />
         <CustomScrollbar
           testId={selectors.pages.Explore.General.scrollView}
-          autoHeightMin={'100%'}
           scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
         >
           {datasourceInstance ? (

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -509,13 +509,13 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
 
     return (
       <>
-        <ExploreToolbar exploreId={exploreId} onChangeTime={this.onChangeTime} topOfViewRef={this.topOfViewRef} />
+        <ExploreToolbar exploreId={exploreId} onChangeTime={this.onChangeTime} />
         <CustomScrollbar
           testId={selectors.pages.Explore.General.scrollView}
           scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
         >
           {datasourceInstance ? (
-            <div className={styles.exploreContainer}>
+            <div className={styles.exploreContainer} ref={this.topOfViewRef}>
               <PanelContainer className={styles.queryContainer}>
                 {correlationsBox}
                 <QueryRows exploreId={exploreId} />

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -54,7 +54,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 interface Props {
   exploreId: string;
   onChangeTime: (range: RawTimeRange, changedByScanner?: boolean) => void;
-  topOfViewRef: RefObject<HTMLDivElement>;
+  topOfViewRef?: RefObject<HTMLDivElement>;
 }
 
 export function ExploreToolbar({ exploreId, topOfViewRef, onChangeTime }: Props) {


### PR DESCRIPTION
After fixing an issue with the FlameGraphHeader and the `ExploreToolbar` [here](https://github.com/grafana/grafana/pull/75710), where FlameGraphHeader was overlapping `ExploreToolbar`, it turns out that there's an issue with the bottom of the container being cut off when scrolling and not allowing it to scroll all the way to the bottom. 

This is because we've moved ExploreToolbar outside of the `CustomScrollbar` component. `CustomScrollbar` has an `autoHeightMin` prop that was used in Explore. The value of this prop was then passed down to Scrollbars component which comes from `react-custom-scrollbars-2` package that needs this value because: 

https://github.com/grafana/grafana/blob/c88d5d7b40f8e787c80ecff21f9e7b64985e1f4c/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx#L138

However, I've removed this prop and tested this in Chrome, Firefox, and Safari and haven't found any issues.

Removing this prop solves the issue of the cut out scroll bar.

Before:
https://github.com/grafana/grafana/assets/58232930/f6fd1def-af7c-4b08-a864-1af474e09293

After:
https://github.com/grafana/grafana/assets/58232930/d2ca9aae-1652-45cc-992a-ef52f0146d8d

Please check that:
- [ ] It works as expected from a user's perspective.
