### PR TITLE
Dashboards: It always detect changes when saving an existing dashboard 

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -1,7 +1,7 @@
 import { keys as _keys } from 'lodash';
 
 import { dateTime, TimeRange, VariableHide } from '@grafana/data';
-import { defaultVariableModel } from '@grafana/schema';
+import { Dashboard, defaultVariableModel } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { getDashboardModel } from '../../../../test/helpers/getDashboardModel';
@@ -49,6 +49,29 @@ describe('DashboardModel', () => {
 
     it('should have default properties', () => {
       expect(model.panels.length).toBe(0);
+    });
+  });
+
+  describe('when storing original dashboard data', () => {
+    let originalDashboard: Dashboard = {
+      editable: true,
+      graphTooltip: 0,
+      schemaVersion: 1,
+      timezone: '',
+      title: 'original.title',
+    };
+    let model: DashboardModel;
+
+    beforeEach(() => {
+      model = new DashboardModel(originalDashboard);
+    });
+
+    it('should be returned from getOriginalDashboard without modifications', () => {
+      expect(model.getOriginalDashboard()).toEqual(originalDashboard);
+    });
+
+    it('should return a copy of the provided object', () => {
+      expect(model.getOriginalDashboard()).not.toBe(originalDashboard);
     });
   });
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -24,6 +24,7 @@ import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERT
 import { contextSrv } from 'app/core/services/context_srv';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { isAngularDatasourcePlugin } from 'app/features/plugins/angularDeprecation/utils';
+import { deepFreeze } from 'app/features/plugins/extensions/utils';
 import { variableAdapters } from 'app/features/variables/adapters';
 import { onTimeRangeUpdated } from 'app/features/variables/state/actions';
 import { GetVariables, getVariablesByKey } from 'app/features/variables/state/selectors';
@@ -172,7 +173,8 @@ export class DashboardModel implements TimeModel {
     this.links = data.links ?? [];
     this.gnetId = data.gnetId || null;
     this.panels = map(data.panels ?? [], (panelData: any) => new PanelModel(panelData));
-    this.originalDashboard = data;
+    // Deep clone original dashboard to avoid mutations by object reference
+    this.originalDashboard = cloneDeep(data);
     this.ensurePanelsHaveUniqueIds();
     this.formatDate = this.formatDate.bind(this);
 
@@ -1081,7 +1083,7 @@ export class DashboardModel implements TimeModel {
   }
 
   resetOriginalTime() {
-    this.originalTime = cloneDeep(this.time);
+    this.originalTime = deepFreeze(this.time);
   }
 
   hasTimeChanged() {
@@ -1267,8 +1269,8 @@ export class DashboardModel implements TimeModel {
     return variables.map((variable) => ({
       name: variable.name,
       type: variable.type,
-      current: cloneDeep(variable.current),
-      filters: cloneDeep(variable.filters),
+      current: deepFreeze(variable.current),
+      filters: deepFreeze(variable.filters),
     }));
   }
 


### PR DESCRIPTION
**Problem**
No matter if you make changes in a dashboard, it always contains changes.

The issue seems to be the mutation of the values of the model that they still point to the original object passed as data to DashboardModel. So, during the initDashboard, the `this.originalDashboard` is modified because the assigned object to the different Model props shares the object reference.

**Solution**
Clone the original object stored in `originalDashboard` to avoid this issue in the future by accidental mutations.

**How to test it:**
1. Go to any non-empty dashboard. For example this one: https://play.grafana.org/d/Ib-GkgRVk/graphite3a-wikimedia-com-metrics?orgId=1
2. Save without making any changes to do the needed mutations
3. Reload and save again. The same change is applied.