### PR TITLE
Chore: Reduce flakiness of e2e tests caused by write contention in sqlite

### DIFF
--- a/scripts/grafana-server/custom.ini
+++ b/scripts/grafana-server/custom.ini
@@ -8,3 +8,5 @@ enable = publicDashboards
 [database]
 type=sqlite3
 wal=true
+max_idle_conn = 2
+max_open_conn = 2


### PR DESCRIPTION
Write contention in sqlite on startup intermittently causes failed tests because of failed service runs. This can have various root causes, one example is dashboard provisioning:

Dashboard provisioning's frequent commits can cause other read transaction snapshots to invalidate and throw SQLITE_BUSY/SQLITE_BUSY_SNAPSHOT. If those failing transactions have a long length but not long enough to ensure all of the dashboards have finished provisioning after retry, it will run out of retries and fail entirely. 

This change helps indirectly reduce these write contentions by limiting the connection pool for e2e tests. 

As a bonus, having our e2e tests run using `max_open_conn = 2` means it acts as a guard against regressions that would affect certain internal instances that run with these settings.