### PR TITLE
Authn: error logs

### DIFF
--- a/pkg/services/authn/error.go
+++ b/pkg/services/authn/error.go
@@ -3,7 +3,7 @@ package authn
 import "github.com/grafana/grafana/pkg/util/errutil"
 
 var (
-	ErrTokenNeedsRotation  = errutil.Unauthorized("session.token.rotate")
+	ErrTokenNeedsRotation  = errutil.Unauthorized("session.token.rotate", errutil.WithLogLevel(errutil.LevelDebug))
 	ErrUnsupportedClient   = errutil.BadRequest("auth.client.unsupported")
 	ErrClientNotConfigured = errutil.BadRequest("auth.client.notConfigured")
 	ErrUnsupportedIdentity = errutil.NotImplemented("auth.identity.unsupported")


### PR DESCRIPTION
**What is this feature?**
Try to use log level from `errutil.Error` for authn service error logs and fallback to warning for everything else.

Also set debug for ErrTokenNeedsRotation so request logger don't log it as an info log.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
