### PR TITLE
Nav: Replace cloneDeep() in MegaMenu

### DIFF
--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { DOMAttributes } from '@react-types/shared';
-import { cloneDeep } from 'lodash';
 import React, { forwardRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -22,13 +21,11 @@ export interface Props extends DOMAttributes {
 
 export const MegaMenu = React.memo(
   forwardRef<HTMLDivElement, Props>(({ onClose, ...restProps }, ref) => {
-    const navBarTree = useSelector((state) => state.navBarTree);
+    const navTree = useSelector((state) => state.navBarTree);
     const styles = useStyles2(getStyles);
     const location = useLocation();
     const { chrome } = useGrafana();
     const state = chrome.useState();
-
-    const navTree = cloneDeep(navBarTree);
 
     // Remove profile + help from tree
     const navItems = navTree

--- a/public/app/core/components/AppChrome/DockedMegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/utils.ts
@@ -30,18 +30,20 @@ export const enrichHelpItem = (helpItem: NavModelItem) => {
 };
 
 export const enrichWithInteractionTracking = (item: NavModelItem, expandedState: boolean) => {
-  const onClick = item.onClick;
-  item.onClick = () => {
+  // creating a new object here to not mutate the original item object
+  const newItem = { ...item };
+  const onClick = newItem.onClick;
+  newItem.onClick = () => {
     reportInteraction('grafana_navigation_item_clicked', {
-      path: item.url ?? item.id,
+      path: newItem.url ?? newItem.id,
       state: expandedState ? 'expanded' : 'collapsed',
     });
     onClick?.();
   };
-  if (item.children) {
-    item.children = item.children.map((item) => enrichWithInteractionTracking(item, expandedState));
+  if (newItem.children) {
+    newItem.children = newItem.children.map((item) => enrichWithInteractionTracking(item, expandedState));
   }
-  return item;
+  return newItem;
 };
 
 export const isMatchOrChildMatch = (itemToCheck: NavModelItem, searchItem?: NavModelItem) => {


### PR DESCRIPTION
**What is this PR about?**
While checking the current set up of MegaMenu I found a deep cloning of the nav tree. It's purpose is not clear in the context that's why I removed it and added required changes to `enrichWithInteractionTracking()` where it would be actually needed. 
In order to make it as reversible as possible in case it breaks something I decided to open this PR separately from all other changes that are currently being in process for MegaMenu. 

**Which issue is this PR related to?**:
Related to #75725 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
