### PR TITLE
Pyroscope: Fix backend panic when querying out of bounds

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
@@ -149,6 +149,11 @@ func (c *PyroscopeClient) GetProfile(ctx context.Context, profileTypeID, labelSe
 		return nil, err
 	}
 
+	if resp.Msg.Flamegraph == nil {
+		// Not an error, can happen when querying data oout of range.
+		return nil, nil
+	}
+
 	levels := make([]*Level, len(resp.Msg.Flamegraph.Levels))
 	for i, level := range resp.Msg.Flamegraph.Levels {
 		levels[i] = &Level{

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -91,22 +91,30 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 				logger.Error("Error GetProfile()", "err", err)
 				return err
 			}
-			frame := responseToDataFrames(prof)
+
+			var frame *data.Frame
+			if prof != nil {
+				frame := responseToDataFrames(prof)
+
+				// If query called with streaming on then return a channel
+				// to subscribe on a client-side and consume updates from a plugin.
+				// Feel free to remove this if you don't need streaming for your datasource.
+				if qm.WithStreaming {
+					channel := live.Channel{
+						Scope:     live.ScopeDatasource,
+						Namespace: pCtx.DataSourceInstanceSettings.UID,
+						Path:      "stream",
+					}
+					frame.SetMeta(&data.FrameMeta{Channel: channel.String()})
+				}
+			} else {
+				// We still send empty data frame to give feedback that query really run, just didn't return any data.
+				frame = getEmptyDataFrame()
+			}
 			responseMutex.Lock()
 			response.Frames = append(response.Frames, frame)
 			responseMutex.Unlock()
 
-			// If query called with streaming on then return a channel
-			// to subscribe on a client-side and consume updates from a plugin.
-			// Feel free to remove this if you don't need streaming for your datasource.
-			if qm.WithStreaming {
-				channel := live.Channel{
-					Scope:     live.ScopeDatasource,
-					Namespace: pCtx.DataSourceInstanceSettings.UID,
-					Path:      "stream",
-				}
-				frame.SetMeta(&data.FrameMeta{Channel: channel.String()})
-			}
 			return nil
 		})
 	}
@@ -271,6 +279,18 @@ func (pt *ProfileTree) String() string {
 		}
 	}
 	return tree.String()
+}
+
+func getEmptyDataFrame() *data.Frame {
+	var emptyProfileDataFrame = data.NewFrame("response")
+	emptyProfileDataFrame.Meta = &data.FrameMeta{PreferredVisualization: "flamegraph"}
+	emptyProfileDataFrame.Fields = data.Fields{
+		data.NewField("level", nil, []int64{}),
+		data.NewField("value", nil, []int64{}),
+		data.NewField("self", nil, []int64{}),
+		data.NewField("label", nil, []string{}),
+	}
+	return emptyProfileDataFrame
 }
 
 type CustomMeta struct {

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -94,7 +94,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 
 			var frame *data.Frame
 			if prof != nil {
-				frame := responseToDataFrames(prof)
+				frame = responseToDataFrames(prof)
 
 				// If query called with streaming on then return a channel
 				// to subscribe on a client-side and consume updates from a plugin.


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/75962

Pyroscope returns different response when querying time range without data than when no data matches the label selector which wasn't handled properly and resulted in nil pointer panic.