### PR TITLE
[v10.0.x] Fix correlation links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 # Documentation sources might have different owners.
 /docs/                                                                       @grafana/docs-tooling
 /docs/sources/                                                               @Eve832
-/docs/sources/administration/                                                @Eve832 @GrafanaWriter
+/docs/sources/administration/                                                @jdbaldry
 /docs/sources/alerting/                                                      @brendamuir
 /docs/sources/dashboards/                                                    @imatwawana
 /docs/sources/datasources/                                                   @lwandz13

--- a/docs/sources/administration/correlations/_index.md
+++ b/docs/sources/administration/correlations/_index.md
@@ -14,25 +14,30 @@ weight: 900
 
 You can create interactive links for Explore visualizations to run queries related to presented data by setting up Correlations.
 
-A correlation defines how data in one [data source]({{< relref "/docs/grafana/latest/datasources/" >}}) is used to query data in another data source. Some examples:
+A correlation defines how data in one [data source]({{< relref "../../datasources" >}}) is used to query data in another data source.
+Some examples:
 
 - an application name returned in a logs data source can be used to query metrics related to that application in a metrics data source, or
 - a user name returned by an SQL data source can be used to query logs related to that particular user in a logs data source
 
-[Explore]({{< relref "/docs/grafana/latest/explore/" >}}) takes user-defined correlations to display links inside the visualizations. You can click on a link to run the related query and see results in [Explore Split View]({{< relref "/docs/grafana/latest/explore/#split-and-compare" >}}).
+[Explore]({{< relref "../../explore" >}}) takes user-defined correlations to display links inside the visualizations.
+You can click on a link to run the related query and see results in [Explore Split View]({{< relref "../../explore#split-and-compare" >}}).
 
 Explore visualizations that currently support showing links based on correlations:
 
 - [Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}})
 - [Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}})
 
-You can configure correlations using [Administration > Correlation page]({{< relref "/docs/grafana/latest/administration/" >}}) or with [provisioning]({{< relref "/docs/grafana/latest/administration/provisioning" >}}).
+You can configure correlations using the **Administration > Correlation** page in Grafana or with [provisioning]({{< relref "../provisioning" >}}).
 
-> **Note:** Correlations are available in Grafana 10.0+ as an opt-in beta feature. Modify Grafana [configuration file]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana/#configuration-file-location" >}}) to enable the `correlations` [feature toggle]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles" >}}) to use it.
+{{% admonition type="note" %}}
+Correlations are available in Grafana 10.0+ as an opt-in beta feature.
+Modify the Grafana [configuration file]({{< relref "../../setup-grafana/configure-grafana#configuration-file-location" >}}) to enable the `correlations` [feature toggle]({{< relref "../../setup-grafana/configure-grafana#feature_toggles" >}}) to use it.
+{{% /admonition %}}
 
 ## Example of how links work in Explore once set up
 
-{{< figure src="/static/img/docs/correlations/correlations-in-explore-10-0.gif" caption="Correlations links in Explore" >}}
+{{< figure src="/static/img/docs/correlations/correlations-in-explore-10-0.gif" alt="Demonstration of following a correlation link in Grafana Explore" caption="Correlations links in Explore" >}}
 
 See also:
 

--- a/docs/sources/administration/correlations/add-permissions-to-create-new-correlations/index.md
+++ b/docs/sources/administration/correlations/add-permissions-to-create-new-correlations/index.md
@@ -12,7 +12,7 @@ weight: 30
 
 ## Before you begin
 
-Adding access to create correlations for [Viewers and Editors]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) is available with [Role-based access control]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}).
+Adding access to create correlations for [Viewers and Editors]({{< relref "../../../administration/roles-and-permissions" >}}) is available with [Role-based access control]({{< relref "../../../administration/roles-and-permissions/access-control" >}}).
 
 ## Add permissions to create correlations
 

--- a/docs/sources/administration/correlations/correlation-configuration/index.md
+++ b/docs/sources/administration/correlations/correlation-configuration/index.md
@@ -33,7 +33,9 @@ Learn how to create correlations using the [Administration page]({{< relref "./c
 
 ## Source data source and result field
 
-Links are shown in Explore visualizations for the results from the correlation’s source data source. A link is assigned to one of the fields from the result provided in the correlation configuration (the results field). Each visualization displays fields with links in a different way ([Correlations in Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}}) and see [Correlations in Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}}))
+Links are shown in Explore visualizations for the results from the correlation’s source data source.
+A link is assigned to one of the fields from the result provided in the correlation configuration (the results field).
+Each visualization displays fields with links in a different way ([Correlations in Logs Panel]({{< relref "./use-correlations-in-visualizations#correlations-in-logs-panel">}}) and see [Correlations in Table]({{< relref "./use-correlations-in-visualizations#correlations-in-table">}})).
 
 ## Target query
 
