### PR TITLE
Devenv: Add `undev` command to the ./setup scrip of devenv

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -13,8 +13,14 @@ Grafana uses [Docker](https://docker.com) to make the task of setting up databas
 
 ## Developer dashboards and data sources
 
+To setup developer dashboards and data sources
 ```bash
 ./setup.sh
+```
+
+To remove the setup developer dashboards and data sources
+```bash
+./setup.sh undev
 ```
 
 After restarting the Grafana server, there should be a number of data sources named `gdev-<type>` provisioned as well as

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -62,22 +62,19 @@ devDatasources() {
 undev() {
     echo -e "\xE2\x9C\x94 Reverting all dev provisioning"
 
-    # Removing generated dashboard files for bulkDashboard
-    COUNTER=0
-    MAX=400
-    while [ $COUNTER -lt $MAX ]; do
-        rm -f "bulk-dashboards/dashboard${COUNTER}.json"
-        let COUNTER=COUNTER+1
-    done
+    # Removing generated dashboard files from bulk-dashboards
+    rm -f bulk-dashboards/dashboard*.json
+    echo -e "    \xE2\x9C\x94 Reverting bulk-dashboards provisioning"
 
-    # Removing generated dashboard and datasource files for bulkAlertingDashboard
-    COUNTER=0
-    MAX=1000
-    while [ $COUNTER -lt $MAX ]; do
-        rm -f "bulk_alerting_dashboards/alerting_dashboard${COUNTER}.json"
-        let COUNTER=COUNTER+1
-    done
+    # Removing generated folders from bulk-folders
+    rm -rf bulk-folders/Bulk\ Folder*
+    echo -e "    \xE2\x9C\x94 Reverting bulk-folders provisioning"
+
+
+    # Removing generated dashboard and datasource files from bulk-alerting-dashboards
+    rm -f bulk_alerting_dashboards/alerting_dashboard*.json
     rm -f "bulk_alerting_dashboards/bulk_alerting_datasources.yaml"
+    echo -e "    \xE2\x9C\x94 Reverting bulk-alerting-dashboards provisioning"
 
     # Removing the symlinks
     rm -f ../conf/provisioning/dashboards/custom.yaml

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -92,6 +92,7 @@ usage() {
 	echo "  bulk-folders [folders] [dashboards]  - provision many folders with dashboards"
 	echo "  bulk-folders                         - provision 200 folders with 3 dashboards in each"
 	echo "  no args                              - provision core datasources and dev dashboards"
+	echo "  undev                                - removes any provisioning done by the setup.sh"
 }
 
 main() {

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -59,6 +59,34 @@ devDatasources() {
 		ln -s -f ../../../devenv/datasources.yaml ../conf/provisioning/datasources/dev.yaml
 }
 
+undev() {
+    echo -e "\xE2\x9C\x94 Reverting all dev provisioning"
+
+    # Removing generated dashboard files for bulkDashboard
+    COUNTER=0
+    MAX=400
+    while [ $COUNTER -lt $MAX ]; do
+        rm -f "bulk-dashboards/dashboard${COUNTER}.json"
+        let COUNTER=COUNTER+1
+    done
+
+    # Removing generated dashboard and datasource files for bulkAlertingDashboard
+    COUNTER=0
+    MAX=1000
+    while [ $COUNTER -lt $MAX ]; do
+        rm -f "bulk_alerting_dashboards/alerting_dashboard${COUNTER}.json"
+        let COUNTER=COUNTER+1
+    done
+    rm -f "bulk_alerting_dashboards/bulk_alerting_datasources.yaml"
+
+    # Removing the symlinks
+    rm -f ../conf/provisioning/dashboards/custom.yaml
+    rm -f ../conf/provisioning/dashboards/bulk-folders.yaml
+    rm -f ../conf/provisioning/dashboards/dev.yaml
+    rm -f ../conf/provisioning/datasources/custom.yaml
+    rm -f ../conf/provisioning/datasources/dev.yaml
+}
+
 usage() {
 	echo -e "\n"
 	echo "Usage:"
@@ -84,6 +112,8 @@ main() {
 		bulkDashboard
 	elif [[ $cmd == "bulk-folders" ]]; then
 		bulkFolders "$arg1"
+	elif [[ $cmd == "undev" ]]; then
+ 	   undev
 	else
 		devDashboards
 		devDatasources


### PR DESCRIPTION

**What is this feature?**

To remove the devenv setup, setup by initiating the ./setup.sh script.