### PR TITLE
Alerting: Prevent cleanup of non-empty folders on migration revert

### DIFF
--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -187,4 +187,106 @@ func TestServiceRevert(t *testing.T) {
 			require.Nil(t, getDashboard(t, x, 1, uid))
 		}
 	})
+
+	t.Run("revert skips migrated folders that are not empty", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		x := sqlStore.GetEngine()
+		alerts = []*legacymodels.Alert{
+			createAlert(t, 1, 8, 1, "alert1", []string{"notifier1"}),
+		}
+		setupLegacyAlertsTables(t, x, channels, alerts, folders, dashes)
+
+		dashCount, err := x.Table("dashboard").Count(&dashboards.Dashboard{})
+		require.NoError(t, err)
+		require.Equal(t, int64(4), dashCount)
+
+		// Run migration.
+		ctx := context.Background()
+		cfg := &setting.Cfg{
+			ForceMigration: true,
+			UnifiedAlerting: setting.UnifiedAlertingSettings{
+				Enabled: pointer(true),
+			},
+		}
+		service := NewTestMigrationService(t, sqlStore, cfg)
+
+		err = service.migrationStore.SetMigrated(ctx, false)
+		require.NoError(t, err)
+
+		err = service.Run(ctx)
+		require.NoError(t, err)
+
+		// Verify migration was run.
+		migrated, err := service.migrationStore.IsMigrated(ctx)
+		require.NoError(t, err)
+		require.Equal(t, true, migrated)
+
+		// Verify we created some folders.
+		newDashCount, err := x.Table("dashboard").Count(&dashboards.Dashboard{})
+		require.NoError(t, err)
+		require.Truef(t, newDashCount > dashCount, "newDashCount: %d should be greater than dashCount: %d", newDashCount, dashCount)
+
+		// Check that dashboards and folders from before migration still exist.
+		require.NotNil(t, getDashboard(t, x, 1, "dash1-1"))
+		require.NotNil(t, getDashboard(t, x, 1, "dash2-1"))
+		require.NotNil(t, getDashboard(t, x, 1, "dash-in-general-1"))
+
+		state, err := service.migrationStore.GetOrgMigrationState(ctx, 1)
+		require.NoError(t, err)
+
+		// Verify list of created folders.
+		require.NotEmpty(t, state.CreatedFolders)
+		var generalAlertingFolder *dashboards.Dashboard
+		for _, uid := range state.CreatedFolders {
+			f := getDashboard(t, x, 1, uid)
+			require.NotNil(t, f)
+			if f.Slug == "general-alerting" {
+				generalAlertingFolder = f
+			}
+		}
+		require.NotNil(t, generalAlertingFolder)
+
+		// Create dashboard in general alerting.
+		newDashes := []*dashboards.Dashboard{
+			createDashboard(t, 99, 1, "dash-in-general-alerting-1", generalAlertingFolder.ID, nil),
+		}
+		_, err = x.Insert(newDashes)
+		require.NoError(t, err)
+
+		newF := getDashboard(t, x, 1, "dash-in-general-alerting-1")
+		require.NotNil(t, newF)
+
+		// Revert migration.
+		service.cfg.UnifiedAlerting.Enabled = pointer(false)
+		err = service.Run(ctx)
+		require.NoError(t, err)
+
+		// Verify revert was run.
+		migrated, err = service.migrationStore.IsMigrated(ctx)
+		require.NoError(t, err)
+		require.Equal(t, false, migrated)
+
+		// Verify we are back to the original count + 2.
+		newDashCount, err = x.Table("dashboard").Count(&dashboards.Dashboard{})
+		require.NoError(t, err)
+		require.Equalf(t, dashCount+2, newDashCount, "newDashCount: %d should be equal to dashCount + 2: %d after revert", newDashCount, dashCount)
+
+		// Check that dashboards and folders from before migration still exist.
+		require.NotNil(t, getDashboard(t, x, 1, "dash1-1"))
+		require.NotNil(t, getDashboard(t, x, 1, "dash2-1"))
+		require.NotNil(t, getDashboard(t, x, 1, "dash-in-general-1"))
+
+		// Check that the general alerting folder still exists.
+		require.NotNil(t, getDashboard(t, x, 1, generalAlertingFolder.UID))
+		// Check that the new dashboard in general alerting folder still exists.
+		require.NotNil(t, getDashboard(t, x, 1, "dash-in-general-alerting-1"))
+
+		// Check that other folders created during migration are gone.
+		for _, uid := range state.CreatedFolders {
+			if uid == generalAlertingFolder.UID {
+				continue
+			}
+			require.Nil(t, getDashboard(t, x, 1, uid))
+		}
+	})
 }


### PR DESCRIPTION
**What is this feature?**

Currently, when the migration reverts, it cleans up folders created during the previous migration. If, between when the migration was run and revert, other resources were added to the automatically created folders, the revert will delete these descendants as well. 

For example, if a dashboard is added to the folder, the dashboard will also be deleted.

This PR will verify that the folder is empty before deleting it. If it is not empty, a warning will be logged and the delete will be skipped.

**Who is this feature for?**

Users migrating from Legacy Alerting to Grafana Alerting.

**Special notes for your reviewer:**

When we attempt the create a folder during the migration, we can no longer fail if the folder already exists. As this possibility will become much more common now. Instead, we will log an informational message and use the existing folder.

This is not a perfect solution, as these existing folders could have different permissions that what would have otherwise been created by the migration. However, the risk of conflict is low because of the strict naming scheme for created folders.

Depends on: https://github.com/grafana/grafana/pull/74504

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
