### PR TITLE
Swagger: Type postDashboardResponse.id as int instead of string

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -79,4 +79,4 @@ make swagger-clean && make openapi3-gen
 
 They can observe its output into the `public/api-merged.json` and `public/openapi3.json` files.
 
-Finally, they can browser and try out both the OpenAPI v2 and v3 via the Swagger UI editor (served by the grafana server) by navigating to `/swagger-ui` and `/openapi3` respectivally.
+Finally, they can browser and try out both the OpenAPI v2 and v3 via the Swagger UI editor (served by the grafana server) by navigating to `/swagger-ui` and `/openapi3` respectively.

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -1283,7 +1283,7 @@ type PostDashboardResponse struct {
 		// ID The unique identifier (id) of the created/updated dashboard.
 		// required: true
 		// example: 1
-		ID int `json:"id"`
+		ID int64 `json:"id"`
 
 		// UID The unique identifier (uid) of the created/updated dashboard.
 		// required: true

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -1283,7 +1283,7 @@ type PostDashboardResponse struct {
 		// ID The unique identifier (id) of the created/updated dashboard.
 		// required: true
 		// example: 1
-		ID string `json:"id"`
+		ID int `json:"id"`
 
 		// UID The unique identifier (uid) of the created/updated dashboard.
 		// required: true

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -2026,52 +2026,6 @@
           }
         }
       }
-    },
-    "/teams/{teamId}/groups/{groupId}": {
-      "delete": {
-        "tags": [
-          "sync_team_groups",
-          "enterprise"
-        ],
-        "summary": "Remove External Group.",
-        "operationId": "removeTeamGroupApi",
-        "deprecated": true,
-        "parameters": [
-          {
-            "type": "string",
-            "name": "groupId",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "integer",
-            "format": "int64",
-            "name": "teamId",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
     }
   },
   "definitions": {
@@ -2699,6 +2653,16 @@
         }
       }
     },
+    "AttributeTypeAndValue": {
+      "description": "AttributeTypeAndValue mirrors the ASN.1 structure of the same name in\nRFC 5280, Section 4.1.2.4.",
+      "type": "object",
+      "properties": {
+        "Type": {
+          "$ref": "#/definitions/ObjectIdentifier"
+        },
+        "Value": {}
+      }
+    },
     "BrandingOptionsDTO": {
       "type": "object",
       "properties": {
@@ -2730,6 +2694,247 @@
           "$ref": "#/definitions/Json"
         },
         "version": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Certificate": {
+      "type": "object",
+      "title": "A Certificate represents an X.509 certificate.",
+      "properties": {
+        "AuthorityKeyId": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "BasicConstraintsValid": {
+          "description": "BasicConstraintsValid indicates whether IsCA, MaxPathLen,\nand MaxPathLenZero are valid.",
+          "type": "boolean"
+        },
+        "CRLDistributionPoints": {
+          "description": "CRL Distribution Points",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DNSNames": {
+          "description": "Subject Alternate Name values. (Note that these values may not be valid\nif invalid values were contained within a parsed certificate. For\nexample, an element of DNSNames may not be a valid DNS domain name.)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "EmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedDNSDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedEmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedIPRanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNet"
+          }
+        },
+        "ExcludedURIDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExtKeyUsage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtKeyUsage"
+          }
+        },
+        "Extensions": {
+          "description": "Extensions contains raw X.509 extensions. When parsing certificates,\nthis can be used to extract non-critical extensions that are not\nparsed by this package. When marshaling certificates, the Extensions\nfield is ignored, see ExtraExtensions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        },
+        "ExtraExtensions": {
+          "description": "ExtraExtensions contains extensions to be copied, raw, into any\nmarshaled certificates. Values override any extensions that would\notherwise be produced based on the other fields. The ExtraExtensions\nfield is not populated when parsing certificates, see Extensions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        },
+        "IPAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IsCA": {
+          "type": "boolean"
+        },
+        "Issuer": {
+          "$ref": "#/definitions/Name"
+        },
+        "IssuingCertificateURL": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "KeyUsage": {
+          "$ref": "#/definitions/KeyUsage"
+        },
+        "MaxPathLen": {
+          "description": "MaxPathLen and MaxPathLenZero indicate the presence and\nvalue of the BasicConstraints' \"pathLenConstraint\".\n\nWhen parsing a certificate, a positive non-zero MaxPathLen\nmeans that the field was specified, -1 means it was unset,\nand MaxPathLenZero being true mean that the field was\nexplicitly set to zero. The case of MaxPathLen==0 with MaxPathLenZero==false\nshould be treated equivalent to -1 (unset).\n\nWhen generating a certificate, an unset pathLenConstraint\ncan be requested with either MaxPathLen == -1 or using the\nzero value for both MaxPathLen and MaxPathLenZero.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "MaxPathLenZero": {
+          "description": "MaxPathLenZero indicates that BasicConstraintsValid==true\nand MaxPathLen==0 should be interpreted as an actual\nmaximum path length of zero. Otherwise, that combination is\ninterpreted as MaxPathLen not being set.",
+          "type": "boolean"
+        },
+        "NotBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "OCSPServer": {
+          "description": "RFC 5280, 4.2.2.1 (Authority Information Access)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedDNSDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedDNSDomainsCritical": {
+          "description": "Name constraints",
+          "type": "boolean"
+        },
+        "PermittedEmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedIPRanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNet"
+          }
+        },
+        "PermittedURIDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PolicyIdentifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "PublicKey": {},
+        "PublicKeyAlgorithm": {
+          "$ref": "#/definitions/PublicKeyAlgorithm"
+        },
+        "Raw": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawIssuer": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawSubject": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawSubjectPublicKeyInfo": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawTBSCertificate": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "SerialNumber": {
+          "type": "string"
+        },
+        "Signature": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "SignatureAlgorithm": {
+          "$ref": "#/definitions/SignatureAlgorithm"
+        },
+        "Subject": {
+          "$ref": "#/definitions/Name"
+        },
+        "SubjectKeyId": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "URIs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/URL"
+          }
+        },
+        "UnhandledCriticalExtensions": {
+          "description": "UnhandledCriticalExtensions contains a list of extension IDs that\nwere not (fully) processed when parsing. Verify will fail if this\nslice is non-empty, unless verification is delegated to an OS\nlibrary which understands all the critical extensions.\n\nUsers can access these extensions using Extensions and can remove\nelements from this slice if they believe that they have been\nhandled.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "UnknownExtKeyUsage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "Version": {
           "type": "integer",
           "format": "int64"
         }
@@ -3720,6 +3925,9 @@
           "description": "Error is a property to be set if the corresponding DataQuery has an error.",
           "type": "string"
         },
+        "ErrorSource": {
+          "$ref": "#/definitions/ErrorSource"
+        },
         "Frames": {
           "$ref": "#/definitions/Frames"
         },
@@ -4027,6 +4235,10 @@
         }
       }
     },
