### PR TITLE
UI Extensions: Allow `React.memo()` objects as component extensions

### DIFF
--- a/public/app/features/plugins/extensions/validators.test.tsx
+++ b/public/app/features/plugins/extensions/validators.test.tsx
@@ -272,6 +272,18 @@ describe('Plugin Extension Validators', () => {
       expect(isReactComponent(() => <div>Some text</div>)).toBe(true);
     });
 
+    it('should return TRUE if we pass in a component wrapped with React.memo()', () => {
+      const Component = () => <div>Some text</div>;
+      const wrapped = React.memo(() => (
+        <div>
+          <Component />
+        </div>
+      ));
+      wrapped.displayName = 'MyComponent';
+
+      expect(isReactComponent(wrapped)).toBe(true);
+    });
+
     it('should return FALSE if we pass in a valid React component', () => {
       expect(isReactComponent('Foo bar')).toBe(false);
       expect(isReactComponent(123)).toBe(false);

--- a/public/app/features/plugins/extensions/validators.ts
+++ b/public/app/features/plugins/extensions/validators.ts
@@ -129,7 +129,14 @@ export function isPromise(value: unknown): value is Promise<unknown> {
 }
 
 export function isReactComponent(component: unknown): component is React.ComponentType {
+  const hasReactTypeProp = (obj: unknown): obj is { $$typeof: Symbol } =>
+    typeof obj === 'object' && obj !== null && '$$typeof' in obj;
+
+  // The sandbox wraps the plugin components with React.memo.
+  const isReactMemoObject = (obj: unknown): boolean =>
+    hasReactTypeProp(obj) && obj.$$typeof === Symbol.for('react.memo');
+
   // We currently don't have any strict runtime-checking for this.
   // (The main reason is that we don't want to start depending on React implementation details.)
-  return typeof component === 'function';
+  return typeof component === 'function' || isReactMemoObject(component);
 }


### PR DESCRIPTION
**Related Slack thread:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1696417889455409

### Why?
We have realised that the `grafana-pdc-app` couldn't register its component type UI extensions anymore after the sandbox was turned on. Turned out that the reason was that sandbox wraps all components as a React memo object, and as this has `typeof component = "object"` it didn't pass our validation.

### What changed?
Updated the validation, so now it also allows React memo objects.

---

**The value of the component:**

|  Sandbox: **ON**  |    Sandbox: **OFF**    |
|--------------|-----------------|
| ![Screenshot 2023-10-06 at 09 04 54](https://github.com/grafana/grafana/assets/9974811/ad3e9627-ae7b-4344-bef7-a3441bdc1430) | ![Screenshot 2023-10-06 at 09 09 15](https://github.com/grafana/grafana/assets/9974811/742a72f7-24de-45ed-8e5e-628cd6d78cfb) |
