### PR TITLE
Teams: Allow team members to list their teams in the UI

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -92,7 +92,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/org/users/new", reqOrgAdmin, hs.Index)
 	r.Get("/org/users/invite", authorize(ac.EvalPermission(ac.ActionOrgUsersAdd)), hs.Index)
 	r.Get("/org/teams", authorize(ac.EvalPermission(ac.ActionTeamsRead)), hs.Index)
-	r.Get("/org/teams/edit/*", authorize(ac.TeamsEditAccessEvaluator), hs.Index)
+	r.Get("/org/teams/edit/*", authorize(ac.EvalPermission(ac.ActionTeamsRead)), hs.Index)
 	r.Get("/org/teams/new", authorize(ac.EvalPermission(ac.ActionTeamsCreate)), hs.Index)
 	r.Get("/org/serviceaccounts", authorize(ac.EvalPermission(serviceaccounts.ActionRead)), hs.Index)
 	r.Get("/org/serviceaccounts/:serviceAccountId", authorize(ac.EvalPermission(serviceaccounts.ActionRead)), hs.Index)

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -503,23 +503,7 @@ func BuiltInRolesWithParents(builtInRoles []string) map[string]struct{} {
 // grants access to a user when they can either create teams or can read and update a team
 var TeamsAccessEvaluator = EvalAny(
 	EvalPermission(ActionTeamsCreate),
-	EvalAll(
-		EvalPermission(ActionTeamsRead),
-		EvalAny(
-			EvalPermission(ActionTeamsWrite),
-			EvalPermission(ActionTeamsPermissionsWrite),
-		),
-	),
-)
-
-// TeamsEditAccessEvaluator is used to protect the "Configuration > Teams > edit" page access
-var TeamsEditAccessEvaluator = EvalAll(
 	EvalPermission(ActionTeamsRead),
-	EvalAny(
-		EvalPermission(ActionTeamsCreate),
-		EvalPermission(ActionTeamsWrite),
-		EvalPermission(ActionTeamsPermissionsWrite),
-	),
 )
 
 // OrgPreferencesAccessEvaluator is used to protect the "Configure > Preferences" page access

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -141,8 +141,8 @@ export class SharedPreferences extends PureComponent<Props, State> {
         {() => {
           return (
             <>
-              <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={disabled}>
-                <Field label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
+              <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>}>
+                <Field label={t('shared-preferences.fields.theme-label', 'Interface theme')} disabled={disabled}>
                   <Select
                     options={this.themeOptions}
                     value={currentThemeOption}
@@ -159,6 +159,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                       </span>
                     </Label>
                   }
+                  disabled={disabled}
                   data-testid="User preferences home dashboard drop down"
                 >
                   <DashboardPicker
@@ -174,6 +175,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 <Field
                   label={t('shared-dashboard.fields.timezone-label', 'Timezone')}
                   data-testid={selectors.components.TimeZonePicker.containerV2}
+                  disabled={disabled}
                 >
                   <TimeZonePicker
                     includeInternal={true}
@@ -186,6 +188,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 <Field
                   label={t('shared-preferences.fields.week-start-label', 'Week start')}
                   data-testid={selectors.components.WeekStartPicker.containerV2}
+                  disabled={disabled}
                 >
                   <WeekStartPicker
                     value={weekStart || ''}
@@ -204,6 +207,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                     </Label>
                   }
                   data-testid="User preferences language drop down"
+                  disabled={disabled}
                 >
                   <Select
                     value={languages.find((lang) => lang.value === language)}
@@ -217,6 +221,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
               <Button
                 type="submit"
                 variant="primary"
+                disabled={disabled}
                 data-testid={selectors.components.UserProfile.preferencesSaveButton}
               >
                 <Trans i18nKey="common.save">Save</Trans>


### PR DESCRIPTION
**What is this feature?**

Allow team members to list their teams through the UI. This is what team members without any additional permissions will see.

Teams listed under the navigation bar:
![Screenshot 2023-10-10 at 15 49 02](https://github.com/grafana/grafana/assets/9482349/e6aa00a3-3ae8-4b9e-8581-465035ce4d58)

List of teams that the user is a member of:
<img width="1436" alt="Screenshot 2023-10-10 at 15 49 57" src="https://github.com/grafana/grafana/assets/9482349/1b11d2ce-5d91-4a4a-a931-53de63aea005">

Details of each of these teams (they won't be able to edit these details):
<img width="897" alt="Screenshot 2023-10-10 at 15 50 25" src="https://github.com/grafana/grafana/assets/9482349/e9734061-ce6d-4fe6-8d33-e70751574489">

**Why do we need this feature?**

Requested by users

**Who is this feature for?**

Anyone who uses teams. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
