### PR TITLE
Added dashboard row accessibility for screen readers

### DIFF
--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -38,6 +38,16 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
 
   onToggle = () => {
     this.props.dashboard.toggleRow(this.props.panel);
+
+    this.updateAriaExpanded();
+  };
+
+  // update the aria-expanded attribute based on panel state
+  updateAriaExpanded = () => {
+    const buttonElement = document.querySelector('.dashboard-row__title');
+    if (buttonElement) {
+      buttonElement.setAttribute('aria-expanded', this.props.panel.collapsed ? 'false' : 'true');
+    }
   };
 
   getWarning = () => {
@@ -100,6 +110,8 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
           type="button"
           data-testid={selectors.components.DashboardRow.title(title)}
           onClick={this.onToggle}
+          // aria-expanded attribute to inform screen readers
+          aria-expanded={this.props.panel.collapsed ? 'false' : 'true'}
         >
           <Icon name={this.props.panel.collapsed ? 'angle-right' : 'angle-down'} />
           {title}

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -38,16 +38,6 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
 
   onToggle = () => {
     this.props.dashboard.toggleRow(this.props.panel);
-
-    this.updateAriaExpanded();
-  };
-
-  // update the aria-expanded attribute based on panel state
-  updateAriaExpanded = () => {
-    const buttonElement = document.querySelector('.dashboard-row__title');
-    if (buttonElement) {
-      buttonElement.setAttribute('aria-expanded', this.props.panel.collapsed ? 'false' : 'true');
-    }
   };
 
   getWarning = () => {
@@ -110,7 +100,6 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
           type="button"
           data-testid={selectors.components.DashboardRow.title(title)}
           onClick={this.onToggle}
-          // aria-expanded attribute to inform screen readers
           aria-expanded={this.props.panel.collapsed ? 'false' : 'true'}
         >
           <Icon name={this.props.panel.collapsed ? 'angle-right' : 'angle-down'} />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Dashboard row inform screen readers if is expanded or collapsed

**Why do we need this feature?**

screen readers allow to provide users with feedback on whether the dashboard row is expanded or collapsed, enhancing the accessibility of the component.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #73742 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
