### PR TITLE
Chore: Improve EchoSrv logging

### DIFF
--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -31,7 +31,7 @@ export const createLogger = (name: string): Logger => {
         return;
       }
       const fn = throttle ? throttledLog : console.log;
-      fn(`[${name}: ${id}]: `, ...t);
+      fn(`[${name}: ${id}]:`, ...t);
     },
     enable: () => (loggingEnabled = true),
     disable: () => (loggingEnabled = false),

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -19,17 +19,22 @@ export interface Logger {
 
 /** @internal */
 export const createLogger = (name: string): Logger => {
-  let LOGGIN_ENABLED = false;
+  let loggingEnabled = false;
+
+  if (typeof window !== 'undefined') {
+    loggingEnabled = window.localStorage.getItem('grafana.debug') === 'true';
+  }
+
   return {
     logger: (id: string, throttle = false, ...t: any[]) => {
-      if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !LOGGIN_ENABLED) {
+      if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !loggingEnabled) {
         return;
       }
       const fn = throttle ? throttledLog : console.log;
       fn(`[${name}: ${id}]: `, ...t);
     },
-    enable: () => (LOGGIN_ENABLED = true),
-    disable: () => (LOGGIN_ENABLED = false),
-    isEnabled: () => LOGGIN_ENABLED,
+    enable: () => (loggingEnabled = true),
+    disable: () => (loggingEnabled = false),
+    isEnabled: () => loggingEnabled,
   };
 };

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -59,7 +59,11 @@ export class Echo implements EchoSrv {
         backend.addEvent(_event);
       }
     }
-    echoLog('Reporting event', false, _event);
+
+    echoLog(`${event.type} event`, false, {
+      ...event.payload,
+      meta: _event.meta,
+    });
   };
 
   getMeta = (): EchoMeta => {


### PR DESCRIPTION
It's hard to locally test interaction reporting - people usually resort to manually adding console.logs to the code and hope they remember to remove them. 

There's an easier way. Turns out we already have a way to log them to the console, but it could do with a bit of polish to make it easier to use:

 - frontend logging is now enabled (logged to the console) by setting a local storage item `grafana.debug` to `true`. At the moment this is only available during local development.
 - improved output of the echo srv logging to make it easier to glance at
![image](https://github.com/grafana/grafana/assets/46142/de4a589a-eb71-445a-b966-dfd0184125d3)
