### PR TITLE
Auth: OAuth token sync improvements

### DIFF
--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -100,18 +100,21 @@ func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn
 		s.cache.Set(identity.ID, struct{}{}, getOAuthTokenCacheTTL(accessTokenExpires, idTokenExpires))
 		return nil
 	}
+	// FIXME: Consider using context.WithoutCancel instead of context.Background after Go 1.21 update
+	updateCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
-	if err := s.service.TryTokenRefresh(ctx, token); err != nil {
+	if err := s.service.TryTokenRefresh(updateCtx, token); err != nil {
 		if !errors.Is(err, oauthtoken.ErrNoRefreshTokenFound) {
-			s.log.FromContext(ctx).Error("Failed to refresh OAuth access token", "id", identity.ID, "error", err)
+			s.log.Error("Failed to refresh OAuth access token", "id", identity.ID, "error", err)
 		}
 
 		if err := s.service.InvalidateOAuthTokens(ctx, token); err != nil {
-			s.log.FromContext(ctx).Error("Failed to invalidate OAuth tokens", "id", identity.ID, "error", err)
+			s.log.Warn("Failed to invalidate OAuth tokens", "id", identity.ID, "error", err)
 		}
 
 		if err := s.sessionService.RevokeToken(ctx, identity.SessionToken, false); err != nil {
-			s.log.FromContext(ctx).Error("Failed to revoke session token", "id", identity.ID, "tokenId", identity.SessionToken.Id, "error", err)
+			s.log.Warn("Failed to revoke session token", "id", identity.ID, "tokenId", identity.SessionToken.Id, "error", err)
 		}
 
 		return authn.ErrExpiredAccessToken.Errorf("oauth access token could not be refreshed: %w", err)

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -105,6 +105,9 @@ func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn
 	defer cancel()
 
 	if err := s.service.TryTokenRefresh(updateCtx, token); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
 		if !errors.Is(err, oauthtoken.ErrNoRefreshTokenFound) {
 			s.log.Error("Failed to refresh OAuth access token", "id", identity.ID, "error", err)
 		}

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/singleflight"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/pkg/services/oauthtoken/oauth_token_test.go
+++ b/pkg/services/oauthtoken/oauth_token_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
@@ -231,10 +232,11 @@ func setupOAuthTokenService(t *testing.T) (*Service, *FakeAuthInfoStore, *social
 	authInfoStore := &FakeAuthInfoStore{}
 	authInfoService := authinfoservice.ProvideAuthInfoService(nil, authInfoStore, &usagestats.UsageStatsMock{})
 	return &Service{
-		Cfg:               setting.NewCfg(),
-		SocialService:     socialService,
-		AuthInfoService:   authInfoService,
-		singleFlightGroup: &singleflight.Group{},
+		Cfg:                  setting.NewCfg(),
+		SocialService:        socialService,
+		AuthInfoService:      authInfoService,
+		singleFlightGroup:    &singleflight.Group{},
+		tokenRefreshDuration: newTokenRefreshDurationMetric(prometheus.NewRegistry()),
 	}, authInfoStore, socialConnector
 }
 


### PR DESCRIPTION
**What is this feature?**
This PR improves the way the OAuth access token is refreshed using the refresh token by creating a separate context derived from context.Background.

Besides, it introduces a new metric called `token_refresh_fetch_duration_seconds` to track the duration of the refresh tokens.

**Why do we need this feature?**
To improve the observability of this functionality.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
