### PR TITLE
Change the structure of externalServiceRegistration

### DIFF
--- a/pkg/plugins/manager/testdata/external-registration/plugin.json
+++ b/pkg/plugins/manager/testdata/external-registration/plugin.json
@@ -18,14 +18,11 @@
     "version": "1.0.0"
   },
   "externalServiceRegistration": {
-    "self": {
-      "enabled" : true,
-      "permissions" :  [
-        {
-          "action": "read",
-          "scope": "datasource"
-        }
-      ]
-    }
+    "permissions" :  [
+      {
+        "action": "read",
+        "scope": "datasource"
+      }
+    ]
   }
 }

--- a/pkg/plugins/manager/testdata/oauth-external-registration/plugin.json
+++ b/pkg/plugins/manager/testdata/oauth-external-registration/plugin.json
@@ -18,7 +18,6 @@
     "version": "1.0.0"
   },
   "externalServiceRegistration": {
-    "authProvider": "OAuth2Server",
     "impersonation": {
       "enabled" : true,
       "groups" : true,
@@ -29,14 +28,11 @@
         }
       ]
     },
-    "self": {
-      "enabled" : true,
-      "permissions" :  [
-        {
-          "action": "read",
-          "scope": "datasource"
-        }
-      ]
-    }
+    "permissions" :  [
+      {
+        "action": "read",
+        "scope": "datasource"
+      }
+    ]
   }
 }

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -413,16 +413,14 @@ schemas: [{
 		// External service registration information
 		externalServiceRegistration: #ExternalServiceRegistration
 
+		// ExternalServiceRegistration allows the service to get a service account token
+		// (or to use the client_credentials grant if the token provider is the OAuth2 Server)
 		#ExternalServiceRegistration: {
-			// // Enabled allows the service to get a service account token
-			// // (or to use the client_credentials grant if the token provider is the OAuth2 Server)
-			// // Defaults to true.
-			// enabled?: bool
-
 			// Permissions are the permissions that the external service needs its associated service account to have.
 			permissions?: [...#Permission]
-			
+
 			// Impersonation describes the permissions that the external service will have on behalf of the user
+			// This is only available with the OAuth2 Server
 			impersonation?: #Impersonation
 		}
 

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -414,13 +414,16 @@ schemas: [{
 		externalServiceRegistration: #ExternalServiceRegistration
 
 		#ExternalServiceRegistration: {
-			// AuthProvider defines which authentication provider will be used by the plugin to authenticate against Grafana.
-			// Defaults to "ServiceAccounts"
-			authProvider?: #AuthProvider
+			// // Enabled allows the service to get a service account token
+			// // (or to use the client_credentials grant if the token provider is the OAuth2 Server)
+			// // Defaults to true.
+			// enabled?: bool
+
+			// Permissions are the permissions that the external service needs its associated service account to have.
+			permissions?: [...#Permission]
+			
 			// Impersonation describes the permissions that the external service will have on behalf of the user
 			impersonation?: #Impersonation
-			// Self describes the permissions that the external service will have on behalf of itself
-			self?: 		#Self
 		}
 
 		#Impersonation: {
@@ -433,19 +436,6 @@ schemas: [{
 			// Permissions are the permissions that the external service needs when impersonating a user.
 			// The intersection of this set with the impersonated user's permission guarantees that the client will not
 			// gain more privileges than the impersonated user has.
-			permissions?: [...#Permission]
-		}
-
-		// AuthProvider is a string which can be 'ServiceAccounts', 'OAuth2Server'.
-		// It identifies which authentication provider will be used by the plugin to authenticate against Grafana.
-		#AuthProvider: "ServiceAccounts" | "OAuth2Server"
-
-		#Self: {
-			// Enabled allows the service to get a service account token if the AuthProvider is 'ServiceAccounts'
-			// or to use the client_credentials grant if the AuthProvider is 'OAuth2Server'
-			// Defaults to true.
-			enabled?: bool
-			// Permissions are the permissions that the external service needs its associated service account to have.
 			permissions?: [...#Permission]
 		}
 	}

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -9,12 +9,6 @@
 
 package plugindef
 
-// Defines values for AuthProvider.
-const (
-	AuthProviderOAuth2Server    AuthProvider = "OAuth2Server"
-	AuthProviderServiceAccounts AuthProvider = "ServiceAccounts"
-)
-
 // Defines values for BasicRole.
 const (
 	BasicRoleAdmin        BasicRole = "Admin"
@@ -78,10 +72,6 @@ const (
 	ReleaseStateStable     ReleaseState = "stable"
 )
 
-// AuthProvider is a string which can be 'ServiceAccounts', 'OAuth2Server'.
-// It identifies which authentication provider will be used by the plugin to authenticate against Grafana.
-type AuthProvider string
-
 // BasicRole is a Grafana basic role, which can be 'Viewer', 'Editor', 'Admin' or 'Grafana Admin'.
 // With RBAC, the Admin basic role inherits its default permissions from the Editor basic role which
 // in turn inherits them from the Viewer basic role.
@@ -134,11 +124,10 @@ type DependencyType string
 
 // ExternalServiceRegistration defines model for ExternalServiceRegistration.
 type ExternalServiceRegistration struct {
-	// AuthProvider is a string which can be 'ServiceAccounts', 'OAuth2Server'.
-	// It identifies which authentication provider will be used by the plugin to authenticate against Grafana.
-	AuthProvider  *AuthProvider  `json:"authProvider,omitempty"`
 	Impersonation *Impersonation `json:"impersonation,omitempty"`
-	Self          *Self          `json:"self,omitempty"`
+
+	// Permissions are the permissions that the external service needs its associated service account to have.
+	Permissions []Permission `json:"permissions,omitempty"`
 }
 
 // Header describes an HTTP header that is forwarded with a proxied request for
@@ -483,17 +472,6 @@ type Route struct {
 	// proxied to.
 	Url       *string    `json:"url,omitempty"`
 	UrlParams []URLParam `json:"urlParams,omitempty"`
-}
-
-// Self defines model for Self.
-type Self struct {
-	// Enabled allows the service to get a service account token if the AuthProvider is 'ServiceAccounts'
-	// or to use the client_credentials grant if the AuthProvider is 'OAuth2Server'
-	// Defaults to true.
-	Enabled *bool `json:"enabled,omitempty"`
-
-	// Permissions are the permissions that the external service needs its associated service account to have.
-	Permissions []Permission `json:"permissions,omitempty"`
 }
 
 // TODO docs

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -122,7 +122,8 @@ type Dependency struct {
 // DependencyType defines model for Dependency.Type.
 type DependencyType string
 
-// ExternalServiceRegistration defines model for ExternalServiceRegistration.
+// ExternalServiceRegistration allows the service to get a service account token
+// (or to use the client_credentials grant if the token provider is the OAuth2 Server)
 type ExternalServiceRegistration struct {
 	Impersonation *Impersonation `json:"impersonation,omitempty"`
 
@@ -316,7 +317,10 @@ type PluginDef struct {
 	// $GOARCH><.exe for Windows>`, e.g. `plugin_linux_amd64`.
 	// Combination of $GOOS and $GOARCH can be found here:
 	// https://golang.org/doc/install/source#environment.
-	Executable                  *string                     `json:"executable,omitempty"`
+	Executable *string `json:"executable,omitempty"`
+
+	// ExternalServiceRegistration allows the service to get a service account token
+	// (or to use the client_credentials grant if the token provider is the OAuth2 Server)
 	ExternalServiceRegistration ExternalServiceRegistration `json:"externalServiceRegistration"`
 
 	// [internal only] Excludes the plugin from listings in Grafana's UI. Only

--- a/pkg/services/pluginsintegration/loader/loader_test.go
+++ b/pkg/services/pluginsintegration/loader/loader_test.go
@@ -497,7 +497,6 @@ func TestLoader_Load(t *testing.T) {
 func TestLoader_Load_ExternalRegistration(t *testing.T) {
 	boolPtr := func(b bool) *bool { return &b }
 	stringPtr := func(s string) *string { return &s }
-	authProvPtr := func(a plugindef.AuthProvider) *plugindef.AuthProvider { return &a }
 
 	t.Run("Load a plugin with oauth client registration", func(t *testing.T) {
 		cfg := &config.Cfg{
@@ -530,7 +529,6 @@ func TestLoader_Load_ExternalRegistration(t *testing.T) {
 					Plugins:        []plugins.Dependency{},
 				},
 				ExternalServiceRegistration: &plugindef.ExternalServiceRegistration{
-					AuthProvider: authProvPtr(plugindef.AuthProviderOAuth2Server),
 					Impersonation: &plugindef.Impersonation{
 						Enabled: boolPtr(true),
 						Groups:  boolPtr(true),
@@ -541,13 +539,10 @@ func TestLoader_Load_ExternalRegistration(t *testing.T) {
 							},
 						},
 					},
-					Self: &plugindef.Self{
-						Enabled: boolPtr(true),
-						Permissions: []plugindef.Permission{
-							{
-								Action: "read",
-								Scope:  stringPtr("datasource"),
-							},
+					Permissions: []plugindef.Permission{
+						{
+							Action: "read",
+							Scope:  stringPtr("datasource"),
 						},
 					},
 				},
@@ -636,13 +631,10 @@ func TestLoader_Load_ExternalRegistration(t *testing.T) {
 					Plugins:        []plugins.Dependency{},
 				},
 				ExternalServiceRegistration: &plugindef.ExternalServiceRegistration{
-					Self: &plugindef.Self{
-						Enabled: boolPtr(true),
-						Permissions: []plugindef.Permission{
-							{
-								Action: "read",
-								Scope:  stringPtr("datasource"),
-							},
+					Permissions: []plugindef.Permission{
+						{
+							Action: "read",
+							Scope:  stringPtr("datasource"),
 						},
 					},
 				},

--- a/pkg/services/pluginsintegration/serviceregistration/serviceregistration.go
+++ b/pkg/services/pluginsintegration/serviceregistration/serviceregistration.go
@@ -38,13 +38,9 @@ func (s *Service) RegisterExternalService(ctx context.Context, svcName string, s
 	}
 
 	self := extsvcauth.SelfCfg{}
-	if svc.Self != nil {
-		self.Permissions = toAccessControlPermissions(svc.Self.Permissions)
-		if svc.Self.Enabled != nil {
-			self.Enabled = *svc.Self.Enabled
-		} else {
-			self.Enabled = true
-		}
+	if len(svc.Permissions) > 0 {
+		self.Permissions = toAccessControlPermissions(svc.Permissions)
+		self.Enabled = true
 	}
 
 	registration := &extsvcauth.ExternalServiceRegistration{
@@ -55,7 +51,7 @@ func (s *Service) RegisterExternalService(ctx context.Context, svcName string, s
 
 	// Default authProvider now is ServiceAccounts
 	registration.AuthProvider = extsvcauth.ServiceAccounts
-	if svc.AuthProvider != nil && *svc.AuthProvider == plugindef.AuthProviderOAuth2Server {
+	if svc.Impersonation != nil {
 		registration.AuthProvider = extsvcauth.OAuth2Server
 		registration.OAuthProviderCfg = &extsvcauth.OAuthProviderCfg{Key: &extsvcauth.KeyOption{Generate: true}}
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR is an attempt to get a simpler registration form for plugins (see comment here: https://github.com/grafana/grafana/pull/76473/files#r1360453005)

We'd be switching from this:
```json
"externalServiceRegistration": {
  "self": {
    "enabled": true,
    "permissions": {"action":  "datasources:read", "scope": "datasources:*"},
   }
  "impersonation": {
    "enabled": true,
    "groups": true,
    "permissions": {"action": "folders:read", "scope": "folders:*"}
  }
}
```
to this:
```json
"externalServiceRegistration": {
  "permissions": {"action":  "datasources:read", "scope": "datasources:*"},
  "impersonation": {
    "enabled": true,
    "groups": true,
    "permissions": {"action": "folders:read", "scope": "folders:*"}
  }
}
```

The presence of the `impersonation` field would trigger the use of the `OAuth2 Server` in place of the `Service account token provider`.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
