### PR TITLE
PluginExtensions: Make sure to pass default timeZone in context

### DIFF
--- a/packages/grafana-data/src/datetime/common.ts
+++ b/packages/grafana-data/src/datetime/common.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash';
+
 import { TimeZone, DefaultTimeZone } from '../types/time';
 
 /**
@@ -57,5 +59,8 @@ export const setTimeZoneResolver = (resolver: TimeZoneResolver) => {
  * @public
  */
 export const getTimeZone = <T extends TimeZoneOptions>(options?: T): TimeZone => {
-  return options?.timeZone ?? defaultTimeZoneResolver() ?? DefaultTimeZone;
+  if (options?.timeZone && !isEmpty(options.timeZone)) {
+    return options.timeZone;
+  }
+  return defaultTimeZoneResolver() ?? DefaultTimeZone;
 };

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -295,6 +295,97 @@ describe('getPanelMenu()', () => {
       expect(getPluginLinkExtensionsMock).toBeCalledWith(expect.objectContaining({ context }));
     });
 
+    it('should pass context with defaul time zone values when configuring extension', () => {
+      const data: PanelData = {
+        series: [
+          toDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time },
+              { name: 'score', type: FieldType.number },
+            ],
+          }),
+        ],
+        timeRange: {
+          from: dateTime(),
+          to: dateTime(),
+          raw: {
+            from: 'now',
+            to: 'now-1h',
+          },
+        },
+        state: LoadingState.Done,
+      };
+
+      const panel = new PanelModel({
+        type: 'timeseries',
+        id: 1,
+        title: 'My panel',
+        targets: [
+          {
+            refId: 'A',
+            datasource: {
+              type: 'testdata',
+            },
+          },
+        ],
+        scopedVars: {
+          a: {
+            text: 'a',
+            value: 'a',
+          },
+        },
+        queryRunner: {
+          getLastResult: jest.fn(() => data),
+        },
+      });
+
+      const dashboard = createDashboardModelFixture({
+        timezone: '',
+        time: {
+          from: 'now-5m',
+          to: 'now',
+        },
+        tags: ['database', 'panel'],
+        uid: '123',
+        title: 'My dashboard',
+      });
+
+      getPanelMenu(dashboard, panel);
+
+      const context: PluginExtensionPanelContext = {
+        pluginId: 'timeseries',
+        id: 1,
+        title: 'My panel',
+        timeZone: 'browser',
+        timeRange: {
+          from: 'now-5m',
+          to: 'now',
+        },
+        targets: [
+          {
+            refId: 'A',
+            datasource: {
+              type: 'testdata',
+            },
+          },
+        ],
+        dashboard: {
+          tags: ['database', 'panel'],
+          uid: '123',
+          title: 'My dashboard',
+        },
+        scopedVars: {
+          a: {
+            text: 'a',
+            value: 'a',
+          },
+        },
+        data,
+      };
+
+      expect(getPluginLinkExtensionsMock).toBeCalledWith(expect.objectContaining({ context }));
+    });
+
     it('should contain menu item with category', () => {
       getPluginLinkExtensionsMock.mockReturnValue({
         extensions: [

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -295,7 +295,7 @@ describe('getPanelMenu()', () => {
       expect(getPluginLinkExtensionsMock).toBeCalledWith(expect.objectContaining({ context }));
     });
 
-    it('should pass context with defaul time zone values when configuring extension', () => {
+    it('should pass context with default time zone values when configuring extension', () => {
       const data: PanelData = {
         series: [
           toDataFrame({

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,4 +1,5 @@
 import {
+  getTimeZone,
   PanelMenuItem,
   PluginExtensionLink,
   PluginExtensionPoints,
@@ -326,7 +327,9 @@ function createExtensionContext(panel: PanelModel, dashboard: DashboardModel): P
     pluginId: panel.type,
     title: panel.title,
     timeRange: dashboard.time,
-    timeZone: dashboard.timezone,
+    timeZone: getTimeZone({
+      timeZone: dashboard.timezone,
+    }),
     dashboard: {
       uid: dashboard.uid,
       title: dashboard.title,

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
@@ -151,6 +151,21 @@ describe('ToolbarExtensionPoint', () => {
       });
     });
 
+    it('should pass a context with correct timeZone when fetching extensions', async () => {
+      const targets = [{ refId: 'A' }];
+      const data = createEmptyQueryResponse();
+
+      renderWithExploreStore(<ToolbarExtensionPoint exploreId="left" timeZone="" splitted={false} />, {
+        targets,
+        data,
+      });
+
+      const [options] = getPluginLinkExtensionsMock.mock.calls[0];
+      const { context } = options;
+
+      expect(context).toHaveProperty('timeZone', 'browser');
+    });
+
     it('should correct extension point id when fetching extensions', async () => {
       renderWithExploreStore(<ToolbarExtensionPoint exploreId="left" timeZone="browser" splitted={false} />);
 

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -1,6 +1,6 @@
 import React, { lazy, ReactElement, Suspense, useMemo, useState } from 'react';
 
-import { type PluginExtensionLink, PluginExtensionPoints, RawTimeRange } from '@grafana/data';
+import { type PluginExtensionLink, PluginExtensionPoints, RawTimeRange, getTimeZone } from '@grafana/data';
 import { getPluginLinkExtensions, config } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
 import { Dropdown, ToolbarButton } from '@grafana/ui';
@@ -101,7 +101,7 @@ function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
       targets: queries,
       data: queryResponse,
       timeRange: range.raw,
-      timeZone: timeZone,
+      timeZone: getTimeZone({ timeZone }),
       shouldShowAddCorrelation:
         config.featureToggles.correlations === true &&
         canWriteCorrelations &&


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR changes so the `getTimeZone` will return the default selected timeZone for the user if empty timeZone is passed via options. We also use this function to make sure to always return a timeZone in the context that is being shared with UI extensions.

**Why do we need this feature?**

To make is easier and more reliable to consume the UI extension context plugins.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