+    "ErrorSource": {
+      "description": "ErrorSource type defines the source of the error",
+      "type": "string"
+    },
     "EvalMatch": {
       "type": "object",
       "properties": {
@@ -4046,6 +4258,31 @@
     },
     "ExplorePanelsState": {
       "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
+    },
+    "ExtKeyUsage": {
+      "description": "Each of the ExtKeyUsage* constants define a unique action.",
+      "type": "integer",
+      "format": "int64",
+      "title": "ExtKeyUsage represents an extended set of actions that are valid for a given key."
+    },
+    "Extension": {
+      "description": "Extension represents the ASN.1 structure of the same name. See RFC\n5280, section 4.2.",
+      "type": "object",
+      "properties": {
+        "Critical": {
+          "type": "boolean"
+        },
+        "Id": {
+          "$ref": "#/definitions/ObjectIdentifier"
+        },
+        "Value": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        }
+      }
     },
     "FailedUser": {
       "description": "FailedUser holds the information of an user that failed",
@@ -4465,6 +4702,27 @@
     "HitType": {
       "type": "string"
     },
+    "IPMask": {
+      "description": "See type IPNet and func ParseCIDR for details.",
+      "type": "array",
+      "title": "An IPMask is a bitmask that can be used to manipulate\nIP addresses for IP addressing and routing.",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      }
+    },
+    "IPNet": {
+      "type": "object",
+      "title": "An IPNet represents an IP network.",
+      "properties": {
+        "IP": {
+          "type": "string"
+        },
+        "Mask": {
+          "$ref": "#/definitions/IPMask"
+        }
+      }
+    },
     "ImportDashboardInput": {
       "type": "object",
       "title": "ImportDashboardInput definition of input parameters when importing a dashboard.",
@@ -4599,23 +4857,6 @@
         }
       }
     },
-    "Item": {
-      "type": "object",
-      "title": "Item defines model for Item.",
-      "properties": {
-        "title": {
-          "description": "Title is an unused property -- it will be removed in the future",
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/ItemType"
-        },
-        "value": {
-          "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
-          "type": "string"
-        }
-      }
-    },
     "ItemDTO": {
       "type": "object",
       "properties": {
@@ -4690,12 +4931,60 @@
         }
       }
     },
-    "ItemType": {
-      "type": "string",
-      "title": "Type of the item."
+    "JSONWebKey": {
+      "type": "object",
+      "title": "JSONWebKey represents a public or private key in JWK format.",
+      "properties": {
+        "Algorithm": {
+          "description": "Key algorithm, parsed from `alg` header.",
+          "type": "string"
+        },
+        "CertificateThumbprintSHA1": {
+          "description": "X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "CertificateThumbprintSHA256": {
+          "description": "X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "Certificates": {
+          "description": "X.509 certificate chain, parsed from `x5c` header.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Certificate"
+          }
+        },
+        "CertificatesURL": {
+          "$ref": "#/definitions/URL"
+        },
+        "Key": {
+          "description": "Cryptographic key, can be a symmetric or asymmetric key."
+        },
+        "KeyID": {
+          "description": "Key identifier, parsed from `kid` header.",
+          "type": "string"
+        },
+        "Use": {
+          "description": "Key use, parsed from `use` header.",
+          "type": "string"
+        }
+      }
     },
     "Json": {
       "type": "object"
+    },
+    "KeyUsage": {
+      "description": "KeyUsage represents the set of actions that are valid for a given key. It's\na bitmap of the KeyUsage* constants.",
+      "type": "integer",
+      "format": "int64"
     },
     "LegacyAlert": {
       "type": "object",
@@ -5051,6 +5340,47 @@
         }
       }
     },
+    "Name": {
+      "description": "Name represents an X.509 distinguished name. This only includes the common\nelements of a DN. Note that Name is only an approximation of the X.509\nstructure. If an accurate representation is needed, asn1.Unmarshal the raw\nsubject or issuer as an RDNSequence.",
+      "type": "object",
+      "properties": {
+        "Country": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExtraNames": {
+          "description": "ExtraNames contains attributes to be copied, raw, into any marshaled\ndistinguished names. Values override any attributes with the same OID.\nThe ExtraNames field is not populated when parsing, see Names.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttributeTypeAndValue"
+          }
+        },
+        "Locality": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Names": {
+          "description": "Names contains all parsed attributes. When parsing distinguished names,\nthis can be used to extract non-standard attributes that are not parsed\nby this package. When marshaling to RDNSequences, the Names field is\nignored, see ExtraNames.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttributeTypeAndValue"
+          }
+        },
+        "SerialNumber": {
+          "type": "string"
+        },
+        "StreetAddress": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "NewApiKeyResult": {
       "type": "object",
       "properties": {
@@ -5125,6 +5455,14 @@
         "type": {
           "type": "string"
         }
+      }
+    },
+    "ObjectIdentifier": {
+      "type": "array",
+      "title": "An ObjectIdentifier represents an ASN.1 OBJECT IDENTIFIER.",
+      "items": {
+        "type": "integer",
+        "format": "int64"
       }
     },
     "OrgDTO": {
@@ -5392,6 +5730,30 @@
         }
       }
     },
+    "PlaylistDTO": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "description": "Interval sets the time between switching views in a playlist.",
+          "type": "string"
+        },
+        "items": {
+          "description": "The ordered list of items that the playlist will iterate over.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlaylistItemDTO"
+          }
+        },
+        "name": {
+          "description": "Name of the playlist.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "Unique playlist identifier. Generated on creation, either by the\ncreator of the playlist of by the application.",
+          "type": "string"
+        }
+      }
+    },
     "PlaylistDashboard": {
       "type": "object",
       "properties": {
@@ -5445,6 +5807,23 @@
           "type": "string"
         },
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "PlaylistItemDTO": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "Title is an unused property -- it will be removed in the future",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the item.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
           "type": "string"
         }
       }
@@ -5523,6 +5902,10 @@
           "type": "string"
         }
       }
+    },
+    "PublicKeyAlgorithm": {
+      "type": "integer",
+      "format": "int64"
     },
     "QueryDataResponse": {
       "description": "It is the return type of a QueryData call.",
@@ -6308,6 +6691,10 @@
         }
       }
     },
+    "SignatureAlgorithm": {
+      "type": "integer",
+      "format": "int64"
+    },
     "Spec": {
       "type": "object",
       "title": "Spec defines model for Spec.",
@@ -6814,6 +7201,46 @@
     },
     "Type": {
       "type": "string"
+    },
+    "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
+      "type": "object",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "properties": {
+        "ForceQuery": {
+          "type": "boolean"
+        },
+        "Fragment": {
+          "type": "string"
+        },
+        "Host": {
+          "type": "string"
+        },
+        "OmitHost": {
+          "type": "boolean"
+        },
+        "Opaque": {
+          "type": "string"
+        },
+        "Path": {
+          "type": "string"
+        },
+        "RawFragment": {
+          "type": "string"
+        },
+        "RawPath": {
+          "type": "string"
+        },
+        "RawQuery": {
+          "type": "string"
+        },
+        "Scheme": {
+          "type": "string"
+        },
+        "User": {
+          "$ref": "#/definitions/Userinfo"
+        }
+      }
     },
     "UpdateAlertNotificationCommand": {
       "type": "object",
@@ -7443,6 +7870,10 @@
           "format": "int64"
         }
       }
