### PR TITLE
Provisioning: Ensure that enterprise provisioning runs [10.1.x]

### DIFF
--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -11,18 +11,14 @@ const (
 	GrafanaAPIServer string = "grafana-apiserver"
 	// HTTPServer is the HTTP server for Grafana
 	HTTPServer string = "http-server"
-	// Provisioning sets up Grafana with preconfigured datasources, dashboards, etc.
-	Provisioning string = "provisioning"
 	// SecretMigrator handles legacy secrets migrations
 	SecretMigrator string = "secret-migrator"
 )
 
 // dependencyMap defines Module Targets => Dependencies
 var dependencyMap = map[string][]string{
-	BackgroundServices: {Provisioning, HTTPServer},
+	BackgroundServices: {HTTPServer},
 	CertGenerator:      {},
 	GrafanaAPIServer:   {CertGenerator},
-	Provisioning:       {SecretMigrator},
-
-	All: {BackgroundServices},
+	All:                {BackgroundServices},
 }

--- a/pkg/modules/registry/registry.go
+++ b/pkg/modules/registry/registry.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/server/backgroundsvcs"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/grafana-apiserver"
-	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/secrets/kvstore/migrations"
 )
 
@@ -26,7 +25,6 @@ func ProvideRegistry(
 	backgroundServiceRunner *backgroundsvcs.BackgroundServiceRunner,
 	certGenerator certgenerator.ServiceInterface,
 	httpServer *api.HTTPServer,
-	provisioningService *provisioning.ProvisioningServiceImpl,
 	secretsMigrator *migrations.SecretMigrationProviderImpl,
 ) *registry {
 	return newRegistry(
@@ -36,7 +34,6 @@ func ProvideRegistry(
 		backgroundServiceRunner,
 		certGenerator,
 		httpServer,
-		provisioningService,
 		secretsMigrator,
 	)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -15,7 +15,7 @@ import (
 
 func testServer(t *testing.T, m *modules.MockModuleEngine) *Server {
 	t.Helper()
-	s, err := newServer(Options{}, setting.NewCfg(), nil, &acimpl.Service{}, m)
+	s, err := newServer(Options{}, setting.NewCfg(), nil, &acimpl.Service{}, nil, m)
 	require.NoError(t, err)
 	// Required to skip configuration initialization that causes
 	// DI errors in this test.

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -2,10 +2,6 @@ package provisioning
 
 import (
 	"context"
-
-	"github.com/grafana/dskit/services"
-
-	"github.com/grafana/grafana/pkg/modules"
 )
 
 type Calls struct {
@@ -21,7 +17,6 @@ type Calls struct {
 }
 
 type ProvisioningServiceMock struct {
-	*services.BasicService
 	Calls                                   *Calls
 	RunInitProvisionersFunc                 func(ctx context.Context) error
 	ProvisionDatasourcesFunc                func(ctx context.Context) error
@@ -37,7 +32,6 @@ func NewProvisioningServiceMock(ctx context.Context) *ProvisioningServiceMock {
 	s := &ProvisioningServiceMock{
 		Calls: &Calls{},
 	}
-	s.BasicService = services.NewBasicService(s.RunInitProvisioners, s.Run, nil).WithName(modules.Provisioning)
 	return s
 }
 

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -40,7 +40,7 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		serviceTest.waitForStop()
 
 		assert.False(t, serviceTest.serviceRunning, "Service should not be running")
-		assert.Nil(t, serviceTest.serviceError, "Service should not return canceled error")
+		assert.Equal(t, context.Canceled, serviceTest.serviceError, "Service should have returned canceled error")
 	})
 
 	t.Run("Failed reloading does not stop polling with old provisioned", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Reverts https://github.com/grafana/grafana/pull/71598 for 10.1.x.

https://github.com/grafana/grafana/pull/71598 has already been reverted for the main (https://github.com/grafana/grafana/pull/72608), but it's a big revert, so instead of backporting all of it, only backport the fix for provisioning.

**Why do we need this feature?**

Enterprise provisioner does not run on 10.1.x.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
