### PR TITLE
Loki Autocomplete: Add more context to comments about situations and completions

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -390,7 +390,7 @@ export async function getLogfmtCompletions(
      * Don't offer parsers if there is no label argument: {label="value"} | logfmt ^
      * The reason is that it would be unusual that they would want to use another parser just after logfmt, and
      * more likely that they would want a flag, labels, or continue with pipe operations.
-     * 
+     *
      * Offer parsers with at least one label argument: {label="value"} | logfmt label ^
      * The rationale here is to offer the same completions as getAfterSelectorCompletions().
      */

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -404,7 +404,7 @@ export async function getLogfmtCompletions(
   const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
 
   /**
-   * We want to decide wether to use a trailing comma or not based on the data we have of the current
+   * We want to decide whether to use a trailing comma or not based on the data we have of the current
    * situation. In particular, the following scenarios will not lead to a trailing comma:
    * {label="value"} | logfmt ^
    * - trailingSpace: true, trailingComma: false, otherLabels: []

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -367,7 +367,7 @@ export async function getLogfmtCompletions(
 
   /**
    * The user is not in the process of writing another label, and has not specified 2 flags.
-   * The current grammar doesn't allow us to know which flags are used (by node name), so we consider flags = true
+   * The current grammar doesn't allow us to know which flags were used (by node name), so we consider flags = true
    * when 2 have been used.
    * For example:
    * - {label="value"} | logfmt ^

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -356,26 +356,39 @@ export async function getLogfmtCompletions(
   otherLabels: string[],
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  if (trailingComma) {
-    // The user is typing a new label, so we remove the last comma
-    logQuery = trimEnd(logQuery, ', ');
-  }
-
   let completions: Completion[] = [];
 
+  if (trailingComma) {
+    // Remove the trailing comma, otherwise the sample query will fail.
+    logQuery = trimEnd(logQuery, ', ');
+  }
   const { extractedLabelKeys, hasJSON, hasLogfmt, hasPack } = await dataProvider.getParserAndLabelKeys(logQuery);
   const pipeOperations = getPipeOperationsCompletions('| ');
 
-  // {label="value"} | logfmt ^
+  /**
+   * The user is not in the process of writing another label, and has not specified 2 flags.
+   * The current grammar doesn't allow us to know which flags are used (by node name), so we consider flags = true
+   * when 2 have been used.
+   * For example:
+   * - {label="value"} | logfmt ^
+   * - {label="value"} | logfmt --strict ^
+   * - {label="value"} | logfmt --strict --keep-empty ^
+   */
   if (!trailingComma && !flags) {
     completions = [...LOGFMT_ARGUMENT_COMPLETIONS];
   }
-  // {label="value"} | logfmt --flag ^
-  // {label="value"} | logfmt label, label2 ^
+
+  /**
+   * If the user has no trailing comma and has a trailing space it can mean that they finished writing the logfmt
+   * part and want to move on, for example, with other parsers or pipe operations.
+   * For example:
+   * - {label="value"} | logfmt --flag ^
+   * - {label="value"} | logfmt label, label2 ^
+   */
   if (!trailingComma && trailingSpace) {
     /**
-     * Don't offer parsers: {label="value"} | logfmt ^
-     * Offer parsers: {label="value"} | logfmt label ^
+     * Don't offer parsers if there is no label argument: {label="value"} | logfmt ^
+     * Offer parsers with at least one label argument: {label="value"} | logfmt label ^
      */
     const parserCompletions =
       otherLabels.length > 0
@@ -387,6 +400,8 @@ export async function getLogfmtCompletions(
   const labels = extractedLabelKeys.filter((label) => !otherLabels.includes(label));
 
   /**
+   * We want to decide wether to use a trailing comma or not based on the data we have of the current
+   * situation. In particular, the following scenarios will not lead to a trailing comma:
    * {label="value"} | logfmt ^
    * - trailingSpace: true, trailingComma: false, otherLabels: []
    * {label="value"} | logfmt lab^

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -388,7 +388,11 @@ export async function getLogfmtCompletions(
   if (!trailingComma && trailingSpace) {
     /**
      * Don't offer parsers if there is no label argument: {label="value"} | logfmt ^
+     * The reason is that it would be unusual that they would want to use another parser just after logfmt, and
+     * more likely that they would want a flag, labels, or continue with pipe operations.
+     * 
      * Offer parsers with at least one label argument: {label="value"} | logfmt label ^
+     * The rationale here is to offer the same completions as getAfterSelectorCompletions().
      */
     const parserCompletions =
       otherLabels.length > 0

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -483,10 +483,11 @@ function resolveLogfmtParser(_: SyntaxNode, text: string, cursorPosition: number
 
 function resolveTopLevel(node: SyntaxNode, text: string, pos: number): Situation | null {
   /**
-   * Top level examples:
+   * The following queries trigger resolveTopLevel().
    * - Empty query
-   * - {label="value"}
-   * - {label="value"} | parser
+   * - {label="value"} ^
+   * - {label="value"} | parser ^
+   * From here, we need to determine if the user is in a resolveLogOrLogRange() or simply at the root.
    */
   const logExprNode = walk(node, [
     ['lastChild', Expr],


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/75561 many comments with query examples were introduced to explain the logic behind some situations and offered completions.

In this PR we're following up a suggestion to improve those comments and add extra context, so they are easier to follow by anyone interested on modifying or extending this part of Grafana.

**Why do we need this feature?**

Less paper cuts, but for the internal users of the code: the developers.

**Who is this feature for?**

Anyone that needs to maintain or extend this part of the data source.

**Which issue(s) does this PR fix?**:

Follow up to https://github.com/grafana/grafana/pull/75561

**Special notes for your reviewer:**

The changes in the comments should add enough context to explain parts of the code that are challenging to understand by just looking at the secuence of expressions. That might mean that we need to add or remove more from this PR.

Feel free to suggest more comments or to remove comments that can be superfluous to self-explanatory code.