### PR TITLE
Chore: Export closestIdx function from @grafana/data

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -8,4 +8,4 @@ export * from './ArrayDataFrame';
 export * from './DataFrameJSON';
 export * from './frameComparisons';
 export { anySeriesWithTimeField, isTimeSeriesFrame, isTimeSeriesFrames } from './utils';
-export { StreamingDataFrame, StreamingFrameAction, type StreamingFrameOptions } from './StreamingDataFrame';
+export { StreamingDataFrame, StreamingFrameAction, type StreamingFrameOptions, closestIdx } from './StreamingDataFrame';

--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -14,10 +14,5 @@ export { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides, useFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
-export {
-  getFieldDisplayName,
-  getFrameDisplayName,
-  cacheFieldDisplayNames,
-  calculateFieldDisplayName,
-} from './fieldState';
+export { getFieldDisplayName, getFrameDisplayName, cacheFieldDisplayNames } from './fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax, getMinMaxAndDelta } from './scale';

--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -14,5 +14,10 @@ export { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides, useFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
-export { getFieldDisplayName, getFrameDisplayName, cacheFieldDisplayNames } from './fieldState';
+export {
+  getFieldDisplayName,
+  getFrameDisplayName,
+  cacheFieldDisplayNames,
+  calculateFieldDisplayName,
+} from './fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax, getMinMaxAndDelta } from './scale';

--- a/public/app/features/live/data/amendTimeSeries.ts
+++ b/public/app/features/live/data/amendTimeSeries.ts
@@ -1,4 +1,4 @@
-import { closestIdx } from '@grafana/data/src/dataframe/StreamingDataFrame';
+import { closestIdx } from '@grafana/data';
 
 export type Table = [times: number[], ...values: any[][]];
 

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -3,7 +3,6 @@ import { flatten, forOwn, groupBy, partition } from 'lodash';
 
 import {
   ArrayDataFrame,
-  calculateFieldDisplayName,
   CoreApp,
   DataFrame,
   DataFrameType,
@@ -15,6 +14,7 @@ import {
   FieldType,
   formatLabels,
   getDisplayProcessor,
+  getFieldDisplayName,
   Labels,
   renderLegendFormat,
   ScopedVars,
@@ -79,7 +79,7 @@ export function transformV2(
         f.fields.forEach((field) => {
           if (field.labels?.__name__ && field.labels?.__name__ === field.name) {
             const fieldCopy = { ...field, name: TIME_SERIES_VALUE_FIELD_NAME };
-            field.config.displayNameFromDS = calculateFieldDisplayName(fieldCopy, f, response.data);
+            field.config.displayNameFromDS = getFieldDisplayName(fieldCopy, f, response.data);
           }
         });
       }

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -3,6 +3,7 @@ import { flatten, forOwn, groupBy, partition } from 'lodash';
 
 import {
   ArrayDataFrame,
+  calculateFieldDisplayName,
   CoreApp,
   DataFrame,
   DataFrameType,
@@ -15,12 +16,11 @@ import {
   formatLabels,
   getDisplayProcessor,
   Labels,
+  renderLegendFormat,
   ScopedVars,
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
-  renderLegendFormat,
 } from '@grafana/data';
-import { calculateFieldDisplayName } from '@grafana/data/src/field/fieldState';
 import { config, FetchResponse, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 
 import {


### PR DESCRIPTION
**What is this feature?**

~~Export `calculateFieldDisplayName` and `closestIdx` functions and import them from `@grafana/data`.~~

- Export `closestIdx` function
  - It is required to be imported from `@grafana/data` for decoupling datasources.
- Use `getFieldDisplayName` instead of `calculateFieldDisplayName`





**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
