### PR TITLE
[v9.5.x] Chore: Upgrade Go to 1.20.10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -74,7 +74,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-starlark .
@@ -300,7 +300,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -384,7 +384,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -418,7 +418,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: lint-backend
 trigger:
   event:
@@ -474,7 +474,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -861,7 +861,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1028,7 +1028,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build shellcheck
@@ -1247,7 +1247,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1324,7 +1324,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - make gen-go
@@ -1338,7 +1338,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: lint-backend
 - commands:
   - ./bin/build verify-drone
@@ -1392,7 +1392,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1835,7 +1835,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -2132,7 +2132,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -2228,7 +2228,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
@@ -2297,7 +2297,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - yarn install --immutable
@@ -2362,7 +2362,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -2450,13 +2450,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build whatsnew-checker
   depends_on:
   - compile-build-cmd
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: whats-new-checker
 trigger:
   event:
@@ -2558,7 +2558,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2936,7 +2936,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3243,7 +3243,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3930,7 +3930,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.18.3
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.8
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.20.10
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
@@ -3957,7 +3957,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.18.3
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.8
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.20.10
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
@@ -4009,7 +4009,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.8
+  image: golang:1.20.10
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss
@@ -4224,6 +4224,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 25f3043d85f5787a701e913386176fcabb564373dd5236b47788546ba2c29ae9
+hmac: 480d4ce1ba21cc2537b360ae11146f379cee7d89b7f96d8d0caabdf8032ed3fc
 
 ...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.8'
+        go-version: '1.20.10'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.8'
+        go-version: '1.20.10'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=alpine:3.18.3
 ARG JS_IMAGE=node:18-alpine3.18
 ARG JS_PLATFORM=linux/amd64
-ARG GO_IMAGE=golang:1.20.8-alpine3.18
+ARG GO_IMAGE=golang:1.20.10-alpine3.18
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg COMMIT_SHA=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
-	--build-arg GO_IMAGE=golang:1.20.8 \
+	--build-arg GO_IMAGE=golang:1.20.10 \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (LTS into 2024) in order to ensure binary compatibility with older glibc's.
 FROM debian:buster-20220822
 
-ENV GOVERSION=1.20.8 \
+ENV GOVERSION=1.20.10 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=18.12.0-1nodesource1 \

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -8,7 +8,7 @@ images = {
     "publish_image": "grafana/grafana-ci-deploy:1.3.3",
     "alpine_image": "alpine:3.18.3",
     "curl_image": "byrnedo/alpine-curl:0.1.8",
-    "go_image": "golang:1.20.8",
+    "go_image": "golang:1.20.10",
     "plugins_slack_image": "plugins/slack",
     "postgres_alpine_image": "postgres:12.3-alpine",
     "mysql5_image": "mysql:5.7.39",


### PR DESCRIPTION
Backport 428768642092392c2da32a4bcee1b2e0a3f5ca6d from #76355

---

Note that this is not a backport from main as main currently looks totally different and so we take v10.1.x as starting point for the rest of the backport
