### PR TITLE
Dashboard: Fix panels overlapping Save Drawer

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -153,6 +153,7 @@ export class DashboardGrid extends PureComponent<Props> {
       const panelClasses = classNames({ 'react-grid-item--fullscreen': panel.isViewing });
 
       // used to allow overflowing content to show on top of the next panel
+      // requires parent create stacking context to prevent overlap with parent elements
       const descIndex = this.props.dashboard.panels.length - panelElements.length;
 
       panelElements.push(
@@ -230,6 +231,8 @@ export class DashboardGrid extends PureComponent<Props> {
      * We have a parent with "flex: 1 1 0" we need to reset it to "flex: 1 1 auto" to have the AutoSizer
      * properly working. For more information go here:
      * https://github.com/bvaughn/react-virtualized/blob/master/docs/usingAutoSizer.md#can-i-use-autosizer-within-a-flex-container
+     *
+     * pos: rel + z-index is required to create a new stacking context to contain the escalating z-indexes of the panels
      */
     return (
       <div

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -232,7 +232,14 @@ export class DashboardGrid extends PureComponent<Props> {
      * https://github.com/bvaughn/react-virtualized/blob/master/docs/usingAutoSizer.md#can-i-use-autosizer-within-a-flex-container
      */
     return (
-      <div style={{ flex: '1 1 auto', display: this.props.editPanel ? 'none' : undefined }}>
+      <div
+        style={{
+          flex: '1 1 auto',
+          position: 'relative',
+          zIndex: 1,
+          display: this.props.editPanel ? 'none' : undefined,
+        }}
+      >
         <AutoSizer disableHeight>
           {({ width }) => {
             if (width === 0) {


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/grafana/grafana/pull/75328 where Dashboards with more than 1020 panels would have their panels z index raised above tooltips and drawers.

This PR fixes the issue by making sure the panels are in their own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) so they cannot overlap anymore.

Before:

![6Y8MkBq5rL](https://github.com/grafana/grafana/assets/46142/5c61c6ce-28ac-4cf3-853e-ed9bedd0c244)

After:

![vT6jnm7O8X](https://github.com/grafana/grafana/assets/46142/b55aaae8-33dc-41b7-b50b-95159da02f9c)

