### PR TITLE
Table: Sticky footer positioning

### DIFF
--- a/packages/grafana-ui/src/components/Table/FooterRow.tsx
+++ b/packages/grafana-ui/src/components/Table/FooterRow.tsx
@@ -14,16 +14,17 @@ export interface FooterRowProps {
   footerValues: FooterItem[];
   isPaginationVisible: boolean;
   tableStyles: TableStyles;
+  isSticky: boolean;
 }
 
 export function FooterRow(props: FooterRowProps) {
-  const { totalColumnsWidth, footerGroups, isPaginationVisible, tableStyles } = props;
+  const { totalColumnsWidth, footerGroups, isPaginationVisible, tableStyles, isSticky } = props;
   const e2eSelectorsTable = selectors.components.Panels.Visualization.Table;
 
   return (
     <div
       style={{
-        position: isPaginationVisible ? 'relative' : 'absolute',
+        position: isPaginationVisible ? 'relative' : isSticky ? 'sticky' : 'absolute',
         width: totalColumnsWidth ? `${totalColumnsWidth}px` : '100%',
         bottom: '0px',
       }}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -383,6 +383,7 @@ export const Table = memo((props: Props) => {
               footerGroups={footerGroups}
               totalColumnsWidth={totalColumnsWidth}
               tableStyles={tableStyles}
+              isSticky={footerOptions?.isSticky ?? false}
             />
           )}
         </div>

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -64,6 +64,7 @@ export interface TableFooterCalc {
   fields?: string[];
   enablePagination?: boolean;
   countRows?: boolean;
+  isSticky?: boolean;
 }
 
 export interface GrafanaTableState extends TableState {


### PR DESCRIPTION

**What is this feature?**
Allows the calling component to define sticky positioning for footer in the footerOptions.

**Why do we need this feature?**
Some footers provide necessary context that need to be visible to end-users without scrolling

**Who is this feature for?**
Developer(s) using table component.

**Special notes for your reviewer:**
It's not applicable for paginated tables since there's no scrolling within the component?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
