### PR TITLE
SQL: Remove query execution tracking for dashboards

### DIFF
--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -141,6 +141,10 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     }
 
     request.targets.forEach((target) => {
+      if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
+        return;
+      }
+
       reportInteraction('grafana_sql_query_executed', {
         datasource: target.datasource?.type,
         editorMode: target.editorMode,


### PR DESCRIPTION
**What is this feature?**
this PR stops queries being tracked if they are executed in dashboards.

**Why do we need this feature?**
this improves performance and keeps feature tracking in sync with other datasources (prom/loki)
