### PR TITLE
Chore: delete team related entries for an org after the org gets deleted

### DIFF
--- a/pkg/services/org/org.go
+++ b/pkg/services/org/org.go
@@ -22,4 +22,5 @@ type Service interface {
 	RemoveOrgUser(context.Context, *RemoveOrgUserCommand) error
 	GetOrgUsers(context.Context, *GetOrgUsersQuery) ([]*OrgUserDTO, error)
 	SearchOrgUsers(context.Context, *SearchOrgUsersQuery) (*SearchOrgUsersQueryResult, error)
+	RegisterDelete(query string)
 }

--- a/pkg/services/org/orgimpl/org.go
+++ b/pkg/services/org/orgimpl/org.go
@@ -241,3 +241,7 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits.Set(userTag, cfg.Quota.User.Org)
 	return limits, nil
 }
+
+func (s *Service) RegisterDelete(query string) {
+	s.store.RegisterDelete(query)
+}

--- a/pkg/services/org/orgimpl/org_test.go
+++ b/pkg/services/org/orgimpl/org_test.go
@@ -154,3 +154,6 @@ func (f *FakeOrgStore) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUser
 func (f *FakeOrgStore) Count(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error) {
 	return nil, nil
 }
+
+func (f *FakeOrgStore) RegisterDelete(query string) {
+}

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -46,14 +46,16 @@ type store interface {
 	RemoveOrgUser(context.Context, *org.RemoveOrgUserCommand) error
 
 	Count(context.Context, *quota.ScopeParameters) (*quota.Map, error)
+	RegisterDelete(query string)
 }
 
 type sqlStore struct {
 	db      db.DB
 	dialect migrator.Dialect
 	//TODO: moved to service
-	log log.Logger
-	cfg *setting.Cfg
+	log     log.Logger
+	cfg     *setting.Cfg
+	deletes []string
 }
 
 func (ss *sqlStore) Get(ctx context.Context, orgID int64) (*org.Org, error) {
@@ -239,7 +241,13 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			"DELETE FROM alert WHERE org_id = ?",
 			"DELETE FROM annotation WHERE org_id = ?",
 			"DELETE FROM kv_store WHERE org_id = ?",
+			"DELETE FROM team WHERE org_id = ?",
+			"DELETE FROM team_member WHERE org_id = ?",
+			"DELETE FROM team_role WHERE org_id = ?",
 		}
+
+		// Add registered deletes
+		deletes = append(deletes, ss.deletes...)
 
 		for _, sql := range deletes {
 			_, err := sess.Exec(sql, cmd.ID)
@@ -821,4 +829,9 @@ func removeUserOrg(sess *db.Session, userID int64) error {
 
 	_, err := sess.ID(userID).MustCols("org_id").Update(&user)
 	return err
+}
+
+// RegisterDelete registers a delete query to be executed when an org is deleted, used to delete enterprise data.
+func (ss *sqlStore) RegisterDelete(query string) {
+	ss.deletes = append(ss.deletes, query)
 }

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -244,6 +244,8 @@ func (ss *sqlStore) Delete(ctx context.Context, cmd *org.DeleteOrgCommand) error
 			"DELETE FROM team WHERE org_id = ?",
 			"DELETE FROM team_member WHERE org_id = ?",
 			"DELETE FROM team_role WHERE org_id = ?",
+			"DELETE FROM user_role WHERE org_id = ?",
+			"DELETE FROM builtin_role WHERE org_id = ?",
 		}
 
 		// Add registered deletes

--- a/pkg/services/org/orgtest/fake.go
+++ b/pkg/services/org/orgtest/fake.go
@@ -99,3 +99,6 @@ func (f *FakeOrgService) RemoveOrgUser(ctx context.Context, cmd *org.RemoveOrgUs
 func (f *FakeOrgService) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
 	return f.ExpectedSearchOrgUsersResult, f.ExpectedError
 }
+
+func (f *FakeOrgService) RegisterDelete(query string) {
+}


### PR DESCRIPTION
**What is this feature?**

Delete team related entries for an org after the org gets deleted.

**Why do we need this feature?**

Keep the DB clean

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
