### PR TITLE
Alerting: Fix HCL export for alerts with non-zero "for" field.

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -605,7 +605,7 @@ func TestProvisioningApi(t *testing.T) {
 
     no_data_state  = "Alerting"
     exec_err_state = "Error"
-    for            = 0
+    for            = "0s"
     annotations = {
       test = "annotation"
     }
@@ -632,7 +632,7 @@ func TestProvisioningApi(t *testing.T) {
 
     no_data_state  = "OK"
     exec_err_state = "OK"
-    for            = 0
+    for            = "0s"
     is_paused      = false
   }
 }

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -186,7 +186,7 @@ func AlertRuleExportFromAlertRule(rule models.AlertRule) (definitions.AlertRuleE
 		IsPaused:     rule.IsPaused,
 	}
 	if rule.For.Seconds() > 0 {
-		result.ForSeconds = util.Pointer(int64(rule.For.Seconds()))
+		result.ForString = util.Pointer(model.Duration(rule.For).String())
 	}
 	if rule.Annotations != nil {
 		result.Annotations = &rule.Annotations

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -44,6 +44,7 @@ resource "grafana_rule_group" "rule_group_0000" {
 
     no_data_state  = "NoData"
     exec_err_state = "Alerting"
+    for            = "2m"
     is_paused      = false
   }
   rule {

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.json
@@ -64,7 +64,7 @@
           ],
           "noDataState": "NoData",
           "execErrState": "Alerting",
-          "for": "0s",
+          "for": "2m",
           "isPaused": false
         },
         {

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.yaml
@@ -48,7 +48,7 @@ groups:
                 type: math
           noDataState: NoData
           execErrState: Alerting
-          for: 0s
+          for: 2m
           isPaused: false
         - title: reduced testdata query - 2
           condition: B

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101.json
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101.json
@@ -3,6 +3,7 @@
   "interval": "10s",
   "rules": [
     {
+      "for": "2m",
       "grafana_alert": {
         "title": "prom query with SSE - 2",
         "condition": "condition",

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -243,10 +243,13 @@ type AlertRuleExport struct {
 	NoDataState  NoDataState         `json:"noDataState" yaml:"noDataState" hcl:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"execErrState" yaml:"execErrState" hcl:"exec_err_state"`
 	For          model.Duration      `json:"for" yaml:"for"`
-	ForSeconds   *int64              `json:"-" yaml:"-" hcl:"for"`
-	Annotations  *map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty" hcl:"annotations"`
-	Labels       *map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty" hcl:"labels"`
-	IsPaused     bool                `json:"isPaused" yaml:"isPaused" hcl:"is_paused"`
+	// ForString is used to:
+	// - Only export the for field for HCL if it is non-zero.
+	// - Format the Prometheus model.Duration type properly for HCL.
+	ForString   *string            `json:"-" yaml:"-" hcl:"for"`
+	Annotations *map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" hcl:"annotations"`
+	Labels      *map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" hcl:"labels"`
+	IsPaused    bool               `json:"isPaused" yaml:"isPaused" hcl:"is_paused"`
 }
 
 // AlertQueryExport is the provisioned export of models.AlertQuery.


### PR DESCRIPTION
The Terraform provider requires the `for` field as a duration string, not seconds. We also document it [here](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/rule_group#example-usage).

Rationale for the change:
- The HCL output appears to be special, in that it omits the field is it is zero.
- The HCL encoder does not appear to format the Prometheus Duration type correctly (`2m` becomes `120000000000`)

I'm not familiar with the HCL encoder, perhaps there is a nicer way to override the conversion for this field.

Fixes #76734
