### PR TITLE
BrowseDashboards: Prevent unnecessary searches

### DIFF
--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -57,7 +57,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       eventTrackingNamespace: folderUid ? 'manage_dashboards' : 'dashboard_search',
     });
 
-    if (doInitialSearch) {
+    if (doInitialSearch && this.hasSearchFilters()) {
       this.doSearch();
     }
   }
@@ -81,8 +81,11 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       sort: this.state.sort,
     });
 
-    // issue new search query
-    this.doSearchWithDebounce();
+    // Prevent searching when user is only clearing the input.
+    // We don't show these results anyway
+    if (this.hasSearchFilters()) {
+      this.doSearchWithDebounce();
+    }
   }
 
   onCloseSearch = () => {


### PR DESCRIPTION
Prevents unnecessary searches in the new Browse Dashboards UI. Results from searchStateManager are not even shown unless hasSearchFilters is true.

We should trigger searches only when there's a valid search query. This includes tag filters, started dashboards, sorting options, etc.

 - prevents a search from being triggered on initial page load if there's no search query
 - prevents a search from being triggered when _clearing_ a search state

Fixes https://github.com/grafana/grafana/issues/75545

