### PR TITLE
Plugins: Display custom deprecation message if available

### DIFF
--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -25,6 +25,7 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     links: local?.info.links || remote?.json?.info.links || [],
     readme: localReadme || remote?.readme,
     versions,
+    statusContext: remote?.statusContext ?? '',
   };
 }
 

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -15,7 +15,7 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
   const isWarningVisible = plugin.isDeprecated && !dismissed;
   const deprecationMessage =
     plugin.details?.statusContext ||
-    `This ${plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the
+    `This ${plugin.type} plugin is deprecated and has been removed from the catalog. No further updates will be made to the
   plugin.`;
 
   return isWarningVisible ? (

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -13,13 +13,14 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
   const { className, plugin } = props;
   const [dismissed, setDismissed] = useState(false);
   const isWarningVisible = plugin.isDeprecated && !dismissed;
+  const deprecationMessage =
+    plugin.details?.statusContext ||
+    `This ${plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the
+  plugin.`;
 
   return isWarningVisible ? (
     <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>
-      <p>
-        This {plugin.type} plugin is deprecated and removed from the catalog. No further updates will be made to the
-        plugin.
-      </p>
+      <p>{deprecationMessage}</p>
     </Alert>
   ) : null;
 }

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -13,10 +13,12 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
   const { className, plugin } = props;
   const [dismissed, setDismissed] = useState(false);
   const isWarningVisible = plugin.isDeprecated && !dismissed;
-  const deprecationMessage =
-    plugin.details?.statusContext ||
-    `This ${plugin.type} plugin is deprecated and has been removed from the catalog. No further updates will be made to the
+  let deprecationMessage = `This ${plugin.type} plugin is deprecated and has been removed from the catalog. No further updates will be made to the
   plugin.`;
+
+  if (plugin.details?.statusContext) {
+    deprecationMessage += ` More information: ${plugin.details.statusContext}`;
+  }
 
   return isWarningVisible ? (
     <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -767,6 +767,21 @@ describe('Plugin details page', () => {
         expect(queryByText(/plugin is deprecated and removed from the catalog/i)).not.toBeInTheDocument()
       );
     });
+
+    it('should display a custom deprecation message if the plugin has it set', async () => {
+      const statusContext = 'A detailed explanation of why this plugin is deprecated.';
+      const { queryByText } = renderPluginDetails({
+        id,
+        isInstalled: true,
+        isDeprecated: true,
+        details: {
+          statusContext,
+          links: [],
+        },
+      });
+
+      await waitFor(() => expect(queryByText(statusContext)).toBeInTheDocument());
+    });
   });
 
   describe('viewed as user without grafana admin permissions', () => {

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -752,7 +752,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() =>
-        expect(queryByText(/plugin is deprecated and removed from the catalog/i)).toBeInTheDocument()
+        expect(queryByText(/plugin is deprecated and has been removed from the catalog/i)).toBeInTheDocument()
       );
     });
 
@@ -764,7 +764,7 @@ describe('Plugin details page', () => {
       });
 
       await waitFor(() =>
-        expect(queryByText(/plugin is deprecated and removed from the catalog/i)).not.toBeInTheDocument()
+        expect(queryByText(/plugin is deprecated and has been removed from the catalog/i)).not.toBeInTheDocument()
       );
     });
 
@@ -780,7 +780,9 @@ describe('Plugin details page', () => {
         },
       });
 
-      await waitFor(() => expect(queryByText(statusContext)).toBeInTheDocument());
+      const re = new RegExp(`No further updates will be made to the plugin. More information: ${statusContext}`, 'i');
+
+      await waitFor(() => expect(queryByText(re)).toBeInTheDocument());
     });
   });
 

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -70,6 +70,7 @@ export interface CatalogPluginDetails {
   }>;
   grafanaDependency?: string;
   pluginDependencies?: PluginDependencies['plugins'];
+  statusContext?: string;
 }
 
 export interface CatalogPluginInfo {
@@ -113,6 +114,7 @@ export type RemotePlugin = {
   signatureType: PluginSignatureType | '';
   slug: string;
   status: RemotePluginStatus;
+  statusContext?: string;
   typeCode: PluginType;
   typeId: number;
   typeName: string;


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/grafana/issues/74723

### What changed?

This change builds on top of https://github.com/grafana/grafana-com/pull/7550 and displays the `statusContext` in case it's not empty and the plugin is deprecated.

| Before | After |
| --- | --- |
|![Screenshot 2023-10-04 at 11 27 30](https://github.com/grafana/grafana/assets/9974811/03167063-f444-4316-b1ad-363655c02d3f)|![Screenshot 2023-10-04 at 11 28 16](https://github.com/grafana/grafana/assets/9974811/41055ede-e6ab-4cdf-b737-e9f331933858)|

@sympatheticmoose for visibility.