### PR TITLE
Elasticsearch: Remove LegacyForms and gf-form from DataLink

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
@@ -3,12 +3,19 @@ import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 
 import { DataSourceInstanceSettings, VariableSuggestion } from '@grafana/data';
-import { Button, LegacyForms, DataLinkInput, stylesFactory } from '@grafana/ui';
+import {
+  Button,
+  DataLinkInput,
+  stylesFactory,
+  InlineField,
+  InlineSwitch,
+  InlineFieldRow,
+  InlineLabel,
+  Input,
+} from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import { DataLinkConfig } from '../types';
-
-const { FormField, Switch } = LegacyForms;
 
 const getStyles = stylesFactory(() => ({
   firstRow: css`
@@ -25,6 +32,7 @@ const getStyles = stylesFactory(() => ({
     align-items: baseline;
   `,
   urlField: css`
+    display: flex;
     flex: 1;
   `,
   urlDisplayLabelField: css`
@@ -53,18 +61,21 @@ export const DataLink = (props: Props) => {
 
   return (
     <div className={className}>
-      <div className={styles.firstRow + ' gf-form'}>
-        <FormField
-          className={styles.nameField}
-          labelWidth={6}
-          // A bit of a hack to prevent using default value for the width from FormField
-          inputWidth={null}
+      <div className={styles.firstRow}>
+        <InlineField
           label="Field"
-          type="text"
-          value={value.field}
+          htmlFor="elasticsearch-datasource-config-field"
+          labelWidth={12}
           tooltip={'Can be exact field name or a regex pattern that will match on the field name.'}
-          onChange={handleChange('field')}
-        />
+        >
+          <Input
+            type="text"
+            id="elasticsearch-datasource-config-field"
+            value={value.field}
+            onChange={handleChange('field')}
+            width={100}
+          />
+        </InlineField>
         <Button
           variant={'destructive'}
           title="Remove field"
@@ -75,52 +86,57 @@ export const DataLink = (props: Props) => {
           }}
         />
       </div>
-      <div className="gf-form">
-        <FormField
-          label={showInternalLink ? 'Query' : 'URL'}
-          labelWidth={6}
-          inputEl={
-            <DataLinkInput
-              placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
-              value={value.url || ''}
-              onChange={(newValue) =>
-                onChange({
-                  ...value,
-                  url: newValue,
-                })
-              }
-              suggestions={suggestions}
-            />
-          }
-          className={styles.urlField}
-        />
-        <FormField
-          className={styles.urlDisplayLabelField}
-          inputWidth={null}
-          labelWidth={7}
-          label="URL Label"
-          type="text"
-          value={value.urlDisplayLabel}
-          onChange={handleChange('urlDisplayLabel')}
-          tooltip={'Use to override the button label.'}
-        />
-      </div>
 
-      <div className={styles.row}>
-        <Switch
-          labelClass={'width-6'}
-          label="Internal link"
-          checked={showInternalLink}
-          onChange={() => {
-            if (showInternalLink) {
+      <InlineFieldRow>
+        <div className={styles.urlField}>
+          <InlineLabel htmlFor="elasticsearch-datasource-internal-link" width={12}>
+            {showInternalLink ? 'Query' : 'URL'}
+          </InlineLabel>
+          <DataLinkInput
+            placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
+            value={value.url || ''}
+            onChange={(newValue) =>
               onChange({
                 ...value,
-                datasourceUid: undefined,
-              });
+                url: newValue,
+              })
             }
-            setShowInternalLink(!showInternalLink);
-          }}
-        />
+            suggestions={suggestions}
+          />
+        </div>
+
+        <div className={styles.urlDisplayLabelField}>
+          <InlineField
+            label="URL Label"
+            htmlFor="elasticsearch-datasource-url-label"
+            labelWidth={14}
+            tooltip={'Use to override the button label.'}
+          >
+            <Input
+              type="text"
+              id="elasticsearch-datasource-url-label"
+              value={value.urlDisplayLabel}
+              onChange={handleChange('urlDisplayLabel')}
+            />
+          </InlineField>
+        </div>
+      </InlineFieldRow>
+
+      <div className={styles.row}>
+        <InlineField label="Internal link" labelWidth={12}>
+          <InlineSwitch
+            value={showInternalLink || false}
+            onChange={() => {
+              if (showInternalLink) {
+                onChange({
+                  ...value,
+                  datasourceUid: undefined,
+                });
+              }
+              setShowInternalLink(!showInternalLink);
+            }}
+          />
+        </InlineField>
 
         {showInternalLink && (
           <DataSourcePicker

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
@@ -125,6 +125,7 @@ export const DataLink = (props: Props) => {
       <div className={styles.row}>
         <InlineField label="Internal link" labelWidth={12}>
           <InlineSwitch
+            label="Internal link"
             value={showInternalLink || false}
             onChange={() => {
               if (showInternalLink) {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR removes all the `gf-form` references and LegacyForm components from the Elastic Search DataLink Page. Below are the images that reflect the change in the UI

The change in width in the input bars is due to the Input component only accepting a number as width instead of a percentage(string). If there is any way to fix that let me know, will follow up with the required changes

**Before UI**
![Screenshot from 2023-10-12 06-13-08](https://github.com/grafana/grafana/assets/65884232/b3c38921-4b27-4382-8dde-fe056725427b)

**After UI**
![Screenshot from 2023-10-12 06-11-26](https://github.com/grafana/grafana/assets/65884232/d4b64444-baa6-4ed6-9d48-379ca0931de0)

**Why do we need this feature?**

Tech Debt

**Who is this feature for?**

Devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #65513 and #76107 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
