### PR TITLE
Alerting: Enable Insights landing page

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -49,6 +49,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `azureMonitorDataplane`                          | Adds dataplane compliant frame metadata in the Azure Monitor datasource                                                                                                                             | Yes                |
 | `prometheusConfigOverhaulAuth`                   | Update the Prometheus configuration page with the new auth component                                                                                                                                | Yes                |
 | `newBrowseDashboards`                            | New browse/manage dashboards UI                                                                                                                                                                     | Yes                |
+| `alertingInsights`                               | Show the new alerting insights landing page                                                                                                                                                         | Yes                |
 | `cloudWatchWildCardDimensionValues`              | Fetches dimension values from CloudWatch to correctly label wildcard dimensions                                                                                                                     | Yes                |
 
 ## Preview feature toggles
@@ -137,7 +138,6 @@ Experimental features might be changed or removed without prior notice.
 | `sseGroupByDatasource`                      | Send query to the same datasource in a single request when using server side expressions                     |
 | `requestInstrumentationStatusSource`        | Include a status source label for request metrics and logs                                                   |
 | `wargamesTesting`                           | Placeholder feature flag for internal testing                                                                |
-| `alertingInsights`                          | Show the new alerting insights landing page                                                                  |
 | `externalCorePlugins`                       | Allow core plugins to be loaded as external                                                                  |
 | `pluginsAPIMetrics`                         | Sends metrics of public grafana packages usage by plugins                                                    |
 | `httpSLOLevels`                             | Adds SLO level to http request metrics                                                                       |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -766,6 +766,7 @@ var (
 			FrontendOnly: true,
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaAlertingSquad,
+			Expression:   "true", // enabled by default
 		},
 		{
 			Name:        "externalCorePlugins",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -764,7 +764,7 @@ var (
 			Name:         "alertingInsights",
 			Description:  "Show the new alerting insights landing page",
 			FrontendOnly: true,
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStageGeneralAvailability,
 			Owner:        grafanaAlertingSquad,
 			Expression:   "true", // enabled by default
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -108,7 +108,7 @@ sseGroupByDatasource,experimental,@grafana/observability-metrics,false,false,fal
 requestInstrumentationStatusSource,experimental,@grafana/plugins-platform-backend,false,false,false,false
 lokiRunQueriesInParallel,privatePreview,@grafana/observability-logs,false,false,false,false
 wargamesTesting,experimental,@grafana/hosted-grafana-team,false,false,false,false
-alertingInsights,experimental,@grafana/alerting-squad,false,false,false,true
+alertingInsights,GA,@grafana/alerting-squad,false,false,false,true
 externalCorePlugins,experimental,@grafana/plugins-platform-backend,false,false,false,false
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,false,false,false,true
 httpSLOLevels,experimental,@grafana/hosted-grafana-team,false,false,true,false


### PR DESCRIPTION
**What is this feature?**

Sets the landing page feature flag to true by default, which will make it show for cloud users when landing in `/alerting`

**Why do we need this feature?**

In order to ship the insights landing page to cloud users.

**Who is this feature for?**

All cloud users.

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/alerting-squad/issues/272

<img width="1460" alt="image" src="https://github.com/grafana/grafana/assets/6271380/fb575146-b216-4ac8-8e4a-710f8a6ab774">

