### PR TITLE
Elasticsearch: Add interval type selector to interval field

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
@@ -26,6 +26,8 @@ import {
 } from './types';
 import { convertOrderByToMetricId, getScriptValue } from './utils';
 
+export const calendarIntervals: string[] = ['1w', '1M', '1q', '1y'];
+
 export class ElasticQueryBuilder {
   timeField: string;
 
@@ -100,7 +102,6 @@ export class ElasticQueryBuilder {
   getDateHistogramAgg(aggDef: DateHistogram) {
     const esAgg: any = {};
     const settings = aggDef.settings || {};
-    const calendarIntervals: string[] = ['1w', '1M', '1q', '1y'];
 
     esAgg.field = aggDef.field || this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
@@ -26,6 +26,7 @@ import {
 } from './types';
 import { convertOrderByToMetricId, getScriptValue } from './utils';
 
+// Omitting 1m, 1h, 1d for now, as these cover the main use cases for calendar_interval
 export const calendarIntervals: string[] = ['1w', '1M', '1q', '1y'];
 
 export class ElasticQueryBuilder {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+
+import { DateHistogram } from 'app/plugins/datasource/elasticsearch/types';
+
+import { useDispatch } from '../../../../hooks/useStatelessReducer';
+
+import { DateHistogramSettingsEditor } from './DateHistogramSettingsEditor';
+
+jest.mock('../../../../hooks/useStatelessReducer');
+
+describe('DateHistogramSettingsEditor', () => {
+  test('Renders the date histogram selector', async () => {
+    const bucketAgg: DateHistogram = {
+      field: "@timestamp",
+      id: "2",
+      settings: {interval: 'auto'},
+      type: "date_histogram",
+    };
+    render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
+    expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
+    expect(await screen.findByText('auto')).toBeInTheDocument();
+  });
+  test('Renders the date histogram selector with a fixed interval', async () => {
+    const bucketAgg: DateHistogram = {
+      field: "@timestamp",
+      id: "2",
+      settings: {interval: '10s'},
+      type: "date_histogram",
+    };
+    render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
+    expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
+    expect(await screen.findByText('10s')).toBeInTheDocument();
+  });
+  test('Renders the date histogram selector with a calendar interval', async () => {
+    const bucketAgg: DateHistogram = {
+      field: "@timestamp",
+      id: "2",
+      settings: {interval: '1w'},
+      type: "date_histogram",
+    };
+    render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
+    expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
+    expect(await screen.findByText('1w')).toBeInTheDocument();
+  });
+
+  describe('Handling change', () => {
+    let dispatch = jest.fn();
+    beforeEach(() => {
+      dispatch.mockClear();
+      jest.mocked(useDispatch).mockReturnValue(dispatch);
+    });
+    test('Handles changing from calendar to fixed interval type', async () => {
+      const bucketAgg: DateHistogram = {
+        field: "@timestamp",
+        id: "2",
+        settings: {interval: '1w'},
+        type: "date_histogram",
+      };
+      render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
+
+      expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
+      expect(await screen.findByText('1w')).toBeInTheDocument();
+      
+      await selectOptionInTest(screen.getByLabelText('Interval type'), 'Fixed interval');
+
+      expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    test('Renders the date histogram selector with a calendar interval', async () => {
+      const bucketAgg: DateHistogram = {
+        field: "@timestamp",
+        id: "2",
+        settings: {interval: '1m'},
+        type: "date_histogram",
+      };
+      render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
+     
+      expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
+      expect(await screen.findByText('1m')).toBeInTheDocument();
+
+      await selectOptionInTest(screen.getByLabelText('Interval type'), 'Calendar interval');
+
+      expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  })
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
@@ -13,10 +13,10 @@ jest.mock('../../../../hooks/useStatelessReducer');
 describe('DateHistogramSettingsEditor', () => {
   test('Renders the date histogram selector', async () => {
     const bucketAgg: DateHistogram = {
-      field: "@timestamp",
-      id: "2",
-      settings: {interval: 'auto'},
-      type: "date_histogram",
+      field: '@timestamp',
+      id: '2',
+      settings: { interval: 'auto' },
+      type: 'date_histogram',
     };
     render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
     expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
@@ -24,10 +24,10 @@ describe('DateHistogramSettingsEditor', () => {
   });
   test('Renders the date histogram selector with a fixed interval', async () => {
     const bucketAgg: DateHistogram = {
-      field: "@timestamp",
-      id: "2",
-      settings: {interval: '10s'},
-      type: "date_histogram",
+      field: '@timestamp',
+      id: '2',
+      settings: { interval: '10s' },
+      type: 'date_histogram',
     };
     render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
     expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
@@ -35,10 +35,10 @@ describe('DateHistogramSettingsEditor', () => {
   });
   test('Renders the date histogram selector with a calendar interval', async () => {
     const bucketAgg: DateHistogram = {
-      field: "@timestamp",
-      id: "2",
-      settings: {interval: '1w'},
-      type: "date_histogram",
+      field: '@timestamp',
+      id: '2',
+      settings: { interval: '1w' },
+      type: 'date_histogram',
     };
     render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
     expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
@@ -53,29 +53,29 @@ describe('DateHistogramSettingsEditor', () => {
     });
     test('Handles changing from calendar to fixed interval type', async () => {
       const bucketAgg: DateHistogram = {
-        field: "@timestamp",
-        id: "2",
-        settings: {interval: '1w'},
-        type: "date_histogram",
+        field: '@timestamp',
+        id: '2',
+        settings: { interval: '1w' },
+        type: 'date_histogram',
       };
       render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
 
       expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
       expect(await screen.findByText('1w')).toBeInTheDocument();
-      
+
       await selectOptionInTest(screen.getByLabelText('Calendar interval'), '10s');
 
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
     test('Renders the date histogram selector with a calendar interval', async () => {
       const bucketAgg: DateHistogram = {
-        field: "@timestamp",
-        id: "2",
-        settings: {interval: '1m'},
-        type: "date_histogram",
+        field: '@timestamp',
+        id: '2',
+        settings: { interval: '1m' },
+        type: 'date_histogram',
       };
       render(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />);
-     
+
       expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
       expect(await screen.findByText('1m')).toBeInTheDocument();
 
@@ -83,5 +83,5 @@ describe('DateHistogramSettingsEditor', () => {
 
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
-  })
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
@@ -63,9 +63,8 @@ describe('DateHistogramSettingsEditor', () => {
       expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
       expect(await screen.findByText('1w')).toBeInTheDocument();
       
-      await selectOptionInTest(screen.getByLabelText('Interval type'), 'Fixed interval');
+      await selectOptionInTest(screen.getByLabelText('Calendar interval'), '10s');
 
-      expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
     test('Renders the date histogram selector with a calendar interval', async () => {
@@ -80,9 +79,8 @@ describe('DateHistogramSettingsEditor', () => {
       expect(await screen.findByText('Fixed interval')).toBeInTheDocument();
       expect(await screen.findByText('1m')).toBeInTheDocument();
 
-      await selectOptionInTest(screen.getByLabelText('Interval type'), 'Calendar interval');
+      await selectOptionInTest(screen.getByLabelText('Fixed interval'), '1q');
 
-      expect(await screen.findByText('Calendar interval')).toBeInTheDocument();
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
   })

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -75,7 +75,8 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
 
   const handleIntervalTypeChange = useCallback(({ value }: SelectableValue<string>) => {
     setIntervalType(value || 'fixed');
-  }, []);
+    dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'interval', newValue: '' }))
+  }, [bucketAgg, dispatch]);
 
   return (
     <>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -79,7 +79,7 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
 
   return (
     <>
-      <InlineField label="Interval type" {...inlineFieldProps}>
+      <InlineField label="Interval type" {...inlineFieldProps} tooltip={"Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes."}>
           <Select
             inputId={uniqueId('es-date_histogram-interval-type')}
             options={intervalTypeOptions}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -1,5 +1,5 @@
 import { uniqueId } from 'lodash';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { GroupBase, OptionsOrGroups } from 'react-select';
 
 import { InternalTimeZones, SelectableValue } from '@grafana/data';
@@ -23,18 +23,10 @@ const defaultIntervalOptions: Array<SelectableValue<string>> = [
   { label: '20m', value: '20m' },
   { label: '1h', value: '1h' },
   { label: '1d', value: '1d' },
-];
-
-const defaultCalendarIntervalOptions: Array<SelectableValue<string>> = [
   { label: '1w', value: '1w' },
   { label: '1M', value: '1M' },
-  { label: '1q', value: '5q' },
+  { label: '1q', value: '1q' },
   { label: '1y', value: '1y' },
-];
-
-const intervalTypeOptions: Array<SelectableValue<string>> = [
-  { label: 'Fixed interval', value: 'fixed' },
-  { label: 'Calendar interval', value: 'calendar' },
 ];
 
 const hasValue =
@@ -62,45 +54,32 @@ interface Props {
 }
 
 const getIntervalType = (interval: string | undefined) => {
-  return interval && calendarIntervals.includes(interval) ? 'calendar' : 'fixed';
+  return interval && calendarIntervals.includes(interval) ? 'Calendar interval' : 'Fixed interval';
 };
 
 export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
   const dispatch = useDispatch();
-  const [intervalType, setIntervalType] = useState(getIntervalType(bucketAgg.settings?.interval || bucketAggregationConfig.date_histogram.defaultSettings?.interval));
   const { current: baseId } = useRef(uniqueId('es-date_histogram-'));
 
   const handleIntervalChange = useCallback(({ value }: SelectableValue<string>) =>
     dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'interval', newValue: value })), [bucketAgg, dispatch]);
 
-  const handleIntervalTypeChange = useCallback(({ value }: SelectableValue<string>) => {
-    setIntervalType(value || 'fixed');
-    dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'interval', newValue: '' }))
-  }, [bucketAgg, dispatch]);
+  const intervalType = getIntervalType(bucketAgg.settings?.interval || bucketAggregationConfig.date_histogram.defaultSettings?.interval);
 
   return (
     <>
-      <InlineField label="Interval type" {...inlineFieldProps} tooltip={"Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes."}>
-          <Select
-            inputId={uniqueId('es-date_histogram-interval-type')}
-            options={intervalTypeOptions}
-            value={intervalType}
-            onChange={handleIntervalTypeChange}
-          />
-        </InlineField>
-      <InlineField label="Interval" {...inlineFieldProps}>
+      <InlineField label={intervalType} tooltip={"Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes."} {...inlineFieldProps}>
         <Select
           inputId={uniqueId('es-date_histogram-interval')}
           isValidNewOption={isValidNewOption}
           filterOption={optionStartsWithValue}
           {...useCreatableSelectPersistedBehaviour({
-            options: intervalType === 'fixed' ? defaultIntervalOptions : defaultCalendarIntervalOptions,
+            options: defaultIntervalOptions,
             value: bucketAgg.settings?.interval || bucketAggregationConfig.date_histogram.defaultSettings?.interval,
             onChange: handleIntervalChange,
           })}
         />
       </InlineField>
-
       <InlineField label="Min Doc Count" {...inlineFieldProps}>
         <Input
           id={`${baseId}-min_doc_count`}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -53,8 +53,8 @@ interface Props {
   bucketAgg: DateHistogram;
 }
 
-const getIntervalType = (interval: string | undefined) => {
-  return interval && calendarIntervals.includes(interval) ? 'Calendar interval' : 'Fixed interval';
+const getIntervalType = (interval: string | undefined): 'calendar' | 'fixed' => {
+  return interval && calendarIntervals.includes(interval) ? 'calendar' : 'fixed';
 };
 
 export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
@@ -74,9 +74,11 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
   return (
     <>
       <InlineField
-        label={intervalType}
+        label={intervalType === 'calendar' ? 'Calendar interval' : 'Fixed interval'}
         tooltip={
-          'Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes.'
+          intervalType === 'calendar' ?
+          'Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context.' :
+          'Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes.'
         }
         {...inlineFieldProps}
       >

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -76,9 +76,9 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
       <InlineField
         label={intervalType === 'calendar' ? 'Calendar interval' : 'Fixed interval'}
         tooltip={
-          intervalType === 'calendar' ?
-          'Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context.' :
-          'Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes.'
+          intervalType === 'calendar'
+            ? 'Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context.'
+            : 'Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes.'
         }
         {...inlineFieldProps}
       >

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -61,14 +61,25 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
   const dispatch = useDispatch();
   const { current: baseId } = useRef(uniqueId('es-date_histogram-'));
 
-  const handleIntervalChange = useCallback(({ value }: SelectableValue<string>) =>
-    dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'interval', newValue: value })), [bucketAgg, dispatch]);
+  const handleIntervalChange = useCallback(
+    ({ value }: SelectableValue<string>) =>
+      dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'interval', newValue: value })),
+    [bucketAgg, dispatch]
+  );
 
-  const intervalType = getIntervalType(bucketAgg.settings?.interval || bucketAggregationConfig.date_histogram.defaultSettings?.interval);
+  const intervalType = getIntervalType(
+    bucketAgg.settings?.interval || bucketAggregationConfig.date_histogram.defaultSettings?.interval
+  );
 
   return (
     <>
-      <InlineField label={intervalType} tooltip={"Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes."} {...inlineFieldProps}>
+      <InlineField
+        label={intervalType}
+        tooltip={
+          'Calendar-aware intervals adapt to varying day lengths, month durations, and leap seconds, considering the calendar context. Fixed intervals remain constant, always being multiples of SI units, independent of calendar changes.'
+        }
+        {...inlineFieldProps}
+      >
         <Select
           inputId={uniqueId('es-date_histogram-interval')}
           isValidNewOption={isValidNewOption}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -15,7 +15,7 @@ import { TermsSettingsEditor } from './TermsSettingsEditor';
 import { useDescription } from './useDescription';
 
 export const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
-  labelWidth: 16,
+  labelWidth: 18,
 };
 
 interface Props {

--- a/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 
@@ -32,7 +32,11 @@ interface Params {
  * and the initial value when it is not present in the option array.
  */
 export const useCreatableSelectPersistedBehaviour = ({ options: initialOptions, value, onChange }: Params) => {
-  const [options, setOptions] = useState(getInitialState(initialOptions, value));
+  const [options, setOptions] = useState<Array<SelectableValue<string>>>([]);
+
+  useEffect(() => {
+    setOptions(getInitialState(initialOptions, value));
+  }, [initialOptions, value]);
 
   const addOption = (newValue: string) => setOptions([...options, { value: newValue, label: newValue }]);
 

--- a/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 
@@ -32,11 +32,7 @@ interface Params {
  * and the initial value when it is not present in the option array.
  */
 export const useCreatableSelectPersistedBehaviour = ({ options: initialOptions, value, onChange }: Params) => {
-  const [options, setOptions] = useState<Array<SelectableValue<string>>>([]);
-
-  useEffect(() => {
-    setOptions(getInitialState(initialOptions, value));
-  }, [initialOptions, value]);
+  const [options, setOptions] = useState(getInitialState(initialOptions, value));
 
   const addOption = (newValue: string) => setOptions([...options, { value: newValue, label: newValue }]);
 


### PR DESCRIPTION
This PR is a follow up to the [recent addition](https://github.com/grafana/grafana/pull/75459) to support calendar_interval in histograms, with the objective of making it easier for users to:
- Understand that calendar_interval is supported.
- Improve the form to display the appropriate suggestions for each interval mode.

The way this was implemented is backwards compatible, doesn't change data structures, and it's purely visual.
 
**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/discussions/55034

**Special notes for your reviewer:**

See demo:

https://github.com/grafana/grafana/assets/1069378/1f0c38e6-35d9-4c67-9a8f-1bfff6e89974

