### PR TITLE
Alerting: display datasource information under each section

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -174,7 +174,7 @@ function getGrafanaManagedScenes() {
         new SceneFlexItem({
           body: new SceneReactObject({
             component: SectionSubheader,
-            props: { children: <div>Grafana-managed rules</div>, datasources: [ashDs, cloudUsageDs] },
+            props: { children: <div>Grafana-managed rules</div>, datasources: [] },
           }),
         }),
         new SceneFlexLayout({
@@ -241,7 +241,7 @@ function getGrafanaAlertmanagerScenes() {
         new SceneFlexItem({
           body: new SceneReactObject({
             component: SectionSubheader,
-            props: { children: <div>Grafana Alertmanager</div>, datasources: [cloudUsageDs] },
+            props: { children: <div>Grafana Alertmanager</div>, datasources: [] },
           }),
         }),
         new SceneFlexLayout({

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -6,6 +6,7 @@ import {
   EmbeddedScene,
   NestedScene,
   QueryVariable,
+  SceneControlsSpacer,
   SceneFlexItem,
   SceneFlexLayout,
   SceneReactObject,
@@ -155,7 +156,15 @@ export function getInsightsScenes() {
 
   return new EmbeddedScene({
     $timeRange: THIS_WEEK_TIME_RANGE,
-    controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
+    controls: [
+      new SceneReactObject({
+        component: SectionSubheader,
+        props: { children: <div>Monitor the status of your system.</div>, datasources: [] },
+      }),
+      new SceneControlsSpacer(),
+      new SceneTimePicker({}),
+      new SceneRefreshPicker({}),
+    ],
     body: new SceneFlexLayout({
       direction: 'column',
       children: categories,

--- a/public/app/features/alerting/unified/insights/DataSourcesInfo.tsx
+++ b/public/app/features/alerting/unified/insights/DataSourcesInfo.tsx
@@ -10,7 +10,7 @@ export function DataSourcesInfo({ datasources }: { datasources: DataSourceInform
   const styles = useStyles2(getStyles);
 
   const displayDs = datasources.map((ds) => (
-    <div key={ds.uid} className={styles.dsItem}>
+    <div key={ds.uid}>
       {ds.settings?.meta.info.logos.small && (
         <img className={styles.dsImage} src={ds.settings?.meta.info.logos.small} alt={ds.settings?.name || ds.uid} />
       )}
@@ -35,5 +35,4 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: '10px',
     justifyContent: 'flex-end',
   }),
-  dsItem: css({}),
 });

--- a/public/app/features/alerting/unified/insights/DataSourcesInfo.tsx
+++ b/public/app/features/alerting/unified/insights/DataSourcesInfo.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data/src/themes';
+import { useStyles2 } from '@grafana/ui';
+
+import { DataSourceInformation } from '../home/Insights';
+
+export function DataSourcesInfo({ datasources }: { datasources: DataSourceInformation[] }) {
+  const styles = useStyles2(getStyles);
+
+  const displayDs = datasources.map((ds) => (
+    <div key={ds.uid} className={styles.dsItem}>
+      {ds.settings?.meta.info.logos.small && (
+        <img className={styles.dsImage} src={ds.settings?.meta.info.logos.small} alt={ds.settings?.name || ds.uid} />
+      )}
+      <span>{ds.settings?.name || ds.uid}</span>
+    </div>
+  ));
+
+  return <div className={styles.dsContainer}>{displayDs}</div>;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  dsImage: css({
+    label: 'ds-image',
+    width: '16px',
+    marginRight: '3px',
+  }),
+  dsContainer: css({
+    display: 'flex',
+    flexDirection: 'row',
+    fontSize: theme.typography.bodySmall.fontSize,
+    gap: '10px',
+    marginBottom: '10px',
+    justifyContent: 'flex-end',
+  }),
+  dsItem: css({}),
+});

--- a/public/app/features/alerting/unified/insights/SectionSubheader.tsx
+++ b/public/app/features/alerting/unified/insights/SectionSubheader.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data/src/themes';
+import { useStyles2 } from '@grafana/ui';
+
+import { DataSourceInformation } from '../home/Insights';
+
+import { DataSourcesInfo } from './DataSourcesInfo';
+
+export function SectionSubheader({
+  children,
+  datasources,
+}: React.PropsWithChildren<{ datasources: DataSourceInformation[] }>) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.container}>
+      <div>{children}</div>
+      <DataSourcesInfo datasources={datasources} />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  }),
+});

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
@@ -32,6 +32,7 @@ export function getGrafanaAlertmanagerNotificationsScene(datasource: DataSourceR
       .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setOverrides((b) =>
         b
           .matchFieldsWithName('success')

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
-import { DataSourceRef, GraphDrawStyle } from '@grafana/schema';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
+import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
@@ -26,6 +26,7 @@ export function getGrafanaAlertmanagerSilencesScene(datasource: DataSourceRef, p
       .setDescription(panelTitle)
       .setData(query)
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setHeaderActions(<InsightsRatingModal panel={panelTitle} />)
       .build(),
   });


### PR DESCRIPTION
**What is this feature?**

Displays info about which datasources are used each section

**Why do we need this feature?**

To give users more clarity about where the data comes from

**Who is this feature for?**

All cloud users

<img width="1256" alt="image" src="https://github.com/grafana/grafana/assets/6271380/14703832-ac15-4007-9d7b-6811a5bfaab1">

Closes https://github.com/grafana/alerting-squad/issues/637
