### PR TITLE
K8s: Add grafana-apiserver config

### DIFF
--- a/pkg/services/grafana-apiserver/config.go
+++ b/pkg/services/grafana-apiserver/config.go
@@ -20,7 +20,7 @@ type config struct {
 	logLevel int
 }
 
-func NewConfig(cfg *setting.Cfg) *config {
+func newConfig(cfg *setting.Cfg) *config {
 	defaultLogLevel := 0
 	if cfg.Env == setting.Dev {
 		defaultLogLevel = 10

--- a/pkg/services/grafana-apiserver/config.go
+++ b/pkg/services/grafana-apiserver/config.go
@@ -20,7 +20,7 @@ type config struct {
 	logLevel int
 }
 
-func provideConfig(cfg *setting.Cfg) *config {
+func ProvideConfig(cfg *setting.Cfg) *config {
 	defaultLogLevel := 0
 	if cfg.Env == setting.Dev {
 		defaultLogLevel = 10

--- a/pkg/services/grafana-apiserver/config.go
+++ b/pkg/services/grafana-apiserver/config.go
@@ -1,0 +1,38 @@
+package grafanaapiserver
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type config struct {
+	enabled bool
+	devMode bool
+
+	host        string
+	appURL      string
+	etcdServers []string
+	dataPath    string
+
+	logLevel int
+}
+
+func provideConfig(cfg *setting.Cfg) *config {
+	defaultLogLevel := 0
+	if cfg.Env == setting.Dev {
+		defaultLogLevel = 10
+	}
+
+	return &config{
+		enabled:     cfg.IsFeatureToggleEnabled(featuremgmt.FlagGrafanaAPIServer),
+		devMode:     cfg.Env == setting.Dev,
+		dataPath:    filepath.Join(cfg.DataPath, "grafana-apiserver"),
+		host:        fmt.Sprintf("%s:%s", cfg.HTTPAddr, cfg.HTTPPort),
+		logLevel:    cfg.SectionWithEnvOverrides("grafana-apiserver").Key("log_level").MustInt(defaultLogLevel),
+		etcdServers: cfg.SectionWithEnvOverrides("grafana-apiserver").Key("etcd_servers").Strings(","),
+		appURL:      cfg.AppURL,
+	}
+}

--- a/pkg/services/grafana-apiserver/config.go
+++ b/pkg/services/grafana-apiserver/config.go
@@ -20,7 +20,7 @@ type config struct {
 	logLevel int
 }
 
-func ProvideConfig(cfg *setting.Cfg) *config {
+func NewConfig(cfg *setting.Cfg) *config {
 	defaultLogLevel := 0
 	if cfg.Env == setting.Dev {
 		defaultLogLevel = 10

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -21,7 +21,7 @@ func TestProvideConfig(t *testing.T) {
 	section.Key("log_level").SetValue("5")
 	section.Key("etcd_servers").SetValue("http://localhost:2379")
 
-	actual := NewConfig(cfg)
+	actual := newConfig(cfg)
 
 	expected := &config{
 		enabled:     true,

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -21,7 +21,7 @@ func TestProvideConfig(t *testing.T) {
 	section.Key("log_level").SetValue("5")
 	section.Key("etcd_servers").SetValue("http://localhost:2379")
 
-	actual := ProvideConfig(cfg)
+	actual := NewConfig(cfg)
 
 	expected := &config{
 		enabled:     true,

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestProvideConfig(t *testing.T) {
+func TestNewConfig(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Env = setting.Dev
 	cfg.DataPath = "/tmp/grafana"

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -21,7 +21,7 @@ func TestProvideConfig(t *testing.T) {
 	section.Key("log_level").SetValue("5")
 	section.Key("etcd_servers").SetValue("http://localhost:2379")
 
-	actual := provideConfig(cfg)
+	actual := ProvideConfig(cfg)
 
 	expected := &config{
 		enabled:     true,
@@ -33,5 +33,4 @@ func TestProvideConfig(t *testing.T) {
 		logLevel:    5,
 	}
 	require.Equal(t, expected, actual)
-
 }

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -1,0 +1,37 @@
+package grafanaapiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestProvideConfig(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.Env = setting.Dev
+	cfg.DataPath = "/tmp/grafana"
+	cfg.HTTPAddr = "test"
+	cfg.HTTPPort = "4000"
+	cfg.IsFeatureToggleEnabled = func(_ string) bool { return true }
+	cfg.AppURL = "http://test:4000"
+
+	section := cfg.Raw.Section("grafana-apiserver")
+	section.Key("log_level").SetValue("5")
+	section.Key("etcd_servers").SetValue("http://localhost:2379")
+
+	actual := provideConfig(cfg)
+
+	expected := &config{
+		enabled:     true,
+		devMode:     true,
+		etcdServers: []string{"http://localhost:2379"},
+		appURL:      "http://test:4000",
+		host:        "test:4000",
+		dataPath:    "/tmp/grafana/grafana-apiserver",
+		logLevel:    5,
+	}
+	require.Equal(t, expected, actual)
+
+}

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -37,8 +37,6 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/registry"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -91,12 +89,9 @@ type RestConfigProvider interface {
 type service struct {
 	*services.BasicService
 
-	restConfig  *clientrest.Config
-	etcdServers []string
+	config     *config
+	restConfig *clientrest.Config
 
-	enabled   bool
-	logLevel  int
-	dataPath  string
 	stopCh    chan struct{}
 	stoppedCh chan error
 
@@ -108,19 +103,16 @@ type service struct {
 }
 
 func ProvideService(
-	cfg *setting.Cfg,
+	cfg *config,
 	rr routing.RouteRegister,
 	authz authorizer.Authorizer,
 ) (*service, error) {
 	s := &service{
-		logLevel:    cfg.SectionWithEnvOverrides("grafana-apiserver").Key("log_level").MustInt(10),
-		etcdServers: cfg.SectionWithEnvOverrides("grafana-apiserver").Key("etcd_servers").Strings(","),
-		enabled:     cfg.IsFeatureToggleEnabled(featuremgmt.FlagGrafanaAPIServer),
-		rr:          rr,
-		dataPath:    path.Join(cfg.DataPath, "k8s"),
-		stopCh:      make(chan struct{}),
-		builders:    []APIGroupBuilder{},
-		authorizer:  authz,
+		config:     cfg,
+		rr:         rr,
+		stopCh:     make(chan struct{}),
+		builders:   []APIGroupBuilder{},
+		authorizer: authz,
 	}
 
 	// This will be used when running as a dskit service
@@ -157,7 +149,7 @@ func (s *service) GetRestConfig() *clientrest.Config {
 }
 
 func (s *service) IsDisabled() bool {
-	return !s.enabled
+	return !s.config.enabled
 }
 
 // Run is an adapter for the BackgroundService interface.
@@ -173,14 +165,14 @@ func (s *service) RegisterAPI(builder APIGroupBuilder) {
 }
 
 func (s *service) start(ctx context.Context) error {
-	logger := logr.New(newLogAdapter(s.logLevel))
+	logger := logr.New(newLogAdapter(s.config.logLevel))
 	klog.SetLoggerWithOptions(logger, klog.ContextualLogger(true))
 
 	o := options.NewRecommendedOptions("", unstructured.UnstructuredJSONScheme)
 	o.SecureServing.BindPort = 6443
 	o.Authentication.RemoteKubeConfigFileOptional = true
 	o.Authorization.RemoteKubeConfigFileOptional = true
-	o.Etcd.StorageConfig.Transport.ServerList = s.etcdServers
+	o.Etcd.StorageConfig.Transport.ServerList = s.config.etcdServers
 
 	o.Admission = nil
 	o.CoreAPI = nil
@@ -190,7 +182,7 @@ func (s *service) start(ctx context.Context) error {
 
 	// Get the util to get the paths to pre-generated certs
 	certUtil := certgenerator.CertUtil{
-		K8sDataPath: s.dataPath,
+		K8sDataPath: s.config.dataPath,
 	}
 
 	if err := certUtil.InitializeCACertPKI(); err != nil {
@@ -357,7 +349,7 @@ func (s *service) writeKubeConfiguration(restConfig *clientrest.Config) error {
 		CurrentContext: "default-context",
 		AuthInfos:      authinfos,
 	}
-	return clientcmd.WriteToFile(clientConfig, path.Join(s.dataPath, "grafana.kubeconfig"))
+	return clientcmd.WriteToFile(clientConfig, path.Join(s.config.dataPath, "grafana.kubeconfig"))
 }
 
 func newAuthenticator(cert *x509.Certificate) (authenticator.Request, error) {

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/registry"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -103,12 +104,12 @@ type service struct {
 }
 
 func ProvideService(
-	cfg *config,
+	cfg *setting.Cfg,
 	rr routing.RouteRegister,
 	authz authorizer.Authorizer,
 ) (*service, error) {
 	s := &service{
-		config:     cfg,
+		config:     NewConfig(cfg),
 		rr:         rr,
 		stopCh:     make(chan struct{}),
 		builders:   []APIGroupBuilder{},

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -109,7 +109,7 @@ func ProvideService(
 	authz authorizer.Authorizer,
 ) (*service, error) {
 	s := &service{
-		config:     NewConfig(cfg),
+		config:     newConfig(cfg),
 		rr:         rr,
 		stopCh:     make(chan struct{}),
 		builders:   []APIGroupBuilder{},

--- a/pkg/services/grafana-apiserver/wireset.go
+++ b/pkg/services/grafana-apiserver/wireset.go
@@ -7,6 +7,7 @@ import (
 )
 
 var WireSet = wire.NewSet(
+	provideConfig,
 	ProvideService,
 	wire.Bind(new(RestConfigProvider), new(*service)),
 	wire.Bind(new(Service), new(*service)),

--- a/pkg/services/grafana-apiserver/wireset.go
+++ b/pkg/services/grafana-apiserver/wireset.go
@@ -7,7 +7,6 @@ import (
 )
 
 var WireSet = wire.NewSet(
-	ProvideConfig,
 	ProvideService,
 	wire.Bind(new(RestConfigProvider), new(*service)),
 	wire.Bind(new(Service), new(*service)),

--- a/pkg/services/grafana-apiserver/wireset.go
+++ b/pkg/services/grafana-apiserver/wireset.go
@@ -7,7 +7,7 @@ import (
 )
 
 var WireSet = wire.NewSet(
-	provideConfig,
+	ProvideConfig,
 	ProvideService,
 	wire.Bind(new(RestConfigProvider), new(*service)),
 	wire.Bind(new(Service), new(*service)),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This splits out config for grafana-apiserver into a separate struct, and provides a wire service to pull the relevant info out of `setting.Cfg`.

**Why do we need this feature?**

Pulling config out of `setting.Cfg` was scattered throughout `service.go` on a different branch, so this is an attempt to clean that up a bit.

**Who is this feature for?**

@grafana/grafana-app-platform-squad 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
