### PR TITLE
IDForwarding: Use feature toggle not generate a key if feature is not enabled

### DIFF
--- a/pkg/services/auth/idimpl/signer.go
+++ b/pkg/services/auth/idimpl/signer.go
@@ -48,7 +48,7 @@ type LocalSigner struct {
 }
 
 func (s *LocalSigner) SignIDToken(ctx context.Context, claims *auth.IDClaims) (string, error) {
-	if s.features.IsEnabled(featuremgmt.FlagIdForwarding) {
+	if !s.features.IsEnabled(featuremgmt.FlagIdForwarding) {
 		return "", nil
 	}
 


### PR DESCRIPTION
**What is this feature?**
Only generate signing key if feature toggle is enabled.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
