### PR TITLE
[v9.5.x] Adding .github/workflows/create-security-patch-from-security-mirror.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -605,7 +605,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/stale.yml @grafana/grafana-frontend-platform
 /.github/workflows/update-changelog.yml @grafana/grafana-delivery
 /.github/workflows/snyk.yml @grafana/security-team
-
+/.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-delivery
 
 # Conf
 /conf/defaults.ini @torkelo

--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -1,0 +1,28 @@
+# Owned by grafana-delivery-squad
+# Intended to be dropped into the base repo (Ex: grafana/grafana) for use in the security mirror. 
+name: Create security patch
+run-name: create-security-patch
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - "main"
+      - "v*.*.*"
+
+# This is run before the pull request has been merged, so we'll run against the src branch
+jobs:
+  trigger_downstream_create_security_patch:
+    concurrency: create-patch-${{ github.ref_name }}
+    uses: grafana/security-patch-actions/.github/workflows/create-patch.yml@main
+    if: github.repository == 'grafana/grafana-security-mirror' 
+    with:
+      repo: "${{ github.repository }}"
+      src_ref: "${{ github.head_ref }}" # this is the source branch name, Ex: "feature/newthing"
+      patch_ref: "${{ github.base_ref }}" # this is the target branch name, Ex: "main"
+      patch_repo: "grafana/grafana-security-patches"
+      patch_prefix: "${{ github.event.pull_request.number }}"
+    secrets: inherit
+


### PR DESCRIPTION
**What is this feature?**

A CI related github action to automatically create security patches from PRs in grafana-security-mirror.

**Why do we need this feature?**

To streamline our private security patching process.

**Who is this feature for?**

Anyone who needs to create an embargoed security fix.

