### PR TITLE
Transformations: Add support for setting timezone in Format time and Convert field type transformations

### DIFF
--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -21,7 +21,6 @@ export interface DateTimeOptionsWhenParsing extends DateTimeOptions {
    */
   roundUp?: boolean;
   fiscalYearStartMonth?: number;
-  applyTz?: boolean;
 }
 
 type DateTimeParser<T extends DateTimeOptions = DateTimeOptions> = (value: DateTimeInput, options?: T) => DateTime;

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -21,6 +21,7 @@ export interface DateTimeOptionsWhenParsing extends DateTimeOptions {
    */
   roundUp?: boolean;
   fiscalYearStartMonth?: number;
+  applyTz?: boolean;
 }
 
 type DateTimeParser<T extends DateTimeOptions = DateTimeOptions> = (value: DateTimeInput, options?: T) => DateTime;

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -1,6 +1,6 @@
 import { map } from 'rxjs/operators';
 
-import { dateTimeParse } from '../../datetime';
+import { DateTimeOptionsWhenParsing, dateTimeParse } from '../../datetime';
 import { SynchronousDataTransformerInfo } from '../../types';
 import { DataFrame, EnumFieldConfig, Field, FieldType } from '../../types/dataFrame';
 import { fieldMatchers } from '../matchers';
@@ -179,12 +179,22 @@ function fieldToBooleanField(field: Field): Field {
   };
 }
 
