### PR TITLE
Docs: Templating: Replace __value.raw with __data.fields

### DIFF
--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -71,6 +71,8 @@ Value-specific variables are available under `__value` namespace:
 - `__value.text` - text representation of a value
 - `__value.calc` - calculation name if the value is result of calculation
 
+Using value-specific variables in data links can show different results depending on the set option of Tooltip mode.
+
 ## Data variables
 
 To access values and labels from other fields use:

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -73,9 +73,12 @@ Value-specific variables are available under `__value` namespace:
 
 ## Data variables
 
-Data-specific variables are available under `__data` namespace:
+To access values and labels from other fields use 
 
-- `__data.fields[i]` - value of data field, `i` is an index starting from 0
+- `${__data.fields[i]}` - value of field i (on the same row)
+- `${__data.fields["NameOfField"]}` - value of field using name instead of index
+- `${__data.fields["NameOfField"]}` - value of field using name instead of index
+- `${__data.fields[1].labels.cluster}` - Access labels of another field 
 
 ## Template variables
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -75,7 +75,7 @@ Value-specific variables are available under `__value` namespace:
 
 To access values and labels from other fields use:
 
-- `${__data.fields[i]}` - value of field i (on the same row)
+- `${__data.fields[i]}` - value of field `i` (on the same row)
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
 - `${__data.fields[1].labels.cluster}` - access labels of another field

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -73,12 +73,12 @@ Value-specific variables are available under `__value` namespace:
 
 ## Data variables
 
-To access values and labels from other fields use 
+To access values and labels from other fields use
 
 - `${__data.fields[i]}` - value of field i (on the same row)
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
-- `${__data.fields[1].labels.cluster}` - Access labels of another field 
+- `${__data.fields[1].labels.cluster}` - Access labels of another field
 
 ## Template variables
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -75,7 +75,7 @@ Value-specific variables are available under `__value` namespace:
 
 Data-specific variables are available under `__data` namespace:
 
-- `__data.fields[i]` - value of data field, `i` is an index starting from 0 
+- `__data.fields[i]` - value of data field, `i` is an index starting from 0
 
 ## Template variables
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -50,7 +50,7 @@ These variables allow you to include the current time range in the data link URL
 
 ## Series variables
 
-Series specific variables are available under `__series` namespace:
+Series-specific variables are available under `__series` namespace:
 
 - `__series.name` - series name to the URL
 
@@ -70,6 +70,12 @@ Value-specific variables are available under `__value` namespace:
 - `__value.numeric` - numeric representation of a value
 - `__value.text` - text representation of a value
 - `__value.calc` - calculation name if the value is result of calculation
+
+## Data variables
+
+Data-specific variables are available under `__data` namespace:
+
+- `__data.fields[i]` - value of data field, `i` is an index starting from 0 
 
 ## Template variables
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -73,7 +73,7 @@ Value-specific variables are available under `__value` namespace:
 
 ## Data variables
 
-To access values and labels from other fields use
+To access values and labels from other fields use:
 
 - `${__data.fields[i]}` - value of field i (on the same row)
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -78,7 +78,7 @@ To access values and labels from other fields use
 - `${__data.fields[i]}` - value of field i (on the same row)
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
 - `${__data.fields["NameOfField"]}` - value of field using name instead of index
-- `${__data.fields[1].labels.cluster}` - Access labels of another field
+- `${__data.fields[1].labels.cluster}` - access labels of another field
 
 ## Template variables
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds documentation on missing information about what seems to be a new feature, but is actually a bug fix: Now we are using `${__data.fields[0]}`, `${__data.fields[1]}`, `${__data.fields[2]}`, etc. instead of `${__value.raw}` for both name and value of data. In 9.1 and previously, we used _only_ `${__value.raw}` to get everything - the name and the value(s) of the data.

The bug was: When "Tooltip > Tooltip mode" panel option is set to `Single`, the user can see the `${__value.raw}` in a data link as if the Tooltip mode is set to `All`. The data link should present the user with different values only when they set Tooltip mode to `All`, whereas when they set it to `Single`, `${__value.raw}` has to show only the data's single raw value.

Before:

https://github.com/grafana/grafana/assets/13227501/3b16a2a3-d6e1-4776-834a-981df578d289

After:

https://github.com/grafana/grafana/assets/13227501/5e9cd842-b918-47c4-9f24-2b2af792bccf

**Why do we need this feature?**

Because the users [don't know what happened](https://community.grafana.com/t/get-column-name-instead-of-value-in-data-link-variable-from-bar-chart/100415), since the documentation hasn't changed.
 
**Who is this feature for?**

Variable/Data/DataLinks users. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Documents 

**Special notes for your reviewer:**
Please check what information is missing from the docs on this page ([Configure data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/)).

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
