### PR TITLE
Breadcrumbs: Fixes issue ignoring duplicates when hideFromBreadcrumbs: true

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -76,7 +76,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         </Tooltip>
       );
     }
-
+    x;
     return button;
   }
 );

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -76,7 +76,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         </Tooltip>
       );
     }
-    x;
     return button;
   }
 );

--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -141,5 +141,28 @@ describe('breadcrumb utils', () => {
         { text: 'My page', href: '/my-page' },
       ]);
     });
+
+    it('does ignore duplicates but not when hideFromBreadcrumbs:true', () => {
+      const pageNav: NavModelItem = {
+        text: 'My page',
+        url: '/my-page',
+        parentItem: {
+          text: 'My section',
+          // same url as section nav, but this one should win/overwrite it
+          url: '/my-section?from=1h&to=now',
+          hideFromBreadcrumbs: true,
+        },
+      };
+
+      const sectionNav: NavModelItem = {
+        text: 'My section',
+        url: '/my-section',
+      };
+
+      expect(buildBreadcrumbs(sectionNav, pageNav, mockHomeNav)).toEqual([
+        { text: 'My section', href: '/my-section' },
+        { text: 'My page', href: '/my-page' },
+      ]);
+    });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -31,13 +31,16 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
       return;
     }
 
-    // This enabled app plugins to control breadcrumbs of their root pages
-    const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
-    // Remember this path for the next breadcrumb
-    lastPath = urlToMatch;
+    if (!node.hideFromBreadcrumbs) {
+      // This enabled app plugins to control breadcrumbs of their root pages
+      const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
 
-    if (!node.hideFromBreadcrumbs && !isSamePathAsLastBreadcrumb) {
-      crumbs.unshift({ text: node.text, href: node.url ?? '' });
+      // Remember this path for the next breadcrumb
+      lastPath = urlToMatch;
+
+      if (!isSamePathAsLastBreadcrumb) {
+        crumbs.unshift({ text: node.text, href: node.url ?? '' });
+      }
     }
 
     if (node.parentItem) {


### PR DESCRIPTION

Noticed an issue with my previous change for breadcrumbs where duplicates are not shown. It did
not account for the common pattern now (to work around the previous behavior of duplicates) to
add hideFromBreadcrumbs: true on the root pages. This means it's  not shown but it was taken into
account in the duplicate detection so no breadcrumb for this node was shown.


