### PR TITLE
Prometheus: PromQAIL feedback improvements

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
@@ -318,6 +318,7 @@ export const PromQail = (props: PromQailProps) => {
                             promQailExplain(dispatch, idx, query, interaction, suggIdx, datasource)
                           }
                           onChange={onChange}
+                          prompt={interaction.prompt ?? ''}
                         />
                       )}
                     </>
@@ -343,6 +344,7 @@ export const PromQail = (props: PromQailProps) => {
                         promQailExplain(dispatch, idx, query, interaction, suggIdx, datasource)
                       }
                       onChange={onChange}
+                      prompt={interaction.prompt ?? ''}
                     />
                   )}
                 </div>
@@ -464,7 +466,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       justifyContent: 'flex-end',
     }),
-    feedbackPadding: css({
+    feedbackStyle: css({
+      margin: 0,
+      textAlign: 'right',
       paddingTop: '22px',
       paddingBottom: '22px',
     }),
@@ -495,6 +499,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     useButton: css({
       marginLeft: 'auto',
+    }),
+    suggestionFeedback: css({
+      textAlign: 'left',
     }),
   };
 };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
@@ -35,6 +35,8 @@ export const PromQail = (props: PromQailProps) => {
 
   const [labelNames, setLabelNames] = useState<string[]>([]);
 
+  const suggestions = state.interactions.reduce((acc, int) => acc + int.suggestions.length, 0);
+
   const responsesEndRef = useRef(null);
 
   const scrollToBottom = () => {
@@ -45,8 +47,9 @@ export const PromQail = (props: PromQailProps) => {
   };
 
   useEffect(() => {
+    // only scroll when an interaction has been added or the suggestions have been updated
     scrollToBottom();
-  }, [state.interactions]);
+  }, [state.interactions.length, suggestions]);
 
   useEffect(() => {
     const fetchLabels = async () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
@@ -417,7 +417,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       maskImage: `linear-gradient(to right, rgba(0, 0, 0, 1) 90%, rgba(0, 0, 0, 0))`,
     }),
     metricTableButton: css({
-      marginLeft: '10px',
+      float: 'right',
     }),
     queryQuestion: css({
       textAlign: 'end',
@@ -491,8 +491,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     useButton: css({
-      width: '10%',
-      marginLeft: '12px',
+      marginLeft: 'auto',
     }),
   };
 };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