@@ -41,9 +43,11 @@ The target query is run when a link is clicked in the visualization. You can use
 
 ### Correlation Variables
 
-You can use variables inside the target query to access the source data related to the query. Correlations use [Grafana variable syntax]({{< relref "/docs/grafana/latest/dashboards/variables/variable-syntax" >}}). Variables are filled with values from the source results when the link is clicked. There are two types of variables you can use:
+You can use variables inside the target query to access the source data related to the query.
+Correlations use [Grafana variable syntax]({{< relref "../../../dashboards/variables/variable-syntax" >}}).
+Variables are filled with values from the source results when the link is clicked. There are two types of variables you can use:
 
-- [field variables]({{< relref "/docs/grafana/latest/panels-visualizations/configure-data-links#field-variables" >}}) (allows to access field values and labels)
+- [field variables]({{< relref "../../../panels-visualizations/configure-data-links#field-variables" >}}) (allows to access field values and labels)
 - correlation variables (allows to access field values and transformations)
 
 Example: If source results contain a field called “employee”, the value of the field can be accessed with:

--- a/docs/sources/administration/correlations/correlation-permissions/index.md
+++ b/docs/sources/administration/correlations/correlation-permissions/index.md
@@ -9,11 +9,11 @@ weight: 20
 
 # Permissions
 
-Users with [Viewer base role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) or with [datasources:query RBAC role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}) can:
+Users with [Viewer base role]({{< relref "../../../administration/roles-and-permissions" >}}) or with [datasources:query RBAC role]({{< relref "../../../administration/roles-and-permissions/access-control" >}}) can:
 
-- Use correlations in Explore’s visualizations
-- List all available correlations in read-only mode
+- Use correlations in Explore’s visualizations.
+- List all available correlations in read-only mode.
 
-Users with [Admin base role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/" >}}) or with [datasources:write RBAC role]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/" >}}) can:
+Users with [Admin base role]({{< relref "../../../administration/roles-and-permissions" >}}) or with [datasources:write RBAC role]({{< relref "../../../administration/roles-and-permissions/access-control" >}}) can:
 
-- Add, edit and delete correlations
+- Add, edit and delete correlations.

--- a/docs/sources/administration/correlations/create-a-new-correlation/index.md
+++ b/docs/sources/administration/correlations/create-a-new-correlation/index.md
@@ -80,7 +80,7 @@ Description of provisioning properties:
 : Correlation type. “query” is the only supported type at the moment
 
 **config.target**
-: [Target query model]({{< relref "#determine-target-query-model-structure" >}})
+: [Target query model](#determine-target-query-model-structure)
 
 **config.field**
 : Name of the field where link is shown

--- a/docs/sources/administration/correlations/use-correlations-in-visualizations/index.md
+++ b/docs/sources/administration/correlations/use-correlations-in-visualizations/index.md
@@ -27,7 +27,7 @@ weight: 70
 1. Open Explore.
 1. Select a data source that you chose as the source data source of the correlation.
 1. Run a query that results in data containing fields required to build variables in the target query.
-1. Links are added to cell rows in the column representing the field with the assigned link ([the results field]({{< relref "/docs/grafana/latest/administration/correlations/correlation-configuration#source-data-source-and-result-field" >}}).
+1. Links are added to cell rows in the column representing the field with the assigned link ([the results field]({{< relref "../correlation-configuration#source-data-source-and-result-field" >}}).
 1. Cells containing multiple links accessible with a context menu.
 
    {{< figure src="/static/img/docs/correlations/correlations-in-table-10-0.png" max-width="600px" caption="Correlations links in table" >}}

--- a/docs/sources/administration/correlations/use-variables-and-transformations/index.md
+++ b/docs/sources/administration/correlations/use-variables-and-transformations/index.md
@@ -73,7 +73,7 @@ Instructions below show how to set up a link that can run metrics query for the 
        - Required correlation type (query)
        - Target query matching test data source model
      - “App metrics” correlation contains the following configuration:
-       - Alias is set to ${application} variable (note that in provisioning files $ is used to access environment variables so it has to be [escaped]({{< relref "/docs/grafana/latest/administration/provisioning#using-environment-variables" >}})).
+       - Alias is set to ${application} variable (note that in provisioning files $ is used to access environment variables so it has to be [escaped]({{< relref "../../../administration/provisioning#using-environment-variables" >}})).
        - Regular expression transformation is created to extract values from “msg” field
          - Regular expression transformation is used to capture the application name from the full name of the service stored in the log line.
          - The output of the transformation is mapped to a variable called “application”.


### PR DESCRIPTION
Backport 87ca68540bf2047217b01025303a47375bdab884 from #76738

---

Presently, the links take users to "latest" even if they are in other versions of documentation.
Sometimes, the destination doesn't even exist in "latest".

There is no need to backport further than `v10.0.x` because these files don't exist in `v9.5.x` and earlier.
