### PR TITLE
Custom variable: Initialize options from query if not present in persisted model

### DIFF
--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -12,6 +12,7 @@ import { variableAdapters } from '../adapters';
 import { createConstantVariableAdapter } from '../constant/adapter';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE, NEW_VARIABLE_ID } from '../constants';
 import { createCustomVariableAdapter } from '../custom/adapter';
+import { createCustomOptionsFromQuery } from '../custom/reducer';
 import { changeVariableName } from '../editor/actions';
 import { changeVariableNameFailed, changeVariableNameSucceeded, cleanEditorState } from '../editor/reducer';
 import { cleanPickerState } from '../pickers/OptionsPicker/reducer';
@@ -192,7 +193,7 @@ describe('shared actions', () => {
         .whenAsyncActionIsDispatched(processVariables(key), true);
 
       await tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
-        expect(dispatchedActions.length).toEqual(5);
+        expect(dispatchedActions.length).toEqual(7);
 
         expect(dispatchedActions[0]).toEqual(
           toKeyedAction(
@@ -213,7 +214,7 @@ describe('shared actions', () => {
         expect(dispatchedActions[2]).toEqual(
           toKeyedAction(
             key,
-            variableStateCompleted(toVariablePayload({ ...custom, id: dispatchedActions[2].payload.action.payload.id }))
+            variableStateFetching(toVariablePayload({ ...custom, id: dispatchedActions[2].payload.action.payload.id }))
           )
         );
 
@@ -229,7 +230,23 @@ describe('shared actions', () => {
         expect(dispatchedActions[4]).toEqual(
           toKeyedAction(
             key,
-            variableStateCompleted(toVariablePayload({ ...query, id: dispatchedActions[4].payload.action.payload.id }))
+            createCustomOptionsFromQuery(
+              toVariablePayload({ ...custom, id: dispatchedActions[4].payload.action.payload.id })
+            )
+          )
+        );
+
+        expect(dispatchedActions[5]).toEqual(
+          toKeyedAction(
+            key,
+            variableStateCompleted(toVariablePayload({ ...custom, id: dispatchedActions[5].payload.action.payload.id }))
+          )
+        );
+
+        expect(dispatchedActions[6]).toEqual(
+          toKeyedAction(
+            key,
+            variableStateCompleted(toVariablePayload({ ...query, id: dispatchedActions[6].payload.action.payload.id }))
           )
         );
 

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -381,6 +381,11 @@ export const processVariable = (
       }
     }
 
+    if (variable.type === 'custom') {
+      await dispatch(updateOptions(toKeyedVariableIdentifier(variable)));
+      return;
+    }
+
     // for variables that aren't updated via URL or refresh, let's simulate the same state changes
     dispatch(completeVariableLoading(identifier));
   };


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/76117 I have removed the `options` property from a serialized custom variable model. I was surprised to discover, that the lack of those makes the variable not usable, as the options are not created from query when variable is processed on initialization.

This PR adds custom variable options from query initialization alongside already initialisation for variables that respect `refresh` property.

To test this PR you can:
1. Create a dashboard with a custom variable.
2. Switch to scene.
3. Export the dashboard to JSON from the scene - custom variable should have empty `options` table in the model.
4. Import dashboard to Grafana.
5. Custom variable should have options available in the UI.