@@ -503,6 +503,20 @@ export const getStyles = (theme: GrafanaTheme2) => {
     suggestionFeedback: css({
       textAlign: 'left',
     }),
+    feedbackQuestion: css({
+      display: 'flex',
+      padding: '8px 0px',
+      h6: { marginBottom: 0 },
+      i: {
+        marginTop: '1px',
+      },
+    }),
+    explationTextInput: css({
+      paddingLeft: '24px',
+    }),
+    submitFeedback: css({
+      padding: '16px 0',
+    }),
   };
 };
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionContainer.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionContainer.tsx
@@ -16,10 +16,11 @@ export type Props = {
   nextInteraction: () => void;
   queryExplain: (idx: number) => void;
   onChange: (query: PromVisualQuery) => void;
+  prompt: string;
 };
 
 export function QuerySuggestionContainer(props: Props) {
-  const { suggestionType, querySuggestions, closeDrawer, nextInteraction, queryExplain, onChange } = props;
+  const { suggestionType, querySuggestions, closeDrawer, nextInteraction, queryExplain, onChange, prompt } = props;
 
   const [hasNextInteraction, updateHasNextInteraction] = useState<boolean>(false);
 
@@ -56,6 +57,11 @@ export function QuerySuggestionContainer(props: Props) {
                 onChange={onChange}
                 closeDrawer={closeDrawer}
                 last={idx === querySuggestions.length - 1}
+                // for feedback rudderstack events
+                allSuggestions={querySuggestions.reduce((acc: string, qs: QuerySuggestion) => {
+                  return acc + '$$' + qs.query;
+                }, '')}
+                prompt={prompt ?? ''}
               />
             );
           })}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -89,36 +89,41 @@ export function QuerySuggestionItem(props: Props) {
                   Prometheus doc
                 </a>
               </div>
-              {!gaveExplanationFeedback && (
-                <div className={cx(styles.rightButtons, styles.secondaryText)}>
-                  Was this explanation helpful?
-                  <div className={styles.floatRight}>
-                    <Button
-                      fill="outline"
-                      variant="secondary"
-                      size="sm"
-                      className={styles.leftButton}
-                      onClick={() => {
-                        explanationFeedback(querySuggestion, true, historical);
-                        updateGaveExplanationFeedback(true);
-                      }}
-                    >
-                      Yes
-                    </Button>
-                    <Button
-                      fill="outline"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => {
-                        explanationFeedback(querySuggestion, false, historical);
-                        updateGaveExplanationFeedback(true);
-                      }}
-                    >
-                      No
-                    </Button>
-                  </div>
+
+              <div className={cx(styles.rightButtons, styles.secondaryText)}>
+                Was this explanation helpful?
+                <div className={styles.floatRight}>
+                  {!gaveExplanationFeedback ? (
+                    <>
+                      <Button
+                        fill="outline"
+                        variant="secondary"
+                        size="sm"
+                        className={styles.leftButton}
+                        onClick={() => {
+                          explanationFeedback(querySuggestion, true, historical);
+                          updateGaveExplanationFeedback(true);
+                        }}
+                      >
+                        Yes
+                      </Button>
+                      <Button
+                        fill="outline"
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => {
+                          explanationFeedback(querySuggestion, false, historical);
+                          updateGaveExplanationFeedback(true);
+                        }}
+                      >
+                        No
+                      </Button>
+                    </>
+                  ) : (
+                    'Thank you!'
+                  )}
                 </div>
-              )}
+              </div>
             </div>
 
             {!last && <hr />}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -35,7 +35,7 @@ export function QuerySuggestionItem(props: Props) {
     <>
       <div className={styles.querySuggestion}>
         <div title={query} className={cx(styles.codeText, styles.longCode)}>
-          {`${order}  ${query}`}
+          {`${order}.  ${query}`}
         </div>
         <div className={styles.useButton}>
           <Button

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -86,6 +86,9 @@ export function QuerySuggestionItem(props: Props) {
       }
     };
 
