### PR TITLE
Feature Management: Update admin page UI after a successful update

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -430,6 +430,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		if hs.Features.IsEnabled(featuremgmt.FlagFeatureToggleAdminPage) {
 			apiRoute.Group("/featuremgmt", func(featuremgmtRoute routing.RouteRegister) {
+				featuremgmtRoute.Get("/state", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.GetFeatureMgmtState)
 				featuremgmtRoute.Get("/", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.GetFeatureToggles)
 				featuremgmtRoute.Post("/", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), hs.UpdateFeatureToggle)
 			})

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -78,7 +78,14 @@ func (hs *HTTPServer) UpdateFeatureToggle(ctx *contextmodel.ReqContext) response
 		return response.Respond(http.StatusBadRequest, "Failed to perform webhook request")
 	}
 
+	hs.Features.SetRestartRequired()
+
 	return response.Respond(http.StatusOK, "feature toggles updated successfully")
+}
+
+func (hs *HTTPServer) GetFeatureMgmtState(ctx *contextmodel.ReqContext) response.Response {
+	fmState := hs.Features.GetState()
+	return response.Respond(http.StatusOK, fmState)
 }
 
 // isFeatureHidden returns whether a toggle should be hidden from the admin page.

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -14,13 +14,14 @@ var (
 )
 
 type FeatureManager struct {
-	isDevMod  bool
-	licensing licensing.Licensing
-	flags     map[string]*FeatureFlag
-	enabled   map[string]bool // only the "on" values
-	config    string          // path to config file
-	vars      map[string]any
-	log       log.Logger
+	isDevMod        bool
+	restartRequired bool
+	licensing       licensing.Licensing
+	flags           map[string]*FeatureFlag
+	enabled         map[string]bool // only the "on" values
+	config          string          // path to config file
+	vars            map[string]any
+	log             log.Logger
 }
 
 // This will merge the flags with the current configuration
@@ -146,6 +147,14 @@ func (fm *FeatureManager) GetFlags() []FeatureFlag {
 		v = append(v, *value)
 	}
 	return v
+}
+
+func (fm *FeatureManager) GetState() *FeatureManagerState {
+	return &FeatureManagerState{RestartRequired: fm.restartRequired}
+}
+
+func (fm *FeatureManager) SetRestartRequired() {
+	fm.restartRequired = true
 }
 
 // Check to see if a feature toggle exists by name

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -127,3 +127,7 @@ type FeatureToggleDTO struct {
 	Enabled     bool   `json:"enabled"`
 	ReadOnly    bool   `json:"readOnly,omitempty"`
 }
+
+type FeatureManagerState struct {
+	RestartRequired bool `json:"restartRequired"`
+}

--- a/public/app/features/admin/AdminFeatureTogglesAPI.ts
+++ b/public/app/features/admin/AdminFeatureTogglesAPI.ts
@@ -30,6 +30,9 @@ export const togglesApi = createApi({
   reducerPath: 'togglesApi',
   baseQuery: backendSrvBaseQuery({ baseUrl: '/api' }),
   endpoints: (builder) => ({
+    getManagerState: builder.query<FeatureMgmtState, void>({
+      query: () => ({ url: '/featuremgmt/state' }),
+    }),
     getFeatureToggles: builder.query<FeatureToggle[], void>({
       query: () => ({ url: '/featuremgmt' }),
     }),
@@ -50,5 +53,9 @@ type FeatureToggle = {
   readOnly?: boolean;
 };
 
-export const { useGetFeatureTogglesQuery, useUpdateFeatureTogglesMutation } = togglesApi;
-export type { FeatureToggle };
+type FeatureMgmtState = {
+  restartRequired: boolean;
+};
+
+export const { useGetManagerStateQuery, useGetFeatureTogglesQuery, useUpdateFeatureTogglesMutation } = togglesApi;
+export type { FeatureToggle, FeatureMgmtState };

--- a/public/app/features/admin/AdminFeatureTogglesPage.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesPage.tsx
@@ -71,6 +71,6 @@ function getStyles(theme: GrafanaTheme2) {
     message: css({
       color: theme.colors.text.secondary,
       marginTop: theme.spacing(0.25),
-    })
+    }),
   };
 }

--- a/public/app/features/admin/AdminFeatureTogglesPage.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesPage.tsx
@@ -29,15 +29,11 @@ export default function AdminFeatureTogglesPage() {
         <div className={styles.icon}>
           <Icon name="exclamation-triangle" />
         </div>
-        {featureMgmtState?.restartRequired || updateSuccessful ? (
-          <span className={styles.message}>
-            A restart is pending for your Grafana instance to apply the latest feature toggle changes
-          </span>
-        ) : (
-          <span className={styles.message}>
-            Saving feature toggle changes will prompt a restart of the instance, which may take a few minutes
-          </span>
-        )}
+        <span className={styles.message}>
+          {featureMgmtState?.restartRequired || updateSuccessful
+            ? 'A restart is pending for your Grafana instance to apply the latest feature toggle changes'
+            : 'Saving feature toggle changes will prompt a restart of the instance, which may take a few minutes'}
+        </span>
       </div>
     );
   };

