### PR TITLE
Explore: Remove redundant TODO

### DIFF
--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -213,7 +213,6 @@ export const getFieldLinksForExplore = (options: {
             range,
             field,
             // Don't track internal links without split view as they are used only in Dashboards
-            // TODO: It should be revisited in #66570
             onClickFn: options.splitOpenFn ? (options) => splitFnWithTracking(options) : undefined,
             replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
           });


### PR DESCRIPTION
We've created https://github.com/grafana/grafana/issues/66570 to revisit how AppCore is passed for tracking. It was noted that the `app` property may not be set up correctly in Dashboards. Since then we removed tracking for external links and this TODO is no longer relevant.