### PR TITLE
Update create-mimir-loki-managed-recording-rule.md

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -24,7 +24,9 @@ weight: 300
 
 You can create and manage recording rules for an external Grafana Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 
-> **Note:** Recording rules are executed as instant queries. Evaluations take place at regular intervals according to the group evaluation interval, with a default of 1m. Each group's evaluation interval can be modified, however cannot be less than the min_interval configured within Grafana.
+{{% admonition type="note" %}}
+Recording rules are executed as instant queries. Evaluations take place at regular intervals according to the group evaluation interval, with a default of `1m`. Each group's evaluation interval can be modified, however cannot be less than the `min_interval` configured within Grafana.
+{{% /admonition %}}
 
 > **Note:** [min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiples of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -28,7 +28,9 @@ You can create and manage recording rules for an external Grafana Mimir or Loki 
 Recording rules are executed as instant queries. Evaluations take place at regular intervals according to the group evaluation interval, with a default of `1m`. Each group's evaluation interval can be modified, however cannot be less than the `min_interval` configured within Grafana.
 {{% /admonition %}}
 
-> **Note:** [min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiples of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
+{{% admonition type="note" %}}
+[min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is `10s`, which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiples of the scheduler interval (`10s`). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
+{{% /admonition %}}
 
 ## Before you begin
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -26,7 +26,7 @@ You can create and manage recording rules for an external Grafana Mimir or Loki 
 
 > **Note:** Recording rules are executed as instant queries. Evaluations take place at regular intervals according to the group evaluation interval, with a default of 1m. Each group's evaluation interval can be modified, however cannot be less than the min_interval configured within Grafana.
 
-> **Note:** [min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
+> **Note:** [min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiples of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
 
 ## Before you begin
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -24,13 +24,9 @@ weight: 300
 
 You can create and manage recording rules for an external Grafana Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 
-**Note:**
+> **Note:** Recording rules are executed as instant queries. Evaluations take place at regular intervals according to the group evaluation interval, with a default of 1m. Each group's evaluation interval can be modified, however cannot be less than the min_interval configured within Grafana.
 
-Recording rules are run as instant rules, which means that they run every 10s. To overwrite this configuration, update the min_interval in your custom configuration file.
-
-[min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time.
-
-This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
+> **Note:** [min_interval][configure-grafana] sets the minimum interval to enforce between rule evaluations. The default value is 10s which equals the scheduler interval. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as fewer evaluations are scheduled over time. This setting has precedence over each individual rule frequency. If a rule frequency is lower than this value, then this value is enforced.
 
 ## Before you begin
 


### PR DESCRIPTION
**What is this feature?**

Corrects the documentation explaining recording rules, particularly the evaluation interval. 

**Why do we need this feature?**

Currently we specify that recording rules are evaluated according to min_interval. However this setting just enforces the minimum interval that could be configured, and they are evaluated by default at a 1m interval.

**Who is this feature for?**

Mimir & Loki users wishing to manage recording rules via the Grafana UI.