+    },
+    "Userinfo": {
+      "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
+      "type": "object"
     },
     "ValueMapping": {
       "description": "ValueMapping allows mapping input values to text and color",
@@ -8135,14 +8566,14 @@
       "schema": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Item"
+          "$ref": "#/definitions/PlaylistItemDTO"
         }
       }
     },
     "getPlaylistResponse": {
       "description": "",
       "schema": {
-        "$ref": "#/definitions/Spec"
+        "$ref": "#/definitions/PlaylistDTO"
       }
     },
     "getPreferencesResponse": {
@@ -8333,6 +8764,20 @@
         "$ref": "#/definitions/ErrorResponseBody"
       }
     },
+    "jwksResponse": {
+      "description": "",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/JSONWebKey"
+            }
+          }
+        }
+      }
+    },
     "listBuiltinRolesResponse": {
       "description": "",
       "schema": {
@@ -8491,8 +8936,9 @@
         "properties": {
           "id": {
             "description": "ID The unique identifier (id) of the created/updated dashboard.",
-            "type": "string",
-            "example": "1"
+            "type": "integer",
+            "format": "int64",
+            "example": 1
           },
           "status": {
             "description": "Status status of the response.",
@@ -8670,7 +9116,7 @@
     "updatePlaylistResponse": {
       "description": "",
       "schema": {
-        "$ref": "#/definitions/Spec"
+        "$ref": "#/definitions/PlaylistDTO"
       }
     },
     "updateServiceAccountResponse": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -6101,6 +6101,9 @@
           "401": {
             "$ref": "#/responses/unauthorisedError"
           },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
           "404": {
             "$ref": "#/responses/notFoundError"
           },
@@ -6215,6 +6218,9 @@
           },
           "401": {
             "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "404": {
             "$ref": "#/responses/notFoundError"
@@ -9256,6 +9262,24 @@
         }
       }
     },
+    "/signing-keys/keys": {
+      "get": {
+        "description": "Required permissions\nNone",
+        "tags": [
+          "signing_keys"
+        ],
+        "summary": "Get JSON Web Key Set (JWKS) with all the keys that can be used to verify tokens (public keys)",
+        "operationId": "retrieveJWKS",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/jwksResponse"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
     "/snapshot/shared-options": {
       "get": {
         "tags": [
@@ -9584,52 +9608,6 @@
             "type": "string",
             "name": "groupId",
             "in": "query"
-          },
-          {
-            "type": "integer",
-            "format": "int64",
-            "name": "teamId",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
-    "/teams/{teamId}/groups/{groupId}": {
-      "delete": {
-        "tags": [
-          "sync_team_groups",
-          "enterprise"
-        ],
-        "summary": "Remove External Group.",
-        "operationId": "removeTeamGroupApi",
-        "deprecated": true,
-        "parameters": [
-          {
-            "type": "string",
-            "name": "groupId",
-            "in": "path",
-            "required": true
           },
           {
             "type": "integer",
@@ -11426,7 +11404,7 @@
           "type": "string"
         },
         "relativeTimeRange": {
-          "$ref": "#/definitions/RelativeTimeRange"
+          "$ref": "#/definitions/RelativeTimeRangeExport"
         }
       }
     },
@@ -11843,6 +11821,9 @@
         "for": {
           "type": "string"
         },
+        "keep_firing_for": {
+          "type": "string"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -11852,6 +11833,16 @@
         "record": {
           "type": "string"
         }
+      }
+    },
+    "AttributeTypeAndValue": {
+      "description": "AttributeTypeAndValue mirrors the ASN.1 structure of the same name in\nRFC 5280, Section 4.1.2.4.",
+      "type": "object",
+      "properties": {
+        "Type": {
+          "$ref": "#/definitions/ObjectIdentifier"
+        },
+        "Value": {}
       }
     },
     "Authorization": {
@@ -11969,6 +11960,247 @@
           "$ref": "#/definitions/Json"
         },
         "version": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Certificate": {
+      "type": "object",
+      "title": "A Certificate represents an X.509 certificate.",
+      "properties": {
+        "AuthorityKeyId": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "BasicConstraintsValid": {
+          "description": "BasicConstraintsValid indicates whether IsCA, MaxPathLen,\nand MaxPathLenZero are valid.",
+          "type": "boolean"
+        },
+        "CRLDistributionPoints": {
+          "description": "CRL Distribution Points",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DNSNames": {
+          "description": "Subject Alternate Name values. (Note that these values may not be valid\nif invalid values were contained within a parsed certificate. For\nexample, an element of DNSNames may not be a valid DNS domain name.)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "EmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedDNSDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedEmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExcludedIPRanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNet"
+          }
+        },
+        "ExcludedURIDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExtKeyUsage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtKeyUsage"
+          }
+        },
+        "Extensions": {
+          "description": "Extensions contains raw X.509 extensions. When parsing certificates,\nthis can be used to extract non-critical extensions that are not\nparsed by this package. When marshaling certificates, the Extensions\nfield is ignored, see ExtraExtensions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        },
+        "ExtraExtensions": {
+          "description": "ExtraExtensions contains extensions to be copied, raw, into any\nmarshaled certificates. Values override any extensions that would\notherwise be produced based on the other fields. The ExtraExtensions\nfield is not populated when parsing certificates, see Extensions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        },
+        "IPAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IsCA": {
+          "type": "boolean"
+        },
+        "Issuer": {
+          "$ref": "#/definitions/Name"
+        },
+        "IssuingCertificateURL": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "KeyUsage": {
+          "$ref": "#/definitions/KeyUsage"
+        },
+        "MaxPathLen": {
+          "description": "MaxPathLen and MaxPathLenZero indicate the presence and\nvalue of the BasicConstraints' \"pathLenConstraint\".\n\nWhen parsing a certificate, a positive non-zero MaxPathLen\nmeans that the field was specified, -1 means it was unset,\nand MaxPathLenZero being true mean that the field was\nexplicitly set to zero. The case of MaxPathLen==0 with MaxPathLenZero==false\nshould be treated equivalent to -1 (unset).\n\nWhen generating a certificate, an unset pathLenConstraint\ncan be requested with either MaxPathLen == -1 or using the\nzero value for both MaxPathLen and MaxPathLenZero.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "MaxPathLenZero": {
+          "description": "MaxPathLenZero indicates that BasicConstraintsValid==true\nand MaxPathLen==0 should be interpreted as an actual\nmaximum path length of zero. Otherwise, that combination is\ninterpreted as MaxPathLen not being set.",
+          "type": "boolean"
+        },
+        "NotBefore": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "OCSPServer": {
+          "description": "RFC 5280, 4.2.2.1 (Authority Information Access)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedDNSDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedDNSDomainsCritical": {
+          "description": "Name constraints",
+          "type": "boolean"
+        },
+        "PermittedEmailAddresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PermittedIPRanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IPNet"
+          }
+        },
+        "PermittedURIDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PolicyIdentifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "PublicKey": {},
+        "PublicKeyAlgorithm": {
+          "$ref": "#/definitions/PublicKeyAlgorithm"
+        },
+        "Raw": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawIssuer": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawSubject": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawSubjectPublicKeyInfo": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "RawTBSCertificate": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "SerialNumber": {
+          "type": "string"
+        },
+        "Signature": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "SignatureAlgorithm": {
+          "$ref": "#/definitions/SignatureAlgorithm"
+        },
+        "Subject": {
+          "$ref": "#/definitions/Name"
+        },
+        "SubjectKeyId": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "URIs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/URL"
+          }
+        },
+        "UnhandledCriticalExtensions": {
+          "description": "UnhandledCriticalExtensions contains a list of extension IDs that\nwere not (fully) processed when parsing. Verify will fail if this\nslice is non-empty, unless verification is delegated to an OS\nlibrary which understands all the critical extensions.\n\nUsers can access these extensions using Extensions and can remove\nelements from this slice if they believe that they have been\nhandled.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "UnknownExtKeyUsage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectIdentifier"
+          }
+        },
+        "Version": {
           "type": "integer",
           "format": "int64"
         }
@@ -13020,6 +13252,9 @@
           "description": "Error is a property to be set if the corresponding DataQuery has an error.",
           "type": "string"
         },
