### PR TITLE
RBAC: Allow the basic role None as option of the org role selector

### DIFF
--- a/public/app/features/admin/OrgRolePicker.tsx
+++ b/public/app/features/admin/OrgRolePicker.tsx
@@ -13,8 +13,7 @@ interface Props {
   width?: number | 'auto';
 }
 
-const basicRoles = Object.values(OrgRole).filter((r) => r !== OrgRole.None);
-const options = basicRoles.map((r) => ({ label: r, value: r }));
+const options = Object.keys(OrgRole).map((key) => ({ label: key, value: key }));
 
 export function OrgRolePicker({ value, onChange, 'aria-label': ariaLabel, inputId, autoFocus, ...restProps }: Props) {
   return (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allows the basic role `None` to be selectable in the org role selector.

**Why do we need this feature?**

We are introducing the `None` basic role in v10.2, so such org role should be an allowed option.

**Which issue(s) does this PR fix?**:

* [Enable the new role None in the UI org role selector](https://github.com/grafana/identity-access-team/issues/403)

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
