### PR TITLE
TooltipPlugin2: Raise parent grid item z-index when pinned

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1092,6 +1092,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "packages/grafana-ui/src/components/uPlot/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -126,10 +126,11 @@ export const TooltipPlugin2 = ({ config, render }: TooltipPlugin2Props) => {
       }
     };
 
-    const mousedownOutside = (e: MouseEvent) => {
-      let clickedOutside = (e.target as HTMLDivElement).closest(`.${styles.tooltipWrapper}`) !== domRef.current;
+    // in some ways this is similar to ClickOutsideWrapper.tsx
+    const downEventOutside = (e: Event) => {
+      let isOutside = (e.target as HTMLDivElement).closest(`.${styles.tooltipWrapper}`) !== domRef.current;
 
-      if (clickedOutside) {
+      if (isOutside) {
         dismiss();
       }
     };
@@ -146,9 +147,11 @@ export const TooltipPlugin2 = ({ config, render }: TooltipPlugin2Props) => {
         _plot!.cursor._lock = _isPinned;
 
         if (_isPinned) {
-          document.addEventListener('mousedown', mousedownOutside, true);
+          document.addEventListener('mousedown', downEventOutside, true);
+          document.addEventListener('keydown', downEventOutside, true);
         } else {
-          document.removeEventListener('mousedown', mousedownOutside, true);
+          document.removeEventListener('mousedown', downEventOutside, true);
+          document.removeEventListener('keydown', downEventOutside, true);
         }
 
         pendingPinned = false;

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -281,7 +281,7 @@ export const TooltipPlugin2 = ({ config, render }: TooltipPlugin2Props) => {
   if (plot && isHovering) {
     return createPortal(
       <div className={styles.tooltipWrapper} style={style} ref={domRef}>
-        {isPinned && <CloseButton onClick={dismiss} style={{ top: '15px' }} />}
+        {isPinned && <CloseButton onClick={dismiss} style={{ top: '16px' }} />}
         {contents}
       </div>,
       plot.over

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -305,5 +305,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: 'absolute',
     background: theme.colors.background.secondary,
     boxShadow: `0 4px 8px ${theme.colors.background.primary}`,
+    userSelect: 'text',
   }),
 });

--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -87,7 +87,7 @@
 }
 
 // Hack to prevent panel overlap during drag/hover (due to descending z-index assignment)
-.react-grid-item {
+.react-grid-item:not(.context-menu-open) {
   &:hover,
   &:active,
   &:focus {
@@ -96,10 +96,11 @@
 }
 
 // Hack for preventing panel menu overlapping.
+.react-grid-item.context-menu-open,
 .react-grid-item.resizing.panel,
 .react-grid-item.panel.dropdown-menu-open,
 .react-grid-item.react-draggable-dragging.panel {
-  z-index: $zindex-dropdown;
+  z-index: $zindex-dropdown !important;
 }
 
 // Disable animation on initial rendering and enable it when component has been mounted.

--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -87,7 +87,7 @@
 }
 
 // Hack to prevent panel overlap during drag/hover (due to descending z-index assignment)
-.react-grid-item:not(.context-menu-open) {
+.react-grid-item:not(.context-menu-open, .resizing) {
   &:hover,
   &:active,
   &:focus {
@@ -97,6 +97,7 @@
 
 // Hack for preventing panel menu overlapping.
 .react-grid-item.context-menu-open,
+.react-grid-item.resizing,
 .react-grid-item.resizing.panel,
 .react-grid-item.panel.dropdown-menu-open,
 .react-grid-item.react-draggable-dragging.panel {


### PR DESCRIPTION
ok, couple things going on here:

- in a dashboard grid, ensures that panels containing pinned context menus which extend beyond the panel bounds are drawn over adjacent panels even when not hovered. before this PR:

  https://github.com/grafana/grafana/assets/43234/e4de1e26-0fba-45dd-9e21-93b83b6ebebe

- with this PR we automatically unpin when there is a mousedown or mouseup outside the pinned menu container. it's similar to what [ClickOutsideWrapper.tsx](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx) does. this prevents a bunch of bug related to positioning and z-index bug when resizing panels with pinned items, or entering panel edit when a pinned menu exists.
- general refactoring/simplification of TooltipPlugin2 to prepare it for merging in of ZoomPlugin, AnnotationEditorPlugin, and PlotTooltipInterpolator