### PR TITLE
Log Context: Add Log Context support to mixed data sources

### DIFF
--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -185,7 +185,11 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     const ds = this.state.logContextSupport[row.dataFrame.refId];
     const query = this.getQuery(logsQueries, row, ds);
 
-    return query && hasLogsContextUiSupport(ds) && ds.getLogRowContextUi ? ds.getLogRowContextUi(row, runContextQuery, query) : <></>;
+    return query && hasLogsContextUiSupport(ds) && ds.getLogRowContextUi ? (
+      ds.getLogRowContextUi(row, runContextQuery, query)
+    ) : (
+      <></>
+    );
   };
 
   showContextToggle = (row?: LogRowModel): boolean => {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -96,11 +96,9 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
         newState.logDetailsFilterAvailable = true;
       }
       if (hasLogsContextSupport(datasourceInstance)) {
-        const logContextSupport: LogsContainerState['logContextSupport'] = {};
         logsQueries.forEach(({ refId }) => {
-          logContextSupport[refId] = datasourceInstance;
+          newState.logContextSupport[refId] = datasourceInstance;
         });
-        newState.logContextSupport = logContextSupport;
       }
       this.setState(newState);
       return;

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -105,16 +105,16 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     }
 
     // Mixed mode.
-    const promises = [];
+    const dsPromises = [];
     const refIds: string[] = [];
     for (const query of logsQueries) {
       if (query.datasource && !newState.logContextSupport[query.refId]) {
-        promises.push(getDataSourceSrv().get(query.datasource));
+        dsPromises.push(getDataSourceSrv().get(query.datasource));
         refIds.push(query.refId);
       }
     }
 
-    Promise.all(promises).then((dataSources) => {
+    Promise.all(dsPromises).then((dataSources) => {
       newState.logDetailsFilterAvailable = dataSources.some(
         (ds) => ds.modifyQuery || hasToggleableQueryFiltersSupport(ds)
       );

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -101,15 +101,21 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     }
 
     // Mixed mode.
-    const dsPromises: Array<Promise<{ ds: DataSourceApi, refId: string}>> = [];
+    const dsPromises: Array<Promise<{ ds: DataSourceApi; refId: string }>> = [];
     for (const query of logsQueries) {
-      const mustCheck = !newState.logContextSupport[query.refId] || newState.logContextSupport[query.refId].uid !== query.datasource?.uid;
+      const mustCheck =
+        !newState.logContextSupport[query.refId] ||
+        newState.logContextSupport[query.refId].uid !== query.datasource?.uid;
       if (mustCheck) {
-        dsPromises.push(new Promise((resolve) => {
-          getDataSourceSrv().get(query.datasource).then(ds => {
-            resolve({ ds, refId: query.refId });
+        dsPromises.push(
+          new Promise((resolve) => {
+            getDataSourceSrv()
+              .get(query.datasource)
+              .then((ds) => {
+                resolve({ ds, refId: query.refId });
+              });
           })
-        }));
+        );
       }
     }
 
@@ -119,7 +125,8 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
 
     Promise.all(dsPromises).then((dsInstances) => {
       dsInstances.forEach(({ ds, refId }) => {
-        newState.logDetailsFilterAvailable = newState.logDetailsFilterAvailable || Boolean(ds.modifyQuery) || hasToggleableQueryFiltersSupport(ds);
+        newState.logDetailsFilterAvailable =
+          newState.logDetailsFilterAvailable || Boolean(ds.modifyQuery) || hasToggleableQueryFiltersSupport(ds);
         if (hasLogsContextSupport(ds)) {
           newState.logContextSupport[refId] = ds;
         } else {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -91,7 +91,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     let newState: LogsContainerState = { ...this.state, logDetailsFilterAvailable: false };
 
     // Not in mixed mode.
-    if (datasourceInstance.name !== MIXED_DATASOURCE_NAME) {
+    if (datasourceInstance.uid !== MIXED_DATASOURCE_NAME) {
       if (datasourceInstance?.modifyQuery || hasToggleableQueryFiltersSupport(datasourceInstance)) {
         newState.logDetailsFilterAvailable = true;
       }

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -103,7 +103,8 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     // Mixed mode.
     const dsPromises: Array<Promise<{ ds: DataSourceApi, refId: string}>> = [];
     for (const query of logsQueries) {
-      if (query.datasource && !newState.logContextSupport[query.refId]) {
+      const mustCheck = !newState.logContextSupport[query.refId] || newState.logContextSupport[query.refId].uid !== query.datasource?.uid;
+      if (mustCheck) {
         dsPromises.push(new Promise((resolve) => {
           getDataSourceSrv().get(query.datasource).then(ds => {
             resolve({ ds, refId: query.refId });
@@ -121,6 +122,8 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
         newState.logDetailsFilterAvailable = newState.logDetailsFilterAvailable || Boolean(ds.modifyQuery) || hasToggleableQueryFiltersSupport(ds);
         if (hasLogsContextSupport(ds)) {
           newState.logContextSupport[refId] = ds;
+        } else {
+          delete newState.logContextSupport[refId];
         }
       });
 

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -103,9 +103,12 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     // Mixed mode.
     const dsPromises: Array<Promise<{ ds: DataSourceApi; refId: string }>> = [];
     for (const query of logsQueries) {
+      if (!query.datasource) {
+        continue;
+      }
       const mustCheck =
         !newState.logContextSupport[query.refId] ||
-        newState.logContextSupport[query.refId].uid !== query.datasource?.uid;
+        newState.logContextSupport[query.refId].uid !== query.datasource.uid;
       if (mustCheck) {
         dsPromises.push(
           new Promise((resolve) => {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -116,11 +116,13 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
       }
     }
 
+    if (!dsPromises.length) {
+      return;
+    }
+
     Promise.all(dsPromises).then((dsInstances) => {
-      newState.logDetailsFilterAvailable = dsInstances.map(({ ds }) => ds).some(
-        (ds) => ds.modifyQuery || hasToggleableQueryFiltersSupport(ds)
-      );
       dsInstances.forEach(({ ds, refId }) => {
+        newState.logDetailsFilterAvailable = newState.logDetailsFilterAvailable || Boolean(ds.modifyQuery) || hasToggleableQueryFiltersSupport(ds);
         if (hasLogsContextSupport(ds)) {
           newState.logContextSupport[refId] = ds;
         }

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -60,10 +60,6 @@ interface LogsContainerProps extends PropsFromRedux {
 
 interface LogsContainerState {
   logDetailsFilterAvailable: boolean;
-  /**
-   * LogContext support for mixed data sources.
-   * @alpha
-   */
   logContextSupport: Record<string, DataSourceApi<DataQuery> & DataSourceWithLogsContextSupport<DataQuery>>;
 }
 


### PR DESCRIPTION
This PR adds support to logs context when using mixed data sources. It has been achieved by using a previously existing data source feature check called `checkFiltersAvailability()` to now additionally maintain a set of data sources that support Logs Context, referenced by the refId. This refId can then be grabbed from the log rows to determine the correct instance to use.

When using "normal" mode, Logs Context behaves as usual, using `datasourceInstance`.

When using mixed data sources, it grabs the resolved data source instance from the aforementioned set.

**Why do we need this feature?**

Enabling a requested feature to work with mixed data sources.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57359

**Special notes for your reviewer:**

Test logs context with mixed data sources and normal data source mode, it should work as expected.

![Set](https://github.com/grafana/grafana/assets/1069378/b21f2947-7fd6-4ca0-bce5-f0f879239776)

Demo:

https://github.com/grafana/grafana/assets/1069378/73741d7d-eab9-4ed4-b76c-b6614f086503

