### PR TITLE
OpenSearch: Add timeRange to parameters passed to getTagValues (#74952)

### DIFF
--- a/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import { DataSourceRef, MetricFindValue, SelectableValue } from '@grafana/data';
 import { SegmentAsync } from '@grafana/ui';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { getDatasourceSrv } from '../../../plugins/datasource_srv';
 
@@ -45,6 +46,7 @@ const fetchFilterValues = async (datasource: DataSourceRef, key: string): Promis
     return [];
   }
 
-  const metrics = await ds.getTagValues({ key });
+  const timeRange = getTimeSrv().timeRange();
+  const metrics = await ds.getTagValues({ key, timeRange });
   return metrics.map((m: MetricFindValue) => ({ label: m.text, value: m.text }));
 };


### PR DESCRIPTION
[AWS requested](https://github.com/grafana/support-escalations/issues/6700) that [this pr](https://github.com/grafana/grafana/pull/74952) be backported to v9.4.x