### PR TITLE
Stack: Add alignItems and justifyContent props

### DIFF
--- a/packages/grafana-ui/src/components/Layout/Flex/Flex.tsx
+++ b/packages/grafana-ui/src/components/Layout/Flex/Flex.tsx
@@ -33,7 +33,7 @@ export type Direction = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
 export type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
-interface FlexProps extends Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
+export interface FlexProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className' | 'style'> {
   gap?: ResponsiveProp<ThemeSpacingTokens>;
   alignItems?: ResponsiveProp<AlignItems>;
   justifyContent?: ResponsiveProp<JustifyContent>;

--- a/packages/grafana-ui/src/components/Layout/Stack/Stack.tsx
+++ b/packages/grafana-ui/src/components/Layout/Stack/Stack.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 
-import { ThemeSpacingTokens } from '@grafana/data';
+import { Flex, FlexProps } from '../Flex/Flex';
 
-import { Flex } from '../Flex/Flex';
-import { ResponsiveProp } from '../utils/responsiveness';
-interface StackProps extends Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
-  direction?: ResponsiveProp<'column' | 'row'>;
-  gap?: ResponsiveProp<ThemeSpacingTokens>;
-}
+interface StackProps extends Pick<FlexProps, 'gap' | 'direction' | 'alignItems' | 'justifyContent'> {}
 
 export const Stack = React.forwardRef<HTMLDivElement, React.PropsWithChildren<StackProps>>(
-  ({ gap = 1, direction = 'column', children, ...rest }, ref) => {
+  ({ gap = 1, alignItems, justifyContent, direction = 'column', children, ...rest }, ref) => {
     return (
-      <Flex ref={ref} gap={gap} direction={direction} wrap="wrap" {...rest}>
+      <Flex
+        ref={ref}
+        gap={gap}
+        direction={direction}
+        alignItems={alignItems}
+        justifyContent={justifyContent}
+        wrap="wrap"
+        {...rest}
+      >
         {React.Children.toArray(children)
           .filter(Boolean)
           .map((child, index) => (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add `alignItems` and `justifyContent` props to Stack and extend its props from `FlexProps`.

**Why do we need this feature?**

To enable more fine-grained layout of the component's children. 
