### PR TITLE
Rendering: Fix Windows plugin signature check

### DIFF
--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -209,7 +209,7 @@ func (s *Signature) Calculate(ctx context.Context, src plugins.PluginSource, plu
 		f = toSlash(f)
 
 		// Ignoring unsigned Chromium debug.log so it doesn't invalidate the signature for Renderer plugin running on Windows
-		if runningWindows && plugin.JSONData.Type == plugins.TypeRenderer && f == "chrome-win/debug.log" {
+		if runningWindows && plugin.JSONData.Type == plugins.TypeRenderer && strings.HasSuffix(f, "debug.log") {
 			continue
 		}
 

--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -209,7 +209,7 @@ func (s *Signature) Calculate(ctx context.Context, src plugins.PluginSource, plu
 		f = toSlash(f)
 
 		// Ignoring unsigned Chromium debug.log so it doesn't invalidate the signature for Renderer plugin running on Windows
-		if runningWindows && plugin.JSONData.Type == plugins.TypeRenderer && strings.HasSuffix(f, "debug.log") {
+		if runningWindows && plugin.JSONData.Type == plugins.TypeRenderer && filepath.Base(f) == "debug.log" {
 			continue
 		}
 


### PR DESCRIPTION
**What is this feature?**
With the [recent puppeteer upgrade](https://github.com/grafana/grafana-image-renderer/pull/433) in the grafana-image-renderer plugin, the path to the `debug.log` file was updated from `chrome/debug.log` to `chrome/win64-<chrome version>/chrome-win64/debug.log`. This PR updates the signature check accordingly (but still support old versions of the image renderer).

**Why do we need this feature?**
Without this, new versions of the image renderer plugin won't be able to load once the `debug.log` is created by the Chrome process. 

**Who is this feature for?**
Windows users using the grafana-image-renderer plugin.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
