### PR TITLE
Explore: Do not assert order of query history items when initializing from URL

### DIFF
--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -10,6 +10,15 @@ export const assertQueryHistoryExists = async (query: string, exploreId = 'left'
   expect(queryItem).toHaveTextContent(query);
 };
 
+export const assertQueryHistoryContains = async (query: string, exploreId = 'left') => {
+  const selector = withinExplore(exploreId);
+
+  await waitFor(() => {
+    const containsQuery = selector.getAllByLabelText('Query text').map((e) => (e.textContent || '').includes(query));
+    expect(containsQuery).toContain(true);
+  });
+};
+
 export const assertQueryHistory = async (expectedQueryTexts: string[], exploreId = 'left') => {
   const selector = withinExplore(exploreId);
   await waitFor(() => {

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -10,6 +10,7 @@ import {
   assertLoadMoreQueryHistoryNotVisible,
   assertQueryHistory,
   assertQueryHistoryComment,
+  assertQueryHistoryContains,
   assertQueryHistoryElementsShown,
   assertQueryHistoryExists,
   assertQueryHistoryIsEmpty,
@@ -163,8 +164,10 @@ describe('Explore: Query History', () => {
     });
 
     it('initial state is in sync', async () => {
-      await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'left');
-      await assertQueryHistory(['{"expr":"query #2"}', '{"expr":"query #1"}'], 'right');
+      await assertQueryHistoryContains('{"expr":"query #1"}', 'left');
+      await assertQueryHistoryContains('{"expr":"query #2"}', 'left');
+      await assertQueryHistoryContains('{"expr":"query #1"}', 'right');
+      await assertQueryHistoryContains('{"expr":"query #2"}', 'right');
     });
 
     it('starred queries are synced', async () => {


### PR DESCRIPTION
The test is asserting that when Explore is initialized from a URL containing two panes, the query history contains two queries from left and right pane but also asserts that queries are always stored in the some order: left pane first, then right pane. However, on load from the URL Explore initializes both panes independently and in parallel so there's no guarantee which query gets saved first. We just need to check that both queries are added to the history.

Fixes #76802