### PR TITLE
TemplateSrv: Fix ad hoc filters not applying correctly when using datasource variables

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -198,7 +198,7 @@ describe('templateSrv', () => {
         {
           type: 'datasource',
           name: 'ds',
-          current: { value: 'logstash', text: 'logstash' },
+          current: { value: 'logstash-id', text: 'logstash' },
         },
         { type: 'adhoc', name: 'test', datasource: { uid: 'oogle' }, filters: [1] },
         { type: 'adhoc', name: 'test2', datasource: { uid: '$ds' }, filters: [2] },
@@ -208,6 +208,10 @@ describe('templateSrv', () => {
           oogle: mockDataSource({
             name: 'oogle',
             uid: 'oogle',
+          }),
+          logstash: mockDataSource({
+            name: 'logstash',
+            uid: 'logstash-id',
           }),
         })
       );

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -142,7 +142,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       if (variableUid === ds.uid) {
         filters = filters.concat(variable.filters);
       } else if (variableUid?.indexOf('$') === 0) {
-        if (this.replace(variableUid) === datasourceName) {
+        if (this.replace(variableUid) === ds.uid) {
           filters = filters.concat(variable.filters);
         }
       }


### PR DESCRIPTION
Fixes an issue where ad-hoc variables targeting a datasource variable were not correctly being applied to queries of the corresponding datasource.