### PR TITLE
[v10.0.x] CI: Remove 0.0.0-test tag event

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -506,37 +506,6 @@ steps:
   depends_on: []
   image: grafana/build-container:1.7.5
   name: yarn-install
-- commands:
-  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
-    --depth=1
-  - cd grafana-enterprise
-  - git fetch origin "refs/tags/*:refs/tags/*" --quiet
-  - if git show-ref --tags $${TEST_TAG} --quiet; then git tag -d $${TEST_TAG} && git
-    push --delete origin $${TEST_TAG}; fi
-  - git tag $${TEST_TAG} && git push origin $${TEST_TAG}
-  - cd -
-  - git fetch https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git "refs/tags/*:refs/tags/*"
-    --quiet && git fetch --quiet
-  - if git show-ref --tags $${TEST_TAG} --quiet; then git tag -d $${TEST_TAG} && git
-    push --delete https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git $${TEST_TAG};
-    fi
-  - git tag $${TEST_TAG} && git push https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git
-    $${TEST_TAG}
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-    TEST_TAG: v0.0.0-test
-  failure: ignore
-  image: grafana/build-container:1.7.5
-  name: trigger-test-release
-  when:
-    branch: main
-    paths:
-      include:
-      - .drone.yml
-      - pkg/build/**
-    repo:
-    - grafana/grafana
 - failure: ignore
   image: grafana/drone-downstream
   name: trigger-enterprise-downstream
@@ -4341,6 +4310,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 4f9de3e9ea36382ed000e362922344465ce0ee049650391e8cc8ef68b988d351
+hmac: 0808b6f03f013b661d4971f2602907805ecbf24a61f6bd2f33d688aa1ff675e8
 
 ...

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -24,7 +24,6 @@ load(
     "store_storybook_step",
     "test_a11y_frontend_step",
     "trigger_oss",
-    "trigger_test_release",
     "upload_cdn_step",
     "upload_packages_step",
     "verify_gen_cue_step",
@@ -65,7 +64,6 @@ def build_e2e(trigger, ver_mode):
     if ver_mode == "pr":
         build_steps.extend(
             [
-                trigger_test_release(),
                 enterprise_downstream_step(ver_mode = ver_mode),
             ],
         )

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1319,40 +1319,6 @@ def verify_gen_jsonnet_step():
         ],
     }
 
-def trigger_test_release():
-    return {
-        "name": "trigger-test-release",
-        "image": images["build_image"],
-        "environment": {
-            "GITHUB_TOKEN": from_secret("github_token"),
-            "TEST_TAG": "v0.0.0-test",
-        },
-        "commands": [
-            'git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git" --depth=1',
-            "cd grafana-enterprise",
-            'git fetch origin "refs/tags/*:refs/tags/*" --quiet',
-            "if git show-ref --tags $${TEST_TAG} --quiet; then git tag -d $${TEST_TAG} && git push --delete origin $${TEST_TAG}; fi",
-            "git tag $${TEST_TAG} && git push origin $${TEST_TAG}",
-            "cd -",
-            'git fetch https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git "refs/tags/*:refs/tags/*" --quiet && git fetch --quiet',
-            "if git show-ref --tags $${TEST_TAG} --quiet; then git tag -d $${TEST_TAG} && git push --delete https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git $${TEST_TAG}; fi",
-            "git tag $${TEST_TAG} && git push https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git $${TEST_TAG}",
-        ],
-        "failure": "ignore",
-        "when": {
-            "paths": {
-                "include": [
-                    ".drone.yml",
-                    "pkg/build/**",
-                ],
-            },
-            "repo": [
-                "grafana/grafana",
-            ],
-            "branch": "main",
-        },
-    }
-
 def end_to_end_tests_deps():
     return [
         "end-to-end-tests-dashboards-suite",


### PR DESCRIPTION
Backport faa22b8f2067fe752af7a16c5605306bd2ef81a6 from #76662

---

**What is this feature?**

Removes `0.0.0-test` tag event on Drone. Currently, every time we make changes to `.drone.yml` or to the `pkg/build/` dir, we trigger a tag event to simulate an actual release build. Since this is not getting attention anymore, we can safely remove it.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/76661

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
