### PR TITLE
Update origin annotation names

### DIFF
--- a/pkg/kinds/general.go
+++ b/pkg/kinds/general.go
@@ -53,10 +53,10 @@ const annoKeyFolder = "grafana.com/folder"
 const annoKeySlug = "grafana.com/slug"
 
 // Identify where values came from
-const annoKeyOriginName = "grafana.com/origin/name"
-const annoKeyOriginPath = "grafana.com/origin/path"
-const annoKeyOriginKey = "grafana.com/origin/key"
-const annoKeyOriginTime = "grafana.com/origin/time"
+const annoKeyOriginName = "grafana.com/originName"
+const annoKeyOriginPath = "grafana.com/originPath"
+const annoKeyOriginKey = "grafana.com/originKey"
+const annoKeyOriginTime = "grafana.com/originTime"
 
 func (m *GrafanaResourceMetadata) GetUpdatedTimestamp() *time.Time {
 	v, ok := m.Annotations[annoKeyUpdatedTimestamp]

--- a/pkg/services/dashboards/models_test.go
+++ b/pkg/services/dashboards/models_test.go
@@ -123,8 +123,8 @@ func TestResourceConversion(t *testing.T) {
 		  "annotations": {
 			"grafana.com/createdBy": "user:10",
 			"grafana.com/folder": "folder:1234",
-			"grafana.com/origin/key": "plugin-xyz",
-			"grafana.com/origin/name": "plugin",
+			"grafana.com/originKey": "plugin-xyz",
+			"grafana.com/originName": "plugin",
 			"grafana.com/slug": "test-dash",
 			"grafana.com/updatedBy": "user:11",
 			"grafana.com/updatedTimestamp": "2010-01-01T08:00:00Z"


### PR DESCRIPTION
k8s does not support annotation names with multiple slashes in them, so this PR updates the origin annotations to match the format for updated and created annotations.
