### PR TITLE
Logs Popover Menu: add string filtering functions

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -234,14 +234,14 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
    * Used by Logs Popover Menu.
    */
   onClickFilterValue = (value: string, refId?: string) => {
-    this.onModifyQueries({ type: 'ADD_LINE_FILTER', options: { value } }, refId);
+    this.onModifyQueries({ type: 'ADD_STRING_FILTER', options: { value } }, refId);
   };
 
   /**
    * Used by Logs Popover Menu.
    */
   onClickFilterOutValue = (value: string, refId?: string) => {
-    this.onModifyQueries({ type: 'ADD_LINE_FILTER_OUT', options: { value } }, refId);
+    this.onModifyQueries({ type: 'ADD_STRING_FILTER_OUT', options: { value } }, refId);
   };
 
   onClickAddQueryRowButton = () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1134,29 +1134,72 @@ describe('enhanceDataFrame', () => {
 
 describe('modifyQuery', () => {
   let ds: ElasticDatasource;
+  let query: ElasticsearchQuery;
   beforeEach(() => {
     ds = getTestContext().ds;
   });
   describe('with empty query', () => {
-    let query: ElasticsearchQuery;
+    describe('ADD_FILTER and ADD_FITER_OUT', () => {
+      beforeEach(() => {
+        query = { query: '', refId: 'A' };
+      });
+  
+      it('should add the filter', () => {
+        expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          'foo:"bar"'
+        );
+      });
+  
+      it('should add the negative filter', () => {
+        expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          '-foo:"bar"'
+        );
+      });
+  
+      it('should do nothing on unknown type', () => {
+        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
+      });
+    });
+  
+    describe('with non-empty query', () => {
+      let query: ElasticsearchQuery;
+      beforeEach(() => {
+        query = { query: 'test:"value"', refId: 'A' };
+      });
+  
+      it('should add the filter', () => {
+        expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          'test:"value" AND foo:"bar"'
+        );
+      });
+  
+      it('should add the negative filter', () => {
+        expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          'test:"value" AND -foo:"bar"'
+        );
+      });
+  
+      it('should do nothing on unknown type', () => {
+        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
+      });
+    });
+  });
+
+  describe('ADD_LINE_FILTER and ADD_LINE_FILTER_OUT', () => {
     beforeEach(() => {
       query = { query: '', refId: 'A' };
     });
 
     it('should add the filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        'foo:"bar"'
+      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER', options: { value: 'bar' } }).query).toBe(
+        '"bar"'
       );
     });
 
     it('should add the negative filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        '-foo:"bar"'
+      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
+        'NOT "bar"'
       );
-    });
-
-    it('should do nothing on unknown type', () => {
-      expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
     });
   });
 
@@ -1167,19 +1210,15 @@ describe('modifyQuery', () => {
     });
 
     it('should add the filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        'test:"value" AND foo:"bar"'
+      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER', options: { value: 'bar' } }).query).toBe(
+        'test:"value" AND "bar"'
       );
     });
 
     it('should add the negative filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        'test:"value" AND -foo:"bar"'
+      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
+        'test:"value" NOT "bar"'
       );
-    });
-
-    it('should do nothing on unknown type', () => {
-      expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1185,19 +1185,19 @@ describe('modifyQuery', () => {
     });
   });
 
-  describe('ADD_LINE_FILTER and ADD_LINE_FILTER_OUT', () => {
+  describe('ADD_STRING_FILTER and ADD_STRING_FILTER_OUT', () => {
     beforeEach(() => {
       query = { query: '', refId: 'A' };
     });
 
     it('should add the filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER', options: { value: 'bar' } }).query).toBe(
+      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER', options: { value: 'bar' } }).query).toBe(
         '"bar"'
       );
     });
 
     it('should add the negative filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
+      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
         'NOT "bar"'
       );
     });
@@ -1210,13 +1210,13 @@ describe('modifyQuery', () => {
     });
 
     it('should add the filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER', options: { value: 'bar' } }).query).toBe(
+      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER', options: { value: 'bar' } }).query).toBe(
         'test:"value" AND "bar"'
       );
     });
 
     it('should add the negative filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_LINE_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
+      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER_OUT', options: { value: 'bar' } }).query).toBe(
         'test:"value" NOT "bar"'
       );
     });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1143,44 +1143,48 @@ describe('modifyQuery', () => {
       beforeEach(() => {
         query = { query: '', refId: 'A' };
       });
-  
+
       it('should add the filter', () => {
         expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
           'foo:"bar"'
         );
       });
-  
+
       it('should add the negative filter', () => {
         expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
           '-foo:"bar"'
         );
       });
