### PR TITLE
Transformations: Update row title

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -7,7 +7,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { ReactUtils, useStyles2 } from '@grafana/ui';
 
-import { QueryOperationRowHeader } from './QueryOperationRowHeader';
+import { QueryOperationRowHeader, ExpanderMessages } from './QueryOperationRowHeader';
 
 export interface QueryOperationRowProps {
   index: number;
@@ -22,6 +22,7 @@ export interface QueryOperationRowProps {
   draggable?: boolean;
   collapsable?: boolean;
   disabled?: boolean;
+  expanderMessages?: ExpanderMessages;
 }
 
 export type QueryOperationRowRenderProp = ((props: QueryOperationRowRenderProps) => React.ReactNode) | React.ReactNode;
@@ -45,6 +46,7 @@ export function QueryOperationRow({
   collapsable,
   index,
   id,
+  expanderMessages
 }: QueryOperationRowProps) {
   const [isContentVisible, setIsContentVisible] = useState(isOpen !== undefined ? isOpen : true);
   const styles = useStyles2(getQueryOperationRowStyles);
@@ -123,6 +125,7 @@ export function QueryOperationRow({
                     onRowToggle={onRowToggle}
                     reportDragMousePosition={reportDragMousePosition}
                     title={title}
+                    expanderMessages={expanderMessages}
                   />
                 </div>
                 {isContentVisible && <div className={styles.content}>{children}</div>}
@@ -147,6 +150,7 @@ export function QueryOperationRow({
         onRowToggle={onRowToggle}
         reportDragMousePosition={reportDragMousePosition}
         title={title}
+        expanderMessages={expanderMessages}
       />
       {isContentVisible && <div className={styles.content}>{children}</div>}
     </div>

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -46,7 +46,7 @@ export function QueryOperationRow({
   collapsable,
   index,
   id,
-  expanderMessages
+  expanderMessages,
 }: QueryOperationRowProps) {
   const [isContentVisible, setIsContentVisible] = useState(isOpen !== undefined ? isOpen : true);
   const styles = useStyles2(getQueryOperationRowStyles);

--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -38,15 +38,14 @@ export const QueryOperationRowHeader = ({
   reportDragMousePosition,
   title,
   id,
-  expanderMessages
+  expanderMessages,
 }: QueryOperationRowHeaderProps) => {
   const styles = useStyles2(getStyles);
 
   let tooltipMessage = isContentVisible ? 'Collapse query row' : 'Expand query row';
   if (expanderMessages !== undefined && isContentVisible) {
     tooltipMessage = expanderMessages.close;
-  }
-  else if (expanderMessages !== undefined) {
+  } else if (expanderMessages !== undefined) {
     tooltipMessage = expanderMessages?.open;
   }
 

--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -18,6 +18,12 @@ export interface QueryOperationRowHeaderProps {
   reportDragMousePosition: MouseEventHandler<HTMLDivElement>;
   title?: string;
   id: string;
+  expanderMessages?: ExpanderMessages;
+}
+
+export interface ExpanderMessages {
+  open: string;
+  close: string;
 }
 
 export const QueryOperationRowHeader = ({
@@ -32,8 +38,17 @@ export const QueryOperationRowHeader = ({
   reportDragMousePosition,
   title,
   id,
+  expanderMessages
 }: QueryOperationRowHeaderProps) => {
   const styles = useStyles2(getStyles);
+
+  let tooltipMessage = isContentVisible ? 'Collapse query row' : 'Expand query row';
+  if (expanderMessages !== undefined && isContentVisible) {
+    tooltipMessage = expanderMessages.close;
+  }
+  else if (expanderMessages !== undefined) {
+    tooltipMessage = expanderMessages?.open;
+  }
 
   return (
     <div className={styles.header}>
@@ -41,7 +56,7 @@ export const QueryOperationRowHeader = ({
         {collapsable && (
           <IconButton
             name={isContentVisible ? 'angle-down' : 'angle-right'}
-            tooltip={isContentVisible ? 'Collapse query row' : 'Expand query row'}
+            tooltip={tooltipMessage}
             className={styles.collapseIcon}
             onClick={onRowToggle}
             aria-expanded={isContentVisible}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -167,6 +167,10 @@ export const TransformationOperationRow = ({
       isOpen={toggleExpand()}
       // Assure that showHelp is untoggled when the row becomes collapsed.
       onClose={() => toggleShowHelp(false)}
+      expanderMessages={{
+        close: 'Collapse transformation row',
+        open: 'Expand transformation row'
+      }}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}
       {filter && (

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -169,7 +169,7 @@ export const TransformationOperationRow = ({
       onClose={() => toggleShowHelp(false)}
       expanderMessages={{
         close: 'Collapse transformation row',
-        open: 'Expand transformation row'
+        open: 'Expand transformation row',
       }}
     >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}


### PR DESCRIPTION
This fixes a bug in transformations in which the title for the row expand/collapse control says "query row" as opposed to "transformation row". This has been fixed by adding a prop to the query row component which allows customization of these messages.

**Which issue(s) does this PR fix?**:

Fixes #75987

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
