### PR TITLE
Cloudwatch: Ignore error while fetching regions

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -151,6 +151,7 @@ func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx ba
 		EC2APIProvider:        ec2Client,
 		Settings:              instance.Settings,
 		Features:              e.features,
+		Logger:                logger,
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/oam"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
@@ -24,6 +25,7 @@ type RequestContext struct {
 	EC2APIProvider        EC2APIProvider
 	Settings              CloudWatchSettings
 	Features              featuremgmt.FeatureToggles
+	Logger                log.Logger
 }
 
 // Services

--- a/pkg/tsdb/cloudwatch/routes/regions.go
+++ b/pkg/tsdb/cloudwatch/routes/regions.go
@@ -44,5 +44,5 @@ var newRegionsService = func(ctx context.Context, pluginCtx backend.PluginContex
 		return nil, err
 	}
 
-	return services.NewRegionsService(reqCtx.EC2APIProvider), nil
+	return services.NewRegionsService(reqCtx.EC2APIProvider, reqCtx.Logger), nil
 }

--- a/pkg/tsdb/cloudwatch/services/regions.go
+++ b/pkg/tsdb/cloudwatch/services/regions.go
@@ -32,10 +32,9 @@ func (r *RegionsService) GetRegions() ([]resources.ResourceResponse[resources.Re
 
 	result := make([]resources.ResourceResponse[resources.Region], 0)
 
-	ec2Regions, err := r.DescribeRegions(&ec2.DescribeRegionsInput{})
-	if err != nil {
-		return nil, err
-	}
+	// we ignore this error and always send default regions
+	// we only fetch incase a user has enabled additional regions
+	ec2Regions, _ := r.DescribeRegions(&ec2.DescribeRegionsInput{})
 
 	mergeEC2RegionsAndConstantRegions(regions, ec2Regions.Regions)
 

--- a/pkg/tsdb/cloudwatch/services/regions.go
+++ b/pkg/tsdb/cloudwatch/services/regions.go
@@ -3,6 +3,8 @@ package services
 import (
 	"sort"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
@@ -11,11 +13,13 @@ import (
 
 type RegionsService struct {
 	models.EC2APIProvider
+	log.Logger
 }
 
-func NewRegionsService(ec2client models.EC2APIProvider) models.RegionsAPIProvider {
+func NewRegionsService(ec2client models.EC2APIProvider, logger log.Logger) models.RegionsAPIProvider {
 	return &RegionsService{
 		ec2client,
+		logger,
 	}
 }
 
@@ -32,9 +36,13 @@ func (r *RegionsService) GetRegions() ([]resources.ResourceResponse[resources.Re
 
 	result := make([]resources.ResourceResponse[resources.Region], 0)
 
+	ec2Regions, err := r.DescribeRegions(&ec2.DescribeRegionsInput{})
 	// we ignore this error and always send default regions
 	// we only fetch incase a user has enabled additional regions
-	ec2Regions, _ := r.DescribeRegions(&ec2.DescribeRegionsInput{})
+	// but we still log it in case the user is expecting to fetch regions specific to their account and are unable to
+	if err != nil {
+		r.Error("Failed to get regions: ", "error", err)
+	}
 
 	mergeEC2RegionsAndConstantRegions(regions, ec2Regions.Regions)
 


### PR DESCRIPTION
**What is this feature?**

After deploying https://github.com/grafana/grafana/pull/74420 we noticed some users were receiving an error on the /regions endpoint and not able to see more than `default` in the dropdown. So we have to [revert](https://github.com/grafana/grafana/pull/76620) the feature toggle.

I believe what's happening here is that some users never set EC2:DescribeRegions permissions to their cloudwatch instance to fetch regions and our previous code path [ignored this error](https://github.com/grafana/grafana/blob/406888d9aad8dab637cf4c2f50f42941ac157a5a/pkg/tsdb/cloudwatch/metric_find_query.go#L64) and always returned the default list of constants. 

Arguably this new /regions endpoint should do the same. 

**Why do we need this feature?**

Fixes a bug related to fetching regions for cloudwatch 

**Who is this feature for?**

cloudwatch users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