+    const disabledButton = () =>
+      type === 'explanation' ? !explanationFeedback.radioInput : !suggestionFeedback.radioInput;
+
     return (
       <div className={styles.suggestionFeedback}>
         <Field label="Were the query suggestions helpful?">
@@ -110,6 +113,7 @@ export function QuerySuggestionItem(props: Props) {
           <Button
             variant="primary"
             size="sm"
+            disabled={disabledButton()}
             onClick={() => {
               // submit the rudderstack event
               if (type === 'explanation') {
@@ -222,7 +226,7 @@ export function QuerySuggestionItem(props: Props) {
                         placement="bottom-end"
                         closeButton={true}
                       >
-                        <Button fill="outline" variant="secondary" size="sm">
+                        <Button variant="success" size="sm">
                           No
                         </Button>
                       </Toggletip>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -66,7 +66,7 @@ export function QuerySuggestionItem(props: Props) {
         >
           Explainer
         </Button>
-        {historical && !showExp && order !== 5 && <div className={styles.textPadding}></div>}
+        {!showExp && order !== 5 && <div className={styles.textPadding}></div>}
 
         {showExp && !querySuggestion.explanation && (
           <div className={styles.center}>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -89,17 +89,29 @@ export function QuerySuggestionItem(props: Props) {
     const disabledButton = () =>
       type === 'explanation' ? !explanationFeedback.radioInput : !suggestionFeedback.radioInput;
 
+    const questionOne =
+      type === 'explanation' ? 'Why was the explanation not helpful?' : 'Were the query suggestions helpful?';
+
     return (
       <div className={styles.suggestionFeedback}>
-        <Field label="Were the query suggestions helpful?">
+        <div>
+          <div className={styles.feedbackQuestion}>
+            <h6>{questionOne}</h6>
+            <i>(Required)</i>
+          </div>
           <RadioButtonList
             name="default"
             options={type === 'explanation' ? explationOptions : suggestionOptions}
             value={type === 'explanation' ? explanationFeedback.radioInput : suggestionFeedback.radioInput}
             onChange={updateRadioFeedback}
           />
-        </Field>
-        <Field label="How can we improve query suggestions?">
+        </div>
+        <div className={cx(type === 'explanation' && styles.explationTextInput)}>
+          {type !== 'explanation' && (
+            <div className={styles.feedbackQuestion}>
+              <h6>How can we improve the query suggestions?</h6>
+            </div>
+          )}
           <TextArea
             type="text"
             aria-label="Promqail suggestion text"
@@ -108,8 +120,9 @@ export function QuerySuggestionItem(props: Props) {
             onChange={updateTextFeedback}
             cols={100}
           />
-        </Field>
-        <div>
+        </div>
+
+        <div className={styles.submitFeedback}>
           <Button
             variant="primary"
             size="sm"
@@ -232,7 +245,7 @@ export function QuerySuggestionItem(props: Props) {
                       </Toggletip>
                     </>
                   ) : (
-                    'Thank you!'
+                    'Thank you for your feedback!'
                   )}
                 </div>
               </div>
@@ -257,7 +270,7 @@ export function QuerySuggestionItem(props: Props) {
             ) : (
               // do this weird thing because the toggle tip doesn't allow an extra close function
               <Button fill="outline" variant="secondary" size="sm" disabled={true}>
-                Thank you!
+                Thank you for your feedback!
               </Button>
             )}
           </div>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -22,6 +22,7 @@ const promQLTemplatesCollection = 'grafana.promql.templates';
 // actions to update the state
 const { updateInteraction } = stateSlice.actions;
 
+// template suggestions
 const commonTemplateSuggestions: string[] = [
   'metric{}',
   'rate(metric{}[1m])',
@@ -42,9 +43,8 @@ interface TemplateSearchResult {
 export function getExplainMessage(
   query: string,
   metric: string,
-  datasource: PrometheusDatasource,
+  datasource: PrometheusDatasource
 ): llms.openai.Message[] {
-
   let metricMetadata = '';
   let metricType = '';
 
@@ -55,25 +55,35 @@ export function getExplainMessage(
     metricMetadata = getMetadataHelp(metric, datasource.languageProvider.metricsMetadata) ?? '';
   }
 
-  const documentationBody = pvq.query.operations.map((op) => {
-    const def = promQueryModeller.getOperationDef(op.id);
-    if (!def) {
-      return '';
-    }
-    const title = def.renderer(op, def, '<expr>');
-    const body = def.explainHandler ? def.explainHandler(op, def) : def.documentation;
+  const documentationBody = pvq.query.operations
+    .map((op) => {
+      const def = promQueryModeller.getOperationDef(op.id);
+      if (!def) {
+        return '';
+      }
+      const title = def.renderer(op, def, '<expr>');
+      const body = def.explainHandler ? def.explainHandler(op, def) : def.documentation;
 
-    if (!body) {
-      return '';
-    }
-    return `### ${title}:\n${body}`;
-  }).filter(item => item !== '').join('\n');
+      if (!body) {
+        return '';
+      }
+      return `### ${title}:\n${body}`;
+    })
+    .filter((item) => item !== '')
+    .join('\n');
 
   return [
     { role: 'system', content: ExplainSystemPrompt },
-    { role: 'user', content: GetExplainUserPrompt(
-      { documentation: documentationBody, metricName: metric, metricType: metricType, metricMetadata: metricMetadata, query: query }
-    )},
+    {
+      role: 'user',
+      content: GetExplainUserPrompt({
+        documentation: documentationBody,
+        metricName: metric,
+        metricType: metricType,
+        metricMetadata: metricMetadata,
+        query: query,
+      }),
+    },
   ];
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/76494

Improves feedback for AI explanation and suggestion.

Add form for when explanation is not helpful.

Add form for suggestion.

Events for rudderstack

```
  const event = 'grafana_prometheus_promqail_suggestion_feedback';

  reportInteraction(event, {
    helpful: radioInputFeedback, // yes, no
    textFeedback: textFeedback,
    suggestionType: historical ? 'historical' : 'AI',
    allSuggestions: allSuggestions, // delimiter is $$
    prompt: prompt,
  });


  const event = 'grafana_prometheus_promqail_explanation_feedback';

  reportInteraction(event, {
    helpful: radioInputFeedback, // yes, too vague, too technical, inaccurate, other
    textFeedback: textFeedback,
    suggestionType: historical ? 'historical' : 'AI',
    query: querySuggestion.query,
    explanation: querySuggestion.explanation,
    prompt: prompt,
  });
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
