### PR TITLE
K8s: Remove /k8s/ prefix

### DIFF
--- a/pkg/services/grafana-apiserver/README.md
+++ b/pkg/services/grafana-apiserver/README.md
@@ -40,4 +40,4 @@ kubectl api-resources
 
 ### Grafana API Access
 
-The Kubernetes compatible API can be accessed using existing Grafana AuthN at: [http://localhost:3000/k8s/apis/](http://localhost:3000/k8s/apis/).
+The Kubernetes compatible API can be accessed using existing Grafana AuthN at: [http://localhost:3000/apis](http://localhost:3000/apis).

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/grafana/dskit/services"
@@ -126,7 +125,7 @@ func ProvideService(
 	// TODO: this is very hacky
 	// We need to register the routes in ProvideService to make sure
 	// the routes are registered before the Grafana HTTP server starts.
-	s.rr.Group("/k8s", func(k8sRoute routing.RouteRegister) {
+	s.rr.Group("/apis", func(k8sRoute routing.RouteRegister) {
 		handler := func(c *contextmodel.ReqContext) {
 			if s.handler == nil {
 				c.Resp.WriteHeader(404)
@@ -277,7 +276,6 @@ func (s *service) start(ctx context.Context) error {
 	// TODO: this is a hack. see note in ProvideService
 	s.handler = func(c *contextmodel.ReqContext) {
 		req := c.Req
-		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/k8s")
 		if req.URL.Path == "" {
 			req.URL.Path = "/"
 		}

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -144,9 +144,6 @@ func ProvideService(
 
 	s.rr.Group("/apis", proxyHandler)
 	s.rr.Group("/openapi", proxyHandler)
-	s.rr.Group("/healthz", proxyHandler)
-	s.rr.Group("/livez", proxyHandler)
-	s.rr.Group("/readyz", proxyHandler)
 
 	return s, nil
 }

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -125,7 +125,7 @@ func ProvideService(
 	// TODO: this is very hacky
 	// We need to register the routes in ProvideService to make sure
 	// the routes are registered before the Grafana HTTP server starts.
-	s.rr.Group("/apis", func(k8sRoute routing.RouteRegister) {
+	proxyHandler := func(k8sRoute routing.RouteRegister) {
 		handler := func(c *contextmodel.ReqContext) {
 			if s.handler == nil {
 				c.Resp.WriteHeader(404)
@@ -140,7 +140,13 @@ func ProvideService(
 		}
 		k8sRoute.Any("/", middleware.ReqSignedIn, handler)
 		k8sRoute.Any("/*", middleware.ReqSignedIn, handler)
-	})
+	}
+
+	s.rr.Group("/apis", proxyHandler)
+	s.rr.Group("/openapi", proxyHandler)
+	s.rr.Group("/healthz", proxyHandler)
+	s.rr.Group("/livez", proxyHandler)
+	s.rr.Group("/readyz", proxyHandler)
 
 	return s, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently the k8s apiserver is mounted at `localhost:3000/k8s/apis`. This change removes the `/k8s/` prefix from the path. The new URL will be: `localhost:3000/apis`

**Why do we need this feature?**

Removing the `/k8s/` prefix will mount the kubernetes compatible APIs at `/apis/`, which is the same path that a standard standalone apiserver would use. 

**Who is this feature for?**

@grafana/grafana-app-platform-squad 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
