### PR TITLE
Slack notifications: Remove CI changes notifications from the `grafana-delivery` channel

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2334,38 +2334,6 @@ volumes:
 ---
 clone:
   retries: 3
-depends_on: []
-kind: pipeline
-name: notify-drone-changes
-platform:
-  arch: amd64
-  os: linux
-steps:
-- image: plugins/slack
-  name: slack
-  settings:
-    channel: slack-webhooks-test
-    template: "`.drone.yml` and `starlark` files have been changed on the OSS repo,
-      by: {{build.author}}. \nBranch: <https://github.com/{{ repo.owner }}/{{ repo.name
-      }}/commits/{{ build.branch }}|{{ build.branch }}>\nCommit hash: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{
-      truncate build.commit 8 }}>"
-    webhook:
-      from_secret: drone-changes-webhook
-trigger:
-  branch: main
-  event:
-  - push
-  paths:
-    exclude:
-    - exclude
-    include:
-    - .drone.yml
-  repo:
-  - grafana/grafana
-type: docker
----
-clone:
-  retries: 3
 depends_on:
 - main-build-e2e-publish
 - main-integration-tests
@@ -4630,6 +4598,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 8713a4d7924e053d6b27acf7beec75ab6c1a85dc279f19c1819f989f7b015861
+hmac: ff105572d451a06880931bc5d3abdb86e50161eb84091e09118d9bf6a229e39b
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -64,7 +64,6 @@ trigger = {
 }
 
 def main_pipelines():
-
     pipelines = [
         docs_pipelines(ver_mode, trigger_docs_main()),
         test_frontend(trigger, ver_mode),

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -64,23 +64,6 @@ trigger = {
 }
 
 def main_pipelines():
-    drone_change_trigger = {
-        "event": [
-            "push",
-        ],
-        "branch": "main",
-        "repo": [
-            "grafana/grafana",
-        ],
-        "paths": {
-            "include": [
-                ".drone.yml",
-            ],
-            "exclude": [
-                "exclude",
-            ],
-        },
-    }
 
     pipelines = [
         docs_pipelines(ver_mode, trigger_docs_main()),

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -41,7 +41,6 @@ load(
 )
 load(
     "scripts/drone/utils/utils.star",
-    "drone_change_template",
     "failure_template",
     "notify_pipeline",
 )
@@ -92,13 +91,6 @@ def main_pipelines():
         build_e2e(trigger, ver_mode),
         integration_tests(trigger, prefix = ver_mode, ver_mode = ver_mode),
         windows(trigger, ver_mode = ver_mode),
-        notify_pipeline(
-            name = "notify-drone-changes",
-            slack_channel = "slack-webhooks-test",
-            trigger = drone_change_trigger,
-            template = drone_change_template,
-            secret = "drone-changes-webhook",
-        ),
         enterprise_downstream_pipeline(),
         notify_pipeline(
             name = "main-notify",

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -9,7 +9,6 @@ load(
 load("scripts/drone/vault.star", "pull_secret")
 
 failure_template = "Build {{build.number}} failed for commit: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 8 }}>: {{build.link}}\nBranch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>\nAuthor: {{build.author}}"
-drone_change_template = "`.drone.yml` and `starlark` files have been changed on the OSS repo, by: {{build.author}}. \nBranch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>\nCommit hash: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 8 }}>"
 
 def pipeline(
         name,


### PR DESCRIPTION
**What is this feature?**

Removes notifications from the `#grafana-delivery` channel, since they don't provide much value lately.