### PR TITLE
Fix correlation links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 # Documentation sources might have different owners.
 /docs/                                                                       @grafana/docs-tooling
 /docs/sources/                                                               @Eve832
-/docs/sources/administration/                                                @Eve832 @GrafanaWriter
+/docs/sources/administration/                                                @jdbaldry
 /docs/sources/alerting/                                                      @brendamuir
 /docs/sources/dashboards/                                                    @imatwawana
 /docs/sources/datasources/                                                   @lwandz13

--- a/docs/sources/administration/correlations/_index.md
+++ b/docs/sources/administration/correlations/_index.md
@@ -14,25 +14,30 @@ weight: 900
 
 You can create interactive links for Explore visualizations to run queries related to presented data by setting up Correlations.
 
-A correlation defines how data in one [data source]({{< relref "/docs/grafana/latest/datasources/" >}}) is used to query data in another data source. Some examples:
+A correlation defines how data in one [data source]({{< relref "../../datasources" >}}) is used to query data in another data source.
+Some examples:
 
 - an application name returned in a logs data source can be used to query metrics related to that application in a metrics data source, or
 - a user name returned by an SQL data source can be used to query logs related to that particular user in a logs data source
 
-[Explore]({{< relref "/docs/grafana/latest/explore/" >}}) takes user-defined correlations to display links inside the visualizations. You can click on a link to run the related query and see results in [Explore Split View]({{< relref "/docs/grafana/latest/explore/#split-and-compare" >}}).
+[Explore]({{< relref "../../explore" >}}) takes user-defined correlations to display links inside the visualizations.
+You can click on a link to run the related query and see results in [Explore Split View]({{< relref "../../explore#split-and-compare" >}}).
 
 Explore visualizations that currently support showing links based on correlations:
 
 - [Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}})
 - [Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}})
 
-You can configure correlations using [Administration > Correlation page]({{< relref "/docs/grafana/latest/administration/" >}}) or with [provisioning]({{< relref "/docs/grafana/latest/administration/provisioning" >}}).
+You can configure correlations using **Administration > Correlation** page in Grafana or with [provisioning]({{< relref "../provisioning" >}}).
 
-> **Note:** Correlations are available in Grafana 10.0+ as an opt-in beta feature. Modify Grafana [configuration file]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana/#configuration-file-location" >}}) to enable the `correlations` [feature toggle]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles" >}}) to use it.
+{{% admonition type="note" %}}
+Correlations are available in Grafana 10.0+ as an opt-in beta feature.
+Modify the Grafana [configuration file]({{< relref "../../setup-grafana/configure-grafana#configuration-file-location" >}}) to enable the `correlations` [feature toggle]({{< relref "../../setup-grafana/configure-grafana#feature_toggles" >}}) to use it.
+{{% /admonition %}}
 
 ## Example of how links work in Explore once set up
 
-{{< figure src="/static/img/docs/correlations/correlations-in-explore-10-0.gif" caption="Correlations links in Explore" >}}
+{{< figure src="/static/img/docs/correlations/correlations-in-explore-10-0.gif" alt="Demonstration of following a correlation link in Grafana Explore" caption="Correlations links in Explore" >}}
 
 See also:
 

--- a/docs/sources/administration/correlations/_index.md
+++ b/docs/sources/administration/correlations/_index.md
@@ -28,7 +28,7 @@ Explore visualizations that currently support showing links based on correlation
 - [Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}})
 - [Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}})
 
-You can configure correlations using **Administration > Correlation** page in Grafana or with [provisioning]({{< relref "../provisioning" >}}).
+You can configure correlations using the **Administration > Correlation** page in Grafana or with [provisioning]({{< relref "../provisioning" >}}).
 
 {{% admonition type="note" %}}
 Correlations are available in Grafana 10.0+ as an opt-in beta feature.

--- a/docs/sources/administration/correlations/add-permissions-to-create-new-correlations/index.md
+++ b/docs/sources/administration/correlations/add-permissions-to-create-new-correlations/index.md
@@ -12,7 +12,7 @@ weight: 30
 
 ## Before you begin
 
-Adding access to create correlations for [Viewers and Editors]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) is available with [Role-based access control]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}).
+Adding access to create correlations for [Viewers and Editors]({{< relref "../../../administration/roles-and-permissions" >}}) is available with [Role-based access control]({{< relref "../../../administration/roles-and-permissions/access-control" >}}).
 
 ## Add permissions to create correlations
 

--- a/docs/sources/administration/correlations/correlation-configuration/index.md
+++ b/docs/sources/administration/correlations/correlation-configuration/index.md
@@ -33,7 +33,9 @@ Learn how to create correlations using the [Administration page]({{< relref "./c
 
 ## Source data source and result field
 
-Links are shown in Explore visualizations for the results from the correlation’s source data source. A link is assigned to one of the fields from the result provided in the correlation configuration (the results field). Each visualization displays fields with links in a different way ([Correlations in Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}}) and see [Correlations in Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}}))
+Links are shown in Explore visualizations for the results from the correlation’s source data source.
+A link is assigned to one of the fields from the result provided in the correlation configuration (the results field).
+Each visualization displays fields with links in a different way ([Correlations in Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}}) and see [Correlations in Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}})).
 
 ## Target query
 