-  
+
       it('should do nothing on unknown type', () => {
-        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
+        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          query.query
+        );
       });
     });
-  
+
     describe('with non-empty query', () => {
       let query: ElasticsearchQuery;
       beforeEach(() => {
         query = { query: 'test:"value"', refId: 'A' };
       });
-  
+
       it('should add the filter', () => {
         expect(ds.modifyQuery(query, { type: 'ADD_FILTER', options: { key: 'foo', value: 'bar' } }).query).toBe(
           'test:"value" AND foo:"bar"'
         );
       });
-  
+
       it('should add the negative filter', () => {
         expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
           'test:"value" AND -foo:"bar"'
         );
       });
-  
+
       it('should do nothing on unknown type', () => {
-        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(query.query);
+        expect(ds.modifyQuery(query, { type: 'unknown', options: { key: 'foo', value: 'bar' } }).query).toBe(
+          query.query
+        );
       });
     });
   });
@@ -1191,9 +1195,7 @@ describe('modifyQuery', () => {
     });
 
     it('should add the filter', () => {
-      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER', options: { value: 'bar' } }).query).toBe(
-        '"bar"'
-      );
+      expect(ds.modifyQuery(query, { type: 'ADD_STRING_FILTER', options: { value: 'bar' } }).query).toBe('"bar"');
     });
 
     it('should add the negative filter', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -63,7 +63,13 @@ import {
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 import { isMetricAggregationWithMeta } from './guards';
-import { addAddHocFilter, addFilterToQuery, queryHasFilter, removeFilterFromQuery } from './modifyQuery';
+import {
+  addAddHocFilter,
+  addFilterToQuery,
+  addStringFilterToQuery,
+  queryHasFilter,
+  removeFilterFromQuery,
+} from './modifyQuery';
 import { trackAnnotationQuery, trackQuery } from './tracking';
 import {
   Logs,
@@ -941,6 +947,14 @@ export class ElasticDatasource
       }
       case 'ADD_FILTER_OUT': {
         expression = addFilterToQuery(expression, action.options.key, action.options.value, '-');
+        break;
+      }
+      case 'ADD_LINE_FILTER': {
+        expression = addStringFilterToQuery(expression, action.options.value);
+        break;
+      }
+      case 'ADD_LINE_FILTER_OUT': {
+        expression = addStringFilterToQuery(expression, action.options.value, false);
         break;
       }
     }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -949,11 +949,11 @@ export class ElasticDatasource
         expression = addFilterToQuery(expression, action.options.key, action.options.value, '-');
         break;
       }