-function fieldToStringField(field: Field, dateFormat?: string): Field {
+/**
+ * @internal
+ * 
+ * @param field
+ *  A gr
+ * @param dateFormat
+ *  A moment.js date time format string.
+ * @returns 
+ *    A new field with the 
+ */
+export function fieldToStringField(field: Field, dateFormat?: string, parseOptions?: DateTimeOptionsWhenParsing): Field {
   let values = field.values;
 
   switch (field.type) {
     case FieldType.time:
-      values = values.map((v) => dateTimeParse(v).format(dateFormat));
+      values = values.map((v) => dateTimeParse(v, parseOptions).format(dateFormat));
       break;
 
     case FieldType.other:

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -1,5 +1,7 @@
 import { map } from 'rxjs/operators';
 
+import { TimeZone } from '@grafana/schema';
+
 import { DateTimeOptionsWhenParsing, dateTimeParse } from '../../datetime';
 import { SynchronousDataTransformerInfo } from '../../types';
 import { DataFrame, EnumFieldConfig, Field, FieldType } from '../../types/dataFrame';
@@ -25,8 +27,13 @@ export interface ConvertFieldTypeOptions {
    * Date format to parse a string datetime
    */
   dateFormat?: string;
-
-  /** When converting to an enumeration, this is the target config */
+  /**
+   * When converting a date to a string an option timezone. 
+   */
+  timezone?: TimeZone;
+  /** 
+   * When converting to an enumeration, this is the target config
+   */
   enumConfig?: EnumFieldConfig;
 }
 
@@ -36,7 +43,7 @@ export const convertFieldTypeTransformer: SynchronousDataTransformerInfo<Convert
   description: 'Convert a field to a specified field type.',
   defaultOptions: {
     fields: {},
-    conversions: [{ targetField: undefined, destinationType: undefined, dateFormat: undefined }],
+    conversions: [{ targetField: undefined, destinationType: undefined, dateFormat: undefined, timezone: undefined }],
   },
 
   operator: (options, ctx) => (source) =>
@@ -96,7 +103,7 @@ export function convertFieldType(field: Field, opts: ConvertFieldTypeOptions): F
     case FieldType.number:
       return fieldToNumberField(field);
     case FieldType.string:
-      return fieldToStringField(field, opts.dateFormat);
+      return fieldToStringField(field, opts.dateFormat, {timeZone: opts.timezone});
     case FieldType.boolean:
       return fieldToBooleanField(field);
     case FieldType.enum:
@@ -181,13 +188,6 @@ function fieldToBooleanField(field: Field): Field {
 
 /**
  * @internal
- * 
- * @param field
- *  A gr
- * @param dateFormat
- *  A moment.js date time format string.
- * @returns 
- *    A new field with the 
  */
 export function fieldToStringField(field: Field, dateFormat?: string, parseOptions?: DateTimeOptionsWhenParsing): Field {
   let values = field.values;

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -28,10 +28,10 @@ export interface ConvertFieldTypeOptions {
    */
   dateFormat?: string;
   /**
-   * When converting a date to a string an option timezone. 
+   * When converting a date to a string an option timezone.
    */
   timezone?: TimeZone;
-  /** 
+  /**
    * When converting to an enumeration, this is the target config
    */
   enumConfig?: EnumFieldConfig;
@@ -103,7 +103,7 @@ export function convertFieldType(field: Field, opts: ConvertFieldTypeOptions): F
     case FieldType.number:
       return fieldToNumberField(field);
     case FieldType.string:
-      return fieldToStringField(field, opts.dateFormat, {timeZone: opts.timezone});
+      return fieldToStringField(field, opts.dateFormat, { timeZone: opts.timezone });
     case FieldType.boolean:
       return fieldToBooleanField(field);
     case FieldType.enum:
@@ -189,7 +189,11 @@ function fieldToBooleanField(field: Field): Field {
 /**
  * @internal
  */
-export function fieldToStringField(field: Field, dateFormat?: string, parseOptions?: DateTimeOptionsWhenParsing): Field {
+export function fieldToStringField(
+  field: Field,
+  dateFormat?: string,
+  parseOptions?: DateTimeOptionsWhenParsing
+): Field {
   let values = field.values;
 
   switch (field.type) {

--- a/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
@@ -51,11 +51,11 @@ describe('Format Time Transformer', () => {
 
     const newFrame = formatter(frame.fields);
     expect(newFrame[0].values).toEqual([
-      '2021-02 1:46:40 am',
-      '2023-07 2:00:00 pm',
-      '2023-04 3:20:00 pm',
-      '2023-07 5:34:49 pm',
-      '2023-08 3:20:00 pm',
+      '2021-02 6:46:40 am',
+      '2023-07 8:00:00 pm',
+      '2023-04 9:20:00 pm',
+      '2023-07 11:34:49 pm',
+      '2023-08 9:20:00 pm',
     ]);
   });
 
@@ -79,10 +79,10 @@ describe('Format Time Transformer', () => {
 
     const newFrame = formatter(frame.fields);
     expect(newFrame[0].values).toEqual([
-      '2021-02 1:46:40 am',
-      '2023-07 2:00:00 pm',
-      '2023-04 3:20:00 pm',
-      '2023-07 5:34:49 pm',
+      '2021-02 6:46:40 am',
+      '2023-07 8:00:00 pm',
+      '2023-04 9:20:00 pm',
+      '2023-07 11:34:49 pm',
       'Invalid date',
     ]);
   });

--- a/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
@@ -13,10 +13,10 @@ describe('Format Time Transformer', () => {
     const options = {
       timeField: 'time',
       outputFormat: 'YYYY-MM',
-      useTimezone: false,
+      timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.useTimezone);
+    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {
@@ -35,10 +35,10 @@ describe('Format Time Transformer', () => {
     const options = {
       timeField: 'time',
       outputFormat: 'YYYY-MM h:mm:ss a',
-      useTimezone: false,
+      timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.useTimezone);
+    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {
@@ -63,10 +63,10 @@ describe('Format Time Transformer', () => {
     const options = {
       timeField: 'time',
       outputFormat: 'YYYY-MM h:mm:ss a',
-      useTimezone: false,
+      timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.useTimezone);
+    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {

--- a/packages/grafana-data/src/transformations/transformers/formatTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.ts
@@ -1,10 +1,8 @@
-import moment from 'moment-timezone';
 import { map } from 'rxjs/operators';
 
 import { TimeZone } from '@grafana/schema';
 
-import { getTimeZone, getTimeZoneInfo } from '../../datetime';
-import { Field, FieldType } from '../../types';
+import { Field } from '../../types';
 import { DataTransformerInfo } from '../../types/transformations';
 
 import { fieldToStringField } from './convertFieldType';
@@ -13,7 +11,6 @@ import { DataTransformerID } from './ids';
 export interface FormatTimeTransformerOptions {
   timeField: string;
   outputFormat: string;
-  useTimezone: boolean;
   timezone: TimeZone;
 }
 
@@ -46,19 +43,17 @@ export const formatTimeTransformer: DataTransformerInfo<FormatTimeTransformerOpt
  */
 export const createTimeFormatter =
   (timeField: string, outputFormat: string, timezone: string) => (fields: Field[]) => {
-    // const tz = getTimeZone();
-
     return fields.map((field) => {
       // Find the configured field
       if (field.name === timeField) {
         // Update values to use the configured format
-          let formattedField = null;
-          if (timezone) {
-            formattedField = fieldToStringField(field, outputFormat, { timeZone: timezone});
-          }
-          else {
-            formattedField = fieldToStringField(field, outputFormat);
-          }
+        let formattedField = null;
+        if (timezone) {
+          formattedField = fieldToStringField(field, outputFormat, { timeZone: timezone});
+        }
+        else {
+          formattedField = fieldToStringField(field, outputFormat);
+        }
 
         return formattedField;
       }

--- a/packages/grafana-data/src/transformations/transformers/formatTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.ts
@@ -41,23 +41,21 @@ export const formatTimeTransformer: DataTransformerInfo<FormatTimeTransformerOpt
 /**
  * @internal
  */
-export const createTimeFormatter =
-  (timeField: string, outputFormat: string, timezone: string) => (fields: Field[]) => {
-    return fields.map((field) => {
-      // Find the configured field
-      if (field.name === timeField) {
-        // Update values to use the configured format
-        let formattedField = null;
-        if (timezone) {
-          formattedField = fieldToStringField(field, outputFormat, { timeZone: timezone});
-        }
-        else {
-          formattedField = fieldToStringField(field, outputFormat);
-        }
-
-        return formattedField;
+export const createTimeFormatter = (timeField: string, outputFormat: string, timezone: string) => (fields: Field[]) => {
+  return fields.map((field) => {
+    // Find the configured field
+    if (field.name === timeField) {
+      // Update values to use the configured format
+      let formattedField = null;
+      if (timezone) {
+        formattedField = fieldToStringField(field, outputFormat, { timeZone: timezone });
+      } else {
+        formattedField = fieldToStringField(field, outputFormat);
       }
 
-      return field;
-    });
-  };
+      return formattedField;
+    }
+
+    return field;
+  });
+};

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -155,7 +155,7 @@ export const ConvertFieldTypeTransformerEditor = ({
                         width={24}
                       />
                     </InlineField>
-                    <InlineField label="Set timezone" tooltip="">
+                    <InlineField label="Set timezone" tooltip="Set the timezone of the date manually">
                       <Select 
                         options={timeZoneOptions} 
                         value={c.timezone}

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -10,6 +10,7 @@ import {
   TransformerRegistryItem,
   TransformerUIProps,
   TransformerCategory,
+  getTimeZones
 } from '@grafana/data';
 import {
   ConvertFieldTypeOptions,
@@ -31,6 +32,13 @@ export const ConvertFieldTypeTransformerEditor = ({
   onChange,
 }: TransformerUIProps<ConvertFieldTypeTransformerOptions>) => {
   const allTypes = allFieldTypeIconOptions.filter((v) => v.value !== FieldType.trace);
+  const timeZoneOptions: Array<SelectableValue<string>> = [];
+
+  // Format timezone options
+  const tzs = getTimeZones();
+  for (const tz of tzs) {
+    timeZoneOptions.push({ label: tz, value: tz});
+  }
 
   const onSelectField = useCallback(
     (idx: number) => (value: string | undefined) => {
@@ -90,6 +98,16 @@ export const ConvertFieldTypeTransformerEditor = ({
     [onChange, options]
   );
 
+  const onTzChange = useCallback(
+    (idx: number) => (value: SelectableValue<string>) => {
+    const conversions = options.conversions;
+    conversions[idx] = { ...conversions[idx], timezone: value?.value };
+    onChange({
+      ...options,
+      conversions: conversions,
+    });
+  }, [onChange, options]);
+
   return (
     <>
       {options.conversions.map((c: ConvertFieldTypeOptions, idx: number) => {
@@ -128,14 +146,24 @@ export const ConvertFieldTypeTransformerEditor = ({
               )}
               {c.destinationType === FieldType.string &&
                 (c.dateFormat || findField(input?.[0], c.targetField)?.type === FieldType.time) && (
-                  <InlineField label="Date format" tooltip="Specify the output format.">
-                    <Input
-                      value={c.dateFormat}
-                      placeholder={'e.g. YYYY-MM-DD'}
-                      onChange={onInputFormat(idx)}
-                      width={24}
-                    />
-                  </InlineField>
+                  <>
+                    <InlineField label="Date format" tooltip="Specify the output format.">
+                      <Input
+                        value={c.dateFormat}
+                        placeholder={'e.g. YYYY-MM-DD'}
+                        onChange={onInputFormat(idx)}
+                        width={24}
+                      />
+                    </InlineField>
+                    <InlineField label="Set timezone" tooltip="">
+                      <Select 
+                        options={timeZoneOptions} 
+                        value={c.timezone}
+                        onChange={onTzChange(idx)}
+                        isClearable
+                      />
+                    </InlineField>
+                  </>
                 )}
               <Button
                 size="md"

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -10,7 +10,7 @@ import {
   TransformerRegistryItem,
   TransformerUIProps,
   TransformerCategory,
-  getTimeZones
+  getTimeZones,
 } from '@grafana/data';
 import {
   ConvertFieldTypeOptions,
@@ -37,7 +37,7 @@ export const ConvertFieldTypeTransformerEditor = ({
   // Format timezone options
   const tzs = getTimeZones();
   for (const tz of tzs) {
-    timeZoneOptions.push({ label: tz, value: tz});
+    timeZoneOptions.push({ label: tz, value: tz });
   }
 
   const onSelectField = useCallback(
@@ -100,13 +100,15 @@ export const ConvertFieldTypeTransformerEditor = ({
 
   const onTzChange = useCallback(
     (idx: number) => (value: SelectableValue<string>) => {
-    const conversions = options.conversions;
-    conversions[idx] = { ...conversions[idx], timezone: value?.value };
-    onChange({
-      ...options,
-      conversions: conversions,
-    });
-  }, [onChange, options]);
+      const conversions = options.conversions;
+      conversions[idx] = { ...conversions[idx], timezone: value?.value };
+      onChange({
+        ...options,
+        conversions: conversions,
+      });
+    },
+    [onChange, options]
+  );
 
   return (
     <>
@@ -156,12 +158,7 @@ export const ConvertFieldTypeTransformerEditor = ({
                       />
                     </InlineField>
                     <InlineField label="Set timezone" tooltip="Set the timezone of the date manually">
-                      <Select 
-                        options={timeZoneOptions} 
-                        value={c.timezone}
-                        onChange={onTzChange(idx)}
-                        isClearable
-                      />
+                      <Select options={timeZoneOptions} value={c.timezone} onChange={onTzChange(idx)} isClearable />
                     </InlineField>
                   </>
                 )}

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -35,9 +35,11 @@ export const ConvertFieldTypeTransformerEditor = ({
   const timeZoneOptions: Array<SelectableValue<string>> = [];
 
   // Format timezone options
-  const tzs = getTimeZones();
+  const tzs = getTimeZones(true);
   for (const tz of tzs) {
-    timeZoneOptions.push({ label: tz, value: tz });
+    if (tz.length > 0) {
+      timeZoneOptions.push({ label: tz, value: tz });
+    }
   }
 
   const onSelectField = useCallback(

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -22,6 +22,8 @@ import { allFieldTypeIconOptions } from '@grafana/ui/src/components/MatchersUI/F
 import { hasAlphaPanels } from 'app/core/config';
 import { findField } from 'app/features/dimensions';
 
+import { getTimezoneOptions } from '../utils';
+
 const fieldNamePickerSettings = {
   settings: { width: 24, isClearable: false },
 } as StandardEditorsRegistryItem<string, FieldNamePickerConfigSettings>;
@@ -32,14 +34,14 @@ export const ConvertFieldTypeTransformerEditor = ({
   onChange,
 }: TransformerUIProps<ConvertFieldTypeTransformerOptions>) => {
   const allTypes = allFieldTypeIconOptions.filter((v) => v.value !== FieldType.trace);
-  const timeZoneOptions: Array<SelectableValue<string>> = [];
+  const timeZoneOptions: Array<SelectableValue<string>> = getTimezoneOptions(true);
 
   // Format timezone options
-  const tzs = getTimeZones(true);
+  const tzs = getTimeZones();
+  timeZoneOptions.push({ label: 'Browser', value: 'browser' });
+  timeZoneOptions.push({ label: 'UTC', value: 'utc' });
   for (const tz of tzs) {
-    if (tz.length > 0) {
-      timeZoneOptions.push({ label: tz, value: tz });
-    }
+    timeZoneOptions.push({ label: tz, value: tz });
   }
 
   const onSelectField = useCallback(

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -100,7 +100,7 @@ export function FormatTimeTransfomerEditor({
         </InlineField>
         <InlineField
           label="Set Timezone"
-          tooltip="Use a configured value for the timezone."
+          tooltip="Set the timezone of the date manually"
           labelWidth={20}
           >
             <Select 

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -34,7 +34,7 @@ export function FormatTimeTransfomerEditor({
   // Format timezone options
   const tzs = getTimeZones();
   for (const tz of tzs) {
-    timeZoneOptions.push({ label: tz, value: tz});
+    timeZoneOptions.push({ label: tz, value: tz });
   }
 
   const onSelectField = useCallback(
@@ -59,15 +59,16 @@ export function FormatTimeTransfomerEditor({
     [onChange, options]
   );
 
-
   const onTzChange = useCallback(
     (value: SelectableValue<string>) => {
-    const val = value?.value !== undefined ? value.value : '';
-    onChange({
-      ...options,
-      timezone: val,
-    });
-  }, [onChange, options]);
+      const val = value?.value !== undefined ? value.value : '';
+      onChange({
+        ...options,
+        timezone: val,
+      });
+    },
+    [onChange, options]
+  );
 
   return (
     <>
@@ -98,16 +99,8 @@ export function FormatTimeTransfomerEditor({
         >
           <Input onChange={onFormatChange} value={options.outputFormat} />
         </InlineField>
-        <InlineField
-          label="Set Timezone"
-          tooltip="Set the timezone of the date manually"
-          labelWidth={20}
-          >
-            <Select 
-              options={timeZoneOptions} 
-              value={options.timezone} 
-              onChange={onTzChange}
-              isClearable />
+        <InlineField label="Set Timezone" tooltip="Set the timezone of the date manually" labelWidth={20}>
+          <Select options={timeZoneOptions} value={options.timezone} onChange={onTzChange} isClearable />
         </InlineField>
       </InlineFieldRow>
     </>

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -33,7 +33,7 @@ export function FormatTimeTransfomerEditor({
 
   // Format timezone options
   const tzs = getTimeZones(false);
-  
+
   for (const tz of tzs) {
     if (tz.length > 0) {
       timeZoneOptions.push({ label: tz, value: tz });

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -32,7 +32,7 @@ export function FormatTimeTransfomerEditor({
   }
 
   // Format timezone options
-  const tzs = getTimeZones(false);
+  const tzs = getTimeZones(true);
 
   for (const tz of tzs) {
     if (tz.length > 0) {

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -32,9 +32,12 @@ export function FormatTimeTransfomerEditor({
   }
 
   // Format timezone options
-  const tzs = getTimeZones();
+  const tzs = getTimeZones(false);
+  
   for (const tz of tzs) {
-    timeZoneOptions.push({ label: tz, value: tz });
+    if (tz.length > 0) {
+      timeZoneOptions.push({ label: tz, value: tz });
+    }
   }
 
   const onSelectField = useCallback(

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -8,6 +8,7 @@ import {
   TransformerUIProps,
   getFieldDisplayName,
   PluginState,
+  getTimeZones,
 } from '@grafana/data';
 import { FormatTimeTransformerOptions } from '@grafana/data/src/transformations/transformers/formatTime';
 import { Select, InlineFieldRow, InlineField, Input, InlineSwitch } from '@grafana/ui';
@@ -18,6 +19,7 @@ export function FormatTimeTransfomerEditor({
   onChange,
 }: TransformerUIProps<FormatTimeTransformerOptions>) {
   const timeFields: Array<SelectableValue<string>> = [];
+  const timeZoneOptions: Array<SelectableValue<string>> = [];
 
   // Get time fields
   for (const frame of input) {
@@ -27,6 +29,12 @@ export function FormatTimeTransfomerEditor({
         timeFields.push({ label: name, value: name });
       }
     }
+  }
+
+  // Format timezone options
+  const tzs = getTimeZones();
+  for (const tz of tzs) {
+    timeZoneOptions.push({ label: tz, value: tz});
   }
 
   const onSelectField = useCallback(
@@ -55,6 +63,15 @@ export function FormatTimeTransfomerEditor({
     onChange({
       ...options,
       useTimezone: !options.useTimezone,
+    });
+  }, [onChange, options]);
+
+  const onTzChange = useCallback(
+    (value: SelectableValue<string>) => {
+    const val = value?.value !== undefined ? value.value : '';
+    onChange({
+      ...options,
+      timezone: val,
     });
   }, [onChange, options]);
 
@@ -87,12 +104,23 @@ export function FormatTimeTransfomerEditor({
         >
           <Input onChange={onFormatChange} value={options.outputFormat} />
         </InlineField>
-        <InlineField
+        {/* <InlineField
           label="Use Timezone"
           tooltip="Use the user's configured timezone when formatting time."
           labelWidth={20}
         >
           <InlineSwitch value={options.useTimezone} transparent={true} onChange={onUseTzChange} />
+        </InlineField> */}
+        <InlineField
+          label="Set Timezone"
+          tooltip="Use a configured value for the timezone."
+          labelWidth={20}
+          >
+            <Select 
+              options={timeZoneOptions} 
+              value={options.timezone} 
+              onChange={onTzChange}
+              isClearable />
         </InlineField>
       </InlineFieldRow>
     </>

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -8,10 +8,11 @@ import {
   TransformerUIProps,
   getFieldDisplayName,
   PluginState,
-  getTimeZones,
 } from '@grafana/data';
 import { FormatTimeTransformerOptions } from '@grafana/data/src/transformations/transformers/formatTime';
 import { Select, InlineFieldRow, InlineField, Input } from '@grafana/ui';
+
+import { getTimezoneOptions } from '../utils';
 
 export function FormatTimeTransfomerEditor({
   input,
@@ -19,7 +20,7 @@ export function FormatTimeTransfomerEditor({
   onChange,
 }: TransformerUIProps<FormatTimeTransformerOptions>) {
   const timeFields: Array<SelectableValue<string>> = [];
-  const timeZoneOptions: Array<SelectableValue<string>> = [];
+  const timeZoneOptions: Array<SelectableValue<string>> = getTimezoneOptions(true);
 
   // Get time fields
   for (const frame of input) {
@@ -28,15 +29,6 @@ export function FormatTimeTransfomerEditor({
         const name = getFieldDisplayName(field, frame, input);
         timeFields.push({ label: name, value: name });
       }
-    }
-  }
-
-  // Format timezone options
-  const tzs = getTimeZones(true);
-
-  for (const tz of tzs) {
-    if (tz.length > 0) {
-      timeZoneOptions.push({ label: tz, value: tz });
     }
   }
 

--- a/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx
@@ -11,7 +11,7 @@ import {
   getTimeZones,
 } from '@grafana/data';
 import { FormatTimeTransformerOptions } from '@grafana/data/src/transformations/transformers/formatTime';
-import { Select, InlineFieldRow, InlineField, Input, InlineSwitch } from '@grafana/ui';
+import { Select, InlineFieldRow, InlineField, Input } from '@grafana/ui';
 
 export function FormatTimeTransfomerEditor({
   input,
@@ -59,12 +59,6 @@ export function FormatTimeTransfomerEditor({
     [onChange, options]
   );
 
-  const onUseTzChange = useCallback(() => {
-    onChange({
-      ...options,
-      useTimezone: !options.useTimezone,
-    });
-  }, [onChange, options]);
 
   const onTzChange = useCallback(
     (value: SelectableValue<string>) => {
@@ -104,13 +98,6 @@ export function FormatTimeTransfomerEditor({
         >
           <Input onChange={onFormatChange} value={options.outputFormat} />
         </InlineField>
-        {/* <InlineField
-          label="Use Timezone"
-          tooltip="Use the user's configured timezone when formatting time."
-          labelWidth={20}
-        >
-          <InlineSwitch value={options.useTimezone} transparent={true} onChange={onUseTzChange} />
-        </InlineField> */}
         <InlineField
           label="Set Timezone"
           tooltip="Use a configured value for the timezone."

--- a/public/app/features/transformers/utils.ts
+++ b/public/app/features/transformers/utils.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { DataFrame, getFieldDisplayName, TransformerCategory } from '@grafana/data';
+import { DataFrame, getFieldDisplayName, TransformerCategory, SelectableValue, getTimeZones } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 export function useAllFieldNamesFromDataFrames(input: DataFrame[]): string[] {
@@ -61,3 +61,23 @@ export const numberOrVariableValidator = (value: string | number) => {
   }
   return false;
 };
+
+export function getTimezoneOptions(includeInternal: boolean) {
+  const timeZoneOptions: Array<SelectableValue<string>> = [];
+
+  // There are currently only two internal timezones
+  // Browser and UTC. We add the manually to avoid
+  // funky string manipulation.
+  if (includeInternal) {
+    timeZoneOptions.push({ label: 'Browser', value: 'browser' });
+    timeZoneOptions.push({ label: 'UTC', value: 'utc' });
+  }
+
+  // Add all other timezones
+  const tzs = getTimeZones();
+  for (const tz of tzs) {
+    timeZoneOptions.push({ label: tz, value: tz });
+  }
+
+  return timeZoneOptions;
+}


### PR DESCRIPTION
**What is this feature?**

This PR makes the time handling within the Format time and Convert field type transformations use the same underlying functionality (and avoids direct usage of Moment.js in the former). It also adds the ability to manually set the timezone. If not manually set normal Grafana timezone settings will be used.

**Why do we need this feature?**

This makes timezone handling more consistent, and makes transformations more powerful by allowing for multiple ways to handle timezones. This happens automatically by default and can be set manually if desired.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
