### PR TITLE
Chore: remove hasAccess and hasAcessInMetadata

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -167,14 +167,6 @@ export class ContextSrv {
     return this.hasPermission(AccessControlAction.DataSourcesExplore) && config.exploreEnabled;
   }
 
-  hasAccess(action: string, fallBack: boolean): boolean {
-    return this.hasPermission(action);
-  }
-
-  hasAccessInMetadata(action: string, object: WithAccessControlMetadata, fallBack: boolean): boolean {
-    return this.hasPermissionInMetadata(action, object);
-  }
-
   // evaluates access control permissions, granting access if the user has any of them
   evaluatePermission(actions: string[]) {
     if (actions.some((action) => this.hasPermission(action))) {

--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -29,7 +29,6 @@ jest.mock('./state/apis', () => ({
 }));
 jest.mock('../../core/services/context_srv', () => ({
   contextSrv: {
-    hasAccess: () => true,
     hasPermission: () => true,
   },
 }));

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.v2.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.v2.tsx
@@ -272,7 +272,7 @@ const ContactPointHeader = (props: ContactPointHeaderProps) => {
 
   // we make a distinction here becase for "canExport" we show the menu item, if not we hide it
   const canExport = isGranaManagedAlertmanager;
-  const allowedToExport = contextSrv.hasAccess(permissions.provisioning.read, isOrgAdmin());
+  const allowedToExport = contextSrv.hasPermission(permissions.provisioning.read);
 
   return (
     <div className={styles.headerWrapper}>

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -47,10 +47,9 @@ export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO):
         loading,
       };
     }
-    const rbacDisabledFallback = folder.canSave;
 
-    const canEditGrafanaRules = contextSrv.hasAccessInMetadata(rulePermission.update, folder, rbacDisabledFallback);
-    const canRemoveGrafanaRules = contextSrv.hasAccessInMetadata(rulePermission.delete, folder, rbacDisabledFallback);
+    const canEditGrafanaRules = contextSrv.hasPermissionInMetadata(rulePermission.update, folder);
+    const canRemoveGrafanaRules = contextSrv.hasPermissionInMetadata(rulePermission.delete, folder);
 
     return {
       isEditable: canEditGrafanaRules,

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/EmailSharingConfiguration.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/EmailSharingConfiguration.tsx
@@ -24,7 +24,6 @@ import {
   useReshareAccessToRecipientMutation,
   useUpdatePublicDashboardMutation,
 } from 'app/features/dashboard/api/publicDashboardApi';
-import { isOrgAdmin } from 'app/features/plugins/admin/permissions';
 import { AccessControlAction, useSelector } from 'app/types';
 
 import { trackDashboardSharingActionPerType } from '../../analytics';
@@ -121,7 +120,7 @@ export const EmailSharingConfiguration = () => {
   const [updateShareType] = useUpdatePublicDashboardMutation();
   const [addEmail, { isLoading: isAddEmailLoading }] = useAddRecipientMutation();
 
-  const hasWritePermissions = contextSrv.hasAccess(AccessControlAction.DashboardsPublicWrite, isOrgAdmin());
+  const hasWritePermissions = contextSrv.hasPermission(AccessControlAction.DashboardsPublicWrite);
 
   const {
     register,

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -111,7 +111,7 @@ jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
 
 jest.mock('app/core/core', () => ({
   contextSrv: {
-    hasAccess: () => true,
+    hasPermission: () => true,
     getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
   },
 }));

--- a/public/app/features/explore/spec/datasourceState.test.tsx
+++ b/public/app/features/explore/spec/datasourceState.test.tsx
@@ -15,7 +15,6 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/core/core', () => ({
   contextSrv: {
-    hasAccess: () => true,
     hasPermission: () => true,
     getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
   },

--- a/public/app/features/explore/spec/interpolation.test.tsx
+++ b/public/app/features/explore/spec/interpolation.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/core/core', () => ({
   contextSrv: {
-    hasAccess: () => true,
+    hasPermission: () => true,
     getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
   },
 }));

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -50,7 +50,6 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('app/core/core', () => ({
   contextSrv: {
     hasPermission: () => true,
-    hasAccess: () => true,
     isSignedIn: true,
     getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
   },

--- a/public/app/features/explore/spec/split.test.tsx
+++ b/public/app/features/explore/spec/split.test.tsx
@@ -16,7 +16,6 @@ jest.mock('app/core/core', () => {
   return {
     contextSrv: {
       hasPermission: () => true,
-      hasAccess: () => true,
       getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
     },
   };

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -7,7 +7,6 @@ import { AccessControlAction } from 'app/types';
 
 import { updatePluginSettings } from '../../api';
 import { usePluginConfig } from '../../hooks/usePluginConfig';
-import { isOrgAdmin } from '../../permissions';
 import { CatalogPlugin } from '../../types';
 
 type Props = {
@@ -22,7 +21,7 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   }
 
   // Enforce RBAC
-  if (!contextSrv.hasAccessInMetadata(AccessControlAction.PluginsWrite, plugin, isOrgAdmin())) {
+  if (!contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)) {
     return null;
   }
 

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -7,7 +7,6 @@ import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
 
 import { usePluginConfig } from '../hooks/usePluginConfig';
-import { isOrgAdmin } from '../permissions';
 import { CatalogPlugin, PluginTabIds, PluginTabLabels } from '../types';
 
 type ReturnType = {
@@ -25,8 +24,7 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, pageId?: PluginTabI
 
   const currentPageId = pageId || defaultTab;
   const navModelChildren = useMemo(() => {
-    const canConfigurePlugins =
-      plugin && contextSrv.hasAccessInMetadata(AccessControlAction.PluginsWrite, plugin, isOrgAdmin());
+    const canConfigurePlugins = plugin && contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin);
     const navModelChildren: NavModelItem[] = [];
     if (isPublished) {
       navModelChildren.push({
@@ -122,7 +120,7 @@ function useDefaultPage(plugin: CatalogPlugin | undefined, pluginConfig: Grafana
     return PluginTabIds.OVERVIEW;
   }
 
-  const hasAccess = contextSrv.hasAccessInMetadata(AccessControlAction.PluginsWrite, plugin, isOrgAdmin());
+  const hasAccess = contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin);
 
   if (!hasAccess || pluginConfig.meta.type !== PluginType.app) {
     return PluginTabIds.OVERVIEW;

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -52,9 +52,8 @@ jest.mock('../helpers.ts', () => ({
 
 jest.mock('app/core/core', () => ({
   contextSrv: {
-    hasAccess: (action: string, fallBack: boolean) => true,
     hasPermission: (action: string) => true,
-    hasAccessInMetadata: (action: string, object: WithAccessControlMetadata, fallBack: boolean) => true,
+    hasPermissionInMetadata: (action: string, object: WithAccessControlMetadata) => true,
   },
 }));
 

--- a/public/app/features/search/components/ManageDashboards.test.tsx
+++ b/public/app/features/search/components/ManageDashboards.test.tsx
@@ -14,7 +14,6 @@ jest.mock('app/core/services/context_srv', () => {
     contextSrv: {
       ...originMock.context_srv,
       user: {},
-      hasAccess: jest.fn(() => false),
       hasPermission: jest.fn(() => false),
     },
   };

--- a/public/app/features/search/components/ManageDashboards.test.tsx
+++ b/public/app/features/search/components/ManageDashboards.test.tsx
@@ -32,19 +32,16 @@ jest.spyOn(console, 'error').mockImplementation();
 
 describe('ManageDashboards', () => {
   beforeEach(() => {
-    (contextSrv.hasAccess as jest.Mock).mockClear();
     (contextSrv.hasPermission as jest.Mock).mockClear();
   });
 
   it("should hide and show dashboard actions based on user's permissions", async () => {
-    (contextSrv.hasAccess as jest.Mock).mockReturnValue(false);
     (contextSrv.hasPermission as jest.Mock).mockReturnValue(false);
 
     const { rerender } = await setup();
 
     expect(screen.queryByRole('button', { name: /new/i })).not.toBeInTheDocument();
 
-    (contextSrv.hasAccess as jest.Mock).mockReturnValue(true);
     (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
     await waitFor(() => rerender(<ManageDashboardsNew folder={{ canEdit: true } as FolderDTO} />));
 

--- a/public/app/features/search/components/ManageDashboardsNew.tsx
+++ b/public/app/features/search/components/ManageDashboardsNew.tsx
@@ -31,9 +31,8 @@ export const ManageDashboardsNew = React.memo(({ folder }: Props) => {
   const { isEditor } = contextSrv;
   const hasEditPermissionInFolders = folder ? canSave : contextSrv.hasEditPermissionInFolders;
   const canCreateFolders = contextSrv.hasPermission(AccessControlAction.FoldersCreate);
-  const canCreateDashboardsFallback = hasEditPermissionInFolders || !!canSave;
   const canCreateDashboards = folderUid
-    ? contextSrv.hasAccessInMetadata(AccessControlAction.DashboardsCreate, folder, canCreateDashboardsFallback)
+    ? contextSrv.hasPermissionInMetadata(AccessControlAction.DashboardsCreate, folder)
     : contextSrv.hasPermission(AccessControlAction.DashboardsCreate);
   const viewActions = (folder === undefined && canCreateFolders) || canCreateDashboards;
 

--- a/public/app/features/serviceaccounts/ServiceAccountPage.test.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.test.tsx
@@ -13,8 +13,7 @@ jest.mock('app/core/core', () => ({
   contextSrv: {
     licensedAccessControlEnabled: () => false,
     hasPermission: () => true,
-    hasPermissionInMetadata: () => true,
-    hasAccessInMetadata: () => false,
+    hasPermissionInMetadata: () => false,
   },
 }));
 

--- a/public/app/features/serviceaccounts/ServiceAccountPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.tsx
@@ -73,10 +73,9 @@ export const ServiceAccountPageUnconnected = ({
     !contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite) || serviceAccount.isDisabled;
 
   const ableToWrite = contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite);
-  const canReadPermissions = contextSrv.hasAccessInMetadata(
+  const canReadPermissions = contextSrv.hasPermissionInMetadata(
     AccessControlAction.ServiceAccountsPermissionsRead,
-    serviceAccount!,
-    false
+    serviceAccount!
   );
 
   const pageNav: NavModelItem = {

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -96,10 +96,9 @@ export const TeamList = ({
               id: 'role',
               header: 'Role',
               cell: ({ cell: { value }, row: { original } }: Cell<'memberCount'>) => {
-                const canSeeTeamRoles = contextSrv.hasAccessInMetadata(
+                const canSeeTeamRoles = contextSrv.hasPermissionInMetadata(
                   AccessControlAction.ActionTeamsRolesList,
-                  original,
-                  false
+                  original
                 );
                 return canSeeTeamRoles && <TeamRolePicker teamId={original.id} roleOptions={roleOptions} />;
               },

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -10,7 +10,6 @@ import { searchQueryChanged } from './state/reducers';
 jest.mock('app/core/core', () => ({
   contextSrv: {
     hasPermission: () => true,
-    hasAccess: () => true,
   },
 }));
 

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -47,6 +47,8 @@ describe('Render', () => {
   });
 
   it('should show invite button', () => {
+    setup();
+
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
   });
 
@@ -64,6 +66,8 @@ describe('Render', () => {
     config.externalUserMngInfo = 'truthy';
     config.disableLoginForm = true;
 
+    setup();
+
     expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
     // Reset the disableLoginForm mock to its original value
     config.externalUserMngInfo = originalExternalUserMngInfo;
@@ -73,6 +77,8 @@ describe('Render', () => {
     config.externalUserMngInfo = '';
     config.disableLoginForm = true;
 
+    setup();
+
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value
     config.disableLoginForm = false;
@@ -81,6 +87,8 @@ describe('Render', () => {
   it('should show invite button when externalUserMngInfo is set and disableLoginForm is false', () => {
     const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
+
+    setup();
 
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -20,7 +20,6 @@ const setup = (propOverrides?: object) => {
     changeSearchQuery: mockToolkitActionCreator(searchQueryChanged),
     onShowInvites: jest.fn(),
     pendingInvitesCount: 0,
-    canInvite: false,
     externalUserMngLinkUrl: '',
     externalUserMngLinkName: '',
     showInvites: false,
@@ -49,10 +48,6 @@ describe('Render', () => {
   });
 
   it('should show invite button', () => {
-    setup({
-      canInvite: true,
-    });
-
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
   });
 
@@ -70,10 +65,6 @@ describe('Render', () => {
     config.externalUserMngInfo = 'truthy';
     config.disableLoginForm = true;
 
-    setup({
-      canInvite: true,
-    });
-
     expect(screen.queryByRole('link', { name: 'Invite' })).not.toBeInTheDocument();
     // Reset the disableLoginForm mock to its original value
     config.externalUserMngInfo = originalExternalUserMngInfo;
@@ -83,10 +74,6 @@ describe('Render', () => {
     config.externalUserMngInfo = '';
     config.disableLoginForm = true;
 
-    setup({
-      canInvite: true,
-    });
-
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value
     config.disableLoginForm = false;
@@ -95,10 +82,6 @@ describe('Render', () => {
   it('should show invite button when externalUserMngInfo is set and disableLoginForm is false', () => {
     const originalExternalUserMngInfo = config.externalUserMngInfo;
     config.externalUserMngInfo = 'truthy';
-
-    setup({
-      canInvite: true,
-    });
 
     expect(screen.getByRole('link', { name: 'Invite' })).toHaveAttribute('href', 'org/users/invite');
     // Reset the disableLoginForm mock to its original value

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -22,7 +22,6 @@ function mapStateToProps(state: StoreState) {
     pendingInvitesCount: selectTotal(state.invites),
     externalUserMngLinkName: state.users.externalUserMngLinkName,
     externalUserMngLinkUrl: state.users.externalUserMngLinkUrl,
-    canInvite: state.users.canInvite,
   };
 }
 
@@ -35,7 +34,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 export type Props = ConnectedProps<typeof connector> & OwnProps;
 
 export const UsersActionBarUnconnected = ({
-  canInvite,
   externalUserMngLinkName,
   externalUserMngLinkUrl,
   searchQuery,
@@ -48,7 +46,7 @@ export const UsersActionBarUnconnected = ({
     { label: 'Users', value: 'users' },
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
   ];
-  const canAddToOrg: boolean = contextSrv.hasAccess(AccessControlAction.OrgUsersAdd, canInvite);
+  const canAddToOrg: boolean = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
   // Show invite button in the following cases:
   // 1) the instance is not a hosted Grafana instance (!config.externalUserMngInfo)
   // 2) new basic auth users can be created for this instance (!config.disableLoginForm).

--- a/public/app/features/users/UsersListPage.test.tsx
+++ b/public/app/features/users/UsersListPage.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../core/app_events', () => ({
 jest.mock('app/core/core', () => ({
   contextSrv: {
     user: { orgId: 1 },
-    hasAccess: () => false,
+    hasPermission: () => false,
     licensedAccessControlEnabled: () => false,
   },
 }));

--- a/public/app/features/users/state/reducers.ts
+++ b/public/app/features/users/state/reducers.ts
@@ -9,7 +9,6 @@ export const initialState: UsersState = {
   page: 0,
   perPage: 30,
   totalPages: 1,
-  canInvite: !config.externalUserMngLinkName,
   externalUserMngInfo: config.externalUserMngInfo,
   externalUserMngLinkName: config.externalUserMngLinkName,
   externalUserMngLinkUrl: config.externalUserMngLinkUrl,

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -72,7 +72,6 @@ export interface Invitee {
 export interface UsersState {
   users: OrgUser[];
   searchQuery: string;
-  canInvite: boolean;
   externalUserMngLinkUrl: string;
   externalUserMngLinkName: string;
   externalUserMngInfo: string;


### PR DESCRIPTION
**What is this feature?**

Removing hasAccess and hasAcessInMetadata in favour of hasPermission and hasPermissionInMetadata, as we don't use the legacy access control fallback anymore.

**Why do we need this feature?**

Cleanup

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/74384

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