+        "ErrorSource": {
+          "$ref": "#/definitions/ErrorSource"
+        },
         "Frames": {
           "$ref": "#/definitions/Frames"
         },
@@ -13478,6 +13713,10 @@
         }
       }
     },
+    "ErrorSource": {
+      "description": "ErrorSource type defines the source of the error",
+      "type": "string"
+    },
     "ErrorType": {
       "type": "string",
       "title": "ErrorType models the different API error types."
@@ -13537,6 +13776,12 @@
     "ExplorePanelsState": {
       "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
     },
+    "ExtKeyUsage": {
+      "description": "Each of the ExtKeyUsage* constants define a unique action.",
+      "type": "integer",
+      "format": "int64",
+      "title": "ExtKeyUsage represents an extended set of actions that are valid for a given key."
+    },
     "ExtendedReceiver": {
       "type": "object",
       "properties": {
@@ -13566,6 +13811,25 @@
         },
         "wechat_configs": {
           "$ref": "#/definitions/WechatConfig"
+        }
+      }
+    },
+    "Extension": {
+      "description": "Extension represents the ASN.1 structure of the same name. See RFC\n5280, section 4.2.",
+      "type": "object",
+      "properties": {
+        "Critical": {
+          "type": "boolean"
+        },
+        "Id": {
+          "$ref": "#/definitions/ObjectIdentifier"
+        },
+        "Value": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
         }
       }
     },
@@ -14049,6 +14313,12 @@
             "$ref": "#/definitions/GettableGrafanaReceiver"
           }
         },
+        "msteams_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MSTeamsConfig"
+          }
+        },
         "name": {
           "description": "A unique identifier for this receiver.",
           "type": "string"
@@ -14081,12 +14351,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/SNSConfig"
-          }
-        },
-        "teams_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsConfig"
           }
         },
         "telegram_configs": {
@@ -14141,6 +14405,9 @@
         },
         "grafana_alert": {
           "$ref": "#/definitions/GettableGrafanaRule"
+        },
+        "keep_firing_for": {
+          "type": "string"
         },
         "labels": {
           "type": "object",
@@ -14588,6 +14855,27 @@
         }
       }
     },
+    "IPMask": {
+      "description": "See type IPNet and func ParseCIDR for details.",
+      "type": "array",
+      "title": "An IPMask is a bitmask that can be used to manipulate\nIP addresses for IP addressing and routing.",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      }
+    },
+    "IPNet": {
+      "type": "object",
+      "title": "An IPNet represents an IP network.",
+      "properties": {
+        "IP": {
+          "type": "string"
+        },
+        "Mask": {
+          "$ref": "#/definitions/IPMask"
+        }
+      }
+    },
     "ImportDashboardInput": {
       "type": "object",
       "title": "ImportDashboardInput definition of input parameters when importing a dashboard.",
@@ -14757,23 +15045,6 @@
         }
       }
     },
-    "Item": {
-      "type": "object",
-      "title": "Item defines model for Item.",
-      "properties": {
-        "title": {
-          "description": "Title is an unused property -- it will be removed in the future",
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/ItemType"
-        },
-        "value": {
-          "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
-          "type": "string"
-        }
-      }
-    },
     "ItemDTO": {
       "type": "object",
       "properties": {
@@ -14848,12 +15119,60 @@
         }
       }
     },
-    "ItemType": {
-      "type": "string",
-      "title": "Type of the item."
+    "JSONWebKey": {
+      "type": "object",
+      "title": "JSONWebKey represents a public or private key in JWK format.",
+      "properties": {
+        "Algorithm": {
+          "description": "Key algorithm, parsed from `alg` header.",
+          "type": "string"
+        },
+        "CertificateThumbprintSHA1": {
+          "description": "X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "CertificateThumbprintSHA256": {
+          "description": "X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8"
+          }
+        },
+        "Certificates": {
+          "description": "X.509 certificate chain, parsed from `x5c` header.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Certificate"
+          }
+        },
+        "CertificatesURL": {
+          "$ref": "#/definitions/URL"
+        },
+        "Key": {
+          "description": "Cryptographic key, can be a symmetric or asymmetric key."
+        },
+        "KeyID": {
+          "description": "Key identifier, parsed from `kid` header.",
+          "type": "string"
+        },
+        "Use": {
+          "description": "Key use, parsed from `use` header.",
+          "type": "string"
+        }
+      }
     },
     "Json": {
       "type": "object"
+    },
+    "KeyUsage": {
+      "description": "KeyUsage represents the set of actions that are valid for a given key. It's\na bitmap of the KeyUsage* constants.",
+      "type": "integer",
+      "format": "int64"
     },
     "Label": {
       "type": "object",
@@ -15325,6 +15644,47 @@
         "$ref": "#/definitions/MuteTimeInterval"
       }
     },
