### PR TITLE
Fix issue-labeled GitHub Action by removing organization field

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           application_id: ${{ secrets.APP_GRAFANA_TEAM_CHECKER_ID }}
           application_private_key: ${{ secrets.APP_GRAFANA_TEAM_CHECKER_KEY }}
-          organization: grafana
 
       - name: "Check that issue author is not part of the team"
         if: ${{ env.TEAM != 'null' }}


### PR DESCRIPTION
One line change to see if it fixes the workflow, the app might be at the repository level.