### PR TITLE
Grafana-ui: Improve a11y for radio button group cursor

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -45,7 +45,7 @@ export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
     const styles = getRadioButtonStyles(theme, size, fullWidth);
 
     return (
-      <>
+      <div className={styles.radioOption}>
         <input
           type="radio"
           className={styles.radio}
@@ -61,7 +61,7 @@ export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
         <label className={styles.radioLabel} htmlFor={id} title={description || ariaLabel}>
           {children}
         </label>
-      </>
+      </div>
     );
   }
 );
@@ -77,10 +77,19 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
   const labelHeight = height * theme.spacing.gridSize - 4 - 2;
 
   return {
+    radioOption: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      position: 'relative',
+      flex: fullWidth ? `1 0 0` : 'none',
+      textAlign: 'center',
+    }),
     radio: css({
       position: 'absolute',
       opacity: 0,
       zIndex: -1000,
+      width: '100% !important',
+      height: '100%',
 
       '&:checked + label': {
         color: theme.colors.text.primary,
@@ -99,8 +108,6 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
       },
     }),
     radioLabel: css({
-      display: 'inline-block',
-      position: 'relative',
       fontSize,
       height: `${labelHeight}px`,
       // Deduct border from line-height for perfect vertical centering on windows and linux
@@ -111,10 +118,9 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
       background: theme.colors.background.primary,
       cursor: 'pointer',
       zIndex: 1,
-      flex: fullWidth ? `1 0 0` : 'none',
-      textAlign: 'center',
       userSelect: 'none',
       whiteSpace: 'nowrap',
+      flexGrow: 1,
 
       '&:hover': {
         color: textColorHover,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Shows VoiceOver cursor over the radio buttons

**Why do we need this feature?**

To make the accessibility cursor accurate

**Who is this feature for?**

Users with poor vision

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

related #73500

## Screenshots

### BEFORE

<img width="493" alt="Screenshot 2023-10-04 at 7 45 53 AM" src="https://github.com/grafana/grafana/assets/6998593/7239f92c-2e17-42f0-afb2-38ba43225281">
<img width="503" alt="Screenshot 2023-10-04 at 7 46 03 AM" src="https://github.com/grafana/grafana/assets/6998593/b6b0d6e6-09f5-43c3-a740-adc0bcecbc89">


### AFTER

<img width="706" alt="Screenshot 2023-10-03 at 8 56 25 PM" src="https://github.com/grafana/grafana/assets/6998593/07c2c2be-4d2b-45b7-9921-6273b7064577">

<img width="705" alt="Screenshot 2023-10-03 at 8 56 16 PM" src="https://github.com/grafana/grafana/assets/6998593/4efd73f2-11b4-47be-82e7-36dd98211424">


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
