### PR TITLE
Alerting: Fix incorrect field description

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx
@@ -29,8 +29,7 @@ export const AlertRuleNameInput = () => {
       title={`Enter ${entityName} name`}
       description={
         <Text variant="bodySmall" color="secondary">
-          {/* sigh language rules – we should use translations ideally but for now we deal with "a" and "an" */}
-          Enter {entityName === 'alert rule' ? 'an' : 'a'} {entityName} name to identify your alert.
+          Enter a name to identify your {entityName}.
         </Text>
       }
     >


### PR DESCRIPTION
Tiny PR to fix an ambiguous field description for the alert or recording rule name.