### PR TITLE
Canvas: Promote Button to beta

### DIFF
--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -94,7 +94,7 @@ export const buttonItem: CanvasElementItem<ButtonConfig, ButtonData> = {
   id: 'button',
   name: 'Button',
   description: 'Button',
-  state: PluginState.alpha,
+  state: PluginState.beta,
 
   standardEditorConfig: {
     background: false,

--- a/public/app/features/canvas/elements/button.tsx
+++ b/public/app/features/canvas/elements/button.tsx
@@ -56,13 +56,7 @@ const ButtonDisplay = ({ data }: CanvasElementProps<ButtonConfig, ButtonData>) =
   };
 
   return (
-    <Button
-      type="submit"
-      variant={data?.style?.variant}
-      onClick={onClick}
-      className={styles.button}
-      disabled={!data?.api?.endpoint}
-    >
+    <Button type="submit" variant={data?.style?.variant} onClick={onClick} className={styles.button}>
       <span>
         {isLoading && <Spinner inline={true} className={styles.buttonSpinner} />}
         {data?.text}

--- a/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/APIEditor.tsx
@@ -6,7 +6,6 @@ import {
   StringFieldConfigSettings,
   SelectableValue,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Button, Field, InlineField, InlineFieldRow, JSONFormatter, RadioButtonGroup, Select } from '@grafana/ui';
 import { StringValueEditor } from 'app/core/components/OptionsUI/string';
 import { defaultApiConfig } from 'app/features/canvas/elements/button';
@@ -141,7 +140,7 @@ export function APIEditor({ value, context, onChange }: Props) {
     return;
   };
 
-  return config.disableSanitizeHtml ? (
+  return (
     <>
       <InlineFieldRow>
         <InlineField label="Endpoint" labelWidth={LABEL_WIDTH} grow={true}>
@@ -195,7 +194,5 @@ export function APIEditor({ value, context, onChange }: Props) {
         value?.contentType === defaultApiConfig.contentType &&
         renderJSON(value?.data ?? '{}')}
     </>
-  ) : (
-    <>Must enable disableSanitizeHtml feature flag to access</>
   );
 }


### PR DESCRIPTION
This PR
- promotes the Canvas Button to beta state
- removes check for `disableSanitizeHtml` feature flag 
- removes the disable check for button - good to have in the future, but maybe in a better form


Fixes #76498

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
