### PR TITLE
Plugins: Add contextual logger to streaming methods in ContextualLoggerMiddleware

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/contextual_logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/contextual_logger_middleware.go
@@ -57,13 +57,16 @@ func (m *ContextualLoggerMiddleware) CollectMetrics(ctx context.Context, req *ba
 }
 
 func (m *ContextualLoggerMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	ctx = instrumentContext(ctx, endpointSubscribeStream, req.PluginContext)
 	return m.next.SubscribeStream(ctx, req)
 }
 
 func (m *ContextualLoggerMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
+	ctx = instrumentContext(ctx, endpointPublishStream, req.PluginContext)
 	return m.next.PublishStream(ctx, req)
 }
 
 func (m *ContextualLoggerMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+	ctx = instrumentContext(ctx, endpointRunStream, req.PluginContext)
 	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/utils.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/utils.go
@@ -9,10 +9,13 @@ const (
 	statusError     = "error"
 	statusCancelled = "cancelled"
 
-	endpointCallResource   = "callResource"
-	endpointCheckHealth    = "checkHealth"
-	endpointCollectMetrics = "collectMetrics"
-	endpointQueryData      = "queryData"
+	endpointCallResource    = "callResource"
+	endpointCheckHealth     = "checkHealth"
+	endpointCollectMetrics  = "collectMetrics"
+	endpointQueryData       = "queryData"
+	endpointSubscribeStream = "subscribeStream"
+	endpointPublishStream   = "publishStream"
+	endpointRunStream       = "runStream"
 )
 
 type callResourceResponseSenderFunc func(res *backend.CallResourceResponse) error


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds contextual logs parameters to streaming methods in the plugin client:

- `SubscribeStream`
- `PublishStream`
- `RunStream`

**Why do we need this feature?**

Better instrmentation.

**Who is this feature for?**

Grafana operators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
