### PR TITLE
Alerting: Let users with regular permissions access export endpoints

### DIFF
--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -189,10 +189,16 @@ func (api *API) authorize(method, path string) web.Handler {
 		return middleware.ReqOrgAdmin
 
 	// Grafana-only Provisioning Read Paths
+	case http.MethodGet + "/api/v1/provisioning/policies/export",
+		http.MethodGet + "/api/v1/provisioning/contact-points/export":
+		eval = ac.EvalAny(
+			ac.EvalPermission(ac.ActionAlertingNotificationsRead),       // organization scope
+			ac.EvalPermission(ac.ActionAlertingProvisioningRead),        // organization scope
+			ac.EvalPermission(ac.ActionAlertingProvisioningReadSecrets), // organization scope
+		)
+
 	case http.MethodGet + "/api/v1/provisioning/policies",
-		http.MethodGet + "/api/v1/provisioning/policies/export",
 		http.MethodGet + "/api/v1/provisioning/contact-points",
-		http.MethodGet + "/api/v1/provisioning/contact-points/export",
 		http.MethodGet + "/api/v1/provisioning/templates",
 		http.MethodGet + "/api/v1/provisioning/templates/{name}",
 		http.MethodGet + "/api/v1/provisioning/mute-timings",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR relaxes permissions required to access export endpoints in provisioning API. Now a user with permissions `alert.notifications:read` will be able to export notification resources.

**Why do we need this feature?**
This is to make the export buttons available to all users who can access notifications via UI. In PR https://github.com/grafana/grafana/pull/75322 we introduced export endpoints for alert rules that are available to UI users. This change makes export functionality consistent.

**Who is this feature for?**
Users that do not have access to provisioning API but want to export resources.



**Special notes for your reviewer:**

Rules export is still protected by only provisioning permissions because the endpoint is more permissive. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