+    "Name": {
+      "description": "Name represents an X.509 distinguished name. This only includes the common\nelements of a DN. Note that Name is only an approximation of the X.509\nstructure. If an accurate representation is needed, asn1.Unmarshal the raw\nsubject or issuer as an RDNSequence.",
+      "type": "object",
+      "properties": {
+        "Country": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExtraNames": {
+          "description": "ExtraNames contains attributes to be copied, raw, into any marshaled\ndistinguished names. Values override any attributes with the same OID.\nThe ExtraNames field is not populated when parsing, see Names.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttributeTypeAndValue"
+          }
+        },
+        "Locality": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Names": {
+          "description": "Names contains all parsed attributes. When parsing distinguished names,\nthis can be used to extract non-standard attributes that are not parsed\nby this package. When marshaling to RDNSequences, the Names field is\nignored, see ExtraNames.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttributeTypeAndValue"
+          }
+        },
+        "SerialNumber": {
+          "type": "string"
+        },
+        "StreetAddress": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "NamespaceConfigResponse": {
       "type": "object",
       "additionalProperties": {
@@ -15508,6 +15868,14 @@
         "token_url": {
           "type": "string"
         }
+      }
+    },
+    "ObjectIdentifier": {
+      "type": "array",
+      "title": "An ObjectIdentifier represents an ASN.1 OBJECT IDENTIFIER.",
+      "items": {
+        "type": "integer",
+        "format": "int64"
       }
     },
     "ObjectMatchers": {
@@ -15957,6 +16325,30 @@
         }
       }
     },
+    "PlaylistDTO": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "description": "Interval sets the time between switching views in a playlist.",
+          "type": "string"
+        },
+        "items": {
+          "description": "The ordered list of items that the playlist will iterate over.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlaylistItemDTO"
+          }
+        },
+        "name": {
+          "description": "Name of the playlist.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "Unique playlist identifier. Generated on creation, either by the\ncreator of the playlist of by the application.",
+          "type": "string"
+        }
+      }
+    },
     "PlaylistDashboard": {
       "type": "object",
       "properties": {
@@ -16010,6 +16402,23 @@
           "type": "string"
         },
         "value": {
+          "type": "string"
+        }
+      }
+    },
+    "PlaylistItemDTO": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "Title is an unused property -- it will be removed in the future",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the item.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
           "type": "string"
         }
       }
@@ -16150,6 +16559,12 @@
             "$ref": "#/definitions/PostableGrafanaReceiver"
           }
         },
+        "msteams_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MSTeamsConfig"
+          }
+        },
         "name": {
           "description": "A unique identifier for this receiver.",
           "type": "string"
@@ -16182,12 +16597,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/SNSConfig"
-          }
-        },
-        "teams_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsConfig"
           }
         },
         "telegram_configs": {
@@ -16242,6 +16651,9 @@
         },
         "grafana_alert": {
           "$ref": "#/definitions/PostableGrafanaRule"
+        },
+        "keep_firing_for": {
+          "type": "string"
         },
         "labels": {
           "type": "object",
@@ -16589,6 +17001,10 @@
         }
       }
     },
+    "PublicKeyAlgorithm": {
+      "type": "integer",
+      "format": "int64"
+    },
     "PushoverConfig": {
       "type": "object",
       "properties": {
@@ -16626,6 +17042,9 @@
           "$ref": "#/definitions/Secret"
         },
         "token_file": {
+          "type": "string"
+        },
+        "ttl": {
           "type": "string"
         },
         "url": {
@@ -16868,6 +17287,12 @@
             "$ref": "#/definitions/EmailConfig"
           }
         },
+        "msteams_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MSTeamsConfig"
+          }
+        },
         "name": {
           "description": "A unique identifier for this receiver.",
           "type": "string"
@@ -16900,12 +17325,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/SNSConfig"
-          }
-        },
-        "teams_configs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MSTeamsConfig"
           }
         },
         "telegram_configs": {
@@ -17017,6 +17436,19 @@
         },
         "to": {
           "$ref": "#/definitions/Duration"
+        }
+      }
+    },
+    "RelativeTimeRangeExport": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "to": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -17908,6 +18340,10 @@
           "$ref": "#/definitions/Secret"
         }
       }
+    },
+    "SignatureAlgorithm": {
+      "type": "integer",
+      "format": "int64"
     },
     "SlackAction": {
       "description": "See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons\nfor more information.",
@@ -18874,8 +19310,9 @@
       "type": "string"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -19283,6 +19720,32 @@
         "version": {
           "type": "integer",
           "format": "int64"
+        }
+      }
+    },
+    "UpdateRuleGroupResponse": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deleted": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "message": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -19718,7 +20181,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -19742,6 +20204,7 @@
       }
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -19902,14 +20365,12 @@
       }
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
       }
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -20145,6 +20606,7 @@
       }
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",
@@ -20958,14 +21420,14 @@
       "schema": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Item"
+          "$ref": "#/definitions/PlaylistItemDTO"
         }
       }
     },
     "getPlaylistResponse": {
       "description": "(empty)",
       "schema": {
-        "$ref": "#/definitions/Spec"
+        "$ref": "#/definitions/PlaylistDTO"
       }
     },
     "getPreferencesResponse": {
@@ -21156,6 +21618,20 @@
         "$ref": "#/definitions/ErrorResponseBody"
       }
     },
+    "jwksResponse": {
+      "description": "(empty)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/JSONWebKey"
+            }
+          }
+        }
+      }
+    },
     "listBuiltinRolesResponse": {
       "description": "(empty)",
       "schema": {
@@ -21314,8 +21790,9 @@
         "properties": {
           "id": {
             "description": "ID The unique identifier (id) of the created/updated dashboard.",
-            "type": "string",
-            "example": "1"
+            "type": "integer",
+            "format": "int64",
+            "example": 1
           },
           "status": {
             "description": "Status status of the response.",
@@ -21502,7 +21979,7 @@
     "updatePlaylistResponse": {
       "description": "(empty)",
       "schema": {
-        "$ref": "#/definitions/Spec"
+        "$ref": "#/definitions/PlaylistDTO"
       }
     },
     "updateServiceAccountResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -988,7 +988,7 @@
           "application/json": {
             "schema": {
               "items": {
-                "$ref": "#/components/schemas/Item"
+                "$ref": "#/components/schemas/PlaylistItemDTO"
               },
               "type": "array"
             }
@@ -1000,7 +1000,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/Spec"
+              "$ref": "#/components/schemas/PlaylistDTO"
             }
           }
         },
@@ -1286,6 +1286,24 @@
         },
         "description": "InternalServerError is a general error indicating something went wrong internally."
       },
