### PR TITLE
Transformations: Add Numeric Index in Title

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -160,7 +160,7 @@ export const TransformationOperationRow = ({
     <QueryOperationRow
       id={id}
       index={index}
-      title={uiConfig.name}
+      title={`${index + 1} - ${uiConfig.name}`}
       draggable
       actions={renderActions}
       disabled={disabled}


### PR DESCRIPTION
**What is this feature?**

This is a really simple change that adds a numeric index to the display of transformations to indicate that they are indeed ordered.

<img width="188" alt="Screenshot 2023-10-10 at 8 13 56 PM" src="https://github.com/grafana/grafana/assets/199847/327d18c8-cd7f-405d-b1b2-65b2978ced47">

I also played around with adding arrows or other indicators between elements, however this tended to create a somewhat jarring experience as indicators would position strangely when dragging elements.

**Why do we need this feature?**

To make it more clear that transformations are applied in order beginning with the first and proceeding to the last.

**Who is this feature for?**

Users of transformations.


**Which issue(s) does this PR fix?**:

Fixes #74208

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
