### PR TITLE
Tracing: Improve interval input link

### DIFF
--- a/public/app/core/components/IntervalInput/IntervalInput.tsx
+++ b/public/app/core/components/IntervalInput/IntervalInput.tsx
@@ -3,7 +3,7 @@ import { useDebounce } from 'react-use';
 
 import { InlineField, Input } from '@grafana/ui';
 
-import { validateInterval, validateIntervalRegex } from './validation';
+import { isValidInterval, validateIntervalRegex } from './validation';
 
 interface Props {
   value: string;
@@ -29,13 +29,13 @@ interface FieldProps {
 
 export const IntervalInput = (props: Props) => {
   const validationRegex = props.validationRegex || validateIntervalRegex;
-  const [intervalIsInvalid, setIntervalIsInvalid] = useState(() => {
-    return props.value ? validateInterval(props.value, validationRegex) : false;
+  const [intervalIsValid, setIntervalIsValid] = useState(() => {
+    return props.value ? isValidInterval(props.value, validationRegex) : true;
   });
 
   useDebounce(
     () => {
-      setIntervalIsInvalid(validateInterval(props.value, validationRegex));
+      setIntervalIsValid(isValidInterval(props.value, validationRegex));
     },
     500,
     [props.value]
@@ -44,7 +44,7 @@ export const IntervalInput = (props: Props) => {
   const fieldProps: FieldProps = {
     labelWidth: 26,
     disabled: props.disabled ?? false,
-    invalid: intervalIsInvalid,
+    invalid: !intervalIsValid,
     error: props.isInvalidError,
   };
   if (props.label) {

--- a/public/app/core/components/IntervalInput/validation.test.ts
+++ b/public/app/core/components/IntervalInput/validation.test.ts
@@ -1,28 +1,28 @@
-import { validateInterval, validateIntervalRegex } from './validation';
+import { isValidInterval, validateIntervalRegex } from './validation';
 
 describe('Validation', () => {
   it('should validate incorrect values correctly', () => {
-    expect(validateInterval('-', validateIntervalRegex)).toBeTruthy();
-    expect(validateInterval('1', validateIntervalRegex)).toBeTruthy();
-    expect(validateInterval('test', validateIntervalRegex)).toBeTruthy();
-    expect(validateInterval('1ds', validateIntervalRegex)).toBeTruthy();
-    expect(validateInterval('10Ms', validateIntervalRegex)).toBeTruthy();
-    expect(validateInterval('-9999999', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('-', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('1', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('test', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('1ds', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('10Ms', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('-9999999', validateIntervalRegex)).toBeFalsy();
   });
 
   it('should validate correct values correctly', () => {
-    expect(validateInterval('1y', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('1M', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('1w', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('1d', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('2h', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('4m', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('8s', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('80ms', validateIntervalRegex)).toBeFalsy();
-    expect(validateInterval('-80ms', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('1y', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('1M', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('1w', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('1d', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('2h', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('4m', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('8s', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('80ms', validateIntervalRegex)).toBeTruthy();
+    expect(isValidInterval('-80ms', validateIntervalRegex)).toBeTruthy();
   });
 
   it('should not return error if no value provided', () => {
-    expect(validateInterval('', validateIntervalRegex)).toBeFalsy();
+    expect(isValidInterval('', validateIntervalRegex)).toBeTruthy();
   });
 });

--- a/public/app/core/components/IntervalInput/validation.ts
+++ b/public/app/core/components/IntervalInput/validation.ts
@@ -1,6 +1,9 @@
 export const validateIntervalRegex = /^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/;
 
 export const validateInterval = (val: string, regex: RegExp) => {
+  if (val === '0') {
+    return false;
+  }
   const matches = val.match(regex);
   return matches || !val ? false : true;
 };

--- a/public/app/core/components/IntervalInput/validation.ts
+++ b/public/app/core/components/IntervalInput/validation.ts
@@ -1,9 +1,9 @@
 export const validateIntervalRegex = /^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/;
 
-export const validateInterval = (val: string, regex: RegExp) => {
+export const isValidInterval = (val: string, regex: RegExp) => {
   if (val === '0') {
-    return false;
+    return true;
   }
   const matches = val.match(regex);
-  return matches || !val ? false : true;
+  return matches || !val ? true : false;
 };

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -17,6 +17,7 @@ import {
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Icon } from '@grafana/ui';
+import { validateInterval, validateIntervalRegex } from 'app/core/components/IntervalInput/validation';
 import { TraceToLogsOptionsV2, TraceToLogsTag } from 'app/core/components/TraceToLogs/TraceToLogsSettings';
 import { TraceToMetricQuery, TraceToMetricsOptions } from 'app/core/components/TraceToMetrics/TraceToMetricsSettings';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -208,12 +209,14 @@ function legacyCreateSpanLinkFactory(
             range: getTimeRangeFromSpan(
               span,
               {
-                startMs: traceToLogsOptions.spanStartTimeShift
-                  ? rangeUtil.intervalToMs(traceToLogsOptions.spanStartTimeShift)
-                  : 0,
-                endMs: traceToLogsOptions.spanEndTimeShift
-                  ? rangeUtil.intervalToMs(traceToLogsOptions.spanEndTimeShift)
-                  : 0,
+                startMs:
+                  traceToLogsOptions.spanStartTimeShift && isValidTimeRange(traceToLogsOptions.spanStartTimeShift)
+                    ? rangeUtil.intervalToMs(traceToLogsOptions.spanStartTimeShift)
+                    : 0,
+                endMs:
+                  traceToLogsOptions.spanEndTimeShift && isValidTimeRange(traceToLogsOptions.spanEndTimeShift)
+                    ? rangeUtil.intervalToMs(traceToLogsOptions.spanEndTimeShift)
+                    : 0,
               },
               isSplunkDS
             ),
@@ -256,12 +259,14 @@ function legacyCreateSpanLinkFactory(
           internalLink: dataLink.internal!,
           scopedVars: {},
           range: getTimeRangeFromSpan(span, {
-            startMs: traceToMetricsOptions.spanStartTimeShift
-              ? rangeUtil.intervalToMs(traceToMetricsOptions.spanStartTimeShift)
-              : -120000,
-            endMs: traceToMetricsOptions.spanEndTimeShift
-              ? rangeUtil.intervalToMs(traceToMetricsOptions.spanEndTimeShift)
-              : 120000,
+            startMs:
+              traceToMetricsOptions.spanStartTimeShift && isValidTimeRange(traceToMetricsOptions.spanStartTimeShift)
+                ? rangeUtil.intervalToMs(traceToMetricsOptions.spanStartTimeShift)
+                : -120000,
+            endMs:
+              traceToMetricsOptions.spanEndTimeShift && isValidTimeRange(traceToMetricsOptions.spanEndTimeShift)
+                ? rangeUtil.intervalToMs(traceToMetricsOptions.spanEndTimeShift)
+                : 120000,
           }),
           field: {} as Field,
           onClickFn: splitOpenFn,
@@ -541,6 +546,10 @@ function getTimeRangeFromSpan(
       to,
     },
   };
+}
+
+function isValidTimeRange(timeRange: string) {
+  return timeRange !== '0' && !validateInterval(timeRange, validateIntervalRegex);
 }
 
 // Interpolates span attributes into trace to metric query, or returns default query

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -17,7 +17,7 @@ import {
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Icon } from '@grafana/ui';
-import { validateInterval, validateIntervalRegex } from 'app/core/components/IntervalInput/validation';
+import { isValidInterval, validateIntervalRegex } from 'app/core/components/IntervalInput/validation';
 import { TraceToLogsOptionsV2, TraceToLogsTag } from 'app/core/components/TraceToLogs/TraceToLogsSettings';
 import { TraceToMetricQuery, TraceToMetricsOptions } from 'app/core/components/TraceToMetrics/TraceToMetricsSettings';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -549,7 +549,7 @@ function getTimeRangeFromSpan(
 }
 
 function isValidTimeRange(timeRange: string) {
-  return timeRange !== '0' && !validateInterval(timeRange, validateIntervalRegex);
+  return timeRange !== '0' && isValidInterval(timeRange, validateIntervalRegex);
 }
 
 // Interpolates span attributes into trace to metric query, or returns default query


### PR DESCRIPTION
**What is this feature?**

Improves logic in interval input component.

**Why do we need this feature?**

Fixes two issues;
- Typing 0 (string) before would show as error but it was really ok as it's essentially the default value
- Typing an incorrect value would show in the interval input component but would error in createSpanLink because the rangeUtil expects a certain format.

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
