### PR TITLE
POC: Use yarn with pnpm linker

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 enableTelemetry: false
 
-nodeLinker: pnp
+nodeLinker: pnpm
 
 packageExtensions:
   '@storybook/core-common@7.4.5':

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -161,4 +161,7 @@ module.exports = {
       },
     },
   },
+  snapshot: {
+    managedPaths: [/^(.+?[\\/]node_modules)[\\/]/],
+  },
 };

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -42,7 +42,6 @@ module.exports = {
       https: false,
       string_decoder: false,
     },
-    symlinks: false,
   },
   ignoreWarnings: [/export .* was not found in/],
   stats: {

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -54,14 +54,14 @@ module.exports = (env = {}) =>
       minimizer: [new EsbuildPlugin(esbuildOptions), new CssMinimizerPlugin()],
     },
 
-    // // enable persistent cache for faster builds
-    // cache: {
-    //   type: 'filesystem',
-    //   name: 'grafana-default-production',
-    //   buildDependencies: {
-    //     config: [__filename],
-    //   },
-    // },
+    // enable persistent cache for faster builds
+    cache: {
+      type: 'filesystem',
+      name: 'grafana-default-production',
+      buildDependencies: {
+        config: [__filename],
+      },
+    },
 
     plugins: [
       new MiniCssExtractPlugin({

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -54,14 +54,14 @@ module.exports = (env = {}) =>
       minimizer: [new EsbuildPlugin(esbuildOptions), new CssMinimizerPlugin()],
     },
 
-    // enable persistent cache for faster builds
-    cache: {
-      type: 'filesystem',
-      name: 'grafana-default-production',
-      buildDependencies: {
-        config: [__filename],
-      },
-    },
+    // // enable persistent cache for faster builds
+    // cache: {
+    //   type: 'filesystem',
+    //   name: 'grafana-default-production',
+    //   buildDependencies: {
+    //     config: [__filename],
+    //   },
+    // },
 
     plugins: [
       new MiniCssExtractPlugin({


### PR DESCRIPTION
Proof of concept for testing the pnpm linker for yarn, building on https://github.com/grafana/grafana/pull/7427.

Required two fixes for jest:
 - update the `moduleDirectories` option to correctly re-include `node_modules`. This isn't an issue in main because yarn pnp has its own module resolution for dependencies.
 - update the `transformIgnorePatterns` option to correctly transpile select dependencies. I believe in main this is incorrectly configured to transpile _all_ dependencies.
 
Part of https://github.com/grafana/grafana/issues/61083