### PR TITLE
Docs: adds K8s installation instructional video

### DIFF
--- a/docs/sources/setup-grafana/installation/kubernetes/index.md
+++ b/docs/sources/setup-grafana/installation/kubernetes/index.md
@@ -15,6 +15,8 @@ weight: 500
 
 On this page, you will find instructions for installing and running Grafana on Kubernetes using Kubernetes manifests for the setup. If Helm is your preferred option, refer to [Grafana Helm community charts](https://github.com/grafana/helm-charts).
 
+Watch this video to learn more about installing Grafana on Kubernetes: {{< vimeo 871940219 >}}
+
 ## Before you begin
 
 To follow this guide:


### PR DESCRIPTION
This PR adds a video recorded during Developer Advocacy office hours and adds it to the install Grafana on K8s docs.