### PR TITLE
Alerting: Alert rule constraint violations return as 400s in provisioning API

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -330,6 +330,9 @@ func (srv *ProvisioningSrv) RoutePostAlertRule(c *contextmodel.ReqContext, ar de
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
 	if err != nil {
+		if errors.Is(err, alerting_models.ErrAlertRuleUniqueConstraintViolation) {
+			return ErrResp(http.StatusBadRequest, err, "")
+		}
 		if errors.Is(err, store.ErrOptimisticLock) {
 			return ErrResp(http.StatusConflict, err, "")
 		}
@@ -352,6 +355,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRule(c *contextmodel.ReqContext, ar def
 	updated.UID = UID
 	provenance := determineProvenance(c)
 	updatedAlertRule, err := srv.alertRules.UpdateAlertRule(c.Req.Context(), updated, alerting_models.Provenance(provenance))
+	if errors.Is(err, alerting_models.ErrAlertRuleUniqueConstraintViolation) {
+		return ErrResp(http.StatusBadRequest, err, "")
+	}
 	if errors.Is(err, alerting_models.ErrAlertRuleNotFound) {
 		return response.Empty(http.StatusNotFound)
 	}
@@ -473,6 +479,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *contextmodel.ReqContext, a
 	}
 	provenance := determineProvenance(c)
 	err = srv.alertRules.ReplaceRuleGroup(c.Req.Context(), c.SignedInUser.GetOrgID(), groupModel, c.UserID, alerting_models.Provenance(provenance))
+	if errors.Is(err, alerting_models.ErrAlertRuleUniqueConstraintViolation) {
+		return ErrResp(http.StatusBadRequest, err, "")
+	}
 	if errors.Is(err, alerting_models.ErrAlertRuleFailedValidation) {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}


### PR DESCRIPTION
**What is this feature?**

Fixes the status code on constraint violation errors.

We use database constraints to enforce things like rule name uniqueness. This will make the API return the correct status code when a user tries to create/modify rule to where it breaches this.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
