### PR TITLE
Prometheus: Fix config bug for sigv4 auth

### DIFF
--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -46,6 +46,7 @@ export interface PromOptions extends DataSourceJsonData {
   incrementalQueryOverlapWindow?: string;
   disableRecordingRules?: boolean;
   sigV4Auth?: boolean;
+  oauthPassThru?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/7809

**What is this fix?**
Allow users to select other methods than sigV4 in the Prometheus configuration page.


**Why do we need this feature?**
We need to set the sigV4 auth selection correctly and not mutate the jsonData. Running Grafana locally you can mutate the data but we are getting this error in cloud.
<img width="483" alt="Screenshot 2023-10-11 at 4 20 08 PM" src="https://github.com/grafana/grafana/assets/25674746/a37ac38f-afa0-4670-98a0-6f027a29c04d">


**Who is this feature for?**
Users with the `sigv4_auth_enabled` toggle turned on.

Notes for reviewers
Turn on the feature toggle `sigv4_auth_enabled`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
