### PR TITLE
I18N: Collect stats on number of untranslated strings in message catalogues

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "i18n:extract": "yarn run i18next -c public/locales/i18next-parser.config.js 'public/**/*.{tsx,ts}' 'packages/grafana-ui/**/*.{tsx,ts}' && yarn i18n:pseudo",
     "i18n:compile": "echo 'no i18n compile yet, all good'",
     "i18n:pseudo": "node ./public/locales/pseudo.js",
+    "i18n:stats": "node ./scripts/cli/reportI18nStats.mjs",
     "betterer": "betterer",
     "betterer:merge": "betterer merge",
     "betterer:stats": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/reportBettererStats.ts",

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -46,6 +46,13 @@ do
   BETTERER_STATS+="\"grafana.ci-code.betterer.${name}\": \"${value}\","
 done <<< "$(yarn betterer:stats)"
 
+I18N_STATS=""
+while read -r name value
+do
+  I18N_STATS+=$'\n  '
+  I18N_STATS+="\"grafana.ci-code.i18n.${name}\": \"${value}\","
+done <<< "$(yarn i18n:stats)"
+
 THEME_TOKEN_USAGE=""
 while read -r name value
 do
@@ -56,6 +63,7 @@ done <<< "$(yarn themes:usage | awk '$4 == "@grafana/theme-token-usage" {print $
 echo "Metrics: {
   $THEME_TOKEN_USAGE
   $BETTERER_STATS
+  $I18N_STATS
   \"grafana.ci-code.strictErrors\": \"${ERROR_COUNT}\",
   \"grafana.ci-code.accessibilityErrors\": \"${ACCESSIBILITY_ERRORS}\",
   \"grafana.ci-code.directives\": \"${DIRECTIVES}\",

--- a/scripts/cli/reportI18nStats.mjs
+++ b/scripts/cli/reportI18nStats.mjs
@@ -1,9 +1,10 @@
 /// @ts-check
 
 import { readdir, stat, readFile } from 'fs/promises';
-import path from 'path';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
-const LOCALES_DIR = path.join('.', 'public', 'locales');
+const LOCALES_DIR = path.resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'public', 'locales');
 
 const locales = await readdir(LOCALES_DIR);
 

--- a/scripts/cli/reportI18nStats.mjs
+++ b/scripts/cli/reportI18nStats.mjs
@@ -24,7 +24,7 @@ for (const fileName of locales) {
   let translatedCount = 0;
   let untranslatedCount = 0;
 
-  eachLeaf(parsedMessages, (value) => {
+  eachMessage(parsedMessages, (value) => {
     if (value === '') {
       untranslatedCount += 1;
     } else {
@@ -61,20 +61,18 @@ async function exists(filePath) {
 
 /**
  * @param {unknown} value
- * @param {(v: unknown) => void} callback
+ * @param {(v: string) => void} callback
  */
-function eachLeaf(value, callback) {
-  if (Array.isArray(value)) {
-    for (const arrayValue of value) {
-      eachLeaf(arrayValue, callback);
-    }
-  } else if (typeof value === 'object') {
+function eachMessage(value, callback) {
+  if (typeof value === 'object') {
     for (const key in value) {
       const element = value[key];
-      eachLeaf(element, callback);
+      eachMessage(element, callback);
     }
-  } else {
+  } else if (typeof value === 'string') {
     callback(value);
+  } else {
+    throw new Error(`Unknown value ${value} in eachMessage`);
   }
 }
 

--- a/scripts/cli/reportI18nStats.mjs
+++ b/scripts/cli/reportI18nStats.mjs
@@ -1,0 +1,89 @@
+/// @ts-check
+
+import { readdir, stat, readFile } from 'fs/promises';
+import path from 'path';
+
+const LOCALES_DIR = path.join('.', 'public', 'locales');
+
+const locales = await readdir(LOCALES_DIR);
+
+/**
+ * @type {Array<{ language: string, untranslatedCount: number, translatedCount: number }>}
+ */
+const stats = [];
+
+for (const fileName of locales) {
+  const filePath = path.join(LOCALES_DIR, fileName, 'grafana.json');
+  if (!(await exists(filePath))) {
+    continue;
+  }
+
+  const messages = await readFile(filePath);
+  const parsedMessages = JSON.parse(messages.toString());
+
+  let translatedCount = 0;
+  let untranslatedCount = 0;
+
+  eachLeaf(parsedMessages, (value) => {
+    if (value === '') {
+      untranslatedCount += 1;
+    } else {
+      translatedCount += 1;
+    }
+  });
+
+  stats.push({
+    language: fileName,
+    translatedCount,
+    untranslatedCount,
+  });
+}
+
+for (const stat of stats) {
+  logStat(`untranslated.${stat.language}`, stat.untranslatedCount);
+  logStat(`translated.${stat.language}`, stat.translatedCount);
+}
+
+/**
+ * @param {string} filePath
+ */
+async function exists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @param {(v: unknown) => void} callback
+ */
+function eachLeaf(value, callback) {
+  if (Array.isArray(value)) {
+    for (const arrayValue of value) {
+      eachLeaf(arrayValue, callback);
+    }
+  } else if (typeof value === 'object') {
+    for (const key in value) {
+      const element = value[key];
+      eachLeaf(element, callback);
+    }
+  } else {
+    callback(value);
+  }
+}
+
+/**
+ * @param {string} name
+ * @param {string | number} value
+ */
+function logStat(name, value) {
+  // Note that this output format must match the parsing in ci-frontend-metrics.sh
+  // which expects the two values to be separated by a space
+  console.log(`${name} ${value}`);
+}


### PR DESCRIPTION
Quick CI stats addition to collect the number of untranslated strings in the grafana.json message catalogues.

Idea being we can monitor (and alert on) if the number of untranslated strings grows too high.