### PR TITLE
Loki: Change run query button text based on number of queries

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -88,21 +88,26 @@ describe('LokiQueryEditorSelector', () => {
     await expectBuilder();
   });
 
-  it('shows Run Queries button in Dashboards', async () => {
+  it('shows Run Query button in Dashboards', async () => {
     renderWithProps({}, { app: CoreApp.Dashboard });
-    await expectRunQueriesButton();
+    await expectRunQueryButton();
   });
 
-  it('hides Run Queries button in Explore', async () => {
+  it('hides Run Query button in Explore', async () => {
     renderWithProps({}, { app: CoreApp.Explore });
     await expectCodeEditor();
-    expectNoRunQueriesButton();
+    expectNoRunQueryButton();
   });
 
-  it('hides Run Queries button in Correlations Page', async () => {
+  it('hides Run Query button in Correlations Page', async () => {
     renderWithProps({}, { app: CoreApp.Correlations });
     await expectCodeEditor();
-    expectNoRunQueriesButton();
+    expectNoRunQueryButton();
+  });
+
+  it('shows Run Queries button in Dashboards when multiple queries', async () => {
+    renderWithProps({}, { app: CoreApp.Dashboard, queries: [defaultQuery, defaultQuery] });
+    await expectRunQueriesButton();
   });
 
   it('changes to builder mode', async () => {
@@ -204,8 +209,12 @@ async function expectRunQueriesButton() {
   expect(await screen.findByRole('button', { name: /run queries/i })).toBeInTheDocument();
 }
 
-function expectNoRunQueriesButton() {
-  expect(screen.queryByRole('button', { name: /run queries/i })).not.toBeInTheDocument();
+async function expectRunQueryButton() {
+  expect(await screen.findByRole('button', { name: /run query/i })).toBeInTheDocument();
+}
+
+function expectNoRunQueryButton() {
+  expect(screen.queryByRole('button', { name: /run query/i })).not.toBeInTheDocument();
 }
 
 async function switchToMode(mode: QueryEditorMode) {

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -179,7 +179,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
             disabled={data?.state === LoadingState.Loading}
           >
-            Run queries
+            {queries && queries.length > 1 ? `Run queries` : `Run query`}
           </Button>
         )}
         <QueryEditorModeToggle mode={editorMode!} onChange={onEditorModeChange} />


### PR DESCRIPTION
We learned that some app plugins use `css` to update the name of button `Run queries` => `Run query` as they only allow users to create 1 query. As in query editor, we have information about how many queries user has, we can update the text of the button based on queries length. 

<img width="919" alt="image" src="https://github.com/grafana/grafana/assets/30407135/a2e7b721-d567-4c2d-bfe8-6b64e2c46f6e">
<img width="476" alt="image" src="https://github.com/grafana/grafana/assets/30407135/b6479f7c-e607-46b8-90ce-16537fb96235">

I tested this with mixed data sources as well


<img width="935" alt="image" src="https://github.com/grafana/grafana/assets/30407135/b58e6f31-4fa6-4f0a-ba5e-e4135076f5f3">

Part of https://github.com/grafana/grafana/issues/76190

