### PR TITLE
Tracing: Do not try to render trace view in dashboard if data missing

### DIFF
--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
@@ -143,6 +143,58 @@ describe('transformTraceData()', () => {
     expect(transformTraceData(traceData)).toEqual(null);
   });
 
+  it('should return null for any span without a spanID', () => {
+    const traceData = {
+      traceID,
+      processes,
+      spans: [
+        {
+          traceID,
+          operationName: 'rootOperation',
+          references: [
+            {
+              refType: 'CHILD_OF',
+              traceID,
+              spanID: rootSpanID,
+            },
+          ],
+          startTime,
+          duration,
+          tags: [],
+          processID: 'p1',
+        },
+      ],
+    } as unknown as TraceResponse;
+
+    expect(transformTraceData(traceData)).toEqual(null);
+  });
+
+  it('should return null for any span without a processID', () => {
+    const traceData = {
+      traceID,
+      processes,
+      spans: [
+        {
+          traceID,
+          spanID: '41f71485ed2593e4',
+          operationName: 'rootOperation',
+          references: [
+            {
+              refType: 'CHILD_OF',
+              traceID,
+              spanID: rootSpanID,
+            },
+          ],
+          startTime,
+          duration,
+          tags: [],
+        },
+      ],
+    } as unknown as TraceResponse;
+
+    expect(transformTraceData(traceData)).toEqual(null);
+  });
+
   it('should return trace data with correct traceName based on root span with missing ref', () => {
     const traceData = {
       traceID,

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -74,7 +74,6 @@ export function orderTags(tags: TraceKeyValuePair[], topPrefixes?: string[]) {
  * generally requires.
  */
 export default function transformTraceData(data: TraceResponse | undefined): Trace | null {
-  console.log(data?.spans);
   if (!data?.traceID || data?.spans.some((x) => !x.processID || !x.spanID)) {
     return null;
   }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -74,7 +74,8 @@ export function orderTags(tags: TraceKeyValuePair[], topPrefixes?: string[]) {
  * generally requires.
  */
 export default function transformTraceData(data: TraceResponse | undefined): Trace | null {
-  if (!data?.traceID) {
+  console.log(data?.spans);
+  if (!data?.traceID || data?.spans.some((x) => !x.processID || !x.spanID)) {
     return null;
   }
   const traceID = data.traceID.toLowerCase();

--- a/public/app/features/explore/TraceView/components/utils/color-generator.tsx
+++ b/public/app/features/explore/TraceView/components/utils/color-generator.tsx
@@ -46,7 +46,7 @@ class ColorGenerator {
   _getColorIndex(key: string): number {
     let i = this.cache.get(key);
     if (i == null) {
-      const hash = this.hashCode(key.toLowerCase());
+      const hash = this.hashCode(key ? key.toLowerCase() : '');
       i = Math.abs(hash % this.colorsHex.length);
 
       if (this.prevColorIndex !== undefined) {


### PR DESCRIPTION
**What is this feature?**

Stops us from trying to render the trace view in a dashboard if we are missing data.

**Why do we need this feature?**

So we show a no data response like other visualisations if the data is not in the correct format.

**Who is this feature for?**

Tracing users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/7895

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
