### PR TITLE
fix(a11y): switch component

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -84,7 +84,9 @@ const getSwitchStyles = stylesFactory((theme: GrafanaTheme2, transparent?: boole
 
       input: {
         opacity: 0,
-        left: '-100vw',
+        height: '100%',
+        width: '100% !important',
+        borderRadius: theme.shape.radius.pill,
         zIndex: -1000,
         position: 'absolute',
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes Accessibility cursor wrap the switch component appropriately

**Why do we need this feature?**

--

**Who is this feature for?**

For users with poor vision

**Which issue(s) does this PR fix?**:

#73500 by @ckbedwell 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Run storybook and VoiceOver (Mac) to select the Switch component

## Screenshots

BEFORE
<img width="150" alt="Screenshot 2023-10-06 at 12 38 40 PM" src="https://github.com/grafana/grafana/assets/6998593/294803cc-e086-4144-bc45-8e860be40cea">

AFTER
<img width="142" alt="Screenshot 2023-10-06 at 12 38 28 PM" src="https://github.com/grafana/grafana/assets/6998593/0ac85c37-798a-47ea-9e50-1fe335b2fe56">


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