-      case 'ADD_LINE_FILTER': {
+      case 'ADD_STRING_FILTER': {
         expression = addStringFilterToQuery(expression, action.options.value);
         break;
       }
-      case 'ADD_LINE_FILTER_OUT': {
+      case 'ADD_STRING_FILTER_OUT': {
         expression = addStringFilterToQuery(expression, action.options.value, false);
         break;
       }

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -1,4 +1,4 @@
-import { queryHasFilter, removeFilterFromQuery, addFilterToQuery } from './modifyQuery';
+import { queryHasFilter, removeFilterFromQuery, addFilterToQuery, addStringFilterToQuery } from './modifyQuery';
 
 describe('queryHasFilter', () => {
   it('should return true if the query contains the positive filter', () => {
@@ -106,5 +106,19 @@ describe('removeFilterFromQuery', () => {
   });
   it('should support filters with quotes', () => {
     expect(removeFilterFromQuery('label\\:name:"the \\"value\\""', 'label:name', 'the "value"')).toBe('');
+  });
+});
+
+describe('addStringFilterToQuery', () => {
+  it('should add a positive filter to a query', () => {
+    expect(addStringFilterToQuery('label:"value"', 'filter')).toBe('label:"value" AND "filter"');
+    expect(addStringFilterToQuery('', 'filter')).toBe('"filter"');
+    expect(addStringFilterToQuery(' ', 'filter')).toBe('"filter"');
+  });
+
+  it('should add a negative filter to a query', () => {
+    expect(addStringFilterToQuery('label:"value"', 'filter', false)).toBe('label:"value" NOT "filter"');
+    expect(addStringFilterToQuery('', 'filter', false)).toBe('NOT "filter"');
+    expect(addStringFilterToQuery(' ', 'filter', false)).toBe('NOT "filter"');
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -121,4 +121,9 @@ describe('addStringFilterToQuery', () => {
     expect(addStringFilterToQuery('', 'filter', false)).toBe('NOT "filter"');
     expect(addStringFilterToQuery(' ', 'filter', false)).toBe('NOT "filter"');
   });
+
+  it('should escape filter values', () => {
+    expect(addStringFilterToQuery('label:"value"', '"filter"')).toBe('label:"value" AND "\\"filter\\""');
+    expect(addStringFilterToQuery('label:"value"', '"filter"', false)).toBe('label:"value" NOT "\\"filter\\""');
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -241,6 +241,6 @@ function parseQuery(query: string) {
 }
 
 export function addStringFilterToQuery(query: string, filter: string, contains = true) {
-  const expression = `"${filter}"`;
+  const expression = `"${escapeFilterValue(filter)}"`;
   return query.trim() ? `${query} ${contains ? 'AND' : 'NOT'} ${expression}` : `${contains ? '' : 'NOT '}${expression}`;
 }

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -239,3 +239,8 @@ function parseQuery(query: string) {
     return null;
   }
 }
+
+export function addStringFilterToQuery(query: string, filter: string, contains = true) {
+  const expression = `"${filter}"`;
+  return query.trim() ? `${query} ${contains ? 'AND' : 'NOT'} ${expression}` : `${contains ? '' : 'NOT '}${expression}`;
+}

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -676,6 +676,50 @@ describe('LokiDatasource', () => {
         });
       });
     });
+
+    describe('when called with ADD_LINE_FILTER', () => {
+      let ds: LokiDatasource;
+      const query: LokiQuery = { refId: 'A', expr: '{bar="baz"}' };
+      beforeEach(() => {
+        ds = createLokiDatasource(templateSrvStub);
+        ds.languageProvider.labelKeys = ['bar', 'job'];
+      });
+
+      it('adds a line filter', () => {
+        const action = { options: { }, type: 'ADD_LINE_FILTER' };
+        const result = ds.modifyQuery(query, action);
+
+        expect(result.expr).toEqual('{bar="baz"} |= ``');
+      });
+      it('adds a line filter with a value', () => {
+        const action = { options: { value: 'value' }, type: 'ADD_LINE_FILTER' };
+        const result = ds.modifyQuery(query, action);
+
+        expect(result.expr).toEqual('{bar="baz"} |= `value`');
+      });
+    });
+
+    describe('when called with ADD_LINE_FILTER_OUT', () => {
+      let ds: LokiDatasource;
+      const query: LokiQuery = { refId: 'A', expr: '{bar="baz"}' };
+      beforeEach(() => {
+        ds = createLokiDatasource(templateSrvStub);
+        ds.languageProvider.labelKeys = ['bar', 'job'];
+      });
+
+      it('adds a line filter', () => {
+        const action = { options: { }, type: 'ADD_LINE_FILTER_OUT' };
+        const result = ds.modifyQuery(query, action);
+
+        expect(result.expr).toEqual('{bar="baz"} != ``');
+      });
+      it('adds a line filter with a value', () => {
+        const action = { options: { value: 'value' }, type: 'ADD_LINE_FILTER_OUT' };
+        const result = ds.modifyQuery(query, action);
+
+        expect(result.expr).toEqual('{bar="baz"} != `value`');
+      });
+    });
   });
 
   describe('toggleQueryFilter', () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -686,7 +686,7 @@ describe('LokiDatasource', () => {
       });
 
       it('adds a line filter', () => {
-        const action = { options: { }, type: 'ADD_LINE_FILTER' };
+        const action = { options: {}, type: 'ADD_LINE_FILTER' };
         const result = ds.modifyQuery(query, action);
 
         expect(result.expr).toEqual('{bar="baz"} |= ``');
@@ -708,7 +708,7 @@ describe('LokiDatasource', () => {
       });
 
       it('adds a line filter', () => {
-        const action = { options: { }, type: 'ADD_LINE_FILTER_OUT' };
+        const action = { options: {}, type: 'ADD_LINE_FILTER_OUT' };
         const result = ds.modifyQuery(query, action);
 
         expect(result.expr).toEqual('{bar="baz"} != ``');

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -932,6 +932,10 @@ export class LokiDatasource
         expression = addLineFilter(expression, action.options?.value);
         break;
       }
+      case 'ADD_LINE_FILTER_OUT': {
+        expression = addLineFilter(expression, action.options?.value, '!=');
+        break;
+      }
       default:
         break;
     }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -928,10 +928,12 @@ export class LokiDatasource
         expression = addFilterAsLabelFilter(expression, [lastPosition], filter);
         break;
       }
+      case 'ADD_STRING_FILTER':
       case 'ADD_LINE_FILTER': {
         expression = addLineFilter(expression, action.options?.value);
         break;
       }
+      case 'ADD_STRING_FILTER_OUT':
       case 'ADD_LINE_FILTER_OUT': {
         expression = addLineFilter(expression, action.options?.value, '!=');
         break;

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -3,6 +3,7 @@ import { SyntaxNode } from '@lezer/common';
 import {
   addLabelFormatToQuery,
   addLabelToQuery,
+  addLineFilter,
   addNoPipelineErrorToQuery,
   addParserToQuery,
   NodePosition,
@@ -304,5 +305,20 @@ describe('removeLabelFromQuery', () => {
     ['{foo="bar"} | logfmt | job!=`grafana`', 'grafana', '{foo="bar"} | logfmt'],
   ])('should remove a negative label matcher from the query', (query: string, value: string, expected: string) => {
     expect(removeLabelFromQuery(query, 'job', '!=', value)).toBe(expected);
+  });
+});
+
+describe.each(['|=', '!='])('addLineFilter type %s', (op: string) => {
+  it('Adds a line filter to a log query', () => {
+    expect(addLineFilter('{place="earth"}', undefined, op)).toBe(`{place="earth"} ${op} \`\``);
+  });
+  it('Adds a line filter with a value to a log query', () => {
+    expect(addLineFilter('{place="earth"}', 'content', op)).toBe(`{place="earth"} ${op} \`content\``);
+  });
+  it('Adds a line filter to a metric query', () => {
+    expect(addLineFilter('avg_over_time({place="earth"} [1m])', undefined, op)).toBe(`avg_over_time({place="earth"} ${op} \`\` [1m])`);
+  });
+  it('Adds a line filter with a value to a metric query', () => {
+    expect(addLineFilter('avg_over_time({place="earth"} [1m])', 'content', op)).toBe(`avg_over_time({place="earth"} ${op} \`content\` [1m])`);
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -316,9 +316,13 @@ describe.each(['|=', '!='])('addLineFilter type %s', (op: string) => {
     expect(addLineFilter('{place="earth"}', 'content', op)).toBe(`{place="earth"} ${op} \`content\``);
   });
   it('Adds a line filter to a metric query', () => {
-    expect(addLineFilter('avg_over_time({place="earth"} [1m])', undefined, op)).toBe(`avg_over_time({place="earth"} ${op} \`\` [1m])`);
+    expect(addLineFilter('avg_over_time({place="earth"} [1m])', undefined, op)).toBe(
+      `avg_over_time({place="earth"} ${op} \`\` [1m])`
+    );
   });
   it('Adds a line filter with a value to a metric query', () => {
-    expect(addLineFilter('avg_over_time({place="earth"} [1m])', 'content', op)).toBe(`avg_over_time({place="earth"} ${op} \`content\` [1m])`);
+    expect(addLineFilter('avg_over_time({place="earth"} [1m])', 'content', op)).toBe(
+      `avg_over_time({place="earth"} ${op} \`content\` [1m])`
+    );
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -540,14 +540,14 @@ function addLabelFormat(
   return newQuery;
 }
 
-export function addLineFilter(query: string, value = ''): string {
+export function addLineFilter(query: string, value = '', operator = '|='): string {
   const streamSelectorPositions = getStreamSelectorPositions(query);
   if (!streamSelectorPositions.length) {
     return query;
   }
   const streamSelectorEnd = streamSelectorPositions[0].to;
 
-  const newQueryExpr = query.slice(0, streamSelectorEnd) + ` |= \`${value}\`` + query.slice(streamSelectorEnd);
+  const newQueryExpr = query.slice(0, streamSelectorEnd) + ` ${operator} \`${value}\`` + query.slice(streamSelectorEnd);
   return newQueryExpr;
 }
 


### PR DESCRIPTION
This PR updates modify query implementations in Elasticsearch and Loki to support adding string filters (contains and does not contain) from the popover menu.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/76129

**Demos**

Elasticsearch:

https://github.com/grafana/grafana/assets/1069378/edd94e72-d23d-40e9-b6ce-be4253045838

Loki:

https://github.com/grafana/grafana/assets/1069378/2ebb781a-dcf9-411a-8524-8d8da42e4025


