### PR TITLE
Dashboard: Minor fixes for TraceQL query editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.1",
     "@grafana/lezer-logql": "0.2.0",
-    "@grafana/lezer-traceql": "0.0.6",
+    "@grafana/lezer-traceql": "0.0.7",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^1.15.0",

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
@@ -65,7 +65,10 @@ describe('Check for syntax errors in query', () => {
     expect(computeErrorMessage(errorNode)).toBe(expectedErrorMessage);
   });
 
-  it.each([['123'], ['abc'], ['1a2b3c']])('valid query - %s', (query: string) => {
-    expect(getErrorNodes(query)).toStrictEqual([]);
-  });
+  it.each([['123'], ['abc'], ['1a2b3c'], ['{span.status = $code}'], ['{span.${attribute} = "GET"}']])(
+    'valid query - %s',
+    (query: string) => {
+      expect(getErrorNodes(query)).toStrictEqual([]);
+    }
+  );
 });

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
@@ -1,6 +1,6 @@
 import { computeErrorMessage, getErrorNodes } from './errorHighlighting';
 
-describe('computeErrorMarkers', () => {
+describe('Check for syntax errors in query', () => {
   it.each([
     ['{span.http.status_code = }', 'Invalid value after comparison or aritmetic operator.'],
     ['{span.http.status_code 200}', 'Invalid comparison operator after field expression.'],
@@ -59,8 +59,13 @@ describe('computeErrorMarkers', () => {
     ['{.foo=300} && {.foo=300} | avg(.value) =', 'Invalid value after comparison operator.'],
     ['{.foo=300} | max(duration) > 1hs', 'Invalid value after comparison operator.'],
     ['{ span.http.status_code', 'Invalid comparison operator after field expression.'],
+    ['abcxyz', 'Invalid query.'],
   ])('error message for invalid query - %s, %s', (query: string, expectedErrorMessage: string) => {
     const errorNode = getErrorNodes(query)[0];
     expect(computeErrorMessage(errorNode)).toBe(expectedErrorMessage);
+  });
+
+  it.each([['123'], ['abc'], ['1a2b3c']])('valid query - %s', (query: string) => {
+    expect(getErrorNodes(query)).toStrictEqual([]);
   });
 });

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
@@ -65,10 +65,14 @@ describe('Check for syntax errors in query', () => {
     expect(computeErrorMessage(errorNode)).toBe(expectedErrorMessage);
   });
 
-  it.each([['123'], ['abc'], ['1a2b3c'], ['{span.status = $code}'], ['{span.${attribute} = "GET"}']])(
-    'valid query - %s',
-    (query: string) => {
-      expect(getErrorNodes(query)).toStrictEqual([]);
-    }
-  );
+  it.each([
+    ['123'],
+    ['abc'],
+    ['1a2b3c'],
+    ['{span.status = $code}'],
+    ['{span.${attribute} = "GET"}'],
+    ['{span.${attribute:format} = ${value:format} }'],
+  ])('valid query - %s', (query: string) => {
+    expect(getErrorNodes(query)).toStrictEqual([]);
+  });
 });

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -70,14 +70,16 @@ export function TraceQLEditor(props: Props) {
         // Register callback for query changes
         editor.onDidChangeModelContent((changeEvent) => {
           const model = editor.getModel();
-          if (!model || model.getValue() === '') {
+
+          if (!model) {
             return;
           }
 
           // Remove previous callback if existing, to prevent squiggles from been shown while the user is still typing
           window.clearTimeout(errorTimeoutId.current);
 
-          const errorNodes = getErrorNodes(model.getValue());
+          const query = model.getValue();
+          const errorNodes = query.trim() !== '' ? getErrorNodes(query) : [];
           const cursorPosition = changeEvent.changes[0].rangeOffset;
 
           // Immediately updates the squiggles, in case the user fixed an error,

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -67,6 +67,13 @@ export function TraceQLEditor(props: Props) {
         }
         setupAutoSize(editor);
 
+        // Parse query that might already exist (e.g., after a page refresh)
+        const model = editor.getModel();
+        if (model) {
+          const errorNodes = getErrorNodes(model.getValue());
+          setErrorMarkers(monaco, model, errorNodes);
+        }
+
         // Register callback for query changes
         editor.onDidChangeModelContent((changeEvent) => {
           const model = editor.getModel();
@@ -78,8 +85,7 @@ export function TraceQLEditor(props: Props) {
           // Remove previous callback if existing, to prevent squiggles from been shown while the user is still typing
           window.clearTimeout(errorTimeoutId.current);
 
-          const query = model.getValue();
-          const errorNodes = query.trim() !== '' ? getErrorNodes(query) : [];
+          const errorNodes = getErrorNodes(model.getValue());
           const cursorPosition = changeEvent.changes[0].rangeOffset;
 
           // Immediately updates the squiggles, in case the user fixed an error,

--- a/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
@@ -89,11 +89,6 @@ export const getErrorNodes = (query: string): SyntaxNode[] => {
     return [];
   }
 
-  // Queries with template variables are not supported yet. Just assume they are correct.
-  if (query.includes('$')) {
-    return [];
-  }
-
   const tree = parser.parse(query);
 
   // Find all error nodes and compute the associated erro boundaries

--- a/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
@@ -89,6 +89,11 @@ export const getErrorNodes = (query: string): SyntaxNode[] => {
     return [];
   }
 
+  // Queries with template variables are not supported yet. Just assume they are correct.
+  if (query.includes('$')) {
+    return [];
+  }
+
   const tree = parser.parse(query);
 
   // Find all error nodes and compute the associated erro boundaries

--- a/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
@@ -78,6 +78,11 @@ export const computeErrorMessage = (errorNode: SyntaxNode) => {
  * @returns the error nodes
  */
 export const getErrorNodes = (query: string): SyntaxNode[] => {
+  // Return immediately if the query is empty, to avoid raising exceptions in processing it
+  if (query.trim() === '') {
+    return [];
+  }
+
   const tree = parser.parse(query);
 
   // Find all error nodes and compute the associated erro boundaries

--- a/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
+++ b/public/app/plugins/datasource/tempo/traceql/errorHighlighting.ts
@@ -83,6 +83,12 @@ export const getErrorNodes = (query: string): SyntaxNode[] => {
     return [];
   }
 
+  // Check whether this is a trace ID or traceQL query by checking if it only contains hex characters
+  const hexOnlyRegex = /^[0-9A-Fa-f]*$/;
+  if (query.trim().match(hexOnlyRegex)) {
+    return [];
+  }
+
   const tree = parser.parse(query);
 
   // Find all error nodes and compute the associated erro boundaries

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,12 +3281,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.6":
-  version: 0.0.6
-  resolution: "@grafana/lezer-traceql@npm:0.0.6"
+"@grafana/lezer-traceql@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@grafana/lezer-traceql@npm:0.0.7"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 166a30c38f4f78e1768e80f724176b71becf3fa51414bc8bea4c2c5288a92d1f8b7872280a06c0d3f7f7608b174e5fc930e1af39339b2c2fdf627fb7ac14c6b4
+  checksum: 920f8116d61907e12ca1dd51949242abf435e675105699c7b2fcd8c024999ed0ddfd3500b1802111f3ed9ad37e16f40826790658bdf94224cd5b615e20360ab9
   languageName: node
   linkType: hard
 
@@ -17642,7 +17642,7 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": 0.1.1
     "@grafana/lezer-logql": 0.2.0
-    "@grafana/lezer-traceql": 0.0.6
+    "@grafana/lezer-traceql": 0.0.7
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": ^1.15.0


### PR DESCRIPTION
This PR provides a few minor fixes:
- Consider empty queries to be valid, since it is accepted by Tempo
- Consider trace IDs to be valid queries
- When refreshing the page, if a query was saved and is shown, parse it to check for errors—now a query is parsed only after the user presses a key
- Do not show errors for template variables