### PR TITLE
Chore: Remove legacy form from InfluxConfigEditor

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
   updateDatasourcePluginJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data/src';
-import { Alert, DataSourceHttpSettings, InlineField, LegacyForms, Select } from '@grafana/ui/src';
+import { Alert, DataSourceHttpSettings, InlineField, Select, Field, Input, FieldSet } from '@grafana/ui/src';
 import { config } from 'app/core/config';
 
 import { BROWSER_MODE_DISABLED_MESSAGE } from '../../../constants';
@@ -17,8 +17,6 @@ import { InfluxOptions, InfluxOptionsV1, InfluxVersion } from '../../../types';
 import { InfluxFluxConfig } from './InfluxFluxConfig';
 import { InfluxInfluxQLConfig } from './InfluxInfluxQLConfig';
 import { InfluxSqlConfig } from './InfluxSQLConfig';
-
-const { Input } = LegacyForms;
 
 const versions: Array<SelectableValue<InfluxVersion>> = [
   {
@@ -131,21 +129,19 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
     return (
       <>
-        <h3 className="page-heading">Query Language</h3>
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <Select
-                aria-label="Query language"
-                className="width-30"
-                value={this.getQueryLanguageDropdownValue(options.jsonData.version)}
-                options={config.featureToggles.influxdbSqlSupport ? versionsWithSQL : versions}
-                defaultValue={versions[0]}
-                onChange={this.onVersionChanged}
-              />
-            </div>
-          </div>
-        </div>
+        <FieldSet>
+          <h3 className="page-heading">Query language</h3>
+          <Field>
+            <Select
+              aria-label="Query language"
+              className="width-30"
+              value={this.getQueryLanguageDropdownValue(options.jsonData.version)}
+              options={config.featureToggles.influxdbSqlSupport ? versionsWithSQL : versions}
+              defaultValue={versions[0]}
+              onChange={this.onVersionChanged}
+            />
+          </Field>
+        </FieldSet>
 
         {options.jsonData.version !== InfluxVersion.InfluxQL && (
           <Alert severity="info" title={this.versionNotice[options.jsonData.version!]}>
@@ -171,34 +167,29 @@ export class ConfigEditor extends PureComponent<Props, State> {
           onChange={onOptionsChange}
           secureSocksDSProxyEnabled={config.secureSocksDSProxyEnabled}
         />
-
-        <div className="gf-form-group">
-          <div>
-            <h3 className="page-heading">InfluxDB Details</h3>
-          </div>
+        <FieldSet>
+          <h3 className="page-heading">InfluxDB Details</h3>
           {this.renderJsonDataOptions()}
-          <div className="gf-form-inline">
-            <InlineField
-              labelWidth={20}
-              label="Max series"
-              tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
-            >
-              <Input
-                placeholder="1000"
-                type="number"
-                className="width-20"
-                value={this.state.maxSeries}
-                onChange={(event) => {
-                  // We duplicate this state so that we allow to write freely inside the input. We don't have
-                  // any influence over saving so this seems to be only way to do this.
-                  this.setState({ maxSeries: event.currentTarget.value });
-                  const val = parseInt(event.currentTarget.value, 10);
-                  updateDatasourcePluginJsonDataOption(this.props, 'maxSeries', Number.isFinite(val) ? val : undefined);
-                }}
-              />
-            </InlineField>
-          </div>
-        </div>
+          <InlineField
+            labelWidth={20}
+            label="Max series"
+            tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
+          >
+            <Input
+              placeholder="1000"
+              type="number"
+              className="width-20"
+              value={this.state.maxSeries}
+              onChange={(event: { currentTarget: { value: string } }) => {
+                // We duplicate this state so that we allow to write freely inside the input. We don't have
+                // any influence over saving so this seems to be only way to do this.
+                this.setState({ maxSeries: event.currentTarget.value });
+                const val = parseInt(event.currentTarget.value, 10);
+                updateDatasourcePluginJsonDataOption(this.props, 'maxSeries', Number.isFinite(val) ? val : undefined);
+              }}
+            />
+          </InlineField>
+        </FieldSet>
       </>
     );
   }


### PR DESCRIPTION
With this commit, legacy form components are remvoed from influxdb config eidtor page. Form is now using FieldSet instead.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removing the legacy form from the core components listed in https://github.com/grafana/grafana/issues/76107

**Why do we need this feature?**

As per the ticket https://github.com/grafana/grafana/issues/76107, these are meant to be replaced with its modern replacement.

**Who is this feature for?**

Dev

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #76107 #65513

**Special notes for your reviewer:**

**Screenshot (Before)**
<img width="1222" alt="Screenshot 2023-10-11 at 20 47 17" src="https://github.com/grafana/grafana/assets/25004086/5c31c403-0419-4e98-946a-ac19f66a5d40">
<img width="1223" alt="Screenshot 2023-10-11 at 20 47 06" src="https://github.com/grafana/grafana/assets/25004086/ac144312-f321-4a83-b161-4f0ced352428">
<img width="1223" alt="Screenshot 2023-10-11 at 20 46 53" src="https://github.com/grafana/grafana/assets/25004086/96c3aa96-86cc-437a-aba5-9ddb8c018821">

**Screenshot (After)**
<img width="1241" alt="Screenshot 2023-10-11 at 20 48 54" src="https://github.com/grafana/grafana/assets/25004086/edf005bf-274d-48f8-9702-7e5fb881fbaa">
<img width="1240" alt="Screenshot 2023-10-11 at 20 48 45" src="https://github.com/grafana/grafana/assets/25004086/89f620c5-d6e3-451e-b692-94ba55403023">
<img width="1233" alt="Screenshot 2023-10-11 at 20 48 37" src="https://github.com/grafana/grafana/assets/25004086/a8ef08dd-cdbb-49ef-83c1-b23af51bf16a">


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
