### PR TITLE
noBasicRole feature: Change RolePickerInput to not show the "None" role

### DIFF
--- a/public/app/core/components/RolePicker/RolePickerInput.tsx
+++ b/public/app/core/components/RolePicker/RolePickerInput.tsx
@@ -49,18 +49,22 @@ export const RolePickerInput = ({
     onQueryChange(query);
   };
 
-  const numberOfRoles = appliedRoles.length;
+  const showBasicRoleOnLabel = showBasicRole && basicRole !== 'None';
 
   return !isFocused ? (
     // TODO: fix keyboard a11y
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className={cx(styles.wrapper, styles.selectedRoles)} onMouseDown={onOpen}>
-      {showBasicRole && <ValueContainer>{basicRole}</ValueContainer>}
-      <RolesLabel appliedRoles={appliedRoles} numberOfRoles={numberOfRoles} showBuiltInRole={showBasicRole} />
+      {showBasicRoleOnLabel && <ValueContainer>{basicRole}</ValueContainer>}
+      <RolesLabel
+        appliedRoles={appliedRoles}
+        numberOfRoles={appliedRoles.length}
+        showBuiltInRole={showBasicRoleOnLabel}
+      />
     </div>
   ) : (
     <div className={styles.wrapper}>
-      {showBasicRole && <ValueContainer>{basicRole}</ValueContainer>}
+      {showBasicRoleOnLabel && <ValueContainer>{basicRole}</ValueContainer>}
       {appliedRoles.map((role) => (
         <ValueContainer key={role.uid}>{role.displayName || role.name}</ValueContainer>
       ))}


### PR DESCRIPTION
**What is this feature?**

Given an admin is using the `feature_toggles.noBasicRole` config option, the RolePickerInput shows the name of the `"None"` role next to other roles the subject has. This seemed confusing, so this change removes the basic role from the input if `"None"` is chosen.

### Example usage

https://github.com/grafana/grafana/assets/4606528/15d82fa4-2d1f-401e-8eda-0871b3e2a4cd

**Why do we need this feature?**

Avoid confusion of the word "None" appearing in a list of roles.

**Who is this feature for?**

Administrators managing role assignments.