### PR TITLE
Navigation: Limit `SectionNav` to rendering items up to 3 levels

### DIFF
--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
@@ -19,6 +19,9 @@ interface Props {
   level?: number;
 }
 
+// max level depth to render
+const MAX_DEPTH = 2;
+
 export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
   const styles = useStyles2(getStyles);
   const FeatureHighlightWrapper = link.highlightText ? FeatureHighlight : React.Fragment;
@@ -26,7 +29,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
   const hasActiveChild = hasChildMatch(link, activeItem);
   const [sectionExpanded, setSectionExpanded] =
     useLocalStorage(`grafana.navigation.expanded[${link.text}]`, false) ?? Boolean(hasActiveChild);
-  const showExpandButton = linkHasChildren(link) || link.emptyMessage;
+  const showExpandButton = level < MAX_DEPTH && (linkHasChildren(link) || link.emptyMessage);
 
   return (
     <li className={styles.listItem}>

--- a/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
+++ b/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
@@ -9,9 +9,10 @@ import { useStyles2, Icon } from '@grafana/ui';
 export interface Props {
   item: NavModelItem;
   isSectionRoot?: boolean;
+  level?: number;
 }
 
-export function SectionNavItem({ item, isSectionRoot = false }: Props) {
+export function SectionNavItem({ item, isSectionRoot = false, level = 0 }: Props) {
   const styles = useStyles2(getStyles);
 
   const children = item.children?.filter((x) => !x.hideFromTabs);
@@ -22,7 +23,7 @@ export function SectionNavItem({ item, isSectionRoot = false }: Props) {
   const linkClass = cx({
     [styles.link]: true,
     [styles.activeStyle]: item.active,
-    [styles.isSection]: Boolean(children?.length) || item.isSection,
+    [styles.isSection]: level < 2 && (Boolean(children?.length) || item.isSection),
     [styles.isSectionRoot]: isSectionRoot,
     [styles.noRootMargin]: noRootMargin,
   });
@@ -56,7 +57,7 @@ export function SectionNavItem({ item, isSectionRoot = false }: Props) {
         {item.text}
         {item.tabSuffix && <item.tabSuffix className={styles.suffix} />}
       </a>
-      {children?.map((child, index) => <SectionNavItem item={child} key={index} />)}
+      {level < 2 && children?.map((child, index) => <SectionNavItem item={child} key={index} level={level + 1} />)}
     </>
   );
 }

--- a/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
+++ b/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
@@ -12,6 +12,9 @@ export interface Props {
   level?: number;
 }
 
+// max level depth to render
+const MAX_DEPTH = 2;
+
 export function SectionNavItem({ item, isSectionRoot = false, level = 0 }: Props) {
   const styles = useStyles2(getStyles);
 
@@ -23,7 +26,7 @@ export function SectionNavItem({ item, isSectionRoot = false, level = 0 }: Props
   const linkClass = cx({
     [styles.link]: true,
     [styles.activeStyle]: item.active,
-    [styles.isSection]: level < 2 && (Boolean(children?.length) || item.isSection),
+    [styles.isSection]: level < MAX_DEPTH && (Boolean(children?.length) || item.isSection),
     [styles.isSectionRoot]: isSectionRoot,
     [styles.noRootMargin]: noRootMargin,
   });
@@ -57,7 +60,8 @@ export function SectionNavItem({ item, isSectionRoot = false, level = 0 }: Props
         {item.text}
         {item.tabSuffix && <item.tabSuffix className={styles.suffix} />}
       </a>
-      {level < 2 && children?.map((child, index) => <SectionNavItem item={child} key={index} level={level + 1} />)}
+      {level < MAX_DEPTH &&
+        children?.map((child, index) => <SectionNavItem item={child} key={index} level={level + 1} />)}
     </>
   );
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- this limits `SectionNav` to only render 3 levels of hierarchy

**Why do we need this feature?**

- currently if you pass an arbitary depth of tree to `SectionNav`, it will render things in a flat(ish) hierarchy regardless of depth which is **very** confusing

**Who is this feature for?**

- anyone using `SectionNav`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
