### PR TITLE
Alerting: Add Mimir Backend image to devenv (blocks)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,6 +187,7 @@
 /devenv/docker/blocks/maildev/ @grafana/alerting-frontend
 /devenv/docker/blocks/mariadb/ @grafana/grafana-bi-squad
 /devenv/docker/blocks/memcached/ @grafana/backend-platform
+/devenv/docker/blocks/mimir_backend/ @grafana/alerting-backend-product
 /devenv/docker/blocks/mssql/ @grafana/grafana-bi-squad
 /devenv/docker/blocks/mssql_arm64/ @grafana/grafana-bi-squad
 /devenv/docker/blocks/mssql_tests/ @grafana/grafana-bi-squad

--- a/devenv/docker/blocks/mimir_backend/docker-compose.yaml
+++ b/devenv/docker/blocks/mimir_backend/docker-compose.yaml
@@ -1,0 +1,16 @@
+  mimir_backend:
+    image: grafana/mimir
+    container_name: mimir_backend
+    command:
+      - -target=backend
+  nginx:
+    environment:
+      - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
+      - MIMIR_BACKEND_URL=mimir_backend:8080
+    hostname: nginx
+    image: nginxinc/nginx-unprivileged:1.22-alpine
+    ports:
+      - 8080:8080
+    volumes:
+      - "./docker/blocks/mimir_backend/nginx/nginx.conf.template:/etc/nginx/templates/nginx.conf.template"
+      - "./docker/blocks/mimir_backend/nginx/.htpasswd:/etc/nginx/.htpasswd"

--- a/devenv/docker/blocks/mimir_backend/nginx/.htpasswd
+++ b/devenv/docker/blocks/mimir_backend/nginx/.htpasswd
@@ -1,0 +1,2 @@
+// test:test
+test:$apr1$fzP1qWUA$gGOojmRicBlNiSdiSGjwv1

--- a/devenv/docker/blocks/mimir_backend/nginx/nginx.conf.template
+++ b/devenv/docker/blocks/mimir_backend/nginx/nginx.conf.template
@@ -1,0 +1,18 @@
+pid /tmp/nginx.pid;
+
+events {}
+
+http {
+  resolver 127.0.0.11 ipv6=off;  
+
+  server {
+    listen 8080;
+    proxy_set_header X-Scope-OrgID $http_x_scope_orgid;
+
+    location / {
+      auth_basic "Mimir Backend";
+      auth_basic_user_file /etc/nginx/.htpasswd;
+      proxy_pass http://${MIMIR_BACKEND_URL};
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a Mimir instance to our blocks.
This image is ran with `-target=backend` as the argument, allowing us to spin up the backend components with `make devenv sources=mimir_backend`

It also adds a proxy for basic auth with `test:test` as credentials.