### PR TITLE
Elasticsearch: move adhoc filters code to modifyQuery module and refactor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1307,8 +1307,14 @@ describe('queryHasFilter()', () => {
 
 describe('addAdhocFilters', () => {
   describe('with invalid filters', () => {
+    let ds: ElasticDatasource, templateSrv: TemplateSrv;
+    beforeEach(() => {
+      const context = getTestContext();
+      ds = context.ds;
+      templateSrv = context.templateSrv;
+    })
+
     it('should filter out ad hoc filter without key', () => {
-      const { ds, templateSrv } = getTestContext();
       jest.mocked(templateSrv.getAdhocFilters).mockReturnValue([{ key: '', operator: '=', value: 'a', condition: '' }]);
 
       const query = ds.addAdHocFilters('foo:"bar"');
@@ -1316,7 +1322,6 @@ describe('addAdhocFilters', () => {
     });
 
     it('should filter out ad hoc filter without value', () => {
-      const { ds, templateSrv } = getTestContext();
       jest.mocked(templateSrv.getAdhocFilters).mockReturnValue([{ key: 'a', operator: '=', value: '', condition: '' }]);
 
       const query = ds.addAdHocFilters('foo:"bar"');
@@ -1324,7 +1329,6 @@ describe('addAdhocFilters', () => {
     });
 
     it('should filter out filter ad hoc filter with invalid operator', () => {
-      const { ds, templateSrv } = getTestContext();
       jest.mocked(templateSrv.getAdhocFilters).mockReturnValue([{ key: 'a', operator: 'A', value: '', condition: '' }]);
 
       const query = ds.addAdHocFilters('foo:"bar"');
@@ -1349,8 +1353,35 @@ describe('addAdhocFilters', () => {
     });
 
     it('should correctly add 1 ad hoc filter when query is empty', () => {
-      const query = ds.addAdHocFilters('');
-      expect(query).toBe('test:"test1"');
+      expect(ds.addAdHocFilters('')).toBe('test:"test1"');
+      expect(ds.addAdHocFilters(' ')).toBe('test:"test1"');
+      expect(ds.addAdHocFilters('  ')).toBe('test:"test1"');
+    });
+
+    it.each(['=', '!=', '=~', '!~', '>', '<', '', ''])(`should properly build queries with '%s' filters`, (operator: string) => {
+      jest.mocked(templateSrvMock.getAdhocFilters).mockReturnValue([{ key: 'key', operator, value: 'value', condition: '' }]);
+
+      const query = ds.addAdHocFilters('foo:"bar"');
+      switch (operator) {
+        case '=':
+          expect(query).toBe('foo:\"bar\" AND key:\"value\"');
+        break;
+        case '!=':
+          expect(query).toBe('foo:\"bar\" AND -key:\"value\"');
+        break;
+        case '=~':
+          expect(query).toBe('foo:\"bar\" AND key:/value/');
+        break;
+        case '!~':
+          expect(query).toBe('foo:\"bar\" AND -key:/value/');
+        break;
+        case '>':
+          expect(query).toBe('foo:\"bar\" AND key:>value');
+        break;
+        case '<':
+          expect(query).toBe('foo:\"bar\" AND key:<value');
+        break;
+      }
     });
 
     it('should escape characters in filter keys', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1358,6 +1358,12 @@ describe('addAdhocFilters', () => {
       expect(ds.addAdHocFilters('  ')).toBe('test:"test1"');
     });
 
+    it('should not fail if the filter value is a number', () => {
+      // @ts-expect-error
+      jest.mocked(templateSrvMock.getAdhocFilters).mockReturnValue([{ key: 'key', operator: '=', value: 1, condition: '' }]);
+      expect(ds.addAdHocFilters('')).toBe('key:"1"');
+    });
+
     it.each(['=', '!=', '=~', '!~', '>', '<', '', ''])(`should properly build queries with '%s' filters`, (operator: string) => {
       jest.mocked(templateSrvMock.getAdhocFilters).mockReturnValue([{ key: 'key', operator, value: 'value', condition: '' }]);
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1312,7 +1312,7 @@ describe('addAdhocFilters', () => {
       const context = getTestContext();
       ds = context.ds;
       templateSrv = context.templateSrv;
-    })
+    });
 
     it('should filter out ad hoc filter without key', () => {
       jest.mocked(templateSrv.getAdhocFilters).mockReturnValue([{ key: '', operator: '=', value: 'a', condition: '' }]);
@@ -1360,35 +1360,42 @@ describe('addAdhocFilters', () => {
 
     it('should not fail if the filter value is a number', () => {
       // @ts-expect-error
-      jest.mocked(templateSrvMock.getAdhocFilters).mockReturnValue([{ key: 'key', operator: '=', value: 1, condition: '' }]);
+      jest
+        .mocked(templateSrvMock.getAdhocFilters)
+        .mockReturnValue([{ key: 'key', operator: '=', value: 1, condition: '' }]);
       expect(ds.addAdHocFilters('')).toBe('key:"1"');
     });
 
-    it.each(['=', '!=', '=~', '!~', '>', '<', '', ''])(`should properly build queries with '%s' filters`, (operator: string) => {
-      jest.mocked(templateSrvMock.getAdhocFilters).mockReturnValue([{ key: 'key', operator, value: 'value', condition: '' }]);
+    it.each(['=', '!=', '=~', '!~', '>', '<', '', ''])(
+      `should properly build queries with '%s' filters`,
+      (operator: string) => {
+        jest
+          .mocked(templateSrvMock.getAdhocFilters)
+          .mockReturnValue([{ key: 'key', operator, value: 'value', condition: '' }]);
 
-      const query = ds.addAdHocFilters('foo:"bar"');
-      switch (operator) {
-        case '=':
-          expect(query).toBe('foo:\"bar\" AND key:\"value\"');
-        break;
-        case '!=':
-          expect(query).toBe('foo:\"bar\" AND -key:\"value\"');
-        break;
-        case '=~':
-          expect(query).toBe('foo:\"bar\" AND key:/value/');
-        break;
-        case '!~':
-          expect(query).toBe('foo:\"bar\" AND -key:/value/');
-        break;
-        case '>':
-          expect(query).toBe('foo:\"bar\" AND key:>value');
-        break;
-        case '<':
-          expect(query).toBe('foo:\"bar\" AND key:<value');
-        break;
+        const query = ds.addAdHocFilters('foo:"bar"');
+        switch (operator) {
+          case '=':
+            expect(query).toBe('foo:"bar" AND key:"value"');
+            break;
+          case '!=':
+            expect(query).toBe('foo:"bar" AND -key:"value"');
+            break;
+          case '=~':
+            expect(query).toBe('foo:"bar" AND key:/value/');
+            break;
+          case '!~':
+            expect(query).toBe('foo:"bar" AND -key:/value/');
+            break;
+          case '>':
+            expect(query).toBe('foo:"bar" AND key:>value');
+            break;
+          case '<':
+            expect(query).toBe('foo:"bar" AND key:<value');
+            break;
+        }
       }
-    });
+    );
 
     it('should escape characters in filter keys', () => {
       jest

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1359,9 +1359,9 @@ describe('addAdhocFilters', () => {
     });
 
     it('should not fail if the filter value is a number', () => {
-      // @ts-expect-error
       jest
         .mocked(templateSrvMock.getAdhocFilters)
+        // @ts-expect-error
         .mockReturnValue([{ key: 'key', operator: '=', value: 1, condition: '' }]);
       expect(ds.addAdHocFilters('')).toBe('key:"1"');
     });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -57,9 +57,8 @@ import {
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 import { isMetricAggregationWithMeta } from './guards';
 import {
+  addAddHocFilter,
   addFilterToQuery,
-  escapeFilter,
-  escapeFilterValue,
   queryHasFilter,
   removeFilterFromQuery,
 } from './modifyQuery';
@@ -955,35 +954,11 @@ export class ElasticDatasource
     if (adhocFilters.length === 0) {
       return query;
     }
-    const esFilters = adhocFilters.map((filter) => {
-      let { key, operator, value } = filter;
-      if (!key || !value) {
-        return;
-      }
-      /**
-       * Keys and values in ad hoc filters may contain characters such as
-       * colons, which needs to be escaped.
-       */
-      key = escapeFilter(key);
-      value = escapeFilterValue(value);
-      switch (operator) {
-        case '=':
-          return `${key}:"${value}"`;
-        case '!=':
-          return `-${key}:"${value}"`;
-        case '=~':
-          return `${key}:/${value}/`;
-        case '!~':
-          return `-${key}:/${value}/`;
-        case '>':
-          return `${key}:>${value}`;
-        case '<':
-          return `${key}:<${value}`;
-      }
-      return;
+    let finalQuery = query;
+    adhocFilters.forEach((filter) => {
+      finalQuery = addAddHocFilter(finalQuery, filter);
     });
 
-    const finalQuery = [query, ...esFilters].filter((f) => f).join(' AND ');
     return finalQuery;
   }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -56,12 +56,7 @@ import {
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 import { isMetricAggregationWithMeta } from './guards';
-import {
-  addAddHocFilter,
-  addFilterToQuery,
-  queryHasFilter,
-  removeFilterFromQuery,
-} from './modifyQuery';
+import { addAddHocFilter, addFilterToQuery, queryHasFilter, removeFilterFromQuery } from './modifyQuery';
 import { trackAnnotationQuery, trackQuery } from './tracking';
 import {
   Logs,

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -1,6 +1,8 @@
 import { isEqual } from 'lodash';
 import lucene, { AST, BinaryAST, LeftOnlyAST, NodeTerm } from 'lucene';
 
+import { AdHocVariableFilter } from '@grafana/data';
+
 type ModifierType = '' | '-';
 
 /**
@@ -65,7 +67,53 @@ export function addFilterToQuery(query: string, key: string, value: string, modi
   value = lucene.phrase.escape(value);
   const filter = `${modifier}${key}:"${value}"`;
 
-  return query === '' ? filter : `${query} AND ${filter}`;
+  return concatenate(query, filter);
+}
+
+/**
+ * Merge a query with a filter.
+ */
+function concatenate(query: string, filter: string, condition = 'AND'): string {
+  if (!filter) {
+    return query;
+  }
+  return query.trim() === '' ? filter : `${query} ${condition} ${filter}`;
+}
+
+/**
+ * Adds a label:"value" expression to the query.
+ */
+export function addAddHocFilter(query: string, filter: AdHocVariableFilter): string {
+  if (!filter.key || !filter.value) {
+    return query;
+  }
+
+  const equalityFilters = ['=', '!='];
+  if (equalityFilters.includes(filter.operator)) {
+    return addFilterToQuery(query, filter.key, filter.value, filter.operator === '=' ? '' : '-');
+  }
+  /**
+   * Keys and values in ad hoc filters may contain characters such as
+   * colons, which needs to be escaped.
+   */
+  const key = escapeFilter(filter.key);
+  const value = escapeFilterValue(filter.value);
+  let addHocFilter = '';
+  switch (filter.operator) {
+    case '=~':
+      addHocFilter = `${key}:/${value}/`;
+    break;
+    case '!~':
+      addHocFilter = `-${key}:/${value}/`;
+    break;
+    case '>':
+      addHocFilter = `${key}:>${value}`;
+    break;
+    case '<':
+      addHocFilter = `${key}:<${value}`;
+    break;
+  }
+  return concatenate(query, addHocFilter);
 }
 
 /**

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -108,16 +108,16 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
   switch (filter.operator) {
     case '=~':
       addHocFilter = `${key}:/${value}/`;
-    break;
+      break;
     case '!~':
       addHocFilter = `-${key}:/${value}/`;
-    break;
+      break;
     case '>':
       addHocFilter = `${key}:>${value}`;
-    break;
+      break;
     case '<':
       addHocFilter = `${key}:<${value}`;
-    break;
+      break;
   }
   return concatenate(query, addHocFilter);
 }

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -88,6 +88,12 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
     return query;
   }
 
+  filter = {
+    ...filter,
+    // Type is defined as string, but it can be a number.
+    value: filter.value.toString(),
+  };
+
   const equalityFilters = ['=', '!='];
   if (equalityFilters.includes(filter.operator)) {
     return addFilterToQuery(query, filter.key, filter.value, filter.operator === '=' ? '' : '-');


### PR DESCRIPTION
We [recently revamped ](https://github.com/grafana/grafana/pull/71954) the modifyQuery implentation introducing a lucene parser and refactoring the implementation. This PR:
- Simplifies the data source implementation by moving the query-building part to `modifyQuery`.
- Uses `addFilterToQuery()` for equality filters, in the same way we do from the LogsDetails panel.
- Adds a few more test cases.
- Resolves a bug where the received value for a filter is a number and not a string.

### Approach

TDD was used to implement these changes, starting with tests that covered the current behavior, and helped to verify that it doesn't change after the refactor.

The underlying functionality remains unchaged.

**Why do we need this feature?**

Simplified data source implementation, part of https://github.com/grafana/grafana/issues/76126
Single point of failure for changing queries in `modifyQuery`.
Unified filter behavior between LogsDetails 🔍  and addhoc filters 🔍 .

**Which issue(s) does this PR fix?**:

Tangentially related with https://github.com/grafana/grafana/issues/76183 . The reason is that the 🔍  icons used with addhoc filters add equality filters that are better handled by `addFilterToQuery()`.

Part of https://github.com/grafana/grafana/issues/76126

**Special notes for your reviewer:**

- Create an elasticsearch instance `make devenv sources=elastic`
- Add an elasticsearch dashboard visualization type Log with a simple query (no query).
  ![imagen](https://github.com/grafana/grafana/assets/1069378/4f5bd9d9-99a2-4f85-9e46-9f2b7a1ac3ac)
- Use addhoc filters:


https://github.com/grafana/grafana/assets/1069378/b52ee6a0-88a5-409e-a51b-cc7058e2c78f

Steps to reproduce the bug:

https://github.com/grafana/grafana/assets/1069378/84c0045a-8bf5-4e32-b5a1-00d584a4c5e7
