### PR TITLE
Add grafana program label command

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -451,5 +451,4 @@
       "url": "https://github.com/orgs/grafana/projects/471"
     }
   }
-
 ]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -442,5 +442,14 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/72"
     }
+  },
+   {
+    "type": "label",
+    "name": "grafana program",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/471"
+    }
   }
+
 ]


### PR DESCRIPTION
Adds the `grafana program` label to the command list as described in https://docs.google.com/document/d/1ZgNnybVOwHjbIWRZ9GixCzbecaCxcNWU00DiMF5KxaY/edit#heading=h.4hkvvmp3q5yk