### PR TITLE
Sandbox: Fix dynamic loaded chunks not processed correcly inside the sandbox

### DIFF
--- a/public/app/features/plugins/cdn/utils.ts
+++ b/public/app/features/plugins/cdn/utils.ts
@@ -7,10 +7,12 @@ export function transformPluginSourceForCDN({
   url,
   source,
   transformSourceMapURL = false,
+  transformAssets = true,
 }: {
   url: string;
   source: string;
   transformSourceMapURL?: boolean;
+  transformAssets?: boolean;
 }): string {
   const splitUrl = url.split('/public/plugins/');
   const baseAddress = splitUrl[0];
@@ -18,8 +20,10 @@ export function transformPluginSourceForCDN({
 
   // handle basic asset paths that include public/plugins
   let newSource = source;
-  newSource = newSource.replace(/(\/?)(public\/plugins)/g, `${baseAddress}/$2`);
-  newSource = newSource.replace(/(["|'])(plugins\/.+?.css)(["|'])/g, `$1${baseAddress}/public/$2$3`);
+  if (transformAssets) {
+    newSource = newSource.replace(/(\/?)(public\/plugins)/g, `${baseAddress}/$2`);
+    newSource = newSource.replace(/(["|'])(plugins\/.+?.css)(["|'])/g, `$1${baseAddress}/public/$2$3`);
+  }
 
   if (transformSourceMapURL) {
     newSource = newSource.replace(

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -41,6 +41,7 @@ export async function loadScriptIntoSandbox(url: string, meta: PluginMeta, sandb
     throw new Error('Only same domain scripts are allowed in sandboxed plugins');
   }
 
+  scriptCode = patchPluginAPIs(scriptCode);
   sandboxEnv.evaluate(scriptCode);
 }
 

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -34,6 +34,7 @@ export async function loadScriptIntoSandbox(url: string, meta: PluginMeta, sandb
       url,
       source: scriptCode,
       transformSourceMapURL: true,
+      transformAssets: true,
     });
   }
 
@@ -55,6 +56,7 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
       url,
       source: pluginCode,
       transformSourceMapURL: true,
+      transformAssets: true,
     });
     return pluginCode;
   } else {
@@ -63,7 +65,12 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
     const pluginCodeUrl = resolveWithCache(meta.module);
     const response = await fetch(pluginCodeUrl);
     let pluginCode = await response.text();
-    pluginCode = patchPluginSourceMap(meta, pluginCode);
+    pluginCode = transformPluginSourceForCDN({
+      url: pluginCodeUrl,
+      source: pluginCode,
+      transformSourceMapURL: true,
+      transformAssets: false,
+    });
     pluginCode = patchPluginAPIs(pluginCode);
     return pluginCode;
   }
@@ -71,31 +78,6 @@ export async function getPluginCode(meta: PluginMeta): Promise<string> {
 
 function patchPluginAPIs(pluginCode: string): string {
   return pluginCode.replace(/window\.location/gi, 'window.locationSandbox');
-}
-
-/**
- * Patches the plugin's module.js source code references to sourcemaps to include the full url
- * of the module.js file instead of the regular relative reference.
- *
- * Because the plugin module.js code is loaded via fetch and then "eval" as a string
- * it can't find the references to the module.js.map directly and we need to patch it
- * to point to the correct location
- */
-function patchPluginSourceMap(meta: PluginMeta, pluginCode: string): string {
-  // skips inlined and files without source maps
-  if (pluginCode.includes('//# sourceMappingURL=module.js.map')) {
-    let replaceWith = '';
-    // make sure we don't add the sourceURL twice
-    if (!pluginCode.includes('//# sourceURL') || !pluginCode.includes('//@ sourceUrl')) {
-      replaceWith += `//# sourceURL=module.js\n`;
-    }
-    // modify the source map url to point to the correct location
-    const sourceCodeMapUrl = meta.module + '.map';
-    replaceWith += `//# sourceMappingURL=${sourceCodeMapUrl}`;
-
-    return pluginCode.replace('//# sourceMappingURL=module.js.map', replaceWith);
-  }
-  return pluginCode;
 }
 
 export function patchSandboxEnvironmentPrototype(sandboxEnvironment: SandboxEnvironment) {

--- a/public/app/features/plugins/sandbox/code_loader.ts
+++ b/public/app/features/plugins/sandbox/code_loader.ts
@@ -19,8 +19,13 @@ export async function loadScriptIntoSandbox(url: string, meta: PluginMeta, sandb
   if (isSameDomainAsHost(url)) {
     const response = await fetch(url);
     scriptCode = await response.text();
-    scriptCode = patchPluginSourceMap(meta, scriptCode);
-
+    //even though this is not loaded via a CDN we need to transform the sourceMapUrl
+    scriptCode = transformPluginSourceForCDN({
+      url,
+      source: scriptCode,
+      transformSourceMapURL: true,
+      transformAssets: false,
+    });
     // cdn loaded
   } else if (isHostedOnCDN(url)) {
     const response = await fetch(url);


### PR DESCRIPTION
**What is this feature?**

Fixes an issue when a plugin running inside the sandbox loads dynamic chunks. Sometimes those chunks get incorrect source map replaced and their native apis were not patched to make them compatible with the sandbox

**Why do we need this feature?**

To make plugins using dynamic chunks compatible with the sandbox

**Who is this feature for?**

plugins running inside the sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