@@ -41,9 +43,11 @@ The target query is run when a link is clicked in the visualization. You can use
 
 ### Correlation Variables
 
-You can use variables inside the target query to access the source data related to the query. Correlations use [Grafana variable syntax]({{< relref "/docs/grafana/latest/dashboards/variables/variable-syntax" >}}). Variables are filled with values from the source results when the link is clicked. There are two types of variables you can use:
+You can use variables inside the target query to access the source data related to the query.
+Correlations use [Grafana variable syntax]({{< relref "../../../dashboards/variables/variable-syntax" >}}).
+Variables are filled with values from the source results when the link is clicked. There are two types of variables you can use:
 
-- [field variables]({{< relref "/docs/grafana/latest/panels-visualizations/configure-data-links#field-variables" >}}) (allows to access field values and labels)
+- [field variables]({{< relref "../../../panels-visualizations/configure-data-links#field-variables" >}}) (allows to access field values and labels)
 - correlation variables (allows to access field values and transformations)
 
 Example: If source results contain a field called “employee”, the value of the field can be accessed with:

--- a/docs/sources/administration/correlations/correlation-permissions/index.md
+++ b/docs/sources/administration/correlations/correlation-permissions/index.md
@@ -9,11 +9,11 @@ weight: 20
 
 # Permissions
 
-Users with [Viewer base role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) or with [datasources:query RBAC role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}) can:
+Users with [Viewer base role]({{< relref "../../../administration/roles-and-permissions" >}}) or with [datasources:query RBAC role]({{< relref "../../../administration/roles-and-permissions/access-control" >}}) can:
 
-- Use correlations in Explore’s visualizations
-- List all available correlations in read-only mode
+- Use correlations in Explore’s visualizations.
+- List all available correlations in read-only mode.
 
-Users with [Admin base role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) or with [datasources:write RBAC role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}) can:
+Users with [Admin base role]({{< relref "../../../administration/roles-and-permissions" >}}) or with [datasources:write RBAC role]({{< relref "../../../administration/roles-and-permissions/access-control" >}}) can:
 
-- Add, edit and delete correlations
+- Add, edit and delete correlations.

--- a/docs/sources/administration/correlations/create-a-new-correlation/index.md
+++ b/docs/sources/administration/correlations/create-a-new-correlation/index.md
@@ -16,21 +16,21 @@ Make sure you have permission to add new correlations. Only users with write per
 ## Create a correlation in Explore's Correlations Editor
 
 1. Go to Explore page.
-1. Select a data source that you would like to be [the source data source]({{< relref "/docs/grafana/latest/administration/correlations/correlation-configuration#source-data-source-and-result-field" >}}) for a new correlation.
-1. Run a query producing data in [a supported visualization]({{< relref "/docs/grafana/latest/administration/correlations/#correlations" >}}).
-1. Click "+ Add" button in the top toolbar and select "Add correlation" (you can also select "Correlations Editor" from the [Command Palette]({{< relref "/docs/grafana/latest/search/#command-palette" >}})).
+1. Select a data source that you would like to be [the source data source]({{< relref "../../../administration/correlations/correlation-configuration#source-data-source-and-result-field" >}}) for a new correlation.
+1. Run a query producing data in [a supported visualization]({{< relref "../../../administration/correlations#correlations" >}}).
+1. Click "+ Add" button in the top toolbar and select "Add correlation" (you can also select "Correlations Editor" from the [Command Palette]({{< relref "../../../search#command-palette" >}})).
 1. Explore is now in Correlations Editor mode indicated by a blue border and top bar. You can exit Correlations Editor using the Exit button in the top bar.
 1. The visualization is enriched with links allowing to create new correlations. Links are attached to the data that you can use to build a new query:
    - Logs: links are displayed next to field values inside log details for each log row
    - Table: every table cell is a link
-1. Click on a link to begin adding new correlation. Links are associated with a field that will be used as [a results field of a correlation]({{< relref "/docs/grafana/latest/administration/correlations/correlation-configuration" >}}). This means the correlation link will be created on the link you select once the correlation is saved.
-1. Explore opens a split view. Use the right pane to setup [the target query source of the correlation]({{< relref "/docs/grafana/latest/administration/correlations/correlation-configuration#target-query" >}}).
-1. Build target query using [variables syntax]({{< relref "/docs/grafana/latest/dashboards/variables/variable-syntax" >}}) with variables from the list provided at the top of the pane. The list contains sample values from the selected data row.
+1. Click on a link to begin adding new correlation. Links are associated with a field that will be used as [a results field of a correlation]({{< relref "../../../administration/correlations/correlation-configuration" >}}). This means the correlation link will be created on the link you select once the correlation is saved.
+1. Explore opens a split view. Use the right pane to setup [the target query source of the correlation]({{< relref "../../../administration/correlations/correlation-configuration#target-query" >}}).
+1. Build target query using [variables syntax]({{< relref "../../../dashboards/variables/variable-syntax" >}}) with variables from the list provided at the top of the pane. The list contains sample values from the selected data row.
 1. Provide optional label and description. Label is used as the name of the link inside the visualization. It can contain variables.
 1. Click "Save" button in the top bar to save the correlation and exit Correlations Editor mode.
 1. The link used to create the correlation will be replaced with a data link in each row. The variables will be dynamically replaced with values from a selected row.
 
