### PR TITLE
Tempo: Hide span limit when table type is traces

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -53,6 +53,16 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               value={query.limit}
             />
           </EditorField>
+          <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
+            <RadioButtonGroup
+              options={[
+                { label: 'Traces', value: SearchTableType.Traces },
+                { label: 'Spans', value: SearchTableType.Spans },
+              ]}
+              value={query.tableType}
+              onChange={onTableTypeChange}
+            />
+          </EditorField>
           {(!query.tableType || query.tableType === SearchTableType.Traces) && (
             <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
               <AutoSizeInput
@@ -66,16 +76,6 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               />
             </EditorField>
           )}
-          <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
-            <RadioButtonGroup
-              options={[
-                { label: 'Traces', value: SearchTableType.Traces },
-                { label: 'Spans', value: SearchTableType.Spans },
-              ]}
-              value={query.tableType}
-              onChange={onTableTypeChange}
-            />
-          </EditorField>
         </QueryOptionGroup>
       </EditorRow>
     </>

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -53,17 +53,19 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               value={query.limit}
             />
           </EditorField>
-          <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
-            <AutoSizeInput
-              className="width-4"
-              placeholder="auto"
-              type="number"
-              min={1}
-              defaultValue={query.spss || DEFAULT_SPSS}
-              onCommitChange={onSpssChange}
-              value={query.spss}
-            />
-          </EditorField>
+          {(!query.tableType || query.tableType === SearchTableType.Traces) && (
+            <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
+              <AutoSizeInput
+                className="width-4"
+                placeholder="auto"
+                type="number"
+                min={1}
+                defaultValue={query.spss || DEFAULT_SPSS}
+                onCommitChange={onSpssChange}
+                value={query.spss}
+              />
+            </EditorField>
+          )}
           <EditorField label="Table Format" tooltip="How the query data should be displayed in the results table">
             <RadioButtonGroup
               options={[

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -35,8 +35,10 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
   const collapsedInfoList = [
     `Limit: ${query.limit || DEFAULT_LIMIT}`,
     `Table Format: ${query.tableType === SearchTableType.Traces ? 'Traces' : 'Spans'}`,
-    `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
   ];
+  if (query.tableType === SearchTableType.Traces) {
+    collapsedInfoList.push(`Spans Limit: ${query.spss || DEFAULT_SPSS}`);
+  }
 
   return (
     <>
@@ -63,7 +65,7 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               onChange={onTableTypeChange}
             />
           </EditorField>
-          {(!query.tableType || query.tableType === SearchTableType.Traces) && (
+          {query.tableType === SearchTableType.Traces && (
             <EditorField label="Span Limit" tooltip="Maximum number of spans to return for each span set.">
               <AutoSizeInput
                 className="width-4"

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -34,8 +34,8 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
 
   const collapsedInfoList = [
     `Limit: ${query.limit || DEFAULT_LIMIT}`,
-    `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
     `Table Format: ${query.tableType === SearchTableType.Traces ? 'Traces' : 'Spans'}`,
+    `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
   ];
 
   return (


### PR DESCRIPTION
**What is this feature?**

Hides the span limit option when the table type is traces.

**Why do we need this feature?**

Better UX as the span limit will do nothing if the table type is spans.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
