### PR TITLE
RBAC: Make fixed role UIDs deterministic

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -321,6 +321,7 @@ func (cmd *SaveExternalServiceRoleCommand) Validate() error {
 const (
 	GlobalOrgID                  = 0
 	FixedRolePrefix              = "fixed:"
+	FixedRoleUIDPrefix           = "fixed_"
 	ManagedRolePrefix            = "managed:"
 	BasicRolePrefix              = "basic:"
 	PluginRolePrefix             = "plugins:"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -1,6 +1,7 @@
 package accesscontrol
 
 import (
+	// #nosec G505 Used only for generating a 160 bit hash, it's not used for security purposes
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -256,7 +256,7 @@ func ConcatPermissions(permissions ...[]Permission) []Permission {
 	return perms
 }
 
-// FixedRoleUID generates a UID of 27 bytes: "fixed_sha1(roleName)"
+// FixedRoleUID generates a UID of 34 bytes: "fixed_" + base64(sha1(roleName))
 func FixedRoleUID(roleName string) string {
 	// #nosec G505 Used only for generating a 160 bit hash, it's not used for security purposes
 	hasher := sha1.New()

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -1,6 +1,8 @@
 package accesscontrol
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -251,6 +253,15 @@ func ConcatPermissions(permissions ...[]Permission) []Permission {
 		perms = append(perms, p...)
 	}
 	return perms
+}
+
+// FixedRoleUID generates a UID of 27 bytes: "fixed_sha1(roleName)"
+func FixedRoleUID(roleName string) string {
+	// #nosec G505 Used only for generating a 160 bit hash, it's not used for security purposes
+	hasher := sha1.New()
+	hasher.Write([]byte(roleName))
+
+	return fmt.Sprintf("%s%s", FixedRoleUIDPrefix, hex.EncodeToString(hasher.Sum(nil)))
 }
 
 // ValidateFixedRole errors when a fixed role does not match expected pattern

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -3,7 +3,7 @@ package accesscontrol
 import (
 	// #nosec G505 Used only for generating a 160 bit hash, it's not used for security purposes
 	"crypto/sha1"
-	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"sync"
@@ -262,7 +262,7 @@ func FixedRoleUID(roleName string) string {
 	hasher := sha1.New()
 	hasher.Write([]byte(roleName))
 
-	return fmt.Sprintf("%s%s", FixedRoleUIDPrefix, hex.EncodeToString(hasher.Sum(nil)))
+	return fmt.Sprintf("%s%s", FixedRoleUIDPrefix, base64.RawURLEncoding.EncodeToString(hasher.Sum(nil)))
 }
 
 // ValidateFixedRole errors when a fixed role does not match expected pattern


### PR DESCRIPTION
Co-authored-by: Karl Persson <kalle.persson@grafana.com>

**What is this feature?**

This PR adds a function to make fixed role UID deterministic: `"fixed_" + base64(sha1(name))`

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

https://github.com/grafana/identity-access-team/issues/399

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
