### PR TITLE
PluginExtensions: Made it possible to control modal size from extension

### DIFF
--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -63,4 +63,5 @@ export {
   type PluginExtensionEventHelpers,
   type PluginExtensionPanelContext,
   type PluginExtensionDataSourceConfigContext,
+  type PluginExtensionOpenModalOptions,
 } from './pluginExtensions';

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -95,15 +95,21 @@ export type PluginExtensionComponentConfig<Context extends object = object> = {
 
 export type PluginExtensionConfig = PluginExtensionLinkConfig | PluginExtensionComponentConfig;
 
+export type PluginExtensionOpenModalOptions = {
+  // The title of the modal
+  title: string;
+  // A React element that will be rendered inside the modal
+  body: React.ElementType<{ onDismiss?: () => void }>;
+  // Width of the modal in pixels or percentage
+  width?: string | number;
+  // Height of the modal in pixels or percentage
+  height?: string | number;
+};
+
 export type PluginExtensionEventHelpers<Context extends object = object> = {
   context?: Readonly<Context>;
   // Opens a modal dialog and renders the provided React component inside it
-  openModal: (options: {
-    // The title of the modal
-    title: string;
-    // A React element that will be rendered inside the modal
-    body: React.ElementType<{ onDismiss?: () => void }>;
-  }) => void;
+  openModal: (options: PluginExtensionOpenModalOptions) => void;
 };
 
 // Extension Points & Contexts

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -343,6 +343,21 @@ describe('Plugin Extensions / Utils', () => {
         expect(screen.getByText('Text in body')).toBeVisible();
       });
 
+      it('should open modal with default width if not specified', async () => {
+        const { openModal } = getEventHelpers();
+
+        openModal({
+          title: 'Title in modal',
+          body: () => <div>Text in body</div>,
+        });
+
+        const modal = screen.getByRole('dialog');
+        const style = window.getComputedStyle(modal);
+
+        expect(style.width).toBe('750px');
+        expect(style.height).toBe('');
+      });
+
       it('should open modal with specified width', async () => {
         const { openModal } = getEventHelpers();
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -1,6 +1,12 @@
-import { PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { type Unsubscribable } from 'rxjs';
 
-import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, getReadOnlyProxy } from './utils';
+import { type PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
+import appEvents from 'app/core/app_events';
+import { ShowModalReactEvent } from 'app/types/events';
+
+import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, getReadOnlyProxy, getEventHelpers } from './utils';
 
 describe('Plugin Extensions / Utils', () => {
   describe('deepFreeze()', () => {
@@ -305,6 +311,75 @@ describe('Plugin Extensions / Utils', () => {
       });
 
       expect(proxy.a()).toBe('testing');
+    });
+  });
+
+  describe('getEventHelpers', () => {
+    describe('openModal', () => {
+      let renderModalSubscription: Unsubscribable | undefined;
+
+      beforeAll(() => {
+        renderModalSubscription = appEvents.subscribe(ShowModalReactEvent, (event) => {
+          const { payload } = event;
+          const Modal = payload.component;
+          render(<Modal />);
+        });
+      });
+
+      afterAll(() => {
+        renderModalSubscription?.unsubscribe();
+      });
+
+      it('should open modal with provided title and body', async () => {
+        const { openModal } = getEventHelpers();
+
+        openModal({
+          title: 'Title in modal',
+          body: () => <div>Text in body</div>,
+        });
+
+        expect(screen.getByRole('dialog')).toBeVisible();
+        expect(screen.getByRole('heading')).toHaveTextContent('Title in modal');
+        expect(screen.getByText('Text in body')).toBeVisible();
+      });
+
+      it('should open modal with specified width', async () => {
+        const { openModal } = getEventHelpers();
+
+        openModal({
+          title: 'Title in modal',
+          body: () => <div>Text in body</div>,
+          width: '70%',
+        });
+
+        const modal = screen.getByRole('dialog');
+        const style = window.getComputedStyle(modal);
+
+        expect(style.width).toBe('70%');
+      });
+
+      it('should open modal with specified height', async () => {
+        const { openModal } = getEventHelpers();
+
+        openModal({
+          title: 'Title in modal',
+          body: () => <div>Text in body</div>,
+          height: 600,
+        });
+
+        const modal = screen.getByRole('dialog');
+        const style = window.getComputedStyle(modal);
+
+        expect(style.height).toBe('600px');
+      });
+    });
+
+    describe('context', () => {
+      it('should return same object as passed to getEventHelpers', () => {
+        const source = {};
+        const { context } = getEventHelpers(source);
+        expect(context).toBe(source);
+      });
     });
   });
 });

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -1,5 +1,6 @@
+import { css } from '@emotion/css';
 import { isArray, isObject } from 'lodash';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import {
   type PluginExtensionLinkConfig,
@@ -42,8 +43,14 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
 
 // Event helpers are designed to make it easier to trigger "core actions" from an extension event handler, e.g. opening a modal or showing a notification.
 export function getEventHelpers(context?: Readonly<object>): PluginExtensionEventHelpers {
-  const openModal: PluginExtensionEventHelpers['openModal'] = ({ title, body }) => {
-    appEvents.publish(new ShowModalReactEvent({ component: getModalWrapper({ title, body }) }));
+  const openModal: PluginExtensionEventHelpers['openModal'] = (options) => {
+    const { title, body, width, height } = options;
+
+    appEvents.publish(
+      new ShowModalReactEvent({
+        component: getModalWrapper({ title, body, width, height }),
+      })
+    );
   };
 
   return { openModal, context };
@@ -60,10 +67,14 @@ export const getModalWrapper = ({
   title,
   // A component that serves the body of the modal
   body: Body,
+  width,
+  height,
 }: Parameters<PluginExtensionEventHelpers['openModal']>[0]) => {
+  const className = css({ width, height });
+
   const ModalWrapper = ({ onDismiss }: ModalWrapperProps) => {
     return (
-      <Modal title={title} isOpen onDismiss={onDismiss} onClickBackdrop={onDismiss}>
+      <Modal title={title} className={className} isOpen onDismiss={onDismiss} onClickBackdrop={onDismiss}>
         <Body onDismiss={onDismiss} />
       </Modal>
     );

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -44,7 +44,7 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
 
 // Event helpers are designed to make it easier to trigger "core actions" from an extension event handler, e.g. opening a modal or showing a notification.
 export function getEventHelpers(context?: Readonly<object>): PluginExtensionEventHelpers {
-  const openModal: (options: PluginExtensionOpenModalOptions) => void = (options) => {
+  const openModal: PluginExtensionEventHelpers['openModal'] = (options) => {
     const { title, body, width, height } = options;
 
     appEvents.publish(

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { isArray, isObject } from 'lodash';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import {
   type PluginExtensionLinkConfig,
@@ -8,6 +8,7 @@ import {
   type PluginExtensionConfig,
   type PluginExtensionEventHelpers,
   PluginExtensionTypes,
+  type PluginExtensionOpenModalOptions,
 } from '@grafana/data';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
@@ -43,7 +44,7 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
 
 // Event helpers are designed to make it easier to trigger "core actions" from an extension event handler, e.g. opening a modal or showing a notification.
 export function getEventHelpers(context?: Readonly<object>): PluginExtensionEventHelpers {
-  const openModal: PluginExtensionEventHelpers['openModal'] = (options) => {
+  const openModal: (options: PluginExtensionOpenModalOptions) => void = (options) => {
     const { title, body, width, height } = options;
 
     appEvents.publish(
@@ -56,20 +57,20 @@ export function getEventHelpers(context?: Readonly<object>): PluginExtensionEven
   return { openModal, context };
 }
 
-export type ModalWrapperProps = {
+type ModalWrapperProps = {
   onDismiss: () => void;
 };
 
 // Wraps a component with a modal.
 // This way we can make sure that the modal is closable, and we also make the usage simpler.
-export const getModalWrapper = ({
+const getModalWrapper = ({
   // The title of the modal (appears in the header)
   title,
   // A component that serves the body of the modal
   body: Body,
   width,
   height,
-}: Parameters<PluginExtensionEventHelpers['openModal']>[0]) => {
+}: PluginExtensionOpenModalOptions) => {
   const className = css({ width, height });
 
   const ModalWrapper = ({ onDismiss }: ModalWrapperProps) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR will allow plugins that use UI extensions to control the size of the modal that will be displayed when calling `openModal` when an user trigger an UI extension. 

You can specify `width` and `height` in either pixels or percent by passing it as options to the `openModal` function.

**Why do we need this feature?**

When opening more advanced flows when the user triggers an UI extension there is a need to control the size of the Modal.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
