### PR TITLE
devenv: postgres: make it work

### DIFF
--- a/devenv/docker/blocks/postgres/docker-compose.yaml
+++ b/devenv/docker/blocks/postgres/docker-compose.yaml
@@ -6,7 +6,7 @@
       POSTGRES_DB: grafana
     ports:
       - "5432:5432"
-    command: postgres -c log_connections=on -c logging_collector=on -c log_destination=stderr -c log_directory=/var/log/postgresql
+    command: postgres -c log_connections=on -c log_disconnections=on -c log_destination=stderr
     healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "grafana", "-U", "grafana" ]
       timeout: 45s


### PR DESCRIPTION
currently `make devenv sources=postgres` does not work. this PR fixes it.

Fixes #75091

NOTES:
1. there is still much to improve on the postgres-devenv, this PR aims to just make it work.
2. the postgres-config-options were added originally in https://github.com/grafana/grafana/commit/a47b31ac62053a59fb27e17bed53367645104e6a , i assume to be able to check that grafana is not connecting/disconnecting too often. i adjusted the line to also log disconnects, not just connects. though, we may want to completely remove this logging in the future, not sure if we still need it.