### PR TITLE
[v9.5.x] Building: Remove dependency to urw-fonts in RPM packages

### DIFF
--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -772,7 +772,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 		systemdFileSrc:         filepath.Join(grafanaDir, "packaging", "rpm", "systemd", "grafana-server.service"),
 		wrapperFilePath:        filepath.Join(grafanaDir, "packaging", "wrappers"),
 		// chkconfig is depended on since our systemd service wraps a SysV init script, and that requires chkconfig
-		depends: []string{"/sbin/service", "chkconfig", "fontconfig", "freetype", "urw-fonts"},
+		depends: []string{"/sbin/service", "chkconfig", "fontconfig", "freetype"},
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 135566031345aeba0d8f4a7a84b6518cc3aadf29 from #76198

---

This should no longer be needed as all relevant image rendering happens in the context of the grafana-image-renderer plugin and is therefore no longer part of core.
