### PR TITLE
Feature: Add Email Header to Identify Notifications

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -65,6 +65,7 @@ func (sc *SmtpClient) buildEmail(msg *Message) *gomail.Message {
 	m.SetHeader("From", msg.From)
 	m.SetHeader("To", msg.To...)
 	m.SetHeader("Subject", msg.Subject)
+	m.SetHeader("X-Grafana-Notification", "true")
 	sc.setFiles(m, msg)
 	for _, replyTo := range msg.ReplyTo {
 		m.SetAddressHeader("Reply-To", replyTo, "")


### PR DESCRIPTION
**What is this feature?**

Set a custom email header, `X-Grafana-Notification` to identify Grafana sourced messages in email filtering rules.

**Why do we need this feature?**

The `Subject` is fully configurable, which means there's no common thread to identify all mail generated by Grafana. As I'm working on converting to Grafana alerting, I need to be able to filter mail sanely. This is currently impossible with the stock setup and templates. There's nothing about the messages to identify them.

**Who is this feature for?**

Users of Email alerting

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

I'm just starting out with golang, and this is my first grafana PR. It's dead simple, but I'm still getting my bearings on the repo. I didn't find any tests which test the SMTP message at this level.  Ideally, once I get my bearings, I'd like to be able to expose a "Custom Headers" to the notification template, so users could set their own headers using the same templating capacity of Subject and Body.  For now this solves an end users' requirement to filter all Grafana notifications into a single folder vie procmail or sieve.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
