### PR TITLE
AuthN: Make logger less noisy

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -226,7 +226,7 @@ func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Req
 	r.OrgID = orgIDFromRequest(r)
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
-		s.log.FromContext(ctx).Warn("Failed to authenticate request", "client", c.Name(), "error", err)
+		s.log.FromContext(ctx).Debug("Failed to authenticate request", "client", c.Name(), "error", err)
 		return nil, err
 	}
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -226,7 +226,12 @@ func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Req
 	r.OrgID = orgIDFromRequest(r)
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
-		s.log.FromContext(ctx).Debug("Failed to authenticate request", "client", c.Name(), "error", err)
+		log := s.log.FromContext(ctx).Warn
+		if errors.Is(err, authn.ErrTokenNeedsRotation) {
+			log = s.log.FromContext(ctx).Debug
+		}
+
+		log("Failed to authenticate request", "client", c.Name(), "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**What is this feature?**
Logs for token needs rotation is a bit noisy when feature toggle `clientTokenRotation` is enabled. Downgrade to debug for those errors

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
