### PR TITLE
Dashboard Save: Add a flag for handled errors if error is not extensible 

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -54,9 +54,9 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
 
   const onSuccess = onSaveSuccess
     ? () => {
-      onDismiss();
-      onSaveSuccess();
-    }
+        onDismiss();
+        onSaveSuccess();
+      }
     : onDismiss;
 
   const renderSaveBody = () => {

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -48,12 +48,15 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
   }, [dashboard, previous, options, isNew]);
 
   const [showDiff, setShowDiff] = useState(false);
+  const [isErrorHandled, setIsErrorHandled] = useState(false);
+
   const { state, onDashboardSave } = useDashboardSave(dashboard, isCopy);
+
   const onSuccess = onSaveSuccess
     ? () => {
-        onDismiss();
-        onSaveSuccess();
-      }
+      onDismiss();
+      onSaveSuccess();
+    }
     : onDismiss;
 
   const renderSaveBody = () => {
@@ -95,7 +98,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
   if (
     state.error &&
     isFetchError(state.error) &&
-    !state.error.isHandled &&
+    (state.error.isHandled ? !isErrorHandled : isErrorHandled) &&
     proxyHandlesError(state.error.data.status)
   ) {
     return (
@@ -104,6 +107,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
         dashboard={dashboard}
         dashboardSaveModel={data.clone}
         onDismiss={onDismiss}
+        setIsHandled={setIsErrorHandled}
       />
     );
   }

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
@@ -17,7 +17,7 @@ interface SaveDashboardErrorProxyProps {
   dashboardSaveModel: DashboardModel;
   error: FetchError;
   /** used if error object is not extensible */
-  setIsHandled?: React.Dispatch<React.SetStateAction<boolean>>
+  setIsHandled?: React.Dispatch<React.SetStateAction<boolean>>;
   onDismiss: () => void;
 }
 

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
@@ -16,6 +16,8 @@ interface SaveDashboardErrorProxyProps {
   /** dashboard save model with applied modifications, i.e. title */
   dashboardSaveModel: DashboardModel;
   error: FetchError;
+  /** used if error object is not extensible */
+  setIsHandled?: React.Dispatch<React.SetStateAction<boolean>>
   onDismiss: () => void;
 }
 
@@ -24,14 +26,19 @@ export const SaveDashboardErrorProxy = ({
   dashboardSaveModel,
   error,
   onDismiss,
+  setIsHandled,
 }: SaveDashboardErrorProxyProps) => {
   const { onDashboardSave } = useDashboardSave(dashboard);
 
   useEffect(() => {
     if (error.data && proxyHandlesError(error.data.status)) {
-      error.isHandled = true;
+      if (Object.isExtensible(error)) {
+        error.isHandled = true;
+      } else {
+        setIsHandled && setIsHandled(true);
+      }
     }
-  }, [error]);
+  }, [error, setIsHandled]);
 
   return (
     <>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a `isHandled` state when there's an error in saving a dashboard, if the `error` object is not extensible

**Why do we need this feature?**

Sometimes the error returned from server is translated to an non-extensible object, but we try to extend it to know it has been handled. This causes grafana to crash, causing all pre-saved work to be lost. 
This particular case happens when someone else has saved the dashboard you're editing before you, and you try to save anyway.

Error log: https://ops.grafana-ops.net/a/grafana-kowalski-app/errors/25/TypeError/11207989473627406561?from=now-24h&to=now&frameIndex=0



**Who is this feature for?**

Dashboard users. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

See discussion in https://raintank-corp.slack.com/archives/C036J5B39/p1696518012751239

**Special notes for your reviewer:**
There's other places where we extend the `error` object, but I haven't changed anything about them. The thing is, I couldn't reproduce a _crashing_ Grafana, but I did reproduce the error not being handled at all:

![image](https://github.com/grafana/grafana/assets/13227501/b2aacccd-dbf6-40d1-b09a-ec32b6f17a0f)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
