### PR TITLE
Alerting: Add support for msteams contact point in external Alertmanagers

### DIFF
--- a/docs/sources/alerting/fundamentals/contact-points/index.md
+++ b/docs/sources/alerting/fundamentals/contact-points/index.md
@@ -47,7 +47,7 @@ The following table lists the contact point integrations supported by Grafana.
 | [Google Chat](https://chat.google.com/)          | `googlechat`              | Supported            | N/A                                                                                                      |
 | [Kafka](https://kafka.apache.org/)               | `kafka`                   | Supported            | N/A                                                                                                      |
 | [Line](https://line.me/en/)                      | `line`                    | Supported            | N/A                                                                                                      |
-| [Microsoft Teams](https://teams.microsoft.com/)  | `teams`                   | Supported            | N/A                                                                                                      |
+| [Microsoft Teams](https://teams.microsoft.com/)  | `teams`                   | Supported            | Supported                                                                                                |
 | [Opsgenie](https://atlassian.com/opsgenie/)      | `opsgenie`                | Supported            | Supported                                                                                                |
 | [Pagerduty](https://www.pagerduty.com/)          | `pagerduty`               | Supported            | Supported                                                                                                |
 | [Prometheus Alertmanager](https://prometheus.io) | `prometheus-alertmanager` | Supported            | N/A                                                                                                      |

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -491,6 +491,22 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
       }),
     ],
   },
+  {
+    name: 'Microsoft Teams',
+    description: 'Sends notifications to Microsoft Teams',
+    type: 'msteams',
+    info: '',
+    heading: 'Microsoft Teams settings',
+    options: [
+      option('webhook_url', 'Webhook URL', 'The incoming webhook URL.'),
+      option('title', 'Title', 'Message title template.', {
+        placeholder: '{{ template "teams.default.title" . }}',
+      }),
+      option('text', 'Text', 'Message body template.', {
+        placeholder: '{{ template "teams.default.text" . }}',
+      }),
+    ],
+  },
 ];
 
 export const globalConfigOptions: NotificationChannelOption[] = [

--- a/public/app/plugins/datasource/alertmanager/consts.ts
+++ b/public/app/plugins/datasource/alertmanager/consts.ts
@@ -10,4 +10,5 @@ export const receiverTypeNames: Record<string, string> = {
   webex: 'Cisco Webex Teams',
   sns: 'Amazon SNS',
   telegram: 'Telegram',
+  msteams: 'Microsoft Teams',
 };

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -71,7 +71,8 @@ export type CloudNotifierType =
   | 'webex'
   | 'telegram'
   | 'sns'
-  | 'discord';
+  | 'discord'
+  | 'msteams';
 
 export type NotifierType = GrafanaNotifierType | CloudNotifierType;
 export interface NotifierDTO<T = NotifierType> {


### PR DESCRIPTION
**What is this feature?**

Alertmanager added an `msteams` contact point recently. It was imported to Mimir as part of this PR: https://github.com/grafana/mimir/pull/5840

However, it's not possible to create this contact point via the Grafana UI, because Grafana doesn't know about it yet.

**Why do we need this feature?**

Adds support for the msteams contact point for external Alertmanagers, via the Grafana UI.

The Grafana backend already has support - this happened implicitly as part of one of the recent AM version bumps in Grafana. We need only expose the option in the frontend.

**Who is this feature for?**

Mimir/Grafana Cloud users who wish to interact with msteams contact points via the Grafana UI.
Tested locally against Grafana Cloud managed Alertmanager.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
