### PR TITLE
Chore: remove gf-forms and LegacyForms from Graphite ConfigEditor

### DIFF
--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -6,7 +6,15 @@ import {
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceJsonDataOptionChecked,
 } from '@grafana/data';
-import { Alert, DataSourceHttpSettings, InlineFormLabel, LegacyForms, Select } from '@grafana/ui';
+import {
+  Alert,
+  DataSourceHttpSettings,
+  FieldSet,
+  InlineField,
+  InlineFieldRow,
+  InlineSwitch,
+  Select,
+} from '@grafana/ui';
 import { config } from 'app/core/config';
 import store from 'app/core/store';
 
@@ -16,7 +24,6 @@ import { DEFAULT_GRAPHITE_VERSION, GRAPHITE_VERSIONS } from '../versions';
 import { MappingsConfiguration } from './MappingsConfiguration';
 import { fromString, toString } from './parseLokiLabelMappings';
 
-const { Switch } = LegacyForms;
 export const SHOW_MAPPINGS_HELP_KEY = 'grafana.datasources.graphite.config.showMappingsHelp';
 
 const graphiteVersions = GRAPHITE_VERSIONS.map((version) => ({ label: `${version}.x`, value: version }));
@@ -77,48 +84,52 @@ export class ConfigEditor extends PureComponent<Props, State> {
           onChange={onOptionsChange}
           secureSocksDSProxyEnabled={config.secureSocksDSProxyEnabled}
         />
-        <h3 className="page-heading">Graphite details</h3>
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel tooltip="This option controls what functions are available in the Graphite query editor.">
-                Version
-              </InlineFormLabel>
+        <FieldSet>
+          <legend className="page-heading">Graphite details</legend>
+          <InlineFieldRow>
+            <InlineField
+              label="Version"
+              tooltip="This option controls what functions are available in the Graphite query editor."
+              labelWidth={20}
+            >
               <Select
+                id="graphite-version"
                 aria-label="Graphite version"
                 value={currentVersion}
                 options={graphiteVersions}
-                className="width-8"
+                width={16}
                 onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteVersion')}
               />
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel tooltip={this.renderTypeHelp}>Type</InlineFormLabel>
+            </InlineField>
+          </InlineFieldRow>
+          <InlineFieldRow>
+            <InlineField label="Type" tooltip={this.renderTypeHelp} labelWidth={20}>
               <Select
+                id="backend-type"
                 aria-label="Graphite backend type"
                 options={graphiteTypes}
                 value={graphiteTypes.find((type) => type.value === options.jsonData.graphiteType)}
-                className="width-8"
+                width={16}
                 onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteType')}
               />
-            </div>
-          </div>
+            </InlineField>
+          </InlineFieldRow>
           {options.jsonData.graphiteType === GraphiteType.Metrictank && (
-            <div className="gf-form-inline">
-              <div className="gf-form">
-                <Switch
-                  label="Rollup indicator"
-                  labelClass={'width-10'}
-                  tooltip="Shows up as an info icon in panel headers when data is aggregated"
-                  checked={!!options.jsonData.rollupIndicatorEnabled}
+            <InlineFieldRow>
+              <InlineField
+                label="Rollup indicator"
+                tooltip="Shows up as an info icon in panel headers when data is aggregated"
+                labelWidth={20}
+              >
+                <InlineSwitch
+                  id="rollup-indicator"
+                  value={!!options.jsonData.rollupIndicatorEnabled}
                   onChange={onUpdateDatasourceJsonDataOptionChecked(this.props, 'rollupIndicatorEnabled')}
                 />
-              </div>
-            </div>
+              </InlineField>
+            </InlineFieldRow>
           )}
-        </div>
+        </FieldSet>
         <MappingsConfiguration
           mappings={(options.jsonData.importConfiguration?.loki?.mappings || []).map(toString)}
           showHelp={this.state.showMappingsHelp}

--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -6,17 +6,7 @@ import {
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceJsonDataOptionChecked,
 } from '@grafana/data';
-import {
-  Alert,
-  DataSourceHttpSettings,
-  Field,
-  FieldSet,
-  InlineField,
-  InlineFieldRow,
-  InlineSwitch,
-  Select,
-  Switch,
-} from '@grafana/ui';
+import { Alert, DataSourceHttpSettings, Field, FieldSet, Select, Switch } from '@grafana/ui';
 import { config } from 'app/core/config';
 import store from 'app/core/store';
 

--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -9,11 +9,13 @@ import {
 import {
   Alert,
   DataSourceHttpSettings,
+  Field,
   FieldSet,
   InlineField,
   InlineFieldRow,
   InlineSwitch,
   Select,
+  Switch,
 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import store from 'app/core/store';
@@ -47,20 +49,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
     };
   }
 
-  renderTypeHelp = () => {
-    return (
-      <p>
-        There are different types of Graphite compatible backends. Here you can specify the type you are using. If you
-        are using{' '}
-        <a href="https://github.com/grafana/metrictank" className="pointer" target="_blank" rel="noreferrer">
-          Metrictank
-        </a>{' '}
-        then select that here. This will enable Metrictank specific features like query processing meta data. Metrictank
-        is a multi-tenant timeseries engine for Graphite and friends.
-      </p>
-    );
-  };
-
   componentDidMount() {
     updateDatasourcePluginJsonDataOption(this.props, 'graphiteVersion', this.currentGraphiteVersion);
   }
@@ -86,48 +74,44 @@ export class ConfigEditor extends PureComponent<Props, State> {
         />
         <FieldSet>
           <legend className="page-heading">Graphite details</legend>
-          <InlineFieldRow>
-            <InlineField
-              label="Version"
-              tooltip="This option controls what functions are available in the Graphite query editor."
-              labelWidth={20}
-            >
-              <Select
-                id="graphite-version"
-                aria-label="Graphite version"
-                value={currentVersion}
-                options={graphiteVersions}
-                width={16}
-                onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteVersion')}
-              />
-            </InlineField>
-          </InlineFieldRow>
-          <InlineFieldRow>
-            <InlineField label="Type" tooltip={this.renderTypeHelp} labelWidth={20}>
-              <Select
-                id="backend-type"
-                aria-label="Graphite backend type"
-                options={graphiteTypes}
-                value={graphiteTypes.find((type) => type.value === options.jsonData.graphiteType)}
-                width={16}
-                onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteType')}
-              />
-            </InlineField>
-          </InlineFieldRow>
+          <Field
+            label="Version"
+            description="This option controls what functions are available in the Graphite query editor."
+          >
+            <Select
+              id="graphite-version"
+              aria-label="Graphite version"
+              value={currentVersion}
+              options={graphiteVersions}
+              width={16}
+              onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteVersion')}
+            />
+          </Field>
+
+          <Field
+            label="Graphite backend type"
+            description="There are different types of Graphite compatible backends. Here you can specify the type you are using. For Metrictank, this will enable specific features, like query processing meta data. Metrictank
+        is a multi-tenant timeseries engine for Graphite and friends."
+          >
+            <Select
+              id="backend-type"
+              options={graphiteTypes}
+              value={graphiteTypes.find((type) => type.value === options.jsonData.graphiteType)}
+              width={16}
+              onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'graphiteType')}
+            />
+          </Field>
           {options.jsonData.graphiteType === GraphiteType.Metrictank && (
-            <InlineFieldRow>
-              <InlineField
-                label="Rollup indicator"
-                tooltip="Shows up as an info icon in panel headers when data is aggregated"
-                labelWidth={20}
-              >
-                <InlineSwitch
-                  id="rollup-indicator"
-                  value={!!options.jsonData.rollupIndicatorEnabled}
-                  onChange={onUpdateDatasourceJsonDataOptionChecked(this.props, 'rollupIndicatorEnabled')}
-                />
-              </InlineField>
-            </InlineFieldRow>
+            <Field
+              label="Rollup indicator"
+              description="Shows up as an info icon in panel headers when data is aggregated."
+            >
+              <Switch
+                id="rollup-indicator"
+                value={!!options.jsonData.rollupIndicatorEnabled}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(this.props, 'rollupIndicatorEnabled')}
+              />
+            </Field>
           )}
         </FieldSet>
         <MappingsConfiguration


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes debt, gf-forms and LegacyForms from Graphite config editor. Adding id's to the selects also makes the labelFor actually work.

**Before**
![image](https://github.com/grafana/grafana/assets/1438972/2a085ff3-2ec0-49f2-a8eb-1fad6aa944a0)

**After**
![image](https://github.com/grafana/grafana/assets/1438972/1008c852-217d-4b35-a6dc-37ce45ea0ffb)

**Why do we need this feature?**

🧹  tech debt

**Who is this feature for?**

Devs

**Which issue(s) does this PR fix?**:

Related to #65513 and #76107

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
