### PR TITLE
TraceView/TracesPanel: Allow providing custom span link creator function

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -27,7 +27,14 @@ import { useDispatch, useSelector } from 'app/types';
 
 import { changePanelState } from '../state/explorePane';
 
-import { SpanBarOptionsData, Trace, TracePageHeader, TraceTimelineViewer, TTraceTimeline } from './components';
+import {
+  SpanBarOptionsData,
+  SpanLinkFunc,
+  Trace,
+  TracePageHeader,
+  TraceTimelineViewer,
+  TTraceTimeline,
+} from './components';
 import SpanGraph from './components/TracePageHeader/SpanGraph';
 import { TopOfViewRefType } from './components/TraceTimelineViewer/VirtualizedTraceView';
 import { createSpanLinkFactory } from './createSpanLink';
@@ -59,10 +66,18 @@ type Props = {
   datasource: DataSourceApi<DataQuery, DataSourceJsonData, {}> | undefined;
   topOfViewRef: RefObject<HTMLDivElement>;
   topOfViewRefType: TopOfViewRefType;
+  createSpanLink?: SpanLinkFunc;
 };
 
 export function TraceView(props: Props) {
-  const { traceProp, datasource, topOfViewRef, topOfViewRefType, exploreId } = props;
+  const {
+    traceProp,
+    datasource,
+    topOfViewRef,
+    topOfViewRefType,
+    exploreId,
+    createSpanLink: createSpanLinkFromProps,
+  } = props;
 
   const {
     detailStates,
@@ -118,6 +133,7 @@ export function TraceView(props: Props) {
 
   const createSpanLink = useMemo(
     () =>
+      createSpanLinkFromProps ??
       createSpanLinkFactory({
         splitOpenFn: props.splitOpenFn!,
         traceToLogsOptions,
@@ -126,7 +142,15 @@ export function TraceView(props: Props) {
         createFocusSpanLink,
         trace: traceProp,
       }),
-    [props.splitOpenFn, traceToLogsOptions, traceToMetricsOptions, props.dataFrames, createFocusSpanLink, traceProp]
+    [
+      props.splitOpenFn,
+      traceToLogsOptions,
+      traceToMetricsOptions,
+      props.dataFrames,
+      createFocusSpanLink,
+      traceProp,
+      createSpanLinkFromProps,
+    ]
   );
   const timeZone = useSelector((state) => getTimeZone(state.user));
   const datasourceType = datasource ? datasource?.type : 'unknown';

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -5,6 +5,7 @@ import { useAsync } from 'react-use';
 import { PanelProps } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { TraceView } from 'app/features/explore/TraceView/TraceView';
+import { SpanLinkFunc } from 'app/features/explore/TraceView/components';
 import { TopOfViewRefType } from 'app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView';
 import { transformDataFrames } from 'app/features/explore/TraceView/utils/transform';
 
@@ -15,7 +16,11 @@ const styles = {
   `,
 };
 
-export const TracesPanel = ({ data }: PanelProps) => {
+export interface TracesPanelOptions {
+  createSpanLink?: SpanLinkFunc;
+}
+
+export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) => {
   const topOfViewRef = createRef<HTMLDivElement>();
   const traceProp = useMemo(() => transformDataFrames(data.series[0]), [data.series]);
   const dataSource = useAsync(async () => {
@@ -41,6 +46,7 @@ export const TracesPanel = ({ data }: PanelProps) => {
         datasource={dataSource.value}
         topOfViewRef={topOfViewRef}
         topOfViewRefType={TopOfViewRefType.Panel}
+        createSpanLink={options.createSpanLink}
       />
     </div>
   );


### PR DESCRIPTION
:wave: 

App o11y has it's own traces & logs exploration pages for a service that essentially provide a subset of explore functionality, scoped to a particular service. Traces page uses `TracesPanel` with the underlying `TraceView`. We have a need to customize span -> logs link to link to app o11y plugin insted of explore. It seems the most direct way to achieve it is to allow providing a custom `createSpanLink` function to panel and trace view that plugins can use to inject own logs link.

Note: I explored using `field.config.links` instead, but it adds links in addion to the default logs explore link instead of replacing the default logs link.

https://github.com/grafana/grafana/assets/847684/c0a6c394-676e-41aa-8d7c-5a544de3b310

