### PR TITLE
Explore: Update info about query history and deleting

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
@@ -90,7 +90,7 @@ export function RichHistorySettingsTab(props: RichHistorySettingsProps) {
         </Field>
       ) : (
         <Alert severity="info" title="History time span">
-          Grafana will keep entries up to {selectedOption?.label}. Starred entries won't be deleted.
+          Grafana will keep entries up to {selectedOption?.label}. Starred entries won&apos;t be deleted.
         </Alert>
       )}
       <InlineField

--- a/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
@@ -90,7 +90,7 @@ export function RichHistorySettingsTab(props: RichHistorySettingsProps) {
         </Field>
       ) : (
         <Alert severity="info" title="History time span">
-          Grafana will keep entries up to {selectedOption?.label}.
+          Grafana will keep entries up to {selectedOption?.label}. Starred entries won't be deleted.
         </Alert>
       )}
       <InlineField


### PR DESCRIPTION
While updating my default tab in the query history, I briefly experienced confusion as it appeared that even starred entries might not be retained beyond a two-week period. Consequently, I decided it would be beneficial to modify the note to explicitly state that starred queries will not be subject to deletion.

Feel free to update the copy, or close the PR if you don't think this is needed. 🙂

Before:
<img width="716" alt="image" src="https://github.com/grafana/grafana/assets/30407135/8859ed6e-5b5a-41d4-b0f2-9b2d562c2bb9">

After: 
<img width="789" alt="image" src="https://github.com/grafana/grafana/assets/30407135/64100ecc-fcf9-4d27-97dd-448b1d45943f">