+      "jwksResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "keys": {
+                  "items": {
+                    "$ref": "#/components/schemas/JSONWebKey"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "listBuiltinRolesResponse": {
         "content": {
           "application/json": {
@@ -1480,8 +1498,9 @@
               "properties": {
                 "id": {
                   "description": "ID The unique identifier (id) of the created/updated dashboard.",
-                  "example": "1",
-                  "type": "string"
+                  "example": 1,
+                  "format": "int64",
+                  "type": "integer"
                 },
                 "status": {
                   "description": "Status status of the response.",
@@ -1773,7 +1792,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/Spec"
+              "$ref": "#/components/schemas/PlaylistDTO"
             }
           }
         },
@@ -2451,7 +2470,7 @@
             "type": "string"
           },
           "relativeTimeRange": {
-            "$ref": "#/components/schemas/RelativeTimeRange"
+            "$ref": "#/components/schemas/RelativeTimeRangeExport"
           }
         },
         "title": "AlertQueryExport is the provisioned export of models.AlertQuery.",
@@ -2869,6 +2888,9 @@
           "for": {
             "type": "string"
           },
+          "keep_firing_for": {
+            "type": "string"
+          },
           "labels": {
             "additionalProperties": {
               "type": "string"
@@ -2878,6 +2900,16 @@
           "record": {
             "type": "string"
           }
+        },
+        "type": "object"
+      },
+      "AttributeTypeAndValue": {
+        "description": "AttributeTypeAndValue mirrors the ASN.1 structure of the same name in\nRFC 5280, Section 4.1.2.4.",
+        "properties": {
+          "Type": {
+            "$ref": "#/components/schemas/ObjectIdentifier"
+          },
+          "Value": {}
         },
         "type": "object"
       },
@@ -2999,6 +3031,247 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "Certificate": {
+        "properties": {
+          "AuthorityKeyId": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "BasicConstraintsValid": {
+            "description": "BasicConstraintsValid indicates whether IsCA, MaxPathLen,\nand MaxPathLenZero are valid.",
+            "type": "boolean"
+          },
+          "CRLDistributionPoints": {
+            "description": "CRL Distribution Points",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "DNSNames": {
+            "description": "Subject Alternate Name values. (Note that these values may not be valid\nif invalid values were contained within a parsed certificate. For\nexample, an element of DNSNames may not be a valid DNS domain name.)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "EmailAddresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ExcludedDNSDomains": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ExcludedEmailAddresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ExcludedIPRanges": {
+            "items": {
+              "$ref": "#/components/schemas/IPNet"
+            },
+            "type": "array"
+          },
+          "ExcludedURIDomains": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ExtKeyUsage": {
+            "items": {
+              "$ref": "#/components/schemas/ExtKeyUsage"
+            },
+            "type": "array"
+          },
+          "Extensions": {
+            "description": "Extensions contains raw X.509 extensions. When parsing certificates,\nthis can be used to extract non-critical extensions that are not\nparsed by this package. When marshaling certificates, the Extensions\nfield is ignored, see ExtraExtensions.",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            },
+            "type": "array"
+          },
+          "ExtraExtensions": {
+            "description": "ExtraExtensions contains extensions to be copied, raw, into any\nmarshaled certificates. Values override any extensions that would\notherwise be produced based on the other fields. The ExtraExtensions\nfield is not populated when parsing certificates, see Extensions.",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            },
+            "type": "array"
+          },
+          "IPAddresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "IsCA": {
+            "type": "boolean"
+          },
+          "Issuer": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "IssuingCertificateURL": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "KeyUsage": {
+            "$ref": "#/components/schemas/KeyUsage"
+          },
+          "MaxPathLen": {
+            "description": "MaxPathLen and MaxPathLenZero indicate the presence and\nvalue of the BasicConstraints' \"pathLenConstraint\".\n\nWhen parsing a certificate, a positive non-zero MaxPathLen\nmeans that the field was specified, -1 means it was unset,\nand MaxPathLenZero being true mean that the field was\nexplicitly set to zero. The case of MaxPathLen==0 with MaxPathLenZero==false\nshould be treated equivalent to -1 (unset).\n\nWhen generating a certificate, an unset pathLenConstraint\ncan be requested with either MaxPathLen == -1 or using the\nzero value for both MaxPathLen and MaxPathLenZero.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "MaxPathLenZero": {
+            "description": "MaxPathLenZero indicates that BasicConstraintsValid==true\nand MaxPathLen==0 should be interpreted as an actual\nmaximum path length of zero. Otherwise, that combination is\ninterpreted as MaxPathLen not being set.",
+            "type": "boolean"
+          },
+          "NotBefore": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "OCSPServer": {
+            "description": "RFC 5280, 4.2.2.1 (Authority Information Access)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "PermittedDNSDomains": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "PermittedDNSDomainsCritical": {
+            "description": "Name constraints",
+            "type": "boolean"
+          },
+          "PermittedEmailAddresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "PermittedIPRanges": {
+            "items": {
+              "$ref": "#/components/schemas/IPNet"
+            },
+            "type": "array"
+          },
+          "PermittedURIDomains": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "PolicyIdentifiers": {
+            "items": {
+              "$ref": "#/components/schemas/ObjectIdentifier"
+            },
+            "type": "array"
+          },
+          "PublicKey": {},
+          "PublicKeyAlgorithm": {
+            "$ref": "#/components/schemas/PublicKeyAlgorithm"
+          },
+          "Raw": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "RawIssuer": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "RawSubject": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "RawSubjectPublicKeyInfo": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "RawTBSCertificate": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "SerialNumber": {
+            "type": "string"
+          },
+          "Signature": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "SignatureAlgorithm": {
+            "$ref": "#/components/schemas/SignatureAlgorithm"
+          },
+          "Subject": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "SubjectKeyId": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "URIs": {
+            "items": {
+              "$ref": "#/components/schemas/URL"
+            },
+            "type": "array"
+          },
+          "UnhandledCriticalExtensions": {
+            "description": "UnhandledCriticalExtensions contains a list of extension IDs that\nwere not (fully) processed when parsing. Verify will fail if this\nslice is non-empty, unless verification is delegated to an OS\nlibrary which understands all the critical extensions.\n\nUsers can access these extensions using Extensions and can remove\nelements from this slice if they believe that they have been\nhandled.",
+            "items": {
+              "$ref": "#/components/schemas/ObjectIdentifier"
+            },
+            "type": "array"
+          },
+          "UnknownExtKeyUsage": {
+            "items": {
+              "$ref": "#/components/schemas/ObjectIdentifier"
+            },
+            "type": "array"
+          },
+          "Version": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "title": "A Certificate represents an X.509 certificate.",
         "type": "object"
       },
       "ChangeUserPasswordCommand": {
@@ -4045,6 +4318,9 @@
             "description": "Error is a property to be set if the corresponding DataQuery has an error.",
             "type": "string"
           },
+          "ErrorSource": {
+            "$ref": "#/components/schemas/ErrorSource"
+          },
           "Frames": {
             "$ref": "#/components/schemas/Frames"
           },
@@ -4505,6 +4781,10 @@
         ],
         "type": "object"
       },
