### PR TITLE
Prometheus: Variable query, allow for label values query type with label, label filters and no metric

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -108,6 +108,27 @@ describe('PromVariableQueryEditor', () => {
     expect(migration).toEqual(expected);
   });
 
+  test('Migrates a query object with no metric and only label filters to an expression correctly', () => {
+    const query: PromVariableQuery = {
+      qryType: PromVariableQueryType.LabelValues,
+      label: 'name',
+      labelFilters: [
+        {
+          label: 'label',
+          op: '=',
+          value: 'value',
+        },
+      ],
+      refId: 'PrometheusDatasource-VariableQuery',
+    };
+
+    const migration: string = migrateVariableEditorBackToVariableSupport(query);
+
+    const expected = 'label_values({label="value"},name)';
+
+    expect(migration).toEqual(expected);
+  });
+
   beforeEach(() => {
     props = {
       datasource: {

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -50,7 +50,7 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
   // seriesQuery is only a whole
   const [seriesQuery, setSeriesQuery] = useState('');
 
-  // the original variable query implementation
+  // the original variable query implementation, e.g. label_value(metric, label_name)
   const [classicQuery, setClassicQuery] = useState('');
 
   // list of label names for label_values(), /api/v1/labels, contains the same results as label_names() function

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -105,7 +105,7 @@ export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVa
       }
       return 'label_names()';
     case QueryType.LabelValues:
-      if (QueryVariable.metric) {
+      if (QueryVariable.metric || (QueryVariable.labelFilters && QueryVariable.labelFilters.length !== 0)) {
         const visualQueryQuery = {
           metric: QueryVariable.metric,
           labels: QueryVariable.labelFilters ?? [],


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/7857

**What is this feature?**
Bug fix for Prometheus Variable query, label values query type, where a user selects a label, label filters and no metric.
<img width="400" alt="Screenshot 2023-10-12 at 11 18 07 AM" src="https://github.com/grafana/grafana/assets/25674746/da2e132e-a724-43d1-a126-7ca294b784a1">

This is supported in the query type "Classic query" and looks like `label_values({action="add_client"}, instance)`
<img width="745" alt="Screenshot 2023-10-12 at 11 19 55 AM" src="https://github.com/grafana/grafana/assets/25674746/49b6ace9-8c1b-4afd-9640-26ed96abe41d">

The bug was that when no metric was selected the query was not run and there were weird UI side effects described in the escalation.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
