### PR TITLE
Fix issue-labeled GitHub Action using app permissions

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -62,6 +62,14 @@ jobs:
           replace-with: "'"
           flags: 'g'
 
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v2
+        with:
+          application_id: ${{ secrets.APP_GRAFANA_TEAM_CHECKER_ID }}
+          application_private_key: ${{ secrets.APP_GRAFANA_TEAM_CHECKER_KEY }}
+          organization: grafana
+
       - name: "Check that issue author is not part of the team"
         if: ${{ env.TEAM != 'null' }}
         run: |
@@ -75,7 +83,7 @@ jobs:
             echo "USER_FOUND=maybe" >> $GITHUB_ENV
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: "Send Slack notification"
         if: ${{ (env.CHANNEL != 'null') && ((env.USER_FOUND == 'false') || (env.TEAM != 'null')) }}


### PR DESCRIPTION
This uses an app created in the Grafana organization, grafana-team-checker, instead of using the GitHub token. This should fix the permissions issues according to what I've read in e.g. https://devopsjournal.io/blog/2022/01/03/GitHub-Tokens.