### PR TITLE
Sandbox: Make jquery available to plugins in the global scope

### DIFF
--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -94,6 +94,12 @@ async function doImportPluginModuleInSandbox(meta: PluginMeta): Promise<System.M
           // Similar to `window.monaco`, `window.Prism` may be undefined when invoked.
           return Reflect.get(window, 'Prism');
         },
+        get jQuery() {
+          return Reflect.get(window, 'jQuery');
+        },
+        get $() {
+          return Reflect.get(window, 'jQuery');
+        },
         get grafanaBootData(): BootData {
           if (!pluginLogCache[meta.id + '-grafanaBootData']) {
             pluginLogCache[meta.id + '-grafanaBootData'] = true;


### PR DESCRIPTION
**What is this feature?**

Makes `jQuery` and `$` available inside `window` for plugins

**Why do we need this feature?**

Some plugin dependencies assume jQuery avialable in the global scope. When not, they fail to execute

**Who is this feature for?**

plugins using jQuery and running inside the sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
