### PR TITLE
Drawer: Add 1 grid unit padding between title and tabs

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -302,7 +302,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     tabsWrapper: css({
       label: 'drawer-tabs',
       paddingLeft: theme.spacing(2),
-      margin: theme.spacing(0, -1, -3, -3),
+      margin: theme.spacing(1, -1, -3, -3),
     }),
   };
 };


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/75354 basically removed all padding/spacing between the title subtitle and tabs making the drawer header feel very tight and cramped. 

Propose adding 1 grid unit (8px) space beteween title/subtile and tabs

before: 
<img src="https://github.com/grafana/grafana/assets/10999/56f44156-c32d-4643-9303-662e31492dad" width="700px" />

after:
<img src="https://github.com/grafana/grafana/assets/10999/1b29b9fd-0c43-4354-a5cc-e088f024f028" width="700px" />


Before (with no subtitle)
<img src="https://github.com/grafana/grafana/assets/10999/b6b883a6-96b2-4b7b-81fa-5b3602e4e2f8" width="700px" />

After (with no subtitle)
<img src="https://github.com/grafana/grafana/assets/10999/3509e47d-6bd2-4465-b71e-9c317b61f3f4" width="700px" />

Another solution would be to restore the original spacing and set the smaller / tighter spacing but as a media query for smaller mobile screens. 