### PR TITLE
Alerting: Add provenance field to /api/v1/provisioning/alert-rules

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -57,7 +57,7 @@ type MuteTimingService interface {
 }
 
 type AlertRuleService interface {
-	GetAlertRules(ctx context.Context, orgID int64) ([]*alerting_models.AlertRule, error)
+	GetAlertRules(ctx context.Context, orgID int64) ([]*alerting_models.AlertRule, map[string]alerting_models.Provenance, error)
 	GetAlertRule(ctx context.Context, orgID int64, ruleUID string) (alerting_models.AlertRule, alerting_models.Provenance, error)
 	CreateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance, userID int64) (alerting_models.AlertRule, error)
 	UpdateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance) (alerting_models.AlertRule, error)
@@ -300,11 +300,11 @@ func (srv *ProvisioningSrv) RouteDeleteMuteTiming(c *contextmodel.ReqContext, na
 }
 
 func (srv *ProvisioningSrv) RouteGetAlertRules(c *contextmodel.ReqContext) response.Response {
-	rules, err := srv.alertRules.GetAlertRules(c.Req.Context(), c.SignedInUser.GetOrgID())
+	rules, provenances, err := srv.alertRules.GetAlertRules(c.Req.Context(), c.SignedInUser.GetOrgID())
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	return response.JSON(http.StatusOK, ProvisionedAlertRuleFromAlertRules(rules))
+	return response.JSON(http.StatusOK, ProvisionedAlertRuleFromAlertRules(rules, provenances))
 }
 
 func (srv *ProvisioningSrv) RouteRouteGetAlertRule(c *contextmodel.ReqContext, UID string) response.Response {

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -55,10 +55,10 @@ func ProvisionedAlertRuleFromAlertRule(rule models.AlertRule, provenance models.
 }
 
 // ProvisionedAlertRuleFromAlertRules converts a collection of models.AlertRule to definitions.ProvisionedAlertRules with provenance status models.ProvenanceNone
-func ProvisionedAlertRuleFromAlertRules(rules []*models.AlertRule) definitions.ProvisionedAlertRules {
+func ProvisionedAlertRuleFromAlertRules(rules []*models.AlertRule, provenances map[string]models.Provenance) definitions.ProvisionedAlertRules {
 	result := make([]definitions.ProvisionedAlertRule, 0, len(rules))
 	for _, r := range rules {
-		result = append(result, ProvisionedAlertRuleFromAlertRule(*r, models.ProvenanceNone))
+		result = append(result, ProvisionedAlertRuleFromAlertRule(*r, provenances[r.UID]))
 	}
 	return result
 }

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -2,9 +2,8 @@ package alerting
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
-	"github.com/go-jose/go-jose/v3/json"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"io"
 	"net/http"
 	"sort"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -368,7 +368,6 @@ func TestIntegrationProvisioning(t *testing.T) {
 		})
 		require.Equal(t, definitions.Provenance("api"), rules[0].Provenance)
 		require.Equal(t, definitions.Provenance(""), rules[1].Provenance)
-
 	})
 }
 

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -3,8 +3,11 @@ package alerting
 import (
 	"bytes"
 	"fmt"
+	"github.com/go-jose/go-jose/v3/json"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"io"
 	"net/http"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +45,11 @@ func TestIntegrationProvisioning(t *testing.T) {
 		Password:       "admin",
 		Login:          "admin",
 	})
+
+	apiClient := newAlertingApiClient(grafanaListedAddr, "editor", "editor")
+	// Create the namespace we'll save our alerts to.
+	namespaceUID := "default"
+	apiClient.CreateFolder(t, namespaceUID, namespaceUID)
 
 	t.Run("when provisioning notification policies", func(t *testing.T) {
 		url := fmt.Sprintf("http://%s/api/v1/provisioning/policies", grafanaListedAddr)
@@ -332,6 +340,35 @@ func TestIntegrationProvisioning(t *testing.T) {
 
 			require.Equal(t, 200, resp.StatusCode)
 		})
+	})
+
+	t.Run("when provisioning alert rules", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s/api/v1/provisioning/alert-rules", grafanaListedAddr)
+		body := `{"orgID":1,"folderUID":"default","ruleGroup":"Test Group","title":"Provisioned","condition":"A","data":[{"refId":"A","queryType":"","relativeTimeRange":{"from":600,"to":0},"datasourceUid":"f558c85f-66ad-4fd1-b31d-7979e6c93db4","model":{"editorMode":"code","exemplar":false,"expr":"sum(rate(low_card[5m])) \u003e 0","format":"time_series","instant":true,"intervalMs":1000,"legendFormat":"__auto","maxDataPoints":43200,"range":false,"refId":"A"}}],"noDataState":"NoData","execErrState":"Error","for":"0s"}`
+		req := createTestRequest("POST", url, "admin", body)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, 201, resp.StatusCode)
+
+		// We want to check the provenances of both provisioned and non-provisioned rules
+		createRule(t, apiClient, namespaceUID)
+
+		req = createTestRequest("GET", url, "admin", "")
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		var rules definitions.ProvisionedAlertRules
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&rules))
+		require.NoError(t, resp.Body.Close())
+
+		require.Len(t, rules, 2)
+		sort.Slice(rules, func(i, j int) bool {
+			return rules[i].ID < rules[j].ID
+		})
+		require.Equal(t, definitions.Provenance("api"), rules[0].Provenance)
+		require.Equal(t, definitions.Provenance(""), rules[1].Provenance)
+
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

This commit adds the missing Provenance field to responses for `/api/v1/provisioning/alert-rules`.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Fixes #76041

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
