### PR TITLE
Tracing: Update configuration editor links

### DIFF
--- a/public/app/core/components/NodeGraphSettings.tsx
+++ b/public/app/core/components/NodeGraphSettings.tsx
@@ -50,13 +50,16 @@ export function NodeGraphSettings({ options, onOptionsChange }: Props) {
 }
 
 export const NodeGraphSection = ({ options, onOptionsChange }: DataSourcePluginOptionsEditorProps) => {
+  let suffix = options.type;
+  suffix += options.type === 'tempo' ? '/configure-tempo-data-source/#node-graph' : '/#node-graph';
+
   return (
     <ConfigSubSection
       title="Node graph"
       description={
         <ConfigDescriptionLink
           description="Show or hide the node graph visualization."
-          suffix={`${options.type}/#node-graph`}
+          suffix={suffix}
           feature="the node graph"
         />
       }

--- a/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
@@ -253,13 +253,16 @@ export const getTimeShiftTooltip = (type: 'start' | 'end', defaultVal: string) =
 export const invalidTimeShiftError = 'Invalid time shift. See tooltip for examples.';
 
 export const TraceToLogsSection = ({ options, onOptionsChange }: DataSourcePluginOptionsEditorProps) => {
+  let suffix = options.type;
+  suffix += options.type === 'tempo' ? '/configure-tempo-data-source/#trace-to-logs' : '/#trace-to-logs';
+
   return (
     <ConfigSection
       title="Trace to logs"
       description={
         <ConfigDescriptionLink
           description="Navigate from a trace span to the selected data source's logs."
-          suffix={`${options.type}/#trace-to-logs`}
+          suffix={suffix}
           feature="trace to logs"
         />
       }

--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -202,13 +202,16 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
 }
 
 export const TraceToMetricsSection = ({ options, onOptionsChange }: DataSourcePluginOptionsEditorProps) => {
+  let suffix = options.type;
+  suffix += options.type === 'tempo' ? '/configure-tempo-data-source/#trace-to-metrics' : '/#trace-to-metrics';
+
   return (
     <ConfigSection
       title="Trace to metrics"
       description={
         <ConfigDescriptionLink
           description="Navigate from a trace span to the selected data source's metrics."
-          suffix={`${options.type}/#trace-to-metrics`}
+          suffix={suffix}
           feature="trace to metrics"
         />
       }

--- a/public/app/features/explore/TraceView/components/settings/SpanBarSettings.tsx
+++ b/public/app/features/explore/TraceView/components/settings/SpanBarSettings.tsx
@@ -79,13 +79,16 @@ export default function SpanBarSettings({ options, onOptionsChange }: Props) {
 }
 
 export const SpanBarSection = ({ options, onOptionsChange }: DataSourcePluginOptionsEditorProps) => {
+  let suffix = options.type;
+  suffix += options.type === 'tempo' ? '/configure-tempo-data-source/#span-bar' : '/#span-bar';
+
   return (
     <ConfigSubSection
       title="Span bar"
       description={
         <ConfigDescriptionLink
           description="Add additional info next to the service and operation on a span bar row in the trace view."
-          suffix={`${options.type}/#span-bar`}
+          suffix={suffix}
           feature="the span bar"
         />
       }

--- a/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
@@ -81,7 +81,7 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
           description={
             <ConfigDescriptionLink
               description="Select a Prometheus data source that contains the service graph data."
-              suffix="tempo/#service-graph"
+              suffix="tempo/configure-tempo-data-source/#service-graph"
               feature="the service graph"
             />
           }
@@ -98,7 +98,7 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
           description={
             <ConfigDescriptionLink
               description="Modify how traces are searched."
-              suffix="tempo/#tempo-search"
+              suffix="tempo/configure-tempo-data-source/#tempo-search"
               feature="Tempo search"
             />
           }
@@ -112,7 +112,7 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
           description={
             <ConfigDescriptionLink
               description="Select a Loki data source to search for traces. Derived fields must be configured in the Loki data source."
-              suffix="tempo/#loki-search"
+              suffix="tempo/configure-tempo-data-source/#loki-search"
               feature="Loki search"
             />
           }
@@ -126,7 +126,7 @@ export const ConfigEditor = ({ options, onOptionsChange }: Props) => {
           description={
             <ConfigDescriptionLink
               description="Modify how TraceID queries are run."
-              suffix="tempo/#traceid-query"
+              suffix="tempo/configure-tempo-data-source/#traceid-query"
               feature="the TraceID query"
             />
           }


### PR DESCRIPTION
**What is this feature?**

Updates configuration editor doc links.

**Why do we need this feature?**

To update the links.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