+      "ErrorSource": {
+        "description": "ErrorSource type defines the source of the error",
+        "type": "string"
+      },
       "ErrorType": {
         "title": "ErrorType models the different API error types.",
         "type": "string"
@@ -4564,6 +4844,12 @@
       "ExplorePanelsState": {
         "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
       },
+      "ExtKeyUsage": {
+        "description": "Each of the ExtKeyUsage* constants define a unique action.",
+        "format": "int64",
+        "title": "ExtKeyUsage represents an extended set of actions that are valid for a given key.",
+        "type": "integer"
+      },
       "ExtendedReceiver": {
         "properties": {
           "email_configs": {
@@ -4592,6 +4878,25 @@
           },
           "wechat_configs": {
             "$ref": "#/components/schemas/WechatConfig"
+          }
+        },
+        "type": "object"
+      },
+      "Extension": {
+        "description": "Extension represents the ASN.1 structure of the same name. See RFC\n5280, section 4.2.",
+        "properties": {
+          "Critical": {
+            "type": "boolean"
+          },
+          "Id": {
+            "$ref": "#/components/schemas/ObjectIdentifier"
+          },
+          "Value": {
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -5075,6 +5380,12 @@
             },
             "type": "array"
           },
+          "msteams_configs": {
+            "items": {
+              "$ref": "#/components/schemas/MSTeamsConfig"
+            },
+            "type": "array"
+          },
           "name": {
             "description": "A unique identifier for this receiver.",
             "type": "string"
@@ -5106,12 +5417,6 @@
           "sns_configs": {
             "items": {
               "$ref": "#/components/schemas/SNSConfig"
-            },
-            "type": "array"
-          },
-          "teams_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsConfig"
             },
             "type": "array"
           },
@@ -5167,6 +5472,9 @@
           },
           "grafana_alert": {
             "$ref": "#/components/schemas/GettableGrafanaRule"
+          },
+          "keep_firing_for": {
+            "type": "string"
           },
           "labels": {
             "additionalProperties": {
@@ -5615,6 +5923,27 @@
         "title": "HostPort represents a \"host:port\" network address.",
         "type": "object"
       },
+      "IPMask": {
+        "description": "See type IPNet and func ParseCIDR for details.",
+        "items": {
+          "format": "uint8",
+          "type": "integer"
+        },
+        "title": "An IPMask is a bitmask that can be used to manipulate\nIP addresses for IP addressing and routing.",
+        "type": "array"
+      },
+      "IPNet": {
+        "properties": {
+          "IP": {
+            "type": "string"
+          },
+          "Mask": {
+            "$ref": "#/components/schemas/IPMask"
+          }
+        },
+        "title": "An IPNet represents an IP network.",
+        "type": "object"
+      },
       "ImportDashboardInput": {
         "properties": {
           "name": {
@@ -5784,23 +6113,6 @@
         },
         "type": "object"
       },
-      "Item": {
-        "properties": {
-          "title": {
-            "description": "Title is an unused property -- it will be removed in the future",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/ItemType"
-          },
-          "value": {
-            "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
-            "type": "string"
-          }
-        },
-        "title": "Item defines model for Item.",
-        "type": "object"
-      },
       "ItemDTO": {
         "properties": {
           "alertId": {
@@ -5875,12 +6187,60 @@
         },
         "type": "object"
       },
-      "ItemType": {
-        "title": "Type of the item.",
-        "type": "string"
+      "JSONWebKey": {
+        "properties": {
+          "Algorithm": {
+            "description": "Key algorithm, parsed from `alg` header.",
+            "type": "string"
+          },
+          "CertificateThumbprintSHA1": {
+            "description": "X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.",
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "CertificateThumbprintSHA256": {
+            "description": "X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.",
+            "items": {
+              "format": "uint8",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "Certificates": {
+            "description": "X.509 certificate chain, parsed from `x5c` header.",
+            "items": {
+              "$ref": "#/components/schemas/Certificate"
+            },
+            "type": "array"
+          },
+          "CertificatesURL": {
+            "$ref": "#/components/schemas/URL"
+          },
+          "Key": {
+            "description": "Cryptographic key, can be a symmetric or asymmetric key."
+          },
+          "KeyID": {
+            "description": "Key identifier, parsed from `kid` header.",
+            "type": "string"
+          },
+          "Use": {
+            "description": "Key use, parsed from `use` header.",
+            "type": "string"
+          }
+        },
+        "title": "JSONWebKey represents a public or private key in JWK format.",
+        "type": "object"
       },
       "Json": {
         "type": "object"
+      },
+      "KeyUsage": {
+        "description": "KeyUsage represents the set of actions that are valid for a given key. It's\na bitmap of the KeyUsage* constants.",
+        "format": "int64",
+        "type": "integer"
       },
       "Label": {
         "properties": {
@@ -6352,6 +6712,47 @@
         },
         "type": "array"
       },
+      "Name": {
+        "description": "Name represents an X.509 distinguished name. This only includes the common\nelements of a DN. Note that Name is only an approximation of the X.509\nstructure. If an accurate representation is needed, asn1.Unmarshal the raw\nsubject or issuer as an RDNSequence.",
+        "properties": {
+          "Country": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ExtraNames": {
+            "description": "ExtraNames contains attributes to be copied, raw, into any marshaled\ndistinguished names. Values override any attributes with the same OID.\nThe ExtraNames field is not populated when parsing, see Names.",
+            "items": {
+              "$ref": "#/components/schemas/AttributeTypeAndValue"
+            },
+            "type": "array"
+          },
+          "Locality": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "Names": {
+            "description": "Names contains all parsed attributes. When parsing distinguished names,\nthis can be used to extract non-standard attributes that are not parsed\nby this package. When marshaling to RDNSequences, the Names field is\nignored, see ExtraNames.",
+            "items": {
+              "$ref": "#/components/schemas/AttributeTypeAndValue"
+            },
+            "type": "array"
+          },
+          "SerialNumber": {
+            "type": "string"
+          },
+          "StreetAddress": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "NamespaceConfigResponse": {
         "additionalProperties": {
           "items": {
@@ -6536,6 +6937,14 @@
         },
         "title": "OAuth2 is the oauth2 client configuration.",
         "type": "object"
+      },
+      "ObjectIdentifier": {
+        "items": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "title": "An ObjectIdentifier represents an ASN.1 OBJECT IDENTIFIER.",
+        "type": "array"
       },
       "ObjectMatchers": {
         "$ref": "#/components/schemas/Matchers"
@@ -6983,6 +7392,30 @@
         },
         "type": "object"
       },
+      "PlaylistDTO": {
+        "properties": {
+          "interval": {
+            "description": "Interval sets the time between switching views in a playlist.",
+            "type": "string"
+          },
+          "items": {
+            "description": "The ordered list of items that the playlist will iterate over.",
+            "items": {
+              "$ref": "#/components/schemas/PlaylistItemDTO"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Name of the playlist.",
+            "type": "string"
+          },
+          "uid": {
+            "description": "Unique playlist identifier. Generated on creation, either by the\ncreator of the playlist of by the application.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "PlaylistDashboard": {
         "properties": {
           "id": {
@@ -7035,6 +7468,23 @@
             "type": "string"
           },
           "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PlaylistItemDTO": {
+        "properties": {
+          "title": {
+            "description": "Title is an unused property -- it will be removed in the future",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of the item.",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value depends on type and describes the playlist item.\n\ndashboard_by_id: The value is an internal numerical identifier set by Grafana. This\nis not portable as the numerical identifier is non-deterministic between different instances.\nWill be replaced by dashboard_by_uid in the future. (deprecated)\ndashboard_by_tag: The value is a tag which is set on any number of dashboards. All\ndashboards behind the tag will be added to the playlist.\ndashboard_by_uid: The value is the dashboard UID",
             "type": "string"
           }
         },
@@ -7175,6 +7625,12 @@
             },
             "type": "array"
           },
+          "msteams_configs": {
+            "items": {
+              "$ref": "#/components/schemas/MSTeamsConfig"
+            },
+            "type": "array"
+          },
           "name": {
             "description": "A unique identifier for this receiver.",
             "type": "string"
@@ -7206,12 +7662,6 @@
           "sns_configs": {
             "items": {
               "$ref": "#/components/schemas/SNSConfig"
-            },
-            "type": "array"
-          },
-          "teams_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsConfig"
             },
             "type": "array"
           },
@@ -7267,6 +7717,9 @@
           },
           "grafana_alert": {
             "$ref": "#/components/schemas/PostableGrafanaRule"
+          },
+          "keep_firing_for": {
+            "type": "string"
           },
           "labels": {
             "additionalProperties": {
@@ -7615,6 +8068,10 @@
         },
         "type": "object"
       },
+      "PublicKeyAlgorithm": {
+        "format": "int64",
+        "type": "integer"
+      },
       "PushoverConfig": {
         "properties": {
           "device": {
@@ -7651,6 +8108,9 @@
             "$ref": "#/components/schemas/Secret"
           },
           "token_file": {
+            "type": "string"
+          },
+          "ttl": {
             "type": "string"
           },
           "url": {
@@ -7892,6 +8352,12 @@
             },
             "type": "array"
           },
+          "msteams_configs": {
+            "items": {
+              "$ref": "#/components/schemas/MSTeamsConfig"
+            },
+            "type": "array"
+          },
           "name": {
             "description": "A unique identifier for this receiver.",
             "type": "string"
@@ -7923,12 +8389,6 @@
           "sns_configs": {
             "items": {
               "$ref": "#/components/schemas/SNSConfig"
-            },
-            "type": "array"
-          },
-          "teams_configs": {
-            "items": {
-              "$ref": "#/components/schemas/MSTeamsConfig"
             },
             "type": "array"
           },
@@ -8042,6 +8502,19 @@
           },
           "to": {
             "$ref": "#/components/schemas/Duration"
+          }
+        },
+        "type": "object"
+      },
+      "RelativeTimeRangeExport": {
+        "properties": {
+          "from": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "to": {
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -8933,6 +9406,10 @@
           }
         },
         "type": "object"
+      },
+      "SignatureAlgorithm": {
+        "format": "int64",
+        "type": "integer"
       },
       "SlackAction": {
         "description": "See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons\nfor more information.",
@@ -9899,6 +10376,7 @@
         "type": "string"
       },
       "URL": {
+        "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the EscapedPath method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
         "properties": {
           "ForceQuery": {
             "type": "boolean"
@@ -9934,7 +10412,7 @@
             "$ref": "#/components/schemas/Userinfo"
           }
         },
-        "title": "URL is a custom URL type that allows validation at configuration load time.",
+        "title": "A URL represents a parsed URL (technically, a URI reference).",
         "type": "object"
       },
       "UpdateAlertNotificationCommand": {
@@ -10307,6 +10785,32 @@
           "version": {
             "format": "int64",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateRuleGroupResponse": {
+        "properties": {
+          "created": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "deleted": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "message": {
+            "type": "string"
+          },
+          "updated": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -10743,7 +11247,6 @@
         "type": "object"
       },
       "alertGroup": {
-        "description": "AlertGroup alert group",
         "properties": {
           "alerts": {
             "description": "alerts",
@@ -10767,6 +11270,7 @@
         "type": "object"
       },
       "alertGroups": {
+        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -10927,14 +11431,12 @@
         "type": "object"
       },
       "gettableAlerts": {
-        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },
         "type": "array"
       },
       "gettableSilence": {
-        "description": "GettableSilence gettable silence",
         "properties": {
           "comment": {
             "description": "comment",
@@ -11170,6 +11672,7 @@
         "type": "object"
       },
       "receiver": {
+        "description": "Receiver receiver",
         "properties": {
           "active": {
             "description": "active",
@@ -18029,6 +18532,9 @@
           "401": {
             "$ref": "#/components/responses/unauthorisedError"
           },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
           "404": {
             "$ref": "#/components/responses/notFoundError"
           },
@@ -18114,6 +18620,9 @@
           },
           "401": {
             "$ref": "#/components/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
           },
           "404": {
             "$ref": "#/components/responses/notFoundError"
@@ -21367,6 +21876,24 @@
         ]
       }
     },
+    "/signing-keys/keys": {
+      "get": {
+        "description": "Required permissions\nNone",
+        "operationId": "retrieveJWKS",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/jwksResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Get JSON Web Key Set (JWKS) with all the keys that can be used to verify tokens (public keys)",
+        "tags": [
+          "signing_keys"
+        ]
+      }
+    },
     "/snapshot/shared-options": {
       "get": {
         "operationId": "getSharingOptions",
@@ -21747,56 +22274,6 @@
           }
         },
         "summary": "Add External Group.",
-        "tags": [
-          "sync_team_groups",
-          "enterprise"
-        ]
-      }
-    },
-    "/teams/{teamId}/groups/{groupId}": {
-      "delete": {
-        "deprecated": true,
-        "operationId": "removeTeamGroupApi",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "groupId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "teamId",
-            "required": true,
-            "schema": {
-              "format": "int64",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/components/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Remove External Group.",
         "tags": [
           "sync_team_groups",
           "enterprise"


### PR DESCRIPTION
**What is this feature?**

It changes the [`postDashboardResponse.id`](https://github.com/grafana/grafana/blob/8b16f2aca88d5b1b8033cd9d70de49ec75dcadfa/pkg/api/dashboard.go#L1286) type from `string` to `int64`, because the `id` it represents [is populated with Dashboard.ID](https://github.com/grafana/grafana/blob/8b16f2aca88d5b1b8033cd9d70de49ec75dcadfa/pkg/api/dashboard.go#L522C1-L523C1) which [is an `int64`](https://github.com/grafana/grafana/blob/455cede6992cfad57f1c5b1749c9454d1475dba6/pkg/services/dashboards/models.go#L31).

**Why do we need this feature?**

As reported [here](https://github.com/grafana/grizzly/pull/262), [the Grafana client generated from the OAPI definition](https://github.com/grafana/grafana-openapi-client-go) fails to _unmarshal_ the `postDashboardResponse`, because of the types mismatch: `json: cannot unmarshal number into Go struct field PostDashboardOKBody.id of type string`.

**Who is this feature for?**

Any consumer of the Swagger definition, in all of its forms.

**Which issue(s) does this PR fix?**:

N/A 

**Special notes for your reviewer:**

I've executed `make swagger-clean && make openapi3-gen` as stated in docs, with the goal of updating the Swagger definitions, but it looks like there's lot of changes, other than the one introduced in this pull request. Perhaps it was out of date? Is that correct?

Should I backport it? 🤔 

Thanks!