### PR TITLE
Plugin: Accept backend plugin process command args

### DIFF
--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -39,7 +39,7 @@ func newPlugin(descriptor PluginDescriptor) backendplugin.PluginFactoryFunc {
 			descriptor: descriptor,
 			logger:     logger,
 			clientFactory: func() *plugin.Client {
-				return plugin.NewClient(newClientConfig(descriptor.executablePath, env(), logger, descriptor.versionedPlugins))
+				return plugin.NewClient(newClientConfig(descriptor.executablePath, descriptor.executableArgs, env(), logger, descriptor.versionedPlugins))
 			},
 		}, nil
 	}


### PR DESCRIPTION
**What is this feature?**

Adds the ability to pass command arguments to a backend plugin process when starting.

**Why do we need this feature?**

To support work such as https://github.com/grafana/grafana-enterprise-sdk/pull/24

**Who is this feature for?**

Plugins Platform

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
