### PR TITLE
Fix issue when ContextMenu was outside the top of the window

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -39,7 +39,7 @@ export const ContextMenu = React.memo(
         setPositionStyles({
           position: 'fixed',
           left: collisions.right ? x - rect.width - OFFSET : x - OFFSET,
-          top: collisions.bottom ? y - rect.height - OFFSET : y + OFFSET,
+          top: collisions.bottom ? Math.max(y - rect.height - OFFSET, 0) : y + OFFSET,
         });
       }
     }, [x, y]);


### PR DESCRIPTION
#76438 
Small fix of ContextMenu when menu was outside the top of the window.
After this change top position of ContextMenu cannot be less than 0.