### PR TITLE
Dashboards: Fix Dashboards not loading when user doesn't have permission on the parent folder

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -539,7 +539,9 @@ export class BackendSrv implements BackendService {
       queryParams.set('accesscontrol', 'true');
     }
 
-    return this.get<FolderDTO>(`/api/folders/${uid}?${queryParams.toString()}`);
+    return this.get<FolderDTO>(`/api/folders/${uid}?${queryParams.toString()}`, undefined, undefined, {
+      showErrorAlert: false,
+    });
   }
 }
 

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -449,10 +449,14 @@ function updateStatePageNavFromProps(props: Props, state: State): State {
   if (folderUid && pageNav) {
     if (newBrowseDashboardsEnabled()) {
       const folderNavModel = getNavModel(navIndex, `folder-dashboards-${folderUid}`).main;
-      pageNav = {
-        ...pageNav,
-        parentItem: folderNavModel,
-      };
+      // If the folder hasn't loaded (maybe user doesn't have permission on it?) then
+      // don't show the "page not found" breadcrumb
+      if (folderNavModel.id !== 'not-found') {
+        pageNav = {
+          ...pageNav,
+          parentItem: folderNavModel,
+        };
+      }
     } else {
       // Check if folder changed
       if (folderTitle && pageNav.parentItem?.text !== folderTitle) {

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -93,8 +93,13 @@ async function fetchDashboard(
         // get parent folder (if it exists) and put it in the store
         // this will be used to populate the full breadcrumb trail
         if (newBrowseDashboardsEnabled() && dashDTO.meta.folderUid) {
-          await dispatch(getFolderByUid(dashDTO.meta.folderUid));
+          try {
+            await dispatch(getFolderByUid(dashDTO.meta.folderUid));
+          } catch (err) {
+            console.warn('Error fetching parent folder', dashDTO.meta.folderUid, 'for dashboard', err);
+          }
         }
+
         if (args.fixUrl && dashDTO.meta.url && !playlistSrv.isPlaying) {
           // check if the current url is correct (might be old slug)
           const dashboardUrl = locationUtil.stripBaseFromUrl(dashDTO.meta.url);


### PR DESCRIPTION
When loading a Dashboard, we also load the parent folder to populate the breadcrubs<sup>1</sup>. If the user does not have permission to view the folder the dashboard is in (but _does_ have permission on the dashboard itself, which is a supported scenario) then the entire dashboard load would fail.

This PR fixes the issue by:
 - try/catch loading the folder so it rejecting from invalid permissions doesn't reject the whole dashboard loading
 - hide the "Page not found" breadcrumb representing the missing folder
 - suppress the toast from the failed API call.

<sup>1</sup> I don't think we actually need to hit the folder API if only `newBrowseDashboards` is enabled, because the dashboard response still contains all the folder information needed. I think we only need to do this if `nestedFolders` is enabled.

Longer term, for nested folders, I would like to use the rtkq subscription to load the folder instead. This will make it easier to get discrete error states so the breadcrumb building can distinguish between missing data vs lack of permissions.