### PR TITLE
 Explore: Cancel streaming queries before running new queries

### DIFF
--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -3,14 +3,14 @@ import React, { useCallback, useMemo } from 'react';
 
 import { CoreApp } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LoadingState } from '@grafana/schema';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { useDispatch, useSelector } from 'app/types';
 
 import { getDatasourceSrv } from '../plugins/datasource_srv';
 import { QueryEditorRows } from '../query/components/QueryEditorRows';
 
-import { changeQueries, runQueries } from './state/query';
+import { cancelQueries, changeQueries, runQueries } from './state/query';
 import { getExploreItemSelector } from './state/selectors';
 
 interface Props {
@@ -45,8 +45,11 @@ export const QueryRows = ({ exploreId }: Props) => {
   const eventBridge = useSelector(getEventBridge);
 
   const onRunQueries = useCallback(() => {
+    if (queryResponse.state === LoadingState.Streaming) {
+      dispatch(cancelQueries(exploreId));
+    }
     dispatch(runQueries({ exploreId }));
-  }, [dispatch, exploreId]);
+  }, [dispatch, exploreId, queryResponse.state]);
 
   const onChange = useCallback(
     (newQueries: DataQuery[]) => {


### PR DESCRIPTION
**What is this feature?**

The query editor for test datasource runs queries again when you change the scenario ([src](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx#L67)). This calls the edited function on QueryRows. This runs the query without knowing about or caring about any existing queries, which causes issues with the supplementary query subscriptions. 

This is a pretty broad change and I'm not super confident in it. We pass in this function to any Query Editor to use, and besides how individual datasources might use it in their editors (which we don't necessarily have control over), it's used 

- As part of a legacy angular refresh ([src](https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRow.tsx#L137))
- Disabling a query ([src](https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRow.tsx#L340))

I'm wondering what I can do to test that this works for other datasources outside the test data datasource. I do have a cloudwatch datasource hooked up to my instance, but it doesn't seem to be configured for live measurements.

The customer who alerted us to this is using a custom plugin, so even harder for us to test with. 

**Why do we need this feature?**

Moving between a streaming query and a non streaming query within the same datasource throws errors. We need to be able to support this scenario.

**Who is this feature for?**

See above.

**Which issue(s) does this PR fix?**:

Fixes #76542

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
