### PR TITLE
Building: Remove dependency to urw-fonts in RPM packages

### DIFF
--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -771,7 +771,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 		defaultFileSrc:         filepath.Join(grafanaDir, "packaging", "rpm", "sysconfig", "grafana-server"),
 		systemdFileSrc:         filepath.Join(grafanaDir, "packaging", "rpm", "systemd", "grafana-server.service"),
 		wrapperFilePath:        filepath.Join(grafanaDir, "packaging", "wrappers"),
-		depends:                []string{"/sbin/service", "fontconfig", "freetype", "urw-fonts"},
+		depends:                []string{"/sbin/service", "fontconfig", "freetype"},
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This should no longer be needed as all relevant image rendering happens in the context of the grafana-image-renderer plugin and is therefore no longer part of core.