### PR TITLE
Alerting: Use common StateReason values for NoData/Error mapped states

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -108,6 +108,7 @@ const (
 
 const (
 	StateReasonMissingSeries = "MissingSeries"
+	StateReasonNoData        = "NoData"
 	StateReasonError         = "Error"
 	StateReasonPaused        = "Paused"
 	StateReasonUpdated       = "Updated"

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -268,7 +268,7 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 		resultAlerting(state, rule, result, logger)
 		// This is a special case where Alerting and Pending should also have an error and reason
 		state.Error = result.Error
-		state.StateReason = "error"
+		state.StateReason = models.StateReasonError
 	case models.ErrorErrState:
 		if state.State == eval.Error {
 			prevEndsAt := state.EndsAt
@@ -326,7 +326,7 @@ func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logg
 	case models.Alerting:
 		logger.Debug("Execution no data state is Alerting", "handler", "resultAlerting", "previous_handler", "resultNoData")
 		resultAlerting(state, rule, result, logger)
-		state.StateReason = models.NoData.String()
+		state.StateReason = models.StateReasonNoData
 	case models.NoData:
 		if state.State == eval.NoData {
 			prevEndsAt := state.EndsAt
@@ -355,7 +355,7 @@ func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logg
 	case models.OK:
 		logger.Debug("Execution no data state is Normal", "handler", "resultNormal", "previous_handler", "resultNoData")
 		resultNormal(state, rule, result, logger)
-		state.StateReason = models.NoData.String()
+		state.StateReason = models.StateReasonNoData
 	default:
 		err := fmt.Errorf("unsupported no data state: %s", rule.NoDataState)
 		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))


### PR DESCRIPTION
**What is this feature?**

The NoData/Error state mapping logic either hardcodes reason strings (with improper capitalization) or stringifies unrelated models to generate the StateReason.

The hardcoded string will cause any future reason comparisons to fail, i.e. `StateReason == models.StateReasonError` is unexpectedly false because the reason uses an all-lowercase `"error"`. It's also visually inconsistent with the other reasons in the UI.

Introduced `models.StateReasonNoData` to complement `StateReasonError` for consistency - it's confusing that one exists, where the other doesn't.

**Why do we need this feature?**

Causes state comparisons against error reasons to not break. Fixes capitalization in UI.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
