### PR TITLE
Alerting: Add docs for Repeat interval

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -138,7 +138,7 @@ export const AmRootRouteForm = ({
               </Field>
               <Field
                 label="Repeat interval"
-                description="The waiting time to resend an alert after they have successfully been sent. Default 4 hours."
+                description="The waiting time to resend an alert after they have successfully been sent. Default 4 hours. Should be a multiple of Group interval."
                 invalid={!!errors.repeatIntervalValue}
                 error={errors.repeatIntervalValue?.message}
                 data-testid="am-repeat-interval"


### PR DESCRIPTION
**What is this feature?**

The Repeat interval should be a multiple of Group interval. If it isn't, then Alertmanager will coerce it into one (due to how repeat interval is checked once an aggregation group is flushed, and this flushing happens on each Group interval).

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