-Please check [an example]({{< relref "/docs/grafana/latest/administration/correlations/use-correlations-editor-in-explore" >}}) to see how to create a sample correlation using test data source.
+Please check [an example]({{< relref "../../../administration/correlations/use-correlations-editor-in-explore" >}}) to see how to create a sample correlation using test data source.
 
 ## Create a correlation in Administration page
 
@@ -99,7 +99,7 @@ Description of provisioning properties:
 : Correlation type. “query” is the only supported type at the moment
 
 **config.target**
-: [Target query model]({{< relref "#determine-target-query-model-structure" >}})
+: [Target query model](#determine-target-query-model-structure)
 
 **config.field**
 : Name of the field where link is shown

--- a/docs/sources/administration/correlations/use-correlations-editor-in-explore/index.md
+++ b/docs/sources/administration/correlations/use-correlations-editor-in-explore/index.md
@@ -15,7 +15,7 @@ This example shows how to create a correlation using Correlations Editor in Expl
 
 Correlations allow you to use results of one query to run a new query in any data source. In this example you will run a query that renders tabular data. The data will be used to run a different query that yields a graph result.
 
-Please make sure you have setup up [a test data source]({{< relref "/docs/grafana/latest/datasources/testdata/#testdata-data-source" >}}).
+Please make sure you have setup up [a test data source]({{< relref "../../../datasources/testdata#testdata-data-source" >}}).
 
 ## Create a new correlation
 

--- a/docs/sources/administration/correlations/use-correlations-editor-in-explore/index.md
+++ b/docs/sources/administration/correlations/use-correlations-editor-in-explore/index.md
@@ -15,7 +15,7 @@ This example shows how to create a correlation using Correlations Editor in Expl
 
 Correlations allow you to use results of one query to run a new query in any data source. In this example you will run a query that renders tabular data. The data will be used to run a different query that yields a graph result.
 
-Please make sure you have setup up [a test data source]({{< relref "../../../datasources/testdata#testdata-data-source" >}}).
+Please make sure you have set up [a test data source]({{< relref "../../../datasources/testdata#testdata-data-source" >}}).
 
 ## Create a new correlation
 

--- a/docs/sources/administration/correlations/use-correlations-in-visualizations/index.md
+++ b/docs/sources/administration/correlations/use-correlations-in-visualizations/index.md
@@ -27,7 +27,7 @@ weight: 70
 1. Open Explore.
 1. Select a data source that you chose as the source data source of the correlation.
 1. Run a query that results in data containing fields required to build variables in the target query.
-1. Links are added to cell rows in the column representing the field with the assigned link ([the results field]({{< relref "/docs/grafana/latest/administration/correlations/correlation-configuration#source-data-source-and-result-field" >}}).
+1. Links are added to cell rows in the column representing the field with the assigned link ([the results field]({{< relref "../correlation-configuration#source-data-source-and-result-field" >}}).
 1. Cells containing multiple links accessible with a context menu.
 
    {{< figure src="/static/img/docs/correlations/correlations-in-table-10-0.png" max-width="600px" caption="Correlations links in table" >}}

--- a/docs/sources/administration/correlations/use-variables-and-transformations/index.md
+++ b/docs/sources/administration/correlations/use-variables-and-transformations/index.md
@@ -73,7 +73,7 @@ Instructions below show how to set up a link that can run metrics query for the 
        - Required correlation type (query)
        - Target query matching test data source model
      - “App metrics” correlation contains the following configuration:
-       - Alias is set to ${application} variable (note that in provisioning files $ is used to access environment variables so it has to be [escaped]({{< relref "/docs/grafana/latest/administration/provisioning#using-environment-variables" >}})).
+       - Alias is set to ${application} variable (note that in provisioning files $ is used to access environment variables so it has to be [escaped]({{< relref "../../../administration/provisioning#using-environment-variables" >}})).
        - Regular expression transformation is created to extract values from “msg” field
          - Regular expression transformation is used to capture the application name from the full name of the service stored in the log line.
          - The output of the transformation is mapped to a variable called “application”.


### PR DESCRIPTION
Presently, the links take users to "latest" even if they are in other versions of documentation.
Sometimes, the destination doesn't even exist in "latest".

There is no need to backport further than `v10.0.x` because these files don't exist in `v9.5.x` and earlier.