### PR TITLE
Chore: Fix window as any when accessing feature toggles in grafana data

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -275,10 +275,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "packages/grafana-data/src/transformations/transformers/utils.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
@@ -5,15 +5,15 @@ import { getFieldMatcher } from '../matchers';
 import { FieldMatcherID } from './ids';
 import { ByNamesMatcherMode } from './nameMatcher';
 
-// mock the default window.grafanaBootData settings
-// eslint-disable-next-line
-(window as any).grafanaBootData = {
-  settings: {
-    featureToggles: {
+jest.mock('../../utils', () => {
+  const actual = jest.requireActual('../../utils');
+  return {
+    ...actual,
+    getGrafanaFeatureToggles: () => ({
       dataplaneFrontendFallback: true,
-    },
-  },
-};
+    }),
+  };
+});
 
 describe('Field Name by Regexp Matcher', () => {
   it('Match all with wildcard regex', () => {

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -2,6 +2,7 @@ import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
 import { DataFrame, Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
 import { FieldMatcher, FieldMatcherInfo, FrameMatcherInfo } from '../../types/transformations';
+import { getGrafanaFeatureToggles } from '../../utils';
 
 import { FieldMatcherID, FrameMatcherID } from './ids';
 
@@ -107,10 +108,7 @@ const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
 export function fieldNameFallback(fields: Set<string>) {
   let fallback: FieldMatcher | undefined = undefined;
 
-  // grafana-data does not have access to runtime so we are accessing the window object
-  // to get access to the feature toggle
-  // eslint-disable-next-line
-  const useMatcherFallback = (window as any)?.grafanaBootData?.settings?.featureToggles?.dataplaneFrontendFallback;
+  const useMatcherFallback = getGrafanaFeatureToggles()?.dataplaneFrontendFallback;
   if (useMatcherFallback) {
     if (fields.has(TIME_SERIES_VALUE_FIELD_NAME)) {
       fallback = (field: Field, frame: DataFrame) => {

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -14,17 +14,15 @@ import {
 import { DataTransformerID } from './ids';
 
 let transformationSupport = false;
-
-jest.mock('./utils', () => {
-  const actual = jest.requireActual('./utils');
+jest.mock('../../utils', () => {
+  const actual = jest.requireActual('../../utils');
   return {
     ...actual,
-    transformationsVariableSupport: () => {
-      return transformationSupport;
-    },
+    getGrafanaFeatureToggles: () => ({
+      transformationsVariableSupport: transformationSupport,
+    }),
   };
 });
-
 const seriesAWithSingleField = toDataFrame({
   name: 'A',
   length: 7,

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -3,12 +3,12 @@ import { map } from 'rxjs/operators';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { DataFrame, Field } from '../../types/dataFrame';
 import { DataTransformerInfo, MatcherConfig } from '../../types/transformations';
+import { getGrafanaFeatureToggles } from '../../utils';
 import { getValueMatcher } from '../matchers';
 import { ValueMatcherID } from '../matchers/ids';
 
 import { DataTransformerID } from './ids';
 import { noopTransformer } from './noop';
-import { transformationsVariableSupport } from './utils';
 
 export enum FilterByValueType {
   exclude = 'exclude',
@@ -52,7 +52,7 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
 
     const interpolatedFilters: FilterByValueFilter[] = [];
 
-    if (transformationsVariableSupport()) {
+    if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
       interpolatedFilters.push(
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
@@ -102,7 +102,7 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
           const fieldIndexByName = groupFieldIndexByName(frame, data);
 
           let matchers;
-          if (transformationsVariableSupport()) {
+          if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
             matchers = createFilterValueMatchers(interpolatedFilters, fieldIndexByName);
           } else {
             matchers = createFilterValueMatchers(filters, fieldIndexByName);

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -4,11 +4,10 @@ import { getDisplayProcessor } from '../../field';
 import { createTheme, GrafanaTheme2 } from '../../themes';
 import { DataFrameType, DataTransformContext, SynchronousDataTransformerInfo } from '../../types';
 import { DataFrame, Field, FieldConfig, FieldType } from '../../types/dataFrame';
-import { roundDecimals } from '../../utils';
+import { roundDecimals, getGrafanaFeatureToggles } from '../../utils';
 
 import { DataTransformerID } from './ids';
 import { AlignedData, join } from './joinDataFrames';
-import { transformationsVariableSupport } from './utils';
 
 /**
  * @internal
@@ -101,7 +100,7 @@ export const histogramTransformer: SynchronousDataTransformerInfo<HistogramTrans
       bucketOffset: number | undefined = undefined;
 
     if (options.bucketSize) {
-      if (transformationsVariableSupport()) {
+      if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
         options.bucketSize = ctx.interpolate(options.bucketSize.toString());
       }
       if (typeof options.bucketSize === 'string') {
@@ -116,7 +115,7 @@ export const histogramTransformer: SynchronousDataTransformerInfo<HistogramTrans
     }
 
     if (options.bucketOffset) {
-      if (transformationsVariableSupport()) {
+      if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
         options.bucketOffset = ctx.interpolate(options.bucketOffset.toString());
       }
       if (typeof options.bucketOffset === 'string') {

--- a/packages/grafana-data/src/transformations/transformers/limit.ts
+++ b/packages/grafana-data/src/transformations/transformers/limit.ts
@@ -1,9 +1,9 @@
 import { map } from 'rxjs/operators';
 
 import { DataTransformerInfo } from '../../types';
+import { getGrafanaFeatureToggles } from '../../utils';
 
 import { DataTransformerID } from './ids';
-import { transformationsVariableSupport } from './utils';
 
 export interface LimitTransformerOptions {
   limitField?: number | string;
@@ -25,7 +25,7 @@ export const limitTransformer: DataTransformerInfo<LimitTransformerOptions> = {
         let limit = DEFAULT_LIMIT_FIELD;
         if (options.limitField !== undefined) {
           if (typeof options.limitField === 'string') {
-            if (transformationsVariableSupport()) {
+            if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
               limit = parseInt(ctx.interpolate(options.limitField), 10);
             } else {
               limit = parseInt(options.limitField, 10);

--- a/packages/grafana-data/src/transformations/transformers/sortBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/sortBy.ts
@@ -4,9 +4,9 @@ import { sortDataFrame } from '../../dataframe';
 import { getFieldDisplayName } from '../../field';
 import { DataFrame } from '../../types';
 import { DataTransformContext, DataTransformerInfo } from '../../types/transformations';
+import { getGrafanaFeatureToggles } from '../../utils';
 
 import { DataTransformerID } from './ids';
-import { transformationsVariableSupport } from './utils';
 
 export interface SortByField {
   field: string;
@@ -59,7 +59,7 @@ function attachFieldIndex(frame: DataFrame, sort: SortByField[], ctx: DataTransf
       // null or undefined
       return s;
     }
-    if (transformationsVariableSupport()) {
+    if (getGrafanaFeatureToggles()?.transformationsVariableSupport) {
       return {
         ...s,
         index: frame.fields.findIndex((f) => ctx.interpolate(s.field) === getFieldDisplayName(f, frame)),

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,3 +1,0 @@
-export const transformationsVariableSupport = () => {
-  return (window as any)?.grafanaBootData?.settings?.featureToggles?.transformationsVariableSupport;
-};

--- a/packages/grafana-data/src/utils/featureToggle.ts
+++ b/packages/grafana-data/src/utils/featureToggle.ts
@@ -1,0 +1,16 @@
+import { BootData } from '../types';
+
+declare global {
+  interface Window {
+    grafanaBootData?: BootData;
+  }
+}
+
+/**
+ * Grafana data does not have access to runtime, so we are accessing the window object to get the feature toggles.
+ *
+ * @returns Grafana feature toggles object
+ */
+export function getGrafanaFeatureToggles() {
+  return window.grafanaBootData?.settings?.featureToggles;
+}

--- a/packages/grafana-data/src/utils/index.ts
+++ b/packages/grafana-data/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './series';
 export * from './binaryOperators';
 export * from './nodeGraph';
 export * from './selectUtils';
+export * from './featureToggle';
 export { PanelOptionsEditorBuilder, FieldConfigEditorBuilder } from './OptionsUIBuilders';
 export { arrayUtils };
 export { getFlotPairs, getFlotPairsConstant } from './flotPairs';


### PR DESCRIPTION
**What is this feature?**

Accessing feature toggles in grafana data is a bit hacky. This tries to at least make it a little bit less hacky after some input @ashharrison90 [here](https://github.com/grafana/grafana/pull/75372#discussion_r1348574882).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
