### PR TITLE
IDForwarding: Use single flight for SignIdentity

### DIFF
--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -28,7 +29,7 @@ func ProvideService(
 	cfg *setting.Cfg, signer auth.IDSigner, cache remotecache.CacheStorage,
 	features featuremgmt.FeatureToggles, authnService authn.Service, reg prometheus.Registerer,
 ) *Service {
-	s := &Service{cfg, log.New("id-service"), signer, cache, newMetrics(reg)}
+	s := &Service{cfg: cfg, logger: log.New("id-service"), signer: signer, cache: cache, metrics: newMetrics(reg)}
 
 	if features.IsEnabled(featuremgmt.FlagIdForwarding) {
 		authnService.RegisterPostAuthHook(s.hook, 140)
@@ -42,6 +43,7 @@ type Service struct {
 	logger  log.Logger
 	signer  auth.IDSigner
 	cache   remotecache.CacheStorage
+	si      singleflight.Group
 	metrics *metrics
 }
 
@@ -50,34 +52,45 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		s.metrics.tokenSigningDurationHistogram.Observe(time.Since(t).Seconds())
 	}(time.Now())
 
-	namespace, identifier := id.GetNamespacedID()
-
 	cacheKey := prefixCacheKey(id.GetCacheKey())
-	cachedToken, err := s.cache.Get(ctx, cacheKey)
-	if err == nil {
-		s.metrics.tokenSigningFromCacheCounter.Inc()
-		s.logger.Debug("Cached token found", "namespace", namespace, "id", identifier)
-		return string(cachedToken), nil
-	}
 
-	s.metrics.tokenSigningCounter.Inc()
-	s.logger.Debug("Sign new id token", "namespace", namespace, "id", identifier)
+	result, err, _ := s.si.Do(cacheKey, func() (interface{}, error) {
+		namespace, identifier := id.GetNamespacedID()
 
-	now := time.Now()
-	token, err := s.signer.SignIDToken(ctx, &auth.IDClaims{
-		Claims: jwt.Claims{
-			Issuer:   s.cfg.AppURL,
-			Audience: getAudience(id.GetOrgID()),
-			Subject:  getSubject(namespace, identifier),
-			Expiry:   jwt.NewNumericDate(now.Add(tokenTTL)),
-			IssuedAt: jwt.NewNumericDate(now),
-		},
+		cachedToken, err := s.cache.Get(ctx, cacheKey)
+		if err == nil {
+			s.metrics.tokenSigningFromCacheCounter.Inc()
+			s.logger.Debug("Cached token found", "namespace", namespace, "id", identifier)
+			return string(cachedToken), nil
+		}
+
+		s.metrics.tokenSigningCounter.Inc()
+		s.logger.Debug("Sign new id token", "namespace", namespace, "id", identifier)
+
+		now := time.Now()
+		token, err := s.signer.SignIDToken(ctx, &auth.IDClaims{
+			Claims: jwt.Claims{
+				Issuer:   s.cfg.AppURL,
+				Audience: getAudience(id.GetOrgID()),
+				Subject:  getSubject(namespace, identifier),
+				Expiry:   jwt.NewNumericDate(now.Add(tokenTTL)),
+				IssuedAt: jwt.NewNumericDate(now),
+			},
+		})
+
+		if err != nil {
+			s.metrics.failedTokenSigningCounter.Inc()
+			return "", err
+		}
+
+		return token, nil
 	})
 
 	if err != nil {
-		s.metrics.failedTokenSigningCounter.Inc()
 		return "", err
 	}
+
+	token := result.(string)
 
 	if err := s.cache.Set(ctx, cacheKey, []byte(token), cacheTTL); err != nil {
 		s.logger.Error("Failed to add id token to cache", "error", err)

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/singleflight"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -13,8 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/singleflight"
 )
 
 const (

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -84,6 +84,10 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 			return "", err
 		}
 
+		if err := s.cache.Set(ctx, cacheKey, []byte(token), cacheTTL); err != nil {
+			s.logger.Error("Failed to add id token to cache", "error", err)
+		}
+
 		return token, nil
 	})
 
@@ -91,13 +95,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		return "", err
 	}
 
-	token := result.(string)
-
-	if err := s.cache.Set(ctx, cacheKey, []byte(token), cacheTTL); err != nil {
-		s.logger.Error("Failed to add id token to cache", "error", err)
-	}
-
-	return token, nil
+	return result.(string), nil
 }
 
 func (s *Service) hook(ctx context.Context, identity *authn.Identity, _ *authn.Request) error {


### PR DESCRIPTION
**What is this feature?**
When feature toggle for id forwarding is enabled this hook is called for all authenticated calls. Using single flight for signing an identity has several benefits.

When we don't have a cached token this prevent more then one token to be singed if several calls are made simultaneously to one instance. 

If no remote cache is configured the default backend is in sql, so this will reduce some load on the db.

**Which issue(s) does this PR fix?**:
Part of: https://github.com/grafana/identity-access-team/issues/310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
