### PR TITLE
Alerting: Allow users to give feedback on each insights panel

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -104,6 +104,15 @@ export const trackNewAlerRuleFormError = async (props: AlertRuleTrackingProps & 
   reportInteraction('grafana_alerting_rule_form_error', props);
 };
 
+export const trackInsightsFeedback = async (props: { useful: boolean; panel: string }) => {
+  const defaults = {
+    grafana_version: config.buildInfo.version,
+    org_id: contextSrv.user.orgId,
+    user_id: contextSrv.user.id,
+  };
+  reportInteraction('grafana_alerting_insights', { ...defaults, ...props });
+};
+
 export type AlertRuleTrackingProps = {
   user_id: number;
   grafana_version?: string;

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -10,10 +10,8 @@ import {
   SceneTimeRange,
   SceneVariableSet,
   VariableValueSelectors,
-  VizPanelMenu,
 } from '@grafana/scenes';
 
-import { trackInsightsFeedback } from '../Analytics';
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/AlertsByStateScene';
 import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
@@ -85,25 +83,6 @@ const LAST_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-2w', to: 'now-1w' }
 
 export function SectionSubheader({ children }: React.PropsWithChildren) {
   return <div>{children}</div>;
-}
-
-export function getPanelMenu(panel: string) {
-  const menu = new VizPanelMenu({});
-
-  menu.setItems([
-    {
-      text: 'I find this useful',
-      iconClassName: 'plus',
-      onClick: () => trackInsightsFeedback({ useful: true, panel }),
-    },
-    {
-      text: "I don't find this useful",
-      iconClassName: 'minus',
-      onClick: () => trackInsightsFeedback({ useful: false, panel }),
-    },
-  ]);
-
-  return menu;
 }
 
 export function getInsightsScenes() {

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -10,8 +10,10 @@ import {
   SceneTimeRange,
   SceneVariableSet,
   VariableValueSelectors,
+  VizPanelMenu,
 } from '@grafana/scenes';
 
+import { trackInsightsFeedback } from '../Analytics';
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/AlertsByStateScene';
 import { getGrafanaEvalSuccessVsFailuresScene } from '../insights/grafana/EvalSuccessVsFailuresScene';
 import { getFiringGrafanaAlertsScene } from '../insights/grafana/Firing';
@@ -83,6 +85,25 @@ const LAST_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-2w', to: 'now-1w' }
 
 export function SectionSubheader({ children }: React.PropsWithChildren) {
   return <div>{children}</div>;
+}
+
+export function getPanelMenu(panel: string) {
+  const menu = new VizPanelMenu({});
+
+  menu.setItems([
+    {
+      text: 'I find this useful',
+      iconClassName: 'plus',
+      onClick: () => trackInsightsFeedback({ useful: true, panel }),
+    },
+    {
+      text: "I don't find this useful",
+      iconClassName: 'minus',
+      onClick: () => trackInsightsFeedback({ useful: false, panel }),
+    },
+  ]);
+
+  return menu;
 }
 
 export function getInsightsScenes() {

--- a/public/app/features/alerting/unified/insights/RatingModal.tsx
+++ b/public/app/features/alerting/unified/insights/RatingModal.tsx
@@ -1,0 +1,95 @@
+import { css } from '@emotion/css';
+import React, { useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data/src/themes';
+import { Button, Dropdown, Icon, IconButton, Menu, Modal, useStyles2 } from '@grafana/ui';
+
+import { trackInsightsFeedback } from '../Analytics';
+
+export function InsightsRatingModal({ panel }: { panel: string }) {
+  const styles = useStyles2(getStyles);
+
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const onDismiss = () => {
+    setShowModal(false);
+  };
+
+  const onButtonClick = (useful: boolean) => {
+    trackInsightsFeedback({ useful, panel: panel });
+    onDismiss();
+  };
+
+  const modal = (
+    <Modal
+      title="Rate this panel"
+      isOpen={showModal}
+      onDismiss={onDismiss}
+      onClickBackdrop={onDismiss}
+      className={styles.container}
+    >
+      <div>
+        <p>Help us improve this page by telling us whether this panel is useful to you!</p>
+        <div className={styles.buttonsContainer}>
+          <Button variant="secondary" className={styles.buttonContainer} onClick={() => onButtonClick(false)}>
+            <div className={styles.button}>
+              <Icon name="thumbs-up" className={styles.thumbsdown} size="xxxl" />
+              <span>{`I don't like it`}</span>
+            </div>
+          </Button>
+          <Button variant="secondary" className={styles.buttonContainer} onClick={() => onButtonClick(true)}>
+            <div className={styles.button}>
+              <Icon name="thumbs-up" size="xxxl" />
+              <span>I like it</span>
+            </div>
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+
+  const menu = (
+    <Menu>
+      <Menu.Item label="Rate this panel" icon="comment-alt-message" onClick={() => setShowModal(true)} />
+    </Menu>
+  );
+
+  return (
+    <div>
+      <Dropdown overlay={menu} placement="bottom-start">
+        <IconButton name="ellipsis-v" variant="secondary" className={styles.menu} aria-label="Rate this panel" />
+      </Dropdown>
+      {modal}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  buttonsContainer: css({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    gap: '25px',
+  }),
+  buttonContainer: css({
+    height: '150px',
+    width: '150px',
+    cursor: 'pointer',
+    justifyContent: 'center',
+  }),
+  button: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  container: css({
+    maxWidth: '370px',
+  }),
+  menu: css({
+    height: '25px',
+    margin: '0',
+  }),
+  thumbsdown: css({
+    transform: 'scale(-1, -1);',
+  }),
+});

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
@@ -43,6 +43,7 @@ export function getGrafanaInstancesByStateScene(
           .matchFieldsWithName('nodata')
           .overrideColor(overrideToFixedColor('nodata'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaInstancesByStateScene(
   timeRange: SceneTimeRange,
@@ -43,7 +46,7 @@ export function getGrafanaInstancesByStateScene(
           .matchFieldsWithName('nodata')
           .overrideColor(overrideToFixedColor('nodata'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -42,6 +42,7 @@ export function getGrafanaEvalSuccessVsFailuresScene(
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -42,7 +45,7 @@ export function getGrafanaEvalSuccessVsFailuresScene(
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -2,7 +2,7 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 
 export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,6 +37,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
         ],
       })
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -1,8 +1,11 @@
+import React from 'react';
+
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,7 +40,7 @@ export function getFiringGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
         ],
       })
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor } from '../../home/Insights';
-
+import { overrideToFixedColor } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 export function getInstanceStatByStatusScene(
   timeRange: SceneTimeRange,
   datasource: DataSourceRef,
@@ -30,7 +32,7 @@ export function getInstanceStatByStatusScene(
       .setData(query)
       .setOverrides((b) => b.matchFieldsWithName(status).overrideColor(overrideToFixedColor(status)))
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { overrideToFixedColor } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor } from '../../home/Insights';
 
 export function getInstanceStatByStatusScene(
   timeRange: SceneTimeRange,
@@ -30,6 +30,7 @@ export function getInstanceStatByStatusScene(
       .setData(query)
       .setOverrides((b) => b.matchFieldsWithName(status).overrideColor(overrideToFixedColor(status)))
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -11,7 +11,7 @@ import {
 } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaMissedIterationsScene(
   timeRange: SceneTimeRange,
@@ -66,6 +66,7 @@ export function getGrafanaMissedIterationsScene(
       .setData(transformation)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Observable, map } from 'rxjs';
 
 import { DataFrame } from '@grafana/data';
@@ -11,7 +12,8 @@ import {
 } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaMissedIterationsScene(
   timeRange: SceneTimeRange,
@@ -66,7 +68,7 @@ export function getGrafanaMissedIterationsScene(
       .setData(transformation)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -14,7 +14,7 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { Link, useStyles2 } from '@grafana/ui';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
 
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
@@ -104,6 +104,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
       .setDescription(panelTitle)
       .setData(transformation)
       .setNoValue('No new alerts fired last week')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -14,8 +14,9 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { Link, useStyles2 } from '@grafana/ui';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -104,7 +105,7 @@ export function getMostFiredInstancesScene(timeRange: SceneTimeRange, datasource
       .setDescription(panelTitle)
       .setData(transformation)
       .setNoValue('No new alerts fired last week')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -2,7 +2,7 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 
 export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,6 +37,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
         ],
       })
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -1,8 +1,11 @@
+import React from 'react';
+
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,7 +40,7 @@ export function getPausedGrafanaAlertsScene(timeRange: SceneTimeRange, datasourc
         ],
       })
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaRulesByEvaluationScene(
   timeRange: SceneTimeRange,
@@ -32,6 +32,7 @@ export function getGrafanaRulesByEvaluationScene(
       .setOverrides((b) =>
         b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaRulesByEvaluationScene(
   timeRange: SceneTimeRange,
@@ -32,7 +35,7 @@ export function getGrafanaRulesByEvaluationScene(
       .setOverrides((b) =>
         b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaRulesByEvaluationPercentageScene(
   timeRange: SceneTimeRange,
@@ -35,7 +38,7 @@ export function getGrafanaRulesByEvaluationPercentageScene(
       .setOverrides((b) =>
         b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getGrafanaRulesByEvaluationPercentageScene(
   timeRange: SceneTimeRange,
@@ -35,6 +35,7 @@ export function getGrafanaRulesByEvaluationPercentageScene(
       .setOverrides((b) =>
         b.matchFieldsWithName('active evaluation').overrideColor(overrideToFixedColor('active evaluation'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getGrafanaAlertmanagerNotificationsScene(
   timeRange: SceneTimeRange,
@@ -41,7 +44,7 @@ export function getGrafanaAlertmanagerNotificationsScene(
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getGrafanaAlertmanagerNotificationsScene(
   timeRange: SceneTimeRange,
@@ -41,6 +41,7 @@ export function getGrafanaAlertmanagerNotificationsScene(
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getGrafanaAlertmanagerSilencesScene(
   timeRange: SceneTimeRange,
@@ -28,6 +28,7 @@ export function getGrafanaAlertmanagerSilencesScene(
       .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getGrafanaAlertmanagerSilencesScene(
   timeRange: SceneTimeRange,
@@ -28,7 +31,7 @@ export function getGrafanaAlertmanagerSilencesScene(
       .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -26,7 +29,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('active').overrideColor(overrideToFixedColor('active')))
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -26,6 +26,7 @@ export function getAlertsByStateScene(timeRange: SceneTimeRange, datasource: Dat
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('active').overrideColor(overrideToFixedColor('active')))
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 
 export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,6 +25,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setUnit('bool_yes_no')
       .setOption('graphMode', BigValueGraphMode.None)
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,7 +28,7 @@ export function getInvalidConfigScene(timeRange: SceneTimeRange, datasource: Dat
       .setData(query)
       .setUnit('bool_yes_no')
       .setOption('graphMode', BigValueGraphMode.None)
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getNotificationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -38,7 +41,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 
 export function getNotificationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -38,6 +38,7 @@ export function getNotificationsScene(timeRange: SceneTimeRange, datasource: Dat
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
 
 export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,6 +25,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
+import { InsightsRatingModal } from '../RatingModal';
 
 export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,7 +28,7 @@ export function getSilencesScene(timeRange: SceneTimeRange, datasource: DataSour
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, ThresholdsMode, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRuleGroupEvaluationDurationIntervalRatioScene(
   timeRange: SceneTimeRange,
@@ -48,6 +48,7 @@ export function getRuleGroupEvaluationDurationIntervalRatioScene(
           },
         ],
       })
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, ThresholdsMode, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationIntervalRatioScene(
   timeRange: SceneTimeRange,
@@ -48,7 +51,7 @@ export function getRuleGroupEvaluationDurationIntervalRatioScene(
           },
         ],
       })
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRuleGroupEvaluationDurationScene(
   timeRange: SceneTimeRange,
@@ -37,6 +37,7 @@ export function getRuleGroupEvaluationDurationScene(
           fixedColor: 'blue',
         })
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationScene(
   timeRange: SceneTimeRange,
@@ -37,7 +40,7 @@ export function getRuleGroupEvaluationDurationScene(
           fixedColor: 'blue',
         })
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -38,7 +41,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -38,6 +38,7 @@ export function getRuleGroupEvaluationsScene(timeRange: SceneTimeRange, datasour
           .matchFieldsWithName('failed')
           .overrideColor(overrideToFixedColor('failed'))
       )
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,6 +25,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
       .setData(query)
       .setUnit('s')
       .setOption('graphMode', BigValueGraphMode.Area)
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -25,7 +28,7 @@ export function getRuleGroupIntervalScene(timeRange: SceneTimeRange, datasource:
       .setData(query)
       .setUnit('s')
       .setOption('graphMode', BigValueGraphMode.Area)
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -32,6 +32,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
         })
       )
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -32,7 +35,7 @@ export function getRulesPerGroupScene(timeRange: SceneTimeRange, datasource: Dat
         })
       )
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -36,7 +39,7 @@ export function getEvalSuccessVsFailuresScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('failed').overrideColor(overrideToFixedColor('failed')))
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getEvalSuccessVsFailuresScene(
   timeRange: SceneTimeRange,
@@ -36,6 +36,7 @@ export function getEvalSuccessVsFailuresScene(
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('failed').overrideColor(overrideToFixedColor('failed')))
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -2,7 +2,7 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,6 +37,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
         ],
       })
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Firing.tsx
@@ -1,8 +1,11 @@
+import React from 'react';
+
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,7 +40,7 @@ export function getFiringCloudAlertsScene(timeRange: SceneTimeRange, datasource:
         ],
       })
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -26,6 +26,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -26,7 +29,7 @@ export function getInstancesByStateScene(timeRange: SceneTimeRange, datasource: 
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
@@ -33,6 +33,7 @@ export function getInstancesPercentageByStateScene(
       .setMax(1)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getInstancesPercentageByStateScene(
   timeRange: SceneTimeRange,
@@ -33,7 +36,7 @@ export function getInstancesPercentageByStateScene(
       .setMax(1)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) => b.matchFieldsWithName('firing').overrideColor(overrideToFixedColor('firing')))
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -27,7 +30,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOption('legend', { showLegend: false })
       .setOverrides((b) => b.matchFieldsWithName('missed').overrideColor(overrideToFixedColor('missed')))
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 
 export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -27,6 +27,7 @@ export function getMissedIterationsScene(timeRange: SceneTimeRange, datasource: 
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOption('legend', { showLegend: false })
       .setOverrides((b) => b.matchFieldsWithName('missed').overrideColor(overrideToFixedColor('missed')))
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -40,6 +40,11 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
-    body: PanelBuilders.table().setTitle(panelTitle).setDescription(panelTitle).setData(transformation).build(),
+    body: PanelBuilders.table()
+      .setTitle(panelTitle)
+      .setDescription(panelTitle)
+      .setData(transformation)
+      .setMenu(getPanelMenu(panelTitle))
+      .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MostFiredRules.tsx
@@ -1,7 +1,10 @@
+import React from 'react';
+
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -44,7 +47,7 @@ export function getMostFiredRulesScene(timeRange: SceneTimeRange, datasource: Da
       .setTitle(panelTitle)
       .setDescription(panelTitle)
       .setData(transformation)
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -2,7 +2,7 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
 
 export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,6 +37,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
         ],
       })
       .setNoValue('0')
+      .setMenu(getPanelMenu(panelTitle))
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -1,8 +1,11 @@
+import React from 'react';
+
 import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { getPanelMenu, PANEL_STYLES } from '../../../home/Insights';
+import {  PANEL_STYLES } from '../../../home/Insights';
+import { InsightsRatingModal } from '../../RatingModal';
 
 export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({
@@ -37,7 +40,7 @@ export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource
         ],
       })
       .setNoValue('0')
-      .setMenu(getPanelMenu(panelTitle))
+      .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });
 }

--- a/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/Pending.tsx
@@ -4,7 +4,7 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import {  PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getPendingCloudAlertsScene(timeRange: SceneTimeRange, datasource: DataSourceRef, panelTitle: string) {


### PR DESCRIPTION
**What is this feature?**

Adds a menu to each panel in the Alerting Insights view that allows to tell users whether they find it useful or not. This information is sent via Rudderstack and can then be consumed in ops from the Google BigQuery datasource.

**Why do we need this feature?**

With this information we can create a dashboard with information on whether users find insights panels useful or not.

**Who is this feature for?**

Cloud users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/635

![2023-10-04 17 19 55](https://github.com/grafana/grafana/assets/6271380/46a67c1b-2df2-468a-9260-5dbdd92dfb2d)

