### PR TITLE
Auto-generate: Improve long text generation

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIPanelDescriptionButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIPanelDescriptionButton.tsx
@@ -17,6 +17,7 @@ const DESCRIPTION_GENERATION_STANDARD_PROMPT =
   'You will be given the title and description of the dashboard the panel is in as well as the JSON for the panel.\n' +
   'Your goal is to write a descriptive and concise panel description.\n' +
   'The panel description is meant to explain the purpose of the panel, not just its attributes.\n' +
+  'Do not refer to the panel; simply describe its purpose.\n' +
   'There should be no numbers in the description except for thresholds.\n' +
   'The description should be, at most, 140 characters.';
 

--- a/public/app/features/dashboard/components/GenAI/GenerationHistoryCarousel.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenerationHistoryCarousel.tsx
@@ -62,6 +62,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexBasis: '100%',
     flexGrow: 3,
+    whiteSpace: 'pre-wrap',
     marginTop: 20,
   }),
 });


### PR DESCRIPTION
|Improve the panel description to not include "This panel..." in the generated text|Format properly the text within the improved toggletip |
|-|-|
![2023-10-09 18 31 33](https://github.com/grafana/grafana/assets/5699976/2cfdbd63-ffc9-46e1-868a-39211d25091d)|<img width="1124" alt="Captura de pantalla 2023-10-09 a las 19 29 24" src="https://github.com/grafana/grafana/assets/5699976/5e992dd5-4a17-4aae-900c-2f6b9902dbe7">

