### PR TITLE
plugins slo - capture error source

### DIFF
--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -58,17 +58,13 @@ const (
 )
 
 type PluginError struct {
-	ErrorSource backend.ErrorSource
+	Source backend.ErrorSource
 
 	Err error
 }
 
 func (r PluginError) Error() string {
 	return r.Err.Error()
-}
-
-func (r PluginError) Source() backend.ErrorSource {
-	return r.ErrorSource
 }
 
 // instrumentPluginRequest instruments success rate and latency of `fn`
@@ -86,7 +82,7 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 		}
 		pluginErr, ok := err.(PluginError)
 		if ok {
-			errorSource = pluginErr.ErrorSource
+			errorSource = pluginErr.Source
 		}
 	}
 

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -61,7 +61,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	}, totalBytes, func(ctx context.Context) (innerErr error) {
 		resp, innerErr = p.QueryData(ctx, req)
 		if resp != nil && innerErr != nil {
-			innerErr = &instrumentation.PluginError{Err: innerErr, ErrorSource: errorSource(resp)}
+			innerErr = &instrumentation.PluginError{Err: innerErr, Source: errorSource(resp)}
 		}
 		return
 	})


### PR DESCRIPTION
capture error source for slos so we can determine if errors are caused by the plugin vs downstream ( database issues, etc )