### PR TITLE
docs: fix typo in packages/README.md

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -36,7 +36,7 @@ Every commit to main that has changes within the `packages` directory is a subje
 
 > All of the steps below must be performed on a release branch, according to Grafana Release Guide.
 
-> You must be logged in to NPM as part of Grafana NPM org before attempting to publish to the npm registery.
+> You must be logged in to NPM as part of Grafana NPM org before attempting to publish to the npm registry.
 
 1. Run `yarn packages:clean` script from the root directory. This will delete any previous builds of the packages.
 2. Run `yarn packages:prepare` script from the root directory. This performs tests on the packages and prompts for the version of the packages. The version should be the same as the one being released.


### PR DESCRIPTION
registery -> registry