### PR TITLE
Snapshots: Fix breakage of some panel types due to missing structureRev

### DIFF
--- a/public/app/features/dashboard/utils/loadSnapshotData.ts
+++ b/public/app/features/dashboard/utils/loadSnapshotData.ts
@@ -36,6 +36,7 @@ export function loadSnapshotData(panel: PanelModel, dashboard: DashboardModel): 
       theme: config.theme2,
       timeZone: dashboard.getTimezone(),
     }),
+    structureRev: 1,
     annotations,
   };
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -104,6 +104,7 @@ export class PanelQueryRunner {
         state: LoadingState.Done,
         series: this.dataConfigSource.snapshotData.map((v) => toDataFrame(v)),
         timeRange: getDefaultTimeRange(), // Don't need real time range for snapshots
+        structureRev,
       };
       return of(snapshotPanelData);
     }


### PR DESCRIPTION
Fixes the panel rendering concerns in https://github.com/grafana/grafana/issues/64262
Fixes https://github.com/grafana/support-escalations/issues/7580

we rely on `structureRev` to re-configure and re-init panel options when the dataframe _shape_ or the config struct changes. in snapshot loading this was always `undefined` and we did not re-init. snapshots re-render the panel 3 times (the first time with empty data), as opposed to the PanelQueryRunner, where it just renders once with data.