### PR TITLE
Azure Monitor: Fix variable in app insights dependencies dashboard

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsPerfDependencies.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsPerfDependencies.json
@@ -57,7 +57,7 @@
       "version": ""
     }
   ],
-  "description": "The dashboard provides insights of Azure Apps via different metrics for app monitoring through Application Insights.",
+  "description": "The dashboard provides insights of dependency performance of Azure Apps through Application Insights.",
   "editable": true,
   "id": null,
   "links": [
@@ -1773,7 +1773,7 @@
         "options": [],
         "query": {
           "azureLogAnalytics": {
-            "query": "dependencies\r\n| where $__timeFilter(timestamp)\r\n| where client_Type != \"Browser\"\r\n| extend type=iff(tolower(type) == \"http (tracked component)\", \"HTTP\", type), target=tostring(split(target, \" | cid-v1\")[0])\r\n| project [\"Dependency Name\"] = strcat(type, \": \", name, \" \", target), duration\r\n| where ['Dependency Name'] in ($dependency)\r\n| top 1 by duration asc\r\n| project tostring(duration)\r\n\r\n",
+            "query": "dependencies\r\n| where $__timeFilter(timestamp)\r\n| where client_Type != \"Browser\"\r\n| extend type=iff(tolower(type) == \"http (tracked component)\", \"HTTP\", type), target=tostring(split(target, \" | cid-v1\")[0])\r\n| project [\"Dependency Name\"] = strcat(type, \": \", name, \" \", target), duration\r\n| where (\"All\" in ($dependency) or [\"Dependency Name\"] in ($dependency))\r\n| top 1 by duration asc\r\n| project tostring(duration)",
             "resources": ["/subscriptions/$sub/resourceGroups/$rg/providers/$ns/$res"]
           },
           "queryType": "Azure Log Analytics",
@@ -1801,7 +1801,7 @@
         "options": [],
         "query": {
           "azureLogAnalytics": {
-            "query": "dependencies\r\n| where $__timeFilter(timestamp)\r\n| where client_Type != \"Browser\"\r\n| extend type=iff(tolower(type) == \"http (tracked component)\", \"HTTP\", type), target=tostring(split(target, \" | cid-v1\")[0])\r\n| project [\"Dependency Name\"] = strcat(type, \": \", name, \" \", target), duration\r\n| where ['Dependency Name'] in ($dependency)\r\n| top 1 by duration desc\r\n| project tostring(duration)\r\n\r\n",
+            "query": "dependencies\r\n| where $__timeFilter(timestamp)\r\n| where client_Type != \"Browser\"\r\n| extend type=iff(tolower(type) == \"http (tracked component)\", \"HTTP\", type), target=tostring(split(target, \" | cid-v1\")[0])\r\n| project [\"Dependency Name\"] = strcat(type, \": \", name, \" \", target), duration\r\n| where (\"All\" in ($dependency) or [\"Dependency Name\"] in ($dependency))\r\n| top 1 by duration desc\r\n| project tostring(duration)",
             "resources": ["/subscriptions/$sub/resourceGroups/$rg/providers/$ns/$res"]
           },
           "queryType": "Azure Log Analytics",

--- a/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsPerfOperations.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/appInsightsPerfOperations.json
@@ -57,7 +57,7 @@
       "version": ""
     }
   ],
-  "description": "The dashboard provides insights of Azure Apps via different metrics for app monitoring through Application Insights.",
+  "description": "The dashboard provides insights of request performance of Azure Apps through Application Insights.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix a bug in query for max and min duration in the the app insights dependencies dashboard, and update the short descriptions

Related to https://github.com/grafana/grafana/pull/75916

**Why do we need this feature?**
This will fix the app insights dependencies dashboard

**Who is this feature for?**
Users using app insights for to monitor their Azure apps and for troubleshooting

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