--- a/public/app/features/admin/AdminFeatureTogglesPage.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Icon } from '@grafana/ui';
@@ -21,7 +21,7 @@ export default function AdminFeatureTogglesPage() {
 
   const handleUpdateSuccess = () => {
     setUpdateSuccessful(true);
-  }
+  };
 
   const AlertMessage = () => {
     return (
@@ -30,9 +30,13 @@ export default function AdminFeatureTogglesPage() {
           <Icon name="exclamation-triangle" />
         </div>
         {featureMgmtState?.restartRequired || updateSuccessful ? (
-          <span className={styles.message}>A restart is pending for your Grafana instance to apply the latest feature toggle changes</span>
+          <span className={styles.message}>
+            A restart is pending for your Grafana instance to apply the latest feature toggle changes
+          </span>
         ) : (
-          <span className={styles.message}>Saving feature toggle changes will prompt a restart of the instance, which may take a few minutes</span>
+          <span className={styles.message}>
+            Saving feature toggle changes will prompt a restart of the instance, which may take a few minutes
+          </span>
         )}
       </div>
     );
@@ -45,7 +49,9 @@ export default function AdminFeatureTogglesPage() {
           {isError && getErrorMessage()}
           {isLoading && 'Fetching feature toggles'}
           <AlertMessage />
-          {featureToggles && <AdminFeatureTogglesTable featureToggles={featureToggles} onUpdateSuccess={handleUpdateSuccess}/>}
+          {featureToggles && (
+            <AdminFeatureTogglesTable featureToggles={featureToggles} onUpdateSuccess={handleUpdateSuccess} />
+          )}
         </>
       </Page.Contents>
     </Page>
@@ -54,17 +60,17 @@ export default function AdminFeatureTogglesPage() {
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    warning: css`
-      display: flex;
-      margin-top: ${theme.spacing(3)};
-    `,
-    icon: css`
-      color: ${theme.colors.warning.main};
-      padding-right: ${theme.spacing()};
-  `,
-    message: css`
-    color: ${theme.colors.text.secondary};
-    margin-top: ${theme.spacing(0.25)};
-  `,
+    warning: css({
+      display: 'flex',
+      marginTop: theme.spacing(3),
+    }),
+    icon: css({
+      color: theme.colors.warning.main,
+      paddingRight: theme.spacing(),
+    }),
+    message: css({
+      color: theme.colors.text.secondary,
+      marginTop: theme.spacing(0.25),
+    })
   };
 }

--- a/public/app/features/admin/AdminFeatureTogglesPage.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesPage.tsx
@@ -1,15 +1,41 @@
-import React from 'react';
+import { css } from '@emotion/css';
+import React, {useState} from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Icon } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
-import { useGetFeatureTogglesQuery } from './AdminFeatureTogglesAPI';
+import { useGetFeatureTogglesQuery, useGetManagerStateQuery } from './AdminFeatureTogglesAPI';
 import { AdminFeatureTogglesTable } from './AdminFeatureTogglesTable';
 
 export default function AdminFeatureTogglesPage() {
   const { data: featureToggles, isLoading, isError } = useGetFeatureTogglesQuery();
+  const { data: featureMgmtState } = useGetManagerStateQuery();
+  const [updateSuccessful, setUpdateSuccessful] = useState(false);
+
+  const styles = useStyles2(getStyles);
 
   const getErrorMessage = () => {
     return 'Error fetching feature toggles';
+  };
+
+  const handleUpdateSuccess = () => {
+    setUpdateSuccessful(true);
+  }
+
+  const AlertMessage = () => {
+    return (
+      <div className={styles.warning}>
+        <div className={styles.icon}>
+          <Icon name="exclamation-triangle" />
+        </div>
+        {featureMgmtState?.restartRequired || updateSuccessful ? (
+          <span className={styles.message}>A restart is pending for your Grafana instance to apply the latest feature toggle changes</span>
+        ) : (
+          <span className={styles.message}>Saving feature toggle changes will prompt a restart of the instance, which may take a few minutes</span>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -18,9 +44,27 @@ export default function AdminFeatureTogglesPage() {
         <>
           {isError && getErrorMessage()}
           {isLoading && 'Fetching feature toggles'}
-          {featureToggles && <AdminFeatureTogglesTable featureToggles={featureToggles} />}
+          <AlertMessage />
+          {featureToggles && <AdminFeatureTogglesTable featureToggles={featureToggles} onUpdateSuccess={handleUpdateSuccess}/>}
         </>
       </Page.Contents>
     </Page>
   );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    warning: css`
+      display: flex;
+      margin-top: ${theme.spacing(3)};
+    `,
+    icon: css`
+      color: ${theme.colors.warning.main};
+      padding-right: ${theme.spacing()};
+  `,
+    message: css`
+    color: ${theme.colors.text.secondary};
+    margin-top: ${theme.spacing(0.25)};
+  `,
+  };
 }

--- a/public/app/features/admin/AdminFeatureTogglesTable.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesTable.tsx
@@ -111,8 +111,8 @@ export function AdminFeatureTogglesTable({ featureToggles, onUpdateSuccess }: Pr
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0 0 5px 0' }}>
-        <Button disabled={!hasModifications() || isSaving } onClick={handleSaveChanges}>
-          { isSaving ? 'Saving...' : 'Save Changes' }
+        <Button disabled={!hasModifications() || isSaving} onClick={handleSaveChanges}>
+          {isSaving ? 'Saving...' : 'Save Changes'}
         </Button>
       </div>
       <InteractiveTable columns={columns} data={localToggles} getRowId={(featureToggle) => featureToggle.name} />

--- a/public/app/features/admin/AdminFeatureTogglesTable.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesTable.tsx
@@ -6,6 +6,7 @@ import { type FeatureToggle, useUpdateFeatureTogglesMutation } from './AdminFeat
 
 interface Props {
   featureToggles: FeatureToggle[];
+  onUpdateSuccess: () => void;
 }
 
 const sortByName: SortByFn<FeatureToggle> = (a, b) => {
@@ -27,10 +28,11 @@ const sortByEnabled: SortByFn<FeatureToggle> = (a, b) => {
   return a.original.enabled === b.original.enabled ? 0 : a.original.enabled ? 1 : -1;
 };
 
-export function AdminFeatureTogglesTable({ featureToggles }: Props) {
+export function AdminFeatureTogglesTable({ featureToggles, onUpdateSuccess }: Props) {
   const [localToggles, setLocalToggles] = useState<FeatureToggle[]>(featureToggles);
   const [updateFeatureToggles] = useUpdateFeatureTogglesMutation();
   const [modifiedToggles, setModifiedToggles] = useState<FeatureToggle[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleToggleChange = (toggle: FeatureToggle, newValue: boolean) => {
     const updatedToggle = { ...toggle, enabled: newValue };
@@ -56,10 +58,16 @@ export function AdminFeatureTogglesTable({ featureToggles }: Props) {
   };
 
   const handleSaveChanges = async () => {
-    const resp = await updateFeatureToggles(modifiedToggles);
-    // Reset modifiedToggles after successful update
-    if (!('error' in resp)) {
-      setModifiedToggles([]);
+    setIsSaving(true);
+    try {
+      const resp = await updateFeatureToggles(modifiedToggles);
+      // Reset modifiedToggles after successful update
+      if (!('error' in resp)) {
+        onUpdateSuccess();
+        setModifiedToggles([]);
+      }
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -103,8 +111,8 @@ export function AdminFeatureTogglesTable({ featureToggles }: Props) {
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0 0 5px 0' }}>
-        <Button disabled={!hasModifications()} onClick={handleSaveChanges}>
-          Save Changes
+        <Button disabled={!hasModifications() || isSaving } onClick={handleSaveChanges}>
+          { isSaving ? 'Saving...' : 'Save Changes' }
         </Button>
       </div>
       <InteractiveTable columns={columns} data={localToggles} getRowId={(featureToggle) => featureToggle.name} />


### PR DESCRIPTION
**What is this feature?**

The feature management admin page allows admin users to view a list of feature toggles and their status on their grafana instance.
This is a UI update to inform the user about a successful update.

**Why do we need this feature?**

Users can see and update their instance feature toggles, and they need to know about it requiring an instance restart. 

**Who is this feature for?**

Grafana Administrators

**Which issue(s) does this PR fix?:**
https://github.com/grafana/grafana/issues/75294

https://github.com/grafana/grafana/assets/13890524/fd97295f-f773-4563-ae5e-407e3500709a
