### PR TITLE
CloudWatch Logs: Add pattern command to syntax

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/logs/language.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/language.ts
@@ -10,12 +10,13 @@ interface CloudWatchLogsLanguage extends monacoType.languages.IMonarchLanguage {
 export const DISPLAY = 'display';
 export const FIELDS = 'fields';
 export const FILTER = 'filter';
+export const PATTERN = 'pattern';
 export const STATS = 'stats';
 export const SORT = 'sort';
 export const LIMIT = 'limit';
 export const PARSE = 'parse';
 export const DEDUP = 'dedup';
-export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, STATS, SORT, LIMIT, PARSE, DEDUP];
+export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP];
 
 export const LOGS_LOGIC_OPERATORS = ['and', 'or', 'not'];
 


### PR DESCRIPTION
Add the [pattern](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-Pattern.html) command to the Logs Insight syntax.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #74759 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
