### PR TITLE
chore: replace Sinon usage with Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,16 +3,7 @@
 // 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).
 process.env.TZ = 'Pacific/Easter'; // UTC-06:00 or UTC-05:00 depending on daylight savings
 
-const esModules = [
-  'ol',
-  'd3',
-  'd3-color',
-  'd3-interpolate',
-  'delaunator',
-  'internmap',
-  'robust-predicates',
-  'sinon',
-].join('|');
+const esModules = ['ol', 'd3', 'd3-color', 'd3-interpolate', 'delaunator', 'internmap', 'robust-predicates'].join('|');
 
 module.exports = {
   verbose: false,

--- a/package.json
+++ b/package.json
@@ -211,7 +211,6 @@
     "rudder-sdk-js": "2.37.0",
     "sass": "1.63.6",
     "sass-loader": "13.3.2",
-    "sinon": "15.2.0",
     "style-loader": "3.3.3",
     "stylelint": "15.10.1",
     "stylelint-config-prettier": "9.0.5",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -80,7 +80,6 @@
     "@types/papaparse": "5.3.7",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",
-    "@types/sinon": "10.0.15",
     "@types/testing-library__jest-dom": "5.14.8",
     "@types/tinycolor2": "1.4.3",
     "esbuild": "0.18.12",
@@ -92,7 +91,6 @@
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-esbuild": "5.0.0",
     "rollup-plugin-node-externals": "^5.0.0",
-    "sinon": "15.2.0",
     "typescript": "4.8.4"
   },
   "peerDependencies": {

--- a/packages/grafana-data/src/datetime/datemath.test.ts
+++ b/packages/grafana-data/src/datetime/datemath.test.ts
@@ -1,5 +1,4 @@
 import { each } from 'lodash';
-import sinon, { SinonFakeTimers } from 'sinon';
 
 import * as dateMath from './datemath';
 import { dateTime, DurationUnit, DateTime } from './moment_wrapper';
@@ -9,7 +8,6 @@ describe('DateMath', () => {
   const anchor = '2014-01-01T06:06:06.666Z';
   const unix = dateTime(anchor).valueOf();
   const format = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
-  let clock: SinonFakeTimers;
 
   describe('errors', () => {
     it('should return undefined if passed empty string', () => {
@@ -57,11 +55,11 @@ describe('DateMath', () => {
   describe('with fiscal quarters', () => {
     beforeEach(() => {
       const fixedTime = dateTime('2023-07-05T06:06:06.666Z').valueOf();
-      clock = sinon.useFakeTimers(fixedTime);
+      jest.useFakeTimers({ now: fixedTime });
     });
 
     afterEach(() => {
-      clock.restore();
+      jest.useRealTimers();
     });
 
     it('should parse current fiscal quarter correctly', () => {
@@ -106,7 +104,7 @@ describe('DateMath', () => {
     let anchored: DateTime;
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers(unix);
+      jest.useFakeTimers({ now: unix });
       now = dateTime();
       anchored = dateTime(anchor);
     });
@@ -125,7 +123,7 @@ describe('DateMath', () => {
     });
 
     afterEach(() => {
-      clock.restore();
+      jest.useRealTimers();
     });
   });
 
@@ -133,7 +131,7 @@ describe('DateMath', () => {
     let now: DateTime;
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers(unix);
+      jest.useFakeTimers({ now: unix });
       now = dateTime();
     });
 
@@ -148,7 +146,7 @@ describe('DateMath', () => {
     });
 
     afterEach(() => {
-      clock.restore();
+      jest.useRealTimers();
     });
   });
 

--- a/public/test/.jshintrc
+++ b/public/test/.jshintrc
@@ -30,7 +30,6 @@
     "expect": true,
     "it": true,
     "describe": true,
-    "sinon": true,
     "define": true,
     "module": true,
     "beforeEach": true,

--- a/public/test/lib/common.ts
+++ b/public/test/lib/common.ts
@@ -1,9 +1,7 @@
 const _global = window as any;
-const sinon = _global.sinon;
-
 const angularMocks = {
   module: _global.module,
   inject: _global.inject,
 };
 
-export { sinon, angularMocks };
+export { angularMocks };

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -6,7 +6,7 @@ import config from 'app/core/config';
 import { ContextSrv } from 'app/core/services/context_srv';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
-import { angularMocks, sinon } from '../lib/common';
+import { angularMocks } from '../lib/common';
 
 export function ControllerTestContext(this: any) {
   const self = this;
@@ -56,8 +56,8 @@ export function ControllerTestContext(this: any) {
         return self.isUtc ? 'utc' : 'browser';
       };
 
-      $rootScope.appEvent = sinon.spy();
-      $rootScope.onAppEvent = sinon.spy();
+      $rootScope.appEvent = jest.fn();
+      $rootScope.onAppEvent = jest.fn();
       $rootScope.colors = [];
 
       for (let i = 0; i < 50; i++) {
@@ -85,8 +85,8 @@ export function ControllerTestContext(this: any) {
       self.scope.dashboard = { meta: {} };
       self.scope.dashboardMeta = {};
       self.scope.dashboardViewState = DashboardViewStateStub();
-      self.scope.appEvent = sinon.spy();
-      self.scope.onAppEvent = sinon.spy();
+      self.scope.appEvent = jest.fn();
+      self.scope.onAppEvent = jest.fn();
 
       $rootScope.colors = [];
       for (let i = 0; i < 50; i++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,7 +3007,6 @@ __metadata:
     "@types/papaparse": 5.3.7
     "@types/react": 18.2.15
     "@types/react-dom": 18.2.7
-    "@types/sinon": 10.0.15
     "@types/string-hash": 1.1.1
     "@types/testing-library__jest-dom": 5.14.8
     "@types/tinycolor2": 1.4.3
@@ -3036,7 +3035,6 @@ __metadata:
     rollup-plugin-esbuild: 5.0.0
     rollup-plugin-node-externals: ^5.0.0
     rxjs: 7.8.1
-    sinon: 15.2.0
     string-hash: ^1.1.3
     tinycolor2: 1.6.0
     tslib: 2.6.0
@@ -7027,15 +7025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@sinonjs/commons@npm:2.0.0"
-  dependencies:
-    type-detect: 4.0.8
-  checksum: 5023ba17edf2b85ed58262313b8e9b59e23c6860681a9af0200f239fe939e2b79736d04a260e8270ddd57196851dde3ba754d7230be5c5234e777ae2ca8af137
-  languageName: node
-  linkType: hard
-
 "@sinonjs/commons@npm:^3.0.0":
   version: 3.0.0
   resolution: "@sinonjs/commons@npm:3.0.0"
@@ -7045,30 +7034,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^10.0.2, @sinonjs/fake-timers@npm:^10.3.0":
+"@sinonjs/fake-timers@npm:^10.0.2":
   version: 10.3.0
   resolution: "@sinonjs/fake-timers@npm:10.3.0"
   dependencies:
     "@sinonjs/commons": ^3.0.0
   checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@sinonjs/samsam@npm:8.0.0"
-  dependencies:
-    "@sinonjs/commons": ^2.0.0
-    lodash.get: ^4.4.2
-    type-detect: ^4.0.8
-  checksum: 95e40d0bb9f7288e27c379bee1b03c3dc51e7e78b9d5ea6aef66a690da7e81efc4715145b561b449cefc5361a171791e3ce30fb1a46ab247d4c0766024c60a60
-  languageName: node
-  linkType: hard
-
-"@sinonjs/text-encoding@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@sinonjs/text-encoding@npm:0.7.1"
-  checksum: 130de0bb568c5f8a611ec21d1a4e3f80ab0c5ec333010f49cfc1adc5cba6d8808699c8a587a46b0f0b016a1f4c1389bc96141e773e8460fcbb441875b2e91ba7
   languageName: node
   linkType: hard
 
@@ -9819,16 +9790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sinon@npm:10.0.15":
-  version: 10.0.15
-  resolution: "@types/sinon@npm:10.0.15"
-  dependencies:
-    "@types/sinonjs__fake-timers": "*"
-  checksum: cec6d7d9d5582ca3ac851b029d5d90451bfe6d376164253792a6eb6ddcd609a0411a7fac9ed92e1879e7d3ec091d2ea2e8dbb4f6140a1065439b81dc20cafa7c
-  languageName: node
-  linkType: hard
-
-"@types/sinonjs__fake-timers@npm:*, @types/sinonjs__fake-timers@npm:8.1.1":
+"@types/sinonjs__fake-timers@npm:8.1.1":
   version: 8.1.1
   resolution: "@types/sinonjs__fake-timers@npm:8.1.1"
   checksum: ca09d54d47091d87020824a73f026300fa06b17cd9f2f9b9387f28b549364b141ef194ee28db762f6588de71d8febcd17f753163cb7ea116b8387c18e80ebd5c
@@ -14812,13 +14774,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "diff@npm:5.1.0"
-  checksum: c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90
-  languageName: node
-  linkType: hard
-
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -17966,7 +17921,6 @@ __metadata:
     sass-loader: 13.3.2
     selecto: 1.26.0
     semver: 7.5.4
-    sinon: 15.2.0
     slate: 0.47.9
     slate-plain-serializer: 0.7.13
     slate-react: 0.22.10
@@ -20779,13 +20733,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"just-extend@npm:^4.0.2":
-  version: 4.2.1
-  resolution: "just-extend@npm:4.2.1"
-  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
-  languageName: node
-  linkType: hard
-
 "kbar@npm:0.1.0-beta.40":
   version: 0.1.0-beta.40
   resolution: "kbar@npm:0.1.0-beta.40"
@@ -21131,13 +21078,6 @@ __metadata:
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
-  languageName: node
-  linkType: hard
-
-"lodash.get@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.get@npm:4.4.2"
-  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
   languageName: node
   linkType: hard
 
@@ -22301,19 +22241,6 @@ __metadata:
     jsesc: ^0.5.0
     loader-utils: ^1.0.2
   checksum: 84ce24512867a469e6f87af20e1abac19afa9a462c011f15d9c1cc2dcef1f5100521f4e90954f65f1b81d6e4286e0141d57f0260cc538e94cf802fb5932581ab
-  languageName: node
-  linkType: hard
-
-"nise@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "nise@npm:5.1.4"
-  dependencies:
-    "@sinonjs/commons": ^2.0.0
-    "@sinonjs/fake-timers": ^10.0.2
-    "@sinonjs/text-encoding": ^0.7.1
-    just-extend: ^4.0.2
-    path-to-regexp: ^1.7.0
-  checksum: bc57c10eaec28a6a7ddfb2e1e9b21d5e1fe22710e514f8858ae477cf9c7e9c891475674d5241519193403db43d16c3675f4207bc094a7a27b7e4f56584a78c1b
   languageName: node
   linkType: hard
 
@@ -27090,20 +27017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:15.2.0":
-  version: 15.2.0
-  resolution: "sinon@npm:15.2.0"
-  dependencies:
-    "@sinonjs/commons": ^3.0.0
-    "@sinonjs/fake-timers": ^10.3.0
-    "@sinonjs/samsam": ^8.0.0
-    diff: ^5.1.0
-    nise: ^5.1.4
-    supports-color: ^7.2.0
-  checksum: 1641b9af8a73ba57c73c9b6fd955a2d062a5d78cce719887869eca45faf33b0fd20cabfeffdfd856bb35bfbd3d49debb2d954ff6ae5e9825a3da5ff4f604ab6c
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^1.0.7":
   version: 1.0.18
   resolution: "sirv@npm:1.0.18"
@@ -28148,7 +28061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -28996,7 +28909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
+"type-detect@npm:4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I noticed Sinon is used for two things in the code base

1. Fake timers
2. Spies

For the first one, Sinon has extracted its fake timer implementation to `@sinonjs/fake-timers` (previously `lolex`). Jest uses this same implementation under the hood if you use the modern fake timers (which is the default).

As for spies, Jest has `jest.fn` builtin. This also works better with `expect`, but that didn't seem to be used here.

~Additionally, I noticed there were still duplicated `@sinonjs/fake-timers` in the lockfile, so I ran `yarn dedupe`, which is the cause for the huge diff. I can extract that into a separate PR if you're interested?~ Extracted to #75944.

**Why do we need this feature?**

N/A, tests (and dependency) changes only

**Who is this feature for?**

Developers of Grafana

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
