### PR TITLE
Debug: Add logging for API route registration

### DIFF
--- a/pkg/api/routing/route_register.go
+++ b/pkg/api/routing/route_register.go
@@ -171,8 +171,9 @@ func (rr *RouteRegisterImpl) route(pattern, method string, handlers ...web.Handl
 
 	if rr.debug && rr.log != nil {
 		// Look twice up the stack as this is a private method called by public methods outside of this package.
-		_, file, line, _ := runtime.Caller(2)
-		rr.log.Debug("register route", "method", method, "pattern", fullPattern, "file", file, "line", line)
+		if _, file, line, ok := runtime.Caller(2); ok {
+			rr.log.Debug("register route", "method", method, "pattern", fullPattern, "file", file, "line", line)
+		}
 	}
 
 	rr.routes = append(rr.routes, route{

--- a/pkg/cmd/grafana-cli/commands/conflict_user_command.go
+++ b/pkg/cmd/grafana-cli/commands/conflict_user_command.go
@@ -66,7 +66,7 @@ func initializeConflictResolver(cmd *utils.ContextCommandLine, f Formatter, ctx 
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to get user service", err)
 	}
-	routing := routing.ProvideRegister()
+	routing := routing.ProvideRegister(cfg)
 	featMgmt, err := featuremgmt.ProvideManagerService(cfg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to get feature management service", err)


### PR DESCRIPTION
## What is this feature?

This adds a debug log entry on each route registration, when the app mode is `development` and log level allows debug entries.

## Why do we need this feature?

Logging of route registration makes it easier to find the location of a route's registration, saving time finding routes that might be in deeply nested route groups (and not registered with the exact full pattern).

## Who is this feature for?

Devs working on Grafana.

## Example

```
DEBUG[10-12|10:01:33] register route                           logger=route.register method=GET pattern=/admin/licensing file=<redacted>/grafana/pkg/extensions/licensing/api/api.go line=73
```