### PR TITLE
chore(grafana-apiserver): expose apiserver metrics endpoint

### DIFF
--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -145,6 +145,7 @@ func ProvideService(
 	}
 
 	s.rr.Group("/apis", proxyHandler)
+	s.rr.Group("/apiserver-metrics", proxyHandler)
 	s.rr.Group("/openapi", proxyHandler)
 
 	return s, nil
@@ -300,6 +301,12 @@ func (s *service) start(ctx context.Context) error {
 		if req.URL.Path == "" {
 			req.URL.Path = "/"
 		}
+
+		//TODO: add support for the existing MetricsEndpointBasicAuth config option
+		if req.URL.Path == "/apiserver-metrics" {
+			req.URL.Path = "/metrics"
+		}
+
 		ctx := req.Context()
 		signedInUser := appcontext.MustUser(ctx)
 


### PR DESCRIPTION
This change proxies the existing apiserver `/metrics` endpoint to `/apiserver-metrics` (for e.g. http://localhost:3000/apiserver-metrics).

We can do this and configure prometheus to scrape that endpoint *or* instead merge the apiserver metrics with the existing metrics endpoint (somehow 🤷🏻 )