### PR TITLE
chore(76107): Removed LegacyForm from FolderSettingsPage

### DIFF
--- a/public/app/features/folders/FolderSettingsPage.tsx
+++ b/public/app/features/folders/FolderSettingsPage.tsx
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { Button, LegacyForms } from '@grafana/ui';
-const { Input } = LegacyForms;
+import { Field, Form, Button, Input, InputControl } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
@@ -57,11 +56,9 @@ export class FolderSettingsPage extends PureComponent<Props, State> {
     this.props.setFolderTitle(evt.target.value);
   };
 
-  onSave = async (evt: React.FormEvent<HTMLFormElement>) => {
-    evt.preventDefault();
-    evt.stopPropagation();
+  onSave = () => {
     this.setState({ isLoading: true });
-    await this.props.saveFolder(this.props.folder);
+    this.props.saveFolder(this.props.folder);
     this.setState({ isLoading: false });
   };
 
@@ -90,31 +87,29 @@ export class FolderSettingsPage extends PureComponent<Props, State> {
       <Page navId="dashboards/browse" pageNav={pageNav.main}>
         <Page.Contents isLoading={this.state.isLoading}>
           <h3 className="page-sub-heading">Folder settings</h3>
-
-          <div className="section gf-form-group">
-            <form name="folderSettingsForm" onSubmit={this.onSave}>
-              <div className="gf-form">
-                <label htmlFor="folder-title" className="gf-form-label width-7">
-                  Name
-                </label>
-                <Input
-                  type="text"
-                  className="gf-form-input width-30"
-                  id="folder-title"
-                  value={folder.title}
-                  onChange={this.onTitleChange}
+          <Form name="folderSettingsForm" onSubmit={this.onSave}>
+            {({ control, errors }) => (
+              <>
+                <InputControl
+                  render={({ field: { ref, ...field } }) => (
+                    <Field label="Title" invalid={!!errors.title} error={errors.title?.message}>
+                      <Input {...field} autoFocus onChange={this.onTitleChange} value={folder.title} />
+                    </Field>
+                  )}
+                  control={control}
+                  name="title"
                 />
-              </div>
-              <div className="gf-form-button-row">
-                <Button type="submit" disabled={!folder.canSave || !folder.hasChanged}>
-                  Save
-                </Button>
-                <Button variant="destructive" onClick={this.onDelete} disabled={!folder.canDelete}>
-                  Delete
-                </Button>
-              </div>
-            </form>
-          </div>
+                <div className="gf-form-button-row">
+                  <Button type="submit" disabled={!folder.canSave || !folder.hasChanged}>
+                    Save
+                  </Button>
+                  <Button variant="destructive" onClick={this.onDelete} disabled={!folder.canDelete}>
+                    Delete
+                  </Button>
+                </div>
+              </>
+            )}
+          </Form>
         </Page.Contents>
       </Page>
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removing legacy form components from `FolderSettingsPage.tsx`

**Why do we need this feature?**

According to #76107, these components are deprecated and have modern replacements.

**Who is this feature for?**

devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #76107

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

# Screenshots
## Before
![image](https://github.com/grafana/grafana/assets/5034394/4c8929e9-cec4-446a-bae2-46d9ffd3bef3)

## After
![image](https://github.com/grafana/grafana/assets/5034394/8f1782b4-0359-482f-b6e3-8e6a6cc6c84f)
