### PR TITLE
SigningKeys: Clean old keys by expiry

### DIFF
--- a/pkg/services/signingkeys/signingkeystore/store.go
+++ b/pkg/services/signingkeys/signingkeystore/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-jose/go-jose/v3"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/localcache"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/signingkeys"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -32,9 +34,13 @@ type SigningStore interface {
 
 var _ SigningStore = (*Store)(nil)
 
+const cleanupRateLimitKey = "signingkeys-cleanup"
+
 type Store struct {
 	dbStore        db.DB
 	secretsService secrets.Service
+	log            log.Logger
+	localCache     *localcache.CacheService
 }
 
 type SigningKey struct {
@@ -50,6 +56,8 @@ func NewSigningKeyStore(dbStore db.DB, secretsService secrets.Service) *Store {
 	return &Store{
 		dbStore:        dbStore,
 		secretsService: secretsService,
+		log:            log.New("signing.key_service"),
+		localCache:     localcache.New(12*time.Hour, 4*time.Hour),
 	}
 }
 
@@ -129,6 +137,26 @@ func (s *Store) AddPrivateKey(ctx context.Context,
 
 		return signingkeys.ErrSigningKeyAlreadyExists.Errorf("The specified key already exists: %s", keyID)
 	})
+
+	if _, ok := s.localCache.Get(cleanupRateLimitKey); !ok {
+		go func() {
+			defer func() {
+				if err := recover(); err != nil {
+					s.log.Error("panic during expired signing key cleanup", "err", err)
+				}
+			}()
+
+			ctxGo, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			if err := s.cleanupExpiredKeys(ctxGo); err != nil {
+				s.log.Error("Failed to cleanup expired signing keys", "err", err)
+			}
+
+		}()
+
+		s.localCache.Set(cleanupRateLimitKey, true, 1*time.Hour)
+	}
 
 	return signer, err
 }
@@ -217,4 +245,15 @@ func (s *Store) decodePrivateKey(ctx context.Context, signingKey *SigningKey) (c
 		return nil, errors.New("failed to assert private key as crypto.Signer")
 	}
 	return assertedKey, nil
+}
+
+// cleanupExpiredKeys removes expired keys from the database that have expired more than 61 days ago
+func (s *Store) cleanupExpiredKeys(ctx context.Context) error {
+	err := s.dbStore.WithTransactionalDbSession(ctx, func(tx *sqlstore.DBSession) error {
+		_, err := tx.Exec("DELETE FROM signing_key WHERE expires_at IS NOT NULL AND expires_at < ?",
+			time.Now().UTC().Add(-61*24*time.Hour))
+		return err
+	})
+
+	return err
 }

--- a/pkg/services/signingkeys/signingkeystore/store.go
+++ b/pkg/services/signingkeys/signingkeystore/store.go
@@ -152,9 +152,7 @@ func (s *Store) AddPrivateKey(ctx context.Context,
 			if err := s.cleanupExpiredKeys(ctxGo); err != nil {
 				s.log.Error("Failed to cleanup expired signing keys", "err", err)
 			}
-
 		}()
-
 		s.localCache.Set(cleanupRateLimitKey, true, 1*time.Hour)
 	}
 

--- a/pkg/services/signingkeys/signingkeystore/store_test.go
+++ b/pkg/services/signingkeys/signingkeystore/store_test.go
@@ -162,6 +162,9 @@ func TestIntegrationAddPrivateKey(t *testing.T) {
 		},
 	}
 
+	_, exists := store.localCache.Get(cleanupRateLimitKey)
+	require.False(t, exists)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := store.AddPrivateKey(ctx, tc.keyID, tc.alg, tc.privateKey, tc.expiresAt, tc.force)
@@ -184,6 +187,9 @@ func TestIntegrationAddPrivateKey(t *testing.T) {
 			}
 		})
 	}
+
+	_, exists = store.localCache.Get(cleanupRateLimitKey)
+	require.True(t, exists)
 }
 
 func generateRSAKey(t *testing.T) *rsa.PrivateKey {


### PR DESCRIPTION
**What is this feature?**

Clean expired signing keys older than 60 days

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
