### PR TITLE
Tabs: Fixes focus style

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -67,10 +67,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'relative',
       display: 'flex',
       whiteSpace: 'nowrap',
+      padding: theme.spacing(0.5),
     }),
     link: css({
       color: theme.colors.text.secondary,
-      padding: theme.spacing(1.5, 2, 1),
+      padding: theme.spacing(1, 1.5, 0.5),
+      borderRadius: theme.shape.radius.default,
+
       display: 'block',
       height: '100%',
 


### PR DESCRIPTION
Noticed the tab focus style looked broken 

Example from share modal:
![Screenshot from 2023-10-10 12-20-34](https://github.com/grafana/grafana/assets/10999/d8de4480-0947-4d9e-bc93-ea94e9b6ba6e)

Same problem everywhere. I think the regression was caused by the change to make tabs [scrollable (added overflow)
](https://github.com/grafana/grafana/pull/66805)

Fix
* Move some of the padding to the wrapping div element 
* Add border radius to the tab link element (The thing that has focus). Does not affect the design in anyway, but makes the focus box have rounded corners (like everywhere else) instead of sharp. 

After
![Screenshot from 2023-10-10 12-19-40](https://github.com/grafana/grafana/assets/10999/2798454b-6ff5-4bcc-8522-b8a8f6136f35)

